### PR TITLE
Let spec roadmaps start from committed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,14 @@ The `spec-to-roadmap` helper also supports a local dry run before mutating
 GitHub:
 
 ```bash
+python3 skills/spec-to-roadmap/scripts/roadmap_plan_scaffold.py \
+  --spec docs/path.md \
+  --repo owner/name \
+  --project-owner owner \
+  --project-title "Project Title" \
+  --output /tmp/roadmap.json
+
 python3 skills/spec-to-roadmap/scripts/create_github_roadmap.py \
-  skills/spec-to-roadmap/references/issue-plan-template.json \
+  /tmp/roadmap.json \
   --dry-run
 ```

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -4,7 +4,7 @@
 
 - Path: [`skills/spec-to-roadmap`](skills/spec-to-roadmap)
 - Trigger: use when a user wants Codex to turn a product/spec issue or document into ordered GitHub issues, create or update the matching GitHub Project/view, and optionally continue through the implementation loop.
-- Activation keywords: `spec to roadmap`, `turn this spec into GitHub issues`, `create roadmap issues from this spec`, `create/update the GitHub project for this spec`, `take this spec through implementation`, `ship this roadmap`
+- Activation keywords: `spec to roadmap`, `turn this spec into GitHub issues`, `create roadmap issues from this spec`, `create/update the GitHub project for this spec`, `take this spec through implementation`, `ship this roadmap`, `roadmap this spec file`, `create project board from this spec`, `split this spec into LLM issues`, `materialize this spec`, `turn this doc into a GitHub project`, `generate implementation issues from docs/path.md`, `run spec-to-roadmap on docs/path.md`
 - Status: governed roadmap workflow with dry-run validation, project reuse, issue idempotency, dependency metadata, and roadmap hygiene checks.
 
 ## Future Skill Checklist

--- a/skills/spec-to-roadmap/SKILL.md
+++ b/skills/spec-to-roadmap/SKILL.md
@@ -35,6 +35,13 @@ Use this skill when the user says things like:
 - `create/update the GitHub project for this spec`
 - `take this spec through implementation`
 - `ship this roadmap`
+- `roadmap this spec file`
+- `create project board from this spec`
+- `split this spec into LLM issues`
+- `materialize this spec`
+- `turn this doc into a GitHub project`
+- `generate implementation issues from docs/path.md`
+- `run spec-to-roadmap on docs/path.md`
 
 ## Inputs
 
@@ -42,6 +49,8 @@ Determine these before acting:
 
 - Repository: from `git remote -v`, current GitHub context, or user input.
 - Spec source: GitHub issue, local file, PR body, markdown doc, or pasted text.
+  - For repo-local spec files, prefer the exact path relative to the repo root, for example `docs/superpowers/specs/topic.md`.
+  - Preserve every source spec path in the tracker and every generated child issue.
 - Project owner/title: default to repo owner and a title derived from the spec.
 - Roadmap mode: default to full roadmap materialization, meaning issue-plan generation plus issue/project creation.
 - Execution mode: continue past roadmap creation only when the user asks to execute, implement, ship, continue, or otherwise requests delivery work.
@@ -98,7 +107,23 @@ work, decompose broad findings into these issue types where applicable:
 - quality gate/regression fixture;
 - project/issue governance.
 
-Use `references/issue-plan-template.json` as the output shape for the issue plan. Use `scripts/create_github_roadmap.py` to create the tracker, child issues, project, project items, and source-spec comment from that plan.
+Use `references/issue-plan-template.json` as the output shape for the issue plan.
+
+For spec-file driven work, first generate a plan scaffold:
+
+```bash
+python3 skills/spec-to-roadmap/scripts/roadmap_plan_scaffold.py \
+  --spec docs/path.md \
+  --repo owner/name \
+  --project-owner owner \
+  --project-title "Project Title" \
+  --output /tmp/roadmap.json
+```
+
+Codex must then fill the scaffold with tracker text and child issue mini-specs.
+Use `scripts/create_github_roadmap.py` to create or update the tracker, child
+issues, labels, project, project items, and source-spec comments supported by
+the available GitHub API surface.
 
 ### 2.5 Validate The Roadmap Plan
 
@@ -110,6 +135,9 @@ Before mutating GitHub:
 4. Confirm required labels exist in the plan.
 5. Confirm project routing is explicit and reuses an existing project when appropriate.
 6. Confirm global gates, blocked labels, and parallelization metadata are present.
+7. For repo-local spec files, confirm `source_spec_paths` includes every source
+   document and `source_spec_url` points at the committed file location when
+   available.
 
 Do not create issues when dry-run validation reports missing dependencies,
 duplicate keys, missing required issue sections, or unclear project routing.
@@ -124,7 +152,8 @@ duplicate keys, missing required issue sections, or unclear project routing.
 6. Add the source spec, tracker, and all child issues to the project.
 7. Backfill tracker and child bodies with final issue numbers, child lists, dependency references, and project URL.
 8. Comment on the source spec with project/tracker/child issue links when the source is a GitHub issue.
-9. Verify counts, project membership, and links before reporting success.
+9. For repo-local spec files, verify tracker and child bodies link the path/URL.
+10. Verify counts, project membership, and links before reporting success.
 
 Generated issues should be idempotent by exact title or configured
 `idempotency_key`. Existing issues should be updated/commented rather than
@@ -189,6 +218,7 @@ Before reporting success, verify:
 - global gates such as `blocked:cloud-rollout` are preserved when applicable;
 - duplicate titles/fingerprints were not created;
 - source spec or parent issue has a comment linking tracker, project, and children.
+- repo-local source specs are referenced by path or committed blob URL in every issue.
 
 ## Safety Gates
 

--- a/skills/spec-to-roadmap/agents/openai.yaml
+++ b/skills/spec-to-roadmap/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Spec to Roadmap"
   short_description: "Create governed roadmap issues, project view, and optional execution loop"
-  default_prompt: "Use this skill to preserve a master spec, split it into ordered LLM-sized GitHub issues, immediately reuse or create the related GitHub Project/view, validate dependency/project hygiene, then continue into branch, PR, review, merge, and closure only when the user asks for execution."
+  default_prompt: "Use this skill to preserve a master spec or repo-local spec file, split it into ordered LLM-sized GitHub issues, immediately reuse or create the related GitHub Project/view, validate dependency/project hygiene, then continue into branch, PR, review, merge, and closure only when the user asks for execution."

--- a/skills/spec-to-roadmap/references/issue-plan-template.json
+++ b/skills/spec-to-roadmap/references/issue-plan-template.json
@@ -1,6 +1,8 @@
 {
   "repo": "owner/name",
   "source_spec": "#203 or URL or docs/path.md",
+  "source_spec_paths": ["docs/path.md"],
+  "source_spec_url": "https://github.com/owner/name/blob/main/docs/path.md",
   "project": {
     "owner": "owner-or-org",
     "number": null,
@@ -10,6 +12,7 @@
     "readme": "Project readme markdown"
   },
   "global_gates": ["#317"],
+  "existing_issue_links": ["#203"],
   "labels": [
     {
       "name": "spec:example",

--- a/skills/spec-to-roadmap/scripts/create_github_roadmap.py
+++ b/skills/spec-to-roadmap/scripts/create_github_roadmap.py
@@ -24,6 +24,7 @@ REQUIRED_ISSUE_SECTIONS = (
     "## Unblocks",
     "## Implementation scope",
     "## Out of scope",
+    "## Parallelization",
     "## Acceptance criteria",
     "## Verification",
 )
@@ -98,12 +99,18 @@ def validate_plan(plan: dict[str, Any]) -> list[str]:
             errors.append(f"{key}: missing labels")
         if not issue.get("parallelization"):
             errors.append(f"{key}: missing parallelization")
+        if plan.get("source_spec_paths"):
+            for path in plan["source_spec_paths"]:
+                if str(path) not in body:
+                    errors.append(f"{key}: missing source spec path {path}")
 
     project = plan.get("project", {})
     if not project.get("owner"):
         errors.append("project.owner is required")
     if not project.get("title") and not project.get("number"):
         errors.append("project.title or project.number is required")
+    if plan.get("source_spec_paths") and not isinstance(plan["source_spec_paths"], list):
+        errors.append("source_spec_paths must be a list when provided")
     return errors
 
 
@@ -254,10 +261,12 @@ def add_project_item_once(owner: str, project_number: int, url: str, existing_ur
     existing_urls.add(url)
 
 
-def source_spec_url(repo: str, source_spec: str) -> str | None:
+def source_spec_issue_or_pr_url(repo: str, source_spec: str) -> str | None:
     if source_spec.startswith("#"):
         return f"https://github.com/{repo}/issues/{source_spec[1:]}"
-    if source_spec.startswith("https://github.com/"):
+    if source_spec.startswith("https://github.com/") and (
+        "/issues/" in source_spec or "/pull/" in source_spec
+    ):
         return source_spec
     return None
 
@@ -323,7 +332,13 @@ def main() -> int:
     edit_project(owner, project_number, project)
     existing_project_urls = project_item_urls(owner, project_number)
 
-    common_values = {"source_spec": source, "project_url": project_url}
+    source_paths = "\n".join(f"- {path}" for path in plan.get("source_spec_paths", []))
+    common_values = {
+        "source_spec": source,
+        "source_spec_paths": source_paths,
+        "source_spec_url": str(plan.get("source_spec_url", "")),
+        "project_url": project_url,
+    }
     tracker_plan = plan["tracker"]
     tracker_ref = upsert_issue(
         repo,
@@ -367,7 +382,7 @@ def main() -> int:
             ]
         )
 
-    source_url = source_spec_url(repo, source)
+    source_url = source_spec_issue_or_pr_url(repo, source)
     if source_url:
         add_project_item_once(owner, project_number, source_url, existing_project_urls)
     add_project_item_once(owner, project_number, tracker_ref.url, existing_project_urls)

--- a/skills/spec-to-roadmap/scripts/roadmap_plan_scaffold.py
+++ b/skills/spec-to-roadmap/scripts/roadmap_plan_scaffold.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Generate a JSON roadmap-plan scaffold for a repo-local spec file.
+
+The scaffold is intentionally incomplete: Codex still reads the spec and fills
+the tracker plus child issue bodies. This script removes repetitive metadata and
+keeps the plan shape consistent before `create_github_roadmap.py --dry-run`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+def run(args: list[str]) -> str:
+    result = subprocess.run(
+        args,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"command failed ({result.returncode}): {' '.join(args)}\n{result.stderr}"
+        )
+    return result.stdout.strip()
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "roadmap"
+
+
+def default_branch(repo: str) -> str:
+    try:
+        data = json.loads(run(["gh", "repo", "view", repo, "--json", "defaultBranchRef"]))
+        return str(data["defaultBranchRef"]["name"])
+    except Exception:
+        return "main"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--spec", required=True, help="Repo-relative spec path")
+    parser.add_argument("--repo", required=True, help="GitHub repo as owner/name")
+    parser.add_argument("--project-owner", required=True)
+    parser.add_argument("--project-title", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--source-url", help="Override committed spec URL")
+    parser.add_argument("--global-gate", action="append", default=[])
+    args = parser.parse_args()
+
+    spec_path = args.spec.strip()
+    branch = default_branch(args.repo)
+    source_url = args.source_url or f"https://github.com/{args.repo}/blob/{branch}/{spec_path}"
+    project_slug = slugify(args.project_title)
+
+    plan = {
+        "repo": args.repo,
+        "source_spec": spec_path,
+        "source_spec_paths": [spec_path],
+        "source_spec_url": source_url,
+        "project": {
+            "owner": args.project_owner,
+            "number": None,
+            "title": args.project_title,
+            "reuse_existing": True,
+            "description": "",
+            "readme": "",
+        },
+        "global_gates": args.global_gate,
+        "existing_issue_links": [],
+        "labels": [
+            {
+                "name": f"spec:{project_slug}",
+                "color": "5319E7",
+                "description": f"Derived from {args.project_title}",
+            }
+        ],
+        "tracker": {
+            "key": "tracker",
+            "title": f"[{args.project_title}] Tracker: implementation roadmap",
+            "labels": [f"spec:{project_slug}", "type:tracker"],
+            "idempotency_key": f"{project_slug}-tracker",
+            "body": (
+                "## Goal\n\n...\n\n"
+                "## Source spec\n\n- {{source_spec}}\n- {{source_spec_url}}\n\n"
+                "## Roadmap\n\n{{child_list}}\n"
+            ),
+        },
+        "issues": [],
+        "source_comment": "",
+    }
+
+    args.output.write_text(json.dumps(plan, indent=2) + "\n", encoding="utf-8")
+    print(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a scaffold generator for repo-local spec files
- extend the roadmap plan template with source spec paths/URLs and existing issue links
- tighten dry-run validation around source paths and parallelization

## Test Plan
- python3 -m py_compile skills/spec-to-roadmap/scripts/create_github_roadmap.py skills/spec-to-roadmap/scripts/roadmap_plan_scaffold.py
- python3 skills/spec-to-roadmap/scripts/roadmap_plan_scaffold.py --spec docs/superpowers/specs/2026-04-30-frontend-design-system-governance.md --repo metabolomics-us/chemlake --project-owner metabolomics-us --project-title "ChemLake Frontend Design System" --global-gate '#317' --output /tmp/frontend-design-system-scaffold.json
- python3 skills/spec-to-roadmap/scripts/create_github_roadmap.py /tmp/frontend-design-system-scaffold.json --dry-run
- uv run --with pyyaml python ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/spec-to-roadmap