### PR TITLE
test(smoke): add install-all-skills roundtrip bats

### DIFF
--- a/tests/smoke/test_install_all_skills.bats
+++ b/tests/smoke/test_install_all_skills.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# tests/smoke/test_install_all_skills.bats — round-trip the top-level
+# install.sh --skill all into a per-test tmpdir HOME and assert that all
+# 5 skill bodies land for every harness, and uninstall removes them.
+#
+# Spec ref: docs/specs/2026-05-01-autospec-meta-improvements-design.md §6.2, §6.3.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    INSTALL="$REPO_ROOT/install.sh"
+    UNINSTALL="$REPO_ROOT/uninstall.sh"
+
+    # Per-test fake HOME to keep the real env untouched.
+    FAKE_HOME="$(mktemp -d)"
+    export HOME="$FAKE_HOME"
+    export CLAUDE_CONFIG_DIR="$FAKE_HOME/.claude"
+    export OPENCODE_CONFIG_DIR="$FAKE_HOME/.config/opencode"
+    export CODEX_HOME="$FAKE_HOME/.codex"
+
+    SKILLS="autospec autospec-define autospec-run autospec-classify autospec-listen"
+}
+
+teardown() {
+    if [ -n "${FAKE_HOME:-}" ] && [ -d "$FAKE_HOME" ]; then
+        rm -rf "$FAKE_HOME"
+    fi
+}
+
+# Helpers.
+_claude_path() { printf '%s/.claude/skills/%s/SKILL.md' "$FAKE_HOME" "$1"; }
+_opencode_path() { printf '%s/.config/opencode/agent/%s.md' "$FAKE_HOME" "$1"; }
+_codex_path() { printf '%s/.codex/prompts/%s.md' "$FAKE_HOME" "$1"; }
+
+# ---- install all 5 skills -----------------------------------------------
+
+@test "install --skill all places 5 skill bodies (one per skill, each harness)" {
+    run bash "$INSTALL" --skill all --harness all
+    [ "$status" -eq 0 ]
+    for s in $SKILLS; do
+        [ -f "$(_claude_path "$s")" ]
+        [ -f "$(_opencode_path "$s")" ]
+        [ -f "$(_codex_path "$s")" ]
+    done
+}
+
+# ---- uninstall cleans up -------------------------------------------------
+
+@test "uninstall --skill all cleans up every harness file" {
+    bash "$INSTALL" --skill all --harness all >/dev/null
+    # Sanity: at least one was placed.
+    [ -f "$(_claude_path autospec)" ]
+
+    run bash "$UNINSTALL" --skill all --harness all
+    [ "$status" -eq 0 ]
+    for s in $SKILLS; do
+        [ ! -f "$(_claude_path "$s")" ]
+        [ ! -f "$(_opencode_path "$s")" ]
+        [ ! -f "$(_codex_path "$s")" ]
+    done
+}
+
+# ---- idempotency ---------------------------------------------------------
+
+@test "install --skill all is idempotent (running twice exits 0 both times)" {
+    run bash "$INSTALL" --skill all --harness all
+    [ "$status" -eq 0 ]
+    run bash "$INSTALL" --skill all --harness all
+    [ "$status" -eq 0 ]
+    for s in $SKILLS; do
+        [ -f "$(_claude_path "$s")" ]
+        [ -f "$(_opencode_path "$s")" ]
+        [ -f "$(_codex_path "$s")" ]
+    done
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,7 +12,7 @@
 #   ./uninstall.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-define | autospec-run | autospec-classify | all
+#   --skill   one of: autospec | autospec-define | autospec-run | autospec-classify | autospec-listen | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -24,7 +24,7 @@
 
 set -eu
 
-ALL_SKILLS="autospec autospec-define autospec-run autospec-classify"
+ALL_SKILLS="autospec autospec-define autospec-run autospec-classify autospec-listen"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -67,7 +67,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$SKILL_ARG" in
-    all|autospec|autospec-define|autospec-run|autospec-classify) ;;
+    all|autospec|autospec-define|autospec-run|autospec-classify|autospec-listen) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
         exit 2


### PR DESCRIPTION
Closes #58

## Summary
- Adds `tests/smoke/test_install_all_skills.bats` — round-trips the top-level `install.sh --skill all` into a tmpdir HOME and asserts all 5 skill bodies land for every harness.
- Verifies `uninstall.sh --skill all` cleans every harness file.
- Asserts `install.sh --skill all` is idempotent.
- Bug-fix: top-level `uninstall.sh` ALL_SKILLS list omitted `autospec-listen`; the new smoke test caught that, and the list now matches `install.sh`.

## Tests
3 named test blocks (matching the issue's acceptance criteria):
- install --skill all places 5 skill bodies
- uninstall --skill all cleans up
- install is idempotent

`scripts/validate.sh` passes.

Spec ref: docs/specs/2026-05-01-autospec-meta-improvements-design.md §6.2, §6.3.