### PR TITLE
feat(autospec-listen): mirror startup preflight to trio

### DIFF
--- a/skills/autospec-listen/SKILL.md
+++ b/skills/autospec-listen/SKILL.md
@@ -10,6 +10,48 @@ Conversation listener that watches for issue-filing or spec-writing intent
 mid-conversation and dispatches to the right downstream flow without forcing
 the user to remember a slash command.
 
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-listen   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
 ## Self-update mode
 
 If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal trigger flow:

--- a/skills/autospec-listen/codex/prompt.md
+++ b/skills/autospec-listen/codex/prompt.md
@@ -5,6 +5,48 @@ Conversation listener that watches for issue-filing or spec-writing intent
 mid-conversation and dispatches to the right downstream flow without forcing
 the user to remember a slash command.
 
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-listen   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
 ## Self-update mode
 
 If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal trigger flow:

--- a/skills/autospec-listen/opencode/agent.md
+++ b/skills/autospec-listen/opencode/agent.md
@@ -9,6 +9,48 @@ Conversation listener that watches for issue-filing or spec-writing intent
 mid-conversation and dispatches to the right downstream flow without forcing
 the user to remember a slash command.
 
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-listen   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
 ## Self-update mode
 
 If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal trigger flow:


### PR DESCRIPTION
Closes #118

Copies the canonical §6 startup self-update bash block from `skills/autospec/SKILL.md` (merged in #115) into all three `autospec-listen` trio files (`SKILL.md`, `opencode/agent.md`, `codex/prompt.md`) with `SKILL_NAME=autospec-listen`. The block is byte-identical to the autospec reference modulo the `SKILL_NAME=` line. Lock-step invariant is preserved and `scripts/validate.sh` passes clean.