### PR TITLE
feat: add autonomous-feature-shipping skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,34 @@ Reusable Codex skills for turning repeated workflows into durable, discoverable 
 | Skill | Purpose |
 | --- | --- |
 | [`spec-to-roadmap`](skills/spec-to-roadmap/SKILL.md) | Convert a product/spec issue or document into a governed roadmap: master spec, LLM-ready issues, dependencies, GitHub Project/view routing, and optional implementation loop. |
+| [`autonomous-feature-shipping`](skills/autonomous-feature-shipping/README.md) | Ship a feature end-to-end: bootstrap repo if missing, brainstorm/design, decompose into linked GitHub issues, then run an autonomous implementation loop with admin auto-merge. Multi-harness (Claude Code, OpenCode, Codex CLI). |
 
 ## Repository Layout
 
 ```text
 skills/
   <skill-name>/
-    SKILL.md
-    agents/openai.yaml
-    scripts/
-    references/
-    assets/
+    SKILL.md                # canonical body (Claude Code skill format)
+    agents/openai.yaml      # optional Codex UI metadata
+    scripts/                # optional helpers
+    references/             # optional supporting docs
+    assets/                 # optional static assets
+
+    # Multi-harness skills additionally include:
+    README.md               # human-facing docs (what / why / install / usage)
+    opencode/agent.md       # OpenCode-flavored variant
+    codex/prompt.md         # Codex CLI prompt-library variant
+    install.sh              # self-installer (--harness claude|opencode|codex|all)
+    uninstall.sh            # symmetrical uninstaller
 ```
 
 Each skill should be self-contained. Keep shared documentation in this repository minimal so future skills remain portable into `~/.codex/skills`.
 
+Skills that target only Codex CLI can stick to the original layout (`SKILL.md` plus optional `agents/`, `scripts/`, `references/`, `assets/`). Skills that target multiple harnesses should add the `opencode/`, `codex/`, `install.sh`, `uninstall.sh`, and `README.md` files shown above.
+
 ## Installing A Skill
 
-Copy a skill directory into your Codex skills directory:
+For Codex-only skills, copy the skill directory into your Codex skills directory:
 
 ```bash
 mkdir -p ~/.codex/skills
@@ -32,6 +42,17 @@ cp -R skills/spec-to-roadmap ~/.codex/skills/
 ```
 
 Start a new Codex session after installation so the skill metadata is loaded.
+
+For multi-harness skills (Claude Code, OpenCode, Codex CLI), use the skill's
+bundled installer:
+
+```bash
+cd skills/autonomous-feature-shipping
+./install.sh --harness all          # or claude / opencode / codex
+```
+
+See the skill's own README for the per-harness install paths and manual
+fallbacks.
 
 ## Adding Future Skills
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -7,6 +7,14 @@
 - Activation keywords: `spec to roadmap`, `turn this spec into GitHub issues`, `create roadmap issues from this spec`, `create/update the GitHub project for this spec`, `take this spec through implementation`, `ship this roadmap`, `roadmap this spec file`, `create project board from this spec`, `split this spec into LLM issues`, `materialize this spec`, `turn this doc into a GitHub project`, `generate implementation issues from docs/path.md`, `run spec-to-roadmap on docs/path.md`
 - Status: governed roadmap workflow with dry-run validation, project reuse, issue idempotency, dependency metadata, and roadmap hygiene checks.
 
+## autonomous-feature-shipping
+
+- Path: [`skills/autonomous-feature-shipping`](skills/autonomous-feature-shipping)
+- Trigger: use when a user asks the agent to ship a feature end-to-end — bootstrap a missing GitHub repo, brainstorm/design, decompose into linked GitHub issues with dependency metadata, and run an autonomous implementation loop with admin auto-merge until done.
+- Activation keywords: `ship this feature`, `autonomous feature shipping`, `bootstrap repo and ship`, `decompose and auto-implement`, `run the autonomous loop`, `create issues and auto-merge`, `auto-implement this feature`, `ship end-to-end`
+- Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
+- Status: 7-phase workflow (bootstrap → investigate → design → decompose → background monitor → status updates → final report) with admin-squash-merge of `auto-implement`-labeled PRs.
+
 ## Future Skill Checklist
 
 1. Create `skills/<skill-name>/SKILL.md`.

--- a/skills/autonomous-feature-shipping/README.md
+++ b/skills/autonomous-feature-shipping/README.md
@@ -1,0 +1,258 @@
+# autonomous-feature-shipping
+
+A multi-harness skill that takes a single feature request and ships it end-to-end:
+bootstrap the GitHub repo (if missing), investigate, brainstorm, write a design spec,
+decompose into linked GitHub issues, then run an autonomous implementation loop with
+admin auto-merge until every child issue is closed — pinging the user with periodic
+status deltas along the way.
+
+Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
+
+## What it does
+
+The skill executes a 7-phase workflow (Phase 0 through Phase 6). The canonical body
+is harness-neutral; each phase delegates to subagents whenever the host harness
+supports them, and falls back to in-thread execution when it doesn't. The whole
+pipeline runs from a single user invocation — the only required interactive step is
+the optional repo-bootstrap question (name, visibility, owner) when no GitHub remote
+is detected.
+
+## Why use it
+
+Reach for this skill when:
+
+- You have a non-trivial feature that decomposes into multiple sequenced PRs.
+- You want the agent to ship the whole thing autonomously, not just plan it.
+- You'd rather review merged PRs than babysit a chat session.
+- You want repo bootstrap (`gh repo create`, scaffold, push) handled automatically
+  if you're starting from nothing.
+- You want an opinionated TDD + branch-per-issue + admin-squash-merge loop, not a
+  bespoke one.
+
+Skip this skill when you only want **planning** — `spec-to-roadmap` covers that
+without the auto-merge loop.
+
+## Architecture (the 7 phases)
+
+| Phase | Name | One-liner |
+|---|---|---|
+| **0** | Bootstrap repo (if missing) | Detect missing git/GitHub remote, ask name/visibility/owner once, scaffold `.gitignore` + `AGENTS.md` + `README.md`, push. |
+| **1** | Investigate (delegate) | Read-only research subagent maps relevant files, schema, services. Real queries against remote systems if the feature touches them. |
+| **2** | Brainstorm + design | Structured 5-section brainstorm (architecture / API / data / errors / testing) with explicit per-section approval, written to `docs/specs/YYYY-MM-DD-<topic>-design.md`. |
+| **3** | Decompose into linked GitHub issues (delegate) | Foreground subagent creates labels, an EPIC umbrella, and N self-contained child mini-specs with `Depends on issue #N` dependency metadata. |
+| **4** | Background autonomous monitor | Background subagent loops: pick next ready issue → worktree → TDD → push → PR → self-review → admin-squash-merge → repeat until drained. |
+| **5** | Periodic status updates | Self-paced ~25 min wakeups posting deltas (closed issues, merged PRs, failures, blockers); slows to ~50 min when quiet. |
+| **6** | Final report | When the monitor terminates, summarize every issue processed, PR merged, wall time, and any human-attention failures. |
+
+## Required capabilities & harness adapter
+
+The canonical body assumes five capabilities. The skill maps each one to your
+harness; if a capability is missing the listed fallback applies.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+
+Persistent project notes are written to `AGENTS.md` in the target repo root — this is
+recognized by all three harnesses.
+
+## Dependencies
+
+Required:
+
+- **`git`** ≥ 2.5 (worktree support — Phase 4 creates a worktree per child issue).
+- **`gh` CLI** ([cli.github.com](https://cli.github.com/)), authenticated via
+  `gh auth login`, with `repo` and `workflow` scopes. For the auto-merge step the
+  authenticated user must have **admin** or **maintain** permission on the target
+  repo (squash-admin-merge requires it).
+- **`jq`** for JSON processing in shell snippets.
+- A POSIX shell (`bash` or `sh`) for the installer.
+- The host harness — one of:
+  - **Claude Code** (any version with skills support).
+  - **OpenCode** (any current version; agents loaded from `~/.config/opencode/agent/`).
+  - **Codex CLI** (any version with the prompt library at `~/.codex/prompts/`).
+- A project-level test runner appropriate to the target codebase — required by
+  Phase 4's implementation subagent. Examples:
+  - Go: `go test ./... -count=1`
+  - Node: `npm test`
+  - Python: `pytest`
+  - Rust: `cargo test`
+  - Scala: `sbt test`
+
+Optional:
+
+- A CI provider (GitHub Actions, TeamCity, GitGuardian, etc.). Slow optional checks
+  are tolerated per the auto-merge rules in `AGENTS.md`.
+- A pre-commit hook framework — the skill respects hooks (it never passes
+  `--no-verify`).
+
+## Installation
+
+### One-shot installer
+
+```bash
+cd skills/autonomous-feature-shipping
+./install.sh                    # interactive — prompts for harness
+./install.sh --harness all      # install for Claude Code, OpenCode, and Codex CLI
+./install.sh --harness claude   # Claude Code only
+./install.sh --harness opencode # OpenCode only
+./install.sh --harness codex    # Codex CLI only
+./install.sh --symlink          # symlink instead of copy (updates propagate)
+```
+
+The installer:
+
+1. Verifies `git`, `gh`, and `jq` are present (warns on missing optional deps).
+2. Verifies `gh auth status` (warns if not authenticated).
+3. Creates the harness-specific skill directory if needed.
+4. Copies (or symlinks) the right variant into place.
+5. Prints the install path and example invocation.
+6. Re-running upgrades the install (idempotent).
+
+Honors `CLAUDE_CONFIG_DIR`, `OPENCODE_CONFIG_DIR`, and `CODEX_HOME` if set.
+
+### Manual install
+
+#### Claude Code
+
+```bash
+mkdir -p ~/.claude/skills/autonomous-feature-shipping
+cp skills/autonomous-feature-shipping/SKILL.md \
+   ~/.claude/skills/autonomous-feature-shipping/SKILL.md
+```
+
+The skill becomes discoverable as `autonomous-feature-shipping` (or the user can
+invoke it via the Skill tool).
+
+#### OpenCode
+
+```bash
+mkdir -p ~/.config/opencode/agent
+cp skills/autonomous-feature-shipping/opencode/agent.md \
+   ~/.config/opencode/agent/autonomous-feature-shipping.md
+```
+
+OpenCode picks up agent markdown files from `~/.config/opencode/agent/`. The
+frontmatter uses `description` + `mode: primary` per current OpenCode conventions;
+if your OpenCode version expects a different schema, the skill body still works
+when the file is loaded as a plain prompt.
+
+#### Codex CLI
+
+```bash
+mkdir -p ~/.codex/prompts
+cp skills/autonomous-feature-shipping/codex/prompt.md \
+   ~/.codex/prompts/autonomous-feature-shipping.md
+```
+
+Codex CLI exposes any markdown file in `~/.codex/prompts/` as a slash command —
+in this case `/autonomous-feature-shipping`.
+
+### Uninstall
+
+```bash
+./uninstall.sh --harness all
+```
+
+Same flags as the installer.
+
+## Usage
+
+### Claude Code
+
+```
+/autonomous-feature-shipping Add a real-time presence indicator to the dashboard
+```
+
+Or invoke via the Skill tool with the same description.
+
+### OpenCode
+
+```
+@autonomous-feature-shipping Add a real-time presence indicator to the dashboard
+```
+
+(Or whichever invocation syntax your OpenCode version uses for primary agents.)
+
+### Codex CLI
+
+```
+codex
+> /autonomous-feature-shipping Add a real-time presence indicator to the dashboard
+```
+
+### Full example
+
+```
+> /autonomous-feature-shipping Build a Slack bot that posts a daily standup digest
+  pulled from yesterday's merged PRs and closed issues across our org
+
+[Phase 0 — Bootstrap]
+No git repo detected. Suggested name: slack-standup-digest
+Visibility? [private]/public  Owner? [berlinguyinca]/<org>
+> private, berlinguyinca
+... gh repo create berlinguyinca/slack-standup-digest --private --source=. --push ...
+
+[Phase 1 — Investigate]
+(empty repo — skipped)
+
+[Phase 2 — Design]
+... structured brainstorm, written to docs/specs/2026-04-30-slack-standup-design.md ...
+
+[Phase 3 — Issues]
+EPIC #1, children #2 #3 #4 #5 #6 #7 with auto-implement labels and dependency metadata.
+
+[Phase 4 — Monitor launched in background]
+agent_id=bg_8a3f...
+
+[Phase 5 — Status, every ~25 min]
+... PR #8 merged (closes #2), PR #9 merged (closes #3), #4 in-progress-by-bot ...
+
+[Phase 6 — Final report]
+6/6 child issues closed in 4h 12m. PRs: #8 #9 #10 #11 #12 #13. No human attention required.
+```
+
+## Limits & known issues
+
+- **Sub-hour cadence requires an in-session background subagent.** Cloud cron
+  services (Anthropic remote routines, GitHub-hosted cron, Vercel cron, etc.)
+  typically have a 1-hour minimum, which is too coarse for the 25-min Phase 5
+  cadence. Use a local `cron`/`launchd` if your harness can't keep a background
+  subagent alive.
+- **Fresh-repo bootstrap requires interactive consent** for repo name / visibility /
+  owner. The skill cannot auto-decide these — running fully unattended on a fresh
+  directory will block at the Phase 0 question.
+- **Auto-merge requires admin or maintain permission** on the target repo. PRs from
+  forks and PRs against repos where the authenticated user lacks merge admin will
+  fall back to opening the PR and stopping (the user merges manually).
+- **OpenCode frontmatter** has evolved over the project's lifetime; the variant in
+  this skill uses `description` + `mode: primary`. If your OpenCode version expects
+  a different schema, drop the frontmatter and load the body as a plain prompt — the
+  workflow content is harness-neutral.
+- **Codex CLI prompt-library** files are loaded as plain markdown; the canonical
+  body is therefore unchanged from `SKILL.md` minus the frontmatter.
+
+## Contributing
+
+The canonical body is `SKILL.md`. The OpenCode and Codex variants are direct copies
+with adjusted (or stripped) frontmatter so each harness loads cleanly. **All three
+files must stay in lock-step** — when you edit one, edit the other two. To keep this
+manageable:
+
+1. Edit the substantive content of `SKILL.md` first.
+2. Copy the body (everything after the `---` frontmatter block) into
+   `opencode/agent.md` and `codex/prompt.md`, preserving each file's frontmatter
+   header.
+3. Run `./install.sh --harness all` (or just diff the three files) to confirm
+   the bodies are identical.
+
+When extending the harness adapter table to a new harness, update all three files
+plus this README's adapter table.
+
+## License
+
+MIT — see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autonomous-feature-shipping/SKILL.md
+++ b/skills/autonomous-feature-shipping/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: autonomous-feature-shipping
+description: Use when the user asks to ship a feature end-to-end — bootstrap repo if missing, brainstorm a design, decompose into linked GitHub issues, and run an autonomous implementation loop with auto-merge until done.
+---
+
+# Autonomous-feature-shipping workflow (harness-neutral)
+
+Take the following feature request and ship it through the full pipeline:
+**bootstrap repo (if missing) → investigate → design → spec → decomposed GitHub issues → autonomous implementation with auto-merge → periodic status updates → final report.**
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
+
+## Feature request
+
+{FEATURE_DESCRIPTION}
+
+---
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there.
+
+---
+
+## Phase 0 — Bootstrap repo (if missing)
+
+Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.
+
+Probe the working directory:
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null
+git remote get-url origin 2>/dev/null   # must contain github.com
+```
+
+If **either** check fails — no git repo, or no GitHub remote — bootstrap a new repo:
+
+1. **Suggest a name.** Slugify the feature description: lowercase, hyphens, drop stop-words, prefix with the obvious stack if inferable (e.g. "Go TUI for X" → `go-tui-x`; "Python ML pipeline that does Y" → `py-ml-y`). Offer 1–2 candidates.
+
+2. **Ask the user once** (single interactive question; combine the three sub-questions if your harness supports it, otherwise ask sequentially):
+   - **Name** (your top suggestion as default).
+   - **Visibility**: `private` | `public` (default: private).
+   - **Owner**: enumerate via `gh org list`; default to the user's personal account.
+
+3. **Initialize locally**:
+   - If `.git` is absent: `git init -b main`.
+   - Write a stack-appropriate `.gitignore` (Go: `bin/ vendor/ *.exe *.test`; Node: `node_modules/ dist/ .next/ .env*`; Python: `__pycache__/ .venv/ *.egg-info/ build/ dist/`; mixed/unknown: skip).
+   - Write a one-line `README.md` containing the feature description.
+   - Write a starter `AGENTS.md` listing the project's coding standards (TDD non-negotiable, no DB mocks, conventional commits, branch-per-issue, no force-push) — this is the source of truth every agent reads.
+   - `git add -A && git commit -m "chore: initial scaffold"`.
+
+4. **Create the remote and push**:
+   ```bash
+   gh repo create <owner>/<name> --<private|public> --source=. --remote=origin --push
+   ```
+
+5. **Verify**: `gh repo view <owner>/<name> --json url,defaultBranchRef`. Capture `<owner>/<name>` as `{repo}` — every subsequent phase uses this value.
+
+If a repo already exists (cwd is in a git tree with a `github.com:<owner>/<name>` remote), capture that as `{repo}` and skip the bootstrap.
+
+## Phase 1 — Investigate (delegate)
+
+Spawn a **read-only research subagent** to map relevant files, schema, services. Get back a 300-word summary with file paths and line numbers. Do NOT read files directly from the main thread.
+
+If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
+
+For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.
+
+## Phase 2 — Brainstorm + design
+
+Run a structured brainstorm — one question at a time, get explicit approval after each section:
+
+1. **Architecture** — where does new code live, what existing patterns does it follow.
+2. **Interactivity / API shape** — how does the user/caller drive it; commands, keys, endpoints, fields.
+3. **Data model** — types, columns, persistence boundary.
+4. **Error handling** — failure modes, recovery, user-visible signals.
+5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services).
+
+Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, scope. The spec must be implementable end-to-end by an agent reading only the spec.
+
+If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
+
+## Phase 3 — Decompose into linked GitHub issues (delegate)
+
+Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
+
+> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. Each child body must be a **self-contained mini-spec** with: **Goal** (1 sentence), **Scope** (what's in / out), **Implementation outline** (file paths + function signatures + data flow), **Tests required** (TDD, real services, no DB mocks, 80%+ coverage per AGENTS.md), **Acceptance criteria** (machine-checkable), **Branch name** (`feat/<slug>`), **Dependencies** (`Depends on issue #N` lines — these will be parsed by the monitor). After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+
+Capture the umbrella + child issue numbers.
+
+## Phase 4 — Background autonomous monitor
+
+Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
+
+> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
+
+Then launch a **background subagent** with this prompt verbatim:
+
+> You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+>
+> Outer loop:
+> ```
+> while true:
+>   ready = [open auto-implement issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   if ready is empty:
+>     latest_close = most recent closedAt of any auto-implement issue
+>     open_count   = count of open auto-implement issues
+>     if open_count == 0 AND latest_close > 1h ago: HARD SHUTDOWN — return final report
+>     else: print state ("blocked: N unmet deps" / "drained, waiting 1h idle"), sleep 300, continue
+>   ISSUE = ready[0]
+>   gh label create in-progress-by-bot --color ededed --force
+>   gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot
+>   process(ISSUE)   # foreground subagent — see template below
+>   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
+> ```
+>
+> `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
+>
+> ```
+> Implement GitHub issue #<ISSUE>: "<TITLE>" on {repo}. Spec is the issue body below.
+>
+> ===ISSUE BODY===
+> <BODY>
+> ===END===
+>
+> 1. Worktree off origin/main:
+>    cd {repo_root} && git fetch origin
+>    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
+> 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
+> 3. Build + test green (use the project's test runner; for Go: `go build ./... && go test ./... -count=1`; for Node: `npm test`; for Python: `pytest`). 80%+ coverage on changed files.
+> 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
+> 5. Push: git push -u origin <BRANCH>
+> 6. PR: gh pr create --base main --head <BRANCH> --title "<TITLE>" --body "Closes #<ISSUE>\n\n<summary>". Capture PR.
+> 7. Self-review loop (max 3 iterations):
+>    Dispatch a **foreground subagent** with brief: "You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
+>    If LGTM: sleep 30; gh pr checks <PR>. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
+>    Else: implement findings, commit, push, continue.
+> 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
+> 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
+> 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
+> 11. Report: PR number, outcome, one-paragraph summary.
+>
+> Hard rules: NEVER push to main, force-push, bypass hooks, or touch the umbrella issue. gh CLI only.
+> ```
+>
+> Hard rules for the monitor: ONE issue at a time, sequential. Do NOT touch the umbrella. On transient gh errors retry once. Do NOT ask the user — auto-merge authority is granted in AGENTS.md.
+>
+> Final output when shutdown: numbered list of every processed issue with PR # and outcome.
+
+Capture the agent ID / log path for monitoring.
+
+If your harness lacks background delegation: open a separate terminal/tmux pane, run the monitor prompt in a fresh session there, and have it write progress to a logfile that Phase 5 can tail.
+
+## Phase 5 — Periodic status updates
+
+Set up a recurring check (every ~25 min) using your harness's self-paced wakeup capability. Each tick:
+
+```bash
+gh issue list --repo {repo} --label auto-implement,in-progress-by-bot,awaiting-merge --state all --json number,state,labels
+gh pr list --repo {repo} --state all --json number,state,title --limit 20
+```
+
+Post a one-paragraph delta to the user (newly closed issues, newly merged PRs, failures, blockers). If two consecutive ticks have nothing new, slow to ~50 min cadence to reduce noise. Stop the loop when:
+- the monitor agent reports completion, OR
+- all child issues are CLOSED, OR
+- the user explicitly stops.
+
+If your harness lacks self-paced wakeup: register a local `cron`/`launchd` job that runs the same status-check prompt at the chosen cadence, OR ask the user to invoke `status-update` manually.
+
+## Phase 6 — Final report
+
+When the monitor terminates, post a final summary to the user: every issue processed, every PR merged, total elapsed wall time, and any failures that need human attention.
+
+---
+
+## Constraints (apply throughout)
+
+- **Cadence**: sub-hour polling needs an in-session background subagent or a local cron. Cloud cron services (e.g. Anthropic remote routines) typically have a 1-hour minimum and are not appropriate.
+- **TDD non-negotiable** per AGENTS.md. Real services in tests, no DB mocks.
+- **Branch-per-issue**, conventional commits, no force-push, no hook bypass.
+- **Auto-merge** on success per AGENTS.md. Do not ask.
+- **Context budget**: stay under 60%. Delegate everything possible.
+- **Failure isolation**: a failed issue restores its `auto-implement` label so the next monitor cycle picks it up; it does not block the cascade unless dependent issues are downstream.
+- **Fresh repo**: if Phase 0 created the repo, the very first commit is the scaffold (incl. `AGENTS.md`); the spec lands as the second commit; child branches branch off that `main`.

--- a/skills/autonomous-feature-shipping/agents/openai.yaml
+++ b/skills/autonomous-feature-shipping/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Autonomous Feature Shipping"
+  short_description: "Bootstrap repo, design, decompose into linked GitHub issues, and run an autonomous implementation loop with auto-merge"
+  default_prompt: "Use this skill to ship a feature end-to-end: optionally bootstrap the GitHub repo, run a delegated investigate/brainstorm/design pass, materialize the design into an EPIC plus auto-implement child issues with dependency metadata, then launch a background monitor that processes each ready issue (worktree, TDD, self-review, admin-merge) until the queue drains."

--- a/skills/autonomous-feature-shipping/codex/prompt.md
+++ b/skills/autonomous-feature-shipping/codex/prompt.md
@@ -1,0 +1,188 @@
+# Autonomous-feature-shipping workflow (harness-neutral)
+
+Take the following feature request and ship it through the full pipeline:
+**bootstrap repo (if missing) → investigate → design → spec → decomposed GitHub issues → autonomous implementation with auto-merge → periodic status updates → final report.**
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
+
+## Feature request
+
+{FEATURE_DESCRIPTION}
+
+---
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there.
+
+---
+
+## Phase 0 — Bootstrap repo (if missing)
+
+Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.
+
+Probe the working directory:
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null
+git remote get-url origin 2>/dev/null   # must contain github.com
+```
+
+If **either** check fails — no git repo, or no GitHub remote — bootstrap a new repo:
+
+1. **Suggest a name.** Slugify the feature description: lowercase, hyphens, drop stop-words, prefix with the obvious stack if inferable (e.g. "Go TUI for X" → `go-tui-x`; "Python ML pipeline that does Y" → `py-ml-y`). Offer 1–2 candidates.
+
+2. **Ask the user once** (single interactive question; combine the three sub-questions if your harness supports it, otherwise ask sequentially):
+   - **Name** (your top suggestion as default).
+   - **Visibility**: `private` | `public` (default: private).
+   - **Owner**: enumerate via `gh org list`; default to the user's personal account.
+
+3. **Initialize locally**:
+   - If `.git` is absent: `git init -b main`.
+   - Write a stack-appropriate `.gitignore` (Go: `bin/ vendor/ *.exe *.test`; Node: `node_modules/ dist/ .next/ .env*`; Python: `__pycache__/ .venv/ *.egg-info/ build/ dist/`; mixed/unknown: skip).
+   - Write a one-line `README.md` containing the feature description.
+   - Write a starter `AGENTS.md` listing the project's coding standards (TDD non-negotiable, no DB mocks, conventional commits, branch-per-issue, no force-push) — this is the source of truth every agent reads.
+   - `git add -A && git commit -m "chore: initial scaffold"`.
+
+4. **Create the remote and push**:
+   ```bash
+   gh repo create <owner>/<name> --<private|public> --source=. --remote=origin --push
+   ```
+
+5. **Verify**: `gh repo view <owner>/<name> --json url,defaultBranchRef`. Capture `<owner>/<name>` as `{repo}` — every subsequent phase uses this value.
+
+If a repo already exists (cwd is in a git tree with a `github.com:<owner>/<name>` remote), capture that as `{repo}` and skip the bootstrap.
+
+## Phase 1 — Investigate (delegate)
+
+Spawn a **read-only research subagent** to map relevant files, schema, services. Get back a 300-word summary with file paths and line numbers. Do NOT read files directly from the main thread.
+
+If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
+
+For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.
+
+## Phase 2 — Brainstorm + design
+
+Run a structured brainstorm — one question at a time, get explicit approval after each section:
+
+1. **Architecture** — where does new code live, what existing patterns does it follow.
+2. **Interactivity / API shape** — how does the user/caller drive it; commands, keys, endpoints, fields.
+3. **Data model** — types, columns, persistence boundary.
+4. **Error handling** — failure modes, recovery, user-visible signals.
+5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services).
+
+Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, scope. The spec must be implementable end-to-end by an agent reading only the spec.
+
+If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
+
+## Phase 3 — Decompose into linked GitHub issues (delegate)
+
+Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
+
+> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. Each child body must be a **self-contained mini-spec** with: **Goal** (1 sentence), **Scope** (what's in / out), **Implementation outline** (file paths + function signatures + data flow), **Tests required** (TDD, real services, no DB mocks, 80%+ coverage per AGENTS.md), **Acceptance criteria** (machine-checkable), **Branch name** (`feat/<slug>`), **Dependencies** (`Depends on issue #N` lines — these will be parsed by the monitor). After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+
+Capture the umbrella + child issue numbers.
+
+## Phase 4 — Background autonomous monitor
+
+Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
+
+> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
+
+Then launch a **background subagent** with this prompt verbatim:
+
+> You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+>
+> Outer loop:
+> ```
+> while true:
+>   ready = [open auto-implement issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   if ready is empty:
+>     latest_close = most recent closedAt of any auto-implement issue
+>     open_count   = count of open auto-implement issues
+>     if open_count == 0 AND latest_close > 1h ago: HARD SHUTDOWN — return final report
+>     else: print state ("blocked: N unmet deps" / "drained, waiting 1h idle"), sleep 300, continue
+>   ISSUE = ready[0]
+>   gh label create in-progress-by-bot --color ededed --force
+>   gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot
+>   process(ISSUE)   # foreground subagent — see template below
+>   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
+> ```
+>
+> `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
+>
+> ```
+> Implement GitHub issue #<ISSUE>: "<TITLE>" on {repo}. Spec is the issue body below.
+>
+> ===ISSUE BODY===
+> <BODY>
+> ===END===
+>
+> 1. Worktree off origin/main:
+>    cd {repo_root} && git fetch origin
+>    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
+> 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
+> 3. Build + test green (use the project's test runner; for Go: `go build ./... && go test ./... -count=1`; for Node: `npm test`; for Python: `pytest`). 80%+ coverage on changed files.
+> 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
+> 5. Push: git push -u origin <BRANCH>
+> 6. PR: gh pr create --base main --head <BRANCH> --title "<TITLE>" --body "Closes #<ISSUE>\n\n<summary>". Capture PR.
+> 7. Self-review loop (max 3 iterations):
+>    Dispatch a **foreground subagent** with brief: "You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
+>    If LGTM: sleep 30; gh pr checks <PR>. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
+>    Else: implement findings, commit, push, continue.
+> 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
+> 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
+> 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
+> 11. Report: PR number, outcome, one-paragraph summary.
+>
+> Hard rules: NEVER push to main, force-push, bypass hooks, or touch the umbrella issue. gh CLI only.
+> ```
+>
+> Hard rules for the monitor: ONE issue at a time, sequential. Do NOT touch the umbrella. On transient gh errors retry once. Do NOT ask the user — auto-merge authority is granted in AGENTS.md.
+>
+> Final output when shutdown: numbered list of every processed issue with PR # and outcome.
+
+Capture the agent ID / log path for monitoring.
+
+If your harness lacks background delegation: open a separate terminal/tmux pane, run the monitor prompt in a fresh session there, and have it write progress to a logfile that Phase 5 can tail.
+
+## Phase 5 — Periodic status updates
+
+Set up a recurring check (every ~25 min) using your harness's self-paced wakeup capability. Each tick:
+
+```bash
+gh issue list --repo {repo} --label auto-implement,in-progress-by-bot,awaiting-merge --state all --json number,state,labels
+gh pr list --repo {repo} --state all --json number,state,title --limit 20
+```
+
+Post a one-paragraph delta to the user (newly closed issues, newly merged PRs, failures, blockers). If two consecutive ticks have nothing new, slow to ~50 min cadence to reduce noise. Stop the loop when:
+- the monitor agent reports completion, OR
+- all child issues are CLOSED, OR
+- the user explicitly stops.
+
+If your harness lacks self-paced wakeup: register a local `cron`/`launchd` job that runs the same status-check prompt at the chosen cadence, OR ask the user to invoke `status-update` manually.
+
+## Phase 6 — Final report
+
+When the monitor terminates, post a final summary to the user: every issue processed, every PR merged, total elapsed wall time, and any failures that need human attention.
+
+---
+
+## Constraints (apply throughout)
+
+- **Cadence**: sub-hour polling needs an in-session background subagent or a local cron. Cloud cron services (e.g. Anthropic remote routines) typically have a 1-hour minimum and are not appropriate.
+- **TDD non-negotiable** per AGENTS.md. Real services in tests, no DB mocks.
+- **Branch-per-issue**, conventional commits, no force-push, no hook bypass.
+- **Auto-merge** on success per AGENTS.md. Do not ask.
+- **Context budget**: stay under 60%. Delegate everything possible.
+- **Failure isolation**: a failed issue restores its `auto-implement` label so the next monitor cycle picks it up; it does not block the cascade unless dependent issues are downstream.
+- **Fresh repo**: if Phase 0 created the repo, the very first commit is the scaffold (incl. `AGENTS.md`); the spec lands as the second commit; child branches branch off that `main`.

--- a/skills/autonomous-feature-shipping/install.sh
+++ b/skills/autonomous-feature-shipping/install.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env sh
+# install.sh — install the autonomous-feature-shipping skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --symlink           # symlink instead of copy (updates propagate)
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: re-running upgrades the install. Exits non-zero on hard failure;
+# exits zero with warnings on missing optional deps.
+
+set -eu
+
+SKILL_NAME="autonomous-feature-shipping"
+SKILL_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+
+# ---------- helpers --------------------------------------------------------
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run]
+
+Installs the ${SKILL_NAME} skill into the chosen harness's standard
+skill/agent/prompt directory.
+
+Examples:
+  $0                          # interactive
+  $0 --harness all            # install everywhere
+  $0 --harness claude         # Claude Code only
+  $0 --harness opencode       # OpenCode only
+  $0 --harness codex          # Codex CLI only
+  $0 --harness all --symlink  # symlink instead of copy
+  $0 --dry-run --harness all  # print plan, change nothing
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    dest_dir="$(dirname "$dest")"
+
+    if [ ! -f "$src" ]; then
+        err "missing source file: $src"
+        return 1
+    fi
+
+    run "mkdir -p \"$dest_dir\""
+
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --symlink)
+            USE_SYMLINK=1
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# ---------- harness prompt -------------------------------------------------
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- dependency checks ---------------------------------------------
+
+dep_warnings=0
+
+check_dep() {
+    name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        warn "$name not found on PATH (required by the skill at runtime)"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+}
+
+check_dep git
+check_dep gh
+check_dep jq
+
+if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+        warn "gh is installed but not authenticated. Run: gh auth login"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+fi
+
+if [ "$dep_warnings" -gt 0 ]; then
+    warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
+fi
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+CLAUDE_SRC="$SKILL_DIR/SKILL.md"
+OPENCODE_SRC="$SKILL_DIR/opencode/agent.md"
+CODEX_SRC="$SKILL_DIR/codex/prompt.md"
+
+# ---------- install --------------------------------------------------------
+
+installed_paths=""
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_SRC" "$CLAUDE_DEST"
+    installed_paths="${installed_paths}  Claude Code: ${CLAUDE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_SRC" "$OPENCODE_DEST"
+    installed_paths="${installed_paths}  OpenCode:    ${OPENCODE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_SRC" "$CODEX_DEST"
+    installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+fi
+
+# ---------- final summary --------------------------------------------------
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    info "Installed:"
+    printf '%b' "$installed_paths"
+    info ""
+    info "Invoke with:"
+    info "  Claude Code:  /${SKILL_NAME} <feature description>"
+    info "  OpenCode:     @${SKILL_NAME} <feature description>"
+    info "  Codex CLI:    /${SKILL_NAME} <feature description>"
+fi
+
+exit 0

--- a/skills/autonomous-feature-shipping/opencode/agent.md
+++ b/skills/autonomous-feature-shipping/opencode/agent.md
@@ -1,0 +1,193 @@
+---
+description: Use when the user asks to ship a feature end-to-end — bootstrap repo if missing, brainstorm a design, decompose into linked GitHub issues, and run an autonomous implementation loop with auto-merge until done.
+mode: primary
+---
+
+# Autonomous-feature-shipping workflow (harness-neutral)
+
+Take the following feature request and ship it through the full pipeline:
+**bootstrap repo (if missing) → investigate → design → spec → decomposed GitHub issues → autonomous implementation with auto-merge → periodic status updates → final report.**
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
+
+## Feature request
+
+{FEATURE_DESCRIPTION}
+
+---
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there.
+
+---
+
+## Phase 0 — Bootstrap repo (if missing)
+
+Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.
+
+Probe the working directory:
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null
+git remote get-url origin 2>/dev/null   # must contain github.com
+```
+
+If **either** check fails — no git repo, or no GitHub remote — bootstrap a new repo:
+
+1. **Suggest a name.** Slugify the feature description: lowercase, hyphens, drop stop-words, prefix with the obvious stack if inferable (e.g. "Go TUI for X" → `go-tui-x`; "Python ML pipeline that does Y" → `py-ml-y`). Offer 1–2 candidates.
+
+2. **Ask the user once** (single interactive question; combine the three sub-questions if your harness supports it, otherwise ask sequentially):
+   - **Name** (your top suggestion as default).
+   - **Visibility**: `private` | `public` (default: private).
+   - **Owner**: enumerate via `gh org list`; default to the user's personal account.
+
+3. **Initialize locally**:
+   - If `.git` is absent: `git init -b main`.
+   - Write a stack-appropriate `.gitignore` (Go: `bin/ vendor/ *.exe *.test`; Node: `node_modules/ dist/ .next/ .env*`; Python: `__pycache__/ .venv/ *.egg-info/ build/ dist/`; mixed/unknown: skip).
+   - Write a one-line `README.md` containing the feature description.
+   - Write a starter `AGENTS.md` listing the project's coding standards (TDD non-negotiable, no DB mocks, conventional commits, branch-per-issue, no force-push) — this is the source of truth every agent reads.
+   - `git add -A && git commit -m "chore: initial scaffold"`.
+
+4. **Create the remote and push**:
+   ```bash
+   gh repo create <owner>/<name> --<private|public> --source=. --remote=origin --push
+   ```
+
+5. **Verify**: `gh repo view <owner>/<name> --json url,defaultBranchRef`. Capture `<owner>/<name>` as `{repo}` — every subsequent phase uses this value.
+
+If a repo already exists (cwd is in a git tree with a `github.com:<owner>/<name>` remote), capture that as `{repo}` and skip the bootstrap.
+
+## Phase 1 — Investigate (delegate)
+
+Spawn a **read-only research subagent** to map relevant files, schema, services. Get back a 300-word summary with file paths and line numbers. Do NOT read files directly from the main thread.
+
+If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
+
+For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.
+
+## Phase 2 — Brainstorm + design
+
+Run a structured brainstorm — one question at a time, get explicit approval after each section:
+
+1. **Architecture** — where does new code live, what existing patterns does it follow.
+2. **Interactivity / API shape** — how does the user/caller drive it; commands, keys, endpoints, fields.
+3. **Data model** — types, columns, persistence boundary.
+4. **Error handling** — failure modes, recovery, user-visible signals.
+5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services).
+
+Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, scope. The spec must be implementable end-to-end by an agent reading only the spec.
+
+If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
+
+## Phase 3 — Decompose into linked GitHub issues (delegate)
+
+Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
+
+> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. Each child body must be a **self-contained mini-spec** with: **Goal** (1 sentence), **Scope** (what's in / out), **Implementation outline** (file paths + function signatures + data flow), **Tests required** (TDD, real services, no DB mocks, 80%+ coverage per AGENTS.md), **Acceptance criteria** (machine-checkable), **Branch name** (`feat/<slug>`), **Dependencies** (`Depends on issue #N` lines — these will be parsed by the monitor). After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+
+Capture the umbrella + child issue numbers.
+
+## Phase 4 — Background autonomous monitor
+
+Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
+
+> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
+
+Then launch a **background subagent** with this prompt verbatim:
+
+> You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+>
+> Outer loop:
+> ```
+> while true:
+>   ready = [open auto-implement issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   if ready is empty:
+>     latest_close = most recent closedAt of any auto-implement issue
+>     open_count   = count of open auto-implement issues
+>     if open_count == 0 AND latest_close > 1h ago: HARD SHUTDOWN — return final report
+>     else: print state ("blocked: N unmet deps" / "drained, waiting 1h idle"), sleep 300, continue
+>   ISSUE = ready[0]
+>   gh label create in-progress-by-bot --color ededed --force
+>   gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot
+>   process(ISSUE)   # foreground subagent — see template below
+>   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
+> ```
+>
+> `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
+>
+> ```
+> Implement GitHub issue #<ISSUE>: "<TITLE>" on {repo}. Spec is the issue body below.
+>
+> ===ISSUE BODY===
+> <BODY>
+> ===END===
+>
+> 1. Worktree off origin/main:
+>    cd {repo_root} && git fetch origin
+>    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
+> 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
+> 3. Build + test green (use the project's test runner; for Go: `go build ./... && go test ./... -count=1`; for Node: `npm test`; for Python: `pytest`). 80%+ coverage on changed files.
+> 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
+> 5. Push: git push -u origin <BRANCH>
+> 6. PR: gh pr create --base main --head <BRANCH> --title "<TITLE>" --body "Closes #<ISSUE>\n\n<summary>". Capture PR.
+> 7. Self-review loop (max 3 iterations):
+>    Dispatch a **foreground subagent** with brief: "You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
+>    If LGTM: sleep 30; gh pr checks <PR>. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
+>    Else: implement findings, commit, push, continue.
+> 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
+> 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
+> 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
+> 11. Report: PR number, outcome, one-paragraph summary.
+>
+> Hard rules: NEVER push to main, force-push, bypass hooks, or touch the umbrella issue. gh CLI only.
+> ```
+>
+> Hard rules for the monitor: ONE issue at a time, sequential. Do NOT touch the umbrella. On transient gh errors retry once. Do NOT ask the user — auto-merge authority is granted in AGENTS.md.
+>
+> Final output when shutdown: numbered list of every processed issue with PR # and outcome.
+
+Capture the agent ID / log path for monitoring.
+
+If your harness lacks background delegation: open a separate terminal/tmux pane, run the monitor prompt in a fresh session there, and have it write progress to a logfile that Phase 5 can tail.
+
+## Phase 5 — Periodic status updates
+
+Set up a recurring check (every ~25 min) using your harness's self-paced wakeup capability. Each tick:
+
+```bash
+gh issue list --repo {repo} --label auto-implement,in-progress-by-bot,awaiting-merge --state all --json number,state,labels
+gh pr list --repo {repo} --state all --json number,state,title --limit 20
+```
+
+Post a one-paragraph delta to the user (newly closed issues, newly merged PRs, failures, blockers). If two consecutive ticks have nothing new, slow to ~50 min cadence to reduce noise. Stop the loop when:
+- the monitor agent reports completion, OR
+- all child issues are CLOSED, OR
+- the user explicitly stops.
+
+If your harness lacks self-paced wakeup: register a local `cron`/`launchd` job that runs the same status-check prompt at the chosen cadence, OR ask the user to invoke `status-update` manually.
+
+## Phase 6 — Final report
+
+When the monitor terminates, post a final summary to the user: every issue processed, every PR merged, total elapsed wall time, and any failures that need human attention.
+
+---
+
+## Constraints (apply throughout)
+
+- **Cadence**: sub-hour polling needs an in-session background subagent or a local cron. Cloud cron services (e.g. Anthropic remote routines) typically have a 1-hour minimum and are not appropriate.
+- **TDD non-negotiable** per AGENTS.md. Real services in tests, no DB mocks.
+- **Branch-per-issue**, conventional commits, no force-push, no hook bypass.
+- **Auto-merge** on success per AGENTS.md. Do not ask.
+- **Context budget**: stay under 60%. Delegate everything possible.
+- **Failure isolation**: a failed issue restores its `auto-implement` label so the next monitor cycle picks it up; it does not block the cascade unless dependent issues are downstream.
+- **Fresh repo**: if Phase 0 created the repo, the very first commit is the scaffold (incl. `AGENTS.md`); the spec lands as the second commit; child branches branch off that `main`.

--- a/skills/autonomous-feature-shipping/uninstall.sh
+++ b/skills/autonomous-feature-shipping/uninstall.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autonomous-feature-shipping skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autonomous-feature-shipping"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        # Try to remove an empty parent skill directory (Claude only — its layout
+        # has a per-skill subdir).
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+# ---------- remove ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Adds a new multi-harness skill, `autonomous-feature-shipping`, that ships a feature end-to-end:

- **Phase 0** — bootstrap a missing GitHub repo (slugified name, visibility, owner) with `.gitignore`, `README.md`, `AGENTS.md`, push.
- **Phase 1** — read-only research subagent maps the codebase / runs real queries against remote systems.
- **Phase 2** — structured 5-section brainstorm (architecture / API / data / errors / testing) with explicit per-section approval, written to `docs/specs/YYYY-MM-DD-<topic>-design.md`.
- **Phase 3** — foreground subagent creates an EPIC umbrella plus N self-contained child mini-specs with `Depends on issue #N` dependency metadata, all carrying the `auto-implement` label.
- **Phase 4** — background subagent loops: pick the next ready issue → worktree → TDD → push → PR → self-review → admin-squash-merge → repeat until drained.
- **Phase 5** — periodic ~25 min status updates, slowing to ~50 min when quiet.
- **Phase 6** — final report.

The canonical body is harness-neutral with a per-harness adapter table for **Claude Code**, **OpenCode**, and **Codex CLI**. Three sibling files share the same body with adjusted frontmatter:

- `SKILL.md` — Claude Code (`name` + `description` frontmatter).
- `opencode/agent.md` — OpenCode (`description` + `mode: primary`).
- `codex/prompt.md` — Codex CLI (no frontmatter; loaded as a slash command from `~/.codex/prompts/`).

`agents/openai.yaml` mirrors the existing `spec-to-roadmap` convention.

## File tree

```
skills/autonomous-feature-shipping/
  README.md                  # comprehensive — what / why / install / usage / limits
  SKILL.md                   # canonical body (Claude Code skill format)
  opencode/agent.md          # OpenCode-flavored variant
  codex/prompt.md            # Codex CLI prompt-library file
  agents/openai.yaml         # Codex UI metadata (matches spec-to-roadmap convention)
  install.sh                 # POSIX installer (--harness claude|opencode|codex|all, --symlink, --dry-run)
  uninstall.sh               # symmetrical
```

Top-level `README.md` and `SKILLS.md` updated to:
- list the new skill,
- document the extended multi-harness layout (Codex-only skills retain the original layout).

## Dependencies

Required at runtime:

- `git` ≥ 2.5 (worktree support).
- `gh` CLI authenticated (`gh auth login`) with `repo` + `workflow` scopes; **admin or maintain** permission on the target repo for the auto-merge step.
- `jq` for JSON shell processing.
- POSIX shell (`bash` or `sh`) for the installer.
- One of: Claude Code, OpenCode, or Codex CLI.
- A project-level test runner appropriate to the codebase (Go `go test`, Node `npm test`, Python `pytest`, etc.) — required by Phase 4's implementation subagent.

Optional: any CI provider; pre-commit hooks (the skill never bypasses them).

## Usage

```text
# Claude Code
/autonomous-feature-shipping Build a Slack bot that posts a daily PR digest

# OpenCode
@autonomous-feature-shipping Build a Slack bot that posts a daily PR digest

# Codex CLI
codex
> /autonomous-feature-shipping Build a Slack bot that posts a daily PR digest
```

## Installation

```bash
cd skills/autonomous-feature-shipping
./install.sh --harness all
# or one of: claude | opencode | codex
# --symlink to symlink instead of copy (updates propagate)
```

The installer honors `CLAUDE_CONFIG_DIR`, `OPENCODE_CONFIG_DIR`, and `CODEX_HOME` env overrides; verifies `git` / `gh` / `jq` and `gh auth status`; is idempotent.

Verified locally with `./install.sh --harness all --dry-run` — all three target paths resolve correctly:
- `~/.claude/skills/autonomous-feature-shipping/SKILL.md`
- `~/.config/opencode/agent/autonomous-feature-shipping.md`
- `~/.codex/prompts/autonomous-feature-shipping.md`

## Uncertainties (for reviewer validation)

- **OpenCode frontmatter**: I used `description` + `mode: primary`, which matches current OpenCode docs for primary-mode agents loaded from `~/.config/opencode/agent/`. If your OpenCode version expects a different schema (e.g. older `name` field, or a `tools:` block), the body still works as a plain prompt — drop the frontmatter or adjust as needed. The README documents this caveat.
- **Codex CLI prompt-library** entries are loaded as plain markdown with no frontmatter; the filename becomes the slash-command. I matched that convention. If a Codex-specific frontmatter pattern emerges later, adapt the codex/prompt.md header.
- **Conventional commits** were used for this PR (per the user's explicit instruction). The repo's existing two commits use a more descriptive imperative style; happy to rebase to match if preferred.

## Test plan

- [ ] `./install.sh --harness all --dry-run` shows three target paths and exits 0.
- [ ] `./install.sh --harness claude` writes `SKILL.md` to `~/.claude/skills/autonomous-feature-shipping/`.
- [ ] `./install.sh --harness opencode` writes `agent.md` to `~/.config/opencode/agent/`.
- [ ] `./install.sh --harness codex` writes `prompt.md` to `~/.codex/prompts/`.
- [ ] `./uninstall.sh --harness all --dry-run` lists the same three paths for removal.
- [ ] Re-running `./install.sh` is idempotent (overwrites cleanly).
- [ ] In Claude Code, `/autonomous-feature-shipping <description>` discovers and runs the skill.
- [ ] In Codex CLI, `/autonomous-feature-shipping` appears in the prompt library.
- [ ] In OpenCode, the agent loads without frontmatter complaints.

## Hard rules respected

- No content changes to the canonical workflow body.
- No push to `main`; PR only.
- No `--no-verify`.
- All GitHub ops via `gh` CLI.