### PR TITLE
feat: small-LLM-friendly issue decomposition

### DIFF
--- a/skills/autospec/README.md
+++ b/skills/autospec/README.md
@@ -47,7 +47,7 @@ is harness-neutral; each phase delegates to subagents whenever the host harness
 supports them, and falls back to in-thread execution when it doesn't. The whole
 pipeline runs from a single user invocation — the only required interactive step is
 the optional repo-bootstrap question (name, visibility, owner) when no GitHub remote
-is detected.
+is detected. Generated child issues are pre-staged for 32B-class local LLMs (Ollama qwen3-style on Mac/Linux), not just cloud agents — file pointers, section anchors, checkbox AC, and a single Primary smoke test per inner loop.
 
 ## Why use it
 
@@ -68,7 +68,7 @@ Reach for this skill when:
 | **0** | Bootstrap repo (if missing) | Detect missing git/GitHub remote, ask name/visibility/owner once, scaffold `.gitignore` + `AGENTS.md` + `README.md`, push. |
 | **1** | Investigate (delegate) | Read-only research subagent maps relevant files, schema, services. Real queries against remote systems if the feature touches them. |
 | **2** | Brainstorm + design | Structured 5-section brainstorm (architecture / API / data / errors / testing) with explicit per-section approval, written to `docs/specs/YYYY-MM-DD-<topic>-design.md`. |
-| **3** | Decompose into linked GitHub issues (delegate) | Foreground subagent creates labels, an EPIC umbrella, and N self-contained child mini-specs with `Depends on issue #N` dependency metadata. |
+| **3** | Decompose into linked GitHub issues (delegate) | Foreground subagent creates labels, an EPIC umbrella, and N self-contained mini-specs sized for 32B-class local LLMs: file pointers, section anchors, checkbox AC, primary smoke test. |
 | **4** | Background autonomous monitor | Background subagent loops: pick next ready issue → worktree → TDD → push → PR → self-review → admin-squash-merge → repeat until drained. |
 | **5** | Periodic status updates | Self-paced ~25 min wakeups posting deltas (closed issues, merged PRs, failures, blockers); slows to ~50 min when quiet. |
 | **6** | Final report | When the monitor terminates, summarize every issue processed, PR merged, wall time, and any human-attention failures. |

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -93,7 +93,33 @@ If this is a fresh repo, commit the spec to `main` directly (`git add docs/... &
 
 Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
 
-> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. Each child body must be a **self-contained mini-spec** with: **Goal** (1 sentence), **Scope** (what's in / out), **Implementation outline** (file paths + function signatures + data flow), **Tests required** (TDD, real services, no DB mocks, 80%+ coverage per AGENTS.md), **Acceptance criteria** (machine-checkable), **Branch name** (`feat/<slug>`), **Dependencies** (`Depends on issue #N` lines — these will be parsed by the monitor). After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+>
+> Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
+>
+> - **Goal** — 1 sentence outcome.
+> - **Source spec** — relative path + GitHub URL of the design doc this issue derives from (if any).
+> - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
+> - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
+> - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
+> - **Implementation outline** — file paths + function signatures + data flow.
+> - **Tests required** — TDD per AGENTS.md, real services, no DB mocks, 80%+ coverage.
+> - **Acceptance criteria** — checkbox list `[ ]` only, no prose. Each item machine-checkable.
+> - **Verification** — split into a **Primary smoke test (inner loop)** with exactly one fast command, and **Operator/full verification** listing the remaining commands.
+> - **Branch name** — `feat/<slug>`.
+> - **Dependencies** — `Depends on issue #N` lines (parsed by the monitor).
+>
+> Sizing rule: aim for ≤ 4 KB body. Issues that span more than 4 canonical tables, more than 3 packages, or schema-wide changes must be split — better to emit two children with a `Depends on` edge than one oversized child a small LLM can't hold in working memory.
+
+### Small-LLM friendliness (applies to every child issue)
+
+Children are written assuming the implementer is a 32B-class local model with **pre-staged context**, not a search-driven cloud agent:
+
+- Every file the implementer needs is named in **Files to read first** with a sectional anchor or a one-line reason. Do not assume the model will grep the codebase.
+- Spec docs are cited by section heading, not as "read this 20 KB doc".
+- Acceptance criteria are checkbox-only so the model can self-verify line-by-line.
+- One **Primary smoke test** runs in the inner loop; the heavier verification list runs once at the end.
+- If the work fans out across many tables/packages, split it. Two 3 KB children chained by `Depends on` beat one 7 KB child a 32B model garbles at 60k tokens of working context.
 
 Capture the umbrella + child issue numbers.
 
@@ -140,10 +166,11 @@ Then launch a **background subagent** with this prompt verbatim:
 > 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
 > 5. Push: git push -u origin <BRANCH>
 > 6. PR: gh pr create --base main --head <BRANCH> --title "<TITLE>" --body "Closes #<ISSUE>\n\n<summary>". Capture PR.
-> 7. Self-review loop (max 3 iterations):
->    Dispatch a **foreground subagent** with brief: "You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
->    If LGTM: sleep 30; gh pr checks <PR>. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
->    Else: implement findings, commit, push, continue.
+> 7. Inner loop (max 3 iterations):
+>    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - Dispatch a **foreground subagent** with brief: "You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
+>    - If LGTM: run the **Operator/full verification** commands; sleep 30; `gh pr checks <PR>`. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
+>    - Else: implement findings, commit, push, continue.
 > 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
 > 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
@@ -191,3 +218,4 @@ When the monitor terminates, post a final summary to the user: every issue proce
 - **Context budget**: stay under 60%. Delegate everything possible.
 - **Failure isolation**: a failed issue restores its `auto-implement` label so the next monitor cycle picks it up; it does not block the cascade unless dependent issues are downstream.
 - **Fresh repo**: if Phase 0 created the repo, the very first commit is the scaffold (incl. `AGENTS.md`); the spec lands as the second commit; child branches branch off that `main`.
+- **Small-LLM target**: child issues are sized and pre-staged for 32B-class local LLMs (e.g. qwen3-32B / Qwen3-30B-A3B on Ollama, 48 GB-class Macs). Bias toward smaller issues, sectional spec anchors, pre-staged file pointers, checkbox AC, and one Primary smoke test.

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -1,3 +1,4 @@
+
 # autospec workflow (harness-neutral)
 
 Take the following feature request and ship it through the full pipeline:
@@ -9,7 +10,6 @@ Manage your own context — never exceed 60%. Delegate to subagents whenever you
 
 {FEATURE_DESCRIPTION}
 
----
 
 ## Required capabilities & harness adapter
 
@@ -25,7 +25,6 @@ This workflow assumes five capabilities. Map each one to your harness's actual t
 
 **Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there.
 
----
 
 ## Phase 0 — Bootstrap repo (if missing)
 
@@ -88,7 +87,33 @@ If this is a fresh repo, commit the spec to `main` directly (`git add docs/... &
 
 Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
 
-> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. Each child body must be a **self-contained mini-spec** with: **Goal** (1 sentence), **Scope** (what's in / out), **Implementation outline** (file paths + function signatures + data flow), **Tests required** (TDD, real services, no DB mocks, 80%+ coverage per AGENTS.md), **Acceptance criteria** (machine-checkable), **Branch name** (`feat/<slug>`), **Dependencies** (`Depends on issue #N` lines — these will be parsed by the monitor). After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+>
+> Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
+>
+> - **Goal** — 1 sentence outcome.
+> - **Source spec** — relative path + GitHub URL of the design doc this issue derives from (if any).
+> - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
+> - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
+> - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
+> - **Implementation outline** — file paths + function signatures + data flow.
+> - **Tests required** — TDD per AGENTS.md, real services, no DB mocks, 80%+ coverage.
+> - **Acceptance criteria** — checkbox list `[ ]` only, no prose. Each item machine-checkable.
+> - **Verification** — split into a **Primary smoke test (inner loop)** with exactly one fast command, and **Operator/full verification** listing the remaining commands.
+> - **Branch name** — `feat/<slug>`.
+> - **Dependencies** — `Depends on issue #N` lines (parsed by the monitor).
+>
+> Sizing rule: aim for ≤ 4 KB body. Issues that span more than 4 canonical tables, more than 3 packages, or schema-wide changes must be split — better to emit two children with a `Depends on` edge than one oversized child a small LLM can't hold in working memory.
+
+### Small-LLM friendliness (applies to every child issue)
+
+Children are written assuming the implementer is a 32B-class local model with **pre-staged context**, not a search-driven cloud agent:
+
+- Every file the implementer needs is named in **Files to read first** with a sectional anchor or a one-line reason. Do not assume the model will grep the codebase.
+- Spec docs are cited by section heading, not as "read this 20 KB doc".
+- Acceptance criteria are checkbox-only so the model can self-verify line-by-line.
+- One **Primary smoke test** runs in the inner loop; the heavier verification list runs once at the end.
+- If the work fans out across many tables/packages, split it. Two 3 KB children chained by `Depends on` beat one 7 KB child a 32B model garbles at 60k tokens of working context.
 
 Capture the umbrella + child issue numbers.
 
@@ -135,10 +160,11 @@ Then launch a **background subagent** with this prompt verbatim:
 > 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
 > 5. Push: git push -u origin <BRANCH>
 > 6. PR: gh pr create --base main --head <BRANCH> --title "<TITLE>" --body "Closes #<ISSUE>\n\n<summary>". Capture PR.
-> 7. Self-review loop (max 3 iterations):
->    Dispatch a **foreground subagent** with brief: "You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
->    If LGTM: sleep 30; gh pr checks <PR>. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
->    Else: implement findings, commit, push, continue.
+> 7. Inner loop (max 3 iterations):
+>    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - Dispatch a **foreground subagent** with brief: "You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
+>    - If LGTM: run the **Operator/full verification** commands; sleep 30; `gh pr checks <PR>`. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
+>    - Else: implement findings, commit, push, continue.
 > 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
 > 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
@@ -175,7 +201,6 @@ If your harness lacks self-paced wakeup: register a local `cron`/`launchd` job t
 
 When the monitor terminates, post a final summary to the user: every issue processed, every PR merged, total elapsed wall time, and any failures that need human attention.
 
----
 
 ## Constraints (apply throughout)
 
@@ -186,3 +211,4 @@ When the monitor terminates, post a final summary to the user: every issue proce
 - **Context budget**: stay under 60%. Delegate everything possible.
 - **Failure isolation**: a failed issue restores its `auto-implement` label so the next monitor cycle picks it up; it does not block the cascade unless dependent issues are downstream.
 - **Fresh repo**: if Phase 0 created the repo, the very first commit is the scaffold (incl. `AGENTS.md`); the spec lands as the second commit; child branches branch off that `main`.
+- **Small-LLM target**: child issues are sized and pre-staged for 32B-class local LLMs (e.g. qwen3-32B / Qwen3-30B-A3B on Ollama, 48 GB-class Macs). Bias toward smaller issues, sectional spec anchors, pre-staged file pointers, checkbox AC, and one Primary smoke test.

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -14,7 +14,6 @@ Manage your own context — never exceed 60%. Delegate to subagents whenever you
 
 {FEATURE_DESCRIPTION}
 
----
 
 ## Required capabilities & harness adapter
 
@@ -30,7 +29,6 @@ This workflow assumes five capabilities. Map each one to your harness's actual t
 
 **Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there.
 
----
 
 ## Phase 0 — Bootstrap repo (if missing)
 
@@ -93,7 +91,33 @@ If this is a fresh repo, commit the spec to `main` directly (`git add docs/... &
 
 Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
 
-> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. Each child body must be a **self-contained mini-spec** with: **Goal** (1 sentence), **Scope** (what's in / out), **Implementation outline** (file paths + function signatures + data flow), **Tests required** (TDD, real services, no DB mocks, 80%+ coverage per AGENTS.md), **Acceptance criteria** (machine-checkable), **Branch name** (`feat/<slug>`), **Dependencies** (`Depends on issue #N` lines — these will be parsed by the monitor). After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+>
+> Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
+>
+> - **Goal** — 1 sentence outcome.
+> - **Source spec** — relative path + GitHub URL of the design doc this issue derives from (if any).
+> - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
+> - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
+> - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
+> - **Implementation outline** — file paths + function signatures + data flow.
+> - **Tests required** — TDD per AGENTS.md, real services, no DB mocks, 80%+ coverage.
+> - **Acceptance criteria** — checkbox list `[ ]` only, no prose. Each item machine-checkable.
+> - **Verification** — split into a **Primary smoke test (inner loop)** with exactly one fast command, and **Operator/full verification** listing the remaining commands.
+> - **Branch name** — `feat/<slug>`.
+> - **Dependencies** — `Depends on issue #N` lines (parsed by the monitor).
+>
+> Sizing rule: aim for ≤ 4 KB body. Issues that span more than 4 canonical tables, more than 3 packages, or schema-wide changes must be split — better to emit two children with a `Depends on` edge than one oversized child a small LLM can't hold in working memory.
+
+### Small-LLM friendliness (applies to every child issue)
+
+Children are written assuming the implementer is a 32B-class local model with **pre-staged context**, not a search-driven cloud agent:
+
+- Every file the implementer needs is named in **Files to read first** with a sectional anchor or a one-line reason. Do not assume the model will grep the codebase.
+- Spec docs are cited by section heading, not as "read this 20 KB doc".
+- Acceptance criteria are checkbox-only so the model can self-verify line-by-line.
+- One **Primary smoke test** runs in the inner loop; the heavier verification list runs once at the end.
+- If the work fans out across many tables/packages, split it. Two 3 KB children chained by `Depends on` beat one 7 KB child a 32B model garbles at 60k tokens of working context.
 
 Capture the umbrella + child issue numbers.
 
@@ -140,10 +164,11 @@ Then launch a **background subagent** with this prompt verbatim:
 > 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
 > 5. Push: git push -u origin <BRANCH>
 > 6. PR: gh pr create --base main --head <BRANCH> --title "<TITLE>" --body "Closes #<ISSUE>\n\n<summary>". Capture PR.
-> 7. Self-review loop (max 3 iterations):
->    Dispatch a **foreground subagent** with brief: "You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
->    If LGTM: sleep 30; gh pr checks <PR>. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
->    Else: implement findings, commit, push, continue.
+> 7. Inner loop (max 3 iterations):
+>    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - Dispatch a **foreground subagent** with brief: "You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
+>    - If LGTM: run the **Operator/full verification** commands; sleep 30; `gh pr checks <PR>`. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
+>    - Else: implement findings, commit, push, continue.
 > 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
 > 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
@@ -180,7 +205,6 @@ If your harness lacks self-paced wakeup: register a local `cron`/`launchd` job t
 
 When the monitor terminates, post a final summary to the user: every issue processed, every PR merged, total elapsed wall time, and any failures that need human attention.
 
----
 
 ## Constraints (apply throughout)
 
@@ -191,3 +215,4 @@ When the monitor terminates, post a final summary to the user: every issue proce
 - **Context budget**: stay under 60%. Delegate everything possible.
 - **Failure isolation**: a failed issue restores its `auto-implement` label so the next monitor cycle picks it up; it does not block the cascade unless dependent issues are downstream.
 - **Fresh repo**: if Phase 0 created the repo, the very first commit is the scaffold (incl. `AGENTS.md`); the spec lands as the second commit; child branches branch off that `main`.
+- **Small-LLM target**: child issues are sized and pre-staged for 32B-class local LLMs (e.g. qwen3-32B / Qwen3-30B-A3B on Ollama, 48 GB-class Macs). Bias toward smaller issues, sectional spec anchors, pre-staged file pointers, checkbox AC, and one Primary smoke test.


### PR DESCRIPTION
## Summary

Phase 3 child issues are now pre-staged for 32B-class local LLMs (e.g. qwen3-32B / Qwen3-30B-A3B on Ollama, 48 GB-class Macs), not just cloud agents.

What changes in every generated child issue:

- **Files to read first** — 3–7 explicit pointers with section anchors, replacing implicit "search the codebase" assumptions.
- **Local-LLM execution notes** — recommended context window (32k routine / 64k stretch / split if larger) and single-pass-vs-subagent guidance.
- **Acceptance criteria** is checkbox-only; the LLM can self-verify line-by-line.
- **Verification** is split into one **Primary smoke test** for the inner loop and **Operator/full verification** for the final pass.
- **Sizing rule** — aim for ≤4 KB body; issues spanning >4 canonical tables, >3 packages, or schema-wide changes must be split.

Phase 4's implementer inner loop runs the Primary smoke test before the review subagent and the full verification list only after LGTM.

All three harness variants (Claude Code SKILL.md, OpenCode agent.md, Codex prompt.md) updated in lock-step per CONTRIBUTING.md.

## Test plan

- [ ] Diff confirms SKILL.md / opencode/agent.md / codex/prompt.md bodies are identical (frontmatters differ as before).
- [ ] Phase 3 prompt produces child bodies with all new sections when re-run.
- [ ] Phase 4 inner-loop prompt references "Primary smoke test" before the review subagent.
- [ ] README.md "What it does" + Phase 3 architecture-row updated.