### PR TITLE
test(fixtures): add good.md + bad-goal-vague.md + bad-goal-hedge.md fixtures

### DIFF
--- a/tests/fixtures/issue-quality/bad-goal-hedge.md
+++ b/tests/fixtures/issue-quality/bad-goal-hedge.md
@@ -1,0 +1,16 @@
+## Goal
+
+Should probably refactor `scripts/foo.sh` to improve handling.
+
+## Acceptance criteria
+
+- [ ] `bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md` exits 0.
+- [ ] `scripts/validate.sh` exits 0.
+
+## Verification
+
+### Primary smoke test (inner loop)
+
+```bash
+bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md && echo OK
+```

--- a/tests/fixtures/issue-quality/bad-goal-vague.md
+++ b/tests/fixtures/issue-quality/bad-goal-vague.md
@@ -1,0 +1,16 @@
+## Goal
+
+Improve the decomposer prompt for better issue quality.
+
+## Acceptance criteria
+
+- [ ] `bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md` exits 0.
+- [ ] `scripts/validate.sh` exits 0.
+
+## Verification
+
+### Primary smoke test (inner loop)
+
+```bash
+bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md && echo OK
+```

--- a/tests/fixtures/issue-quality/good.md
+++ b/tests/fixtures/issue-quality/good.md
@@ -1,0 +1,23 @@
+## Goal
+
+Add `scripts/lint-issue.sh` that exits non-zero when an issue body fails the §3 quality contract.
+
+## Acceptance criteria
+
+- [ ] `bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md` exits 0.
+- [ ] `scripts/validate.sh` exits 0 after adding the fixture files.
+- [ ] `grep -c GOAL_VAGUE` returns 0 for this file.
+
+## Verification
+
+### Primary smoke test (inner loop)
+
+```bash
+bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md && echo OK
+```
+
+### Operator/full verification
+
+```bash
+bash scripts/validate.sh
+```


### PR DESCRIPTION
Closes #149

Adds three golden fixture files under `tests/fixtures/issue-quality/` for the GOAL-rule cases of `scripts/lint-issue.sh`: `good.md` passes all rules (exit 0); `bad-goal-vague.md` triggers `GOAL_VAGUE` (bare "Improve" with no concrete object); `bad-goal-hedge.md` triggers `GOAL_HEDGE` ("Should probably" hedging). All three verified against the script.