### PR TITLE
feat(scripts): implement deterministic detectors in lint-implementation.sh

### DIFF
--- a/scripts/lint-implementation.sh
+++ b/scripts/lint-implementation.sh
@@ -190,24 +190,18 @@ fi
 
 # ── per-RULE_ID emit cap tracking ─────────────────────────────────────────────
 
-declare -A RULE_EMIT_COUNT 2>/dev/null || {
-    # Fallback for shells without associative arrays (use temp files)
-    :
-}
 RULE_EMIT_CAP=10
 
 # emit_capped RULE_ID PATH LINE DESC
 # Honors per-RULE_ID cap of 10 lines; collapses extras to "+ N more (truncated)"
-declare -A RULE_EMIT_COUNT 2>/dev/null || true
 emit_capped() {
     local rule_id="$1"
     local path="$2"
     local line="$3"
     local desc="$4"
 
-    # Get current count for this rule
+    # Get current count for this rule using eval for portability
     local cur=0
-    # Use eval for portability across bash versions
     eval "cur=\${RULE_EMIT_COUNT_${rule_id}:-0}"
     cur=$((cur + 1))
     eval "RULE_EMIT_COUNT_${rule_id}=${cur}"
@@ -226,36 +220,395 @@ emit_capped() {
     # Beyond cap+1: silently drop
 }
 
-# ── detector stubs ────────────────────────────────────────────────────────────
-# Each detector is a function that reads TMP_DIFF (and TMP_ISSUE) and calls
-# emit_capped for each finding. Bodies are wired in issue #206.
+# ── diff parsing helpers ──────────────────────────────────────────────────────
+
+# get_diff_files — print each path touched in the diff (one per line)
+get_diff_files() {
+    grep -E '^diff --git ' "$TMP_DIFF" | sed 's|^diff --git a/[^ ]* b/||' || true
+}
+
+# get_added_lines_for_file FILE — print added lines (without leading +) for a file
+# Scans the diff hunk by hunk, limiting to the given file section.
+get_added_lines_for_file() {
+    local target="$1"
+    awk -v tgt="$target" '
+        /^diff --git / {
+            in_file = ($0 ~ " b/" tgt "$")
+            next
+        }
+        in_file && /^\+\+\+ / { next }
+        in_file && /^--- / { next }
+        in_file && /^\+/ { print substr($0,2) }
+    ' "$TMP_DIFF"
+}
+
+# get_added_lines_with_lineno FILE — print "LINENO:LINE" for each added line
+get_added_lines_with_lineno() {
+    local target="$1"
+    awk -v tgt="$target" '
+        /^diff --git / {
+            in_file = ($0 ~ " b/" tgt "$")
+            new_line = 0
+            next
+        }
+        in_file && /^@@ / {
+            # Parse @@ -old +new,count @@ — extract new-file start line
+            # Portable: use sub() to strip up to + then grab the number
+            hdr = $0
+            sub(/.*\+/, "", hdr)
+            sub(/[^0-9].*/, "", hdr)
+            new_line = hdr + 0
+            next
+        }
+        in_file && /^\+\+\+ / { next }
+        in_file && /^--- / { next }
+        in_file && /^ / { new_line++; next }
+        in_file && /^\+/ {
+            print new_line ":" substr($0,2)
+            new_line++
+        }
+        in_file && /^-/ { next }
+    ' "$TMP_DIFF"
+}
+
+# is_test_file PATH — returns 0 if path is under tests/
+is_test_file() {
+    case "$1" in
+        tests/*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# is_doc_file PATH — returns 0 if path is a doc file
+is_doc_file() {
+    case "$1" in
+        README*|AGENTS.md|docs/*|*/SKILL.md|SKILL.md) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# ── §3.1 OUT_OF_SCOPE detector ────────────────────────────────────────────────
+# Files touched ∉ issue body ## Implementation outline paths.
+# Only active when ISSUE_NUMBER is set (needs issue body).
 
 detect_out_of_scope() {
-    return 0
+    # Requires issue body; skip if not available
+    if [ ! -s "$TMP_ISSUE" ]; then
+        return 0
+    fi
+
+    # Extract ## Implementation outline section from issue body
+    local outline
+    outline="$(awk '
+        /^## Implementation (outline|scope)/ { in_section=1; next }
+        in_section && /^## / { exit }
+        in_section { print }
+    ' "$TMP_ISSUE")"
+
+    if [ -z "$outline" ]; then
+        return 0
+    fi
+
+    # Extract all path-shaped tokens from the outline (backtick-quoted or bare path-like)
+    local allowed_paths
+    allowed_paths="$(printf '%s\n' "$outline" | grep -oE '`[^`]+`' | tr -d '`' | grep -E '[/.]' || true)"
+    allowed_paths="$allowed_paths
+$(printf '%s\n' "$outline" | grep -oE '[A-Za-z0-9_./\-]+\.[A-Za-z0-9]+' || true)"
+
+    if [ -z "$(printf '%s' "$allowed_paths" | tr -d '[:space:]')" ]; then
+        return 0
+    fi
+
+    # For each file in the diff, check if it matches any allowed path
+    while IFS= read -r diff_file; do
+        [ -z "$diff_file" ] && continue
+        local matched=0
+        while IFS= read -r allowed; do
+            [ -z "$allowed" ] && continue
+            # Match: diff_file ends with allowed, or allowed is a prefix/substring
+            case "$diff_file" in
+                *"$allowed"*) matched=1; break ;;
+            esac
+            # Also check if allowed contains diff_file base
+            local base
+            base="$(basename "$diff_file")"
+            case "$allowed" in
+                *"$base"*) matched=1; break ;;
+            esac
+        done <<EOF
+$allowed_paths
+EOF
+        if [ "$matched" -eq 0 ]; then
+            emit_capped "OUT_OF_SCOPE" "$diff_file" "-" "file not listed in ## Implementation outline"
+        fi
+    done <<EOF
+$(get_diff_files)
+EOF
 }
+
+# ── §3.1 MISSING_TEST detector ────────────────────────────────────────────────
+# Required test tier from ## Tests required not present in diff.
 
 detect_missing_test() {
-    return 0
+    if [ ! -s "$TMP_ISSUE" ]; then
+        return 0
+    fi
+
+    # Extract ## Tests required section
+    local tests_section
+    tests_section="$(awk '
+        /^## Tests required/ { in_section=1; next }
+        in_section && /^## / { exit }
+        in_section { print }
+    ' "$TMP_ISSUE" | tr '[:upper:]' '[:lower:]')"
+
+    if [ -z "$tests_section" ]; then
+        return 0
+    fi
+
+    # Get list of test paths in the diff
+    local diff_test_paths
+    diff_test_paths="$(get_diff_files | grep '^tests/' || true)"
+
+    # Check each tier mentioned in the tests section
+    for tier in unit integration smoke e2e; do
+        if printf '%s' "$tests_section" | grep -qiE "\b${tier}\b"; then
+            if ! printf '%s\n' "$diff_test_paths" | grep -q "^tests/${tier}/"; then
+                emit_capped "MISSING_TEST" "tests/${tier}/" "-" "required test tier '${tier}' not present in diff"
+            fi
+        fi
+    done
 }
 
+# ── §3.1 COMPLEXITY detector ──────────────────────────────────────────────────
+# Function >50 LOC, file >500 LOC, nesting >4.
+
 detect_complexity() {
-    return 0
+    while IFS= read -r diff_file; do
+        [ -z "$diff_file" ] && continue
+
+        # Skip non-code files (docs, fixtures, etc.)
+        case "$diff_file" in
+            *.md|*.txt|*.json|*.yaml|*.yml|*.diff) continue ;;
+        esac
+
+        # Count total added lines for this file (proxy for file LOC in diff)
+        local added_count
+        added_count="$(get_added_lines_for_file "$diff_file" | wc -l | tr -d ' ')"
+
+        # File LOC check: if entire new file and >500 added lines
+        if [ "$added_count" -gt 500 ]; then
+            emit_capped "COMPLEXITY" "$diff_file" "-" "file adds ${added_count} lines (threshold: 500)"
+        fi
+
+        # Function LOC check: scan for function definitions, count body lines
+        # Strategy: track function start/end in added lines
+        local in_func=0
+        local func_start=0
+        local func_name=""
+        local func_loc=0
+        local line_no=0
+
+        while IFS=: read -r lineno content; do
+            line_no="$lineno"
+
+            # Detect function start (bash-style: name() { or function name {)
+            if printf '%s' "$content" | grep -qE '^[[:space:]]*(function[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*\(\)[[:space:]]*\{?[[:space:]]*$'; then
+                if [ "$in_func" -eq 1 ] && [ "$func_loc" -gt 50 ]; then
+                    emit_capped "COMPLEXITY" "$diff_file" "$func_start" "function '${func_name}' is ${func_loc} LOC (threshold: 50)"
+                fi
+                in_func=1
+                func_start="$lineno"
+                func_name="$(printf '%s' "$content" | grep -oE '[A-Za-z_][A-Za-z0-9_]*' | head -1)"
+                func_loc=0
+                continue
+            fi
+
+            if [ "$in_func" -eq 1 ]; then
+                # Detect closing brace at column 0 (end of function)
+                if printf '%s' "$content" | grep -qE '^}[[:space:]]*$'; then
+                    func_loc=$((func_loc + 1))
+                    if [ "$func_loc" -gt 50 ]; then
+                        emit_capped "COMPLEXITY" "$diff_file" "$func_start" "function '${func_name}' is ${func_loc} LOC (threshold: 50)"
+                    fi
+                    in_func=0
+                    func_loc=0
+                else
+                    func_loc=$((func_loc + 1))
+                fi
+            fi
+
+            # Nesting depth check: count leading spaces / 4 as proxy for depth
+            local leading_spaces
+            leading_spaces="$(printf '%s' "$content" | sed 's/[^ ].*//' | wc -c | tr -d ' ')"
+            # leading_spaces includes the newline from wc -c, adjust
+            leading_spaces=$((leading_spaces - 1))
+            local depth=$((leading_spaces / 4))
+            if [ "$depth" -gt 4 ]; then
+                emit_capped "COMPLEXITY" "$diff_file" "$lineno" "nesting depth ~${depth} (threshold: 4) at line ${lineno}"
+            fi
+        done <<EOF
+$(get_added_lines_with_lineno "$diff_file")
+EOF
+
+        # Flush last open function
+        if [ "$in_func" -eq 1 ] && [ "$func_loc" -gt 50 ]; then
+            emit_capped "COMPLEXITY" "$diff_file" "$func_start" "function '${func_name}' is ${func_loc} LOC (threshold: 50)"
+        fi
+
+    done <<EOF
+$(get_diff_files)
+EOF
+}
+
+# ── §3.1 SECURITY detector ────────────────────────────────────────────────────
+# Dangerous patterns in any diff hunk.
+
+# scan_security_pattern PAT DESC — scan TMP_DIFF added lines for pattern
+scan_security_pattern() {
+    local pat="$1"
+    local desc="$2"
+    local current_file="-"
+    local current_line=0
+    while IFS= read -r raw_line; do
+        if printf '%s' "$raw_line" | grep -qE '^diff --git '; then
+            current_file="$(printf '%s' "$raw_line" | sed 's|^diff --git a/[^ ]* b/||')"
+            current_line=0
+            continue
+        fi
+        if printf '%s' "$raw_line" | grep -qE '^@@ '; then
+            local hdr="$raw_line"
+            hdr="$(printf '%s' "$raw_line" | grep -oE '\+[0-9]+' | head -1 | tr -d '+')"
+            current_line="${hdr:-0}"
+            continue
+        fi
+        if printf '%s' "$raw_line" | grep -qE '^\+\+\+|^---'; then
+            continue
+        fi
+        if printf '%s' "$raw_line" | grep -qE '^ '; then
+            current_line=$((current_line + 1))
+            continue
+        fi
+        if printf '%s' "$raw_line" | grep -qE '^\+'; then
+            current_line=$((current_line + 1))
+            local content="${raw_line#\+}"
+            if printf '%s' "$content" | grep -qE "$pat"; then
+                emit_capped "SECURITY" "$current_file" "$current_line" "$desc"
+            fi
+        fi
+    done < "$TMP_DIFF"
 }
 
 detect_security() {
-    return 0
+    scan_security_pattern 'eval\(' "eval() usage — potential code injection"
+    scan_security_pattern 'exec\(' "exec() usage — potential code injection"
+    scan_security_pattern '\-\-no\-verify' "--no-verify flag — bypasses git hooks"
+    scan_security_pattern 'git reset --hard' "git reset --hard — destructive operation"
+    scan_security_pattern 'rm -rf /' "rm -rf / — dangerous recursive delete"
+    scan_security_pattern 'AKIA[0-9A-Z]{16}' "hardcoded AWS access key (AKIA...)"
+    scan_security_pattern 'gh[pousr]_[A-Za-z0-9]{36,}' "hardcoded GitHub token"
+    scan_security_pattern '\-\-\-\-\-BEGIN [A-Z ]*PRIVATE KEY\-\-\-\-\-' "private key material in committed file"
 }
+
+# ── §3.1 TODO_LEFT detector ───────────────────────────────────────────────────
+# \b(TODO|XXX|FIXME)\b in non-test added diff hunks.
 
 detect_todo_left() {
-    return 0
+    while IFS= read -r diff_file; do
+        [ -z "$diff_file" ] && continue
+        is_test_file "$diff_file" && continue
+
+        while IFS=: read -r lineno content; do
+            if printf '%s' "$content" | grep -qE '\b(TODO|XXX|FIXME)\b'; then
+                local match
+                match="$(printf '%s' "$content" | grep -oE '\b(TODO|XXX|FIXME)\b' | head -1)"
+                emit_capped "TODO_LEFT" "$diff_file" "$lineno" "${match} found in non-test source"
+            fi
+        done <<EOF
+$(get_added_lines_with_lineno "$diff_file")
+EOF
+    done <<EOF
+$(get_diff_files)
+EOF
 }
+
+# ── §3.1 MOCK_DB detector ─────────────────────────────────────────────────────
+# \b(mock|stub)\b near DB-symbol heuristics in test diff hunks.
 
 detect_mock_db() {
-    return 0
+    local db_pattern='(db\.|database|DataSource|pg|mysql|sqlite)'
+    local mock_pattern='\b(mock|stub)\b'
+
+    while IFS= read -r diff_file; do
+        [ -z "$diff_file" ] && continue
+        is_test_file "$diff_file" || continue
+
+        while IFS=: read -r lineno content; do
+            if printf '%s' "$content" | grep -qiE "$mock_pattern"; then
+                if printf '%s' "$content" | grep -qiE "$db_pattern"; then
+                    emit_capped "MOCK_DB" "$diff_file" "$lineno" "mock/stub of DB symbol detected in test"
+                fi
+            fi
+        done <<EOF
+$(get_added_lines_with_lineno "$diff_file")
+EOF
+    done <<EOF
+$(get_diff_files)
+EOF
 }
 
+# ── §3.1 DOC_OUT_OF_SYNC detector (det half) ─────────────────────────────────
+# Any change to public surface (CLI flag/env var/exported func/config key)
+# without a touched doc file.
+
 detect_doc_out_of_sync() {
-    return 0
+    local diff_files
+    diff_files="$(get_diff_files)"
+
+    # Check if any doc file was touched
+    local doc_touched=0
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        if is_doc_file "$f"; then
+            doc_touched=1
+            break
+        fi
+    done <<EOF
+$diff_files
+EOF
+
+    if [ "$doc_touched" -eq 1 ]; then
+        return 0
+    fi
+
+    # Look for public-surface changes in non-test, non-doc source files
+    while IFS= read -r diff_file; do
+        [ -z "$diff_file" ] && continue
+        is_test_file "$diff_file" && continue
+        is_doc_file "$diff_file" && continue
+
+        # Skip binary-ish and fixture files
+        case "$diff_file" in
+            *.diff|*.png|*.jpg|*.gif) continue ;;
+        esac
+
+        while IFS=: read -r lineno content; do
+            # CLI flag pattern: --flag-name with at least 3 chars (avoid -f style short flags in comments)
+            if printf '%s' "$content" | grep -qE '(^|[[:space:]])(--[a-z][a-z0-9-]{2,})[[:space:]=]'; then
+                emit_capped "DOC_OUT_OF_SYNC" "$diff_file" "$lineno" "CLI long-flag introduced without touching a doc file"
+                break
+            fi
+            # Env var export pattern: export FOO_BAR= or FOO_BAR= at start of line (require underscore or 3+ caps)
+            if printf '%s' "$content" | grep -qE '^(export[[:space:]]+)?[A-Z][A-Z0-9]*_[A-Z0-9_]+='; then
+                emit_capped "DOC_OUT_OF_SYNC" "$diff_file" "$lineno" "env var introduced without touching a doc file"
+                break
+            fi
+        done <<EOF
+$(get_added_lines_with_lineno "$diff_file")
+EOF
+    done <<EOF
+$diff_files
+EOF
 }
 
 # ── main ──────────────────────────────────────────────────────────────────────

--- a/tests/fixtures/implementation-quality/bad-complexity.diff
+++ b/tests/fixtures/implementation-quality/bad-complexity.diff
@@ -2,7 +2,7 @@ diff --git a/scripts/complex.sh b/scripts/complex.sh
 new file mode 100755
 --- /dev/null
 +++ b/scripts/complex.sh
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,72 @@
 +#!/usr/bin/env bash
 +# scripts/complex.sh — overly complex function exceeding 50 LOC threshold.
 +set -eu
@@ -53,6 +53,16 @@ new file mode 100755
 +            echo "branch t"
 +        elif [ "$input" = "u" ]; then
 +            echo "branch u"
++        elif [ "$input" = "v" ]; then
++            echo "branch v"
++        elif [ "$input" = "w" ]; then
++            echo "branch w"
++        elif [ "$input" = "x" ]; then
++            echo "branch x"
++        elif [ "$input" = "y" ]; then
++            echo "branch y"
++        elif [ "$input" = "z" ]; then
++            echo "branch z"
 +        else
 +            echo "branch other"
 +        fi


### PR DESCRIPTION
Closes #206

## Summary

- Implements 7 deterministic RULE_ID detectors per spec §3.1:
  - `OUT_OF_SCOPE`: compares diff file paths against `## Implementation outline` from issue body
  - `MISSING_TEST`: checks required test tiers from `## Tests required` are present in diff
  - `COMPLEXITY`: detects functions >50 LOC, files >500 LOC, nesting >4 levels
  - `SECURITY`: regex for eval/exec/--no-verify/git-reset-hard/rm-rf/AWS-key/GH-token/private-key
  - `TODO_LEFT`: finds TODO/XXX/FIXME in non-test added lines
  - `MOCK_DB`: finds mock/stub near DB symbols in test added lines
  - `DOC_OUT_OF_SYNC` det-half: public surface change without doc file touched
- Per-RULE_ID emit cap of 10 enforced via `emit_capped`
- Skip-directive honoring via `parse_skip_directives` (INFO: prefix instead of blocking)
- Portable awk (no gawk-only match() array capture)
- Extended `bad-complexity.diff` fixture to reliably exceed 50 LOC threshold

## Verification

- `bash -n scripts/lint-implementation.sh` exits 0
- `good.diff` → exit 0, no findings
- `bad-todo-left.diff` → `TODO_LEFT` fired
- `bad-secret.diff` → `SECURITY` fired
- `bad-mock-db.diff` → `MOCK_DB` fired
- `bad-complexity.diff` → `COMPLEXITY` fired (59 LOC)
- `bash scripts/validate.sh` exits 0