### PR TITLE
fix(install): write SKILL.md to ~/.codex/skills/<name>/SKILL.md (trio A)

### DIFF
--- a/skills/autospec-define/install.sh
+++ b/skills/autospec-define/install.sh
@@ -268,7 +268,9 @@ if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
     info ""
     info "Codex CLI:"
     install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
     installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
 fi
 
 # ---------- final summary --------------------------------------------------

--- a/skills/autospec-run/install.sh
+++ b/skills/autospec-run/install.sh
@@ -268,7 +268,9 @@ if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
     info ""
     info "Codex CLI:"
     install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
     installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
 fi
 
 # ---------- final summary --------------------------------------------------

--- a/skills/autospec/install.sh
+++ b/skills/autospec/install.sh
@@ -268,7 +268,9 @@ if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
     info ""
     info "Codex CLI:"
     install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
     installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
 fi
 
 # ---------- final summary --------------------------------------------------


### PR DESCRIPTION
Closes #129

Adds a second `install_one` call in the Codex CLI block of `install.sh` for `autospec`, `autospec-define`, and `autospec-run` that writes the canonical `SKILL.md` to `$CODEX_DIR/skills/$SKILL_NAME/SKILL.md` — the path that the Codex CLI slash-command registry actually reads. The legacy `$CODEX_DIR/prompts/$SKILL_NAME.md` install is preserved. Both paths appear in `--dry-run --harness codex` output; `scripts/validate.sh` passes clean.