### PR TITLE
test(unit): add sizing-caps helper + bats

### DIFF
--- a/scripts/sizing-check.sh
+++ b/scripts/sizing-check.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# scripts/sizing-check.sh — validate a draft issue body against the spec
+# §3.4 sizing caps:
+#   - Body ≤400 words (counted across the whole body).
+#   - Implementation outline ≤30 lines (lines under "## Implementation outline"
+#     until the next "## " heading).
+#   - Files touched ≤3 (distinct file paths under the outline; counted as
+#     bullet lines beginning with "- `<path>`" — backtick-delimited paths).
+#
+# Usage:
+#   scripts/sizing-check.sh < body.md      # read body on stdin
+#   cat body.md | scripts/sizing-check.sh
+#
+# Exit codes:
+#   0 — all caps satisfied.
+#   non-zero — at least one cap violated. The script prints the failing
+#     cap name on a single line to stderr (e.g. `body-words`,
+#     `outline-lines`, `outline-files`) and exits 1.
+
+set -eu
+
+WORD_CAP=400
+OUTLINE_LINE_CAP=30
+OUTLINE_FILE_CAP=3
+
+fail() {
+    printf '%s\n' "$1" >&2
+    exit 1
+}
+
+# Slurp stdin into a tmp file so we can scan it multiple times.
+TMP="$(mktemp -t sizing-check.XXXXXX)"
+trap 'rm -f "$TMP"' EXIT INT TERM
+cat > "$TMP"
+
+# 1. Body word count.
+words="$(wc -w < "$TMP" | awk '{print $1}')"
+if [ "$words" -gt "$WORD_CAP" ]; then
+    fail "body-words: ${words} > ${WORD_CAP}"
+fi
+
+# 2. Implementation outline line count.
+# Extract everything between `## Implementation outline` and the next `## `.
+outline_lines="$(awk '
+    /^## Implementation outline/ { in_section = 1; next }
+    /^## / && in_section { exit }
+    in_section { print }
+' "$TMP" | grep -c -E '\S' || true)"
+if [ "$outline_lines" -gt "$OUTLINE_LINE_CAP" ]; then
+    fail "outline-lines: ${outline_lines} > ${OUTLINE_LINE_CAP}"
+fi
+
+# 3. Distinct file paths in the outline.
+# A file path here is any backtick-quoted token on a bullet line that
+# starts with "- `". Count distinct values.
+outline_files="$(awk '
+    /^## Implementation outline/ { in_section = 1; next }
+    /^## / && in_section { exit }
+    in_section && /^- `/ {
+        line = $0
+        sub(/^- `/, "", line)
+        idx = index(line, "`")
+        if (idx > 0) {
+            print substr(line, 1, idx - 1)
+        }
+    }
+' "$TMP" | awk 'NF > 0' | sort -u | wc -l | awk '{print $1}')"
+if [ "$outline_files" -gt "$OUTLINE_FILE_CAP" ]; then
+    fail "outline-files: ${outline_files} > ${OUTLINE_FILE_CAP}"
+fi
+
+exit 0

--- a/tests/unit/test_sizing_caps.bats
+++ b/tests/unit/test_sizing_caps.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# tests/unit/test_sizing_caps.bats — exercises scripts/sizing-check.sh
+# against positive (compliant) and negative (over-cap) fixture bodies for
+# each of the three §3.4 caps:
+#   - Body ≤400 words
+#   - Implementation outline ≤30 lines
+#   - Files touched ≤3
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SIZING="$REPO_ROOT/scripts/sizing-check.sh"
+}
+
+# ---- helpers -------------------------------------------------------------
+
+# Generate a body with N "word" tokens — used to drive the body-words cap.
+gen_words() {
+    n="$1"
+    i=0
+    while [ "$i" -lt "$n" ]; do
+        printf 'word '
+        i=$((i + 1))
+    done
+}
+
+# Generate an outline section with N bullet lines, each touching a unique
+# file path (so the file-cap is not the trigger — we are testing the
+# line-count cap).
+gen_outline_lines() {
+    n="$1"
+    printf '## Implementation outline\n'
+    i=0
+    while [ "$i" -lt "$n" ]; do
+        printf '- `path/file_%d.txt` — note line.\n' "$i"
+        i=$((i + 1))
+    done
+}
+
+# Generate an outline section with N distinct file paths (one bullet each).
+gen_outline_files() {
+    n="$1"
+    gen_outline_lines "$n"
+}
+
+# ---- body-words cap ------------------------------------------------------
+
+@test "body-words: 100 words passes (under cap)" {
+    body="$(gen_words 100)"
+    run bash -c "printf '%s\n' \"$body\" | '$SIZING'"
+    [ "$status" -eq 0 ]
+}
+
+@test "body-words: 400 words passes (at cap)" {
+    body="$(gen_words 400)"
+    run bash -c "printf '%s\n' \"$body\" | '$SIZING'"
+    [ "$status" -eq 0 ]
+}
+
+@test "body-words: 401 words fails (over cap)" {
+    body="$(gen_words 401)"
+    run bash -c "printf '%s\n' \"$body\" | '$SIZING'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *body-words* ]]
+}
+
+# ---- outline-lines cap ---------------------------------------------------
+
+@test "outline-lines: 10 bullets passes (under cap)" {
+    body="$(gen_outline_lines 10)"
+    run bash -c "printf '%s\n' \"$body\" | '$SIZING'"
+    # Note: 10 bullets = 10 outline lines, plus 10 distinct files (over the
+    # file cap). To isolate the line cap, ensure file count ≤ 3 by reusing
+    # one path. Re-render with shared paths.
+    body="$(printf '## Implementation outline\n'; i=0; while [ "$i" -lt 10 ]; do printf -- '- `path/a.txt` — note line.\n'; i=$((i + 1)); done)"
+    run bash -c "printf '%s\n' \"$body\" | '$SIZING'"
+    [ "$status" -eq 0 ]
+}
+
+@test "outline-lines: 30 bullets passes (at cap)" {
+    body="$(printf '## Implementation outline\n'; i=0; while [ "$i" -lt 30 ]; do printf -- '- `path/a.txt` — n.\n'; i=$((i + 1)); done)"
+    run bash -c "printf '%s\n' \"$body\" | '$SIZING'"
+    [ "$status" -eq 0 ]
+}
+
+@test "outline-lines: 31 bullets fails (over cap)" {
+    body="$(printf '## Implementation outline\n'; i=0; while [ "$i" -lt 31 ]; do printf -- '- `path/a.txt` — n.\n'; i=$((i + 1)); done)"
+    run bash -c "printf '%s\n' \"$body\" | '$SIZING'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *outline-lines* ]]
+}
+
+# ---- outline-files cap ---------------------------------------------------
+
+@test "outline-files: 3 distinct files passes (at cap)" {
+    body="$(printf '## Implementation outline\n- \`a.txt\` — n.\n- \`b.txt\` — n.\n- \`c.txt\` — n.\n')"
+    run bash -c "printf '%s\n' \"$body\" | '$SIZING'"
+    [ "$status" -eq 0 ]
+}
+
+@test "outline-files: 4 distinct files fails (over cap)" {
+    body="$(printf '## Implementation outline\n- \`a.txt\` — n.\n- \`b.txt\` — n.\n- \`c.txt\` — n.\n- \`d.txt\` — n.\n')"
+    run bash -c "printf '%s\n' \"$body\" | '$SIZING'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *outline-files* ]]
+}
+
+@test "outline-files: 5 bullets all referencing the same path passes" {
+    body="$(printf '## Implementation outline\n- \`shared.txt\` — n.\n- \`shared.txt\` — n.\n- \`shared.txt\` — n.\n- \`shared.txt\` — n.\n- \`shared.txt\` — n.\n')"
+    run bash -c "printf '%s\n' \"$body\" | '$SIZING'"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #57

Adds:

- `scripts/sizing-check.sh` — reads markdown body on stdin and exits non-zero if any §3.4 cap is violated, printing the failing cap name (`body-words`, `outline-lines`, or `outline-files`).
- `tests/unit/test_sizing_caps.bats` — 9 `@test` blocks (≥6 required) covering positive and negative fixtures for each cap.

Caps enforced:

- Body ≤400 words
- Implementation outline ≤30 lines (rows under `## Implementation outline` until next `## `)
- Files touched ≤3 (distinct backtick-quoted paths in outline bullets)

`bats tests/unit/test_sizing_caps.bats` -> all 9 pass.
`scripts/validate.sh` passes.