### PR TITLE
fix(autospec): drop shell-eval of user request from mode dispatch

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -60,8 +60,8 @@ Decide this purely from the request text the harness handed you. Do NOT
 shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
 test the user's free-form request — passing it through a shell is what
 historically tripped harness permission engines (e.g. parse errors near
-backtick/pipe characters in the user's prose). Read the request, mentally
-normalize it (collapse whitespace, trim, lowercase), and if the result is
+backtick/pipe characters in the user's prose). Read the request, normalize
+it in your reasoning (collapse whitespace, trim, lowercase), and if the result is
 exactly `update`, this skill enters self-update mode and does NOT run the
 normal pipeline.
 
@@ -115,10 +115,12 @@ If the file is missing on run start:
      (ignore header/blank lines, capture first column only).
    - For each discovered model, write a local profile using conservative defaults:
      `ctx: 64k`, `reasoning: medium`.
-   - Normalize the profile key by lowercasing and replacing path/space punctuation
-     with `-`, then append `-laptop` (e.g. `qwen3:32b` → `qwen3-32b-laptop`).
-   - If `ollama` is installed but returns zero usable models, treat as no local models
-     (do not force a false-positive local profile).
+   - Normalize the profile key by lowercasing and replacing each of `:`, `/`, `.`,
+     and whitespace with `-`, then append `-laptop` (e.g. `qwen3:32b` →
+     `qwen3-32b-laptop`, `library/llama3:latest` → `library-llama3-latest-laptop`).
+   - If `ollama list` exits non-zero (e.g. daemon not running) or returns zero
+     usable model rows, treat as no local models (do not force a false-positive
+     local profile).
 2. If `ANTHROPIC_API_KEY` is set in the environment, append two cloud profiles:
    `claude-sonnet-cloud` and `claude-opus-cloud`, both `ctx: 120k`,
    `reasoning: deep`.

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -56,7 +56,14 @@ echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 
 ## Self-update mode
 
-If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+Decide this purely from the request text the harness handed you. Do NOT
+shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
+test the user's free-form request — passing it through a shell is what
+historically tripped harness permission engines (e.g. parse errors near
+backtick/pipe characters in the user's prose). Read the request, mentally
+normalize it (collapse whitespace, trim, lowercase), and if the result is
+exactly `update`, this skill enters self-update mode and does NOT run the
+normal pipeline.
 
 1. **Detect harness** by checking which install path exists for this skill:
    - Claude Code: `~/.claude/skills/autospec-run/SKILL.md`
@@ -74,9 +81,13 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 
 ## Stop mode
 
-If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
-(case-insensitive), this skill enters stop mode and does not run the normal
-pipeline:
+Apply the same read-and-normalize approach used for self-update mode (do
+NOT shell out the user's request). If the normalized request is exactly
+`stop`, or `stop` followed by one or more `--<word>` flags (examples:
+`stop`, `stop --graceful`, `stop --immediate`, `stop --status`,
+`stop --resume`, `stop --help`, `stop --flag`), this skill enters stop
+mode and does NOT run the normal pipeline. When dispatching, pass any
+`--<flag>` tokens the user provided as separate words to the helper.
 
 1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
 2. Print the helper's stdout to the user.
@@ -96,10 +107,18 @@ pipeline:
 
 If the file is missing on run start:
 
-1. Probe `ollama list 2>/dev/null` and grep for known local-model name patterns
-   (`qwen3`, `llama3`, `qwen2`, `mistral`, `phi3`, `gemma`). For each match, write
-   a profile keyed on the model name with conservative defaults:
-   `ctx: 64k`, `reasoning: medium`. (`qwen3:32b` → `qwen3-32b-laptop`.)
+1. Probe local Ollama availability directly:
+   - Detect the binary robustly:
+     - macOS/Linux: `command -v ollama`
+     - Windows: `where.exe ollama`
+   - If present, run `ollama list 2>/dev/null` once and parse returned model rows
+     (ignore header/blank lines, capture first column only).
+   - For each discovered model, write a local profile using conservative defaults:
+     `ctx: 64k`, `reasoning: medium`.
+   - Normalize the profile key by lowercasing and replacing path/space punctuation
+     with `-`, then append `-laptop` (e.g. `qwen3:32b` → `qwen3-32b-laptop`).
+   - If `ollama` is installed but returns zero usable models, treat as no local models
+     (do not force a false-positive local profile).
 2. If `ANTHROPIC_API_KEY` is set in the environment, append two cloud profiles:
    `claude-sonnet-cloud` and `claude-opus-cloud`, both `ctx: 120k`,
    `reasoning: deep`.

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -56,8 +56,8 @@ Decide this purely from the request text the harness handed you. Do NOT
 shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
 test the user's free-form request — passing it through a shell is what
 historically tripped harness permission engines (e.g. parse errors near
-backtick/pipe characters in the user's prose). Read the request, mentally
-normalize it (collapse whitespace, trim, lowercase), and if the result is
+backtick/pipe characters in the user's prose). Read the request, normalize
+it in your reasoning (collapse whitespace, trim, lowercase), and if the result is
 exactly `update`, this skill enters self-update mode and does NOT run the
 normal pipeline.
 
@@ -111,10 +111,12 @@ If the file is missing on run start:
      (ignore header/blank lines, capture first column only).
    - For each discovered model, write a local profile using conservative defaults:
      `ctx: 64k`, `reasoning: medium`.
-   - Normalize the profile key by lowercasing and replacing path/space punctuation
-     with `-`, then append `-laptop` (e.g. `qwen3:32b` → `qwen3-32b-laptop`).
-   - If `ollama` is installed but returns zero usable models, treat as no local models
-     (do not force a false-positive local profile).
+   - Normalize the profile key by lowercasing and replacing each of `:`, `/`, `.`,
+     and whitespace with `-`, then append `-laptop` (e.g. `qwen3:32b` →
+     `qwen3-32b-laptop`, `library/llama3:latest` → `library-llama3-latest-laptop`).
+   - If `ollama list` exits non-zero (e.g. daemon not running) or returns zero
+     usable model rows, treat as no local models (do not force a false-positive
+     local profile).
 2. If `ANTHROPIC_API_KEY` is set in the environment, append two cloud profiles:
    `claude-sonnet-cloud` and `claude-opus-cloud`, both `ctx: 120k`,
    `reasoning: deep`.

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -52,7 +52,14 @@ echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 
 ## Self-update mode
 
-If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+Decide this purely from the request text the harness handed you. Do NOT
+shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
+test the user's free-form request — passing it through a shell is what
+historically tripped harness permission engines (e.g. parse errors near
+backtick/pipe characters in the user's prose). Read the request, mentally
+normalize it (collapse whitespace, trim, lowercase), and if the result is
+exactly `update`, this skill enters self-update mode and does NOT run the
+normal pipeline.
 
 1. **Detect harness** by checking which install path exists for this skill:
    - Claude Code: `~/.claude/skills/autospec-run/SKILL.md`
@@ -70,9 +77,13 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 
 ## Stop mode
 
-If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
-(case-insensitive), this skill enters stop mode and does not run the normal
-pipeline:
+Apply the same read-and-normalize approach used for self-update mode (do
+NOT shell out the user's request). If the normalized request is exactly
+`stop`, or `stop` followed by one or more `--<word>` flags (examples:
+`stop`, `stop --graceful`, `stop --immediate`, `stop --status`,
+`stop --resume`, `stop --help`, `stop --flag`), this skill enters stop
+mode and does NOT run the normal pipeline. When dispatching, pass any
+`--<flag>` tokens the user provided as separate words to the helper.
 
 1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
 2. Print the helper's stdout to the user.
@@ -92,10 +103,18 @@ pipeline:
 
 If the file is missing on run start:
 
-1. Probe `ollama list 2>/dev/null` and grep for known local-model name patterns
-   (`qwen3`, `llama3`, `qwen2`, `mistral`, `phi3`, `gemma`). For each match, write
-   a profile keyed on the model name with conservative defaults:
-   `ctx: 64k`, `reasoning: medium`. (`qwen3:32b` → `qwen3-32b-laptop`.)
+1. Probe local Ollama availability directly:
+   - Detect the binary robustly:
+     - macOS/Linux: `command -v ollama`
+     - Windows: `where.exe ollama`
+   - If present, run `ollama list 2>/dev/null` once and parse returned model rows
+     (ignore header/blank lines, capture first column only).
+   - For each discovered model, write a local profile using conservative defaults:
+     `ctx: 64k`, `reasoning: medium`.
+   - Normalize the profile key by lowercasing and replacing path/space punctuation
+     with `-`, then append `-laptop` (e.g. `qwen3:32b` → `qwen3-32b-laptop`).
+   - If `ollama` is installed but returns zero usable models, treat as no local models
+     (do not force a false-positive local profile).
 2. If `ANTHROPIC_API_KEY` is set in the environment, append two cloud profiles:
    `claude-sonnet-cloud` and `claude-opus-cloud`, both `ctx: 120k`,
    `reasoning: deep`.

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -60,8 +60,8 @@ Decide this purely from the request text the harness handed you. Do NOT
 shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
 test the user's free-form request — passing it through a shell is what
 historically tripped harness permission engines (e.g. parse errors near
-backtick/pipe characters in the user's prose). Read the request, mentally
-normalize it (collapse whitespace, trim, lowercase), and if the result is
+backtick/pipe characters in the user's prose). Read the request, normalize
+it in your reasoning (collapse whitespace, trim, lowercase), and if the result is
 exactly `update`, this skill enters self-update mode and does NOT run the
 normal pipeline.
 
@@ -115,10 +115,12 @@ If the file is missing on run start:
      (ignore header/blank lines, capture first column only).
    - For each discovered model, write a local profile using conservative defaults:
      `ctx: 64k`, `reasoning: medium`.
-   - Normalize the profile key by lowercasing and replacing path/space punctuation
-     with `-`, then append `-laptop` (e.g. `qwen3:32b` → `qwen3-32b-laptop`).
-   - If `ollama` is installed but returns zero usable models, treat as no local models
-     (do not force a false-positive local profile).
+   - Normalize the profile key by lowercasing and replacing each of `:`, `/`, `.`,
+     and whitespace with `-`, then append `-laptop` (e.g. `qwen3:32b` →
+     `qwen3-32b-laptop`, `library/llama3:latest` → `library-llama3-latest-laptop`).
+   - If `ollama list` exits non-zero (e.g. daemon not running) or returns zero
+     usable model rows, treat as no local models (do not force a false-positive
+     local profile).
 2. If `ANTHROPIC_API_KEY` is set in the environment, append two cloud profiles:
    `claude-sonnet-cloud` and `claude-opus-cloud`, both `ctx: 120k`,
    `reasoning: deep`.

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -56,7 +56,14 @@ echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 
 ## Self-update mode
 
-If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+Decide this purely from the request text the harness handed you. Do NOT
+shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
+test the user's free-form request — passing it through a shell is what
+historically tripped harness permission engines (e.g. parse errors near
+backtick/pipe characters in the user's prose). Read the request, mentally
+normalize it (collapse whitespace, trim, lowercase), and if the result is
+exactly `update`, this skill enters self-update mode and does NOT run the
+normal pipeline.
 
 1. **Detect harness** by checking which install path exists for this skill:
    - Claude Code: `~/.claude/skills/autospec-run/SKILL.md`
@@ -74,9 +81,13 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 
 ## Stop mode
 
-If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
-(case-insensitive), this skill enters stop mode and does not run the normal
-pipeline:
+Apply the same read-and-normalize approach used for self-update mode (do
+NOT shell out the user's request). If the normalized request is exactly
+`stop`, or `stop` followed by one or more `--<word>` flags (examples:
+`stop`, `stop --graceful`, `stop --immediate`, `stop --status`,
+`stop --resume`, `stop --help`, `stop --flag`), this skill enters stop
+mode and does NOT run the normal pipeline. When dispatching, pass any
+`--<flag>` tokens the user provided as separate words to the helper.
 
 1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
 2. Print the helper's stdout to the user.
@@ -96,10 +107,18 @@ pipeline:
 
 If the file is missing on run start:
 
-1. Probe `ollama list 2>/dev/null` and grep for known local-model name patterns
-   (`qwen3`, `llama3`, `qwen2`, `mistral`, `phi3`, `gemma`). For each match, write
-   a profile keyed on the model name with conservative defaults:
-   `ctx: 64k`, `reasoning: medium`. (`qwen3:32b` → `qwen3-32b-laptop`.)
+1. Probe local Ollama availability directly:
+   - Detect the binary robustly:
+     - macOS/Linux: `command -v ollama`
+     - Windows: `where.exe ollama`
+   - If present, run `ollama list 2>/dev/null` once and parse returned model rows
+     (ignore header/blank lines, capture first column only).
+   - For each discovered model, write a local profile using conservative defaults:
+     `ctx: 64k`, `reasoning: medium`.
+   - Normalize the profile key by lowercasing and replacing path/space punctuation
+     with `-`, then append `-laptop` (e.g. `qwen3:32b` → `qwen3-32b-laptop`).
+   - If `ollama` is installed but returns zero usable models, treat as no local models
+     (do not force a false-positive local profile).
 2. If `ANTHROPIC_API_KEY` is set in the environment, append two cloud profiles:
    `claude-sonnet-cloud` and `claude-opus-cloud`, both `ctx: 120k`,
    `reasoning: deep`.

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -58,8 +58,8 @@ Decide this purely from the request text the harness handed you. Do NOT
 shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
 test the user's free-form request — passing it through a shell is what
 historically tripped harness permission engines (e.g. parse errors near
-backtick/pipe characters in the user's prose). Read the request, mentally
-normalize it (collapse whitespace, trim, lowercase), and if the result is
+backtick/pipe characters in the user's prose). Read the request, normalize
+it in your reasoning (collapse whitespace, trim, lowercase), and if the result is
 exactly `update`, this skill enters self-update mode and does NOT run the
 normal pipeline.
 

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -54,7 +54,14 @@ echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 
 ## Self-update mode
 
-If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+Decide this purely from the request text the harness handed you. Do NOT
+shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
+test the user's free-form request — passing it through a shell is what
+historically tripped harness permission engines (e.g. parse errors near
+backtick/pipe characters in the user's prose). Read the request, mentally
+normalize it (collapse whitespace, trim, lowercase), and if the result is
+exactly `update`, this skill enters self-update mode and does NOT run the
+normal pipeline.
 
 1. **Detect harness** by checking which install path exists for this skill:
    - Claude Code: `~/.claude/skills/autospec/SKILL.md`
@@ -72,9 +79,13 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 
 ## Stop mode
 
-If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
-(case-insensitive), this skill enters stop mode and does not run the normal
-pipeline:
+Apply the same read-and-normalize approach used for self-update mode (do
+NOT shell out the user's request). If the normalized request is exactly
+`stop`, or `stop` followed by one or more `--<word>` flags (examples:
+`stop`, `stop --graceful`, `stop --immediate`, `stop --status`,
+`stop --resume`, `stop --help`, `stop --flag`), this skill enters stop
+mode and does NOT run the normal pipeline. When dispatching, pass any
+`--<flag>` tokens the user provided as separate words to the helper.
 
 1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
 2. Print the helper's stdout to the user.

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -50,7 +50,14 @@ echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 
 ## Self-update mode
 
-If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+Decide this purely from the request text the harness handed you. Do NOT
+shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
+test the user's free-form request — passing it through a shell is what
+historically tripped harness permission engines (e.g. parse errors near
+backtick/pipe characters in the user's prose). Read the request, mentally
+normalize it (collapse whitespace, trim, lowercase), and if the result is
+exactly `update`, this skill enters self-update mode and does NOT run the
+normal pipeline.
 
 1. **Detect harness** by checking which install path exists for this skill:
    - Claude Code: `~/.claude/skills/autospec/SKILL.md`
@@ -68,9 +75,13 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 
 ## Stop mode
 
-If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
-(case-insensitive), this skill enters stop mode and does not run the normal
-pipeline:
+Apply the same read-and-normalize approach used for self-update mode (do
+NOT shell out the user's request). If the normalized request is exactly
+`stop`, or `stop` followed by one or more `--<word>` flags (examples:
+`stop`, `stop --graceful`, `stop --immediate`, `stop --status`,
+`stop --resume`, `stop --help`, `stop --flag`), this skill enters stop
+mode and does NOT run the normal pipeline. When dispatching, pass any
+`--<flag>` tokens the user provided as separate words to the helper.
 
 1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
 2. Print the helper's stdout to the user.

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -54,8 +54,8 @@ Decide this purely from the request text the harness handed you. Do NOT
 shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
 test the user's free-form request — passing it through a shell is what
 historically tripped harness permission engines (e.g. parse errors near
-backtick/pipe characters in the user's prose). Read the request, mentally
-normalize it (collapse whitespace, trim, lowercase), and if the result is
+backtick/pipe characters in the user's prose). Read the request, normalize
+it in your reasoning (collapse whitespace, trim, lowercase), and if the result is
 exactly `update`, this skill enters self-update mode and does NOT run the
 normal pipeline.
 

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -58,8 +58,8 @@ Decide this purely from the request text the harness handed you. Do NOT
 shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
 test the user's free-form request — passing it through a shell is what
 historically tripped harness permission engines (e.g. parse errors near
-backtick/pipe characters in the user's prose). Read the request, mentally
-normalize it (collapse whitespace, trim, lowercase), and if the result is
+backtick/pipe characters in the user's prose). Read the request, normalize
+it in your reasoning (collapse whitespace, trim, lowercase), and if the result is
 exactly `update`, this skill enters self-update mode and does NOT run the
 normal pipeline.
 

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -54,7 +54,14 @@ echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 
 ## Self-update mode
 
-If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+Decide this purely from the request text the harness handed you. Do NOT
+shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
+test the user's free-form request — passing it through a shell is what
+historically tripped harness permission engines (e.g. parse errors near
+backtick/pipe characters in the user's prose). Read the request, mentally
+normalize it (collapse whitespace, trim, lowercase), and if the result is
+exactly `update`, this skill enters self-update mode and does NOT run the
+normal pipeline.
 
 1. **Detect harness** by checking which install path exists for this skill:
    - Claude Code: `~/.claude/skills/autospec/SKILL.md`
@@ -72,9 +79,13 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 
 ## Stop mode
 
-If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
-(case-insensitive), this skill enters stop mode and does not run the normal
-pipeline:
+Apply the same read-and-normalize approach used for self-update mode (do
+NOT shell out the user's request). If the normalized request is exactly
+`stop`, or `stop` followed by one or more `--<word>` flags (examples:
+`stop`, `stop --graceful`, `stop --immediate`, `stop --status`,
+`stop --resume`, `stop --help`, `stop --flag`), this skill enters stop
+mode and does NOT run the normal pipeline. When dispatching, pass any
+`--<flag>` tokens the user provided as separate words to the helper.
 
 1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
 2. Print the helper's stdout to the user.


### PR DESCRIPTION
## Summary

- Self-update mode + Stop mode sections in the `autospec` and `autospec-run` lock-step trios shipped a bash heredoc that piped `{FEATURE_DESCRIPTION}` through `tr`/`sed`. No harness substitutes that placeholder, so any model that ran the bash literally shell-processed the user's free-form request. Claude Code's permission-pattern checker then bombed on metacharacters anywhere in the prose with `Error: Shell command failed for pattern "!\` | "`. The skill aborted before Phase 0 every time.
- Replaced both bash blocks (6 trio files) with pure prose: read the request text already in your context, mentally normalize (trim/collapse/lowercase), compare to the literal mode keyword. Never put user text in a shell.
- Kept the in-flight Ollama-probe rewrite: detect the binary via `command -v` / `where.exe` (not a hardcoded model-name allowlist) and parse every model row, so "ollama installed but model name not in allowlist" no longer false-negatives.

## Test plan

- [x] `scripts/validate.sh` passes (lock-step, frontmatter, self-update, stop-mode, guardian-block, all green)
- [x] `bats tests/unit` passes (221/221 — including `test_stop_inline_subagent_regex.bats` and `test_self_update_preflight.bats`)
- [ ] CI green
- [ ] Sanity-check `/autospec <free-form prose with no special chars>` no longer trips the parse error
- [ ] Sanity-check `/autospec stop --graceful` still routes to stop mode
- [ ] Sanity-check `/autospec-run` auto-init detects an Ollama model whose name is not in the old allowlist (e.g. `gpt-oss`, `deepseek-coder`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)