### PR TITLE
docs: document startup self-update behavior in README + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,15 @@ Admin-merge `auto-implement` PRs (`gh pr merge <#> --admin --squash --delete-bra
 - The self-review subagent returned `LGTM`.
 - PR closes an `auto-implement` issue from a `feat/*` branch.
 
+## Startup self-update
+
+Every multi-harness skill runs a preflight at startup that updates the installed copy
+from `main` at most once per 24 hours (fail-open: any network or install error logs a
+`WARN:` line and continues). Set `AUTOSPEC_NO_SELF_UPDATE=1` to skip. The canonical
+bash block lives in `skills/autospec/SKILL.md` (`## Startup self-update` section) and
+is mirrored byte-identically (modulo `SKILL_NAME=`) across all five skill trios.
+`scripts/validate.sh` (`check_startup_preflight`) enforces byte-identity.
+
 ## Small-LLM target
 
 Generated child issues are sized for 32B-class local LLMs. Pre-staged context, sectional spec anchors, checkbox AC, one Primary smoke test per inner loop.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/
 
 Honors `CLAUDE_CONFIG_DIR`, `OPENCODE_CONFIG_DIR`, and `CODEX_HOME` if set.
 
+### Auto-update
+
+Each `/autospec*` skill checks `main` for a newer commit at most once per 24 hours at
+startup and reinstalls in place if there is one. The check is fail-open: any network
+or install error logs one `WARN:` line to stderr and proceeds normally.
+Set `AUTOSPEC_NO_SELF_UPDATE=1` to skip the check entirely. For the full contract
+see `## Startup self-update` in `AGENTS.md`.
+
 ## Self-update
 
 Each installed skill supports an in-place self-update: invoke the skill with


### PR DESCRIPTION
Closes #123

Adds a `### Auto-update` subsection to the `README.md` Installation section explaining the 24h rate-limited startup preflight, the fail-open contract, and the `AUTOSPEC_NO_SELF_UPDATE=1` opt-out. Adds a `## Startup self-update` heading to `AGENTS.md` (after `## Auto-merge authority`) codifying the contract and pointing to the canonical block location and `check_startup_preflight` validator. Both files now reference `AUTOSPEC_NO_SELF_UPDATE=1` and `scripts/validate.sh` passes clean.