### PR TITLE
feat: add project-map.yml reader + auto-init across autospec / autospec-define / autospec-classify

### DIFF
--- a/skills/autospec-classify/SKILL.md
+++ b/skills/autospec-classify/SKILL.md
@@ -42,10 +42,11 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 - `--label <label>` — restrict to issues carrying a specific label
   (default: `auto-implement`).
 - `--apply-boards` — also assign issues to GitHub Projects per
-  `~/.autospec/project-map.yml`. **Currently a documented no-op** until PR B3
-  (issue #16) lands the project-map reader; the flag prints
-  `--apply-boards: project-map reader not yet implemented (lands in B3); skipping board assignment.`
-  and continues with labels-only behavior.
+  `~/.autospec/project-map.yml`. If the file is missing on first run, auto-init
+  writes a starter file keyed on the repo's labels with `null` project numbers
+  and exits with `Wrote ~/.autospec/project-map.yml. Edit project numbers
+  (currently null) and re-run.`. Without `--apply-boards` the project-map is
+  not consulted.
 - `--dry-run` — print proposed labels, model-fit blocks, and board assignments
   without calling `gh issue edit` or `gh project item-add`.
 
@@ -129,11 +130,42 @@ For each candidate issue:
    Apply via `gh issue edit <N> --body-file <tmp>`.
 
 5. **Board assignment** (only if `--apply-boards`):
-   - Today: print
-     `--apply-boards: project-map reader not yet implemented (lands in B3); skipping board assignment for issue <N>.`
-   - When B3 (issue #16) lands, this step reads `~/.autospec/project-map.yml`
-     and calls `gh project item-add` for each matching mapping. The reader will
-     be wired in by replacing this placeholder block.
+   - Read `~/.autospec/project-map.yml`. If the file is missing, auto-init it
+     (see below) and exit so the user can fill in project numbers.
+   - **File schema:**
+     ```yaml
+     # ~/.autospec/project-map.yml
+     multi_match: union          # `union` (assign to every match) or `first`
+     mappings:
+       ctx:32k: <project_number>
+       ctx:64k: <project_number>
+       ctx:120k: <project_number>
+       reasoning:shallow: <project_number>
+       reasoning:medium:  <project_number>
+       reasoning:deep:    <project_number>
+       <any-other-label>: <project_number>
+     ```
+   - **Reader procedure.** For each label L on the issue, look up
+     `mappings[L]`. Skip null / missing entries. With `multi_match: union`
+     (default), assign the issue to every matching project number; with
+     `multi_match: first`, assign only to the first match in label-order.
+     For each chosen `<P>`:
+     `gh project item-add <P> --owner <owner> --url <issue-url>`. The
+     command is idempotent so re-running this skill does not duplicate
+     project items.
+   - **Auto-init when the file is missing.** Probe
+     `gh project list --owner <owner> --format json` to confirm the user
+     can author projects. Probe
+     `gh label list --repo {repo} --json name -q '.[].name'` to enumerate
+     the repo's labels. Write a starter file with every label as a
+     `mappings:` key and `null` project numbers, plus `multi_match: union`
+     at the top. Print:
+     ```
+     Wrote ~/.autospec/project-map.yml. Edit project numbers (currently null) and re-run.
+     ```
+     Then **exit non-zero** (this is a hard stop unique to
+     `--apply-boards`; without the flag the run continues normally).
+   - Skip in `--dry-run`.
 
 ## Sibling normalization (forward reference)
 
@@ -154,7 +186,7 @@ autospec-classify run summary on {repo}
 - skipped (needs-autospec-template): M
 - ctx:32k=A  ctx:64k=B  ctx:120k=C
 - reasoning:shallow=X  reasoning:medium=Y  reasoning:deep=Z
-- boards assigned: 0  (project-map reader lands in B3)
+- boards assigned: <K>  (or "skipped — --apply-boards not set" / "skipped — no project-map.yml")
 ```
 
 ## Hard rules

--- a/skills/autospec-classify/codex/prompt.md
+++ b/skills/autospec-classify/codex/prompt.md
@@ -38,10 +38,11 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 - `--label <label>` — restrict to issues carrying a specific label
   (default: `auto-implement`).
 - `--apply-boards` — also assign issues to GitHub Projects per
-  `~/.autospec/project-map.yml`. **Currently a documented no-op** until PR B3
-  (issue #16) lands the project-map reader; the flag prints
-  `--apply-boards: project-map reader not yet implemented (lands in B3); skipping board assignment.`
-  and continues with labels-only behavior.
+  `~/.autospec/project-map.yml`. If the file is missing on first run, auto-init
+  writes a starter file keyed on the repo's labels with `null` project numbers
+  and exits with `Wrote ~/.autospec/project-map.yml. Edit project numbers
+  (currently null) and re-run.`. Without `--apply-boards` the project-map is
+  not consulted.
 - `--dry-run` — print proposed labels, model-fit blocks, and board assignments
   without calling `gh issue edit` or `gh project item-add`.
 
@@ -125,11 +126,42 @@ For each candidate issue:
    Apply via `gh issue edit <N> --body-file <tmp>`.
 
 5. **Board assignment** (only if `--apply-boards`):
-   - Today: print
-     `--apply-boards: project-map reader not yet implemented (lands in B3); skipping board assignment for issue <N>.`
-   - When B3 (issue #16) lands, this step reads `~/.autospec/project-map.yml`
-     and calls `gh project item-add` for each matching mapping. The reader will
-     be wired in by replacing this placeholder block.
+   - Read `~/.autospec/project-map.yml`. If the file is missing, auto-init it
+     (see below) and exit so the user can fill in project numbers.
+   - **File schema:**
+     ```yaml
+     # ~/.autospec/project-map.yml
+     multi_match: union          # `union` (assign to every match) or `first`
+     mappings:
+       ctx:32k: <project_number>
+       ctx:64k: <project_number>
+       ctx:120k: <project_number>
+       reasoning:shallow: <project_number>
+       reasoning:medium:  <project_number>
+       reasoning:deep:    <project_number>
+       <any-other-label>: <project_number>
+     ```
+   - **Reader procedure.** For each label L on the issue, look up
+     `mappings[L]`. Skip null / missing entries. With `multi_match: union`
+     (default), assign the issue to every matching project number; with
+     `multi_match: first`, assign only to the first match in label-order.
+     For each chosen `<P>`:
+     `gh project item-add <P> --owner <owner> --url <issue-url>`. The
+     command is idempotent so re-running this skill does not duplicate
+     project items.
+   - **Auto-init when the file is missing.** Probe
+     `gh project list --owner <owner> --format json` to confirm the user
+     can author projects. Probe
+     `gh label list --repo {repo} --json name -q '.[].name'` to enumerate
+     the repo's labels. Write a starter file with every label as a
+     `mappings:` key and `null` project numbers, plus `multi_match: union`
+     at the top. Print:
+     ```
+     Wrote ~/.autospec/project-map.yml. Edit project numbers (currently null) and re-run.
+     ```
+     Then **exit non-zero** (this is a hard stop unique to
+     `--apply-boards`; without the flag the run continues normally).
+   - Skip in `--dry-run`.
 
 ## Sibling normalization (forward reference)
 
@@ -150,7 +182,7 @@ autospec-classify run summary on {repo}
 - skipped (needs-autospec-template): M
 - ctx:32k=A  ctx:64k=B  ctx:120k=C
 - reasoning:shallow=X  reasoning:medium=Y  reasoning:deep=Z
-- boards assigned: 0  (project-map reader lands in B3)
+- boards assigned: <K>  (or "skipped — --apply-boards not set" / "skipped — no project-map.yml")
 ```
 
 ## Hard rules

--- a/skills/autospec-classify/opencode/agent.md
+++ b/skills/autospec-classify/opencode/agent.md
@@ -42,10 +42,11 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 - `--label <label>` — restrict to issues carrying a specific label
   (default: `auto-implement`).
 - `--apply-boards` — also assign issues to GitHub Projects per
-  `~/.autospec/project-map.yml`. **Currently a documented no-op** until PR B3
-  (issue #16) lands the project-map reader; the flag prints
-  `--apply-boards: project-map reader not yet implemented (lands in B3); skipping board assignment.`
-  and continues with labels-only behavior.
+  `~/.autospec/project-map.yml`. If the file is missing on first run, auto-init
+  writes a starter file keyed on the repo's labels with `null` project numbers
+  and exits with `Wrote ~/.autospec/project-map.yml. Edit project numbers
+  (currently null) and re-run.`. Without `--apply-boards` the project-map is
+  not consulted.
 - `--dry-run` — print proposed labels, model-fit blocks, and board assignments
   without calling `gh issue edit` or `gh project item-add`.
 
@@ -129,11 +130,42 @@ For each candidate issue:
    Apply via `gh issue edit <N> --body-file <tmp>`.
 
 5. **Board assignment** (only if `--apply-boards`):
-   - Today: print
-     `--apply-boards: project-map reader not yet implemented (lands in B3); skipping board assignment for issue <N>.`
-   - When B3 (issue #16) lands, this step reads `~/.autospec/project-map.yml`
-     and calls `gh project item-add` for each matching mapping. The reader will
-     be wired in by replacing this placeholder block.
+   - Read `~/.autospec/project-map.yml`. If the file is missing, auto-init it
+     (see below) and exit so the user can fill in project numbers.
+   - **File schema:**
+     ```yaml
+     # ~/.autospec/project-map.yml
+     multi_match: union          # `union` (assign to every match) or `first`
+     mappings:
+       ctx:32k: <project_number>
+       ctx:64k: <project_number>
+       ctx:120k: <project_number>
+       reasoning:shallow: <project_number>
+       reasoning:medium:  <project_number>
+       reasoning:deep:    <project_number>
+       <any-other-label>: <project_number>
+     ```
+   - **Reader procedure.** For each label L on the issue, look up
+     `mappings[L]`. Skip null / missing entries. With `multi_match: union`
+     (default), assign the issue to every matching project number; with
+     `multi_match: first`, assign only to the first match in label-order.
+     For each chosen `<P>`:
+     `gh project item-add <P> --owner <owner> --url <issue-url>`. The
+     command is idempotent so re-running this skill does not duplicate
+     project items.
+   - **Auto-init when the file is missing.** Probe
+     `gh project list --owner <owner> --format json` to confirm the user
+     can author projects. Probe
+     `gh label list --repo {repo} --json name -q '.[].name'` to enumerate
+     the repo's labels. Write a starter file with every label as a
+     `mappings:` key and `null` project numbers, plus `multi_match: union`
+     at the top. Print:
+     ```
+     Wrote ~/.autospec/project-map.yml. Edit project numbers (currently null) and re-run.
+     ```
+     Then **exit non-zero** (this is a hard stop unique to
+     `--apply-boards`; without the flag the run continues normally).
+   - Skip in `--dry-run`.
 
 ## Sibling normalization (forward reference)
 
@@ -154,7 +186,7 @@ autospec-classify run summary on {repo}
 - skipped (needs-autospec-template): M
 - ctx:32k=A  ctx:64k=B  ctx:120k=C
 - reasoning:shallow=X  reasoning:medium=Y  reasoning:deep=Z
-- boards assigned: 0  (project-map reader lands in B3)
+- boards assigned: <K>  (or "skipped — --apply-boards not set" / "skipped — no project-map.yml")
 ```
 
 ## Hard rules

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -217,12 +217,37 @@ labels and patches each body with a `## Model fit` block.
 >    markers, replace it in place. Never stack duplicates. Apply via
 >    `gh issue edit <N> --body-file <tmp>`.
 >
-> 6. **Board assignment (forward reference).** If `~/.autospec/project-map.yml`
->    exists, look up each issue's labels in `mappings:` and call
->    `gh project item-add <project_number> --owner <owner> --url <issue-url>`
->    for each match. If the file is missing, warn once and skip — do not fail
->    the phase. Full reader logic lands in PR B3 (#16); this step is a stub
->    today.
+> 6. **Board assignment** — read `~/.autospec/project-map.yml` and assign each
+>    just-classified child to the GitHub Projects mapped from its labels.
+>
+>    **File schema** (auto-init if missing — see below):
+>    ```yaml
+>    # ~/.autospec/project-map.yml
+>    multi_match: union          # `union` (assign to every match) or `first`
+>    mappings:
+>      ctx:32k: <project_number>
+>      ctx:64k: <project_number>
+>      ctx:120k: <project_number>
+>      reasoning:shallow: <project_number>
+>      reasoning:medium:  <project_number>
+>      reasoning:deep:    <project_number>
+>      <any-other-label>: <project_number>
+>    ```
+>
+>    **Reader procedure** for each issue I:
+>    - For each label L on I, look up `mappings[L]`. Skip null / missing entries.
+>    - With `multi_match: union` (default), collect all matching project numbers and assign to every one of them. With `multi_match: first`, take the first match in label-order and assign to that single project.
+>    - For each chosen `<P>`: `gh project item-add <P> --owner <owner> --url <issue-url>`. The `gh` command is idempotent — repeated calls do not duplicate items, so re-running Phase 3.5 is safe.
+>
+>    **Auto-init when the file is missing.** Probe `gh project list --owner <owner> --format json` to confirm the user can author projects. Probe `gh label list --repo {repo} --json name -q '.[].name'` to enumerate the repo's labels. Write a starter file with every label as a `mappings:` key and `null` project numbers, plus `multi_match: union` at the top. Print:
+>    ```
+>    Wrote ~/.autospec/project-map.yml. Edit project numbers (currently null) and re-run.
+>    ```
+>    Then **exit Phase 3.5** without assigning any boards (the labels and `## Model fit` blocks remain applied — only the assign step is deferred).
+>
+>    **Hard rules.**
+>    - Never call `gh project item-add` in `--dry-run`.
+>    - Missing file in `autospec` / `autospec-define` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
 >
 > 7. **Dependency-edge sanity checks.** After labeling, validate the dep graph
 >    of the just-created children:

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -211,12 +211,37 @@ labels and patches each body with a `## Model fit` block.
 >    markers, replace it in place. Never stack duplicates. Apply via
 >    `gh issue edit <N> --body-file <tmp>`.
 >
-> 6. **Board assignment (forward reference).** If `~/.autospec/project-map.yml`
->    exists, look up each issue's labels in `mappings:` and call
->    `gh project item-add <project_number> --owner <owner> --url <issue-url>`
->    for each match. If the file is missing, warn once and skip — do not fail
->    the phase. Full reader logic lands in PR B3 (#16); this step is a stub
->    today.
+> 6. **Board assignment** — read `~/.autospec/project-map.yml` and assign each
+>    just-classified child to the GitHub Projects mapped from its labels.
+>
+>    **File schema** (auto-init if missing — see below):
+>    ```yaml
+>    # ~/.autospec/project-map.yml
+>    multi_match: union          # `union` (assign to every match) or `first`
+>    mappings:
+>      ctx:32k: <project_number>
+>      ctx:64k: <project_number>
+>      ctx:120k: <project_number>
+>      reasoning:shallow: <project_number>
+>      reasoning:medium:  <project_number>
+>      reasoning:deep:    <project_number>
+>      <any-other-label>: <project_number>
+>    ```
+>
+>    **Reader procedure** for each issue I:
+>    - For each label L on I, look up `mappings[L]`. Skip null / missing entries.
+>    - With `multi_match: union` (default), collect all matching project numbers and assign to every one of them. With `multi_match: first`, take the first match in label-order and assign to that single project.
+>    - For each chosen `<P>`: `gh project item-add <P> --owner <owner> --url <issue-url>`. The `gh` command is idempotent — repeated calls do not duplicate items, so re-running Phase 3.5 is safe.
+>
+>    **Auto-init when the file is missing.** Probe `gh project list --owner <owner> --format json` to confirm the user can author projects. Probe `gh label list --repo {repo} --json name -q '.[].name'` to enumerate the repo's labels. Write a starter file with every label as a `mappings:` key and `null` project numbers, plus `multi_match: union` at the top. Print:
+>    ```
+>    Wrote ~/.autospec/project-map.yml. Edit project numbers (currently null) and re-run.
+>    ```
+>    Then **exit Phase 3.5** without assigning any boards (the labels and `## Model fit` blocks remain applied — only the assign step is deferred).
+>
+>    **Hard rules.**
+>    - Never call `gh project item-add` in `--dry-run`.
+>    - Missing file in `autospec` / `autospec-define` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
 >
 > 7. **Dependency-edge sanity checks.** After labeling, validate the dep graph
 >    of the just-created children:

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -215,12 +215,37 @@ labels and patches each body with a `## Model fit` block.
 >    markers, replace it in place. Never stack duplicates. Apply via
 >    `gh issue edit <N> --body-file <tmp>`.
 >
-> 6. **Board assignment (forward reference).** If `~/.autospec/project-map.yml`
->    exists, look up each issue's labels in `mappings:` and call
->    `gh project item-add <project_number> --owner <owner> --url <issue-url>`
->    for each match. If the file is missing, warn once and skip — do not fail
->    the phase. Full reader logic lands in PR B3 (#16); this step is a stub
->    today.
+> 6. **Board assignment** — read `~/.autospec/project-map.yml` and assign each
+>    just-classified child to the GitHub Projects mapped from its labels.
+>
+>    **File schema** (auto-init if missing — see below):
+>    ```yaml
+>    # ~/.autospec/project-map.yml
+>    multi_match: union          # `union` (assign to every match) or `first`
+>    mappings:
+>      ctx:32k: <project_number>
+>      ctx:64k: <project_number>
+>      ctx:120k: <project_number>
+>      reasoning:shallow: <project_number>
+>      reasoning:medium:  <project_number>
+>      reasoning:deep:    <project_number>
+>      <any-other-label>: <project_number>
+>    ```
+>
+>    **Reader procedure** for each issue I:
+>    - For each label L on I, look up `mappings[L]`. Skip null / missing entries.
+>    - With `multi_match: union` (default), collect all matching project numbers and assign to every one of them. With `multi_match: first`, take the first match in label-order and assign to that single project.
+>    - For each chosen `<P>`: `gh project item-add <P> --owner <owner> --url <issue-url>`. The `gh` command is idempotent — repeated calls do not duplicate items, so re-running Phase 3.5 is safe.
+>
+>    **Auto-init when the file is missing.** Probe `gh project list --owner <owner> --format json` to confirm the user can author projects. Probe `gh label list --repo {repo} --json name -q '.[].name'` to enumerate the repo's labels. Write a starter file with every label as a `mappings:` key and `null` project numbers, plus `multi_match: union` at the top. Print:
+>    ```
+>    Wrote ~/.autospec/project-map.yml. Edit project numbers (currently null) and re-run.
+>    ```
+>    Then **exit Phase 3.5** without assigning any boards (the labels and `## Model fit` blocks remain applied — only the assign step is deferred).
+>
+>    **Hard rules.**
+>    - Never call `gh project item-add` in `--dry-run`.
+>    - Missing file in `autospec` / `autospec-define` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
 >
 > 7. **Dependency-edge sanity checks.** After labeling, validate the dep graph
 >    of the just-created children:

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -217,12 +217,37 @@ labels and patches each body with a `## Model fit` block.
 >    markers, replace it in place. Never stack duplicates. Apply via
 >    `gh issue edit <N> --body-file <tmp>`.
 >
-> 6. **Board assignment (forward reference).** If `~/.autospec/project-map.yml`
->    exists, look up each issue's labels in `mappings:` and call
->    `gh project item-add <project_number> --owner <owner> --url <issue-url>`
->    for each match. If the file is missing, warn once and skip — do not fail
->    the phase. Full reader logic lands in PR B3 (#16); this step is a stub
->    today.
+> 6. **Board assignment** — read `~/.autospec/project-map.yml` and assign each
+>    just-classified child to the GitHub Projects mapped from its labels.
+>
+>    **File schema** (auto-init if missing — see below):
+>    ```yaml
+>    # ~/.autospec/project-map.yml
+>    multi_match: union          # `union` (assign to every match) or `first`
+>    mappings:
+>      ctx:32k: <project_number>
+>      ctx:64k: <project_number>
+>      ctx:120k: <project_number>
+>      reasoning:shallow: <project_number>
+>      reasoning:medium:  <project_number>
+>      reasoning:deep:    <project_number>
+>      <any-other-label>: <project_number>
+>    ```
+>
+>    **Reader procedure** for each issue I:
+>    - For each label L on I, look up `mappings[L]`. Skip null / missing entries.
+>    - With `multi_match: union` (default), collect all matching project numbers and assign to every one of them. With `multi_match: first`, take the first match in label-order and assign to that single project.
+>    - For each chosen `<P>`: `gh project item-add <P> --owner <owner> --url <issue-url>`. The `gh` command is idempotent — repeated calls do not duplicate items, so re-running Phase 3.5 is safe.
+>
+>    **Auto-init when the file is missing.** Probe `gh project list --owner <owner> --format json` to confirm the user can author projects. Probe `gh label list --repo {repo} --json name -q '.[].name'` to enumerate the repo's labels. Write a starter file with every label as a `mappings:` key and `null` project numbers, plus `multi_match: union` at the top. Print:
+>    ```
+>    Wrote ~/.autospec/project-map.yml. Edit project numbers (currently null) and re-run.
+>    ```
+>    Then **exit Phase 3.5** without assigning any boards (the labels and `## Model fit` blocks remain applied — only the assign step is deferred).
+>
+>    **Hard rules.**
+>    - Never call `gh project item-add` in `--dry-run`.
+>    - Missing file in `autospec` / `autospec-define` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
 >
 > 7. **Dependency-edge sanity checks.** After labeling, validate the dep graph
 >    of the just-created children:

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -211,12 +211,37 @@ labels and patches each body with a `## Model fit` block.
 >    markers, replace it in place. Never stack duplicates. Apply via
 >    `gh issue edit <N> --body-file <tmp>`.
 >
-> 6. **Board assignment (forward reference).** If `~/.autospec/project-map.yml`
->    exists, look up each issue's labels in `mappings:` and call
->    `gh project item-add <project_number> --owner <owner> --url <issue-url>`
->    for each match. If the file is missing, warn once and skip — do not fail
->    the phase. Full reader logic lands in PR B3 (#16); this step is a stub
->    today.
+> 6. **Board assignment** — read `~/.autospec/project-map.yml` and assign each
+>    just-classified child to the GitHub Projects mapped from its labels.
+>
+>    **File schema** (auto-init if missing — see below):
+>    ```yaml
+>    # ~/.autospec/project-map.yml
+>    multi_match: union          # `union` (assign to every match) or `first`
+>    mappings:
+>      ctx:32k: <project_number>
+>      ctx:64k: <project_number>
+>      ctx:120k: <project_number>
+>      reasoning:shallow: <project_number>
+>      reasoning:medium:  <project_number>
+>      reasoning:deep:    <project_number>
+>      <any-other-label>: <project_number>
+>    ```
+>
+>    **Reader procedure** for each issue I:
+>    - For each label L on I, look up `mappings[L]`. Skip null / missing entries.
+>    - With `multi_match: union` (default), collect all matching project numbers and assign to every one of them. With `multi_match: first`, take the first match in label-order and assign to that single project.
+>    - For each chosen `<P>`: `gh project item-add <P> --owner <owner> --url <issue-url>`. The `gh` command is idempotent — repeated calls do not duplicate items, so re-running Phase 3.5 is safe.
+>
+>    **Auto-init when the file is missing.** Probe `gh project list --owner <owner> --format json` to confirm the user can author projects. Probe `gh label list --repo {repo} --json name -q '.[].name'` to enumerate the repo's labels. Write a starter file with every label as a `mappings:` key and `null` project numbers, plus `multi_match: union` at the top. Print:
+>    ```
+>    Wrote ~/.autospec/project-map.yml. Edit project numbers (currently null) and re-run.
+>    ```
+>    Then **exit Phase 3.5** without assigning any boards (the labels and `## Model fit` blocks remain applied — only the assign step is deferred).
+>
+>    **Hard rules.**
+>    - Never call `gh project item-add` in `--dry-run`.
+>    - Missing file in `autospec` / `autospec-define` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
 >
 > 7. **Dependency-edge sanity checks.** After labeling, validate the dep graph
 >    of the just-created children:

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -215,12 +215,37 @@ labels and patches each body with a `## Model fit` block.
 >    markers, replace it in place. Never stack duplicates. Apply via
 >    `gh issue edit <N> --body-file <tmp>`.
 >
-> 6. **Board assignment (forward reference).** If `~/.autospec/project-map.yml`
->    exists, look up each issue's labels in `mappings:` and call
->    `gh project item-add <project_number> --owner <owner> --url <issue-url>`
->    for each match. If the file is missing, warn once and skip — do not fail
->    the phase. Full reader logic lands in PR B3 (#16); this step is a stub
->    today.
+> 6. **Board assignment** — read `~/.autospec/project-map.yml` and assign each
+>    just-classified child to the GitHub Projects mapped from its labels.
+>
+>    **File schema** (auto-init if missing — see below):
+>    ```yaml
+>    # ~/.autospec/project-map.yml
+>    multi_match: union          # `union` (assign to every match) or `first`
+>    mappings:
+>      ctx:32k: <project_number>
+>      ctx:64k: <project_number>
+>      ctx:120k: <project_number>
+>      reasoning:shallow: <project_number>
+>      reasoning:medium:  <project_number>
+>      reasoning:deep:    <project_number>
+>      <any-other-label>: <project_number>
+>    ```
+>
+>    **Reader procedure** for each issue I:
+>    - For each label L on I, look up `mappings[L]`. Skip null / missing entries.
+>    - With `multi_match: union` (default), collect all matching project numbers and assign to every one of them. With `multi_match: first`, take the first match in label-order and assign to that single project.
+>    - For each chosen `<P>`: `gh project item-add <P> --owner <owner> --url <issue-url>`. The `gh` command is idempotent — repeated calls do not duplicate items, so re-running Phase 3.5 is safe.
+>
+>    **Auto-init when the file is missing.** Probe `gh project list --owner <owner> --format json` to confirm the user can author projects. Probe `gh label list --repo {repo} --json name -q '.[].name'` to enumerate the repo's labels. Write a starter file with every label as a `mappings:` key and `null` project numbers, plus `multi_match: union` at the top. Print:
+>    ```
+>    Wrote ~/.autospec/project-map.yml. Edit project numbers (currently null) and re-run.
+>    ```
+>    Then **exit Phase 3.5** without assigning any boards (the labels and `## Model fit` blocks remain applied — only the assign step is deferred).
+>
+>    **Hard rules.**
+>    - Never call `gh project item-add` in `--dry-run`.
+>    - Missing file in `autospec` / `autospec-define` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
 >
 > 7. **Dependency-edge sanity checks.** After labeling, validate the dep graph
 >    of the just-created children:


### PR DESCRIPTION
Closes #16.

## Summary

- Replaces the Phase 3.5 step-6 stub in `skills/autospec/SKILL.md` and `skills/autospec-define/SKILL.md` with the real `~/.autospec/project-map.yml` reader: documents the file schema (`multi_match: union|first`, `mappings: <label>: <project_number>`), the per-issue reader procedure (`gh project item-add <P> --owner <owner> --url <url>`), and the auto-init behavior (probe `gh project list` + `gh label list`, write starter file with null project numbers, exit Phase 3.5 so the user can fill it in).
- Replaces the placeholder language in `skills/autospec-classify/SKILL.md` (Invocation, Per-issue procedure step 5, Run-end summary). With `--apply-boards`, missing `project-map.yml` auto-inits and exits non-zero; without `--apply-boards`, the file is not consulted.
- Synced trios for all three skills.

## Validation

- `bash scripts/validate.sh` passes.
- `project-map.yml` referenced 4 times in `skills/autospec/SKILL.md`, 4 in `skills/autospec-define/SKILL.md`, 8 in `skills/autospec-classify/SKILL.md`.
- Lock-step diffs are clean across all three trios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)