### PR TITLE
docs: add ## Stop mode authority to AGENTS.md + ## Stopping a run to README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,21 @@ the body matches one of those criteria.
 Escape hatch: set `AUTOSPEC_NO_AUTOMERGE_SPEC=1` to short-circuit the auto-merge and
 fall back to "open PR + ask user".
 
+## Stop mode authority
+
+Operators can halt a running autospec monitor in two ways, both leaving clean state:
+
+- **Graceful** (`/autospec-stop --graceful`, default): the monitor finishes the current `process(ISSUE)` to its natural end (success → admin-merge, or 3-iter failure → label restore + comment). The outer loop exits BEFORE dispatching the next issue.
+- **Immediate** (`/autospec-stop --immediate`): the current `process(ISSUE)` commits any uncommitted work (`chore: WIP — autospec stop`), pushes the branch, marks the issue `paused-by-user`, inserts a `## Resume context` block, and exits at the next major-step boundary.
+
+**Sentinel file**: `~/.autospec/stop.flag`. Two-line format: `<mode>\n<ISO8601> <user>@<host>`. Atomic write via `temp+mv`. Stale flags (>24h) are ignored with a WARN to stderr.
+
+**`paused-by-user` label**: color `#d4c5f9` (lavender), created idempotently by the abort path. Issues carrying this label are removed from the `auto-implement` queue until `/autospec-stop --resume` strips the label.
+
+**Resume procedure**: `/autospec-stop --resume` strips `paused-by-user` from every paused issue, restores `auto-implement`, and deletes `~/.autospec/stop.flag`. The `## Resume context` block is kept as an audit trail. The next `/autospec-run` invocation picks up the restored issues normally.
+
+**Inline sub-modes**: both `/autospec` and `/autospec-run` accept `stop [--flag]` as a feature-request argument (regex `^\s*stop(\s+--\w+)*\s*$`, case-insensitive), routing through the same `scripts/autospec-stop.sh`.
+
 ## Startup self-update
 
 Every multi-harness skill runs a preflight at startup that updates the installed copy

--- a/README.md
+++ b/README.md
@@ -136,3 +136,15 @@ See [`examples/README.md`](examples/README.md) for the full schema and the auto-
 ## Quality gate
 
 Every issue filed by autospec is linted by `scripts/lint-issue.sh` before it reaches the implementation queue. The Phase 3 decomposer runs an adaptive retry loop (up to `MAX_LINT_RETRIES=5` attempts) that accumulates lint findings as prompt directives, skipping a child only if attempt 5 still fails. Phase 3.5 and `/autospec-classify` run a one-shot post-filing audit: issues that fail the lint get the `needs-quality-bar` label (color `#fbca04`), an idempotent `## Quality lint` block inserted into their body, and a comment with the findings. The `auto-implement` label is never removed — the operator decides whether to proceed or hand-fix. See [`docs/specs/2026-05-01-autospec-issue-quality-gate-design.md`](docs/specs/2026-05-01-autospec-issue-quality-gate-design.md) for the full contract.
+
+## Stopping a run
+
+To halt a running autospec monitor, use the `/autospec-stop` skill or the inline sub-modes:
+
+```bash
+/autospec-stop --immediate          # abort at next step boundary; commit+push+mark paused
+/autospec stop --graceful           # finish current issue then exit monitor
+/autospec-run stop --status         # check current stop sentinel state
+```
+
+All three paths route through `scripts/autospec-stop.sh`. Use `--resume` to strip the `paused-by-user` label from paused issues and restart the queue. See [`AGENTS.md` § Stop mode authority](AGENTS.md) for the full contract.


### PR DESCRIPTION
Closes #183

Adds `## Stop mode authority` heading to `AGENTS.md` (after `## Auto-merge authority`) covering: graceful vs immediate semantics, `~/.autospec/stop.flag` sentinel path, `paused-by-user` label colour `#d4c5f9`, WIP-commit-on-immediate contract, resume procedure, and inline sub-mode regex. Adds `## Stopping a run` section to `README.md` with all three invocation paths from spec §3.2 (`/autospec-stop --immediate`, `/autospec stop --graceful`, `/autospec-run stop --status`). Validate.sh passes.