### PR TITLE
feat(autospec-run): add inline stop sub-mode regex shortcut (lock-step trio)

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -70,6 +70,16 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
 
 If no install path is detected, print `Self-update: no installed copy of autospec-run found; run install.sh first.` and exit.
 
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
+(case-insensitive), this skill enters stop mode and does not run the normal
+pipeline:
+
+1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+2. Print the helper's stdout to the user.
+3. Stop. Do not enter Phase 0 or any pipeline phase.
+
 ## Invocation
 
 ```

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -66,6 +66,16 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
 
 If no install path is detected, print `Self-update: no installed copy of autospec-run found; run install.sh first.` and exit.
 
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
+(case-insensitive), this skill enters stop mode and does not run the normal
+pipeline:
+
+1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+2. Print the helper's stdout to the user.
+3. Stop. Do not enter Phase 0 or any pipeline phase.
+
 ## Invocation
 
 ```

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -70,6 +70,16 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
 
 If no install path is detected, print `Self-update: no installed copy of autospec-run found; run install.sh first.` and exit.
 
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
+(case-insensitive), this skill enters stop mode and does not run the normal
+pipeline:
+
+1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+2. Print the helper's stdout to the user.
+3. Stop. Do not enter Phase 0 or any pipeline phase.
+
 ## Invocation
 
 ```


### PR DESCRIPTION
Closes #185

Mirrors the spec §2.2 `## Stop mode` block from `skills/autospec/` into the `skills/autospec-run/` lock-step trio immediately after `## Self-update mode`. When the feature-request matches `^\s*stop(\s+--\w+)*\s*$` (case-insensitive), the skill dispatches to `bash scripts/autospec-stop.sh <args>` and stops before Phase 0. Regex literal, `scripts/autospec-stop.sh` reference, and `## Stop mode` heading present in all three files; codex/prompt.md leading blank line preserved; validate.sh passes.