### PR TITLE
docs: add ## Issue-quality contract to AGENTS.md + README mention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,3 +127,37 @@ distinct two-step lifecycle on the way to the `auto-implement` queue:
   `needs-classify` issues are swept by re-running `/autospec-classify`
   manually or via the sample crontab in
   `docs/runbooks/needs-classify-sweep.md`.
+
+## Issue-quality contract
+
+Every GitHub issue created by autospec (Phase 3 decomposer, Phase 3.5 reviewer, or
+`/autospec-classify`) must satisfy the three rules below before an implementation
+agent picks it up. The enforcer is `scripts/lint-issue.sh` (exits 0 on pass, N on
+fail where N = number of findings).
+
+### Goal concreteness
+
+The `## Goal` section must contain exactly one sentence (one terminal `.`, `?`, or
+`!`). It must NOT use bare vague verbs (`improve`, `enhance`, `optimize`, `polish`,
+`simplify`, `refactor`, `harden`) unless the same sentence also contains a concrete
+object (a file path, a backtick-quoted command/identifier, a number, or an
+`UPPER_SNAKE` label/env-var). It must NOT use hedging words (`should`, `might`,
+`could try`, `try to`).
+
+PASS: `Add \`scripts/lint-issue.sh\` that exits non-zero if the body fails the §3 quality contract.`
+
+FAIL: `Improve the decomposer prompt for better issue quality.`
+
+### AC machine-checkability
+
+Every non-blank line in the `## Acceptance criteria` section must start with
+`- [ ] ` followed by content. Each item must contain at least one of: a path-shaped
+token, a backtick-quoted span, an integer, or a regex literal. Each item must NOT
+use subjective adjectives (`looks`, `feels`, `seems`, `clean`, `elegant`). Each
+item ≤120 characters. Section must contain ≥1 item.
+
+### Primary smoke test shape
+
+The first fenced code block under `### Primary smoke test (inner loop)` must contain
+exactly one non-blank, non-comment line. It must NOT contain `...`, `<TODO>`, `TBD`,
+or `XXX`.

--- a/README.md
+++ b/README.md
@@ -132,3 +132,7 @@ See [`examples/README.md`](examples/README.md) for the full schema and the auto-
 
 - [`docs/user-manual.md`](docs/user-manual.md) — narrative walkthrough of all five skills (what each does, when to use it, example output).
 - [`docs/architecture.md`](docs/architecture.md) — single-source-of-truth for the cross-cutting design rules: concurrency model, lock-step body rule, model tier policy, trigger keyword theory.
+
+## Quality gate
+
+Every issue filed by autospec is linted by `scripts/lint-issue.sh` before it reaches the implementation queue. The Phase 3 decomposer runs an adaptive retry loop (up to `MAX_LINT_RETRIES=5` attempts) that accumulates lint findings as prompt directives, skipping a child only if attempt 5 still fails. Phase 3.5 and `/autospec-classify` run a one-shot post-filing audit: issues that fail the lint get the `needs-quality-bar` label (color `#fbca04`), an idempotent `## Quality lint` block inserted into their body, and a comment with the findings. The `auto-implement` label is never removed — the operator decides whether to proceed or hand-fix. See [`docs/specs/2026-05-01-autospec-issue-quality-gate-design.md`](docs/specs/2026-05-01-autospec-issue-quality-gate-design.md) for the full contract.


### PR DESCRIPTION
Closes #159

Add a `## Issue-quality contract` section to `AGENTS.md` inlining the three §3 rules (Goal concreteness, AC machine-checkability, Primary smoke test shape) with PASS/FAIL examples drawn from the spec. Add a one-paragraph `## Quality gate` section to `README.md` referencing `needs-quality-bar`, `scripts/lint-issue.sh`, the retry loop, Phase 3.5 audit behavior, and linking to the design spec.