### PR TITLE
Teach spec-to-roadmap to create governed implementation roadmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Reusable Codex skills for turning repeated workflows into durable, discoverable 
 
 | Skill | Purpose |
 | --- | --- |
-| [`spec-to-roadmap`](skills/spec-to-roadmap/SKILL.md) | Convert a product/spec issue or document into ordered GitHub issues, a GitHub Project, and an end-to-end branch/PR/merge execution loop. |
+| [`spec-to-roadmap`](skills/spec-to-roadmap/SKILL.md) | Convert a product/spec issue or document into a governed roadmap: master spec, LLM-ready issues, dependencies, project routing, and optional execution loop. |
 
 ## Repository Layout
 
@@ -52,3 +52,12 @@ python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/s
 ```
 
 Some environments require running that validator inside a virtual environment with `PyYAML` installed.
+
+The `spec-to-roadmap` helper also supports a local dry run before mutating
+GitHub:
+
+```bash
+python3 skills/spec-to-roadmap/scripts/create_github_roadmap.py \
+  skills/spec-to-roadmap/references/issue-plan-template.json \
+  --dry-run
+```

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -4,7 +4,7 @@
 
 - Path: [`skills/spec-to-roadmap`](skills/spec-to-roadmap)
 - Trigger: use when a user wants Codex to turn a product/spec issue or document into ordered GitHub issues, a GitHub Project, and an end-to-end branch/PR/merge execution loop.
-- Status: initial published skill.
+- Status: governed roadmap workflow with dry-run validation, project reuse, issue idempotency, dependency metadata, and roadmap hygiene checks.
 
 ## Future Skill Checklist
 

--- a/skills/spec-to-roadmap/SKILL.md
+++ b/skills/spec-to-roadmap/SKILL.md
@@ -7,7 +7,14 @@ description: Use when a user wants Codex to turn a product/spec issue or documen
 
 ## Overview
 
-Convert a large spec into small, ordered, LLM-executable GitHub issues, create or update a GitHub Project, then execute each issue through branch, implementation, self-review, PR, merge, project update, and issue closure.
+Convert a large spec into small, ordered, LLM-executable GitHub issues, create
+or update the related GitHub Project, then optionally execute each issue through
+branch, implementation, self-review, PR, merge, project update, and issue
+closure.
+
+The roadmap output is itself a durable engineering artifact. For multi-issue
+work, preserve a master spec and make every child issue a mini-spec that an LLM
+implementation agent can execute without rereading the full conversation.
 
 This is a high-side-effect workflow. Prefer GitHub plugin/app capabilities when available; use `gh` as the reliable fallback.
 
@@ -20,6 +27,10 @@ Determine these before acting:
 - Project owner/title: default to repo owner and a title derived from the spec.
 - Execution mode: default full end-to-end when the user asks to execute; otherwise generate roadmap only.
 - Merge policy: default to normal PR merge after self-review and verification, respecting branch protection.
+- Existing project routing: inspect current projects first and reuse the most
+  appropriate board unless the user explicitly requests a new one.
+- Dependency gate policy: identify global gates, prerequisite issues, and work
+  that can safely run in parallel.
 
 If the repository, spec source, or merge authority is unclear, ask one concise question. Do not ask for confirmation for ordinary issue/project/branch/PR steps after the user has requested the full workflow.
 
@@ -29,12 +40,16 @@ If the repository, spec source, or merge authority is unclear, ask one concise q
 
 1. Fetch the spec body and comments.
 2. Save or reference the canonical spec in an issue/doc if the spec currently exists only in chat.
+   - If the source is only conversation text, create a master spec document or
+     tracker issue before child issues.
+   - Keep the source spec path/URL in every child issue.
 3. Identify hard constraints, non-goals, destructive risks, external dependencies, and acceptance criteria.
 4. Inspect existing issues/projects to avoid duplicates.
 
 ### 2. Decompose Into LLM-Sized Issues
 
-Create a structured plan before creating issues. Each issue must fit one implementation context and include:
+Create a structured plan before creating issues. Each issue must fit one
+implementation context and include:
 
 - Title with product/phase prefix.
 - Goal.
@@ -44,22 +59,56 @@ Create a structured plan before creating issues. Each issue must fit one impleme
 - Implementation scope.
 - Out of scope.
 - Acceptance criteria.
+- Verification commands or fixture expectations.
 - Labels.
+- Project routing.
+- Parallelization/concurrency guidance.
 - Risk or safety guardrails when relevant.
 
-Prefer fewer, sharper issues over broad phase buckets. Add a tracker issue unless an authoritative tracker already exists.
+Prefer fewer, sharper issues over broad phase buckets. Add a tracker issue
+unless an authoritative tracker already exists.
+
+For service-agent, reliability, data pipeline, infrastructure, or automation
+work, decompose broad findings into these issue types where applicable:
+
+- schema/state foundation;
+- deterministic detector/scanner;
+- remediation/rebuild/orchestration;
+- API/NATS/frontend status contract;
+- current incident fixture;
+- quality gate/regression fixture;
+- project/issue governance.
 
 Use `references/issue-plan-template.json` as the output shape for the issue plan. Use `scripts/create_github_roadmap.py` to create the tracker, child issues, project, project items, and source-spec comment from that plan.
+
+### 2.5 Validate The Roadmap Plan
+
+Before mutating GitHub:
+
+1. Run the helper in `--dry-run` mode.
+2. Confirm every issue has the required mini-spec sections.
+3. Confirm issue keys are unique and dependency keys resolve.
+4. Confirm required labels exist in the plan.
+5. Confirm project routing is explicit and reuses an existing project when appropriate.
+6. Confirm global gates, blocked labels, and parallelization metadata are present.
+
+Do not create issues when dry-run validation reports missing dependencies,
+duplicate keys, missing required issue sections, or unclear project routing.
 
 ### 3. Create The GitHub Roadmap
 
 1. Ensure required labels exist.
-2. Create/update the tracker issue.
-3. Create child issues in dependency order.
-4. Create/update the GitHub Project.
+2. Reuse the existing project when the plan specifies a project number or matching title; otherwise create the project.
+3. Create/update the tracker issue.
+4. Create/update child issues in dependency order.
 5. Add the source spec, tracker, and all child issues to the project.
-6. Comment on the source spec with project/tracker/child issue links.
-7. Verify counts and links before reporting success.
+6. Backfill tracker and child bodies with final issue numbers, child lists, dependency references, and project URL.
+7. Comment on the source spec with project/tracker/child issue links when the source is a GitHub issue.
+8. Verify counts, project membership, and links before reporting success.
+
+Generated issues should be idempotent by exact title or configured
+`idempotency_key`. Existing issues should be updated/commented rather than
+duplicated.
 
 ### 4. Execute Each Issue End-To-End
 
@@ -104,6 +153,19 @@ If GitHub Project fields exist, update them opportunistically:
 
 If field updates are unavailable or brittle, adding items and using issue comments is sufficient. Do not block the workflow on optional Project field automation.
 
+## Roadmap Hygiene Checks
+
+Before reporting success, verify:
+
+- tracker exists and lists all children in execution order;
+- every child issue links the master spec;
+- every child issue includes dependency and unblocks metadata;
+- every child issue is assigned to the target project;
+- required labels are present;
+- global gates such as `blocked:cloud-rollout` are preserved when applicable;
+- duplicate titles/fingerprints were not created;
+- source spec or parent issue has a comment linking tracker, project, and children.
+
 ## Safety Gates
 
 Stop and ask only for:
@@ -124,6 +186,7 @@ Before reporting completion of a roadmap generation run:
 - Confirm tracker exists and lists all child issues.
 - Confirm project exists and contains source spec, tracker, and children.
 - Confirm source spec has a comment linking project/tracker/children.
+- Confirm dry-run validation passed before mutation, or explain why no helper was available.
 
 Before reporting completion of an execution run:
 
@@ -131,4 +194,3 @@ Before reporting completion of an execution run:
 - Confirm merged PR links exist.
 - Confirm default branch contains the merged work.
 - Confirm final tests/checks run or document why they could not.
-

--- a/skills/spec-to-roadmap/agents/openai.yaml
+++ b/skills/spec-to-roadmap/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Spec to Roadmap"
-  short_description: "Create roadmap issues and execute them"
-  default_prompt: "Use this skill to split a spec into ordered LLM-sized GitHub issues, create or update the related project, then execute each issue through branch, PR, review, merge, and closure."
+  short_description: "Create governed implementation roadmaps"
+  default_prompt: "Use this skill to preserve a master spec, split it into ordered LLM-sized GitHub issues, reuse or create the related project, validate dependency/project hygiene, then optionally execute each issue through branch, PR, review, merge, and closure."

--- a/skills/spec-to-roadmap/references/issue-plan-template.json
+++ b/skills/spec-to-roadmap/references/issue-plan-template.json
@@ -3,10 +3,13 @@
   "source_spec": "#203 or URL or docs/path.md",
   "project": {
     "owner": "owner-or-org",
+    "number": null,
     "title": "Project Title",
+    "reuse_existing": true,
     "description": "Short project description",
     "readme": "Project readme markdown"
   },
+  "global_gates": ["#317"],
   "labels": [
     {
       "name": "spec:example",
@@ -15,19 +18,35 @@
     }
   ],
   "tracker": {
+    "key": "tracker",
     "title": "[Example] Tracker: implementation roadmap",
     "labels": ["spec:example", "type:tracker"],
-    "body": "Tracker body. Use {{child_list}} where generated child links should appear."
+    "idempotency_key": "example-tracker",
+    "body": "Tracker body. Use {{child_list}} where generated child links should appear. Use {{project_url}} and {{tracker_ref}} where useful."
   },
   "issues": [
     {
       "key": "phase0-data-safety",
       "title": "[Example Phase 0] Data safety",
       "labels": ["spec:example", "llm-ready"],
+      "idempotency_key": "example-phase0-data-safety",
       "depends_on": ["#203"],
       "unblocks": ["phase1-skeleton"],
-      "body": "Full issue body with Goal, Source spec, Depends on, Unblocks, Scope, Out of scope, Acceptance criteria."
+      "parallelization": "serial-foundation",
+      "project": "Project Title",
+      "body": "## Goal\n\n...\n\n## Source spec\n\n- {{source_spec}}\n\n## Depends on\n\n- #203\n\n## Unblocks\n\n- {{issue_ref:phase1-skeleton}}\n\n## Implementation scope\n\n...\n\n## Out of scope\n\n...\n\n## Parallelization\n\n...\n\n## Acceptance criteria\n\n...\n\n## Verification\n\n..."
+    },
+    {
+      "key": "phase1-skeleton",
+      "title": "[Example Phase 1] Implementation skeleton",
+      "labels": ["spec:example", "llm-ready"],
+      "idempotency_key": "example-phase1-skeleton",
+      "depends_on": ["phase0-data-safety"],
+      "unblocks": [],
+      "parallelization": "parallel-ok-after-foundation",
+      "project": "Project Title",
+      "body": "## Goal\n\n...\n\n## Source spec\n\n- {{source_spec}}\n\n## Depends on\n\n- {{issue_ref:phase0-data-safety}}\n\n## Unblocks\n\n- None.\n\n## Implementation scope\n\n...\n\n## Out of scope\n\n...\n\n## Parallelization\n\n...\n\n## Acceptance criteria\n\n...\n\n## Verification\n\n..."
     }
   ],
-  "source_comment": "Optional comment template. Use {{project_url}}, {{tracker_ref}}, and {{child_list}}."
+  "source_comment": "Optional comment template. Use {{project_url}}, {{tracker_ref}}, {{tracker_url}}, and {{child_list}}."
 }

--- a/skills/spec-to-roadmap/scripts/create_github_roadmap.py
+++ b/skills/spec-to-roadmap/scripts/create_github_roadmap.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Create GitHub roadmap issues/project from a JSON plan.
+"""Create or update GitHub roadmap issues/project from a JSON plan.
 
-This script intentionally handles the mechanical GitHub operations only.
-Codex remains responsible for reading the spec and producing the plan.
+The script intentionally handles mechanical GitHub operations only. Codex is
+still responsible for reading the spec, making engineering decisions, and
+writing issue bodies that are implementation-ready.
 """
 
 from __future__ import annotations
@@ -11,7 +12,33 @@ import argparse
 import json
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+
+
+REQUIRED_ISSUE_SECTIONS = (
+    "## Goal",
+    "## Source spec",
+    "## Depends on",
+    "## Unblocks",
+    "## Implementation scope",
+    "## Out of scope",
+    "## Acceptance criteria",
+    "## Verification",
+)
+
+
+@dataclass
+class IssueRef:
+    number: int
+    url: str
+    title: str
+    created: bool
+
+    @property
+    def ref(self) -> str:
+        return f"#{self.number}"
 
 
 def run(args: list[str], *, input_text: str | None = None) -> str:
@@ -30,9 +57,64 @@ def run(args: list[str], *, input_text: str | None = None) -> str:
     return result.stdout.strip()
 
 
-def gh_json(args: list[str]) -> object:
-    out = run(["gh", *args, "--format", "json"])
-    return json.loads(out)
+def gh_json(args: list[str]) -> Any:
+    out = run(["gh", *args])
+    return json.loads(out or "{}")
+
+
+def validate_plan(plan: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in ("repo", "source_spec", "project", "tracker", "issues"):
+        if field not in plan:
+            errors.append(f"missing top-level field: {field}")
+
+    keys: set[str] = set()
+    for issue in plan.get("issues", []):
+        key = issue.get("key")
+        if not key:
+            errors.append(f"issue without key: {issue.get('title', '<missing title>')}")
+            continue
+        if key in keys:
+            errors.append(f"duplicate issue key: {key}")
+        keys.add(key)
+
+    for issue in plan.get("issues", []):
+        key = issue.get("key", "<missing>")
+        body = issue.get("body", "")
+        for section in REQUIRED_ISSUE_SECTIONS:
+            if section not in body:
+                errors.append(f"{key}: missing required section {section}")
+        for dep in issue.get("depends_on", []):
+            if isinstance(dep, str) and dep.startswith("#"):
+                continue
+            if dep not in keys:
+                errors.append(f"{key}: unresolved depends_on key {dep}")
+        for unblock in issue.get("unblocks", []):
+            if isinstance(unblock, str) and unblock.startswith("#"):
+                continue
+            if unblock not in keys:
+                errors.append(f"{key}: unresolved unblocks key {unblock}")
+        if not issue.get("labels"):
+            errors.append(f"{key}: missing labels")
+        if not issue.get("parallelization"):
+            errors.append(f"{key}: missing parallelization")
+
+    project = plan.get("project", {})
+    if not project.get("owner"):
+        errors.append("project.owner is required")
+    if not project.get("title") and not project.get("number"):
+        errors.append("project.title or project.number is required")
+    return errors
+
+
+def render(template: str, values: dict[str, str], issue_refs: dict[str, IssueRef]) -> str:
+    rendered = template
+    for key, value in values.items():
+        rendered = rendered.replace("{{" + key + "}}", value)
+    for key, ref in issue_refs.items():
+        rendered = rendered.replace("{{issue_ref:" + key + "}}", ref.ref)
+        rendered = rendered.replace("{{issue_url:" + key + "}}", ref.url)
+    return rendered
 
 
 def ensure_label(repo: str, label: dict[str, str]) -> None:
@@ -57,24 +139,82 @@ def ensure_label(repo: str, label: dict[str, str]) -> None:
     )
 
 
-def create_issue(repo: str, title: str, labels: list[str], body: str) -> tuple[int, str]:
+def find_issue_by_title(repo: str, title: str) -> IssueRef | None:
+    data = gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "all",
+            "--search",
+            f'in:title "{title}"',
+            "--limit",
+            "100",
+            "--json",
+            "number,title,url",
+        ]
+    )
+    for issue in data:
+        if issue.get("title") == title:
+            return IssueRef(
+                number=int(issue["number"]),
+                url=str(issue["url"]),
+                title=title,
+                created=False,
+            )
+    return None
+
+
+def upsert_issue(repo: str, title: str, labels: list[str], body: str) -> IssueRef:
+    existing = find_issue_by_title(repo, title)
+    if existing:
+        run(["gh", "issue", "edit", str(existing.number), "--repo", repo, "--body", body])
+        if labels:
+            run(
+                [
+                    "gh",
+                    "issue",
+                    "edit",
+                    str(existing.number),
+                    "--repo",
+                    repo,
+                    "--add-label",
+                    ",".join(labels),
+                ]
+            )
+        return existing
+
     args = ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body]
     if labels:
         args.extend(["--label", ",".join(labels)])
     url = run(args).splitlines()[-1]
-    return int(url.rstrip("/").split("/")[-1]), url
+    return IssueRef(number=int(url.rstrip("/").split("/")[-1]), url=url, title=title, created=True)
 
 
-def edit_issue_body(repo: str, number: int, body: str) -> None:
-    run(["gh", "issue", "edit", str(number), "--repo", repo, "--body", body])
+def project_list(owner: str) -> list[dict[str, Any]]:
+    data = gh_json(["project", "list", "--owner", owner, "--format", "json", "--limit", "100"])
+    return list(data.get("projects", []))
 
 
-def create_project(owner: str, title: str) -> tuple[int, str]:
-    data = gh_json(["project", "create", "--owner", owner, "--title", title])
-    return int(data["number"]), data["url"]
+def resolve_project(owner: str, project: dict[str, Any]) -> tuple[int, str]:
+    if project.get("number"):
+        number = int(project["number"])
+        data = gh_json(["project", "view", str(number), "--owner", owner, "--format", "json"])
+        return number, str(data["url"])
+
+    title = str(project["title"])
+    if project.get("reuse_existing", True):
+        for existing in project_list(owner):
+            if existing.get("title") == title:
+                return int(existing["number"]), str(existing["url"])
+
+    data = gh_json(["project", "create", "--owner", owner, "--title", title, "--format", "json"])
+    return int(data["number"]), str(data["url"])
 
 
-def edit_project(owner: str, number: int, project: dict[str, str]) -> None:
+def edit_project(owner: str, number: int, project: dict[str, Any]) -> None:
     args = ["gh", "project", "edit", str(number), "--owner", owner]
     if project.get("description"):
         args.extend(["--description", project["description"]])
@@ -84,14 +224,75 @@ def edit_project(owner: str, number: int, project: dict[str, str]) -> None:
         run(args)
 
 
-def add_project_item(owner: str, project_number: int, url: str) -> None:
+def project_item_urls(owner: str, project_number: int) -> set[str]:
+    data = gh_json(
+        [
+            "project",
+            "item-list",
+            str(project_number),
+            "--owner",
+            owner,
+            "--format",
+            "json",
+            "--limit",
+            "500",
+        ]
+    )
+    urls: set[str] = set()
+    for item in data.get("items", []):
+        content = item.get("content") or {}
+        url = content.get("url")
+        if url:
+            urls.add(str(url))
+    return urls
+
+
+def add_project_item_once(owner: str, project_number: int, url: str, existing_urls: set[str]) -> None:
+    if url in existing_urls:
+        return
     run(["gh", "project", "item-add", str(project_number), "--owner", owner, "--url", url])
+    existing_urls.add(url)
 
 
-def render(template: str, values: dict[str, str]) -> str:
-    for key, value in values.items():
-        template = template.replace("{{" + key + "}}", value)
-    return template
+def source_spec_url(repo: str, source_spec: str) -> str | None:
+    if source_spec.startswith("#"):
+        return f"https://github.com/{repo}/issues/{source_spec[1:]}"
+    if source_spec.startswith("https://github.com/"):
+        return source_spec
+    return None
+
+
+def child_list_lines(issue_refs: dict[str, IssueRef], issues: list[dict[str, Any]]) -> str:
+    lines = []
+    for issue in issues:
+        ref = issue_refs[issue["key"]]
+        marker = "created" if ref.created else "updated"
+        lines.append(f"- {ref.ref} {issue['title']} ({marker})")
+    return "\n".join(lines)
+
+
+def dry_run(plan: dict[str, Any], errors: list[str]) -> None:
+    output = {
+        "valid": not errors,
+        "errors": errors,
+        "repo": plan.get("repo"),
+        "source_spec": plan.get("source_spec"),
+        "project": plan.get("project"),
+        "tracker": plan.get("tracker", {}).get("title"),
+        "issue_count": len(plan.get("issues", [])),
+        "issues": [
+            {
+                "key": issue.get("key"),
+                "title": issue.get("title"),
+                "depends_on": issue.get("depends_on", []),
+                "unblocks": issue.get("unblocks", []),
+                "parallelization": issue.get("parallelization"),
+                "labels": issue.get("labels", []),
+            }
+            for issue in plan.get("issues", [])
+        ],
+    }
+    print(json.dumps(output, indent=2))
 
 
 def main() -> int:
@@ -100,75 +301,94 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
 
-    plan = json.loads(args.plan.read_text())
-    repo = plan["repo"]
-    project = plan["project"]
-    owner = project["owner"]
-
+    plan = json.loads(args.plan.read_text(encoding="utf-8"))
+    errors = validate_plan(plan)
     if args.dry_run:
-        print(json.dumps(plan, indent=2))
-        return 0
+        dry_run(plan, errors)
+        return 1 if errors else 0
+    if errors:
+        for error in errors:
+            print(f"validation error: {error}", file=sys.stderr)
+        return 1
+
+    repo = str(plan["repo"])
+    source = str(plan["source_spec"])
+    project = plan["project"]
+    owner = str(project["owner"])
 
     for label in plan.get("labels", []):
         ensure_label(repo, label)
 
-    tracker_num, tracker_url = create_issue(
-        repo,
-        plan["tracker"]["title"],
-        plan["tracker"].get("labels", []),
-        plan["tracker"]["body"],
-    )
-
-    issue_refs: dict[str, str] = {}
-    child_lines: list[str] = []
-    child_urls: list[str] = []
-    for issue in plan["issues"]:
-        number, url = create_issue(repo, issue["title"], issue.get("labels", []), issue["body"])
-        issue_refs[issue["key"]] = f"#{number}"
-        child_lines.append(f"- #{number} {issue['title']}")
-        child_urls.append(url)
-        print(f"created #{number}: {issue['title']}")
-
-    child_list = "\n".join(child_lines)
-    tracker_body = render(
-        plan["tracker"]["body"],
-        {"child_list": child_list, "tracker_ref": f"#{tracker_num}", "tracker_url": tracker_url},
-    )
-    edit_issue_body(repo, tracker_num, tracker_body)
-
-    project_number, project_url = create_project(owner, project["title"])
+    project_number, project_url = resolve_project(owner, project)
     edit_project(owner, project_number, project)
+    existing_project_urls = project_item_urls(owner, project_number)
 
-    source_spec = str(plan.get("source_spec", ""))
-    if source_spec.startswith("#"):
-        source_url = f"https://github.com/{repo}/issues/{source_spec[1:]}"
-        add_project_item(owner, project_number, source_url)
-    add_project_item(owner, project_number, tracker_url)
-    for url in child_urls:
-        add_project_item(owner, project_number, url)
+    common_values = {"source_spec": source, "project_url": project_url}
+    tracker_plan = plan["tracker"]
+    tracker_ref = upsert_issue(
+        repo,
+        tracker_plan["title"],
+        tracker_plan.get("labels", []),
+        render(tracker_plan["body"], common_values, {}),
+    )
+
+    issue_refs: dict[str, IssueRef] = {}
+    common_values.update({"tracker_ref": tracker_ref.ref, "tracker_url": tracker_ref.url})
+
+    for issue in plan["issues"]:
+        body = render(issue["body"], common_values, issue_refs)
+        issue_refs[issue["key"]] = upsert_issue(
+            repo,
+            issue["title"],
+            issue.get("labels", []),
+            body,
+        )
+        status = "created" if issue_refs[issue["key"]].created else "updated"
+        print(f"{status} {issue_refs[issue['key']].ref}: {issue['title']}")
+
+    child_list = child_list_lines(issue_refs, plan["issues"])
+    common_values["child_list"] = child_list
+
+    final_tracker_body = render(tracker_plan["body"], common_values, issue_refs)
+    run(["gh", "issue", "edit", str(tracker_ref.number), "--repo", repo, "--body", final_tracker_body])
+
+    for issue in plan["issues"]:
+        final_body = render(issue["body"], common_values, issue_refs)
+        run(
+            [
+                "gh",
+                "issue",
+                "edit",
+                str(issue_refs[issue["key"]].number),
+                "--repo",
+                repo,
+                "--body",
+                final_body,
+            ]
+        )
+
+    source_url = source_spec_url(repo, source)
+    if source_url:
+        add_project_item_once(owner, project_number, source_url, existing_project_urls)
+    add_project_item_once(owner, project_number, tracker_ref.url, existing_project_urls)
+    for ref in issue_refs.values():
+        add_project_item_once(owner, project_number, ref.url, existing_project_urls)
 
     comment = plan.get("source_comment")
-    if comment and source_spec.startswith("#"):
-        body = render(
-            comment,
-            {
-                "project_url": project_url,
-                "tracker_ref": f"#{tracker_num}",
-                "tracker_url": tracker_url,
-                "child_list": child_list,
-            },
-        )
-        run(["gh", "issue", "comment", source_spec[1:], "--repo", repo, "--body", body])
+    if comment and source.startswith("#"):
+        body = render(comment, common_values, issue_refs)
+        run(["gh", "issue", "comment", source[1:], "--repo", repo, "--body", body])
+
+    final_urls = project_item_urls(owner, project_number)
+    missing = [ref.url for ref in [tracker_ref, *issue_refs.values()] if ref.url not in final_urls]
+    if missing:
+        raise RuntimeError(f"project membership verification failed: {missing}")
 
     print(f"project: {project_url}")
-    print(f"tracker: #{tracker_num} {tracker_url}")
+    print(f"tracker: {tracker_ref.ref} {tracker_ref.url}")
     print(child_list)
     return 0
 
 
 if __name__ == "__main__":
-    try:
-        raise SystemExit(main())
-    except Exception as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        raise SystemExit(1)
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Updates `spec-to-roadmap` so large specs become governed implementation roadmaps, not only a set of issues:

- preserve a master spec before child issues
- require child issues to be implementation-ready mini-specs
- add dependency, unblocks, project routing, and parallelization metadata
- add dry-run validation before GitHub mutation
- reuse existing GitHub Projects when configured or when titles match
- upsert issues by exact title to reduce duplicate roadmap creation
- verify project membership after tracker/child issue creation

## Verification

- `python3 -m py_compile skills/spec-to-roadmap/scripts/create_github_roadmap.py`
- `python3 skills/spec-to-roadmap/scripts/create_github_roadmap.py skills/spec-to-roadmap/references/issue-plan-template.json --dry-run`
- `/Users/wohlgemuth/IdeaProjects/chem-evidence/.venv/bin/python ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/spec-to-roadmap`
