### PR TITLE
feat(autospec-stop): add skill trio + scaffold (SKILL.md, install.sh, uninstall.sh, README.md)

### DIFF
--- a/skills/autospec-stop/README.md
+++ b/skills/autospec-stop/README.md
@@ -1,0 +1,52 @@
+# autospec-stop
+
+Halt a running **autospec** monitor gracefully or immediately. Writes the
+`~/.autospec/stop.flag` sentinel so the monitor exits cleanly after the current
+issue (`--graceful`) or aborts at the next step boundary with a WIP-commit +
+paused label (`--immediate`).
+
+Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
+
+## Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-stop/install.sh | sh -s -- --harness all
+```
+
+Per-harness:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-stop/install.sh | sh -s -- --harness claude
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-stop/install.sh | sh -s -- --harness opencode
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-stop/install.sh | sh -s -- --harness codex
+```
+
+From a clone:
+
+```bash
+cd skills/autospec-stop
+./install.sh --harness all
+```
+
+## Flags
+
+| Flag | Behaviour |
+|---|---|
+| `--graceful` (default) | Write sentinel mode=graceful; monitor exits after current issue finishes. |
+| `--immediate` | Write sentinel mode=immediate; process(ISSUE) commits+pushes+marks paused at next step boundary. |
+| `--status` | Report current sentinel state, paused-by-user issue count. |
+| `--resume` | Strip paused-by-user labels, restore auto-implement, delete stop.flag. |
+
+## Invocation examples
+
+```bash
+/autospec-stop --immediate          # canonical (new skill)
+/autospec stop --immediate          # inline sub-mode in existing /autospec skill
+/autospec-run stop --graceful       # inline sub-mode in monitor skill
+```
+
+All three paths route through `scripts/autospec-stop.sh`.
+
+## Spec
+
+`docs/specs/2026-05-01-autospec-stop-mechanism-design.md`

--- a/skills/autospec-stop/SKILL.md
+++ b/skills/autospec-stop/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: autospec-stop
+description: Use when the user wants to halt a running autospec monitor gracefully or immediately — writes the ~/.autospec/stop.flag sentinel so the monitor exits after the current issue (--graceful) or aborts at the next step boundary (--immediate). Also supports --status, --resume, and inline stop sub-mode matching `^\s*stop(\s+--\w+)*\s*$`.
+---
+
+# autospec-stop (harness-neutral)
+
+Halt a running autospec monitor gracefully or immediately. All paths route
+through `bash scripts/autospec-stop.sh "$@"`.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-stop   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-stop
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-stop/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-stop.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-stop.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-stop/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-stop found; run install.sh first.` and exit.
+
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
+(case-insensitive), this skill enters stop mode and does not run the normal
+pipeline:
+
+1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+2. Print the helper's stdout to the user.
+3. Stop. Do not enter Phase 0 or any pipeline phase.
+
+## Invocation
+
+```
+/autospec-stop [--graceful|--immediate|--status|--resume|--help]
+```
+
+Dispatches directly to `bash scripts/autospec-stop.sh "$@"`. All logic lives
+in the helper script.
+
+| Flag | Behaviour |
+|---|---|
+| `--graceful` (default) | Write sentinel mode=graceful; monitor exits after current issue finishes. |
+| `--immediate` | Write sentinel mode=immediate; process(ISSUE) commits+pushes+marks paused at next step boundary. |
+| `--status` | Report current sentinel state, paused-by-user issue count, last monitor progress line. |
+| `--resume` | Strip paused-by-user labels from all paused issues, restore auto-implement, delete stop.flag. |
+| `--help` | Print usage and exit. |
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Run shell command            | `Bash`                               | `bash` tool                              | `shell` / `apply_patch`                  | Ask user to run manually                           |
+| Ask the user a question      | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Subagent model tier          | Tier B: `sonnet` + medium thinking   | Tier B: smaller-tier `task` + medium reasoning | Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Fall back UP on unavailability |
+
+**Model tier:** Tier B (implementation work) — this skill is a thin dispatch wrapper.
+
+## Procedure
+
+1. Run startup self-update block above.
+2. Parse the user's invocation arguments (default to `--graceful` if no flag given).
+3. Execute: `bash scripts/autospec-stop.sh "$@"`
+4. Print stdout to user and exit.
+
+If `scripts/autospec-stop.sh` is not found, print:
+```
+autospec-stop: helper not found at scripts/autospec-stop.sh.
+Run from the autospec repo root, or re-install the skill.
+```
+and exit non-zero.
+
+## Hard rules
+
+- Never call `scripts/autospec-stop.sh --abort-current-issue` from user invocation. That flag is internal.
+- Never modify issue bodies, labels, or PRs directly — the helper script owns all GitHub mutations.
+- This skill is a thin wrapper. All behaviour is in the helper script.

--- a/skills/autospec-stop/codex/prompt.md
+++ b/skills/autospec-stop/codex/prompt.md
@@ -1,0 +1,126 @@
+
+# autospec-stop (harness-neutral)
+
+Halt a running autospec monitor gracefully or immediately. All paths route
+through `bash scripts/autospec-stop.sh "$@"`.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-stop   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-stop
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-stop/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-stop.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-stop.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-stop/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-stop found; run install.sh first.` and exit.
+
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
+(case-insensitive), this skill enters stop mode and does not run the normal
+pipeline:
+
+1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+2. Print the helper's stdout to the user.
+3. Stop. Do not enter Phase 0 or any pipeline phase.
+
+## Invocation
+
+```
+/autospec-stop [--graceful|--immediate|--status|--resume|--help]
+```
+
+Dispatches directly to `bash scripts/autospec-stop.sh "$@"`. All logic lives
+in the helper script.
+
+| Flag | Behaviour |
+|---|---|
+| `--graceful` (default) | Write sentinel mode=graceful; monitor exits after current issue finishes. |
+| `--immediate` | Write sentinel mode=immediate; process(ISSUE) commits+pushes+marks paused at next step boundary. |
+| `--status` | Report current sentinel state, paused-by-user issue count, last monitor progress line. |
+| `--resume` | Strip paused-by-user labels from all paused issues, restore auto-implement, delete stop.flag. |
+| `--help` | Print usage and exit. |
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Run shell command            | `Bash`                               | `bash` tool                              | `shell` / `apply_patch`                  | Ask user to run manually                           |
+| Ask the user a question      | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Subagent model tier          | Tier B: `sonnet` + medium thinking   | Tier B: smaller-tier `task` + medium reasoning | Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Fall back UP on unavailability |
+
+**Model tier:** Tier B (implementation work) — this skill is a thin dispatch wrapper.
+
+## Procedure
+
+1. Run startup self-update block above.
+2. Parse the user's invocation arguments (default to `--graceful` if no flag given).
+3. Execute: `bash scripts/autospec-stop.sh "$@"`
+4. Print stdout to user and exit.
+
+If `scripts/autospec-stop.sh` is not found, print:
+```
+autospec-stop: helper not found at scripts/autospec-stop.sh.
+Run from the autospec repo root, or re-install the skill.
+```
+and exit non-zero.
+
+## Hard rules
+
+- Never call `scripts/autospec-stop.sh --abort-current-issue` from user invocation. That flag is internal.
+- Never modify issue bodies, labels, or PRs directly — the helper script owns all GitHub mutations.
+- This skill is a thin wrapper. All behaviour is in the helper script.

--- a/skills/autospec-stop/install.sh
+++ b/skills/autospec-stop/install.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec-stop skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --symlink           # symlink instead of copy (updates propagate)
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#   ./install.sh --update            # idempotent re-install (overwrite existing)
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-stop/install.sh \
+#     | sh -s -- --harness all
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPEC_STOP_REF         (default: main)
+#   AUTOSPEC_STOP_RAW_BASE    (override raw URL base entirely)
+
+set -eu
+
+SKILL_NAME="autospec-stop"
+SKILL_RAW_BASE="${AUTOSPEC_STOP_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_STOP_REF:-main}/skills/autospec-stop}"
+
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+UPDATE_MODE=0
+TMP_FETCH_DIR=""
+
+# ---------- helpers --------------------------------------------------------
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
+
+Installs the ${SKILL_NAME} skill into the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    if ! command -v curl >/dev/null 2>&1; then
+        err "curl is required when running from stdin."
+        exit 1
+    fi
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/$rel"
+            exit 1
+        fi
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    dest_dir="$(dirname "$dest")"
+
+    if [ ! -f "$src" ]; then
+        err "missing source file: $src"
+        return 1
+    fi
+
+    run "mkdir -p \"$dest_dir\""
+
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --symlink)
+            USE_SYMLINK=1
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        --update)
+            UPDATE_MODE=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# ---------- harness prompt -------------------------------------------------
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- ensure source files are available ------------------------------
+
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+
+if [ "$need_fetch" -eq 1 ]; then
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        err "--symlink requires running from a checkout (no local files to symlink to)."
+        exit 2
+    fi
+    fetch_source_files
+fi
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+CLAUDE_SRC="$SKILL_DIR/SKILL.md"
+OPENCODE_SRC="$SKILL_DIR/opencode/agent.md"
+CODEX_SRC="$SKILL_DIR/codex/prompt.md"
+
+# ---------- install --------------------------------------------------------
+
+installed_paths=""
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_SRC" "$CLAUDE_DEST"
+    installed_paths="${installed_paths}  Claude Code: ${CLAUDE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_SRC" "$OPENCODE_DEST"
+    installed_paths="${installed_paths}  OpenCode:    ${OPENCODE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+    installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
+fi
+
+# ---------- final summary --------------------------------------------------
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    if [ "$UPDATE_MODE" -eq 1 ]; then
+        info "Updated (idempotent overwrite):"
+    else
+        info "Installed:"
+    fi
+    printf '%b' "$installed_paths"
+    info ""
+    info "Invoke with:"
+    info "  Claude Code:  /${SKILL_NAME} --graceful"
+    info "  OpenCode:     @${SKILL_NAME} --immediate"
+    info "  Codex CLI:    /${SKILL_NAME} --status"
+fi
+
+exit 0

--- a/skills/autospec-stop/opencode/agent.md
+++ b/skills/autospec-stop/opencode/agent.md
@@ -1,0 +1,130 @@
+---
+description: Use when the user wants to halt a running autospec monitor gracefully or immediately — writes the ~/.autospec/stop.flag sentinel so the monitor exits after the current issue (--graceful) or aborts at the next step boundary (--immediate). Also supports --status, --resume, and inline stop sub-mode matching `^\s*stop(\s+--\w+)*\s*$`.
+mode: primary
+---
+
+# autospec-stop (harness-neutral)
+
+Halt a running autospec monitor gracefully or immediately. All paths route
+through `bash scripts/autospec-stop.sh "$@"`.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-stop   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-stop
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-stop/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-stop.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-stop.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-stop/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-stop found; run install.sh first.` and exit.
+
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
+(case-insensitive), this skill enters stop mode and does not run the normal
+pipeline:
+
+1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+2. Print the helper's stdout to the user.
+3. Stop. Do not enter Phase 0 or any pipeline phase.
+
+## Invocation
+
+```
+/autospec-stop [--graceful|--immediate|--status|--resume|--help]
+```
+
+Dispatches directly to `bash scripts/autospec-stop.sh "$@"`. All logic lives
+in the helper script.
+
+| Flag | Behaviour |
+|---|---|
+| `--graceful` (default) | Write sentinel mode=graceful; monitor exits after current issue finishes. |
+| `--immediate` | Write sentinel mode=immediate; process(ISSUE) commits+pushes+marks paused at next step boundary. |
+| `--status` | Report current sentinel state, paused-by-user issue count, last monitor progress line. |
+| `--resume` | Strip paused-by-user labels from all paused issues, restore auto-implement, delete stop.flag. |
+| `--help` | Print usage and exit. |
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Run shell command            | `Bash`                               | `bash` tool                              | `shell` / `apply_patch`                  | Ask user to run manually                           |
+| Ask the user a question      | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Subagent model tier          | Tier B: `sonnet` + medium thinking   | Tier B: smaller-tier `task` + medium reasoning | Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Fall back UP on unavailability |
+
+**Model tier:** Tier B (implementation work) — this skill is a thin dispatch wrapper.
+
+## Procedure
+
+1. Run startup self-update block above.
+2. Parse the user's invocation arguments (default to `--graceful` if no flag given).
+3. Execute: `bash scripts/autospec-stop.sh "$@"`
+4. Print stdout to user and exit.
+
+If `scripts/autospec-stop.sh` is not found, print:
+```
+autospec-stop: helper not found at scripts/autospec-stop.sh.
+Run from the autospec repo root, or re-install the skill.
+```
+and exit non-zero.
+
+## Hard rules
+
+- Never call `scripts/autospec-stop.sh --abort-current-issue` from user invocation. That flag is internal.
+- Never modify issue bodies, labels, or PRs directly — the helper script owns all GitHub mutations.
+- This skill is a thin wrapper. All behaviour is in the helper script.

--- a/skills/autospec-stop/uninstall.sh
+++ b/skills/autospec-stop/uninstall.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec-stop skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autospec-stop"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+CODEX_SKILL_DEST="$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+
+# ---------- remove ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+    remove_one "$CODEX_SKILL_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0


### PR DESCRIPTION
Closes #176

Creates the complete `skills/autospec-stop/` directory: lock-step trio (`SKILL.md`, `opencode/agent.md`, `codex/prompt.md`) wrapping `bash scripts/autospec-stop.sh "$@"`, plus required scaffold files (`install.sh`, `uninstall.sh`, `README.md`). The trio includes `## Stop mode`, `## Self-update mode`, and `## Startup self-update` sections; `codex/prompt.md` starts with a leading blank line; body is byte-identical across all three files (verified by `bash scripts/validate.sh`). Note: scaffold files also satisfy the #179 scope (install/uninstall/README), so #179 will be a no-op merge.