### PR TITLE
docs(contributing): document bats workflow + golden refresh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,50 @@ Only include optional directories when they are useful.
 - Helper scripts have been syntax-checked or run in dry-run mode.
 - Large examples or templates are moved out of `SKILL.md`.
 - README and `SKILLS.md` are updated.
+
+## Testing
+
+Every PR is expected to leave the test suite green. The recommended local
+loop is:
+
+1. **Bootstrap** — install the dev dependencies (`bats`, `gh`, `jq`,
+   `python3`, etc.) once per machine:
+
+   ```bash
+   bash scripts/dev-bootstrap.sh
+   ```
+
+2. **Run the suites** — fast unit + smoke tests plus the repo-wide
+   validator:
+
+   ```bash
+   bats tests/unit tests/smoke && scripts/validate.sh
+   ```
+
+   The `bats` run is well under a minute on commodity hardware. E2E
+   tests (`tests/e2e/*.bats`) are opt-in: they create throwaway gh
+   repos and should only run when the GitHub credentials in the
+   environment are willing to absorb the side-effect.
+
+3. **Validate before pushing** — `scripts/validate.sh` enforces the
+   lock-step body rule across every multi-harness skill plus the
+   self-update / model-tier invariants. Treat a non-zero exit as a
+   blocker.
+
+### Updating goldens
+
+Several tests compare subagent output against committed golden files
+under `tests/golden/`. When a deliberate body change makes a golden go
+stale, regenerate it via:
+
+```bash
+tests/refresh-goldens.sh
+```
+
+The script pairs each fixture in `tests/fixtures/` with its target
+golden in `tests/golden/` and prints the manual subagent-capture step a
+maintainer is expected to run (per spec §6.4 the loop is intentionally
+manual). Replay the fixture through the corresponding skill, capture
+the output, and replace the golden file in-place. Commit the diff
+alongside the body change that motivated the refresh — never commit a
+stale golden.


### PR DESCRIPTION
Closes #64

Adds a `Testing` section to `CONTRIBUTING.md` per spec §6.5 / §7.1:

- `bash scripts/dev-bootstrap.sh` — one-time dev dependency install.
- `bats tests/unit tests/smoke && scripts/validate.sh` — recommended pre-push loop. E2E tests are opt-in.
- `scripts/validate.sh` documented as the gating invariant.

Adds an `Updating goldens` subsection pointing at `tests/refresh-goldens.sh` and explaining the manual subagent-capture loop per spec §6.4.

`scripts/validate.sh` passes; mentions of `dev-bootstrap.sh`, `bats tests/unit tests/smoke`, and `refresh-goldens` are all present in CONTRIBUTING.md.