### PR TITLE
feat(monitor): extend idle shutdown timeout from 1h to 2h

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -211,7 +211,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
->     if open_count == 0 AND latest_close > 1h ago: HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
+>     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
 >     else: print state ("blocked: N unmet deps" / "deferred: M off-profile" / "drained, waiting 1h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -206,7 +206,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
->     if open_count == 0 AND latest_close > 1h ago: HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
+>     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
 >     else: print state ("blocked: N unmet deps" / "deferred: M off-profile" / "drained, waiting 1h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -210,7 +210,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
->     if open_count == 0 AND latest_close > 1h ago: HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
+>     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
 >     else: print state ("blocked: N unmet deps" / "deferred: M off-profile" / "drained, waiting 1h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -437,7 +437,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
->     if open_count == 0 AND latest_close > 1h ago: HARD SHUTDOWN — return final report
+>     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — return final report
 >     else: print state ("blocked: N unmet deps" / "drained, waiting 1h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -431,7 +431,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
->     if open_count == 0 AND latest_close > 1h ago: HARD SHUTDOWN — return final report
+>     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — return final report
 >     else: print state ("blocked: N unmet deps" / "drained, waiting 1h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -435,7 +435,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
->     if open_count == 0 AND latest_close > 1h ago: HARD SHUTDOWN — return final report
+>     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — return final report
 >     else: print state ("blocked: N unmet deps" / "drained, waiting 1h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then


### PR DESCRIPTION
## Problem

The autospec monitor shuts down after only 1 hour of idle time (no new issues), even though the loop is designed to stay running and continuously process issues. This was too aggressive — the agent appeared to stop before the user could see it keep working.

## Change

Update the idle timeout threshold in both  and  skills (all 6 harness variants) from  to .

## Files changed

- skills/autospec-run/SKILL.md
- skills/autospec-run/codex/prompt.md
- skills/autospec-run/opencode/agent.md
- skills/autospec/SKILL.md
- skills/autospec/codex/prompt.md
- skills/autospec/opencode/agent.md

## Validation

- validate: scanning multi-harness skills under skills/ ...
validate: lock-step: autospec-classify
validate: frontmatter parse: skills/autospec-classify/SKILL.md
validate: frontmatter parse: skills/autospec-classify/opencode/agent.md
validate: bash -n: skills/autospec-classify/install.sh
validate: bash -n: skills/autospec-classify/uninstall.sh
validate: self-update: autospec-classify
validate: subagent model tier: autospec-classify
validate: lock-step: autospec-define
validate: frontmatter parse: skills/autospec-define/SKILL.md
validate: frontmatter parse: skills/autospec-define/opencode/agent.md
validate: bash -n: skills/autospec-define/install.sh
validate: bash -n: skills/autospec-define/uninstall.sh
validate: self-update: autospec-define
validate: subagent model tier: autospec-define
validate: lock-step: autospec-listen
validate: frontmatter parse: skills/autospec-listen/SKILL.md
validate: frontmatter parse: skills/autospec-listen/opencode/agent.md
validate: bash -n: skills/autospec-listen/install.sh
validate: bash -n: skills/autospec-listen/uninstall.sh
validate: self-update: autospec-listen
validate: subagent model tier: autospec-listen
validate: lock-step: autospec-run
validate: frontmatter parse: skills/autospec-run/SKILL.md
validate: frontmatter parse: skills/autospec-run/opencode/agent.md
validate: bash -n: skills/autospec-run/install.sh
validate: bash -n: skills/autospec-run/uninstall.sh
validate: self-update: autospec-run
validate: subagent model tier: autospec-run
validate: lock-step: autospec-stop
validate: frontmatter parse: skills/autospec-stop/SKILL.md
validate: frontmatter parse: skills/autospec-stop/opencode/agent.md
validate: bash -n: skills/autospec-stop/install.sh
validate: bash -n: skills/autospec-stop/uninstall.sh
validate: self-update: autospec-stop
validate: subagent model tier: autospec-stop
validate: lock-step: autospec
validate: frontmatter parse: skills/autospec/SKILL.md
validate: frontmatter parse: skills/autospec/opencode/agent.md
validate: bash -n: skills/autospec/install.sh
validate: bash -n: skills/autospec/uninstall.sh
validate: self-update: autospec
validate: subagent model tier: autospec
validate: stop-mode: autospec
validate: stop-mode: autospec-run
validate: stop-mode: autospec-stop
validate: codex skills-dir install: all skills
validate: AGENTS.md: two-tier subagent model selection section
validate: presence: skills/autospec-listen/
validate: presence: examples/
validate: governance headings: AGENTS.md / README.md / SKILLS.md
validate: lint-issue helpers: scripts/lint-issue.sh + fixtures
validate: lint-implementation helpers: scripts/lint-implementation.sh
validate: phase4 guardian block lockstep: autospec + autospec-run trio
validate: guardian lockstep: all 6 trio files byte-identical
validate: bash -n: install.sh
validate: bash -n: uninstall.sh
validate: OK — all validation checks passed. passes (lock-step consistency + all harness variants)
- All changes are single-line, 1h → 2h, identical across SKILL.md ↔ codex/prompt.md ↔ opencode/agent.md for both autospec and autospec-run trios

## Related

Closes #228
