### PR TITLE
feat(autospec-listen): add references/trigger-keywords.md

### DIFF
--- a/skills/autospec-listen/references/trigger-keywords.md
+++ b/skills/autospec-listen/references/trigger-keywords.md
@@ -1,0 +1,42 @@
+# Trigger keywords
+
+Canonical list of trigger phrases the `autospec-listen` skill watches for in
+chat. These are the verbatim phrases from spec §4.4. Matching rules:
+
+- Case-insensitive.
+- Word-boundary anchored (`\b<phrase>\b`).
+- Multi-word phrases match contiguously (whitespace tolerant).
+- Bare nouns are NOT triggers — only the phrases below classify.
+
+## Issue triggers
+
+- `file an issue`
+- `file this as an issue`
+- `new issue`
+- `open an issue`
+- `create a ticket`
+- `make an issue`
+
+## Spec triggers
+
+- `write a spec`
+- `design spec`
+- `new spec`
+- `start a spec`
+- `write a design spec`
+
+## Notes
+
+Bare nouns are NOT triggers. The following do NOT classify:
+
+- `issue` (alone)
+- `spec` (alone)
+- `ticket` (alone)
+
+Phrases like "the issue here is...", "the spec says...", or "this ticket
+needs review" must classify as `none`. Only the imperative-verb phrases above
+fire the listener.
+
+Matching is case-insensitive and word-boundary anchored — embedded triggers
+inside larger sentences DO classify (e.g. "could you file an issue for
+that?" classifies as `issue`).


### PR DESCRIPTION
Closes #37

Adds the canonical trigger-phrase reference at `skills/autospec-listen/references/trigger-keywords.md` enumerating the 6 issue trigger phrases and 5 spec trigger phrases verbatim from spec §4.4, with a footer noting bare nouns are NOT triggers and that matching is case-insensitive + word-boundary anchored.

`scripts/validate.sh` passes.