### PR TITLE
test(fixtures): add bad-smoke-multi-line.md + bad-multiple.md + bad-ac-too-long.md fixtures

### DIFF
--- a/tests/fixtures/issue-quality/bad-ac-too-long.md
+++ b/tests/fixtures/issue-quality/bad-ac-too-long.md
@@ -1,0 +1,15 @@
+## Goal
+
+Add `scripts/lint-issue.sh` that exits non-zero when an issue body fails the §3 quality contract.
+
+## Acceptance criteria
+
+- [ ] `bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md` exits 0 with no output on stderr and the command completes in under 5 seconds and also handles edge cases properly.
+
+## Verification
+
+### Primary smoke test (inner loop)
+
+```bash
+bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md && echo OK
+```

--- a/tests/fixtures/issue-quality/bad-multiple.md
+++ b/tests/fixtures/issue-quality/bad-multiple.md
@@ -1,0 +1,16 @@
+## Goal
+
+Improve the decomposer prompt for better issue quality.
+
+## Acceptance criteria
+
+- AC formatting looks clean and appropriate.
+
+## Verification
+
+### Primary smoke test (inner loop)
+
+```bash
+cd /tmp
+bash scripts/lint-issue.sh foo.md
+```

--- a/tests/fixtures/issue-quality/bad-smoke-multi-line.md
+++ b/tests/fixtures/issue-quality/bad-smoke-multi-line.md
@@ -1,0 +1,17 @@
+## Goal
+
+Add `scripts/lint-issue.sh` that exits non-zero when an issue body fails the §3 quality contract.
+
+## Acceptance criteria
+
+- [ ] `bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md` exits 0.
+- [ ] `scripts/validate.sh` exits 0.
+
+## Verification
+
+### Primary smoke test (inner loop)
+
+```bash
+cd /tmp
+bash scripts/lint-issue.sh foo.md
+```


### PR DESCRIPTION
Closes #150

Adds three golden fixture files under `tests/fixtures/issue-quality/` for the SMOKE, AC_TOO_LONG, and multi-rule cases of `scripts/lint-issue.sh`: `bad-smoke-multi-line.md` triggers `SMOKE_MULTI_LINE` (2-line bash block); `bad-ac-too-long.md` triggers `AC_TOO_LONG` (187-char item); `bad-multiple.md` exits 3 triggering all three rule families simultaneously (GOAL_VAGUE + AC_EMPTY + SMOKE_MULTI_LINE). All verified against the script.