### PR TITLE
[autospec-classify] Create autospec-classify skill (retro labeler)

### DIFF
--- a/skills/autospec-classify/README.md
+++ b/skills/autospec-classify/README.md
@@ -1,0 +1,107 @@
+# autospec-classify
+
+Standalone retro-labeler for the **autospec** suite. Walks every open
+`auto-implement` issue in the current GitHub repo (excluding `type:tracker`),
+classifies each with `ctx:*` / `reasoning:*` labels per the Phase 3.5 rubric,
+and inserts a `## Model fit` block into the issue body. Defaults to labels-only;
+`--apply-boards` opts into board assignment from `~/.autospec/project-map.yml`.
+
+Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
+
+## Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-classify/install.sh | sh -s -- --harness all
+```
+
+Per-harness:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-classify/install.sh | sh -s -- --harness claude
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-classify/install.sh | sh -s -- --harness opencode
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-classify/install.sh | sh -s -- --harness codex
+```
+
+From a clone:
+
+```bash
+cd skills/autospec-classify
+./install.sh --harness all
+```
+
+## Invocation
+
+```
+/autospec-classify [--issues N,N,N] [--label <label>] [--apply-boards] [--dry-run]
+```
+
+| Flag | Default | Behavior |
+|---|---|---|
+| `--issues N,N,N` | (all open) | Restrict to specific issue numbers. |
+| `--label <label>` | `auto-implement` | Restrict to issues with the given label. |
+| `--apply-boards` | off | Also assign issues to GitHub Projects per `~/.autospec/project-map.yml`. |
+| `--dry-run` | off | Print proposed labels and `## Model fit` blocks without calling `gh issue edit`. |
+
+The skill is **idempotent**: running twice on the same issue produces the same
+labels and the same `## Model fit` block (delimited by HTML comment markers so
+the previous block is replaced in place rather than stacked).
+
+## What `--apply-boards` does (today vs. when B3 lands)
+
+Today, `--apply-boards` is a documented **no-op** that prints:
+
+```
+--apply-boards: project-map reader not yet implemented (lands in B3); skipping board assignment for issue <N>.
+```
+
+When **PR B3** (issue #16) lands, the project-map reader replaces this
+placeholder. The eventual config file:
+
+```yaml
+# ~/.autospec/project-map.yml
+multi_match: union          # or first
+mappings:
+  ctx:32k: 7
+  ctx:64k: 7
+  ctx:120k: 12
+  reasoning:deep: 12
+```
+
+For each issue's labels, look up project numbers and call
+`gh project item-add <project_number> --owner <owner> --url <issue-url>`.
+With `multi_match: union`, all matching projects get the issue.
+
+## Rubric (`ctx:*` and `reasoning:*`)
+
+See the [SKILL.md](./SKILL.md) Rubric section for the full table. Quick summary:
+
+- `ctx:32k` — one canonical table or shell script; ≤3 staged files.
+- `ctx:64k` — multi-file change; 4–7 staged files.
+- `ctx:120k` — cross-skill or cross-package; 8+ files.
+
+- `reasoning:shallow` — copy/rename/transcribe.
+- `reasoning:medium` — template-following with judgment calls.
+- `reasoning:deep` — novel design choices.
+
+Default for issues lacking signal: `ctx:64k`, `reasoning:medium`.
+
+## Related skills
+
+| Skill | Purpose |
+| --- | --- |
+| [`autospec`](../autospec/README.md) | The full pipeline (Phases 0–6) — Phase 3.5 inside that pipeline calls into the same rubric this skill applies retroactively. |
+| [`autospec-define`](../autospec-define/README.md) | Planning half (Phases 0–3). |
+| [`autospec-run`](../autospec-run/README.md) | Implementation half (Phases 4–6) — consumes the `ctx:*` / `reasoning:*` labels this skill backfills. |
+
+## Self-update
+
+Once installed, run the skill with the literal argument `update` to refresh in
+place (self-update mode arrives in PR A4):
+
+```
+/autospec-classify update
+```
+
+## License
+
+MIT — see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autospec-classify/SKILL.md
+++ b/skills/autospec-classify/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: autospec-classify
+description: Use when the user wants to retro-apply autospec's Phase 3.5 model-fit rubric to already-existing auto-implement issues — walks open issues in the current GitHub repo, classifies each with ctx:* / reasoning:* labels, and inserts a ## Model fit block in the issue body. Defaults to labels-only; --apply-boards opts into ~/.autospec/project-map.yml board assignment.
+---
+
+# autospec-classify (harness-neutral)
+
+Standalone retro-labeler. Walk every open `auto-implement` issue in the current
+GitHub repo (excluding `type:tracker`-labeled issues), apply the Phase 3.5
+model-fit rubric, and write a `## Model fit` block into the issue body. Default
+mode is labels-only; the `--apply-boards` flag opts into board assignment from
+`~/.autospec/project-map.yml`.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
+
+## Invocation
+
+```
+/autospec-classify [--issues N,N,N] [--label <label>] [--apply-boards] [--dry-run]
+```
+
+- `--issues N,N,N` — restrict to a comma-separated list of issue numbers (default:
+  every open issue in the current repo).
+- `--label <label>` — restrict to issues carrying a specific label
+  (default: `auto-implement`).
+- `--apply-boards` — also assign issues to GitHub Projects per
+  `~/.autospec/project-map.yml`. **Currently a documented no-op** until PR B3
+  (issue #16) lands the project-map reader; the flag prints
+  `--apply-boards: project-map reader not yet implemented (lands in B3); skipping board assignment.`
+  and continues with labels-only behavior.
+- `--dry-run` — print proposed labels, model-fit blocks, and board assignments
+  without calling `gh issue edit` or `gh project item-add`.
+
+The skill exits non-zero if `gh auth status` fails or the current cwd is not a
+GitHub-tracked repo.
+
+## Pre-flight
+
+1. Verify `gh auth status` is authenticated.
+2. Capture `{repo}` from `gh repo view --json nameWithOwner -q .nameWithOwner`.
+3. Resolve the candidate set:
+   - `gh issue list --repo {repo} --label <label> --state open --limit 500 --json number,title,labels,body,url`.
+   - Filter out any issue whose labels include `type:tracker`.
+   - Apply the `--issues` filter if provided.
+
+## Rubric
+
+### `ctx:*` — context-window axis
+
+Pick the smallest tier that holds the staged context (issue body + every file
+listed under `## Files to read first` + the relevant spec sections).
+
+| Label | Approx. token ceiling | Trigger |
+|---|---|---|
+| `ctx:32k`  | ~32k tokens of staged context | One canonical table or one shell script; ≤3 files in *Files to read first*; spec anchors are short. |
+| `ctx:64k`  | ~64k tokens                   | Multi-file change; 4-7 files staged; one trio + one installer; medium spec sections (~1-3 KB). |
+| `ctx:120k` | ~120k tokens                  | Cross-skill or cross-package; 8+ files; long spec excerpts; deep call graphs. |
+
+If unsure between two tiers, prefer the larger tier.
+
+### `reasoning:*` — reasoning-depth axis
+
+Pick the depth required to **derive** the implementation, not just transcribe it.
+
+| Label | Trigger |
+|---|---|
+| `reasoning:shallow` | Mechanical: copy-and-rename, regex-replace, README transcription, runbook authoring. Verbs in the issue: *copy*, *rename*, *transcribe*, *list*. |
+| `reasoning:medium`  | Template-following with judgment calls: synthesize a new SKILL.md by mirroring an existing one, modify a script with new flags, write tests for a documented contract. Verbs: *mirror*, *adapt*, *integrate*, *wire*. |
+| `reasoning:deep`    | Novel design choices: pick a new abstraction, resolve a contradiction in the spec, reconcile cross-cutting concerns. Verbs: *design*, *reconcile*, *resolve*, *redesign*. |
+
+Default for issues that lack any of these signals: `ctx:64k`, `reasoning:medium`.
+
+## Per-issue procedure
+
+For each candidate issue:
+
+1. **Sanity check.** Body must contain both `## Files to read first` and
+   `## Implementation scope`. If either is missing:
+   - Add label `needs-autospec-template` (idempotent, `gh label create --force`
+     once at the top of the run).
+   - Skip — do not modify body, do not assign a model-fit class.
+
+2. **Classify.** Apply the rubric to assign one `ctx:*` and one `reasoning:*`
+   label. Print the rationale in the dry-run preview.
+
+3. **Apply labels.**
+   - `gh label create ctx:32k --color c5def5 --force` (and ctx:64k, ctx:120k).
+   - `gh label create reasoning:shallow --color c2e0c6 --force`
+     (and reasoning:medium, reasoning:deep).
+   - `gh issue edit <N> --add-label "ctx:<tier>,reasoning:<depth>" --repo {repo}`.
+   - Skip in `--dry-run`.
+
+4. **Patch body.** Insert a `## Model fit` block immediately before the first
+   `## Dependencies` line (or, if absent, at end of body). Block format:
+
+   ```markdown
+   ## Model fit
+
+   - **ctx:** `ctx:<tier>` — <1-line rationale>.
+   - **reasoning:** `reasoning:<depth>` — <1-line rationale>.
+
+   <!-- autospec-classify:begin -->
+   *Auto-classified by `/autospec-classify` on YYYY-MM-DD.*
+   <!-- autospec-classify:end -->
+   ```
+
+   **Idempotency:** if a `## Model fit` block already exists (delimited by the
+   `<!-- autospec-classify:begin -->` / `<!-- autospec-classify:end -->`
+   markers), replace it in place. Never stack duplicate blocks.
+
+   Apply via `gh issue edit <N> --body-file <tmp>`.
+
+5. **Board assignment** (only if `--apply-boards`):
+   - Today: print
+     `--apply-boards: project-map reader not yet implemented (lands in B3); skipping board assignment for issue <N>.`
+   - When B3 (issue #16) lands, this step reads `~/.autospec/project-map.yml`
+     and calls `gh project item-add` for each matching mapping. The reader will
+     be wired in by replacing this placeholder block.
+
+## Sibling normalization (forward reference)
+
+When 5+ sibling issues share a structural criterion (e.g. all are
+"per-source-table writers"), harmonize their `ctx:*` and `reasoning:*` labels so
+the operator can run a single profile across the whole group. The full
+sibling-normalization prompt is part of Phase 3.5 (PR B1, issue #14); when it
+lands, this skill calls into it. Until then, classify each sibling
+independently.
+
+## Run-end summary
+
+Print:
+
+```
+autospec-classify run summary on {repo}
+- classified: N
+- skipped (needs-autospec-template): M
+- ctx:32k=A  ctx:64k=B  ctx:120k=C
+- reasoning:shallow=X  reasoning:medium=Y  reasoning:deep=Z
+- boards assigned: 0  (project-map reader lands in B3)
+```
+
+## Hard rules
+
+- Never modify the issue title.
+- Never remove existing labels — only add `ctx:*`, `reasoning:*`,
+  `needs-autospec-template`.
+- Never call `gh issue edit` in `--dry-run` mode.
+- Always idempotent — running twice on the same issue results in no diff after
+  the second run (same labels, same `## Model fit` block).
+- `gh` CLI only; no direct GraphQL.

--- a/skills/autospec-classify/codex/prompt.md
+++ b/skills/autospec-classify/codex/prompt.md
@@ -1,0 +1,146 @@
+
+# autospec-classify (harness-neutral)
+
+Standalone retro-labeler. Walk every open `auto-implement` issue in the current
+GitHub repo (excluding `type:tracker`-labeled issues), apply the Phase 3.5
+model-fit rubric, and write a `## Model fit` block into the issue body. Default
+mode is labels-only; the `--apply-boards` flag opts into board assignment from
+`~/.autospec/project-map.yml`.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
+
+## Invocation
+
+```
+/autospec-classify [--issues N,N,N] [--label <label>] [--apply-boards] [--dry-run]
+```
+
+- `--issues N,N,N` — restrict to a comma-separated list of issue numbers (default:
+  every open issue in the current repo).
+- `--label <label>` — restrict to issues carrying a specific label
+  (default: `auto-implement`).
+- `--apply-boards` — also assign issues to GitHub Projects per
+  `~/.autospec/project-map.yml`. **Currently a documented no-op** until PR B3
+  (issue #16) lands the project-map reader; the flag prints
+  `--apply-boards: project-map reader not yet implemented (lands in B3); skipping board assignment.`
+  and continues with labels-only behavior.
+- `--dry-run` — print proposed labels, model-fit blocks, and board assignments
+  without calling `gh issue edit` or `gh project item-add`.
+
+The skill exits non-zero if `gh auth status` fails or the current cwd is not a
+GitHub-tracked repo.
+
+## Pre-flight
+
+1. Verify `gh auth status` is authenticated.
+2. Capture `{repo}` from `gh repo view --json nameWithOwner -q .nameWithOwner`.
+3. Resolve the candidate set:
+   - `gh issue list --repo {repo} --label <label> --state open --limit 500 --json number,title,labels,body,url`.
+   - Filter out any issue whose labels include `type:tracker`.
+   - Apply the `--issues` filter if provided.
+
+## Rubric
+
+### `ctx:*` — context-window axis
+
+Pick the smallest tier that holds the staged context (issue body + every file
+listed under `## Files to read first` + the relevant spec sections).
+
+| Label | Approx. token ceiling | Trigger |
+|---|---|---|
+| `ctx:32k`  | ~32k tokens of staged context | One canonical table or one shell script; ≤3 files in *Files to read first*; spec anchors are short. |
+| `ctx:64k`  | ~64k tokens                   | Multi-file change; 4-7 files staged; one trio + one installer; medium spec sections (~1-3 KB). |
+| `ctx:120k` | ~120k tokens                  | Cross-skill or cross-package; 8+ files; long spec excerpts; deep call graphs. |
+
+If unsure between two tiers, prefer the larger tier.
+
+### `reasoning:*` — reasoning-depth axis
+
+Pick the depth required to **derive** the implementation, not just transcribe it.
+
+| Label | Trigger |
+|---|---|
+| `reasoning:shallow` | Mechanical: copy-and-rename, regex-replace, README transcription, runbook authoring. Verbs in the issue: *copy*, *rename*, *transcribe*, *list*. |
+| `reasoning:medium`  | Template-following with judgment calls: synthesize a new SKILL.md by mirroring an existing one, modify a script with new flags, write tests for a documented contract. Verbs: *mirror*, *adapt*, *integrate*, *wire*. |
+| `reasoning:deep`    | Novel design choices: pick a new abstraction, resolve a contradiction in the spec, reconcile cross-cutting concerns. Verbs: *design*, *reconcile*, *resolve*, *redesign*. |
+
+Default for issues that lack any of these signals: `ctx:64k`, `reasoning:medium`.
+
+## Per-issue procedure
+
+For each candidate issue:
+
+1. **Sanity check.** Body must contain both `## Files to read first` and
+   `## Implementation scope`. If either is missing:
+   - Add label `needs-autospec-template` (idempotent, `gh label create --force`
+     once at the top of the run).
+   - Skip — do not modify body, do not assign a model-fit class.
+
+2. **Classify.** Apply the rubric to assign one `ctx:*` and one `reasoning:*`
+   label. Print the rationale in the dry-run preview.
+
+3. **Apply labels.**
+   - `gh label create ctx:32k --color c5def5 --force` (and ctx:64k, ctx:120k).
+   - `gh label create reasoning:shallow --color c2e0c6 --force`
+     (and reasoning:medium, reasoning:deep).
+   - `gh issue edit <N> --add-label "ctx:<tier>,reasoning:<depth>" --repo {repo}`.
+   - Skip in `--dry-run`.
+
+4. **Patch body.** Insert a `## Model fit` block immediately before the first
+   `## Dependencies` line (or, if absent, at end of body). Block format:
+
+   ```markdown
+   ## Model fit
+
+   - **ctx:** `ctx:<tier>` — <1-line rationale>.
+   - **reasoning:** `reasoning:<depth>` — <1-line rationale>.
+
+   <!-- autospec-classify:begin -->
+   *Auto-classified by `/autospec-classify` on YYYY-MM-DD.*
+   <!-- autospec-classify:end -->
+   ```
+
+   **Idempotency:** if a `## Model fit` block already exists (delimited by the
+   `<!-- autospec-classify:begin -->` / `<!-- autospec-classify:end -->`
+   markers), replace it in place. Never stack duplicate blocks.
+
+   Apply via `gh issue edit <N> --body-file <tmp>`.
+
+5. **Board assignment** (only if `--apply-boards`):
+   - Today: print
+     `--apply-boards: project-map reader not yet implemented (lands in B3); skipping board assignment for issue <N>.`
+   - When B3 (issue #16) lands, this step reads `~/.autospec/project-map.yml`
+     and calls `gh project item-add` for each matching mapping. The reader will
+     be wired in by replacing this placeholder block.
+
+## Sibling normalization (forward reference)
+
+When 5+ sibling issues share a structural criterion (e.g. all are
+"per-source-table writers"), harmonize their `ctx:*` and `reasoning:*` labels so
+the operator can run a single profile across the whole group. The full
+sibling-normalization prompt is part of Phase 3.5 (PR B1, issue #14); when it
+lands, this skill calls into it. Until then, classify each sibling
+independently.
+
+## Run-end summary
+
+Print:
+
+```
+autospec-classify run summary on {repo}
+- classified: N
+- skipped (needs-autospec-template): M
+- ctx:32k=A  ctx:64k=B  ctx:120k=C
+- reasoning:shallow=X  reasoning:medium=Y  reasoning:deep=Z
+- boards assigned: 0  (project-map reader lands in B3)
+```
+
+## Hard rules
+
+- Never modify the issue title.
+- Never remove existing labels — only add `ctx:*`, `reasoning:*`,
+  `needs-autospec-template`.
+- Never call `gh issue edit` in `--dry-run` mode.
+- Always idempotent — running twice on the same issue results in no diff after
+  the second run (same labels, same `## Model fit` block).
+- `gh` CLI only; no direct GraphQL.

--- a/skills/autospec-classify/install.sh
+++ b/skills/autospec-classify/install.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --symlink           # symlink instead of copy (updates propagate)
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-classify/install.sh \
+#     | sh -s -- --harness all
+# When piped, the script auto-downloads the skill files from the same branch.
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPEC_CLASSIFY_REF         (default: main) — git ref to fetch from when piped
+#   AUTOSPEC_CLASSIFY_RAW_BASE    (override the raw URL base entirely)
+#
+# Idempotent: re-running upgrades the install. Exits non-zero on hard failure;
+# exits zero with warnings on missing optional deps.
+
+set -eu
+
+SKILL_NAME="autospec-classify"
+SKILL_RAW_BASE="${AUTOSPEC_CLASSIFY_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_CLASSIFY_REF:-main}/skills/autospec-classify}"
+
+# Resolve the directory containing this script. When piped through stdin (e.g.
+# `curl ... | sh`), $0 will not be a real file — detect that and fall back to
+# downloading the source files from the raw GitHub URL.
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+TMP_FETCH_DIR=""
+
+# ---------- helpers --------------------------------------------------------
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run]
+
+Installs the ${SKILL_NAME} skill into the chosen harness's standard
+skill/agent/prompt directory.
+
+Examples:
+  $0                          # interactive
+  $0 --harness all            # install everywhere
+  $0 --harness claude         # Claude Code only
+  $0 --harness opencode       # OpenCode only
+  $0 --harness codex          # Codex CLI only
+  $0 --harness all --symlink  # symlink instead of copy
+  $0 --dry-run --harness all  # print plan, change nothing
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    # Download the files we need into a temp dir and set SKILL_DIR to it.
+    if ! command -v curl >/dev/null 2>&1; then
+        err "curl is required when running from stdin (e.g. piped via 'curl | sh')."
+        exit 1
+    fi
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/$rel"
+            exit 1
+        fi
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    dest_dir="$(dirname "$dest")"
+
+    if [ ! -f "$src" ]; then
+        err "missing source file: $src"
+        return 1
+    fi
+
+    run "mkdir -p \"$dest_dir\""
+
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --symlink)
+            USE_SYMLINK=1
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# ---------- harness prompt -------------------------------------------------
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- ensure source files are available ------------------------------
+
+# If we couldn't resolve a local SKILL_DIR (piped from curl) OR the local dir
+# doesn't actually contain the skill files, fall back to remote fetch.
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+
+if [ "$need_fetch" -eq 1 ]; then
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        err "--symlink requires running from a checkout of the codex-skills repo (no local files to symlink to)."
+        exit 2
+    fi
+    fetch_source_files
+fi
+
+# ---------- dependency checks ---------------------------------------------
+
+dep_warnings=0
+
+check_dep() {
+    name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        warn "$name not found on PATH (required by the skill at runtime)"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+}
+
+check_dep git
+check_dep gh
+check_dep jq
+
+if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+        warn "gh is installed but not authenticated. Run: gh auth login"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+fi
+
+if [ "$dep_warnings" -gt 0 ]; then
+    warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
+fi
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+CLAUDE_SRC="$SKILL_DIR/SKILL.md"
+OPENCODE_SRC="$SKILL_DIR/opencode/agent.md"
+CODEX_SRC="$SKILL_DIR/codex/prompt.md"
+
+# ---------- install --------------------------------------------------------
+
+installed_paths=""
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_SRC" "$CLAUDE_DEST"
+    installed_paths="${installed_paths}  Claude Code: ${CLAUDE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_SRC" "$OPENCODE_DEST"
+    installed_paths="${installed_paths}  OpenCode:    ${OPENCODE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_SRC" "$CODEX_DEST"
+    installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+fi
+
+# ---------- final summary --------------------------------------------------
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    info "Installed:"
+    printf '%b' "$installed_paths"
+    info ""
+    info "Invoke with:"
+    info "  Claude Code:  /${SKILL_NAME} <feature description>"
+    info "  OpenCode:     @${SKILL_NAME} <feature description>"
+    info "  Codex CLI:    /${SKILL_NAME} <feature description>"
+fi
+
+exit 0

--- a/skills/autospec-classify/opencode/agent.md
+++ b/skills/autospec-classify/opencode/agent.md
@@ -1,0 +1,150 @@
+---
+description: Use when the user wants to retro-apply autospec's Phase 3.5 model-fit rubric to already-existing auto-implement issues — walks open issues in the current GitHub repo, classifies each with ctx:* / reasoning:* labels, and inserts a ## Model fit block in the issue body. Defaults to labels-only; --apply-boards opts into ~/.autospec/project-map.yml board assignment.
+mode: primary
+---
+
+# autospec-classify (harness-neutral)
+
+Standalone retro-labeler. Walk every open `auto-implement` issue in the current
+GitHub repo (excluding `type:tracker`-labeled issues), apply the Phase 3.5
+model-fit rubric, and write a `## Model fit` block into the issue body. Default
+mode is labels-only; the `--apply-boards` flag opts into board assignment from
+`~/.autospec/project-map.yml`.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
+
+## Invocation
+
+```
+/autospec-classify [--issues N,N,N] [--label <label>] [--apply-boards] [--dry-run]
+```
+
+- `--issues N,N,N` — restrict to a comma-separated list of issue numbers (default:
+  every open issue in the current repo).
+- `--label <label>` — restrict to issues carrying a specific label
+  (default: `auto-implement`).
+- `--apply-boards` — also assign issues to GitHub Projects per
+  `~/.autospec/project-map.yml`. **Currently a documented no-op** until PR B3
+  (issue #16) lands the project-map reader; the flag prints
+  `--apply-boards: project-map reader not yet implemented (lands in B3); skipping board assignment.`
+  and continues with labels-only behavior.
+- `--dry-run` — print proposed labels, model-fit blocks, and board assignments
+  without calling `gh issue edit` or `gh project item-add`.
+
+The skill exits non-zero if `gh auth status` fails or the current cwd is not a
+GitHub-tracked repo.
+
+## Pre-flight
+
+1. Verify `gh auth status` is authenticated.
+2. Capture `{repo}` from `gh repo view --json nameWithOwner -q .nameWithOwner`.
+3. Resolve the candidate set:
+   - `gh issue list --repo {repo} --label <label> --state open --limit 500 --json number,title,labels,body,url`.
+   - Filter out any issue whose labels include `type:tracker`.
+   - Apply the `--issues` filter if provided.
+
+## Rubric
+
+### `ctx:*` — context-window axis
+
+Pick the smallest tier that holds the staged context (issue body + every file
+listed under `## Files to read first` + the relevant spec sections).
+
+| Label | Approx. token ceiling | Trigger |
+|---|---|---|
+| `ctx:32k`  | ~32k tokens of staged context | One canonical table or one shell script; ≤3 files in *Files to read first*; spec anchors are short. |
+| `ctx:64k`  | ~64k tokens                   | Multi-file change; 4-7 files staged; one trio + one installer; medium spec sections (~1-3 KB). |
+| `ctx:120k` | ~120k tokens                  | Cross-skill or cross-package; 8+ files; long spec excerpts; deep call graphs. |
+
+If unsure between two tiers, prefer the larger tier.
+
+### `reasoning:*` — reasoning-depth axis
+
+Pick the depth required to **derive** the implementation, not just transcribe it.
+
+| Label | Trigger |
+|---|---|
+| `reasoning:shallow` | Mechanical: copy-and-rename, regex-replace, README transcription, runbook authoring. Verbs in the issue: *copy*, *rename*, *transcribe*, *list*. |
+| `reasoning:medium`  | Template-following with judgment calls: synthesize a new SKILL.md by mirroring an existing one, modify a script with new flags, write tests for a documented contract. Verbs: *mirror*, *adapt*, *integrate*, *wire*. |
+| `reasoning:deep`    | Novel design choices: pick a new abstraction, resolve a contradiction in the spec, reconcile cross-cutting concerns. Verbs: *design*, *reconcile*, *resolve*, *redesign*. |
+
+Default for issues that lack any of these signals: `ctx:64k`, `reasoning:medium`.
+
+## Per-issue procedure
+
+For each candidate issue:
+
+1. **Sanity check.** Body must contain both `## Files to read first` and
+   `## Implementation scope`. If either is missing:
+   - Add label `needs-autospec-template` (idempotent, `gh label create --force`
+     once at the top of the run).
+   - Skip — do not modify body, do not assign a model-fit class.
+
+2. **Classify.** Apply the rubric to assign one `ctx:*` and one `reasoning:*`
+   label. Print the rationale in the dry-run preview.
+
+3. **Apply labels.**
+   - `gh label create ctx:32k --color c5def5 --force` (and ctx:64k, ctx:120k).
+   - `gh label create reasoning:shallow --color c2e0c6 --force`
+     (and reasoning:medium, reasoning:deep).
+   - `gh issue edit <N> --add-label "ctx:<tier>,reasoning:<depth>" --repo {repo}`.
+   - Skip in `--dry-run`.
+
+4. **Patch body.** Insert a `## Model fit` block immediately before the first
+   `## Dependencies` line (or, if absent, at end of body). Block format:
+
+   ```markdown
+   ## Model fit
+
+   - **ctx:** `ctx:<tier>` — <1-line rationale>.
+   - **reasoning:** `reasoning:<depth>` — <1-line rationale>.
+
+   <!-- autospec-classify:begin -->
+   *Auto-classified by `/autospec-classify` on YYYY-MM-DD.*
+   <!-- autospec-classify:end -->
+   ```
+
+   **Idempotency:** if a `## Model fit` block already exists (delimited by the
+   `<!-- autospec-classify:begin -->` / `<!-- autospec-classify:end -->`
+   markers), replace it in place. Never stack duplicate blocks.
+
+   Apply via `gh issue edit <N> --body-file <tmp>`.
+
+5. **Board assignment** (only if `--apply-boards`):
+   - Today: print
+     `--apply-boards: project-map reader not yet implemented (lands in B3); skipping board assignment for issue <N>.`
+   - When B3 (issue #16) lands, this step reads `~/.autospec/project-map.yml`
+     and calls `gh project item-add` for each matching mapping. The reader will
+     be wired in by replacing this placeholder block.
+
+## Sibling normalization (forward reference)
+
+When 5+ sibling issues share a structural criterion (e.g. all are
+"per-source-table writers"), harmonize their `ctx:*` and `reasoning:*` labels so
+the operator can run a single profile across the whole group. The full
+sibling-normalization prompt is part of Phase 3.5 (PR B1, issue #14); when it
+lands, this skill calls into it. Until then, classify each sibling
+independently.
+
+## Run-end summary
+
+Print:
+
+```
+autospec-classify run summary on {repo}
+- classified: N
+- skipped (needs-autospec-template): M
+- ctx:32k=A  ctx:64k=B  ctx:120k=C
+- reasoning:shallow=X  reasoning:medium=Y  reasoning:deep=Z
+- boards assigned: 0  (project-map reader lands in B3)
+```
+
+## Hard rules
+
+- Never modify the issue title.
+- Never remove existing labels — only add `ctx:*`, `reasoning:*`,
+  `needs-autospec-template`.
+- Never call `gh issue edit` in `--dry-run` mode.
+- Always idempotent — running twice on the same issue results in no diff after
+  the second run (same labels, same `## Model fit` block).
+- `gh` CLI only; no direct GraphQL.

--- a/skills/autospec-classify/uninstall.sh
+++ b/skills/autospec-classify/uninstall.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autospec-classify"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        # Try to remove an empty parent skill directory (Claude only — its layout
+        # has a per-skill subdir).
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+# ---------- remove ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0


### PR DESCRIPTION
Closes #9

Creates the `autospec-classify` skill: the standalone retro-labeler half of the
autospec suite. Walks open `auto-implement` issues in the current GitHub repo
(excluding `type:tracker`), applies the Phase 3.5 model-fit rubric (`ctx:*` +
`reasoning:*` axes), and inserts an idempotent `## Model fit` block into each
issue body.

Flags: `--issues`, `--label`, `--apply-boards`, `--dry-run`.

`--apply-boards` is a documented no-op until issue #16 (PR B3) lands the
project-map reader — the flag prints a clear placeholder message and continues
with labels-only behavior. Sibling normalization is referenced as a forward link
to issue #14 (PR B1).

Trio (`SKILL.md` / `opencode/agent.md` / `codex/prompt.md`) is kept lock-step.

## Validation
- `bash scripts/validate.sh` passes.
- Primary smoke test from issue #9 passes:
  ```
  diff <(awk '/^---$/{c++; next} c>=2' skills/autospec-classify/SKILL.md) <(cat skills/autospec-classify/codex/prompt.md)
  diff <(awk '/^---$/{c++; next} c>=2' skills/autospec-classify/SKILL.md) <(awk '/^---$/{c++; next} c>=2' skills/autospec-classify/opencode/agent.md)
  ```
  Both diffs are empty.
- Required flags (`--dry-run`, `--apply-boards`) and B3 forward reference all present in SKILL.md.