### PR TITLE
[autospec-define] Create autospec-define skill (Phases 0-3, multi-harness)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# scripts/validate.sh — repository-wide validation harness.
+#
+# This repo has no language-level test runner. Validation checks:
+#   1. Lock-step rule: SKILL.md body == opencode/agent.md body == codex/prompt.md
+#      body for every multi-harness skill (after frontmatter is stripped per the
+#      project convention: awk '/^---$/{c++; next} c>=2').
+#   2. install.sh / uninstall.sh in every skill pass `bash -n` syntax check.
+#   3. YAML frontmatter in SKILL.md and opencode/agent.md parses.
+#   4. Required files exist for every multi-harness skill.
+#
+# Exit 0 on success; non-zero on first failure (with a clear diagnostic).
+
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+fail() {
+    printf 'validate: FAIL — %s\n' "$*" >&2
+    exit 1
+}
+
+info() {
+    printf 'validate: %s\n' "$*"
+}
+
+# Discover multi-harness skills: directories under skills/ that contain SKILL.md
+# *and* opencode/agent.md *and* codex/prompt.md.
+discover_skills() {
+    for d in skills/*/; do
+        [ -d "$d" ] || continue
+        if [ -f "$d/SKILL.md" ] && [ -f "$d/opencode/agent.md" ] && [ -f "$d/codex/prompt.md" ]; then
+            printf '%s\n' "${d%/}"
+        fi
+    done
+}
+
+# Strip frontmatter and any HR --- separator lines per repo convention.
+strip_body() {
+    awk '/^---$/{c++; next} c>=2' "$1"
+}
+
+check_lockstep() {
+    skill_dir="$1"
+    name="$(basename "$skill_dir")"
+    info "lock-step: $name"
+    if ! diff <(strip_body "$skill_dir/SKILL.md") <(cat "$skill_dir/codex/prompt.md") >/dev/null; then
+        diff <(strip_body "$skill_dir/SKILL.md") <(cat "$skill_dir/codex/prompt.md") | head -40 >&2
+        fail "$name: SKILL.md body diverges from codex/prompt.md"
+    fi
+    if ! diff <(strip_body "$skill_dir/SKILL.md") <(strip_body "$skill_dir/opencode/agent.md") >/dev/null; then
+        diff <(strip_body "$skill_dir/SKILL.md") <(strip_body "$skill_dir/opencode/agent.md") | head -40 >&2
+        fail "$name: SKILL.md body diverges from opencode/agent.md"
+    fi
+}
+
+check_bash_syntax() {
+    target="$1"
+    if [ -f "$target" ]; then
+        info "bash -n: $target"
+        bash -n "$target" || fail "$target: bash syntax error"
+    fi
+}
+
+extract_frontmatter() {
+    awk 'BEGIN{in_fm=0} /^---$/{in_fm++; if(in_fm==1) next; if(in_fm==2) exit} in_fm==1{print}' "$1"
+}
+
+check_frontmatter() {
+    target="$1"
+    info "frontmatter parse: $target"
+    fm="$(extract_frontmatter "$target")"
+    if [ -z "$fm" ]; then
+        fail "$target: missing or empty YAML frontmatter"
+    fi
+    # Validate via python yaml if available; otherwise minimal sanity (key: value).
+    if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" 2>/dev/null; then
+        printf '%s\n' "$fm" | python3 -c "import sys, yaml; yaml.safe_load(sys.stdin.read())" \
+            || fail "$target: frontmatter is not valid YAML"
+    else
+        printf '%s\n' "$fm" | grep -E '^[A-Za-z_][A-Za-z0-9_-]*:' >/dev/null \
+            || fail "$target: frontmatter does not look like key: value pairs"
+    fi
+}
+
+check_required_files() {
+    skill_dir="$1"
+    name="$(basename "$skill_dir")"
+    for f in SKILL.md README.md install.sh uninstall.sh opencode/agent.md codex/prompt.md; do
+        [ -f "$skill_dir/$f" ] || fail "$name: missing required file $f"
+    done
+}
+
+main() {
+    info "scanning multi-harness skills under skills/ ..."
+    skills="$(discover_skills)"
+    if [ -z "$skills" ]; then
+        fail "no multi-harness skills found under skills/"
+    fi
+
+    for skill_dir in $skills; do
+        check_required_files "$skill_dir"
+        check_lockstep "$skill_dir"
+        check_frontmatter "$skill_dir/SKILL.md"
+        check_frontmatter "$skill_dir/opencode/agent.md"
+        check_bash_syntax "$skill_dir/install.sh"
+        check_bash_syntax "$skill_dir/uninstall.sh"
+    done
+
+    # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
+    # if present; absence is OK before that PR lands.
+    check_bash_syntax "install.sh"
+    check_bash_syntax "uninstall.sh"
+
+    info "OK — all validation checks passed."
+}
+
+main "$@"

--- a/skills/autospec-define/README.md
+++ b/skills/autospec-define/README.md
@@ -1,0 +1,77 @@
+# autospec-define
+
+Planning half of the **autospec** suite. Runs Phases 0–3 of the autospec pipeline
+(bootstrap repo if missing → investigate → design → spec → decomposed GitHub issues),
+then stops with a handoff message pointing the user at `/autospec-run --profile <name>`
+to begin autonomous implementation.
+
+Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
+
+## Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-define/install.sh | sh -s -- --harness all
+```
+
+Per-harness:
+
+```bash
+# Claude Code only
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-define/install.sh | sh -s -- --harness claude
+# OpenCode only
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-define/install.sh | sh -s -- --harness opencode
+# Codex CLI only
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-define/install.sh | sh -s -- --harness codex
+```
+
+From a clone:
+
+```bash
+cd skills/autospec-define
+./install.sh --harness all
+```
+
+## What it does
+
+- **Phase 0** — Bootstrap a fresh GitHub repo if the cwd has no git/remote (asks
+  name / visibility / owner once).
+- **Phase 1** — Read-only research subagent maps the codebase.
+- **Phase 2** — Structured 5-section brainstorm (architecture / API / data / errors /
+  testing), written to `docs/specs/YYYY-MM-DD-<topic>-design.md`.
+- **Phase 3** — Foreground subagent decomposes the spec into an EPIC umbrella plus
+  N self-contained children pre-staged for 32B-class local LLMs.
+
+When Phase 3 completes the skill stops and prints:
+
+```
+Phase 3 complete. Run /autospec-run --profile <name> to begin implementation.
+```
+
+## Related skills
+
+| Skill | Purpose |
+| --- | --- |
+| [`autospec`](../autospec/README.md) | The full pipeline (Phases 0–6) when you want one skill that plans **and** ships. |
+| [`autospec-run`](../autospec-run/README.md) | Implementation half (Phases 4–6). Picks up where `autospec-define` stops; supports `--profile <name>` filtering against `~/.autospec/model-profiles.yml`. |
+| [`autospec-classify`](../autospec-classify/README.md) | Standalone retro-labeler for already-existing `auto-implement` issues; applies the Phase 3.5 `ctx:*` / `reasoning:*` rubric. |
+
+## Self-update
+
+Once installed, run the skill with the literal argument `update` to refresh in place
+(self-update mode arrives in PR A4):
+
+```
+/autospec-define update
+```
+
+## Usage
+
+```
+/autospec-define Build a Slack bot that posts a daily standup digest
+```
+
+(Replace `/` with `@` for OpenCode, or invoke through Codex CLI as a slash command.)
+
+## License
+
+MIT — see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: autospec-define
+description: Use when the user wants to plan a feature — bootstrap repo if missing, brainstorm a design spec, and decompose into linked GitHub issues. Stops after Phase 3 and hands off to /autospec-run for autonomous implementation.
+---
+
+# autospec-define workflow (harness-neutral)
+
+Take the following feature request and run the planning half of the autospec pipeline:
+**bootstrap repo (if missing) → investigate → design → spec → decomposed GitHub issues.** Stop after Phase 3; the implementation half is handed off to `/autospec-run`.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
+
+## Feature request
+
+{FEATURE_DESCRIPTION}
+
+---
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there.
+
+---
+
+## Phase 0 — Bootstrap repo (if missing)
+
+Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.
+
+Probe the working directory:
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null
+git remote get-url origin 2>/dev/null   # must contain github.com
+```
+
+If **either** check fails — no git repo, or no GitHub remote — bootstrap a new repo:
+
+1. **Suggest a name.** Slugify the feature description: lowercase, hyphens, drop stop-words, prefix with the obvious stack if inferable (e.g. "Go TUI for X" → `go-tui-x`; "Python ML pipeline that does Y" → `py-ml-y`). Offer 1–2 candidates.
+
+2. **Ask the user once** (single interactive question; combine the three sub-questions if your harness supports it, otherwise ask sequentially):
+   - **Name** (your top suggestion as default).
+   - **Visibility**: `private` | `public` (default: private).
+   - **Owner**: enumerate via `gh org list`; default to the user's personal account.
+
+3. **Initialize locally**:
+   - If `.git` is absent: `git init -b main`.
+   - Write a stack-appropriate `.gitignore` (Go: `bin/ vendor/ *.exe *.test`; Node: `node_modules/ dist/ .next/ .env*`; Python: `__pycache__/ .venv/ *.egg-info/ build/ dist/`; mixed/unknown: skip).
+   - Write a one-line `README.md` containing the feature description.
+   - Write a starter `AGENTS.md` listing the project's coding standards (TDD non-negotiable, no DB mocks, conventional commits, branch-per-issue, no force-push) — this is the source of truth every agent reads.
+   - `git add -A && git commit -m "chore: initial scaffold"`.
+
+4. **Create the remote and push**:
+   ```bash
+   gh repo create <owner>/<name> --<private|public> --source=. --remote=origin --push
+   ```
+
+5. **Verify**: `gh repo view <owner>/<name> --json url,defaultBranchRef`. Capture `<owner>/<name>` as `{repo}` — every subsequent phase uses this value.
+
+If a repo already exists (cwd is in a git tree with a `github.com:<owner>/<name>` remote), capture that as `{repo}` and skip the bootstrap.
+
+## Phase 1 — Investigate (delegate)
+
+Spawn a **read-only research subagent** to map relevant files, schema, services. Get back a 300-word summary with file paths and line numbers. Do NOT read files directly from the main thread.
+
+If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
+
+For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.
+
+## Phase 2 — Brainstorm + design
+
+Run a structured brainstorm — one question at a time, get explicit approval after each section:
+
+1. **Architecture** — where does new code live, what existing patterns does it follow.
+2. **Interactivity / API shape** — how does the user/caller drive it; commands, keys, endpoints, fields.
+3. **Data model** — types, columns, persistence boundary.
+4. **Error handling** — failure modes, recovery, user-visible signals.
+5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services).
+
+Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, scope. The spec must be implementable end-to-end by an agent reading only the spec.
+
+If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
+
+## Phase 3 — Decompose into linked GitHub issues (delegate)
+
+Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
+
+> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+>
+> Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
+>
+> - **Goal** — 1 sentence outcome.
+> - **Source spec** — relative path + GitHub URL of the design doc this issue derives from (if any).
+> - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
+> - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
+> - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
+> - **Implementation outline** — file paths + function signatures + data flow.
+> - **Tests required** — TDD per AGENTS.md, real services, no DB mocks, 80%+ coverage.
+> - **Acceptance criteria** — checkbox list `[ ]` only, no prose. Each item machine-checkable.
+> - **Verification** — split into a **Primary smoke test (inner loop)** with exactly one fast command, and **Operator/full verification** listing the remaining commands.
+> - **Branch name** — `feat/<slug>`.
+> - **Dependencies** — `Depends on issue #N` lines (parsed by the monitor).
+>
+> Sizing rule: aim for ≤ 4 KB body. Issues that span more than 4 canonical tables, more than 3 packages, or schema-wide changes must be split — better to emit two children with a `Depends on` edge than one oversized child a small LLM can't hold in working memory.
+
+### Small-LLM friendliness (applies to every child issue)
+
+Children are written assuming the implementer is a 32B-class local model with **pre-staged context**, not a search-driven cloud agent:
+
+- Every file the implementer needs is named in **Files to read first** with a sectional anchor or a one-line reason. Do not assume the model will grep the codebase.
+- Spec docs are cited by section heading, not as "read this 20 KB doc".
+- Acceptance criteria are checkbox-only so the model can self-verify line-by-line.
+- One **Primary smoke test** runs in the inner loop; the heavier verification list runs once at the end.
+- If the work fans out across many tables/packages, split it. Two 3 KB children chained by `Depends on` beat one 7 KB child a 32B model garbles at 60k tokens of working context.
+
+Capture the umbrella + child issue numbers.
+
+
+---
+
+## Handoff
+
+Phase 3 complete. Run `/autospec-run --profile <name>` to begin implementation.

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -1,0 +1,124 @@
+
+# autospec-define workflow (harness-neutral)
+
+Take the following feature request and run the planning half of the autospec pipeline:
+**bootstrap repo (if missing) → investigate → design → spec → decomposed GitHub issues.** Stop after Phase 3; the implementation half is handed off to `/autospec-run`.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
+
+## Feature request
+
+{FEATURE_DESCRIPTION}
+
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there.
+
+
+## Phase 0 — Bootstrap repo (if missing)
+
+Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.
+
+Probe the working directory:
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null
+git remote get-url origin 2>/dev/null   # must contain github.com
+```
+
+If **either** check fails — no git repo, or no GitHub remote — bootstrap a new repo:
+
+1. **Suggest a name.** Slugify the feature description: lowercase, hyphens, drop stop-words, prefix with the obvious stack if inferable (e.g. "Go TUI for X" → `go-tui-x`; "Python ML pipeline that does Y" → `py-ml-y`). Offer 1–2 candidates.
+
+2. **Ask the user once** (single interactive question; combine the three sub-questions if your harness supports it, otherwise ask sequentially):
+   - **Name** (your top suggestion as default).
+   - **Visibility**: `private` | `public` (default: private).
+   - **Owner**: enumerate via `gh org list`; default to the user's personal account.
+
+3. **Initialize locally**:
+   - If `.git` is absent: `git init -b main`.
+   - Write a stack-appropriate `.gitignore` (Go: `bin/ vendor/ *.exe *.test`; Node: `node_modules/ dist/ .next/ .env*`; Python: `__pycache__/ .venv/ *.egg-info/ build/ dist/`; mixed/unknown: skip).
+   - Write a one-line `README.md` containing the feature description.
+   - Write a starter `AGENTS.md` listing the project's coding standards (TDD non-negotiable, no DB mocks, conventional commits, branch-per-issue, no force-push) — this is the source of truth every agent reads.
+   - `git add -A && git commit -m "chore: initial scaffold"`.
+
+4. **Create the remote and push**:
+   ```bash
+   gh repo create <owner>/<name> --<private|public> --source=. --remote=origin --push
+   ```
+
+5. **Verify**: `gh repo view <owner>/<name> --json url,defaultBranchRef`. Capture `<owner>/<name>` as `{repo}` — every subsequent phase uses this value.
+
+If a repo already exists (cwd is in a git tree with a `github.com:<owner>/<name>` remote), capture that as `{repo}` and skip the bootstrap.
+
+## Phase 1 — Investigate (delegate)
+
+Spawn a **read-only research subagent** to map relevant files, schema, services. Get back a 300-word summary with file paths and line numbers. Do NOT read files directly from the main thread.
+
+If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
+
+For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.
+
+## Phase 2 — Brainstorm + design
+
+Run a structured brainstorm — one question at a time, get explicit approval after each section:
+
+1. **Architecture** — where does new code live, what existing patterns does it follow.
+2. **Interactivity / API shape** — how does the user/caller drive it; commands, keys, endpoints, fields.
+3. **Data model** — types, columns, persistence boundary.
+4. **Error handling** — failure modes, recovery, user-visible signals.
+5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services).
+
+Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, scope. The spec must be implementable end-to-end by an agent reading only the spec.
+
+If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
+
+## Phase 3 — Decompose into linked GitHub issues (delegate)
+
+Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
+
+> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+>
+> Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
+>
+> - **Goal** — 1 sentence outcome.
+> - **Source spec** — relative path + GitHub URL of the design doc this issue derives from (if any).
+> - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
+> - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
+> - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
+> - **Implementation outline** — file paths + function signatures + data flow.
+> - **Tests required** — TDD per AGENTS.md, real services, no DB mocks, 80%+ coverage.
+> - **Acceptance criteria** — checkbox list `[ ]` only, no prose. Each item machine-checkable.
+> - **Verification** — split into a **Primary smoke test (inner loop)** with exactly one fast command, and **Operator/full verification** listing the remaining commands.
+> - **Branch name** — `feat/<slug>`.
+> - **Dependencies** — `Depends on issue #N` lines (parsed by the monitor).
+>
+> Sizing rule: aim for ≤ 4 KB body. Issues that span more than 4 canonical tables, more than 3 packages, or schema-wide changes must be split — better to emit two children with a `Depends on` edge than one oversized child a small LLM can't hold in working memory.
+
+### Small-LLM friendliness (applies to every child issue)
+
+Children are written assuming the implementer is a 32B-class local model with **pre-staged context**, not a search-driven cloud agent:
+
+- Every file the implementer needs is named in **Files to read first** with a sectional anchor or a one-line reason. Do not assume the model will grep the codebase.
+- Spec docs are cited by section heading, not as "read this 20 KB doc".
+- Acceptance criteria are checkbox-only so the model can self-verify line-by-line.
+- One **Primary smoke test** runs in the inner loop; the heavier verification list runs once at the end.
+- If the work fans out across many tables/packages, split it. Two 3 KB children chained by `Depends on` beat one 7 KB child a 32B model garbles at 60k tokens of working context.
+
+Capture the umbrella + child issue numbers.
+
+
+
+## Handoff
+
+Phase 3 complete. Run `/autospec-run --profile <name>` to begin implementation.

--- a/skills/autospec-define/install.sh
+++ b/skills/autospec-define/install.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --symlink           # symlink instead of copy (updates propagate)
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-define/install.sh \
+#     | sh -s -- --harness all
+# When piped, the script auto-downloads the skill files from the same branch.
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPEC_DEFINE_REF         (default: main) — git ref to fetch from when piped
+#   AUTOSPEC_DEFINE_RAW_BASE    (override the raw URL base entirely)
+#
+# Idempotent: re-running upgrades the install. Exits non-zero on hard failure;
+# exits zero with warnings on missing optional deps.
+
+set -eu
+
+SKILL_NAME="autospec-define"
+SKILL_RAW_BASE="${AUTOSPEC_DEFINE_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_DEFINE_REF:-main}/skills/autospec-define}"
+
+# Resolve the directory containing this script. When piped through stdin (e.g.
+# `curl ... | sh`), $0 will not be a real file — detect that and fall back to
+# downloading the source files from the raw GitHub URL.
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+TMP_FETCH_DIR=""
+
+# ---------- helpers --------------------------------------------------------
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run]
+
+Installs the ${SKILL_NAME} skill into the chosen harness's standard
+skill/agent/prompt directory.
+
+Examples:
+  $0                          # interactive
+  $0 --harness all            # install everywhere
+  $0 --harness claude         # Claude Code only
+  $0 --harness opencode       # OpenCode only
+  $0 --harness codex          # Codex CLI only
+  $0 --harness all --symlink  # symlink instead of copy
+  $0 --dry-run --harness all  # print plan, change nothing
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    # Download the files we need into a temp dir and set SKILL_DIR to it.
+    if ! command -v curl >/dev/null 2>&1; then
+        err "curl is required when running from stdin (e.g. piped via 'curl | sh')."
+        exit 1
+    fi
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/$rel"
+            exit 1
+        fi
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    dest_dir="$(dirname "$dest")"
+
+    if [ ! -f "$src" ]; then
+        err "missing source file: $src"
+        return 1
+    fi
+
+    run "mkdir -p \"$dest_dir\""
+
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --symlink)
+            USE_SYMLINK=1
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# ---------- harness prompt -------------------------------------------------
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- ensure source files are available ------------------------------
+
+# If we couldn't resolve a local SKILL_DIR (piped from curl) OR the local dir
+# doesn't actually contain the skill files, fall back to remote fetch.
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+
+if [ "$need_fetch" -eq 1 ]; then
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        err "--symlink requires running from a checkout of the codex-skills repo (no local files to symlink to)."
+        exit 2
+    fi
+    fetch_source_files
+fi
+
+# ---------- dependency checks ---------------------------------------------
+
+dep_warnings=0
+
+check_dep() {
+    name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        warn "$name not found on PATH (required by the skill at runtime)"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+}
+
+check_dep git
+check_dep gh
+check_dep jq
+
+if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+        warn "gh is installed but not authenticated. Run: gh auth login"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+fi
+
+if [ "$dep_warnings" -gt 0 ]; then
+    warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
+fi
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+CLAUDE_SRC="$SKILL_DIR/SKILL.md"
+OPENCODE_SRC="$SKILL_DIR/opencode/agent.md"
+CODEX_SRC="$SKILL_DIR/codex/prompt.md"
+
+# ---------- install --------------------------------------------------------
+
+installed_paths=""
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_SRC" "$CLAUDE_DEST"
+    installed_paths="${installed_paths}  Claude Code: ${CLAUDE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_SRC" "$OPENCODE_DEST"
+    installed_paths="${installed_paths}  OpenCode:    ${OPENCODE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_SRC" "$CODEX_DEST"
+    installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+fi
+
+# ---------- final summary --------------------------------------------------
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    info "Installed:"
+    printf '%b' "$installed_paths"
+    info ""
+    info "Invoke with:"
+    info "  Claude Code:  /${SKILL_NAME} <feature description>"
+    info "  OpenCode:     @${SKILL_NAME} <feature description>"
+    info "  Codex CLI:    /${SKILL_NAME} <feature description>"
+fi
+
+exit 0

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -1,0 +1,128 @@
+---
+description: Use when the user wants to plan a feature — bootstrap repo if missing, brainstorm a design spec, and decompose into linked GitHub issues. Stops after Phase 3 and hands off to /autospec-run for autonomous implementation.
+mode: primary
+---
+
+# autospec-define workflow (harness-neutral)
+
+Take the following feature request and run the planning half of the autospec pipeline:
+**bootstrap repo (if missing) → investigate → design → spec → decomposed GitHub issues.** Stop after Phase 3; the implementation half is handed off to `/autospec-run`.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
+
+## Feature request
+
+{FEATURE_DESCRIPTION}
+
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there.
+
+
+## Phase 0 — Bootstrap repo (if missing)
+
+Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.
+
+Probe the working directory:
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null
+git remote get-url origin 2>/dev/null   # must contain github.com
+```
+
+If **either** check fails — no git repo, or no GitHub remote — bootstrap a new repo:
+
+1. **Suggest a name.** Slugify the feature description: lowercase, hyphens, drop stop-words, prefix with the obvious stack if inferable (e.g. "Go TUI for X" → `go-tui-x`; "Python ML pipeline that does Y" → `py-ml-y`). Offer 1–2 candidates.
+
+2. **Ask the user once** (single interactive question; combine the three sub-questions if your harness supports it, otherwise ask sequentially):
+   - **Name** (your top suggestion as default).
+   - **Visibility**: `private` | `public` (default: private).
+   - **Owner**: enumerate via `gh org list`; default to the user's personal account.
+
+3. **Initialize locally**:
+   - If `.git` is absent: `git init -b main`.
+   - Write a stack-appropriate `.gitignore` (Go: `bin/ vendor/ *.exe *.test`; Node: `node_modules/ dist/ .next/ .env*`; Python: `__pycache__/ .venv/ *.egg-info/ build/ dist/`; mixed/unknown: skip).
+   - Write a one-line `README.md` containing the feature description.
+   - Write a starter `AGENTS.md` listing the project's coding standards (TDD non-negotiable, no DB mocks, conventional commits, branch-per-issue, no force-push) — this is the source of truth every agent reads.
+   - `git add -A && git commit -m "chore: initial scaffold"`.
+
+4. **Create the remote and push**:
+   ```bash
+   gh repo create <owner>/<name> --<private|public> --source=. --remote=origin --push
+   ```
+
+5. **Verify**: `gh repo view <owner>/<name> --json url,defaultBranchRef`. Capture `<owner>/<name>` as `{repo}` — every subsequent phase uses this value.
+
+If a repo already exists (cwd is in a git tree with a `github.com:<owner>/<name>` remote), capture that as `{repo}` and skip the bootstrap.
+
+## Phase 1 — Investigate (delegate)
+
+Spawn a **read-only research subagent** to map relevant files, schema, services. Get back a 300-word summary with file paths and line numbers. Do NOT read files directly from the main thread.
+
+If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
+
+For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.
+
+## Phase 2 — Brainstorm + design
+
+Run a structured brainstorm — one question at a time, get explicit approval after each section:
+
+1. **Architecture** — where does new code live, what existing patterns does it follow.
+2. **Interactivity / API shape** — how does the user/caller drive it; commands, keys, endpoints, fields.
+3. **Data model** — types, columns, persistence boundary.
+4. **Error handling** — failure modes, recovery, user-visible signals.
+5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services).
+
+Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, scope. The spec must be implementable end-to-end by an agent reading only the spec.
+
+If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
+
+## Phase 3 — Decompose into linked GitHub issues (delegate)
+
+Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
+
+> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+>
+> Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
+>
+> - **Goal** — 1 sentence outcome.
+> - **Source spec** — relative path + GitHub URL of the design doc this issue derives from (if any).
+> - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
+> - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
+> - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
+> - **Implementation outline** — file paths + function signatures + data flow.
+> - **Tests required** — TDD per AGENTS.md, real services, no DB mocks, 80%+ coverage.
+> - **Acceptance criteria** — checkbox list `[ ]` only, no prose. Each item machine-checkable.
+> - **Verification** — split into a **Primary smoke test (inner loop)** with exactly one fast command, and **Operator/full verification** listing the remaining commands.
+> - **Branch name** — `feat/<slug>`.
+> - **Dependencies** — `Depends on issue #N` lines (parsed by the monitor).
+>
+> Sizing rule: aim for ≤ 4 KB body. Issues that span more than 4 canonical tables, more than 3 packages, or schema-wide changes must be split — better to emit two children with a `Depends on` edge than one oversized child a small LLM can't hold in working memory.
+
+### Small-LLM friendliness (applies to every child issue)
+
+Children are written assuming the implementer is a 32B-class local model with **pre-staged context**, not a search-driven cloud agent:
+
+- Every file the implementer needs is named in **Files to read first** with a sectional anchor or a one-line reason. Do not assume the model will grep the codebase.
+- Spec docs are cited by section heading, not as "read this 20 KB doc".
+- Acceptance criteria are checkbox-only so the model can self-verify line-by-line.
+- One **Primary smoke test** runs in the inner loop; the heavier verification list runs once at the end.
+- If the work fans out across many tables/packages, split it. Two 3 KB children chained by `Depends on` beat one 7 KB child a 32B model garbles at 60k tokens of working context.
+
+Capture the umbrella + child issue numbers.
+
+
+
+## Handoff
+
+Phase 3 complete. Run `/autospec-run --profile <name>` to begin implementation.

--- a/skills/autospec-define/uninstall.sh
+++ b/skills/autospec-define/uninstall.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autospec-define"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        # Try to remove an empty parent skill directory (Claude only — its layout
+        # has a per-skill subdir).
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+# ---------- remove ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0


### PR DESCRIPTION
Closes #7

Creates the `autospec-define` skill: the planning half of the autospec suite.
Mirrors autospec Phases 0-3 (bootstrap → investigate → design → spec → decomposed
GitHub issues), then stops and prints a handoff pointing the user at
`/autospec-run --profile <name>` to begin implementation.

Trio (`SKILL.md` / `opencode/agent.md` / `codex/prompt.md`) is kept in lock-step
per CONTRIBUTING.md — only frontmatter differs. Bundles a per-skill `install.sh`
/ `uninstall.sh` modeled on `skills/autospec/install.sh` and a one-page README
that cross-links the suite siblings.

Also introduces `scripts/validate.sh` as the repository-wide validation harness
(lock-step diffs, frontmatter parse, `bash -n` on installer scripts, required
files). Subsequent PRs extend rather than replace it.

## Validation
- `bash scripts/validate.sh` passes.
- Primary smoke test from issue #7 passes:
  ```
  diff <(awk '/^---$/{c++; next} c>=2' skills/autospec-define/SKILL.md) <(cat skills/autospec-define/codex/prompt.md)
  diff <(awk '/^---$/{c++; next} c>=2' skills/autospec-define/SKILL.md) <(awk '/^---$/{c++; next} c>=2' skills/autospec-define/opencode/agent.md)
  ```
  Both diffs are empty.
- `bash skills/autospec-define/install.sh --dry-run --harness all` lists all three install paths.