### PR TITLE
test(unit): add `test_phase3_lint_integration.bats` greps for trio mentions

### DIFF
--- a/tests/unit/test_phase3_lint_integration.bats
+++ b/tests/unit/test_phase3_lint_integration.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# tests/unit/test_phase3_lint_integration.bats — grep assertions verifying that
+# every trio file in skills/autospec, skills/autospec-define, and
+# skills/autospec-classify mentions the Phase 3 lint loop and Phase 3.5 audit
+# keywords (scripts/lint-issue.sh, needs-quality-bar, ## Quality lint).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+# ── skills/autospec ────────────────────────────────────────────────────────────
+
+@test "autospec Phase 3 trio: SKILL.md mentions scripts/lint-issue.sh" {
+    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec/SKILL.md"
+}
+
+@test "autospec Phase 3 trio: codex/prompt.md mentions scripts/lint-issue.sh" {
+    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec/codex/prompt.md"
+}
+
+@test "autospec Phase 3 trio: opencode/agent.md mentions scripts/lint-issue.sh" {
+    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec/opencode/agent.md"
+}
+
+@test "autospec Phase 3.5 trio: SKILL.md mentions needs-quality-bar" {
+    grep -q 'needs-quality-bar' "$REPO_ROOT/skills/autospec/SKILL.md"
+}
+
+@test "autospec Phase 3.5 trio: SKILL.md mentions ## Quality lint" {
+    grep -q '## Quality lint' "$REPO_ROOT/skills/autospec/SKILL.md"
+}
+
+@test "autospec Phase 3.5 trio: codex/prompt.md mentions needs-quality-bar" {
+    grep -q 'needs-quality-bar' "$REPO_ROOT/skills/autospec/codex/prompt.md"
+}
+
+@test "autospec Phase 3.5 trio: opencode/agent.md mentions needs-quality-bar" {
+    grep -q 'needs-quality-bar' "$REPO_ROOT/skills/autospec/opencode/agent.md"
+}
+
+# ── skills/autospec-define ────────────────────────────────────────────────────
+
+@test "autospec-define Phase 3 trio: SKILL.md mentions scripts/lint-issue.sh" {
+    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec-define/SKILL.md"
+}
+
+@test "autospec-define Phase 3 trio: codex/prompt.md mentions scripts/lint-issue.sh" {
+    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec-define/codex/prompt.md"
+}
+
+@test "autospec-define Phase 3 trio: opencode/agent.md mentions scripts/lint-issue.sh" {
+    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec-define/opencode/agent.md"
+}
+
+@test "autospec-define Phase 3.5 trio: SKILL.md mentions needs-quality-bar" {
+    grep -q 'needs-quality-bar' "$REPO_ROOT/skills/autospec-define/SKILL.md"
+}
+
+@test "autospec-define Phase 3.5 trio: SKILL.md mentions ## Quality lint" {
+    grep -q '## Quality lint' "$REPO_ROOT/skills/autospec-define/SKILL.md"
+}
+
+@test "autospec-define Phase 3.5 trio: codex/prompt.md mentions needs-quality-bar" {
+    grep -q 'needs-quality-bar' "$REPO_ROOT/skills/autospec-define/codex/prompt.md"
+}
+
+@test "autospec-define Phase 3.5 trio: opencode/agent.md mentions needs-quality-bar" {
+    grep -q 'needs-quality-bar' "$REPO_ROOT/skills/autospec-define/opencode/agent.md"
+}
+
+# ── skills/autospec-classify ──────────────────────────────────────────────────
+
+@test "autospec-classify audit trio: SKILL.md mentions scripts/lint-issue.sh" {
+    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec-classify/SKILL.md"
+}
+
+@test "autospec-classify audit trio: SKILL.md mentions needs-quality-bar" {
+    grep -q 'needs-quality-bar' "$REPO_ROOT/skills/autospec-classify/SKILL.md"
+}
+
+@test "autospec-classify audit trio: SKILL.md mentions ## Quality lint" {
+    grep -q '## Quality lint' "$REPO_ROOT/skills/autospec-classify/SKILL.md"
+}
+
+@test "autospec-classify audit trio: codex/prompt.md mentions needs-quality-bar" {
+    grep -q 'needs-quality-bar' "$REPO_ROOT/skills/autospec-classify/codex/prompt.md"
+}
+
+@test "autospec-classify audit trio: opencode/agent.md mentions needs-quality-bar" {
+    grep -q 'needs-quality-bar' "$REPO_ROOT/skills/autospec-classify/opencode/agent.md"
+}
+
+# ── cross-skill lock-step parity ──────────────────────────────────────────────
+
+@test "lock-step: all 3 autospec-define harness files mention scripts/lint-issue.sh" {
+    COUNT=$(grep -rl 'scripts/lint-issue.sh' \
+        "$REPO_ROOT/skills/autospec-define/SKILL.md" \
+        "$REPO_ROOT/skills/autospec-define/codex/prompt.md" \
+        "$REPO_ROOT/skills/autospec-define/opencode/agent.md" | wc -l | tr -d ' ')
+    [ "$COUNT" -eq 3 ]
+}
+
+@test "lock-step: all 3 autospec-classify harness files mention needs-quality-bar" {
+    COUNT=$(grep -rl 'needs-quality-bar' \
+        "$REPO_ROOT/skills/autospec-classify/SKILL.md" \
+        "$REPO_ROOT/skills/autospec-classify/codex/prompt.md" \
+        "$REPO_ROOT/skills/autospec-classify/opencode/agent.md" | wc -l | tr -d ' ')
+    [ "$COUNT" -eq 3 ]
+}


### PR DESCRIPTION
Closes #158

Add `tests/unit/test_phase3_lint_integration.bats` with 21 `@test` blocks asserting lock-step parity across all trio files in `skills/autospec`, `skills/autospec-define`, and `skills/autospec-classify`. Tests verify: Phase 3 lint loop (`scripts/lint-issue.sh`) is mentioned in all 3 harness files per skill, Phase 3.5 audit keywords (`needs-quality-bar`, `## Quality lint`) are present in all applicable trios, and cross-skill lock-step parity checks confirm all 3 harness files agree. All 21 tests pass on current main.