### PR TITLE
feat(ci): add validate.yml workflow for push + PR

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,38 @@
+name: validate
+
+# Run the repository-wide validation harness on every push and pull_request.
+# Spec ref: docs/specs/2026-05-01-autospec-meta-improvements-design.md §6.6.
+#
+# Steps:
+#   1. checkout the workspace
+#   2. dev-bootstrap (installs bats-core if missing; verifies gh/jq/python3)
+#   3. scripts/validate.sh — repository-wide presence and lock-step checks
+#   4. bats tests/unit tests/smoke — fast tests, target <60s wall time
+#
+# E2E tests are NOT run here — see .github/workflows/e2e.yml (gated on the
+# `e2e` PR label) for those.
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    name: validate (bootstrap + validate.sh + bats unit/smoke)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Bootstrap dev environment (bats-core, tool checks)
+        shell: bash
+        run: bash scripts/dev-bootstrap.sh
+
+      - name: Run scripts/validate.sh
+        shell: bash
+        run: bash scripts/validate.sh
+
+      - name: Run bats unit + smoke tests
+        shell: bash
+        run: bats tests/unit tests/smoke

--- a/tests/unit/test_validate_workflow.bats
+++ b/tests/unit/test_validate_workflow.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+# tests/unit/test_validate_workflow.bats — assert that the validate.yml
+# CI workflow exists, parses as YAML, and contains the required triggers
+# and steps.
+#
+# Spec ref: docs/specs/2026-05-01-autospec-meta-improvements-design.md §6.6.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    WORKFLOW="$REPO_ROOT/.github/workflows/validate.yml"
+}
+
+@test ".github/workflows/validate.yml exists" {
+    [ -f "$WORKFLOW" ]
+}
+
+@test "validate.yml is valid YAML" {
+    if ! command -v python3 >/dev/null 2>&1; then
+        skip "python3 not available"
+    fi
+    run python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate.yml triggers on push" {
+    run grep -q '^  *push:' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate.yml triggers on pull_request" {
+    run grep -q '^  *pull_request:' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate.yml runs scripts/dev-bootstrap.sh" {
+    run grep -q 'scripts/dev-bootstrap.sh' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate.yml runs scripts/validate.sh" {
+    run grep -q 'scripts/validate.sh' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate.yml runs bats tests/unit tests/smoke" {
+    run grep -q 'bats tests/unit tests/smoke' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate.yml uses ubuntu-latest" {
+    run grep -q 'runs-on: ubuntu-latest' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate.yml uses actions/checkout@v4" {
+    run grep -q 'actions/checkout@v4' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #69

## Summary
- Adds `.github/workflows/validate.yml` — runs the repo-wide validation harness on every push and pull_request.
- Steps: checkout → `scripts/dev-bootstrap.sh` → `scripts/validate.sh` → `bats tests/unit tests/smoke`. 5-minute timeout.
- E2E tests are NOT run here (separate gated workflow in #70).

## Tests
`tests/unit/test_validate_workflow.bats` (9 tests):
- file exists, parses as YAML
- triggers on `push` + `pull_request`
- runs `dev-bootstrap.sh` + `validate.sh` + `bats tests/unit tests/smoke`
- runs on `ubuntu-latest`, uses `actions/checkout@v4`

`scripts/validate.sh` and all 86 unit/smoke tests pass locally.

Spec ref: docs/specs/2026-05-01-autospec-meta-improvements-design.md §6.6.