### PR TITLE
feat(autospec): split existing specs into issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Code**, **OpenCode**, and **Codex CLI**.
 
 | Skill | Phases | Purpose |
 | --- | --- | --- |
-| [`autospec`](skills/autospec/README.md) | 0–6 (incl. **Phase 3.5**) | Full pipeline. Bootstrap repo if missing, design spec, decompose into issues, **review-and-label children with `ctx:*`/`reasoning:*` rubric (Phase 3.5)**, then run autonomous monitor with admin auto-merge. |
-| [`autospec-define`](skills/autospec-define/README.md) | 0–3.5 | Planning half. Stops after Phase 3.5 review-and-label step and hands off to `/autospec-run`. |
+| [`autospec`](skills/autospec/README.md) | 0–6 (incl. **Phase 3.5**) | Full pipeline. Bootstrap repo if missing, design spec, decompose into issues, **review-and-label children with `ctx:*`/`reasoning:*` rubric (Phase 3.5)**, then run autonomous monitor with admin auto-merge. Also supports splitting an existing tracked `docs/specs/*.md` into issues. |
+| [`autospec-define`](skills/autospec-define/README.md) | 0–3.5 | Planning half. Stops after Phase 3.5 review-and-label step and hands off to `/autospec-run`. Also supports splitting an existing tracked `docs/specs/*.md` into issues. |
 | [`autospec-run`](skills/autospec-run/README.md) | 4–6 | Implementation half. Picks up the populated `auto-implement` queue and runs the autonomous monitor. Supports `--profile <name>` filtering against `~/.autospec/model-profiles.yml`. |
 | [`autospec-classify`](skills/autospec-classify/README.md) | retro | Standalone retro-labeler for already-existing `auto-implement` issues; applies the Phase 3.5 rubric to a queue that pre-dates Phase 3.5. |
 | [`autospec-listen`](skills/autospec-listen/README.md) | passive | Passive listener for chat-driven issue / spec triggers. On a phrase like "file an issue" or "write a spec", drafts a GitHub issue body for confirmation or routes to `/autospec-define`. |
@@ -136,6 +136,17 @@ See [`examples/README.md`](examples/README.md) for the full schema and the auto-
 ## Quality gate
 
 Every issue filed by autospec is linted by `scripts/lint-issue.sh` before it reaches the implementation queue. The Phase 3 decomposer runs an adaptive retry loop (up to `MAX_LINT_RETRIES=5` attempts) that accumulates lint findings as prompt directives, skipping a child only if attempt 5 still fails. Phase 3.5 and `/autospec-classify` run a one-shot post-filing audit: issues that fail the lint get the `needs-quality-bar` label (color `#fbca04`), an idempotent `## Quality lint` block inserted into their body, and a comment with the findings. The `auto-implement` label is never removed — the operator decides whether to proceed or hand-fix. See [`docs/specs/2026-05-01-autospec-issue-quality-gate-design.md`](docs/specs/2026-05-01-autospec-issue-quality-gate-design.md) for the full contract.
+
+## Existing Specs
+
+`/autospec` and `/autospec-define` can split an already-written spec into the
+same EPIC + `auto-implement` child issue queue used by the normal pipeline.
+Invoke with phrases such as `split existing spec`, `split latest spec`, or
+`turn docs/specs/2026-05-01-example-design.md into GitHub issues`. When no path
+is provided, the skills choose the newest `docs/specs/*.md` by filename date as
+the default; if multiple specs are available, they ask before filing issues.
+The selected spec must already be tracked on `origin/main` so child issues can
+cite a stable GitHub URL.
 
 ## Stopping a run
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -3,8 +3,8 @@
 ## autospec
 
 - Path: [`skills/autospec`](skills/autospec)
-- Trigger: use when a user asks the agent to ship a feature end-to-end — bootstrap a missing GitHub repo, brainstorm/design, decompose into linked GitHub issues with dependency metadata, and run an autonomous implementation loop with admin auto-merge until done.
-- Activation keywords: `autospec`, `ship this feature`, `autonomous feature shipping`, `bootstrap repo and ship`, `decompose and auto-implement`, `run the autonomous loop`, `create issues and auto-merge`, `auto-implement this feature`, `ship end-to-end`, `turn this spec into GitHub issues`, `roadmap this spec`, `materialize this spec`
+- Trigger: use when a user asks the agent to ship a feature end-to-end — bootstrap a missing GitHub repo, brainstorm/design, decompose into linked GitHub issues with dependency metadata, split an existing `docs/specs/*.md` into issues, and run an autonomous implementation loop with admin auto-merge until done.
+- Activation keywords: `autospec`, `ship this feature`, `autonomous feature shipping`, `bootstrap repo and ship`, `decompose and auto-implement`, `run the autonomous loop`, `create issues and auto-merge`, `auto-implement this feature`, `ship end-to-end`, `turn this spec into GitHub issues`, `roadmap this spec`, `materialize this spec`, `split existing spec`, `split latest spec`
 - Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
 - Status: 7-phase workflow (bootstrap → investigate → design → decompose → background monitor → status updates → final report) with admin-squash-merge of `auto-implement`-labeled PRs.
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -352,6 +352,23 @@ check_governance_headings() {
         || fail "SKILLS.md: missing 'autospec-listen' reference"
 }
 
+# Existing spec mode invariants: autospec and autospec-define must expose the
+# shortcut that skips Phase 1/2 and reuses Phase 3 + Phase 3.5 for a tracked
+# docs/specs/*.md file. Enforce all trio files so harness variants cannot drift.
+check_existing_spec_mode() {
+    info "existing-spec mode: autospec + autospec-define"
+    for s in autospec autospec-define; do
+        for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
+            grep -q '^## Existing spec mode' "$f" \
+                || fail "$f missing '## Existing spec mode' section"
+            grep -q 'git cat-file -e origin/main:<spec-path>' "$f" \
+                || fail "$f missing origin/main selected-spec verification"
+            grep -q 'If Existing spec mode is active' "$f" \
+                || fail "$f missing Phase 3 selected-spec handoff"
+        done
+    done
+}
+
 main() {
     info "scanning multi-harness skills under skills/ ..."
     skills="$(discover_skills)"
@@ -378,6 +395,7 @@ main() {
     check_autospec_listen_files
     check_examples_dir
     check_governance_headings
+    check_existing_spec_mode
     check_lint_issue_helpers
     check_lint_implementation_helpers
     check_phase4_guardian_block_lockstep

--- a/skills/autospec-define/README.md
+++ b/skills/autospec-define/README.md
@@ -5,6 +5,11 @@ Planning half of the **autospec** suite. Runs Phases 0–3 of the autospec pipel
 then stops with a handoff message pointing the user at `/autospec-run --profile <name>`
 to begin autonomous implementation.
 
+It can also split an already-written, tracked `docs/specs/*.md` into the same
+EPIC plus `auto-implement` child issue queue. Invoke with `split existing spec`,
+`split latest spec`, or an explicit path such as
+`turn docs/specs/2026-05-01-example-design.md into GitHub issues`.
+
 Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
 
 ## Quick install
@@ -40,6 +45,11 @@ cd skills/autospec-define
   testing), written to `docs/specs/YYYY-MM-DD-<topic>-design.md`.
 - **Phase 3** — Foreground subagent decomposes the spec into an EPIC umbrella plus
   N self-contained children pre-staged for 32B-class local LLMs.
+
+In existing spec mode, the skill verifies the selected spec is present on
+`origin/main`, skips Phases 1–2, then runs Phase 3 and Phase 3.5 against that
+spec. If multiple specs are available and no path is supplied, it asks which
+spec to split before filing issues.
 
 When Phase 3 completes the skill stops and prints:
 
@@ -83,6 +93,8 @@ Or re-run the per-skill installer with `--update`:
 
 ```
 /autospec-define Build a Slack bot that posts a daily standup digest
+/autospec-define split latest spec
+/autospec-define turn docs/specs/2026-05-01-example-design.md into GitHub issues
 ```
 
 (Replace `/` with `@` for OpenCode, or invoke through Codex CLI as a slash command.)

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -1,12 +1,17 @@
 ---
 name: autospec-define
-description: Use when the user wants to plan a feature — bootstrap repo if missing, brainstorm a design spec, and decompose into linked GitHub issues. Stops after Phase 3 and hands off to /autospec-run for autonomous implementation.
+description: Use when the user wants to plan a feature — bootstrap repo if missing, brainstorm a design spec, decompose into linked GitHub issues, or split an existing spec into issues. Stops after Phase 3 and hands off to /autospec-run for autonomous implementation.
 ---
 
 # autospec-define workflow (harness-neutral)
 
 Take the following feature request and run the planning half of the autospec pipeline:
 **bootstrap repo (if missing) → investigate → design → spec → decomposed GitHub issues.** Stop after Phase 3; the implementation half is handed off to `/autospec-run`.
+
+If the request asks to split, materialize, roadmap, decompose, or turn an
+already-written spec into GitHub issues, use **Existing spec mode** below:
+select a tracked `docs/specs/*.md` file, skip Phases 1-2, run Phase 3 and
+Phase 3.5 against that spec, then continue to the Phase 3 pre-impl gate.
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
@@ -75,6 +80,48 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 {FEATURE_DESCRIPTION}
 
 ---
+
+## Existing spec mode
+
+Use this mode when the request asks to split, materialize, roadmap, decompose,
+or turn an existing spec into GitHub issues. Examples:
+`split existing spec`, `split latest spec`, `turn this spec into GitHub issues`,
+`roadmap docs/specs/2026-05-01-example-design.md`, or
+`materialize the newest spec`.
+
+Do not run Phase 1 or Phase 2 in this mode. The design already exists; this
+mode is a shortcut into Phase 3 using the same issue decomposition and Phase 3.5
+classification path as the normal pipeline.
+
+1. **Verify repo.** Run the Phase 0 repo probes. If the current directory is
+   not a git repo with a GitHub remote, use Phase 0 bootstrap before selecting
+   a spec.
+2. **Resolve candidate specs.**
+   - If the request contains an explicit `docs/specs/*.md` path, use that file.
+   - Otherwise list tracked and untracked local files matching `docs/specs/*.md`.
+   - Sort by ISO date in the filename (`YYYY-MM-DD-...`) descending. For files
+     without a date prefix, sort after dated files by filesystem modified time.
+   - The first item is the default "newest" spec.
+3. **Ask on ambiguity.**
+   - If zero specs exist, stop with: `No docs/specs/*.md files found. Create or
+     point me at a spec before running existing spec mode.`
+   - If exactly one spec exists and no explicit path was provided, use it.
+   - If more than one spec exists and no explicit path was provided, ask the user
+     to confirm the default newest spec or choose another path. Show at most the
+     five newest candidates with relative paths. Do not file issues until the
+     user answers.
+4. **Verify selected spec is filed.**
+   - The selected path must be under `docs/specs/` and end in `.md`.
+   - The selected file must be tracked on `origin/main` before Phase 3, so child
+     issues can cite a stable GitHub URL. Verify with:
+     `git fetch origin` and `git cat-file -e origin/main:<spec-path>`.
+   - If the selected file is missing from `origin/main`, stop and tell the user:
+     `Selected spec is not on origin/main yet: <spec-path>. Land the spec first,
+     or run normal /autospec-define so Phase 2 can create and merge the spec PR.`
+5. **Continue at Phase 3.** Capture `{selected_spec_path}` and its GitHub URL as
+   `https://github.com/{repo}/blob/main/{selected_spec_path}`. Run Phase 3 and
+   Phase 3.5 using that selected spec. Then proceed to the existing Phase 3
+   pre-impl gate.
 
 ## Required capabilities & harness adapter
 
@@ -163,16 +210,21 @@ For an existing repo, land the spec via a short-lived PR so CI can validate it:
 
 ## Phase 3 — Decompose into linked GitHub issues (delegate)
 
+If Existing spec mode is active, use `{selected_spec_path}` and its GitHub URL.
+Otherwise use the spec path written and merged in Phase 2.
+
 Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
 
 > **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+>
+> Read the selected design spec at `<spec-path>` (`<spec-github-url>`) and split it into linked GitHub issues for {repo}.
 >
 > Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
 >
 > Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
 >
 > - **Goal** — 1 sentence outcome.
-> - **Source spec** — relative path + GitHub URL of the design doc this issue derives from (if any).
+> - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -4,6 +4,11 @@
 Take the following feature request and run the planning half of the autospec pipeline:
 **bootstrap repo (if missing) → investigate → design → spec → decomposed GitHub issues.** Stop after Phase 3; the implementation half is handed off to `/autospec-run`.
 
+If the request asks to split, materialize, roadmap, decompose, or turn an
+already-written spec into GitHub issues, use **Existing spec mode** below:
+select a tracked `docs/specs/*.md` file, skip Phases 1-2, run Phase 3 and
+Phase 3.5 against that spec, then continue to the Phase 3 pre-impl gate.
+
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
 ## Startup self-update
@@ -70,6 +75,48 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 
 {FEATURE_DESCRIPTION}
 
+
+## Existing spec mode
+
+Use this mode when the request asks to split, materialize, roadmap, decompose,
+or turn an existing spec into GitHub issues. Examples:
+`split existing spec`, `split latest spec`, `turn this spec into GitHub issues`,
+`roadmap docs/specs/2026-05-01-example-design.md`, or
+`materialize the newest spec`.
+
+Do not run Phase 1 or Phase 2 in this mode. The design already exists; this
+mode is a shortcut into Phase 3 using the same issue decomposition and Phase 3.5
+classification path as the normal pipeline.
+
+1. **Verify repo.** Run the Phase 0 repo probes. If the current directory is
+   not a git repo with a GitHub remote, use Phase 0 bootstrap before selecting
+   a spec.
+2. **Resolve candidate specs.**
+   - If the request contains an explicit `docs/specs/*.md` path, use that file.
+   - Otherwise list tracked and untracked local files matching `docs/specs/*.md`.
+   - Sort by ISO date in the filename (`YYYY-MM-DD-...`) descending. For files
+     without a date prefix, sort after dated files by filesystem modified time.
+   - The first item is the default "newest" spec.
+3. **Ask on ambiguity.**
+   - If zero specs exist, stop with: `No docs/specs/*.md files found. Create or
+     point me at a spec before running existing spec mode.`
+   - If exactly one spec exists and no explicit path was provided, use it.
+   - If more than one spec exists and no explicit path was provided, ask the user
+     to confirm the default newest spec or choose another path. Show at most the
+     five newest candidates with relative paths. Do not file issues until the
+     user answers.
+4. **Verify selected spec is filed.**
+   - The selected path must be under `docs/specs/` and end in `.md`.
+   - The selected file must be tracked on `origin/main` before Phase 3, so child
+     issues can cite a stable GitHub URL. Verify with:
+     `git fetch origin` and `git cat-file -e origin/main:<spec-path>`.
+   - If the selected file is missing from `origin/main`, stop and tell the user:
+     `Selected spec is not on origin/main yet: <spec-path>. Land the spec first,
+     or run normal /autospec-define so Phase 2 can create and merge the spec PR.`
+5. **Continue at Phase 3.** Capture `{selected_spec_path}` and its GitHub URL as
+   `https://github.com/{repo}/blob/main/{selected_spec_path}`. Run Phase 3 and
+   Phase 3.5 using that selected spec. Then proceed to the existing Phase 3
+   pre-impl gate.
 
 ## Required capabilities & harness adapter
 
@@ -157,16 +204,21 @@ For an existing repo, land the spec via a short-lived PR so CI can validate it:
 
 ## Phase 3 — Decompose into linked GitHub issues (delegate)
 
+If Existing spec mode is active, use `{selected_spec_path}` and its GitHub URL.
+Otherwise use the spec path written and merged in Phase 2.
+
 Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
 
 > **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+>
+> Read the selected design spec at `<spec-path>` (`<spec-github-url>`) and split it into linked GitHub issues for {repo}.
 >
 > Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
 >
 > Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
 >
 > - **Goal** — 1 sentence outcome.
-> - **Source spec** — relative path + GitHub URL of the design doc this issue derives from (if any).
+> - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -1,5 +1,5 @@
 ---
-description: Use when the user wants to plan a feature — bootstrap repo if missing, brainstorm a design spec, and decompose into linked GitHub issues. Stops after Phase 3 and hands off to /autospec-run for autonomous implementation.
+description: Use when the user wants to plan a feature — bootstrap repo if missing, brainstorm a design spec, decompose into linked GitHub issues, or split an existing spec into issues. Stops after Phase 3 and hands off to /autospec-run for autonomous implementation.
 mode: primary
 ---
 
@@ -7,6 +7,11 @@ mode: primary
 
 Take the following feature request and run the planning half of the autospec pipeline:
 **bootstrap repo (if missing) → investigate → design → spec → decomposed GitHub issues.** Stop after Phase 3; the implementation half is handed off to `/autospec-run`.
+
+If the request asks to split, materialize, roadmap, decompose, or turn an
+already-written spec into GitHub issues, use **Existing spec mode** below:
+select a tracked `docs/specs/*.md` file, skip Phases 1-2, run Phase 3 and
+Phase 3.5 against that spec, then continue to the Phase 3 pre-impl gate.
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
@@ -74,6 +79,48 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 
 {FEATURE_DESCRIPTION}
 
+
+## Existing spec mode
+
+Use this mode when the request asks to split, materialize, roadmap, decompose,
+or turn an existing spec into GitHub issues. Examples:
+`split existing spec`, `split latest spec`, `turn this spec into GitHub issues`,
+`roadmap docs/specs/2026-05-01-example-design.md`, or
+`materialize the newest spec`.
+
+Do not run Phase 1 or Phase 2 in this mode. The design already exists; this
+mode is a shortcut into Phase 3 using the same issue decomposition and Phase 3.5
+classification path as the normal pipeline.
+
+1. **Verify repo.** Run the Phase 0 repo probes. If the current directory is
+   not a git repo with a GitHub remote, use Phase 0 bootstrap before selecting
+   a spec.
+2. **Resolve candidate specs.**
+   - If the request contains an explicit `docs/specs/*.md` path, use that file.
+   - Otherwise list tracked and untracked local files matching `docs/specs/*.md`.
+   - Sort by ISO date in the filename (`YYYY-MM-DD-...`) descending. For files
+     without a date prefix, sort after dated files by filesystem modified time.
+   - The first item is the default "newest" spec.
+3. **Ask on ambiguity.**
+   - If zero specs exist, stop with: `No docs/specs/*.md files found. Create or
+     point me at a spec before running existing spec mode.`
+   - If exactly one spec exists and no explicit path was provided, use it.
+   - If more than one spec exists and no explicit path was provided, ask the user
+     to confirm the default newest spec or choose another path. Show at most the
+     five newest candidates with relative paths. Do not file issues until the
+     user answers.
+4. **Verify selected spec is filed.**
+   - The selected path must be under `docs/specs/` and end in `.md`.
+   - The selected file must be tracked on `origin/main` before Phase 3, so child
+     issues can cite a stable GitHub URL. Verify with:
+     `git fetch origin` and `git cat-file -e origin/main:<spec-path>`.
+   - If the selected file is missing from `origin/main`, stop and tell the user:
+     `Selected spec is not on origin/main yet: <spec-path>. Land the spec first,
+     or run normal /autospec-define so Phase 2 can create and merge the spec PR.`
+5. **Continue at Phase 3.** Capture `{selected_spec_path}` and its GitHub URL as
+   `https://github.com/{repo}/blob/main/{selected_spec_path}`. Run Phase 3 and
+   Phase 3.5 using that selected spec. Then proceed to the existing Phase 3
+   pre-impl gate.
 
 ## Required capabilities & harness adapter
 
@@ -161,16 +208,21 @@ For an existing repo, land the spec via a short-lived PR so CI can validate it:
 
 ## Phase 3 — Decompose into linked GitHub issues (delegate)
 
+If Existing spec mode is active, use `{selected_spec_path}` and its GitHub URL.
+Otherwise use the spec path written and merged in Phase 2.
+
 Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
 
 > **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+>
+> Read the selected design spec at `<spec-path>` (`<spec-github-url>`) and split it into linked GitHub issues for {repo}.
 >
 > Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
 >
 > Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
 >
 > - **Goal** — 1 sentence outcome.
-> - **Source spec** — relative path + GitHub URL of the design doc this issue derives from (if any).
+> - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).

--- a/skills/autospec/README.md
+++ b/skills/autospec/README.md
@@ -73,11 +73,20 @@ pipeline runs from a single user invocation — the only required interactive st
 the optional repo-bootstrap question (name, visibility, owner) when no GitHub remote
 is detected. Generated child issues are pre-staged for 32B-class local LLMs (Ollama qwen3-style on Mac/Linux), not just cloud agents — file pointers, section anchors, checkbox AC, and a single Primary smoke test per inner loop.
 
+Existing spec mode skips investigation and design when a tracked
+`docs/specs/*.md` already exists. Invoke with `split existing spec`,
+`split latest spec`, or an explicit path such as
+`turn docs/specs/2026-05-01-example-design.md into GitHub issues`. If multiple
+specs are available and no path is supplied, autospec asks which one to split
+before filing issues.
+
 ## Why use it
 
 Reach for this skill when:
 
 - You have a non-trivial feature that decomposes into multiple sequenced PRs.
+- You already have a `docs/specs/*.md` design and want the normal EPIC plus
+  `auto-implement` issue queue generated from it.
 - You want the agent to ship the whole thing autonomously, not just plan it.
 - You'd rather review merged PRs than babysit a chat session.
 - You want repo bootstrap (`gh repo create`, scaffold, push) handled automatically

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -1,12 +1,17 @@
 ---
 name: autospec
-description: Use when the user wants to ship a feature end-to-end across multiple commits — bootstraps repo if missing, brainstorms a design spec, decomposes into linked GitHub issues, and runs an autonomous implementation loop with auto-merge.
+description: Use when the user wants to ship a feature end-to-end across multiple commits — bootstraps repo if missing, brainstorms a design spec, decomposes into linked GitHub issues, or splits an existing spec into issues, then runs an autonomous implementation loop with auto-merge.
 ---
 
 # autospec workflow (harness-neutral)
 
 Take the following feature request and ship it through the full pipeline:
 **bootstrap repo (if missing) → investigate → design → spec → decomposed GitHub issues → autonomous implementation with auto-merge → periodic status updates → final report.**
+
+If the request asks to split, materialize, roadmap, decompose, or turn an
+already-written spec into GitHub issues, use **Existing spec mode** below:
+select a tracked `docs/specs/*.md` file, skip Phases 1-2, run Phase 3 and
+Phase 3.5 against that spec, then continue to the Phase 3 pre-impl gate.
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
@@ -97,6 +102,48 @@ mode and does NOT run the normal pipeline. When dispatching, pass any
 
 ---
 
+## Existing spec mode
+
+Use this mode when the request asks to split, materialize, roadmap, decompose,
+or turn an existing spec into GitHub issues. Examples:
+`split existing spec`, `split latest spec`, `turn this spec into GitHub issues`,
+`roadmap docs/specs/2026-05-01-example-design.md`, or
+`materialize the newest spec`.
+
+Do not run Phase 1 or Phase 2 in this mode. The design already exists; this
+mode is a shortcut into Phase 3 using the same issue decomposition and Phase 3.5
+classification path as the normal pipeline.
+
+1. **Verify repo.** Run the Phase 0 repo probes. If the current directory is
+   not a git repo with a GitHub remote, use Phase 0 bootstrap before selecting
+   a spec.
+2. **Resolve candidate specs.**
+   - If the request contains an explicit `docs/specs/*.md` path, use that file.
+   - Otherwise list tracked and untracked local files matching `docs/specs/*.md`.
+   - Sort by ISO date in the filename (`YYYY-MM-DD-...`) descending. For files
+     without a date prefix, sort after dated files by filesystem modified time.
+   - The first item is the default "newest" spec.
+3. **Ask on ambiguity.**
+   - If zero specs exist, stop with: `No docs/specs/*.md files found. Create or
+     point me at a spec before running existing spec mode.`
+   - If exactly one spec exists and no explicit path was provided, use it.
+   - If more than one spec exists and no explicit path was provided, ask the user
+     to confirm the default newest spec or choose another path. Show at most the
+     five newest candidates with relative paths. Do not file issues until the
+     user answers.
+4. **Verify selected spec is filed.**
+   - The selected path must be under `docs/specs/` and end in `.md`.
+   - The selected file must be tracked on `origin/main` before Phase 3, so child
+     issues can cite a stable GitHub URL. Verify with:
+     `git fetch origin` and `git cat-file -e origin/main:<spec-path>`.
+   - If the selected file is missing from `origin/main`, stop and tell the user:
+     `Selected spec is not on origin/main yet: <spec-path>. Land the spec first,
+     or run normal /autospec so Phase 2 can create and merge the spec PR.`
+5. **Continue at Phase 3.** Capture `{selected_spec_path}` and its GitHub URL as
+   `https://github.com/{repo}/blob/main/{selected_spec_path}`. Run Phase 3 and
+   Phase 3.5 using that selected spec. Then proceed to the existing Phase 3
+   pre-impl gate.
+
 ## Required capabilities & harness adapter
 
 This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
@@ -186,16 +233,21 @@ For an existing repo, land the spec via a short-lived PR so CI can validate it:
 
 ## Phase 3 — Decompose into linked GitHub issues (delegate)
 
+If Existing spec mode is active, use `{selected_spec_path}` and its GitHub URL.
+Otherwise use the spec path written and merged in Phase 2.
+
 Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
 
 > **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+>
+> Read the selected design spec at `<spec-path>` (`<spec-github-url>`) and split it into linked GitHub issues for {repo}.
 >
 > Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
 >
 > Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
 >
 > - **Goal** — 1 sentence outcome.
-> - **Source spec** — relative path + GitHub URL of the design doc this issue derives from (if any).
+> - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -4,6 +4,11 @@
 Take the following feature request and ship it through the full pipeline:
 **bootstrap repo (if missing) → investigate → design → spec → decomposed GitHub issues → autonomous implementation with auto-merge → periodic status updates → final report.**
 
+If the request asks to split, materialize, roadmap, decompose, or turn an
+already-written spec into GitHub issues, use **Existing spec mode** below:
+select a tracked `docs/specs/*.md` file, skip Phases 1-2, run Phase 3 and
+Phase 3.5 against that spec, then continue to the Phase 3 pre-impl gate.
+
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
 ## Startup self-update
@@ -91,6 +96,48 @@ mode and does NOT run the normal pipeline. When dispatching, pass any
 
 {FEATURE_DESCRIPTION}
 
+
+## Existing spec mode
+
+Use this mode when the request asks to split, materialize, roadmap, decompose,
+or turn an existing spec into GitHub issues. Examples:
+`split existing spec`, `split latest spec`, `turn this spec into GitHub issues`,
+`roadmap docs/specs/2026-05-01-example-design.md`, or
+`materialize the newest spec`.
+
+Do not run Phase 1 or Phase 2 in this mode. The design already exists; this
+mode is a shortcut into Phase 3 using the same issue decomposition and Phase 3.5
+classification path as the normal pipeline.
+
+1. **Verify repo.** Run the Phase 0 repo probes. If the current directory is
+   not a git repo with a GitHub remote, use Phase 0 bootstrap before selecting
+   a spec.
+2. **Resolve candidate specs.**
+   - If the request contains an explicit `docs/specs/*.md` path, use that file.
+   - Otherwise list tracked and untracked local files matching `docs/specs/*.md`.
+   - Sort by ISO date in the filename (`YYYY-MM-DD-...`) descending. For files
+     without a date prefix, sort after dated files by filesystem modified time.
+   - The first item is the default "newest" spec.
+3. **Ask on ambiguity.**
+   - If zero specs exist, stop with: `No docs/specs/*.md files found. Create or
+     point me at a spec before running existing spec mode.`
+   - If exactly one spec exists and no explicit path was provided, use it.
+   - If more than one spec exists and no explicit path was provided, ask the user
+     to confirm the default newest spec or choose another path. Show at most the
+     five newest candidates with relative paths. Do not file issues until the
+     user answers.
+4. **Verify selected spec is filed.**
+   - The selected path must be under `docs/specs/` and end in `.md`.
+   - The selected file must be tracked on `origin/main` before Phase 3, so child
+     issues can cite a stable GitHub URL. Verify with:
+     `git fetch origin` and `git cat-file -e origin/main:<spec-path>`.
+   - If the selected file is missing from `origin/main`, stop and tell the user:
+     `Selected spec is not on origin/main yet: <spec-path>. Land the spec first,
+     or run normal /autospec so Phase 2 can create and merge the spec PR.`
+5. **Continue at Phase 3.** Capture `{selected_spec_path}` and its GitHub URL as
+   `https://github.com/{repo}/blob/main/{selected_spec_path}`. Run Phase 3 and
+   Phase 3.5 using that selected spec. Then proceed to the existing Phase 3
+   pre-impl gate.
 
 ## Required capabilities & harness adapter
 
@@ -180,16 +227,21 @@ For an existing repo, land the spec via a short-lived PR so CI can validate it:
 
 ## Phase 3 — Decompose into linked GitHub issues (delegate)
 
+If Existing spec mode is active, use `{selected_spec_path}` and its GitHub URL.
+Otherwise use the spec path written and merged in Phase 2.
+
 Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
 
 > **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+>
+> Read the selected design spec at `<spec-path>` (`<spec-github-url>`) and split it into linked GitHub issues for {repo}.
 >
 > Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
 >
 > Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
 >
 > - **Goal** — 1 sentence outcome.
-> - **Source spec** — relative path + GitHub URL of the design doc this issue derives from (if any).
+> - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -1,5 +1,5 @@
 ---
-description: Use when the user wants to ship a feature end-to-end across multiple commits — bootstraps repo if missing, brainstorms a design spec, decomposes into linked GitHub issues, and runs an autonomous implementation loop with auto-merge.
+description: Use when the user wants to ship a feature end-to-end across multiple commits — bootstraps repo if missing, brainstorms a design spec, decomposes into linked GitHub issues, or splits an existing spec into issues, then runs an autonomous implementation loop with auto-merge.
 mode: primary
 ---
 
@@ -7,6 +7,11 @@ mode: primary
 
 Take the following feature request and ship it through the full pipeline:
 **bootstrap repo (if missing) → investigate → design → spec → decomposed GitHub issues → autonomous implementation with auto-merge → periodic status updates → final report.**
+
+If the request asks to split, materialize, roadmap, decompose, or turn an
+already-written spec into GitHub issues, use **Existing spec mode** below:
+select a tracked `docs/specs/*.md` file, skip Phases 1-2, run Phase 3 and
+Phase 3.5 against that spec, then continue to the Phase 3 pre-impl gate.
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
@@ -96,6 +101,48 @@ mode and does NOT run the normal pipeline. When dispatching, pass any
 {FEATURE_DESCRIPTION}
 
 
+## Existing spec mode
+
+Use this mode when the request asks to split, materialize, roadmap, decompose,
+or turn an existing spec into GitHub issues. Examples:
+`split existing spec`, `split latest spec`, `turn this spec into GitHub issues`,
+`roadmap docs/specs/2026-05-01-example-design.md`, or
+`materialize the newest spec`.
+
+Do not run Phase 1 or Phase 2 in this mode. The design already exists; this
+mode is a shortcut into Phase 3 using the same issue decomposition and Phase 3.5
+classification path as the normal pipeline.
+
+1. **Verify repo.** Run the Phase 0 repo probes. If the current directory is
+   not a git repo with a GitHub remote, use Phase 0 bootstrap before selecting
+   a spec.
+2. **Resolve candidate specs.**
+   - If the request contains an explicit `docs/specs/*.md` path, use that file.
+   - Otherwise list tracked and untracked local files matching `docs/specs/*.md`.
+   - Sort by ISO date in the filename (`YYYY-MM-DD-...`) descending. For files
+     without a date prefix, sort after dated files by filesystem modified time.
+   - The first item is the default "newest" spec.
+3. **Ask on ambiguity.**
+   - If zero specs exist, stop with: `No docs/specs/*.md files found. Create or
+     point me at a spec before running existing spec mode.`
+   - If exactly one spec exists and no explicit path was provided, use it.
+   - If more than one spec exists and no explicit path was provided, ask the user
+     to confirm the default newest spec or choose another path. Show at most the
+     five newest candidates with relative paths. Do not file issues until the
+     user answers.
+4. **Verify selected spec is filed.**
+   - The selected path must be under `docs/specs/` and end in `.md`.
+   - The selected file must be tracked on `origin/main` before Phase 3, so child
+     issues can cite a stable GitHub URL. Verify with:
+     `git fetch origin` and `git cat-file -e origin/main:<spec-path>`.
+   - If the selected file is missing from `origin/main`, stop and tell the user:
+     `Selected spec is not on origin/main yet: <spec-path>. Land the spec first,
+     or run normal /autospec so Phase 2 can create and merge the spec PR.`
+5. **Continue at Phase 3.** Capture `{selected_spec_path}` and its GitHub URL as
+   `https://github.com/{repo}/blob/main/{selected_spec_path}`. Run Phase 3 and
+   Phase 3.5 using that selected spec. Then proceed to the existing Phase 3
+   pre-impl gate.
+
 ## Required capabilities & harness adapter
 
 This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
@@ -184,16 +231,21 @@ For an existing repo, land the spec via a short-lived PR so CI can validate it:
 
 ## Phase 3 — Decompose into linked GitHub issues (delegate)
 
+If Existing spec mode is active, use `{selected_spec_path}` and its GitHub URL.
+Otherwise use the spec path written and merged in Phase 2.
+
 Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
 
 > **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+>
+> Read the selected design spec at `<spec-path>` (`<spec-github-url>`) and split it into linked GitHub issues for {repo}.
 >
 > Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
 >
 > Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
 >
 > - **Goal** — 1 sentence outcome.
-> - **Source spec** — relative path + GitHub URL of the design doc this issue derives from (if any).
+> - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).


### PR DESCRIPTION
Adds existing-spec mode to autospec and autospec-define so an already-written docs/specs/*.md can be split into the existing EPIC + auto-implement issue flow.

Changes:
- add existing-spec mode to autospec and autospec-define lock-step trios
- require selected specs to be present on origin/main before Phase 3
- reuse Phase 3 decomposition and Phase 3.5 classification paths
- document invocation examples and add validation invariants

Tested:
- bash scripts/validate.sh