### PR TITLE
feat(install): extend top-level install.sh + uninstall.sh to include autospec-stop

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ set -eu
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$REPO_ROOT/skills"
 
-ALL_SKILLS="autospec autospec-define autospec-run autospec-classify autospec-listen"
+ALL_SKILLS="autospec autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -75,10 +75,10 @@ done
 
 # Validate --skill
 case "$SKILL_ARG" in
-    all|autospec|autospec-define|autospec-run|autospec-classify|autospec-listen) ;;
+    all|autospec|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-stop) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
-        err "must be one of: autospec | autospec-define | autospec-run | autospec-classify | autospec-listen | all"
+        err "must be one of: autospec | autospec-define | autospec-run | autospec-classify | autospec-listen | autospec-stop | all"
         exit 2
         ;;
 esac

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -24,7 +24,7 @@
 
 set -eu
 
-ALL_SKILLS="autospec autospec-define autospec-run autospec-classify autospec-listen"
+ALL_SKILLS="autospec autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -67,7 +67,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$SKILL_ARG" in
-    all|autospec|autospec-define|autospec-run|autospec-classify|autospec-listen) ;;
+    all|autospec|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-stop) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
         exit 2


### PR DESCRIPTION
Closes #184

Adds `autospec-stop` to the `ALL_SKILLS` variable in both top-level `install.sh` and `uninstall.sh`, mirroring how `autospec-classify` is wired. Also extends the `--skill` case statement in both files to accept `autospec-stop` as a valid single-skill argument. `bash scripts/validate.sh` passes; `bash -n` syntax checks pass on both files.