### PR TITLE
feat(autospec-run): extend monitor idle timeout from 1h to 2h

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -225,7 +225,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
 >     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
->     else: print state ("blocked: N unmet deps" / "deferred: M off-profile" / "drained, waiting 1h idle"), sleep 300, continue
+>     else: print state ("blocked: N unmet deps" / "deferred: M off-profile" / "drained, waiting 2h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then
 >     MODE=$(head -1 "$HOME/.autospec/stop.flag" 2>/dev/null || echo "")

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -220,7 +220,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
 >     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
->     else: print state ("blocked: N unmet deps" / "deferred: M off-profile" / "drained, waiting 1h idle"), sleep 300, continue
+>     else: print state ("blocked: N unmet deps" / "deferred: M off-profile" / "drained, waiting 2h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then
 >     MODE=$(head -1 "$HOME/.autospec/stop.flag" 2>/dev/null || echo "")

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -224,7 +224,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
 >     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
->     else: print state ("blocked: N unmet deps" / "deferred: M off-profile" / "drained, waiting 1h idle"), sleep 300, continue
+>     else: print state ("blocked: N unmet deps" / "deferred: M off-profile" / "drained, waiting 2h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then
 >     MODE=$(head -1 "$HOME/.autospec/stop.flag" 2>/dev/null || echo "")

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -451,7 +451,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
 >     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — return final report
->     else: print state ("blocked: N unmet deps" / "drained, waiting 1h idle"), sleep 300, continue
+>     else: print state ("blocked: N unmet deps" / "drained, waiting 2h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then
 >     MODE=$(head -1 "$HOME/.autospec/stop.flag" 2>/dev/null || echo "")

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -445,7 +445,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
 >     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — return final report
->     else: print state ("blocked: N unmet deps" / "drained, waiting 1h idle"), sleep 300, continue
+>     else: print state ("blocked: N unmet deps" / "drained, waiting 2h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then
 >     MODE=$(head -1 "$HOME/.autospec/stop.flag" 2>/dev/null || echo "")

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -449,7 +449,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
 >     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — return final report
->     else: print state ("blocked: N unmet deps" / "drained, waiting 1h idle"), sleep 300, continue
+>     else: print state ("blocked: N unmet deps" / "drained, waiting 2h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then
 >     MODE=$(head -1 "$HOME/.autospec/stop.flag" 2>/dev/null || echo "")


### PR DESCRIPTION
Closes #227\n\nThis updates the monitor idle wait message in all autospec and autospec-run harness variants to reflect the new 2h drained-idle shutdown threshold.