### PR TITLE
docs: update READMEs for the four-skill suite + self-update + Phase 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
-# Codex Skills
+# autospec
 
-Reusable Codex skills for turning repeated workflows into durable, discoverable automation.
+Multi-harness skill suite for shipping a feature end-to-end across many GitHub
+issues — design spec → decomposed `auto-implement` queue → autonomous
+implementation loop with admin auto-merge — split across four cooperating
+skills so each invocation runs only the phases you need. Works on **Claude
+Code**, **OpenCode**, and **Codex CLI**.
 
 ## Skills
 
-| Skill | Purpose |
-| --- | --- |
-| [`autospec`](skills/autospec/README.md) | Ship a feature end-to-end: bootstrap repo if missing, brainstorm/design, decompose into linked GitHub issues, then run an autonomous implementation loop with admin auto-merge. Multi-harness (Claude Code, OpenCode, Codex CLI). |
+| Skill | Phases | Purpose |
+| --- | --- | --- |
+| [`autospec`](skills/autospec/README.md) | 0–6 (incl. **Phase 3.5**) | Full pipeline. Bootstrap repo if missing, design spec, decompose into issues, **review-and-label children with `ctx:*`/`reasoning:*` rubric (Phase 3.5)**, then run autonomous monitor with admin auto-merge. |
+| [`autospec-define`](skills/autospec-define/README.md) | 0–3.5 | Planning half. Stops after Phase 3.5 review-and-label step and hands off to `/autospec-run`. |
+| [`autospec-run`](skills/autospec-run/README.md) | 4–6 | Implementation half. Picks up the populated `auto-implement` queue and runs the autonomous monitor. Supports `--profile <name>` filtering against `~/.autospec/model-profiles.yml`. |
+| [`autospec-classify`](skills/autospec-classify/README.md) | retro | Standalone retro-labeler for already-existing `auto-implement` issues; applies the Phase 3.5 rubric to a queue that pre-dates Phase 3.5. |
 
 ## Repository Layout
 
@@ -31,32 +38,55 @@ Each skill should be self-contained. Keep shared documentation in this repositor
 
 Skills that target only Codex CLI can stick to the original layout (`SKILL.md` plus optional `agents/`, `scripts/`, `references/`, `assets/`). Skills that target multiple harnesses should add the `opencode/`, `codex/`, `install.sh`, `uninstall.sh`, and `README.md` files shown above.
 
-## Installing A Skill
+## Installation
 
-For multi-harness skills (Claude Code, OpenCode, Codex CLI), use the skill's
-bundled installer. The fastest path is the one-line installer described in the
-skill's README, e.g.:
+Install the whole suite into every supported harness in one call:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/berlinguyinca/codex-skills/main/skills/autospec/install.sh | sh -s -- --harness all
+git clone https://github.com/berlinguyinca/autospec.git
+cd autospec
+./install.sh --skill all --harness all
 ```
 
-Or run it from a clone:
+Or pick a subset:
 
 ```bash
-cd skills/autospec
-./install.sh --harness all          # or claude / opencode / codex
+./install.sh --skill autospec-run --harness claude   # one skill, one harness
+./install.sh --skill all          --harness opencode # every skill, one harness
+./install.sh --skill autospec     --harness all      # one skill, every harness
+./uninstall.sh --skill all --harness all             # symmetric uninstall
 ```
 
-For Codex-only skills, copy the skill directory into your Codex skills directory:
+Each per-skill installer remains standalone-callable, e.g.:
 
 ```bash
-mkdir -p ~/.codex/skills
-cp -R skills/<skill-name> ~/.codex/skills/
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec/install.sh \
+  | sh -s -- --harness all
 ```
 
-Start a new Codex session after installation so the skill metadata is loaded.
-See each skill's own README for per-harness install paths and manual fallbacks.
+Honors `CLAUDE_CONFIG_DIR`, `OPENCODE_CONFIG_DIR`, and `CODEX_HOME` if set.
+
+## Self-update
+
+Each installed skill supports an in-place self-update: invoke the skill with
+the literal argument `update` (case-insensitive) and it detects its harness,
+re-runs the canonical install one-liner with `--update`, shows the diff, and
+stops without entering the normal pipeline:
+
+```
+/autospec update
+/autospec-define update
+/autospec-run update
+/autospec-classify update
+```
+
+You can also re-run the suite installer with `--update`:
+
+```bash
+./install.sh --skill all --harness all --update
+```
+
+The flag forces an idempotent overwrite of every (skill, harness) pair.
 
 ## Adding Future Skills
 

--- a/skills/autospec-classify/README.md
+++ b/skills/autospec-classify/README.md
@@ -96,10 +96,17 @@ Default for issues lacking signal: `ctx:64k`, `reasoning:medium`.
 ## Self-update
 
 Once installed, run the skill with the literal argument `update` to refresh in
-place (self-update mode arrives in PR A4):
+place. The skill detects its harness, re-runs the canonical install one-liner
+with `--update`, shows the diff, and stops without classifying any issue:
 
 ```
 /autospec-classify update
+```
+
+Or re-run the per-skill installer with `--update`:
+
+```bash
+./install.sh --harness all --update
 ```
 
 ## License

--- a/skills/autospec-define/README.md
+++ b/skills/autospec-define/README.md
@@ -57,11 +57,18 @@ Phase 3 complete. Run /autospec-run --profile <name> to begin implementation.
 
 ## Self-update
 
-Once installed, run the skill with the literal argument `update` to refresh in place
-(self-update mode arrives in PR A4):
+Once installed, run the skill with the literal argument `update` to refresh in
+place. The skill detects its harness, re-runs the canonical install one-liner
+with `--update`, shows the diff, and stops without entering Phase 0:
 
 ```
 /autospec-define update
+```
+
+Or re-run the per-skill installer with `--update`:
+
+```bash
+./install.sh --harness all --update
 ```
 
 ## Usage

--- a/skills/autospec-run/README.md
+++ b/skills/autospec-run/README.md
@@ -92,10 +92,17 @@ at run-end.
 ## Self-update
 
 Once installed, run the skill with the literal argument `update` to refresh in
-place (self-update mode arrives in PR A4):
+place. The skill detects its harness, re-runs the canonical install one-liner
+with `--update`, shows the diff, and stops without entering Phase 4:
 
 ```
 /autospec-run update
+```
+
+Or re-run the per-skill installer with `--update`:
+
+```bash
+./install.sh --harness all --update
 ```
 
 ## License

--- a/skills/autospec/README.md
+++ b/skills/autospec/README.md
@@ -8,6 +8,30 @@ status deltas along the way.
 
 Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
 
+## Related skills
+
+| Skill | Purpose |
+| --- | --- |
+| [`autospec-define`](../autospec-define/README.md) | Planning half (Phases 0–3.5). Stops after the review-and-label step and hands off to `autospec-run`. |
+| [`autospec-run`](../autospec-run/README.md) | Implementation half (Phases 4–6). Consumes the populated `auto-implement` queue; supports `--profile <name>` filtering. |
+| [`autospec-classify`](../autospec-classify/README.md) | Standalone retro-labeler. Applies the Phase 3.5 `ctx:*` / `reasoning:*` rubric to issues that pre-date Phase 3.5. |
+
+## Self-update
+
+Once installed, run the skill with the literal argument `update` to refresh in
+place. The skill detects its harness, re-runs the canonical install one-liner
+with `--update`, shows the diff, and stops without entering Phase 0:
+
+```
+/autospec update
+```
+
+Or re-run the per-skill installer with `--update`:
+
+```bash
+./install.sh --harness all --update
+```
+
 ## Quick install
 
 One-line install for all three supported agents (Claude Code, OpenCode, Codex CLI):
@@ -61,7 +85,7 @@ Reach for this skill when:
 - You want an opinionated TDD + branch-per-issue + admin-squash-merge loop, not a
   bespoke one.
 
-## Architecture (the 7 phases)
+## Architecture (the phases)
 
 | Phase | Name | One-liner |
 |---|---|---|
@@ -69,6 +93,7 @@ Reach for this skill when:
 | **1** | Investigate (delegate) | Read-only research subagent maps relevant files, schema, services. Real queries against remote systems if the feature touches them. |
 | **2** | Brainstorm + design | Structured 5-section brainstorm (architecture / API / data / errors / testing) with explicit per-section approval, written to `docs/specs/YYYY-MM-DD-<topic>-design.md`. |
 | **3** | Decompose into linked GitHub issues (delegate) | Foreground subagent creates labels, an EPIC umbrella, and N self-contained mini-specs sized for 32B-class local LLMs: file pointers, section anchors, checkbox AC, primary smoke test. |
+| **3.5** | Review and label (delegate) | Foreground subagent applies the `ctx:*` / `reasoning:*` rubric to each child, writes a `## Model fit` block into the body (idempotent), runs sibling-normalization across split children, and validates dep edges (closed-dep / child-less-tracker warnings; circular sibling-dep hard fail). Optional board assignment via `~/.autospec/project-map.yml` (full reader lands in PR B3 / #16). |
 | **4** | Background autonomous monitor | Background subagent loops: pick next ready issue → worktree → TDD → push → PR → self-review → admin-squash-merge → repeat until drained. |
 | **5** | Periodic status updates | Self-paced ~25 min wakeups posting deltas (closed issues, merged PRs, failures, blockers); slows to ~50 min when quiet. |
 | **6** | Final report | When the monitor terminates, summarize every issue processed, PR merged, wall time, and any human-attention failures. |


### PR DESCRIPTION
Closes #12.

## Summary

- Top-level `README.md` rewritten as the autospec suite landing page: Skills table lists all four skills with their phase coverage; new Installation section uses the top-level `install.sh --skill --harness` flags; new Self-update section documents `/<skill> update` and `install.sh --update`.
- `skills/autospec/README.md` gains a Related-skills cross-link table to the other three, gains a Self-update section, and its architecture table now contains a Phase 3.5 row describing the rubric, Model-fit block, sibling normalization, dep-edge sanity checks, and the project-map forward-reference (B3 / #16).
- The other three per-skill READMEs (`autospec-define`, `autospec-run`, `autospec-classify`) had their Self-update sections updated to drop the "arrives in PR A4" caveat (A4 / #10 has shipped) and document the `install.sh --update` fallback alongside the slash-command invocation.

## Validation

- `bash scripts/validate.sh` passes.
- Top-level README mentions all three other skills (count check returned 7 occurrences for `autospec-define|autospec-run|autospec-classify`).
- All four per-skill READMEs document `update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)