### PR TITLE
[autospec-run] Create autospec-run skill (Phases 4-6, --profile filter)

### DIFF
--- a/skills/autospec-run/README.md
+++ b/skills/autospec-run/README.md
@@ -1,0 +1,103 @@
+# autospec-run
+
+Implementation half of the **autospec** suite. Picks up where `/autospec-define`
+stops: takes the populated `auto-implement` queue on the current GitHub repo and
+runs Phases 4–6 of autospec — autonomous monitor + admin-squash-merge of each PR
++ periodic status updates + final report.
+
+Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
+
+## Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-run/install.sh | sh -s -- --harness all
+```
+
+Per-harness:
+
+```bash
+# Claude Code only
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-run/install.sh | sh -s -- --harness claude
+# OpenCode only
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-run/install.sh | sh -s -- --harness opencode
+# Codex CLI only
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-run/install.sh | sh -s -- --harness codex
+```
+
+From a clone:
+
+```bash
+cd skills/autospec-run
+./install.sh --harness all
+```
+
+## Invocation
+
+```
+/autospec-run [--profile <name>]
+```
+
+- `--profile <name>` — filter the candidate queue against
+  `~/.autospec/model-profiles.yml` so only issues whose `ctx:*` and `reasoning:*`
+  labels fit the named profile are picked up. Issues that exceed the profile on
+  either axis are appended to a `Deferred` list and reported at run-end.
+- (no flag) — run with the file's `default:` profile if present; otherwise prints
+  `Profile filter inactive — running all auto-implement issues.` and continues
+  without filtering.
+
+The full filter logic, deferred-summary accumulation, and `model-profiles.yml`
+auto-init arrive in PR B2 (issue #15). This skill currently plumbs the flag with
+no filter behaviour yet — runs all auto-implement issues regardless of profile.
+
+## What it does
+
+- **Phase 4** — Background autonomous monitor: outer loop picks the next ready
+  `auto-implement` issue (deps closed), labels it `in-progress-by-bot`, dispatches
+  a foreground subagent to implement it (worktree → TDD → push → PR → self-review
+  → admin-squash-merge), then loops without sleeping so a freshly-merged PR can
+  unblock the next issue immediately.
+- **Phase 5** — Periodic status updates posted to the user every ~25 min (slows
+  to ~50 min when quiet).
+- **Phase 6** — Final report on monitor termination: every issue processed, every
+  PR merged, total elapsed wall time, any failures needing human attention.
+
+## Profile filter (forward reference)
+
+When PR B2 (issue #15) lands, the candidate queue is filtered by profile:
+
+```yaml
+# ~/.autospec/model-profiles.yml
+default: claude-sonnet-cloud
+profiles:
+  qwen3-32b-laptop:
+    ctx: 64k       # 32k < 64k < 120k
+    reasoning: medium  # shallow < medium < deep
+  claude-sonnet-cloud:
+    ctx: 120k
+    reasoning: deep
+```
+
+The filter excludes issues whose `ctx:*` / `reasoning:*` labels exceed the
+profile ceilings; excluded issues are appended to a `Deferred` list and reported
+at run-end.
+
+## Related skills
+
+| Skill | Purpose |
+| --- | --- |
+| [`autospec`](../autospec/README.md) | The full pipeline (Phases 0–6) when you want one skill that plans **and** ships. |
+| [`autospec-define`](../autospec-define/README.md) | Planning half (Phases 0–3). Produces the `auto-implement` queue this skill consumes. |
+| [`autospec-classify`](../autospec-classify/README.md) | Standalone retro-labeler that backfills `ctx:*` / `reasoning:*` labels onto already-existing `auto-implement` issues so the `--profile` filter has data to work with. |
+
+## Self-update
+
+Once installed, run the skill with the literal argument `update` to refresh in
+place (self-update mode arrives in PR A4):
+
+```
+/autospec-run update
+```
+
+## License
+
+MIT — see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: autospec-run
+description: Use when the user has already run /autospec-define (or otherwise has a populated set of auto-implement GitHub issues) and wants the implementation half — Phases 4-6 — to run autonomously with admin auto-merge. Supports --profile <name> filtering against ~/.autospec/model-profiles.yml.
+---
+
+# autospec-run workflow (harness-neutral)
+
+Take the populated `auto-implement` queue on the current GitHub repo and run the implementation half of the autospec pipeline:
+**autonomous monitor → admin-squash-merge each PR → periodic status updates → final report.**
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
+
+## Invocation
+
+```
+/autospec-run [--profile <name>]
+```
+
+- `--profile <name>` — filter the candidate queue against `~/.autospec/model-profiles.yml` so only issues whose `ctx:*` and `reasoning:*` labels fit the named profile are picked up. Issues that exceed the profile on either axis are appended to a `Deferred` list and reported at run-end.
+- (no flag) — run with the file's `default:` profile if present; otherwise print `Profile filter inactive — running all auto-implement issues.` and continue without filtering.
+- If `~/.autospec/model-profiles.yml` is missing, the skill prints `Profile filter inactive — running all auto-implement issues.` and continues. (Auto-init of the file lands in PR B2; this skill plumbs the flag with no filter behaviour yet.)
+- `--profile <unknown>` — exit non-zero and print the available profile names.
+
+The actual filter logic, deferred-summary accumulation, and `model-profiles.yml` auto-init arrive in PR B2 (issue #15). This issue ships the skill structure with the flag plumbed but no filter yet.
+
+---
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there.
+
+## Phase 4 — Background autonomous monitor
+
+Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
+
+> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
+
+Then launch a **background subagent** with this prompt verbatim:
+
+> You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+>
+> Outer loop:
+> ```
+> while true:
+>   ready = [open auto-implement issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   if ready is empty:
+>     latest_close = most recent closedAt of any auto-implement issue
+>     open_count   = count of open auto-implement issues
+>     if open_count == 0 AND latest_close > 1h ago: HARD SHUTDOWN — return final report
+>     else: print state ("blocked: N unmet deps" / "drained, waiting 1h idle"), sleep 300, continue
+>   ISSUE = ready[0]
+>   gh label create in-progress-by-bot --color ededed --force
+>   gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot
+>   process(ISSUE)   # foreground subagent — see template below
+>   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
+> ```
+>
+> `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
+>
+> ```
+> Implement GitHub issue #<ISSUE>: "<TITLE>" on {repo}. Spec is the issue body below.
+>
+> ===ISSUE BODY===
+> <BODY>
+> ===END===
+>
+> 1. Worktree off origin/main:
+>    cd {repo_root} && git fetch origin
+>    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
+> 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
+> 3. Build + test green (use the project's test runner; for Go: `go build ./... && go test ./... -count=1`; for Node: `npm test`; for Python: `pytest`). 80%+ coverage on changed files.
+> 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
+> 5. Push: git push -u origin <BRANCH>
+> 6. PR: gh pr create --base main --head <BRANCH> --title "<TITLE>" --body "Closes #<ISSUE>\n\n<summary>". Capture PR.
+> 7. Inner loop (max 3 iterations):
+>    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - Dispatch a **foreground subagent** with brief: "You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
+>    - If LGTM: run the **Operator/full verification** commands; sleep 30; `gh pr checks <PR>`. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
+>    - Else: implement findings, commit, push, continue.
+> 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
+> 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
+> 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
+> 11. Report: PR number, outcome, one-paragraph summary.
+>
+> Hard rules: NEVER push to main, force-push, bypass hooks, or touch the umbrella issue. gh CLI only.
+> ```
+>
+> Hard rules for the monitor: ONE issue at a time, sequential. Do NOT touch the umbrella. On transient gh errors retry once. Do NOT ask the user — auto-merge authority is granted in AGENTS.md.
+>
+> Final output when shutdown: numbered list of every processed issue with PR # and outcome.
+
+Capture the agent ID / log path for monitoring.
+
+If your harness lacks background delegation: open a separate terminal/tmux pane, run the monitor prompt in a fresh session there, and have it write progress to a logfile that Phase 5 can tail.
+
+## Phase 5 — Periodic status updates
+
+Set up a recurring check (every ~25 min) using your harness's self-paced wakeup capability. Each tick:
+
+```bash
+gh issue list --repo {repo} --label auto-implement,in-progress-by-bot,awaiting-merge --state all --json number,state,labels
+gh pr list --repo {repo} --state all --json number,state,title --limit 20
+```
+
+Post a one-paragraph delta to the user (newly closed issues, newly merged PRs, failures, blockers). If two consecutive ticks have nothing new, slow to ~50 min cadence to reduce noise. Stop the loop when:
+- the monitor agent reports completion, OR
+- all child issues are CLOSED, OR
+- the user explicitly stops.
+
+If your harness lacks self-paced wakeup: register a local `cron`/`launchd` job that runs the same status-check prompt at the chosen cadence, OR ask the user to invoke `status-update` manually.
+
+## Phase 6 — Final report
+
+When the monitor terminates, post a final summary to the user: every issue processed, every PR merged, total elapsed wall time, and any failures that need human attention.
+
+---
+
+## Constraints (apply throughout)
+
+- **Cadence**: sub-hour polling needs an in-session background subagent or a local cron. Cloud cron services (e.g. Anthropic remote routines) typically have a 1-hour minimum and are not appropriate.
+- **TDD non-negotiable** per AGENTS.md. Real services in tests, no DB mocks.
+- **Branch-per-issue**, conventional commits, no force-push, no hook bypass.
+- **Auto-merge** on success per AGENTS.md. Do not ask.
+- **Context budget**: stay under 60%. Delegate everything possible.
+- **Failure isolation**: a failed issue restores its `auto-implement` label so the next monitor cycle picks it up; it does not block the cascade unless dependent issues are downstream.
+- **Fresh repo**: if Phase 0 created the repo, the very first commit is the scaffold (incl. `AGENTS.md`); the spec lands as the second commit; child branches branch off that `main`.
+- **Small-LLM target**: child issues are sized and pre-staged for 32B-class local LLMs (e.g. qwen3-32B / Qwen3-30B-A3B on Ollama, 48 GB-class Macs). Bias toward smaller issues, sectional spec anchors, pre-staged file pointers, checkbox AC, and one Primary smoke test.

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -1,0 +1,131 @@
+
+# autospec-run workflow (harness-neutral)
+
+Take the populated `auto-implement` queue on the current GitHub repo and run the implementation half of the autospec pipeline:
+**autonomous monitor → admin-squash-merge each PR → periodic status updates → final report.**
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
+
+## Invocation
+
+```
+/autospec-run [--profile <name>]
+```
+
+- `--profile <name>` — filter the candidate queue against `~/.autospec/model-profiles.yml` so only issues whose `ctx:*` and `reasoning:*` labels fit the named profile are picked up. Issues that exceed the profile on either axis are appended to a `Deferred` list and reported at run-end.
+- (no flag) — run with the file's `default:` profile if present; otherwise print `Profile filter inactive — running all auto-implement issues.` and continue without filtering.
+- If `~/.autospec/model-profiles.yml` is missing, the skill prints `Profile filter inactive — running all auto-implement issues.` and continues. (Auto-init of the file lands in PR B2; this skill plumbs the flag with no filter behaviour yet.)
+- `--profile <unknown>` — exit non-zero and print the available profile names.
+
+The actual filter logic, deferred-summary accumulation, and `model-profiles.yml` auto-init arrive in PR B2 (issue #15). This issue ships the skill structure with the flag plumbed but no filter yet.
+
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there.
+
+## Phase 4 — Background autonomous monitor
+
+Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
+
+> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
+
+Then launch a **background subagent** with this prompt verbatim:
+
+> You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+>
+> Outer loop:
+> ```
+> while true:
+>   ready = [open auto-implement issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   if ready is empty:
+>     latest_close = most recent closedAt of any auto-implement issue
+>     open_count   = count of open auto-implement issues
+>     if open_count == 0 AND latest_close > 1h ago: HARD SHUTDOWN — return final report
+>     else: print state ("blocked: N unmet deps" / "drained, waiting 1h idle"), sleep 300, continue
+>   ISSUE = ready[0]
+>   gh label create in-progress-by-bot --color ededed --force
+>   gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot
+>   process(ISSUE)   # foreground subagent — see template below
+>   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
+> ```
+>
+> `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
+>
+> ```
+> Implement GitHub issue #<ISSUE>: "<TITLE>" on {repo}. Spec is the issue body below.
+>
+> ===ISSUE BODY===
+> <BODY>
+> ===END===
+>
+> 1. Worktree off origin/main:
+>    cd {repo_root} && git fetch origin
+>    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
+> 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
+> 3. Build + test green (use the project's test runner; for Go: `go build ./... && go test ./... -count=1`; for Node: `npm test`; for Python: `pytest`). 80%+ coverage on changed files.
+> 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
+> 5. Push: git push -u origin <BRANCH>
+> 6. PR: gh pr create --base main --head <BRANCH> --title "<TITLE>" --body "Closes #<ISSUE>\n\n<summary>". Capture PR.
+> 7. Inner loop (max 3 iterations):
+>    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - Dispatch a **foreground subagent** with brief: "You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
+>    - If LGTM: run the **Operator/full verification** commands; sleep 30; `gh pr checks <PR>`. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
+>    - Else: implement findings, commit, push, continue.
+> 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
+> 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
+> 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
+> 11. Report: PR number, outcome, one-paragraph summary.
+>
+> Hard rules: NEVER push to main, force-push, bypass hooks, or touch the umbrella issue. gh CLI only.
+> ```
+>
+> Hard rules for the monitor: ONE issue at a time, sequential. Do NOT touch the umbrella. On transient gh errors retry once. Do NOT ask the user — auto-merge authority is granted in AGENTS.md.
+>
+> Final output when shutdown: numbered list of every processed issue with PR # and outcome.
+
+Capture the agent ID / log path for monitoring.
+
+If your harness lacks background delegation: open a separate terminal/tmux pane, run the monitor prompt in a fresh session there, and have it write progress to a logfile that Phase 5 can tail.
+
+## Phase 5 — Periodic status updates
+
+Set up a recurring check (every ~25 min) using your harness's self-paced wakeup capability. Each tick:
+
+```bash
+gh issue list --repo {repo} --label auto-implement,in-progress-by-bot,awaiting-merge --state all --json number,state,labels
+gh pr list --repo {repo} --state all --json number,state,title --limit 20
+```
+
+Post a one-paragraph delta to the user (newly closed issues, newly merged PRs, failures, blockers). If two consecutive ticks have nothing new, slow to ~50 min cadence to reduce noise. Stop the loop when:
+- the monitor agent reports completion, OR
+- all child issues are CLOSED, OR
+- the user explicitly stops.
+
+If your harness lacks self-paced wakeup: register a local `cron`/`launchd` job that runs the same status-check prompt at the chosen cadence, OR ask the user to invoke `status-update` manually.
+
+## Phase 6 — Final report
+
+When the monitor terminates, post a final summary to the user: every issue processed, every PR merged, total elapsed wall time, and any failures that need human attention.
+
+
+## Constraints (apply throughout)
+
+- **Cadence**: sub-hour polling needs an in-session background subagent or a local cron. Cloud cron services (e.g. Anthropic remote routines) typically have a 1-hour minimum and are not appropriate.
+- **TDD non-negotiable** per AGENTS.md. Real services in tests, no DB mocks.
+- **Branch-per-issue**, conventional commits, no force-push, no hook bypass.
+- **Auto-merge** on success per AGENTS.md. Do not ask.
+- **Context budget**: stay under 60%. Delegate everything possible.
+- **Failure isolation**: a failed issue restores its `auto-implement` label so the next monitor cycle picks it up; it does not block the cascade unless dependent issues are downstream.
+- **Fresh repo**: if Phase 0 created the repo, the very first commit is the scaffold (incl. `AGENTS.md`); the spec lands as the second commit; child branches branch off that `main`.
+- **Small-LLM target**: child issues are sized and pre-staged for 32B-class local LLMs (e.g. qwen3-32B / Qwen3-30B-A3B on Ollama, 48 GB-class Macs). Bias toward smaller issues, sectional spec anchors, pre-staged file pointers, checkbox AC, and one Primary smoke test.

--- a/skills/autospec-run/install.sh
+++ b/skills/autospec-run/install.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --symlink           # symlink instead of copy (updates propagate)
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-run/install.sh \
+#     | sh -s -- --harness all
+# When piped, the script auto-downloads the skill files from the same branch.
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPEC_RUN_REF         (default: main) — git ref to fetch from when piped
+#   AUTOSPEC_RUN_RAW_BASE    (override the raw URL base entirely)
+#
+# Idempotent: re-running upgrades the install. Exits non-zero on hard failure;
+# exits zero with warnings on missing optional deps.
+
+set -eu
+
+SKILL_NAME="autospec-run"
+SKILL_RAW_BASE="${AUTOSPEC_RUN_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_RUN_REF:-main}/skills/autospec-run}"
+
+# Resolve the directory containing this script. When piped through stdin (e.g.
+# `curl ... | sh`), $0 will not be a real file — detect that and fall back to
+# downloading the source files from the raw GitHub URL.
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+TMP_FETCH_DIR=""
+
+# ---------- helpers --------------------------------------------------------
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run]
+
+Installs the ${SKILL_NAME} skill into the chosen harness's standard
+skill/agent/prompt directory.
+
+Examples:
+  $0                          # interactive
+  $0 --harness all            # install everywhere
+  $0 --harness claude         # Claude Code only
+  $0 --harness opencode       # OpenCode only
+  $0 --harness codex          # Codex CLI only
+  $0 --harness all --symlink  # symlink instead of copy
+  $0 --dry-run --harness all  # print plan, change nothing
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    # Download the files we need into a temp dir and set SKILL_DIR to it.
+    if ! command -v curl >/dev/null 2>&1; then
+        err "curl is required when running from stdin (e.g. piped via 'curl | sh')."
+        exit 1
+    fi
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/$rel"
+            exit 1
+        fi
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    dest_dir="$(dirname "$dest")"
+
+    if [ ! -f "$src" ]; then
+        err "missing source file: $src"
+        return 1
+    fi
+
+    run "mkdir -p \"$dest_dir\""
+
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --symlink)
+            USE_SYMLINK=1
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# ---------- harness prompt -------------------------------------------------
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- ensure source files are available ------------------------------
+
+# If we couldn't resolve a local SKILL_DIR (piped from curl) OR the local dir
+# doesn't actually contain the skill files, fall back to remote fetch.
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+
+if [ "$need_fetch" -eq 1 ]; then
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        err "--symlink requires running from a checkout of the codex-skills repo (no local files to symlink to)."
+        exit 2
+    fi
+    fetch_source_files
+fi
+
+# ---------- dependency checks ---------------------------------------------
+
+dep_warnings=0
+
+check_dep() {
+    name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        warn "$name not found on PATH (required by the skill at runtime)"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+}
+
+check_dep git
+check_dep gh
+check_dep jq
+
+if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+        warn "gh is installed but not authenticated. Run: gh auth login"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+fi
+
+if [ "$dep_warnings" -gt 0 ]; then
+    warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
+fi
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+CLAUDE_SRC="$SKILL_DIR/SKILL.md"
+OPENCODE_SRC="$SKILL_DIR/opencode/agent.md"
+CODEX_SRC="$SKILL_DIR/codex/prompt.md"
+
+# ---------- install --------------------------------------------------------
+
+installed_paths=""
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_SRC" "$CLAUDE_DEST"
+    installed_paths="${installed_paths}  Claude Code: ${CLAUDE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_SRC" "$OPENCODE_DEST"
+    installed_paths="${installed_paths}  OpenCode:    ${OPENCODE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_SRC" "$CODEX_DEST"
+    installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+fi
+
+# ---------- final summary --------------------------------------------------
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    info "Installed:"
+    printf '%b' "$installed_paths"
+    info ""
+    info "Invoke with:"
+    info "  Claude Code:  /${SKILL_NAME} <feature description>"
+    info "  OpenCode:     @${SKILL_NAME} <feature description>"
+    info "  Codex CLI:    /${SKILL_NAME} <feature description>"
+fi
+
+exit 0

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -1,0 +1,135 @@
+---
+description: Use when the user has already run /autospec-define (or otherwise has a populated set of auto-implement GitHub issues) and wants the implementation half — Phases 4-6 — to run autonomously with admin auto-merge. Supports --profile <name> filtering against ~/.autospec/model-profiles.yml.
+mode: primary
+---
+
+# autospec-run workflow (harness-neutral)
+
+Take the populated `auto-implement` queue on the current GitHub repo and run the implementation half of the autospec pipeline:
+**autonomous monitor → admin-squash-merge each PR → periodic status updates → final report.**
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
+
+## Invocation
+
+```
+/autospec-run [--profile <name>]
+```
+
+- `--profile <name>` — filter the candidate queue against `~/.autospec/model-profiles.yml` so only issues whose `ctx:*` and `reasoning:*` labels fit the named profile are picked up. Issues that exceed the profile on either axis are appended to a `Deferred` list and reported at run-end.
+- (no flag) — run with the file's `default:` profile if present; otherwise print `Profile filter inactive — running all auto-implement issues.` and continue without filtering.
+- If `~/.autospec/model-profiles.yml` is missing, the skill prints `Profile filter inactive — running all auto-implement issues.` and continues. (Auto-init of the file lands in PR B2; this skill plumbs the flag with no filter behaviour yet.)
+- `--profile <unknown>` — exit non-zero and print the available profile names.
+
+The actual filter logic, deferred-summary accumulation, and `model-profiles.yml` auto-init arrive in PR B2 (issue #15). This issue ships the skill structure with the flag plumbed but no filter yet.
+
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there.
+
+## Phase 4 — Background autonomous monitor
+
+Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
+
+> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
+
+Then launch a **background subagent** with this prompt verbatim:
+
+> You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+>
+> Outer loop:
+> ```
+> while true:
+>   ready = [open auto-implement issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   if ready is empty:
+>     latest_close = most recent closedAt of any auto-implement issue
+>     open_count   = count of open auto-implement issues
+>     if open_count == 0 AND latest_close > 1h ago: HARD SHUTDOWN — return final report
+>     else: print state ("blocked: N unmet deps" / "drained, waiting 1h idle"), sleep 300, continue
+>   ISSUE = ready[0]
+>   gh label create in-progress-by-bot --color ededed --force
+>   gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot
+>   process(ISSUE)   # foreground subagent — see template below
+>   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
+> ```
+>
+> `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
+>
+> ```
+> Implement GitHub issue #<ISSUE>: "<TITLE>" on {repo}. Spec is the issue body below.
+>
+> ===ISSUE BODY===
+> <BODY>
+> ===END===
+>
+> 1. Worktree off origin/main:
+>    cd {repo_root} && git fetch origin
+>    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
+> 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
+> 3. Build + test green (use the project's test runner; for Go: `go build ./... && go test ./... -count=1`; for Node: `npm test`; for Python: `pytest`). 80%+ coverage on changed files.
+> 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
+> 5. Push: git push -u origin <BRANCH>
+> 6. PR: gh pr create --base main --head <BRANCH> --title "<TITLE>" --body "Closes #<ISSUE>\n\n<summary>". Capture PR.
+> 7. Inner loop (max 3 iterations):
+>    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - Dispatch a **foreground subagent** with brief: "You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
+>    - If LGTM: run the **Operator/full verification** commands; sleep 30; `gh pr checks <PR>`. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
+>    - Else: implement findings, commit, push, continue.
+> 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
+> 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
+> 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
+> 11. Report: PR number, outcome, one-paragraph summary.
+>
+> Hard rules: NEVER push to main, force-push, bypass hooks, or touch the umbrella issue. gh CLI only.
+> ```
+>
+> Hard rules for the monitor: ONE issue at a time, sequential. Do NOT touch the umbrella. On transient gh errors retry once. Do NOT ask the user — auto-merge authority is granted in AGENTS.md.
+>
+> Final output when shutdown: numbered list of every processed issue with PR # and outcome.
+
+Capture the agent ID / log path for monitoring.
+
+If your harness lacks background delegation: open a separate terminal/tmux pane, run the monitor prompt in a fresh session there, and have it write progress to a logfile that Phase 5 can tail.
+
+## Phase 5 — Periodic status updates
+
+Set up a recurring check (every ~25 min) using your harness's self-paced wakeup capability. Each tick:
+
+```bash
+gh issue list --repo {repo} --label auto-implement,in-progress-by-bot,awaiting-merge --state all --json number,state,labels
+gh pr list --repo {repo} --state all --json number,state,title --limit 20
+```
+
+Post a one-paragraph delta to the user (newly closed issues, newly merged PRs, failures, blockers). If two consecutive ticks have nothing new, slow to ~50 min cadence to reduce noise. Stop the loop when:
+- the monitor agent reports completion, OR
+- all child issues are CLOSED, OR
+- the user explicitly stops.
+
+If your harness lacks self-paced wakeup: register a local `cron`/`launchd` job that runs the same status-check prompt at the chosen cadence, OR ask the user to invoke `status-update` manually.
+
+## Phase 6 — Final report
+
+When the monitor terminates, post a final summary to the user: every issue processed, every PR merged, total elapsed wall time, and any failures that need human attention.
+
+
+## Constraints (apply throughout)
+
+- **Cadence**: sub-hour polling needs an in-session background subagent or a local cron. Cloud cron services (e.g. Anthropic remote routines) typically have a 1-hour minimum and are not appropriate.
+- **TDD non-negotiable** per AGENTS.md. Real services in tests, no DB mocks.
+- **Branch-per-issue**, conventional commits, no force-push, no hook bypass.
+- **Auto-merge** on success per AGENTS.md. Do not ask.
+- **Context budget**: stay under 60%. Delegate everything possible.
+- **Failure isolation**: a failed issue restores its `auto-implement` label so the next monitor cycle picks it up; it does not block the cascade unless dependent issues are downstream.
+- **Fresh repo**: if Phase 0 created the repo, the very first commit is the scaffold (incl. `AGENTS.md`); the spec lands as the second commit; child branches branch off that `main`.
+- **Small-LLM target**: child issues are sized and pre-staged for 32B-class local LLMs (e.g. qwen3-32B / Qwen3-30B-A3B on Ollama, 48 GB-class Macs). Bias toward smaller issues, sectional spec anchors, pre-staged file pointers, checkbox AC, and one Primary smoke test.

--- a/skills/autospec-run/uninstall.sh
+++ b/skills/autospec-run/uninstall.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autospec-run"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        # Try to remove an empty parent skill directory (Claude only — its layout
+        # has a per-skill subdir).
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+# ---------- remove ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0


### PR DESCRIPTION
Closes #8

Creates the `autospec-run` skill: the implementation half of the autospec suite.
Mirrors autospec Phases 4-6 verbatim (autonomous monitor → status updates →
final report) with a new `## Invocation` block documenting the `--profile <name>`
flag.

The `--profile` flag is plumbed into the body but the filter logic itself,
deferred-summary accumulation, and `~/.autospec/model-profiles.yml` auto-init
are deferred to issue #15 (PR B2) per its scope. When `--profile` is absent or
the YAML is missing, the skill prints `Profile filter inactive — running all
auto-implement issues.` and continues unchanged — keeping backward compat with
the original autospec behaviour.

Trio (`SKILL.md` / `opencode/agent.md` / `codex/prompt.md`) is kept lock-step.

## Validation
- `bash scripts/validate.sh` passes (covers lock-step, frontmatter, bash -n).
- Primary smoke test from issue #8 passes:
  ```
  diff <(awk '/^---$/{c++; next} c>=2' skills/autospec-run/SKILL.md) <(cat skills/autospec-run/codex/prompt.md)
  diff <(awk '/^---$/{c++; next} c>=2' skills/autospec-run/SKILL.md) <(awk '/^---$/{c++; next} c>=2' skills/autospec-run/opencode/agent.md)
  ```
  Both diffs are empty.
- `grep -c '\-\-profile' skills/autospec-run/SKILL.md` returns 4 (flag documented in body).