### PR TITLE
feat(scripts): extend validate.sh with new file + heading checks

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -169,6 +169,56 @@ check_agents_md_subagent_section() {
         || fail "AGENTS.md missing '### Tier B — Implementation work' subheading"
 }
 
+# Listener skill must ship a complete trio plus references/trigger-keywords.md
+# and a README. Per spec §6.1, validate enforces presence of every required
+# file so the skill is never partially shipped.
+check_autospec_listen_files() {
+    info "presence: skills/autospec-listen/"
+    listen_dir="skills/autospec-listen"
+    [ -d "$listen_dir" ] || fail "$listen_dir: directory missing"
+    for f in \
+        SKILL.md \
+        install.sh \
+        uninstall.sh \
+        opencode/agent.md \
+        codex/prompt.md \
+        references/trigger-keywords.md \
+        README.md
+    do
+        [ -f "$listen_dir/$f" ] || fail "$listen_dir/$f: required file missing"
+    done
+}
+
+# Examples must ship the canonical model-profiles.yml + project-map.yml so
+# users can copy them into ~/.autospec/ on day one (spec §6.1, §7.1).
+check_examples_dir() {
+    info "presence: examples/"
+    [ -d examples ] || fail "examples/: directory missing"
+    for f in model-profiles.yml project-map.yml README.md; do
+        [ -f "examples/$f" ] || fail "examples/$f: required file missing"
+    done
+}
+
+# Governance copy: the listener lifecycle and anti-loop guardrails must be
+# documented in AGENTS.md, and the listener skill must appear in both the
+# top-level README.md and SKILLS.md skill index. Spec §6.1, §7.1.
+check_governance_headings() {
+    info "governance headings: AGENTS.md / README.md / SKILLS.md"
+    [ -f AGENTS.md ] || fail "AGENTS.md: file missing at repo root"
+    grep -q '^## Anti-loop guardrails' AGENTS.md \
+        || fail "AGENTS.md: missing '## Anti-loop guardrails' heading"
+    grep -q '^## Listener-filed issues lifecycle' AGENTS.md \
+        || fail "AGENTS.md: missing '## Listener-filed issues lifecycle' heading"
+
+    [ -f README.md ] || fail "README.md: file missing at repo root"
+    grep -q 'autospec-listen' README.md \
+        || fail "README.md: missing 'autospec-listen' reference"
+
+    [ -f SKILLS.md ] || fail "SKILLS.md: file missing at repo root"
+    grep -q 'autospec-listen' SKILLS.md \
+        || fail "SKILLS.md: missing 'autospec-listen' reference"
+}
+
 main() {
     info "scanning multi-harness skills under skills/ ..."
     skills="$(discover_skills)"
@@ -188,6 +238,9 @@ main() {
     done
 
     check_agents_md_subagent_section
+    check_autospec_listen_files
+    check_examples_dir
+    check_governance_headings
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.

--- a/tests/unit/test_validate_extension.bats
+++ b/tests/unit/test_validate_extension.bats
@@ -1,0 +1,195 @@
+#!/usr/bin/env bats
+# tests/unit/test_validate_extension.bats — exercise the new check functions
+# added to scripts/validate.sh (presence checks for skills/autospec-listen,
+# examples/, and governance headings in AGENTS.md / README.md / SKILLS.md).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    VALIDATE="$REPO_ROOT/scripts/validate.sh"
+    # Per-test scratch root mirroring the repo layout for hermetic checks.
+    SCRATCH="$(mktemp -d)"
+    export SCRATCH
+}
+
+teardown() {
+    if [ -n "${SCRATCH:-}" ] && [ -d "$SCRATCH" ]; then
+        rm -rf "$SCRATCH"
+    fi
+}
+
+# ---- baseline ------------------------------------------------------------
+
+@test "validate.sh: passes against the real repo as-is" {
+    run bash "$VALIDATE"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate.sh: bash -n syntax check passes" {
+    run bash -n "$VALIDATE"
+    [ "$status" -eq 0 ]
+}
+
+# ---- new check functions exist as named functions ------------------------
+
+@test "validate.sh: defines check_autospec_listen_files" {
+    run grep -q '^check_autospec_listen_files()' "$VALIDATE"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate.sh: defines check_examples_dir" {
+    run grep -q '^check_examples_dir()' "$VALIDATE"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate.sh: defines check_governance_headings" {
+    run grep -q '^check_governance_headings()' "$VALIDATE"
+    [ "$status" -eq 0 ]
+}
+
+# ---- removing a required listener file makes validate fail ---------------
+
+# Helper: clone the repo working set into a per-test scratch, run the
+# scratch copy of validate.sh and capture its exit code.
+_run_scratch_validate() {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    (cd "$SCRATCH" && bash scripts/validate.sh)
+}
+
+@test "validate.sh: fails when skills/autospec-listen/SKILL.md is missing" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    rm -f "$SCRATCH/skills/autospec-listen/SKILL.md"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'skills/autospec-listen/SKILL.md'
+}
+
+@test "validate.sh: fails when skills/autospec-listen/install.sh is missing" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    rm -f "$SCRATCH/skills/autospec-listen/install.sh"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    # The pre-existing per-skill check reports as
+    # "autospec-listen: missing required file install.sh"; the new check
+    # reports as "skills/autospec-listen/install.sh: required file missing".
+    # Either is acceptable.
+    echo "$output" | grep -E 'install\.sh' >/dev/null
+    echo "$output" | grep -F 'autospec-listen' >/dev/null
+}
+
+@test "validate.sh: fails when skills/autospec-listen/uninstall.sh is missing" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    rm -f "$SCRATCH/skills/autospec-listen/uninstall.sh"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -E 'uninstall\.sh' >/dev/null
+    echo "$output" | grep -F 'autospec-listen' >/dev/null
+}
+
+@test "validate.sh: fails when skills/autospec-listen/opencode/agent.md is missing" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    rm -f "$SCRATCH/skills/autospec-listen/opencode/agent.md"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'skills/autospec-listen/opencode/agent.md'
+}
+
+@test "validate.sh: fails when skills/autospec-listen/codex/prompt.md is missing" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    rm -f "$SCRATCH/skills/autospec-listen/codex/prompt.md"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'skills/autospec-listen/codex/prompt.md'
+}
+
+@test "validate.sh: fails when references/trigger-keywords.md is missing" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    rm -f "$SCRATCH/skills/autospec-listen/references/trigger-keywords.md"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'references/trigger-keywords.md'
+}
+
+@test "validate.sh: fails when skills/autospec-listen/README.md is missing" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    rm -f "$SCRATCH/skills/autospec-listen/README.md"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'README.md' >/dev/null
+    echo "$output" | grep -F 'autospec-listen' >/dev/null
+}
+
+# ---- removing a required examples file makes validate fail --------------
+
+@test "validate.sh: fails when examples/model-profiles.yml is missing" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    rm -f "$SCRATCH/examples/model-profiles.yml"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'examples/model-profiles.yml'
+}
+
+@test "validate.sh: fails when examples/project-map.yml is missing" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    rm -f "$SCRATCH/examples/project-map.yml"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'examples/project-map.yml'
+}
+
+@test "validate.sh: fails when examples/README.md is missing" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    rm -f "$SCRATCH/examples/README.md"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'examples/README.md'
+}
+
+# ---- governance headings ------------------------------------------------
+
+@test "validate.sh: fails when AGENTS.md is missing '## Anti-loop guardrails' heading" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    # Rewrite AGENTS.md without the heading.
+    grep -v '^## Anti-loop guardrails' "$REPO_ROOT/AGENTS.md" > "$SCRATCH/AGENTS.md"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'Anti-loop guardrails'
+}
+
+@test "validate.sh: fails when AGENTS.md is missing '## Listener-filed issues lifecycle' heading" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    grep -v '^## Listener-filed issues lifecycle' "$REPO_ROOT/AGENTS.md" > "$SCRATCH/AGENTS.md"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'Listener-filed issues lifecycle'
+}
+
+@test "validate.sh: fails when README.md does not mention autospec-listen" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    grep -v 'autospec-listen' "$REPO_ROOT/README.md" > "$SCRATCH/README.md"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'README.md'
+}
+
+@test "validate.sh: fails when SKILLS.md does not mention autospec-listen" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    grep -v 'autospec-listen' "$REPO_ROOT/SKILLS.md" > "$SCRATCH/SKILLS.md"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'SKILLS.md'
+}


### PR DESCRIPTION
Closes #54

## Summary

Extends `scripts/validate.sh` with three new check functions that pin
the listener skill, examples/, and governance headings in place so
they cannot regress silently:

- `check_autospec_listen_files()` — every required file under
  `skills/autospec-listen/` (SKILL trio, install/uninstall, README,
  `references/trigger-keywords.md`).
- `check_examples_dir()` — `examples/{model-profiles.yml,project-map.yml,README.md}`.
- `check_governance_headings()` — `## Anti-loop guardrails` and
  `## Listener-filed issues lifecycle` headings in `AGENTS.md`, plus
  the `autospec-listen` row in `README.md` and `SKILLS.md`.

## Tests

`tests/unit/test_validate_extension.bats` (19 tests):
- Baseline: validate.sh passes against the real repo, syntax-checks clean.
- Function presence: all three new check functions exist as named functions.
- Negative: removing any required file or heading causes validate.sh to
  exit non-zero with a diagnostic naming the missing target.

All 67 unit tests pass.

Spec ref: `docs/specs/2026-05-01-autospec-meta-improvements-design.md` §6.1, §7.1.