### PR TITLE
feat(autospec): add Phase 1 anti-loop guardrails (lock-step trio)

### DIFF
--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -92,6 +92,8 @@ Spawn a **read-only research subagent** to map relevant files, schema, services.
 
 > **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
 
+> **Hard limits.** Max 25 tool calls. If 3 consecutive read/grep calls return nothing useful, stop and write your best-effort summary even if incomplete. Do not retry the same query verbatim. No wall-clock cap.
+
 If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
 
 For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -86,6 +86,8 @@ Spawn a **read-only research subagent** to map relevant files, schema, services.
 
 > **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
 
+> **Hard limits.** Max 25 tool calls. If 3 consecutive read/grep calls return nothing useful, stop and write your best-effort summary even if incomplete. Do not retry the same query verbatim. No wall-clock cap.
+
 If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
 
 For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -90,6 +90,8 @@ Spawn a **read-only research subagent** to map relevant files, schema, services.
 
 > **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
 
+> **Hard limits.** Max 25 tool calls. If 3 consecutive read/grep calls return nothing useful, stop and write your best-effort summary even if incomplete. Do not retry the same query verbatim. No wall-clock cap.
+
 If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
 
 For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.


### PR DESCRIPTION
Closes #46

Insert spec §5.1 Hard limits admonition into the Phase 1 research subagent prompt across the autospec lock-step trio.

## Primary smoke
- grep 'Max 25 tool calls' in all 3 files
- grep '3 consecutive read/grep calls' in all 3 files
- bash scripts/validate.sh passes (lock-step diff)