### PR TITLE
feat: add self-update mode to all four skills

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -92,6 +92,21 @@ check_required_files() {
     done
 }
 
+# Self-update invariants (introduced by issue #10): every multi-harness skill
+# must document `## Self-update mode` in all three trio files, and its
+# install.sh must accept the `--update` flag.
+check_self_update() {
+    skill_dir="$1"
+    name="$(basename "$skill_dir")"
+    info "self-update: $name"
+    for trio in SKILL.md opencode/agent.md codex/prompt.md; do
+        grep -q '^## Self-update mode' "$skill_dir/$trio" \
+            || fail "$name: $trio missing '## Self-update mode' section"
+    done
+    grep -q -- '--update' "$skill_dir/install.sh" \
+        || fail "$name: install.sh missing --update flag handling"
+}
+
 main() {
     info "scanning multi-harness skills under skills/ ..."
     skills="$(discover_skills)"
@@ -106,6 +121,7 @@ main() {
         check_frontmatter "$skill_dir/opencode/agent.md"
         check_bash_syntax "$skill_dir/install.sh"
         check_bash_syntax "$skill_dir/uninstall.sh"
+        check_self_update "$skill_dir"
     done
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax

--- a/skills/autospec-classify/SKILL.md
+++ b/skills/autospec-classify/SKILL.md
@@ -13,6 +13,24 @@ mode is labels-only; the `--apply-boards` flag opts into board assignment from
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
 
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-classify/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-classify.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-classify.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-classify/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-classify found; run install.sh first.` and exit.
+
 ## Invocation
 
 ```

--- a/skills/autospec-classify/codex/prompt.md
+++ b/skills/autospec-classify/codex/prompt.md
@@ -9,6 +9,24 @@ mode is labels-only; the `--apply-boards` flag opts into board assignment from
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
 
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-classify/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-classify.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-classify.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-classify/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-classify found; run install.sh first.` and exit.
+
 ## Invocation
 
 ```

--- a/skills/autospec-classify/install.sh
+++ b/skills/autospec-classify/install.sh
@@ -41,6 +41,7 @@ fi
 HARNESS=""
 USE_SYMLINK=0
 DRY_RUN=0
+UPDATE_MODE=0
 TMP_FETCH_DIR=""
 
 # ---------- helpers --------------------------------------------------------
@@ -51,7 +52,7 @@ info() { printf '%s\n' "$*"; }
 
 usage() {
     cat <<EOF
-Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run]
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
 
 Installs the ${SKILL_NAME} skill into the chosen harness's standard
 skill/agent/prompt directory.
@@ -64,6 +65,7 @@ Examples:
   $0 --harness codex          # Codex CLI only
   $0 --harness all --symlink  # symlink instead of copy
   $0 --dry-run --harness all  # print plan, change nothing
+  $0 --harness claude --update  # idempotent re-install (overwrite existing)
 EOF
 }
 
@@ -138,6 +140,9 @@ while [ $# -gt 0 ]; do
             ;;
         --dry-run)
             DRY_RUN=1
+            ;;
+        --update)
+            UPDATE_MODE=1
             ;;
         -h|--help)
             usage
@@ -272,7 +277,11 @@ info ""
 if [ "$DRY_RUN" -eq 1 ]; then
     info "Dry run complete. No files were written."
 else
-    info "Installed:"
+    if [ "$UPDATE_MODE" -eq 1 ]; then
+        info "Updated (idempotent overwrite):"
+    else
+        info "Installed:"
+    fi
     printf '%b' "$installed_paths"
     info ""
     info "Invoke with:"

--- a/skills/autospec-classify/opencode/agent.md
+++ b/skills/autospec-classify/opencode/agent.md
@@ -13,6 +13,24 @@ mode is labels-only; the `--apply-boards` flag opts into board assignment from
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
 
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-classify/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-classify.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-classify.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-classify/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-classify found; run install.sh first.` and exit.
+
 ## Invocation
 
 ```

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -10,6 +10,24 @@ Take the following feature request and run the planning half of the autospec pip
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-define/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-define.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-define.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-define/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-define found; run install.sh first.` and exit.
+
 ## Feature request
 
 {FEATURE_DESCRIPTION}

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -6,6 +6,24 @@ Take the following feature request and run the planning half of the autospec pip
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-define/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-define.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-define.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-define/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-define found; run install.sh first.` and exit.
+
 ## Feature request
 
 {FEATURE_DESCRIPTION}

--- a/skills/autospec-define/install.sh
+++ b/skills/autospec-define/install.sh
@@ -41,6 +41,7 @@ fi
 HARNESS=""
 USE_SYMLINK=0
 DRY_RUN=0
+UPDATE_MODE=0
 TMP_FETCH_DIR=""
 
 # ---------- helpers --------------------------------------------------------
@@ -51,7 +52,7 @@ info() { printf '%s\n' "$*"; }
 
 usage() {
     cat <<EOF
-Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run]
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
 
 Installs the ${SKILL_NAME} skill into the chosen harness's standard
 skill/agent/prompt directory.
@@ -64,6 +65,7 @@ Examples:
   $0 --harness codex          # Codex CLI only
   $0 --harness all --symlink  # symlink instead of copy
   $0 --dry-run --harness all  # print plan, change nothing
+  $0 --harness claude --update  # idempotent re-install (overwrite existing)
 EOF
 }
 
@@ -138,6 +140,9 @@ while [ $# -gt 0 ]; do
             ;;
         --dry-run)
             DRY_RUN=1
+            ;;
+        --update)
+            UPDATE_MODE=1
             ;;
         -h|--help)
             usage
@@ -272,7 +277,11 @@ info ""
 if [ "$DRY_RUN" -eq 1 ]; then
     info "Dry run complete. No files were written."
 else
-    info "Installed:"
+    if [ "$UPDATE_MODE" -eq 1 ]; then
+        info "Updated (idempotent overwrite):"
+    else
+        info "Installed:"
+    fi
     printf '%b' "$installed_paths"
     info ""
     info "Invoke with:"

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -10,6 +10,24 @@ Take the following feature request and run the planning half of the autospec pip
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-define/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-define.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-define.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-define/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-define found; run install.sh first.` and exit.
+
 ## Feature request
 
 {FEATURE_DESCRIPTION}

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -10,6 +10,24 @@ Take the populated `auto-implement` queue on the current GitHub repo and run the
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-run/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-run.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-run.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-run/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-run found; run install.sh first.` and exit.
+
 ## Invocation
 
 ```

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -6,6 +6,24 @@ Take the populated `auto-implement` queue on the current GitHub repo and run the
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-run/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-run.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-run.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-run/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-run found; run install.sh first.` and exit.
+
 ## Invocation
 
 ```

--- a/skills/autospec-run/install.sh
+++ b/skills/autospec-run/install.sh
@@ -41,6 +41,7 @@ fi
 HARNESS=""
 USE_SYMLINK=0
 DRY_RUN=0
+UPDATE_MODE=0
 TMP_FETCH_DIR=""
 
 # ---------- helpers --------------------------------------------------------
@@ -51,7 +52,7 @@ info() { printf '%s\n' "$*"; }
 
 usage() {
     cat <<EOF
-Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run]
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
 
 Installs the ${SKILL_NAME} skill into the chosen harness's standard
 skill/agent/prompt directory.
@@ -64,6 +65,7 @@ Examples:
   $0 --harness codex          # Codex CLI only
   $0 --harness all --symlink  # symlink instead of copy
   $0 --dry-run --harness all  # print plan, change nothing
+  $0 --harness claude --update  # idempotent re-install (overwrite existing)
 EOF
 }
 
@@ -138,6 +140,9 @@ while [ $# -gt 0 ]; do
             ;;
         --dry-run)
             DRY_RUN=1
+            ;;
+        --update)
+            UPDATE_MODE=1
             ;;
         -h|--help)
             usage
@@ -272,7 +277,11 @@ info ""
 if [ "$DRY_RUN" -eq 1 ]; then
     info "Dry run complete. No files were written."
 else
-    info "Installed:"
+    if [ "$UPDATE_MODE" -eq 1 ]; then
+        info "Updated (idempotent overwrite):"
+    else
+        info "Installed:"
+    fi
     printf '%b' "$installed_paths"
     info ""
     info "Invoke with:"

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -10,6 +10,24 @@ Take the populated `auto-implement` queue on the current GitHub repo and run the
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-run/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-run.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-run.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-run/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-run found; run install.sh first.` and exit.
+
 ## Invocation
 
 ```

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -10,6 +10,24 @@ Take the following feature request and ship it through the full pipeline:
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec.md`
+   - Codex CLI:   `~/.codex/prompts/autospec.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec found; run install.sh first.` and exit.
+
 ## Feature request
 
 {FEATURE_DESCRIPTION}

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -6,6 +6,24 @@ Take the following feature request and ship it through the full pipeline:
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec.md`
+   - Codex CLI:   `~/.codex/prompts/autospec.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec found; run install.sh first.` and exit.
+
 ## Feature request
 
 {FEATURE_DESCRIPTION}

--- a/skills/autospec/install.sh
+++ b/skills/autospec/install.sh
@@ -41,6 +41,7 @@ fi
 HARNESS=""
 USE_SYMLINK=0
 DRY_RUN=0
+UPDATE_MODE=0
 TMP_FETCH_DIR=""
 
 # ---------- helpers --------------------------------------------------------
@@ -51,7 +52,7 @@ info() { printf '%s\n' "$*"; }
 
 usage() {
     cat <<EOF
-Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run]
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
 
 Installs the ${SKILL_NAME} skill into the chosen harness's standard
 skill/agent/prompt directory.
@@ -64,6 +65,7 @@ Examples:
   $0 --harness codex          # Codex CLI only
   $0 --harness all --symlink  # symlink instead of copy
   $0 --dry-run --harness all  # print plan, change nothing
+  $0 --harness claude --update  # idempotent re-install (overwrite existing)
 EOF
 }
 
@@ -138,6 +140,9 @@ while [ $# -gt 0 ]; do
             ;;
         --dry-run)
             DRY_RUN=1
+            ;;
+        --update)
+            UPDATE_MODE=1
             ;;
         -h|--help)
             usage
@@ -272,7 +277,11 @@ info ""
 if [ "$DRY_RUN" -eq 1 ]; then
     info "Dry run complete. No files were written."
 else
-    info "Installed:"
+    if [ "$UPDATE_MODE" -eq 1 ]; then
+        info "Updated (idempotent overwrite):"
+    else
+        info "Installed:"
+    fi
     printf '%b' "$installed_paths"
     info ""
     info "Invoke with:"

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -10,6 +10,24 @@ Take the following feature request and ship it through the full pipeline:
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec.md`
+   - Codex CLI:   `~/.codex/prompts/autospec.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec found; run install.sh first.` and exit.
+
 ## Feature request
 
 {FEATURE_DESCRIPTION}


### PR DESCRIPTION
Closes #10.

## Summary

- Inserts `## Self-update mode` into all four skill bodies (autospec, autospec-define, autospec-run, autospec-classify) so invoking `/<skill> update` (case-insensitive) detects the harness, re-runs the canonical install one-liner with `--update`, shows the diff, and stops.
- Adds `--update` flag handling to every per-skill `install.sh` so the install path can be invoked idempotently and reports `Updated (idempotent overwrite)` instead of `Installed`.
- Extends `scripts/validate.sh` with `check_self_update()` to enforce both invariants going forward (Self-update section present in every trio file; install.sh accepts `--update`).

## Validation

- `bash scripts/validate.sh` passes; new self-update check runs for every multi-harness skill.
- Lock-step diffs are clean across all four trios.
- `bash -n` passes on every install.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)