### PR TITLE
fix(autospec-run): sync lock-step heartbeat schema in opencode doc

### DIFF
--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -252,7 +252,7 @@ Then launch a **background subagent** with this prompt verbatim:
 > Keep a progress heartbeat so the monitor can prove forward movement:
 > - Create/update `~/.autospec/process-heartbeats/<ISSUE>.json` at each major step:
 >   - `claimed`, `worktree_ready`, `tests_started`, `tests_passed`, `pr_created`, `smoke_retry`, `reviewed`, `merged`, `failed`
-> - Schema: `{"issue":"<ISSUE>","branch":"<BRANCH>","step":"<STEP>","ts":<unix_epoch>,"pr":"<PR>","repo":"{repo}"`
+> - Schema: `{"issue":"<ISSUE>","branch":"<BRANCH>","step":"<STEP>","ts":<unix_epoch>,"pr":"<PR>","repo":"{repo}"}`
 > - Delete this file on terminal SUCCESS/FAILURE in both clean and failure paths.
 > 
 > 1. Worktree off origin/main:


### PR DESCRIPTION
## Summary
- Fix typo in `skills/autospec-run/opencode/agent.md` schema line so heartbeat heartbeat payload matches the lock-step `SKILL.md` body.
- This restores cross-harness skill body identity required by repo validation.

## Verification
- `bash scripts/validate.sh`
