### PR TITLE
feat(monitor): add harness loop persistence guidance and claim conflict detection

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -184,6 +184,19 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 Then launch a **background subagent** with this prompt verbatim:
 
 > You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+
+> **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
+> 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
+> while true; do
+>   # ... monitor logic ...
+> done
+> EOF` — keeps a single bash process alive with your agent dispatching subcommands inside it.
+> 2. **nohup background process:** `nohup bash -c 'while true; do ...; sleep 1; done' > ~/.autospec/monitor.log 2>&1 &`
+> 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
+> while true; do ...; done
+> HEREDOC'`
+> **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
+
 >
 > **Profile load (run-start, once).** If `--profile <name>` was passed, look it up in `~/.autospec/model-profiles.yml`; if `<name>` is not a key under `profiles:`, exit non-zero and print the available names. If no flag was passed, load the file's `default:` profile. If the file is missing, run auto-init and exit (per the Invocation section).
 >
@@ -252,8 +265,21 @@ Then launch a **background subagent** with this prompt verbatim:
 >     fi
 >   fi
 >   ISSUE = ready[0]
+>   # Claim check: verify the issue is still labeled auto-implement before processing.
+>   # Multiple monitors can query the same candidate list simultaneously;
+>   # the first to claim wins, others must skip to the next candidate.
+>   CURRENT_LABELS=$(gh issue view ISSUE --json labels --jq -r '.labels[].name')
+>   if ! echo "$CURRENT_LABELS" | grep -q "^auto-implement$"; then
+>     echo "[monitor] ISSUE $ISSUE already claimed (no auto-implement label); skipping"
+>     READY_REMOVE=$(printf "%s\n%s" "$READY_REMOVE" "$ISSUE" | grep -v "^${ISSUE}$" || true)
+>     ready=($READY_REMOVE)
+>     continue
+>   fi
 >   gh label create in-progress-by-bot --color ededed --force
->   gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot
+>   if ! gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot; then
+>     echo "[monitor] ISSUE $ISSUE claim failed (another monitor claimed it); skipping"
+>     continue
+>   fi
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -179,6 +179,19 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 Then launch a **background subagent** with this prompt verbatim:
 
 > You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+
+> **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
+> 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
+> while true; do
+>   # ... monitor logic ...
+> done
+> EOF` — keeps a single bash process alive with your agent dispatching subcommands inside it.
+> 2. **nohup background process:** `nohup bash -c 'while true; do ...; sleep 1; done' > ~/.autospec/monitor.log 2>&1 &`
+> 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
+> while true; do ...; done
+> HEREDOC'`
+> **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
+
 >
 > **Profile load (run-start, once).** If `--profile <name>` was passed, look it up in `~/.autospec/model-profiles.yml`; if `<name>` is not a key under `profiles:`, exit non-zero and print the available names. If no flag was passed, load the file's `default:` profile. If the file is missing, run auto-init and exit (per the Invocation section).
 >
@@ -247,8 +260,21 @@ Then launch a **background subagent** with this prompt verbatim:
 >     fi
 >   fi
 >   ISSUE = ready[0]
+>   # Claim check: verify the issue is still labeled auto-implement before processing.
+>   # Multiple monitors can query the same candidate list simultaneously;
+>   # the first to claim wins, others must skip to the next candidate.
+>   CURRENT_LABELS=$(gh issue view ISSUE --json labels --jq -r '.labels[].name')
+>   if ! echo "$CURRENT_LABELS" | grep -q "^auto-implement$"; then
+>     echo "[monitor] ISSUE $ISSUE already claimed (no auto-implement label); skipping"
+>     READY_REMOVE=$(printf "%s\n%s" "$READY_REMOVE" "$ISSUE" | grep -v "^${ISSUE}$" || true)
+>     ready=($READY_REMOVE)
+>     continue
+>   fi
 >   gh label create in-progress-by-bot --color ededed --force
->   gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot
+>   if ! gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot; then
+>     echo "[monitor] ISSUE $ISSUE claim failed (another monitor claimed it); skipping"
+>     continue
+>   fi
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -183,6 +183,19 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 Then launch a **background subagent** with this prompt verbatim:
 
 > You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+
+> **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
+> 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
+> while true; do
+>   # ... monitor logic ...
+> done
+> EOF` — keeps a single bash process alive with your agent dispatching subcommands inside it.
+> 2. **nohup background process:** `nohup bash -c 'while true; do ...; sleep 1; done' > ~/.autospec/monitor.log 2>&1 &`
+> 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
+> while true; do ...; done
+> HEREDOC'`
+> **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
+
 >
 > **Profile load (run-start, once).** If `--profile <name>` was passed, look it up in `~/.autospec/model-profiles.yml`; if `<name>` is not a key under `profiles:`, exit non-zero and print the available names. If no flag was passed, load the file's `default:` profile. If the file is missing, run auto-init and exit (per the Invocation section).
 >
@@ -251,8 +264,21 @@ Then launch a **background subagent** with this prompt verbatim:
 >     fi
 >   fi
 >   ISSUE = ready[0]
+>   # Claim check: verify the issue is still labeled auto-implement before processing.
+>   # Multiple monitors can query the same candidate list simultaneously;
+>   # the first to claim wins, others must skip to the next candidate.
+>   CURRENT_LABELS=$(gh issue view ISSUE --json labels --jq -r '.labels[].name')
+>   if ! echo "$CURRENT_LABELS" | grep -q "^auto-implement$"; then
+>     echo "[monitor] ISSUE $ISSUE already claimed (no auto-implement label); skipping"
+>     READY_REMOVE=$(printf "%s\n%s" "$READY_REMOVE" "$ISSUE" | grep -v "^${ISSUE}$" || true)
+>     ready=($READY_REMOVE)
+>     continue
+>   fi
 >   gh label create in-progress-by-bot --color ededed --force
->   gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot
+>   if ! gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot; then
+>     echo "[monitor] ISSUE $ISSUE claim failed (another monitor claimed it); skipping"
+>     continue
+>   fi
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -429,6 +429,19 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 Then launch a **background subagent** with this prompt verbatim:
 
 > You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+
+> **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
+> 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
+> while true; do
+>   # ... monitor logic ...
+> done
+> EOF` — keeps a single bash process alive with your agent dispatching subcommands inside it.
+> 2. **nohup background process:** `nohup bash -c 'while true; do ...; sleep 1; done' > ~/.autospec/monitor.log 2>&1 &`
+> 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
+> while true; do ...; done
+> HEREDOC'`
+> **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
+
 >
 > Outer loop:
 > ```
@@ -478,8 +491,21 @@ Then launch a **background subagent** with this prompt verbatim:
 >     fi
 >   fi
 >   ISSUE = ready[0]
+>   # Claim check: verify the issue is still labeled auto-implement before processing.
+>   # Multiple monitors can query the same candidate list simultaneously;
+>   # the first to claim wins, others must skip to the next candidate.
+>   CURRENT_LABELS=$(gh issue view ISSUE --json labels --jq -r '.labels[].name')
+>   if ! echo "$CURRENT_LABELS" | grep -q "^auto-implement$"; then
+>     echo "[monitor] ISSUE $ISSUE already claimed (no auto-implement label); skipping"
+>     READY_REMOVE=$(printf "%s\n%s" "$READY_REMOVE" "$ISSUE" | grep -v "^${ISSUE}$" || true)
+>     ready=($READY_REMOVE)
+>     continue
+>   fi
 >   gh label create in-progress-by-bot --color ededed --force
->   gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot
+>   if ! gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot; then
+>     echo "[monitor] ISSUE $ISSUE claim failed (another monitor claimed it); skipping"
+>     continue
+>   fi
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -423,6 +423,19 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 Then launch a **background subagent** with this prompt verbatim:
 
 > You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+
+> **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
+> 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
+> while true; do
+>   # ... monitor logic ...
+> done
+> EOF` — keeps a single bash process alive with your agent dispatching subcommands inside it.
+> 2. **nohup background process:** `nohup bash -c 'while true; do ...; sleep 1; done' > ~/.autospec/monitor.log 2>&1 &`
+> 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
+> while true; do ...; done
+> HEREDOC'`
+> **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
+
 >
 > Outer loop:
 > ```
@@ -472,8 +485,21 @@ Then launch a **background subagent** with this prompt verbatim:
 >     fi
 >   fi
 >   ISSUE = ready[0]
+>   # Claim check: verify the issue is still labeled auto-implement before processing.
+>   # Multiple monitors can query the same candidate list simultaneously;
+>   # the first to claim wins, others must skip to the next candidate.
+>   CURRENT_LABELS=$(gh issue view ISSUE --json labels --jq -r '.labels[].name')
+>   if ! echo "$CURRENT_LABELS" | grep -q "^auto-implement$"; then
+>     echo "[monitor] ISSUE $ISSUE already claimed (no auto-implement label); skipping"
+>     READY_REMOVE=$(printf "%s\n%s" "$READY_REMOVE" "$ISSUE" | grep -v "^${ISSUE}$" || true)
+>     ready=($READY_REMOVE)
+>     continue
+>   fi
 >   gh label create in-progress-by-bot --color ededed --force
->   gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot
+>   if ! gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot; then
+>     echo "[monitor] ISSUE $ISSUE claim failed (another monitor claimed it); skipping"
+>     continue
+>   fi
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -427,6 +427,19 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 Then launch a **background subagent** with this prompt verbatim:
 
 > You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+
+> **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
+> 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
+> while true; do
+>   # ... monitor logic ...
+> done
+> EOF` — keeps a single bash process alive with your agent dispatching subcommands inside it.
+> 2. **nohup background process:** `nohup bash -c 'while true; do ...; sleep 1; done' > ~/.autospec/monitor.log 2>&1 &`
+> 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
+> while true; do ...; done
+> HEREDOC'`
+> **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
+
 >
 > Outer loop:
 > ```
@@ -476,8 +489,21 @@ Then launch a **background subagent** with this prompt verbatim:
 >     fi
 >   fi
 >   ISSUE = ready[0]
+>   # Claim check: verify the issue is still labeled auto-implement before processing.
+>   # Multiple monitors can query the same candidate list simultaneously;
+>   # the first to claim wins, others must skip to the next candidate.
+>   CURRENT_LABELS=$(gh issue view ISSUE --json labels --jq -r '.labels[].name')
+>   if ! echo "$CURRENT_LABELS" | grep -q "^auto-implement$"; then
+>     echo "[monitor] ISSUE $ISSUE already claimed (no auto-implement label); skipping"
+>     READY_REMOVE=$(printf "%s\n%s" "$READY_REMOVE" "$ISSUE" | grep -v "^${ISSUE}$" || true)
+>     ready=($READY_REMOVE)
+>     continue
+>   fi
 >   gh label create in-progress-by-bot --color ededed --force
->   gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot
+>   if ! gh issue edit ISSUE --remove-label auto-implement --add-label in-progress-by-bot; then
+>     echo "[monitor] ISSUE $ISSUE claim failed (another monitor claimed it); skipping"
+>     continue
+>   fi
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```


### PR DESCRIPTION
## Problem

Two issues observed in Codex/OpenCode when running autospec:

1. **Loop doesn't persist** — Codex and OpenCode lack built-in loop primitives (`/loop`, `ScheduleWakeup`). Without guidance, the monitor agent exits after processing one issue instead of staying in the `while true:` loop.

2. **Claim conflicts** — When multiple monitors query the same candidate list simultaneously, both can claim the same issue, causing race conditions.

## Change

### 1. Harness adaptation section (loop persistence)

Add explicit guidance for harnesses without built-in loops, recommending three patterns:

- **Shell wrapper** (preferred): `exec bash << 'EOF' ... EOF` — keeps a single bash process alive with the agent dispatching subcommands inside it
- **nohup background process**: `nohup bash -c 'while true; do ...; sleep 1; done' > ~/.autospec/monitor.log 2>&1 &`
- **tmux pane**: `tmux new-window 'bash << 'HEREDOC' ... HEREDOC'`

### 2. Claim conflict detection

Before processing an issue, check that the `auto-implement` label is still present:

```bash
CURRENT_LABELS=$(gh issue view ISSUE --json labels --jq -r '.labels[].name')
if ! echo "$CURRENT_LABELS" | grep -q "^auto-implement$"; then
  echo "[monitor] ISSUE $ISSUE already claimed; skipping"
  continue
fi
```

Also check the `gh issue edit` command itself — if another monitor claimed it between our check and our edit, the command will fail and we skip.

## Files changed

- skills/autospec-run/SKILL.md
- skills/autospec-run/codex/prompt.md
- skills/autospec-run/opencode/agent.md
- skills/autospec/SKILL.md
- skills/autospec/codex/prompt.md
- skills/autospec/opencode/agent.md

## Validation

- `bash scripts/validate.sh` passes (lock-step consistency + all harness variants)
- All changes are additive (loop persistence + claim check), no behavior changes to existing logic