### PR TITLE
feat(ci): add e2e.yml workflow gated by e2e label

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,37 @@
+name: e2e
+
+# Opt-in end-to-end tests. Runs only when:
+#   * a PR is labeled `e2e` (each fresh `labeled` event re-runs), or
+#   * triggered manually via `workflow_dispatch`.
+#
+# Per AGENTS.md, e2e tests are real-services-only — they create and tear
+# down throwaway gh repos using the workflow's GITHUB_TOKEN. Cleanup is
+# handled inside each bats file's `teardown()`/trap so a crashed run
+# never leaks.
+#
+# Spec ref: docs/specs/2026-05-01-autospec-meta-improvements-design.md §6.6.
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: e2e (bats tests/e2e)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'e2e' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Bootstrap dev environment (bats-core, tool checks)
+        shell: bash
+        run: bash scripts/dev-bootstrap.sh
+
+      - name: Run bats tests/e2e
+        shell: bash
+        run: bats tests/e2e

--- a/tests/unit/test_e2e_workflow.bats
+++ b/tests/unit/test_e2e_workflow.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+# tests/unit/test_e2e_workflow.bats — assert that the e2e.yml CI workflow
+# exists, parses as YAML, is gated on the `e2e` PR label or
+# workflow_dispatch, and runs `bats tests/e2e`.
+#
+# Spec ref: docs/specs/2026-05-01-autospec-meta-improvements-design.md §6.6.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    WORKFLOW="$REPO_ROOT/.github/workflows/e2e.yml"
+}
+
+@test ".github/workflows/e2e.yml exists" {
+    [ -f "$WORKFLOW" ]
+}
+
+@test "e2e.yml is valid YAML" {
+    if ! command -v python3 >/dev/null 2>&1; then
+        skip "python3 not available"
+    fi
+    run python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "e2e.yml triggers on pull_request labeled" {
+    run grep -q 'pull_request:' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+    run grep -q 'types:' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+    run grep -qE '\blabeled\b' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "e2e.yml triggers on workflow_dispatch" {
+    run grep -q 'workflow_dispatch:' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "e2e.yml gates the job on the 'e2e' label" {
+    run grep -q "label.name == 'e2e'" "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "e2e.yml runs bats tests/e2e" {
+    run grep -q 'bats tests/e2e' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "e2e.yml uses ubuntu-latest" {
+    run grep -q 'runs-on: ubuntu-latest' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "e2e.yml exposes GH_TOKEN to the run step" {
+    run grep -q 'GH_TOKEN' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "e2e.yml has a 5-minute timeout" {
+    run grep -q 'timeout-minutes: 5' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #70

## Summary
- Adds `.github/workflows/e2e.yml` — opt-in workflow that runs `bats tests/e2e` only when a PR carries the `e2e` label or via manual `workflow_dispatch`.
- Job uses `ubuntu-latest`, exposes `GH_TOKEN` from secrets so throwaway gh repo lifecycle works, capped at 5-minute timeout.
- Cleanup of throwaway repos is owned by the bats `teardown()` blocks.

## Tests
`tests/unit/test_e2e_workflow.bats` (9 tests):
- file exists, parses as YAML
- triggers on `pull_request` (`labeled`) + `workflow_dispatch`
- gates job with `if: github.event.label.name == 'e2e'`
- runs `bats tests/e2e`, exposes `GH_TOKEN`, 5-minute timeout
- runs on `ubuntu-latest`

`scripts/validate.sh` passes; the validate.yml workflow added in #69 will run this PR.

Spec ref: docs/specs/2026-05-01-autospec-meta-improvements-design.md §6.6.