### PR TITLE
fix(install): write SKILL.md to ~/.codex/skills/<name>/SKILL.md (trio B + validator)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -130,6 +130,20 @@ check_startup_preflight() {
     done
 }
 
+# Codex skills-dir install invariants (introduced by issues #129–#130): every
+# multi-harness skill's install.sh must write SKILL.md to both the legacy
+# prompts/ path AND the new skills/ slash-command registry path.
+check_codex_skills_install() {
+    info "codex skills-dir install: all skills"
+    for s in autospec autospec-define autospec-run autospec-listen autospec-classify; do
+        f="skills/$s/install.sh"
+        grep -q 'skills/\$SKILL_NAME/SKILL\.md' "$f" \
+            || fail "$f missing Codex skills-dir install (skills/\$SKILL_NAME/SKILL.md)"
+        grep -q 'prompts/\$SKILL_NAME\.md\|CODEX_DEST' "$f" \
+            || fail "$f missing legacy Codex prompts-file install"
+    done
+}
+
 # Two-tier subagent model selection invariants: every dispatching SKILL.md
 # must include the literal "**Model tier:**" directive at least once, every
 # such directive must specify either "Tier A (spec work)" or
@@ -261,6 +275,7 @@ main() {
     done
 
     check_startup_preflight
+    check_codex_skills_install
 
     check_agents_md_subagent_section
     check_autospec_listen_files

--- a/skills/autospec-classify/install.sh
+++ b/skills/autospec-classify/install.sh
@@ -268,7 +268,9 @@ if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
     info ""
     info "Codex CLI:"
     install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
     installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
 fi
 
 # ---------- final summary --------------------------------------------------

--- a/skills/autospec-listen/install.sh
+++ b/skills/autospec-listen/install.sh
@@ -268,7 +268,9 @@ if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
     info ""
     info "Codex CLI:"
     install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
     installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
 fi
 
 # ---------- final summary --------------------------------------------------


### PR DESCRIPTION
Closes #130

Applies the same Codex skills-dir fix from #129 to `autospec-listen` and `autospec-classify` `install.sh` files: adds `install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"` alongside the existing `prompts/` install so Codex slash-command registration works. Also adds `check_codex_skills_install` to `scripts/validate.sh` asserting all 5 skills write both paths. Both new skills show 4 lines in `--dry-run --harness codex` output; `validate.sh` passes clean.