### PR TITLE
feat: add top-level install.sh / uninstall.sh for autospec suite

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# install.sh — top-level orchestrator for the autospec four-skill suite.
+#
+# Delegates to per-skill installers under skills/<skill>/install.sh. Use this
+# script to install every skill into every harness in one call. The per-skill
+# installers remain standalone-callable.
+#
+# Usage:
+#   ./install.sh                                 # install every skill into every harness
+#   ./install.sh --skill autospec                # only one skill
+#   ./install.sh --harness claude                # only one harness
+#   ./install.sh --skill all --harness all       # explicit (same as default)
+#   ./install.sh --skill autospec-run --update   # idempotent re-install
+#   ./install.sh --help                          # show this help
+#
+# Flags:
+#   --skill   one of: autospec | autospec-define | autospec-run | autospec-classify | all
+#             (default: all)
+#   --harness one of: claude | opencode | codex | all
+#             (default: all)
+#   --update  forwarded to each per-skill installer; idempotent overwrite.
+#
+# Exits non-zero on any sub-installer failure; reports per-pair status.
+
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SKILLS_DIR="$REPO_ROOT/skills"
+
+ALL_SKILLS="autospec autospec-define autospec-run autospec-classify"
+ALL_HARNESSES="claude opencode codex"
+
+SKILL_ARG="all"
+HARNESS_ARG="all"
+UPDATE=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --skill)
+            shift
+            SKILL_ARG="${1:-}"
+            ;;
+        --skill=*)
+            SKILL_ARG="${1#--skill=}"
+            ;;
+        --harness)
+            shift
+            HARNESS_ARG="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS_ARG="${1#--harness=}"
+            ;;
+        --update)
+            UPDATE=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# Validate --skill
+case "$SKILL_ARG" in
+    all|autospec|autospec-define|autospec-run|autospec-classify) ;;
+    *)
+        err "invalid --skill: $SKILL_ARG"
+        err "must be one of: autospec | autospec-define | autospec-run | autospec-classify | all"
+        exit 2
+        ;;
+esac
+
+# Validate --harness
+case "$HARNESS_ARG" in
+    all|claude|opencode|codex) ;;
+    *)
+        err "invalid --harness: $HARNESS_ARG"
+        err "must be one of: claude | opencode | codex | all"
+        exit 2
+        ;;
+esac
+
+# Resolve skill list
+if [ "$SKILL_ARG" = "all" ]; then
+    SKILLS_TO_RUN="$ALL_SKILLS"
+else
+    SKILLS_TO_RUN="$SKILL_ARG"
+fi
+
+# Resolve harness list
+if [ "$HARNESS_ARG" = "all" ]; then
+    HARNESSES_TO_RUN="$ALL_HARNESSES"
+else
+    HARNESSES_TO_RUN="$HARNESS_ARG"
+fi
+
+failures=0
+total=0
+
+info ""
+info "autospec suite installer"
+info "  skills:   $SKILLS_TO_RUN"
+info "  harness:  $HARNESSES_TO_RUN"
+[ "$UPDATE" -eq 1 ] && info "  mode:     --update (idempotent overwrite)"
+info ""
+
+for skill in $SKILLS_TO_RUN; do
+    skill_installer="$SKILLS_DIR/$skill/install.sh"
+    if [ ! -f "$skill_installer" ]; then
+        err "missing per-skill installer: $skill_installer"
+        failures=$((failures + 1))
+        continue
+    fi
+    for harness in $HARNESSES_TO_RUN; do
+        total=$((total + 1))
+        info "==> $skill -> $harness"
+        cmd="bash \"$skill_installer\" --harness \"$harness\""
+        if [ "$UPDATE" -eq 1 ]; then
+            cmd="$cmd --update"
+        fi
+        if eval "$cmd"; then
+            info "    OK: $skill ($harness)"
+        else
+            err  "    FAIL: $skill ($harness)"
+            failures=$((failures + 1))
+        fi
+        info ""
+    done
+done
+
+succeeded=$((total - failures))
+info ""
+info "Suite install summary: $succeeded/$total pairs OK ($failures failed)"
+
+if [ "$failures" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# uninstall.sh — top-level orchestrator for removing the autospec suite.
+#
+# Removes the install paths for every (skill, harness) pair selected. Idempotent:
+# missing paths are not an error.
+#
+# Usage:
+#   ./uninstall.sh                                 # remove every skill from every harness
+#   ./uninstall.sh --skill autospec                # only one skill
+#   ./uninstall.sh --harness claude                # only one harness
+#   ./uninstall.sh --skill all --harness all       # explicit (same as default)
+#   ./uninstall.sh --help                          # show this help
+#
+# Flags:
+#   --skill   one of: autospec | autospec-define | autospec-run | autospec-classify | all
+#             (default: all)
+#   --harness one of: claude | opencode | codex | all
+#             (default: all)
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+
+set -eu
+
+ALL_SKILLS="autospec autospec-define autospec-run autospec-classify"
+ALL_HARNESSES="claude opencode codex"
+
+SKILL_ARG="all"
+HARNESS_ARG="all"
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --skill)
+            shift
+            SKILL_ARG="${1:-}"
+            ;;
+        --skill=*)
+            SKILL_ARG="${1#--skill=}"
+            ;;
+        --harness)
+            shift
+            HARNESS_ARG="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS_ARG="${1#--harness=}"
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+case "$SKILL_ARG" in
+    all|autospec|autospec-define|autospec-run|autospec-classify) ;;
+    *)
+        err "invalid --skill: $SKILL_ARG"
+        exit 2
+        ;;
+esac
+case "$HARNESS_ARG" in
+    all|claude|opencode|codex) ;;
+    *)
+        err "invalid --harness: $HARNESS_ARG"
+        exit 2
+        ;;
+esac
+
+if [ "$SKILL_ARG" = "all" ]; then
+    SKILLS_TO_RUN="$ALL_SKILLS"
+else
+    SKILLS_TO_RUN="$SKILL_ARG"
+fi
+if [ "$HARNESS_ARG" = "all" ]; then
+    HARNESSES_TO_RUN="$ALL_HARNESSES"
+else
+    HARNESSES_TO_RUN="$HARNESS_ARG"
+fi
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+removed=0
+missing=0
+
+remove_path() {
+    target="$1"
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        rm -rf "$target"
+        info "  removed: $target"
+        removed=$((removed + 1))
+    else
+        info "  (skip — not present): $target"
+        missing=$((missing + 1))
+    fi
+}
+
+info ""
+info "autospec suite uninstaller"
+info "  skills:   $SKILLS_TO_RUN"
+info "  harness:  $HARNESSES_TO_RUN"
+info ""
+
+for skill in $SKILLS_TO_RUN; do
+    info "==> $skill"
+    for harness in $HARNESSES_TO_RUN; do
+        case "$harness" in
+            claude)
+                remove_path "$CLAUDE_DIR/skills/$skill"
+                ;;
+            opencode)
+                remove_path "$OPENCODE_DIR/agent/$skill.md"
+                ;;
+            codex)
+                remove_path "$CODEX_DIR/prompts/$skill.md"
+                ;;
+        esac
+    done
+    info ""
+done
+
+info ""
+info "Suite uninstall summary: removed=$removed, already-absent=$missing"
+exit 0


### PR DESCRIPTION
Closes #11.

## Summary

- New `install.sh` at repo root orchestrates the four per-skill installers via `--skill` and `--harness` flags (each defaulting to `all`); forwards `--update` to per-skill installers.
- New `uninstall.sh` at repo root removes the install paths for every selected (skill, harness) pair. Idempotent — missing paths are reported as `(skip — not present)` and counted separately.
- Per-skill installers stay standalone-callable; the top-level one is purely a dispatcher.

## Validation

- `bash scripts/validate.sh` passes (already syntax-checks top-level install.sh / uninstall.sh).
- End-to-end test against isolated harness roots: 12/12 install pairs OK; `--update` reports `Updated (idempotent overwrite)`; uninstall removes 12; re-running uninstall is a no-op (`removed=0, already-absent=12`); `--skill bogus` exits non-zero with a clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)