### PR TITLE
feat(autospec): add Phase 4 anti-loop guardrails to autospec trio

### DIFF
--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -308,6 +308,8 @@ Then launch a **background subagent** with this prompt verbatim:
 > ```
 > **Model tier:** Tier B (implementation work) — cheaper model with medium thinking per AGENTS.md. Claude Code: `sonnet`; Codex: `gpt-5.1-codex-spark`; OpenCode: smaller task tier. Fall back UP on unavailability.
 >
+> **Hard limits.** Max 40 tool calls per issue. Max 3 self-review iterations. If you rewrite the same file twice with no test progress, abort: comment the blocker on the issue, release the lock label, exit. No wall-clock cap.
+>
 > Implement GitHub issue #<ISSUE>: "<TITLE>" on {repo}. Spec is the issue body below.
 >
 > ===ISSUE BODY===

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -302,6 +302,8 @@ Then launch a **background subagent** with this prompt verbatim:
 > ```
 > **Model tier:** Tier B (implementation work) — cheaper model with medium thinking per AGENTS.md. Claude Code: `sonnet`; Codex: `gpt-5.1-codex-spark`; OpenCode: smaller task tier. Fall back UP on unavailability.
 >
+> **Hard limits.** Max 40 tool calls per issue. Max 3 self-review iterations. If you rewrite the same file twice with no test progress, abort: comment the blocker on the issue, release the lock label, exit. No wall-clock cap.
+>
 > Implement GitHub issue #<ISSUE>: "<TITLE>" on {repo}. Spec is the issue body below.
 >
 > ===ISSUE BODY===

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -306,6 +306,8 @@ Then launch a **background subagent** with this prompt verbatim:
 > ```
 > **Model tier:** Tier B (implementation work) — cheaper model with medium thinking per AGENTS.md. Claude Code: `sonnet`; Codex: `gpt-5.1-codex-spark`; OpenCode: smaller task tier. Fall back UP on unavailability.
 >
+> **Hard limits.** Max 40 tool calls per issue. Max 3 self-review iterations. If you rewrite the same file twice with no test progress, abort: comment the blocker on the issue, release the lock label, exit. No wall-clock cap.
+>
 > Implement GitHub issue #<ISSUE>: "<TITLE>" on {repo}. Spec is the issue body below.
 >
 > ===ISSUE BODY===


### PR DESCRIPTION
Closes #47

Insert spec §5.1 Phase 4 Hard limits admonition into the implementer subagent prompt across the autospec lock-step trio.

## Primary smoke
- grep 'Max 40 tool calls per issue' in all 3 files
- grep 'Max 3 self-review iterations' in all 3 files
- bash scripts/validate.sh passes