### PR TITLE
feat(autospec): add inline stop sub-mode regex shortcut (lock-step trio)

### DIFF
--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -70,6 +70,16 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
 
 If no install path is detected, print `Self-update: no installed copy of autospec found; run install.sh first.` and exit.
 
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
+(case-insensitive), this skill enters stop mode and does not run the normal
+pipeline:
+
+1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+2. Print the helper's stdout to the user.
+3. Stop. Do not enter Phase 0 or any pipeline phase.
+
 ## Feature request
 
 {FEATURE_DESCRIPTION}

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -66,6 +66,16 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
 
 If no install path is detected, print `Self-update: no installed copy of autospec found; run install.sh first.` and exit.
 
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
+(case-insensitive), this skill enters stop mode and does not run the normal
+pipeline:
+
+1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+2. Print the helper's stdout to the user.
+3. Stop. Do not enter Phase 0 or any pipeline phase.
+
 ## Feature request
 
 {FEATURE_DESCRIPTION}

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -70,6 +70,16 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
 
 If no install path is detected, print `Self-update: no installed copy of autospec found; run install.sh first.` and exit.
 
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
+(case-insensitive), this skill enters stop mode and does not run the normal
+pipeline:
+
+1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+2. Print the helper's stdout to the user.
+3. Stop. Do not enter Phase 0 or any pipeline phase.
+
 ## Feature request
 
 {FEATURE_DESCRIPTION}


### PR DESCRIPTION
Closes #181

Inserts the spec §2.2 `## Stop mode` block into the `skills/autospec/` lock-step trio immediately after the `## Self-update mode` block. When the feature-request matches `^\s*stop(\s+--\w+)*\s*$` (case-insensitive), the skill dispatches to `bash scripts/autospec-stop.sh <args>` and stops — it does not enter Phase 0 or any pipeline phase. Regex literal, `scripts/autospec-stop.sh` reference, and `## Stop mode` heading present in all three trio files; codex/prompt.md leading blank line preserved; validate.sh passes.