### PR TITLE
feat: expose autosplit skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ build/
 # Agent-state artifacts (codesight, omc, claude session state)
 .codesight/
 .omc/
+.omx/
 .claude/scheduled_tasks.lock
 **/.omc/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Every multi-harness skill runs a preflight at startup that updates the installed
 from `main` at most once per 24 hours (fail-open: any network or install error logs a
 `WARN:` line and continues). Set `AUTOSPEC_NO_SELF_UPDATE=1` to skip. The canonical
 bash block lives in `skills/autospec/SKILL.md` (`## Startup self-update` section) and
-is mirrored byte-identically (modulo `SKILL_NAME=`) across all five skill trios.
+is mirrored byte-identically (modulo `SKILL_NAME=`) across all multi-harness skill trios.
 `scripts/validate.sh` (`check_startup_preflight`) enforces byte-identity.
 
 ## Small-LLM target

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Multi-harness skill suite for shipping a feature end-to-end across many GitHub
 issues — design spec → decomposed `auto-implement` queue → autonomous
-implementation loop with admin auto-merge — split across five cooperating
+implementation loop with admin auto-merge — split across six cooperating
 skills so each invocation runs only the phases you need. Works on **Claude
 Code**, **OpenCode**, and **Codex CLI**.
 
@@ -11,6 +11,7 @@ Code**, **OpenCode**, and **Codex CLI**.
 | Skill | Phases | Purpose |
 | --- | --- | --- |
 | [`autospec`](skills/autospec/README.md) | 0–6 (incl. **Phase 3.5**) | Full pipeline. Bootstrap repo if missing, design spec, decompose into issues, **review-and-label children with `ctx:*`/`reasoning:*` rubric (Phase 3.5)**, then run autonomous monitor with admin auto-merge. Also supports splitting an existing tracked `docs/specs/*.md` into issues. |
+| [`autosplit`](skills/autosplit/README.md) | 3–3.5 | Shortcut for splitting an existing tracked `docs/specs/*.md` into the same EPIC plus `auto-implement` child issue queue. Runs startup self-update before selecting the spec. |
 | [`autospec-define`](skills/autospec-define/README.md) | 0–3.5 | Planning half. Stops after Phase 3.5 review-and-label step and hands off to `/autospec-run`. Also supports splitting an existing tracked `docs/specs/*.md` into issues. |
 | [`autospec-run`](skills/autospec-run/README.md) | 4–6 | Implementation half. Picks up the populated `auto-implement` queue and runs the autonomous monitor. Supports `--profile <name>` filtering against `~/.autospec/model-profiles.yml`. |
 | [`autospec-classify`](skills/autospec-classify/README.md) | retro | Standalone retro-labeler for already-existing `auto-implement` issues; applies the Phase 3.5 rubric to a queue that pre-dates Phase 3.5. |
@@ -55,6 +56,7 @@ Or pick a subset:
 
 ```bash
 ./install.sh --skill autospec-run --harness claude   # one skill, one harness
+./install.sh --skill autosplit    --harness all      # install the split shortcut
 ./install.sh --skill all          --harness opencode # every skill, one harness
 ./install.sh --skill autospec     --harness all      # one skill, every harness
 ./uninstall.sh --skill all --harness all             # symmetric uninstall
@@ -86,6 +88,7 @@ stops without entering the normal pipeline:
 
 ```
 /autospec update
+/autosplit update
 /autospec-define update
 /autospec-run update
 /autospec-classify update
@@ -130,7 +133,7 @@ See [`examples/README.md`](examples/README.md) for the full schema and the auto-
 
 ## Docs
 
-- [`docs/user-manual.md`](docs/user-manual.md) — narrative walkthrough of all five skills (what each does, when to use it, example output).
+- [`docs/user-manual.md`](docs/user-manual.md) — narrative walkthrough of all suite skills (what each does, when to use it, example output).
 - [`docs/architecture.md`](docs/architecture.md) — single-source-of-truth for the cross-cutting design rules: concurrency model, lock-step body rule, model tier policy, trigger keyword theory.
 
 ## Quality gate

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -16,6 +16,14 @@
 - Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
 - Status: trigger-listener for chat-driven issue / spec creation. Files issues with `needs-classify` label so `/autospec-classify` can transition them onto the `auto-implement` queue. See [`skills/autospec-listen/README.md`](skills/autospec-listen/README.md).
 
+## autosplit
+
+- Path: [`skills/autosplit`](skills/autosplit)
+- Trigger: use when a user asks to split, materialize, roadmap, decompose, or turn an existing tracked `docs/specs/*.md` design spec into GitHub issues.
+- Activation keywords: `autosplit`, `split existing spec`, `split latest spec`, `turn this spec into GitHub issues`, `roadmap this spec`, `materialize this spec`
+- Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
+- Status: existing-spec shortcut for Phase 3 plus Phase 3.5 with startup self-update before normal execution.
+
 ## Future Skill Checklist
 
 1. Create `skills/<skill-name>/SKILL.md`.

--- a/docs/specs/2026-05-01-autospec-startup-self-update-design.md
+++ b/docs/specs/2026-05-01-autospec-startup-self-update-design.md
@@ -29,8 +29,8 @@ introducing a runtime version-pin file.
 Every multi-harness skill body grows a single `## Startup self-update`
 section, inserted **above** the existing `## Self-update mode` section.
 The section contains a small bash block (≤30 lines) the harness executes
-at startup. The block is byte-identical across all five skills (only the
-hard-coded `SKILL_NAME` differs) and **lock-stepped** across the trio
+at startup. The block is byte-identical across all multi-harness skills
+(only the hard-coded `SKILL_NAME` differs) and **lock-stepped** across the trio
 files (`SKILL.md` / `opencode/agent.md` / `codex/prompt.md`) per the
 existing repo invariant (`scripts/validate.sh:44`).
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,12 +1,12 @@
 # Autospec user manual
 
-A narrative walkthrough of the five autospec skills. Use this manual
+A narrative walkthrough of the autospec skills. Use this manual
 as the "what does this do, when do I run it, what do I expect to see"
 companion to the per-skill `README.md` and `SKILL.md` files.
 
 The skills are presented in the order an end-to-end ship goes through
-them: umbrella → planning → classification → implementation → passive
-listener.
+them: umbrella → existing-spec split → planning → classification →
+implementation → passive listener.
 
 ## autospec
 
@@ -67,6 +67,32 @@ Spec written, 7 issues filed. Start /autospec-run now, defer to your
 external daemon, or keep refining? [run / defer / refine] (default: defer)
 > defer
 Issues are ready. Your external monitor will pick them up. Exiting.
+```
+
+## autosplit
+
+### What it does
+
+`/autosplit` is the existing-spec shortcut: it selects a tracked
+`docs/specs/*.md` file, skips Phases 1–2, decomposes that spec into an
+EPIC plus `auto-implement` child issues, runs Phase 3.5 review-and-label,
+then stops with the `/autospec-run` handoff.
+
+### When to use it
+
+Use `/autosplit` when the design spec already exists on `origin/main`
+and you only need to materialize it into GitHub issues. Use
+`/autospec-define` instead when the spec still needs to be written or
+landed.
+
+### Example output
+
+```
+/autosplit split latest spec
+selected docs/specs/2026-05-01-example-design.md
+Phase 3: decompose — 6 child issues filed (#130…#135)
+Phase 3.5: classify — labeled with ctx:* and reasoning:*
+Phase 3 complete. Run /autospec-run --profile <name> to begin implementation.
 ```
 
 ## autospec-run

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# install.sh — top-level orchestrator for the autospec four-skill suite.
+# install.sh — top-level orchestrator for the autospec multi-skill suite.
 #
 # Delegates to per-skill installers under skills/<skill>/install.sh. Use this
 # script to install every skill into every harness in one call. The per-skill
@@ -14,7 +14,7 @@
 #   ./install.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-define | autospec-run | autospec-classify | autospec-listen | all
+#   --skill   one of: autospec | autosplit | autospec-define | autospec-run | autospec-classify | autospec-listen | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -27,7 +27,7 @@ set -eu
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$REPO_ROOT/skills"
 
-ALL_SKILLS="autospec autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
+ALL_SKILLS="autospec autosplit autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -75,10 +75,10 @@ done
 
 # Validate --skill
 case "$SKILL_ARG" in
-    all|autospec|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-stop) ;;
+    all|autospec|autosplit|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-stop) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
-        err "must be one of: autospec | autospec-define | autospec-run | autospec-classify | autospec-listen | autospec-stop | all"
+        err "must be one of: autospec | autosplit | autospec-define | autospec-run | autospec-classify | autospec-listen | autospec-stop | all"
         exit 2
         ;;
 esac

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -135,7 +135,7 @@ check_startup_preflight() {
     }
     canonical=$(extract_block skills/autospec/SKILL.md)
     [ -n "$canonical" ] || fail "autospec SKILL.md missing ## Startup self-update section"
-    for s in autospec autospec-define autospec-run autospec-listen autospec-classify; do
+    for s in autospec autosplit autospec-define autospec-run autospec-listen autospec-classify autospec-stop; do
         for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
             body=$(extract_block "$f")
             [ -n "$body" ] || fail "$f missing ## Startup self-update section"
@@ -152,7 +152,7 @@ check_startup_preflight() {
 # prompts/ path AND the new skills/ slash-command registry path.
 check_codex_skills_install() {
     info "codex skills-dir install: all skills"
-    for s in autospec autospec-define autospec-run autospec-listen autospec-classify; do
+    for s in autospec autosplit autospec-define autospec-run autospec-listen autospec-classify autospec-stop; do
         f="skills/$s/install.sh"
         grep -q 'skills/\$SKILL_NAME/SKILL\.md' "$f" \
             || fail "$f missing Codex skills-dir install (skills/\$SKILL_NAME/SKILL.md)"
@@ -193,7 +193,7 @@ check_subagent_model_tier() {
     case "$name" in
         autospec)
             expected_a=4; expected_b=2 ;;
-        autospec-define)
+        autospec-define|autosplit)
             expected_a=3; expected_b=0 ;;
         autospec-run)
             expected_a=1; expected_b=2 ;;
@@ -352,12 +352,12 @@ check_governance_headings() {
         || fail "SKILLS.md: missing 'autospec-listen' reference"
 }
 
-# Existing spec mode invariants: autospec and autospec-define must expose the
+# Existing spec mode invariants: autospec, autosplit, and autospec-define must expose the
 # shortcut that skips Phase 1/2 and reuses Phase 3 + Phase 3.5 for a tracked
 # docs/specs/*.md file. Enforce all trio files so harness variants cannot drift.
 check_existing_spec_mode() {
-    info "existing-spec mode: autospec + autospec-define"
-    for s in autospec autospec-define; do
+    info "existing-spec mode: autospec + autosplit + autospec-define"
+    for s in autospec autosplit autospec-define; do
         for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
             grep -q '^## Existing spec mode' "$f" \
                 || fail "$f missing '## Existing spec mode' section"

--- a/skills/autosplit/README.md
+++ b/skills/autosplit/README.md
@@ -1,0 +1,101 @@
+# autosplit
+
+Existing-spec split shortcut for the **autospec** suite. It splits an already-written, tracked `docs/specs/*.md` into the same
+EPIC plus `auto-implement` child issue queue. Invoke with `split existing spec`,
+`split latest spec`, or an explicit path such as
+`turn docs/specs/2026-05-01-example-design.md into GitHub issues`.
+
+Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
+
+## Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh | sh -s -- --harness all
+```
+
+Per-harness:
+
+```bash
+# Claude Code only
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh | sh -s -- --harness claude
+# OpenCode only
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh | sh -s -- --harness opencode
+# Codex CLI only
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh | sh -s -- --harness codex
+```
+
+From a clone:
+
+```bash
+cd skills/autosplit
+./install.sh --harness all
+```
+
+## What it does
+
+- **Startup self-update** — Refreshes the installed `autosplit` copy from `main`
+  before normal execution, using the same fail-open preflight as the other
+  autospec skills.
+- **Phase 0** — Verifies the current directory is a GitHub-backed git repo.
+- **Phase 3** — Foreground subagent decomposes the selected spec into an EPIC
+  umbrella plus N self-contained children pre-staged for 32B-class local LLMs.
+- **Phase 3.5** — Reviews and labels the generated child issues with the
+  `ctx:*` / `reasoning:*` rubric.
+
+In existing spec mode, the skill verifies the selected spec is present on
+`origin/main`, skips Phases 1–2, then runs Phase 3 and Phase 3.5 against that
+spec. If multiple specs are available and no path is supplied, it asks which
+spec to split before filing issues.
+
+When Phase 3 completes the skill stops and prints:
+
+```
+Phase 3 complete. Run /autospec-run --profile <name> to begin implementation.
+```
+
+## Subagent model selection (Tier A only)
+
+This skill is the existing-spec split shortcut. Its Phase 3 decomposition and
+Phase 3.5 review-and-label subagents run on **Tier A** per `AGENTS.md`: top
+model with extended/maximum thinking. Issue quality is the bottleneck, so we pay
+for the top model here once rather than N times in cheap-implementer corrections
+downstream.
+
+The Tier B (cheaper + medium thinking) tier is **not used** by this skill; it's reserved for `autospec-run`'s implementation loop.
+
+## Related skills
+
+| Skill | Purpose |
+| --- | --- |
+| [`autospec`](../autospec/README.md) | The full pipeline (Phases 0–6) when you want one skill that plans **and** ships. |
+| [`autospec-run`](../autospec-run/README.md) | Implementation half (Phases 4–6). Picks up where `autosplit` stops; supports `--profile <name>` filtering against `~/.autospec/model-profiles.yml`. |
+| [`autospec-classify`](../autospec-classify/README.md) | Standalone retro-labeler for already-existing `auto-implement` issues; applies the Phase 3.5 `ctx:*` / `reasoning:*` rubric. |
+
+## Self-update
+
+Once installed, run the skill with the literal argument `update` to refresh in
+place. The skill detects its harness, re-runs the canonical install one-liner
+with `--update`, shows the diff, and stops without entering Phase 0:
+
+```
+/autosplit update
+```
+
+Or re-run the per-skill installer with `--update`:
+
+```bash
+./install.sh --harness all --update
+```
+
+## Usage
+
+```
+/autosplit split latest spec
+/autosplit turn docs/specs/2026-05-01-example-design.md into GitHub issues
+```
+
+(Replace `/` with `@` for OpenCode, or invoke through Codex CLI as a slash command.)
+
+## License
+
+MIT — see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autosplit/SKILL.md
+++ b/skills/autosplit/SKILL.md
@@ -1,0 +1,451 @@
+---
+name: autosplit
+description: Use when the user wants to split an existing tracked docs/specs/*.md design spec into GitHub issues, then stop after Phase 3.5 and hand off to /autospec-run.
+---
+
+# autosplit workflow (harness-neutral)
+
+Take the following request and run the autospec existing-spec split shortcut: select a tracked `docs/specs/*.md` file, skip Phases 1-2, run Phase 3 and Phase 3.5 against that spec, then stop with the `/autospec-run` handoff.
+
+If the request does not identify an existing spec to split, resolve the newest `docs/specs/*.md` candidate using **Existing spec mode** below. Do not brainstorm or write a new spec from `/autosplit`; tell the user to use `/autospec-define` for new feature planning.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autosplit   # per-skill: autosplit / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autosplit/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autosplit.md`
+   - Codex CLI:   `~/.codex/prompts/autosplit.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autosplit found; run install.sh first.` and exit.
+
+## Feature request
+
+{FEATURE_DESCRIPTION}
+
+---
+
+## Existing spec mode
+
+Use this mode when the request asks to split, materialize, roadmap, decompose,
+or turn an existing spec into GitHub issues. Examples:
+`split existing spec`, `split latest spec`, `turn this spec into GitHub issues`,
+`roadmap docs/specs/2026-05-01-example-design.md`, or
+`materialize the newest spec`.
+
+Do not run Phase 1 or Phase 2 in this mode. The design already exists; this
+mode is a shortcut into Phase 3 using the same issue decomposition and Phase 3.5
+classification path as the normal pipeline.
+
+1. **Verify repo.** Run the Phase 0 repo probes. If the current directory is
+   not a git repo with a GitHub remote, use Phase 0 bootstrap before selecting
+   a spec.
+2. **Resolve candidate specs.**
+   - If the request contains an explicit `docs/specs/*.md` path, use that file.
+   - Otherwise list tracked and untracked local files matching `docs/specs/*.md`.
+   - Sort by ISO date in the filename (`YYYY-MM-DD-...`) descending. For files
+     without a date prefix, sort after dated files by filesystem modified time.
+   - The first item is the default "newest" spec.
+3. **Ask on ambiguity.**
+   - If zero specs exist, stop with: `No docs/specs/*.md files found. Create or
+     point me at a spec before running existing spec mode.`
+   - If exactly one spec exists and no explicit path was provided, use it.
+   - If more than one spec exists and no explicit path was provided, ask the user
+     to confirm the default newest spec or choose another path. Show at most the
+     five newest candidates with relative paths. Do not file issues until the
+     user answers.
+4. **Verify selected spec is filed.**
+   - The selected path must be under `docs/specs/` and end in `.md`.
+   - The selected file must be tracked on `origin/main` before Phase 3, so child
+     issues can cite a stable GitHub URL. Verify with:
+     `git fetch origin` and `git cat-file -e origin/main:<spec-path>`.
+   - If the selected file is missing from `origin/main`, stop and tell the user:
+     `Selected spec is not on origin/main yet: <spec-path>. Land the spec first,
+     or run /autospec-define so Phase 2 can create and merge the spec PR.`
+5. **Continue at Phase 3.** Capture `{selected_spec_path}` and its GitHub URL as
+   `https://github.com/{repo}/blob/main/{selected_spec_path}`. Run Phase 3 and
+   Phase 3.5 using that selected spec. Then proceed to the existing Phase 3
+   pre-impl gate.
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; fall back UP on unavailability |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work (research, decompose, review/label); Tier B (cheaper model + medium thinking) for implementation work (Phase 4 implementer + LGTM review — not used by this skill). The orchestrator keeps the user's invoked model. Fall back UP the tier on unavailability.
+
+---
+
+## Phase 0 — Bootstrap repo (if missing)
+
+Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.
+
+Probe the working directory:
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null
+git remote get-url origin 2>/dev/null   # must contain github.com
+```
+
+If **either** check fails — no git repo, or no GitHub remote — bootstrap a new repo:
+
+1. **Suggest a name.** Slugify the feature description: lowercase, hyphens, drop stop-words, prefix with the obvious stack if inferable (e.g. "Go TUI for X" → `go-tui-x`; "Python ML pipeline that does Y" → `py-ml-y`). Offer 1–2 candidates.
+
+2. **Ask the user once** (single interactive question; combine the three sub-questions if your harness supports it, otherwise ask sequentially):
+   - **Name** (your top suggestion as default).
+   - **Visibility**: `private` | `public` (default: private).
+   - **Owner**: enumerate via `gh org list`; default to the user's personal account.
+
+3. **Initialize locally**:
+   - If `.git` is absent: `git init -b main`.
+   - Write a stack-appropriate `.gitignore` (Go: `bin/ vendor/ *.exe *.test`; Node: `node_modules/ dist/ .next/ .env*`; Python: `__pycache__/ .venv/ *.egg-info/ build/ dist/`; mixed/unknown: skip).
+   - Write a one-line `README.md` containing the feature description.
+   - Write a starter `AGENTS.md` listing the project's coding standards (TDD non-negotiable, no DB mocks, conventional commits, branch-per-issue, no force-push) — this is the source of truth every agent reads.
+   - `git add -A && git commit -m "chore: initial scaffold"`.
+
+4. **Create the remote and push**:
+   ```bash
+   gh repo create <owner>/<name> --<private|public> --source=. --remote=origin --push
+   ```
+
+5. **Verify**: `gh repo view <owner>/<name> --json url,defaultBranchRef`. Capture `<owner>/<name>` as `{repo}` — every subsequent phase uses this value.
+
+If a repo already exists (cwd is in a git tree with a `github.com:<owner>/<name>` remote), capture that as `{repo}` and skip the bootstrap.
+
+## Phase 1 — Investigate (delegate)
+
+Spawn a **read-only research subagent** to map relevant files, schema, services. Get back a 300-word summary with file paths and line numbers. Do NOT read files directly from the main thread.
+
+> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+
+If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
+
+For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.
+
+## Phase 2 — Brainstorm + design
+
+> **Spec quality is the bottleneck.** Phase 2's output drives every downstream cycle's cost; if you care about spec quality, invoke this skill with your top-tier model (Claude Code: `claude-code --model opus`; Codex: top GPT). Phase 2 itself runs in the orchestrator (no subagent dispatch) — your invocation model IS the spec model. Subagents in Phases 1, 3, 3.5 follow this lead by selecting Tier A; Phase 4 implementation work uses Tier B. See AGENTS.md.
+
+Run a structured brainstorm — one question at a time, get explicit approval after each section:
+
+1. **Architecture** — where does new code live, what existing patterns does it follow.
+2. **Interactivity / API shape** — how does the user/caller drive it; commands, keys, endpoints, fields.
+3. **Data model** — types, columns, persistence boundary.
+4. **Error handling** — failure modes, recovery, user-visible signals.
+5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services).
+
+Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, scope. The spec must be implementable end-to-end by an agent reading only the spec.
+
+If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
+
+For an existing repo, land the spec via a short-lived PR so CI can validate it:
+1. Create branch `feat/spec-<topic>`, commit `docs/specs/...design.md`, push.
+2. `gh pr create --base main --head feat/spec-<topic> --title "docs: <topic> design spec" --body "Source spec: docs/specs/..."`
+3. Wait for required CI checks to pass (`gh pr checks <#> --repo {repo}`).
+4. Unless `AUTOSPEC_NO_AUTOMERGE_SPEC=1` is set, admin-merge: `gh pr merge <#> --admin --squash --delete-branch --repo {repo}`. If the env var is set, pause and ask the user to merge before continuing.
+5. Verify the spec is reachable at `https://github.com/{repo}/blob/main/docs/specs/...` before dispatching Phase 3.
+
+## Phase 3 — Decompose into linked GitHub issues (delegate)
+
+If Existing spec mode is active, use `{selected_spec_path}` and its GitHub URL.
+Otherwise use the spec path written and merged in Phase 2.
+
+Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
+
+> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+>
+> Read the selected design spec at `<spec-path>` (`<spec-github-url>`) and split it into linked GitHub issues for {repo}.
+>
+> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+>
+> Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
+>
+> - **Goal** — 1 sentence outcome.
+> - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
+> - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
+> - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
+> - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
+> - **Implementation outline** — file paths + function signatures + data flow.
+> - **Tests required** — TDD per AGENTS.md, real services, no DB mocks, 80%+ coverage.
+> - **Acceptance criteria** — checkbox list `[ ]` only, no prose. Each item machine-checkable.
+> - **Verification** — split into a **Primary smoke test (inner loop)** with exactly one fast command, and **Operator/full verification** listing the remaining commands.
+> - **Branch name** — `feat/<slug>`.
+> - **Dependencies** — `Depends on issue #N` lines (parsed by the monitor).
+>
+> Sizing rule: aim for ≤ 4 KB body. Issues that span more than 4 canonical tables, more than 3 packages, or schema-wide changes must be split — better to emit two children with a `Depends on` edge than one oversized child a small LLM can't hold in working memory.
+>
+> **Sizing caps (hard, per spec §3.4):**
+>
+> - **Body ≤400 words** including all sections.
+> - **Implementation outline ≤30 lines** (file paths + function signatures).
+> - **Files touched ≤3** per child issue.
+> - If a candidate child would exceed any cap, split into a parent + child pair with a `Depends on` edge.
+> - The whole spec + a single child issue body must fit comfortably in a 60–120k context window.
+>
+> Self-check each issue against the caps **before** calling `gh issue create`. If a cap is violated and a split is not feasible, surface the issue inline (print the over-cap body to the operator) instead of filing it.
+>
+> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash scripts/lint-issue.sh /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
+>
+> | Finding | Directive appended to next prompt |
+> |---|---|
+> | `GOAL_VAGUE: "improve" used without concrete object` | `AVOID: bare verb \`improve\` without naming a file path, command, label, or number in the same sentence.` |
+> | `GOAL_HEDGE: "should probably"` | `AVOID: hedging words \`should/might/could try/try to\`. State the outcome flatly.` |
+> | `GOAL_NOT_ONE_SENTENCE: N terminals` | `REWRITE: Goal must be exactly one sentence ending with a single . ? or !` |
+> | `AC_PROSE: line N not a checkbox` | `FORMAT: every AC line must start with \`- [ ] \` followed by content.` |
+> | `AC_SUBJECTIVE: "looks clean"` | `AVOID: subjective adjectives \`looks/feels/seems/clean/elegant\` in AC items. Use a \`grep\`/\`test\`/\`diff\`/\`bats\` command instead.` |
+> | `AC_TOO_LONG: N chars` | `SHORTEN: AC item exceeds 120 chars; split into two items or compress to one assertion.` |
+> | `AC_EMPTY` | `ADD: Acceptance criteria section must contain at least one \`- [ ] \` checkbox item.` |
+> | `SMOKE_MULTI_LINE: N lines` | `COLLAPSE: Primary smoke test must be exactly one command line. Use \`&&\` to chain or move setup to Operator/full verification.` |
+> | `SMOKE_PLACEHOLDER: contains "<TODO>"` | `RESOLVE: Replace placeholders \`<TODO>/TBD/XXX/...\` with the actual command before filing.` |
+> | `SMOKE_NOT_FENCED` | `ADD: Primary smoke test section must contain exactly one fenced code block.` |
+
+### Small-LLM friendliness (applies to every child issue)
+
+Children are written assuming the implementer is a 32B-class local model with **pre-staged context**, not a search-driven cloud agent:
+
+- Every file the implementer needs is named in **Files to read first** with a sectional anchor or a one-line reason. Do not assume the model will grep the codebase.
+- Spec docs are cited by section heading, not as "read this 20 KB doc".
+- Acceptance criteria are checkbox-only so the model can self-verify line-by-line.
+- One **Primary smoke test** runs in the inner loop; the heavier verification list runs once at the end.
+- If the work fans out across many tables/packages, split it. Two 3 KB children chained by `Depends on` beat one 7 KB child a 32B model garbles at 60k tokens of working context.
+
+Capture the umbrella + child issue numbers.
+
+## Phase 3.5 — Review and label (delegate)
+
+Dispatch a **foreground subagent** to retro-review the child issues just
+created in Phase 3 and apply the model-fit rubric. The subagent must NOT modify
+issue titles or remove existing labels; it only adds `ctx:*` and `reasoning:*`
+labels and patches each body with a `## Model fit` block.
+
+> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+>
+> Walk every child issue created in Phase 3 (skip any issue carrying the
+> `type:tracker` label). For each:
+>
+> 1. **Stage context.** Read `gh issue view <N> --repo {repo} --json title,body,labels`. The
+>    body should already contain `## Files to read first` and
+>    `## Implementation scope`. If either is missing, add label
+>    `needs-autospec-template` (idempotent `gh label create --force` once at run
+>    start) and skip — do not classify or patch.
+>
+> 2. **Apply the rubric.** Pick the smallest `ctx:*` tier that holds the
+>    staged context (issue body + every file in `## Files to read first` +
+>    cited spec sections). Pick the `reasoning:*` depth required to derive
+>    (not just transcribe) the implementation.
+>
+>    **`ctx:*` — context-window axis**
+>
+>    | Label | Trigger |
+>    |---|---|
+>    | `ctx:32k`  | One canonical table or shell script; ≤3 files in *Files to read first*; short spec anchors. |
+>    | `ctx:64k`  | Multi-file change; 4-7 files staged; one trio + one installer; medium spec sections (~1-3 KB). |
+>    | `ctx:120k` | Cross-skill or cross-package; 8+ files; long spec excerpts; deep call graphs. |
+>
+>    **`reasoning:*` — reasoning-depth axis**
+>
+>    | Label | Trigger |
+>    |---|---|
+>    | `reasoning:shallow` | Mechanical: copy-and-rename, regex-replace, README transcription, runbook authoring. Verbs: *copy*, *rename*, *transcribe*, *list*. |
+>    | `reasoning:medium`  | Template-following with judgment: synthesize a SKILL.md mirroring an existing one, modify a script with new flags, write tests for a documented contract. Verbs: *mirror*, *adapt*, *integrate*, *wire*. |
+>    | `reasoning:deep`    | Novel design choices: pick a new abstraction, resolve a contradiction in the spec, reconcile cross-cutting concerns. Verbs: *design*, *reconcile*, *resolve*, *redesign*. |
+>
+>    Default for issues that lack any of these signals: `ctx:64k`,
+>    `reasoning:medium`. If unsure between two ctx tiers, prefer the larger.
+>
+> 3. **Sibling normalization.** When 5+ split children share a structural
+>    criterion (e.g. all per-source-table writers, all per-skill installers),
+>    harmonize their `ctx:*`/`reasoning:*` labels so the operator can run a
+>    single profile across the whole group. Override individual classifications
+>    only when the difference is a true outlier (e.g. one sibling pulls in a
+>    schema-wide refactor that no other sibling touches).
+>
+> 4. **Apply labels.** Idempotent at run start:
+>    `gh label create ctx:32k  --color c5def5 --force --repo {repo}`,
+>    `gh label create ctx:64k  --color c5def5 --force --repo {repo}`,
+>    `gh label create ctx:120k --color c5def5 --force --repo {repo}`,
+>    `gh label create reasoning:shallow --color c2e0c6 --force --repo {repo}`,
+>    `gh label create reasoning:medium  --color c2e0c6 --force --repo {repo}`,
+>    `gh label create reasoning:deep    --color c2e0c6 --force --repo {repo}`,
+>    `gh label create needs-quality-bar --color fbca04 --force --repo {repo}`.
+>    Then per issue:
+>    `gh issue edit <N> --add-label "ctx:<tier>,reasoning:<depth>" --repo {repo}`.
+>
+> 5. **Patch body — `## Model fit` block.** Insert immediately before the first
+>    `## Dependencies` line (or at end of body if absent):
+>
+>    ```markdown
+>    ## Model fit
+>
+>    - **ctx:** `ctx:<tier>` — <1-line rationale>.
+>    - **reasoning:** `reasoning:<depth>` — <1-line rationale>.
+>
+>    <!-- autospec-classify:begin -->
+>    *Auto-classified by Phase 3.5 on YYYY-MM-DD.*
+>    <!-- autospec-classify:end -->
+>    ```
+>
+>    **Idempotency:** if a `## Model fit` block already exists between the
+>    `<!-- autospec-classify:begin -->` and `<!-- autospec-classify:end -->`
+>    markers, replace it in place. Never stack duplicates. Apply via
+>    `gh issue edit <N> --body-file <tmp>`.
+>
+> 6. **Board assignment** — read `~/.autospec/project-map.yml` and assign each
+>    just-classified child to the GitHub Projects mapped from its labels.
+>
+>    **File schema** (auto-init if missing — see below):
+>    ```yaml
+>    # ~/.autospec/project-map.yml
+>    multi_match: union          # `union` (assign to every match) or `first`
+>    mappings:
+>      ctx:32k: <project_number>
+>      ctx:64k: <project_number>
+>      ctx:120k: <project_number>
+>      reasoning:shallow: <project_number>
+>      reasoning:medium:  <project_number>
+>      reasoning:deep:    <project_number>
+>      <any-other-label>: <project_number>
+>    ```
+>
+>    **Reader procedure** for each issue I:
+>    - For each label L on I, look up `mappings[L]`. Skip null / missing entries.
+>    - With `multi_match: union` (default), collect all matching project numbers and assign to every one of them. With `multi_match: first`, take the first match in label-order and assign to that single project.
+>    - For each chosen `<P>`: `gh project item-add <P> --owner <owner> --url <issue-url>`. The `gh` command is idempotent — repeated calls do not duplicate items, so re-running Phase 3.5 is safe.
+>
+>    **Auto-init when the file is missing.** Probe `gh project list --owner <owner> --format json` to confirm the user can author projects. Probe `gh label list --repo {repo} --json name -q '.[].name'` to enumerate the repo's labels. Write a starter file with every label as a `mappings:` key and `null` project numbers, plus `multi_match: union` at the top. Print:
+>    ```
+>    Wrote ~/.autospec/project-map.yml. Edit project numbers (currently null) and re-run.
+>    ```
+>    Then **exit Phase 3.5** without assigning any boards (the labels and `## Model fit` blocks remain applied — only the assign step is deferred).
+>
+>    **Hard rules.**
+>    - Never call `gh project item-add` in `--dry-run`.
+>    - Missing file in `autospec` / `autosplit` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
+>
+> 7. **Dependency-edge sanity checks.** After labeling, validate the dep graph
+>    of the just-created children:
+>    - **closed-dep warning** — emit `WARN: child #<N> depends on closed issue #<M>` for each `Depends on #M` line where `gh issue view #<M> --json state` is `CLOSED`.
+>    - **child-less tracker dep warning** — emit `WARN: child #<N> depends on tracker #<M> with no children` when `#<M>` carries `type:tracker` and has no other open `auto-implement` deps pointing at it.
+>    - **circular sibling-dep hard fail** — exit non-zero if any cycle exists among the just-created children's `Depends on #N` edges.
+>
+> 8. **Post-filing quality audit.** For each child issue (skip `type:tracker`):
+>    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
+>    - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+>    - On non-zero exit (lint fails):
+>      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
+>      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:
+>        ```markdown
+>        ## Quality lint
+>
+>        - **GOAL** — <1-line finding>.
+>        - **AC#<n>** — <1-line finding>.
+>        - **SMOKE** — <1-line finding>.
+>
+>        <!-- autospec-quality:begin -->
+>        *Auto-linted by Phase 3.5 on YYYY-MM-DD.*
+>        <!-- autospec-quality:end -->
+>        ```
+>      - Comment findings: `gh issue comment <N> --body "<findings>" --repo {repo}`
+>    - Do NOT remove `auto-implement` label. Operator decides whether to proceed.
+>
+> 9. **Run-end summary.** Print to stdout:
+>    ```
+>    Phase 3.5 summary on {repo}
+>    - classified: N
+>    - skipped (needs-autospec-template): M
+>    - ctx:32k=A  ctx:64k=B  ctx:120k=C
+>    - reasoning:shallow=X  reasoning:medium=Y  reasoning:deep=Z
+>    - boards assigned: <K> (or "skipped — no project-map.yml")
+>    - dep warnings: <count>; circular cycles: <count>
+>    ```
+
+---
+
+## Phase 3 pre-impl gate
+
+After Phase 3 decomposition completes (and Phase 3.5 review-and-label has
+applied `ctx:*` / `reasoning:*` labels), end Phase 3 by asking the user
+this verbatim question (no auto-launch — always ask explicitly, per spec
+§3.3):
+
+> `"Spec written, N issues filed. Start /autospec-run now, defer to your external daemon, or keep refining? [run / defer / refine]"`
+
+Substitute `N` with the actual issue count from Phase 3. Default highlight
+is **`defer`** for `/autosplit` (the plan-only skill — the user
+invoked `/autosplit` expecting plan-only behavior, so the gate
+defaults to `defer`).
+
+- **`run`** — invoke `/autospec-run` in the current session.
+- **`defer`** (default for `/autosplit`) — print
+  `"Issues are ready. Your external monitor will pick them up. Exiting."`
+  and stop without launching `/autospec-run`. The just-filed `auto-implement`
+  queue persists on the GitHub side so an external daemon (or a later
+  `/autospec-run` invocation) can pick it up.
+- **`refine`** — re-enter Phase 2 from question 1 (Architecture).
+
+No daemon auto-detection — always ask explicitly.
+
+## Handoff
+
+If the gate answer was `run`, hand off to `/autospec-run --profile <name>`
+to begin implementation. If the answer was `defer`, the run ends here and
+the queue is left for an external monitor.

--- a/skills/autosplit/codex/prompt.md
+++ b/skills/autosplit/codex/prompt.md
@@ -1,0 +1,444 @@
+
+# autosplit workflow (harness-neutral)
+
+Take the following request and run the autospec existing-spec split shortcut: select a tracked `docs/specs/*.md` file, skip Phases 1-2, run Phase 3 and Phase 3.5 against that spec, then stop with the `/autospec-run` handoff.
+
+If the request does not identify an existing spec to split, resolve the newest `docs/specs/*.md` candidate using **Existing spec mode** below. Do not brainstorm or write a new spec from `/autosplit`; tell the user to use `/autospec-define` for new feature planning.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autosplit   # per-skill: autosplit / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autosplit/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autosplit.md`
+   - Codex CLI:   `~/.codex/prompts/autosplit.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autosplit found; run install.sh first.` and exit.
+
+## Feature request
+
+{FEATURE_DESCRIPTION}
+
+
+## Existing spec mode
+
+Use this mode when the request asks to split, materialize, roadmap, decompose,
+or turn an existing spec into GitHub issues. Examples:
+`split existing spec`, `split latest spec`, `turn this spec into GitHub issues`,
+`roadmap docs/specs/2026-05-01-example-design.md`, or
+`materialize the newest spec`.
+
+Do not run Phase 1 or Phase 2 in this mode. The design already exists; this
+mode is a shortcut into Phase 3 using the same issue decomposition and Phase 3.5
+classification path as the normal pipeline.
+
+1. **Verify repo.** Run the Phase 0 repo probes. If the current directory is
+   not a git repo with a GitHub remote, use Phase 0 bootstrap before selecting
+   a spec.
+2. **Resolve candidate specs.**
+   - If the request contains an explicit `docs/specs/*.md` path, use that file.
+   - Otherwise list tracked and untracked local files matching `docs/specs/*.md`.
+   - Sort by ISO date in the filename (`YYYY-MM-DD-...`) descending. For files
+     without a date prefix, sort after dated files by filesystem modified time.
+   - The first item is the default "newest" spec.
+3. **Ask on ambiguity.**
+   - If zero specs exist, stop with: `No docs/specs/*.md files found. Create or
+     point me at a spec before running existing spec mode.`
+   - If exactly one spec exists and no explicit path was provided, use it.
+   - If more than one spec exists and no explicit path was provided, ask the user
+     to confirm the default newest spec or choose another path. Show at most the
+     five newest candidates with relative paths. Do not file issues until the
+     user answers.
+4. **Verify selected spec is filed.**
+   - The selected path must be under `docs/specs/` and end in `.md`.
+   - The selected file must be tracked on `origin/main` before Phase 3, so child
+     issues can cite a stable GitHub URL. Verify with:
+     `git fetch origin` and `git cat-file -e origin/main:<spec-path>`.
+   - If the selected file is missing from `origin/main`, stop and tell the user:
+     `Selected spec is not on origin/main yet: <spec-path>. Land the spec first,
+     or run /autospec-define so Phase 2 can create and merge the spec PR.`
+5. **Continue at Phase 3.** Capture `{selected_spec_path}` and its GitHub URL as
+   `https://github.com/{repo}/blob/main/{selected_spec_path}`. Run Phase 3 and
+   Phase 3.5 using that selected spec. Then proceed to the existing Phase 3
+   pre-impl gate.
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; fall back UP on unavailability |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work (research, decompose, review/label); Tier B (cheaper model + medium thinking) for implementation work (Phase 4 implementer + LGTM review — not used by this skill). The orchestrator keeps the user's invoked model. Fall back UP the tier on unavailability.
+
+
+## Phase 0 — Bootstrap repo (if missing)
+
+Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.
+
+Probe the working directory:
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null
+git remote get-url origin 2>/dev/null   # must contain github.com
+```
+
+If **either** check fails — no git repo, or no GitHub remote — bootstrap a new repo:
+
+1. **Suggest a name.** Slugify the feature description: lowercase, hyphens, drop stop-words, prefix with the obvious stack if inferable (e.g. "Go TUI for X" → `go-tui-x`; "Python ML pipeline that does Y" → `py-ml-y`). Offer 1–2 candidates.
+
+2. **Ask the user once** (single interactive question; combine the three sub-questions if your harness supports it, otherwise ask sequentially):
+   - **Name** (your top suggestion as default).
+   - **Visibility**: `private` | `public` (default: private).
+   - **Owner**: enumerate via `gh org list`; default to the user's personal account.
+
+3. **Initialize locally**:
+   - If `.git` is absent: `git init -b main`.
+   - Write a stack-appropriate `.gitignore` (Go: `bin/ vendor/ *.exe *.test`; Node: `node_modules/ dist/ .next/ .env*`; Python: `__pycache__/ .venv/ *.egg-info/ build/ dist/`; mixed/unknown: skip).
+   - Write a one-line `README.md` containing the feature description.
+   - Write a starter `AGENTS.md` listing the project's coding standards (TDD non-negotiable, no DB mocks, conventional commits, branch-per-issue, no force-push) — this is the source of truth every agent reads.
+   - `git add -A && git commit -m "chore: initial scaffold"`.
+
+4. **Create the remote and push**:
+   ```bash
+   gh repo create <owner>/<name> --<private|public> --source=. --remote=origin --push
+   ```
+
+5. **Verify**: `gh repo view <owner>/<name> --json url,defaultBranchRef`. Capture `<owner>/<name>` as `{repo}` — every subsequent phase uses this value.
+
+If a repo already exists (cwd is in a git tree with a `github.com:<owner>/<name>` remote), capture that as `{repo}` and skip the bootstrap.
+
+## Phase 1 — Investigate (delegate)
+
+Spawn a **read-only research subagent** to map relevant files, schema, services. Get back a 300-word summary with file paths and line numbers. Do NOT read files directly from the main thread.
+
+> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+
+If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
+
+For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.
+
+## Phase 2 — Brainstorm + design
+
+> **Spec quality is the bottleneck.** Phase 2's output drives every downstream cycle's cost; if you care about spec quality, invoke this skill with your top-tier model (Claude Code: `claude-code --model opus`; Codex: top GPT). Phase 2 itself runs in the orchestrator (no subagent dispatch) — your invocation model IS the spec model. Subagents in Phases 1, 3, 3.5 follow this lead by selecting Tier A; Phase 4 implementation work uses Tier B. See AGENTS.md.
+
+Run a structured brainstorm — one question at a time, get explicit approval after each section:
+
+1. **Architecture** — where does new code live, what existing patterns does it follow.
+2. **Interactivity / API shape** — how does the user/caller drive it; commands, keys, endpoints, fields.
+3. **Data model** — types, columns, persistence boundary.
+4. **Error handling** — failure modes, recovery, user-visible signals.
+5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services).
+
+Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, scope. The spec must be implementable end-to-end by an agent reading only the spec.
+
+If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
+
+For an existing repo, land the spec via a short-lived PR so CI can validate it:
+1. Create branch `feat/spec-<topic>`, commit `docs/specs/...design.md`, push.
+2. `gh pr create --base main --head feat/spec-<topic> --title "docs: <topic> design spec" --body "Source spec: docs/specs/..."`
+3. Wait for required CI checks to pass (`gh pr checks <#> --repo {repo}`).
+4. Unless `AUTOSPEC_NO_AUTOMERGE_SPEC=1` is set, admin-merge: `gh pr merge <#> --admin --squash --delete-branch --repo {repo}`. If the env var is set, pause and ask the user to merge before continuing.
+5. Verify the spec is reachable at `https://github.com/{repo}/blob/main/docs/specs/...` before dispatching Phase 3.
+
+## Phase 3 — Decompose into linked GitHub issues (delegate)
+
+If Existing spec mode is active, use `{selected_spec_path}` and its GitHub URL.
+Otherwise use the spec path written and merged in Phase 2.
+
+Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
+
+> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+>
+> Read the selected design spec at `<spec-path>` (`<spec-github-url>`) and split it into linked GitHub issues for {repo}.
+>
+> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+>
+> Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
+>
+> - **Goal** — 1 sentence outcome.
+> - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
+> - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
+> - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
+> - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
+> - **Implementation outline** — file paths + function signatures + data flow.
+> - **Tests required** — TDD per AGENTS.md, real services, no DB mocks, 80%+ coverage.
+> - **Acceptance criteria** — checkbox list `[ ]` only, no prose. Each item machine-checkable.
+> - **Verification** — split into a **Primary smoke test (inner loop)** with exactly one fast command, and **Operator/full verification** listing the remaining commands.
+> - **Branch name** — `feat/<slug>`.
+> - **Dependencies** — `Depends on issue #N` lines (parsed by the monitor).
+>
+> Sizing rule: aim for ≤ 4 KB body. Issues that span more than 4 canonical tables, more than 3 packages, or schema-wide changes must be split — better to emit two children with a `Depends on` edge than one oversized child a small LLM can't hold in working memory.
+>
+> **Sizing caps (hard, per spec §3.4):**
+>
+> - **Body ≤400 words** including all sections.
+> - **Implementation outline ≤30 lines** (file paths + function signatures).
+> - **Files touched ≤3** per child issue.
+> - If a candidate child would exceed any cap, split into a parent + child pair with a `Depends on` edge.
+> - The whole spec + a single child issue body must fit comfortably in a 60–120k context window.
+>
+> Self-check each issue against the caps **before** calling `gh issue create`. If a cap is violated and a split is not feasible, surface the issue inline (print the over-cap body to the operator) instead of filing it.
+>
+> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash scripts/lint-issue.sh /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
+>
+> | Finding | Directive appended to next prompt |
+> |---|---|
+> | `GOAL_VAGUE: "improve" used without concrete object` | `AVOID: bare verb \`improve\` without naming a file path, command, label, or number in the same sentence.` |
+> | `GOAL_HEDGE: "should probably"` | `AVOID: hedging words \`should/might/could try/try to\`. State the outcome flatly.` |
+> | `GOAL_NOT_ONE_SENTENCE: N terminals` | `REWRITE: Goal must be exactly one sentence ending with a single . ? or !` |
+> | `AC_PROSE: line N not a checkbox` | `FORMAT: every AC line must start with \`- [ ] \` followed by content.` |
+> | `AC_SUBJECTIVE: "looks clean"` | `AVOID: subjective adjectives \`looks/feels/seems/clean/elegant\` in AC items. Use a \`grep\`/\`test\`/\`diff\`/\`bats\` command instead.` |
+> | `AC_TOO_LONG: N chars` | `SHORTEN: AC item exceeds 120 chars; split into two items or compress to one assertion.` |
+> | `AC_EMPTY` | `ADD: Acceptance criteria section must contain at least one \`- [ ] \` checkbox item.` |
+> | `SMOKE_MULTI_LINE: N lines` | `COLLAPSE: Primary smoke test must be exactly one command line. Use \`&&\` to chain or move setup to Operator/full verification.` |
+> | `SMOKE_PLACEHOLDER: contains "<TODO>"` | `RESOLVE: Replace placeholders \`<TODO>/TBD/XXX/...\` with the actual command before filing.` |
+> | `SMOKE_NOT_FENCED` | `ADD: Primary smoke test section must contain exactly one fenced code block.` |
+
+### Small-LLM friendliness (applies to every child issue)
+
+Children are written assuming the implementer is a 32B-class local model with **pre-staged context**, not a search-driven cloud agent:
+
+- Every file the implementer needs is named in **Files to read first** with a sectional anchor or a one-line reason. Do not assume the model will grep the codebase.
+- Spec docs are cited by section heading, not as "read this 20 KB doc".
+- Acceptance criteria are checkbox-only so the model can self-verify line-by-line.
+- One **Primary smoke test** runs in the inner loop; the heavier verification list runs once at the end.
+- If the work fans out across many tables/packages, split it. Two 3 KB children chained by `Depends on` beat one 7 KB child a 32B model garbles at 60k tokens of working context.
+
+Capture the umbrella + child issue numbers.
+
+## Phase 3.5 — Review and label (delegate)
+
+Dispatch a **foreground subagent** to retro-review the child issues just
+created in Phase 3 and apply the model-fit rubric. The subagent must NOT modify
+issue titles or remove existing labels; it only adds `ctx:*` and `reasoning:*`
+labels and patches each body with a `## Model fit` block.
+
+> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+>
+> Walk every child issue created in Phase 3 (skip any issue carrying the
+> `type:tracker` label). For each:
+>
+> 1. **Stage context.** Read `gh issue view <N> --repo {repo} --json title,body,labels`. The
+>    body should already contain `## Files to read first` and
+>    `## Implementation scope`. If either is missing, add label
+>    `needs-autospec-template` (idempotent `gh label create --force` once at run
+>    start) and skip — do not classify or patch.
+>
+> 2. **Apply the rubric.** Pick the smallest `ctx:*` tier that holds the
+>    staged context (issue body + every file in `## Files to read first` +
+>    cited spec sections). Pick the `reasoning:*` depth required to derive
+>    (not just transcribe) the implementation.
+>
+>    **`ctx:*` — context-window axis**
+>
+>    | Label | Trigger |
+>    |---|---|
+>    | `ctx:32k`  | One canonical table or shell script; ≤3 files in *Files to read first*; short spec anchors. |
+>    | `ctx:64k`  | Multi-file change; 4-7 files staged; one trio + one installer; medium spec sections (~1-3 KB). |
+>    | `ctx:120k` | Cross-skill or cross-package; 8+ files; long spec excerpts; deep call graphs. |
+>
+>    **`reasoning:*` — reasoning-depth axis**
+>
+>    | Label | Trigger |
+>    |---|---|
+>    | `reasoning:shallow` | Mechanical: copy-and-rename, regex-replace, README transcription, runbook authoring. Verbs: *copy*, *rename*, *transcribe*, *list*. |
+>    | `reasoning:medium`  | Template-following with judgment: synthesize a SKILL.md mirroring an existing one, modify a script with new flags, write tests for a documented contract. Verbs: *mirror*, *adapt*, *integrate*, *wire*. |
+>    | `reasoning:deep`    | Novel design choices: pick a new abstraction, resolve a contradiction in the spec, reconcile cross-cutting concerns. Verbs: *design*, *reconcile*, *resolve*, *redesign*. |
+>
+>    Default for issues that lack any of these signals: `ctx:64k`,
+>    `reasoning:medium`. If unsure between two ctx tiers, prefer the larger.
+>
+> 3. **Sibling normalization.** When 5+ split children share a structural
+>    criterion (e.g. all per-source-table writers, all per-skill installers),
+>    harmonize their `ctx:*`/`reasoning:*` labels so the operator can run a
+>    single profile across the whole group. Override individual classifications
+>    only when the difference is a true outlier (e.g. one sibling pulls in a
+>    schema-wide refactor that no other sibling touches).
+>
+> 4. **Apply labels.** Idempotent at run start:
+>    `gh label create ctx:32k  --color c5def5 --force --repo {repo}`,
+>    `gh label create ctx:64k  --color c5def5 --force --repo {repo}`,
+>    `gh label create ctx:120k --color c5def5 --force --repo {repo}`,
+>    `gh label create reasoning:shallow --color c2e0c6 --force --repo {repo}`,
+>    `gh label create reasoning:medium  --color c2e0c6 --force --repo {repo}`,
+>    `gh label create reasoning:deep    --color c2e0c6 --force --repo {repo}`,
+>    `gh label create needs-quality-bar --color fbca04 --force --repo {repo}`.
+>    Then per issue:
+>    `gh issue edit <N> --add-label "ctx:<tier>,reasoning:<depth>" --repo {repo}`.
+>
+> 5. **Patch body — `## Model fit` block.** Insert immediately before the first
+>    `## Dependencies` line (or at end of body if absent):
+>
+>    ```markdown
+>    ## Model fit
+>
+>    - **ctx:** `ctx:<tier>` — <1-line rationale>.
+>    - **reasoning:** `reasoning:<depth>` — <1-line rationale>.
+>
+>    <!-- autospec-classify:begin -->
+>    *Auto-classified by Phase 3.5 on YYYY-MM-DD.*
+>    <!-- autospec-classify:end -->
+>    ```
+>
+>    **Idempotency:** if a `## Model fit` block already exists between the
+>    `<!-- autospec-classify:begin -->` and `<!-- autospec-classify:end -->`
+>    markers, replace it in place. Never stack duplicates. Apply via
+>    `gh issue edit <N> --body-file <tmp>`.
+>
+> 6. **Board assignment** — read `~/.autospec/project-map.yml` and assign each
+>    just-classified child to the GitHub Projects mapped from its labels.
+>
+>    **File schema** (auto-init if missing — see below):
+>    ```yaml
+>    # ~/.autospec/project-map.yml
+>    multi_match: union          # `union` (assign to every match) or `first`
+>    mappings:
+>      ctx:32k: <project_number>
+>      ctx:64k: <project_number>
+>      ctx:120k: <project_number>
+>      reasoning:shallow: <project_number>
+>      reasoning:medium:  <project_number>
+>      reasoning:deep:    <project_number>
+>      <any-other-label>: <project_number>
+>    ```
+>
+>    **Reader procedure** for each issue I:
+>    - For each label L on I, look up `mappings[L]`. Skip null / missing entries.
+>    - With `multi_match: union` (default), collect all matching project numbers and assign to every one of them. With `multi_match: first`, take the first match in label-order and assign to that single project.
+>    - For each chosen `<P>`: `gh project item-add <P> --owner <owner> --url <issue-url>`. The `gh` command is idempotent — repeated calls do not duplicate items, so re-running Phase 3.5 is safe.
+>
+>    **Auto-init when the file is missing.** Probe `gh project list --owner <owner> --format json` to confirm the user can author projects. Probe `gh label list --repo {repo} --json name -q '.[].name'` to enumerate the repo's labels. Write a starter file with every label as a `mappings:` key and `null` project numbers, plus `multi_match: union` at the top. Print:
+>    ```
+>    Wrote ~/.autospec/project-map.yml. Edit project numbers (currently null) and re-run.
+>    ```
+>    Then **exit Phase 3.5** without assigning any boards (the labels and `## Model fit` blocks remain applied — only the assign step is deferred).
+>
+>    **Hard rules.**
+>    - Never call `gh project item-add` in `--dry-run`.
+>    - Missing file in `autospec` / `autosplit` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
+>
+> 7. **Dependency-edge sanity checks.** After labeling, validate the dep graph
+>    of the just-created children:
+>    - **closed-dep warning** — emit `WARN: child #<N> depends on closed issue #<M>` for each `Depends on #M` line where `gh issue view #<M> --json state` is `CLOSED`.
+>    - **child-less tracker dep warning** — emit `WARN: child #<N> depends on tracker #<M> with no children` when `#<M>` carries `type:tracker` and has no other open `auto-implement` deps pointing at it.
+>    - **circular sibling-dep hard fail** — exit non-zero if any cycle exists among the just-created children's `Depends on #N` edges.
+>
+> 8. **Post-filing quality audit.** For each child issue (skip `type:tracker`):
+>    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
+>    - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+>    - On non-zero exit (lint fails):
+>      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
+>      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:
+>        ```markdown
+>        ## Quality lint
+>
+>        - **GOAL** — <1-line finding>.
+>        - **AC#<n>** — <1-line finding>.
+>        - **SMOKE** — <1-line finding>.
+>
+>        <!-- autospec-quality:begin -->
+>        *Auto-linted by Phase 3.5 on YYYY-MM-DD.*
+>        <!-- autospec-quality:end -->
+>        ```
+>      - Comment findings: `gh issue comment <N> --body "<findings>" --repo {repo}`
+>    - Do NOT remove `auto-implement` label. Operator decides whether to proceed.
+>
+> 9. **Run-end summary.** Print to stdout:
+>    ```
+>    Phase 3.5 summary on {repo}
+>    - classified: N
+>    - skipped (needs-autospec-template): M
+>    - ctx:32k=A  ctx:64k=B  ctx:120k=C
+>    - reasoning:shallow=X  reasoning:medium=Y  reasoning:deep=Z
+>    - boards assigned: <K> (or "skipped — no project-map.yml")
+>    - dep warnings: <count>; circular cycles: <count>
+>    ```
+
+
+## Phase 3 pre-impl gate
+
+After Phase 3 decomposition completes (and Phase 3.5 review-and-label has
+applied `ctx:*` / `reasoning:*` labels), end Phase 3 by asking the user
+this verbatim question (no auto-launch — always ask explicitly, per spec
+§3.3):
+
+> `"Spec written, N issues filed. Start /autospec-run now, defer to your external daemon, or keep refining? [run / defer / refine]"`
+
+Substitute `N` with the actual issue count from Phase 3. Default highlight
+is **`defer`** for `/autosplit` (the plan-only skill — the user
+invoked `/autosplit` expecting plan-only behavior, so the gate
+defaults to `defer`).
+
+- **`run`** — invoke `/autospec-run` in the current session.
+- **`defer`** (default for `/autosplit`) — print
+  `"Issues are ready. Your external monitor will pick them up. Exiting."`
+  and stop without launching `/autospec-run`. The just-filed `auto-implement`
+  queue persists on the GitHub side so an external daemon (or a later
+  `/autospec-run` invocation) can pick it up.
+- **`refine`** — re-enter Phase 2 from question 1 (Architecture).
+
+No daemon auto-detection — always ask explicitly.
+
+## Handoff
+
+If the gate answer was `run`, hand off to `/autospec-run --profile <name>`
+to begin implementation. If the answer was `defer`, the run ends here and
+the queue is left for an external monitor.

--- a/skills/autosplit/install.sh
+++ b/skills/autosplit/install.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --symlink           # symlink instead of copy (updates propagate)
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh \
+#     | sh -s -- --harness all
+# When piped, the script auto-downloads the skill files from the same branch.
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPLIT_REF         (default: main) — git ref to fetch from when piped
+#   AUTOSPLIT_RAW_BASE    (override the raw URL base entirely)
+#
+# Idempotent: re-running upgrades the install. Exits non-zero on hard failure;
+# exits zero with warnings on missing optional deps.
+
+set -eu
+
+SKILL_NAME="autosplit"
+SKILL_RAW_BASE="${AUTOSPLIT_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPLIT_REF:-main}/skills/autosplit}"
+
+# Resolve the directory containing this script. When piped through stdin (e.g.
+# `curl ... | sh`), $0 will not be a real file — detect that and fall back to
+# downloading the source files from the raw GitHub URL.
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+UPDATE_MODE=0
+TMP_FETCH_DIR=""
+
+# ---------- helpers --------------------------------------------------------
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
+
+Installs the ${SKILL_NAME} skill into the chosen harness's standard
+skill/agent/prompt directory.
+
+Examples:
+  $0                          # interactive
+  $0 --harness all            # install everywhere
+  $0 --harness claude         # Claude Code only
+  $0 --harness opencode       # OpenCode only
+  $0 --harness codex          # Codex CLI only
+  $0 --harness all --symlink  # symlink instead of copy
+  $0 --dry-run --harness all  # print plan, change nothing
+  $0 --harness claude --update  # idempotent re-install (overwrite existing)
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    # Download the files we need into a temp dir and set SKILL_DIR to it.
+    if ! command -v curl >/dev/null 2>&1; then
+        err "curl is required when running from stdin (e.g. piped via 'curl | sh')."
+        exit 1
+    fi
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/$rel"
+            exit 1
+        fi
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    dest_dir="$(dirname "$dest")"
+
+    if [ ! -f "$src" ]; then
+        err "missing source file: $src"
+        return 1
+    fi
+
+    run "mkdir -p \"$dest_dir\""
+
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --symlink)
+            USE_SYMLINK=1
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        --update)
+            UPDATE_MODE=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# ---------- harness prompt -------------------------------------------------
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- ensure source files are available ------------------------------
+
+# If we couldn't resolve a local SKILL_DIR (piped from curl) OR the local dir
+# doesn't actually contain the skill files, fall back to remote fetch.
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+
+if [ "$need_fetch" -eq 1 ]; then
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        err "--symlink requires running from a checkout of the codex-skills repo (no local files to symlink to)."
+        exit 2
+    fi
+    fetch_source_files
+fi
+
+# ---------- dependency checks ---------------------------------------------
+
+dep_warnings=0
+
+check_dep() {
+    name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        warn "$name not found on PATH (required by the skill at runtime)"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+}
+
+check_dep git
+check_dep gh
+check_dep jq
+
+if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+        warn "gh is installed but not authenticated. Run: gh auth login"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+fi
+
+if [ "$dep_warnings" -gt 0 ]; then
+    warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
+fi
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+CLAUDE_SRC="$SKILL_DIR/SKILL.md"
+OPENCODE_SRC="$SKILL_DIR/opencode/agent.md"
+CODEX_SRC="$SKILL_DIR/codex/prompt.md"
+
+# ---------- install --------------------------------------------------------
+
+installed_paths=""
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_SRC" "$CLAUDE_DEST"
+    installed_paths="${installed_paths}  Claude Code: ${CLAUDE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_SRC" "$OPENCODE_DEST"
+    installed_paths="${installed_paths}  OpenCode:    ${OPENCODE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+    installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
+fi
+
+# ---------- final summary --------------------------------------------------
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    if [ "$UPDATE_MODE" -eq 1 ]; then
+        info "Updated (idempotent overwrite):"
+    else
+        info "Installed:"
+    fi
+    printf '%b' "$installed_paths"
+    info ""
+    info "Invoke with:"
+    info "  Claude Code:  /${SKILL_NAME} <feature description>"
+    info "  OpenCode:     @${SKILL_NAME} <feature description>"
+    info "  Codex CLI:    /${SKILL_NAME} <feature description>"
+fi
+
+exit 0

--- a/skills/autosplit/opencode/agent.md
+++ b/skills/autosplit/opencode/agent.md
@@ -1,0 +1,448 @@
+---
+description: Use when the user wants to split an existing tracked docs/specs/*.md design spec into GitHub issues, then stop after Phase 3.5 and hand off to /autospec-run.
+mode: primary
+---
+
+# autosplit workflow (harness-neutral)
+
+Take the following request and run the autospec existing-spec split shortcut: select a tracked `docs/specs/*.md` file, skip Phases 1-2, run Phase 3 and Phase 3.5 against that spec, then stop with the `/autospec-run` handoff.
+
+If the request does not identify an existing spec to split, resolve the newest `docs/specs/*.md` candidate using **Existing spec mode** below. Do not brainstorm or write a new spec from `/autosplit`; tell the user to use `/autospec-define` for new feature planning.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autosplit   # per-skill: autosplit / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autosplit/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autosplit.md`
+   - Codex CLI:   `~/.codex/prompts/autosplit.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autosplit found; run install.sh first.` and exit.
+
+## Feature request
+
+{FEATURE_DESCRIPTION}
+
+
+## Existing spec mode
+
+Use this mode when the request asks to split, materialize, roadmap, decompose,
+or turn an existing spec into GitHub issues. Examples:
+`split existing spec`, `split latest spec`, `turn this spec into GitHub issues`,
+`roadmap docs/specs/2026-05-01-example-design.md`, or
+`materialize the newest spec`.
+
+Do not run Phase 1 or Phase 2 in this mode. The design already exists; this
+mode is a shortcut into Phase 3 using the same issue decomposition and Phase 3.5
+classification path as the normal pipeline.
+
+1. **Verify repo.** Run the Phase 0 repo probes. If the current directory is
+   not a git repo with a GitHub remote, use Phase 0 bootstrap before selecting
+   a spec.
+2. **Resolve candidate specs.**
+   - If the request contains an explicit `docs/specs/*.md` path, use that file.
+   - Otherwise list tracked and untracked local files matching `docs/specs/*.md`.
+   - Sort by ISO date in the filename (`YYYY-MM-DD-...`) descending. For files
+     without a date prefix, sort after dated files by filesystem modified time.
+   - The first item is the default "newest" spec.
+3. **Ask on ambiguity.**
+   - If zero specs exist, stop with: `No docs/specs/*.md files found. Create or
+     point me at a spec before running existing spec mode.`
+   - If exactly one spec exists and no explicit path was provided, use it.
+   - If more than one spec exists and no explicit path was provided, ask the user
+     to confirm the default newest spec or choose another path. Show at most the
+     five newest candidates with relative paths. Do not file issues until the
+     user answers.
+4. **Verify selected spec is filed.**
+   - The selected path must be under `docs/specs/` and end in `.md`.
+   - The selected file must be tracked on `origin/main` before Phase 3, so child
+     issues can cite a stable GitHub URL. Verify with:
+     `git fetch origin` and `git cat-file -e origin/main:<spec-path>`.
+   - If the selected file is missing from `origin/main`, stop and tell the user:
+     `Selected spec is not on origin/main yet: <spec-path>. Land the spec first,
+     or run /autospec-define so Phase 2 can create and merge the spec PR.`
+5. **Continue at Phase 3.** Capture `{selected_spec_path}` and its GitHub URL as
+   `https://github.com/{repo}/blob/main/{selected_spec_path}`. Run Phase 3 and
+   Phase 3.5 using that selected spec. Then proceed to the existing Phase 3
+   pre-impl gate.
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; fall back UP on unavailability |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work (research, decompose, review/label); Tier B (cheaper model + medium thinking) for implementation work (Phase 4 implementer + LGTM review — not used by this skill). The orchestrator keeps the user's invoked model. Fall back UP the tier on unavailability.
+
+
+## Phase 0 — Bootstrap repo (if missing)
+
+Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.
+
+Probe the working directory:
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null
+git remote get-url origin 2>/dev/null   # must contain github.com
+```
+
+If **either** check fails — no git repo, or no GitHub remote — bootstrap a new repo:
+
+1. **Suggest a name.** Slugify the feature description: lowercase, hyphens, drop stop-words, prefix with the obvious stack if inferable (e.g. "Go TUI for X" → `go-tui-x`; "Python ML pipeline that does Y" → `py-ml-y`). Offer 1–2 candidates.
+
+2. **Ask the user once** (single interactive question; combine the three sub-questions if your harness supports it, otherwise ask sequentially):
+   - **Name** (your top suggestion as default).
+   - **Visibility**: `private` | `public` (default: private).
+   - **Owner**: enumerate via `gh org list`; default to the user's personal account.
+
+3. **Initialize locally**:
+   - If `.git` is absent: `git init -b main`.
+   - Write a stack-appropriate `.gitignore` (Go: `bin/ vendor/ *.exe *.test`; Node: `node_modules/ dist/ .next/ .env*`; Python: `__pycache__/ .venv/ *.egg-info/ build/ dist/`; mixed/unknown: skip).
+   - Write a one-line `README.md` containing the feature description.
+   - Write a starter `AGENTS.md` listing the project's coding standards (TDD non-negotiable, no DB mocks, conventional commits, branch-per-issue, no force-push) — this is the source of truth every agent reads.
+   - `git add -A && git commit -m "chore: initial scaffold"`.
+
+4. **Create the remote and push**:
+   ```bash
+   gh repo create <owner>/<name> --<private|public> --source=. --remote=origin --push
+   ```
+
+5. **Verify**: `gh repo view <owner>/<name> --json url,defaultBranchRef`. Capture `<owner>/<name>` as `{repo}` — every subsequent phase uses this value.
+
+If a repo already exists (cwd is in a git tree with a `github.com:<owner>/<name>` remote), capture that as `{repo}` and skip the bootstrap.
+
+## Phase 1 — Investigate (delegate)
+
+Spawn a **read-only research subagent** to map relevant files, schema, services. Get back a 300-word summary with file paths and line numbers. Do NOT read files directly from the main thread.
+
+> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+
+If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
+
+For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.
+
+## Phase 2 — Brainstorm + design
+
+> **Spec quality is the bottleneck.** Phase 2's output drives every downstream cycle's cost; if you care about spec quality, invoke this skill with your top-tier model (Claude Code: `claude-code --model opus`; Codex: top GPT). Phase 2 itself runs in the orchestrator (no subagent dispatch) — your invocation model IS the spec model. Subagents in Phases 1, 3, 3.5 follow this lead by selecting Tier A; Phase 4 implementation work uses Tier B. See AGENTS.md.
+
+Run a structured brainstorm — one question at a time, get explicit approval after each section:
+
+1. **Architecture** — where does new code live, what existing patterns does it follow.
+2. **Interactivity / API shape** — how does the user/caller drive it; commands, keys, endpoints, fields.
+3. **Data model** — types, columns, persistence boundary.
+4. **Error handling** — failure modes, recovery, user-visible signals.
+5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services).
+
+Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, scope. The spec must be implementable end-to-end by an agent reading only the spec.
+
+If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
+
+For an existing repo, land the spec via a short-lived PR so CI can validate it:
+1. Create branch `feat/spec-<topic>`, commit `docs/specs/...design.md`, push.
+2. `gh pr create --base main --head feat/spec-<topic> --title "docs: <topic> design spec" --body "Source spec: docs/specs/..."`
+3. Wait for required CI checks to pass (`gh pr checks <#> --repo {repo}`).
+4. Unless `AUTOSPEC_NO_AUTOMERGE_SPEC=1` is set, admin-merge: `gh pr merge <#> --admin --squash --delete-branch --repo {repo}`. If the env var is set, pause and ask the user to merge before continuing.
+5. Verify the spec is reachable at `https://github.com/{repo}/blob/main/docs/specs/...` before dispatching Phase 3.
+
+## Phase 3 — Decompose into linked GitHub issues (delegate)
+
+If Existing spec mode is active, use `{selected_spec_path}` and its GitHub URL.
+Otherwise use the spec path written and merged in Phase 2.
+
+Dispatch a **foreground subagent** with this prompt (substitute the spec path and `{repo}`):
+
+> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+>
+> Read the selected design spec at `<spec-path>` (`<spec-github-url>`) and split it into linked GitHub issues for {repo}.
+>
+> Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
+>
+> Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
+>
+> - **Goal** — 1 sentence outcome.
+> - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
+> - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
+> - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
+> - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
+> - **Implementation outline** — file paths + function signatures + data flow.
+> - **Tests required** — TDD per AGENTS.md, real services, no DB mocks, 80%+ coverage.
+> - **Acceptance criteria** — checkbox list `[ ]` only, no prose. Each item machine-checkable.
+> - **Verification** — split into a **Primary smoke test (inner loop)** with exactly one fast command, and **Operator/full verification** listing the remaining commands.
+> - **Branch name** — `feat/<slug>`.
+> - **Dependencies** — `Depends on issue #N` lines (parsed by the monitor).
+>
+> Sizing rule: aim for ≤ 4 KB body. Issues that span more than 4 canonical tables, more than 3 packages, or schema-wide changes must be split — better to emit two children with a `Depends on` edge than one oversized child a small LLM can't hold in working memory.
+>
+> **Sizing caps (hard, per spec §3.4):**
+>
+> - **Body ≤400 words** including all sections.
+> - **Implementation outline ≤30 lines** (file paths + function signatures).
+> - **Files touched ≤3** per child issue.
+> - If a candidate child would exceed any cap, split into a parent + child pair with a `Depends on` edge.
+> - The whole spec + a single child issue body must fit comfortably in a 60–120k context window.
+>
+> Self-check each issue against the caps **before** calling `gh issue create`. If a cap is violated and a split is not feasible, surface the issue inline (print the over-cap body to the operator) instead of filing it.
+>
+> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash scripts/lint-issue.sh /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
+>
+> | Finding | Directive appended to next prompt |
+> |---|---|
+> | `GOAL_VAGUE: "improve" used without concrete object` | `AVOID: bare verb \`improve\` without naming a file path, command, label, or number in the same sentence.` |
+> | `GOAL_HEDGE: "should probably"` | `AVOID: hedging words \`should/might/could try/try to\`. State the outcome flatly.` |
+> | `GOAL_NOT_ONE_SENTENCE: N terminals` | `REWRITE: Goal must be exactly one sentence ending with a single . ? or !` |
+> | `AC_PROSE: line N not a checkbox` | `FORMAT: every AC line must start with \`- [ ] \` followed by content.` |
+> | `AC_SUBJECTIVE: "looks clean"` | `AVOID: subjective adjectives \`looks/feels/seems/clean/elegant\` in AC items. Use a \`grep\`/\`test\`/\`diff\`/\`bats\` command instead.` |
+> | `AC_TOO_LONG: N chars` | `SHORTEN: AC item exceeds 120 chars; split into two items or compress to one assertion.` |
+> | `AC_EMPTY` | `ADD: Acceptance criteria section must contain at least one \`- [ ] \` checkbox item.` |
+> | `SMOKE_MULTI_LINE: N lines` | `COLLAPSE: Primary smoke test must be exactly one command line. Use \`&&\` to chain or move setup to Operator/full verification.` |
+> | `SMOKE_PLACEHOLDER: contains "<TODO>"` | `RESOLVE: Replace placeholders \`<TODO>/TBD/XXX/...\` with the actual command before filing.` |
+> | `SMOKE_NOT_FENCED` | `ADD: Primary smoke test section must contain exactly one fenced code block.` |
+
+### Small-LLM friendliness (applies to every child issue)
+
+Children are written assuming the implementer is a 32B-class local model with **pre-staged context**, not a search-driven cloud agent:
+
+- Every file the implementer needs is named in **Files to read first** with a sectional anchor or a one-line reason. Do not assume the model will grep the codebase.
+- Spec docs are cited by section heading, not as "read this 20 KB doc".
+- Acceptance criteria are checkbox-only so the model can self-verify line-by-line.
+- One **Primary smoke test** runs in the inner loop; the heavier verification list runs once at the end.
+- If the work fans out across many tables/packages, split it. Two 3 KB children chained by `Depends on` beat one 7 KB child a 32B model garbles at 60k tokens of working context.
+
+Capture the umbrella + child issue numbers.
+
+## Phase 3.5 — Review and label (delegate)
+
+Dispatch a **foreground subagent** to retro-review the child issues just
+created in Phase 3 and apply the model-fit rubric. The subagent must NOT modify
+issue titles or remove existing labels; it only adds `ctx:*` and `reasoning:*`
+labels and patches each body with a `## Model fit` block.
+
+> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+>
+> Walk every child issue created in Phase 3 (skip any issue carrying the
+> `type:tracker` label). For each:
+>
+> 1. **Stage context.** Read `gh issue view <N> --repo {repo} --json title,body,labels`. The
+>    body should already contain `## Files to read first` and
+>    `## Implementation scope`. If either is missing, add label
+>    `needs-autospec-template` (idempotent `gh label create --force` once at run
+>    start) and skip — do not classify or patch.
+>
+> 2. **Apply the rubric.** Pick the smallest `ctx:*` tier that holds the
+>    staged context (issue body + every file in `## Files to read first` +
+>    cited spec sections). Pick the `reasoning:*` depth required to derive
+>    (not just transcribe) the implementation.
+>
+>    **`ctx:*` — context-window axis**
+>
+>    | Label | Trigger |
+>    |---|---|
+>    | `ctx:32k`  | One canonical table or shell script; ≤3 files in *Files to read first*; short spec anchors. |
+>    | `ctx:64k`  | Multi-file change; 4-7 files staged; one trio + one installer; medium spec sections (~1-3 KB). |
+>    | `ctx:120k` | Cross-skill or cross-package; 8+ files; long spec excerpts; deep call graphs. |
+>
+>    **`reasoning:*` — reasoning-depth axis**
+>
+>    | Label | Trigger |
+>    |---|---|
+>    | `reasoning:shallow` | Mechanical: copy-and-rename, regex-replace, README transcription, runbook authoring. Verbs: *copy*, *rename*, *transcribe*, *list*. |
+>    | `reasoning:medium`  | Template-following with judgment: synthesize a SKILL.md mirroring an existing one, modify a script with new flags, write tests for a documented contract. Verbs: *mirror*, *adapt*, *integrate*, *wire*. |
+>    | `reasoning:deep`    | Novel design choices: pick a new abstraction, resolve a contradiction in the spec, reconcile cross-cutting concerns. Verbs: *design*, *reconcile*, *resolve*, *redesign*. |
+>
+>    Default for issues that lack any of these signals: `ctx:64k`,
+>    `reasoning:medium`. If unsure between two ctx tiers, prefer the larger.
+>
+> 3. **Sibling normalization.** When 5+ split children share a structural
+>    criterion (e.g. all per-source-table writers, all per-skill installers),
+>    harmonize their `ctx:*`/`reasoning:*` labels so the operator can run a
+>    single profile across the whole group. Override individual classifications
+>    only when the difference is a true outlier (e.g. one sibling pulls in a
+>    schema-wide refactor that no other sibling touches).
+>
+> 4. **Apply labels.** Idempotent at run start:
+>    `gh label create ctx:32k  --color c5def5 --force --repo {repo}`,
+>    `gh label create ctx:64k  --color c5def5 --force --repo {repo}`,
+>    `gh label create ctx:120k --color c5def5 --force --repo {repo}`,
+>    `gh label create reasoning:shallow --color c2e0c6 --force --repo {repo}`,
+>    `gh label create reasoning:medium  --color c2e0c6 --force --repo {repo}`,
+>    `gh label create reasoning:deep    --color c2e0c6 --force --repo {repo}`,
+>    `gh label create needs-quality-bar --color fbca04 --force --repo {repo}`.
+>    Then per issue:
+>    `gh issue edit <N> --add-label "ctx:<tier>,reasoning:<depth>" --repo {repo}`.
+>
+> 5. **Patch body — `## Model fit` block.** Insert immediately before the first
+>    `## Dependencies` line (or at end of body if absent):
+>
+>    ```markdown
+>    ## Model fit
+>
+>    - **ctx:** `ctx:<tier>` — <1-line rationale>.
+>    - **reasoning:** `reasoning:<depth>` — <1-line rationale>.
+>
+>    <!-- autospec-classify:begin -->
+>    *Auto-classified by Phase 3.5 on YYYY-MM-DD.*
+>    <!-- autospec-classify:end -->
+>    ```
+>
+>    **Idempotency:** if a `## Model fit` block already exists between the
+>    `<!-- autospec-classify:begin -->` and `<!-- autospec-classify:end -->`
+>    markers, replace it in place. Never stack duplicates. Apply via
+>    `gh issue edit <N> --body-file <tmp>`.
+>
+> 6. **Board assignment** — read `~/.autospec/project-map.yml` and assign each
+>    just-classified child to the GitHub Projects mapped from its labels.
+>
+>    **File schema** (auto-init if missing — see below):
+>    ```yaml
+>    # ~/.autospec/project-map.yml
+>    multi_match: union          # `union` (assign to every match) or `first`
+>    mappings:
+>      ctx:32k: <project_number>
+>      ctx:64k: <project_number>
+>      ctx:120k: <project_number>
+>      reasoning:shallow: <project_number>
+>      reasoning:medium:  <project_number>
+>      reasoning:deep:    <project_number>
+>      <any-other-label>: <project_number>
+>    ```
+>
+>    **Reader procedure** for each issue I:
+>    - For each label L on I, look up `mappings[L]`. Skip null / missing entries.
+>    - With `multi_match: union` (default), collect all matching project numbers and assign to every one of them. With `multi_match: first`, take the first match in label-order and assign to that single project.
+>    - For each chosen `<P>`: `gh project item-add <P> --owner <owner> --url <issue-url>`. The `gh` command is idempotent — repeated calls do not duplicate items, so re-running Phase 3.5 is safe.
+>
+>    **Auto-init when the file is missing.** Probe `gh project list --owner <owner> --format json` to confirm the user can author projects. Probe `gh label list --repo {repo} --json name -q '.[].name'` to enumerate the repo's labels. Write a starter file with every label as a `mappings:` key and `null` project numbers, plus `multi_match: union` at the top. Print:
+>    ```
+>    Wrote ~/.autospec/project-map.yml. Edit project numbers (currently null) and re-run.
+>    ```
+>    Then **exit Phase 3.5** without assigning any boards (the labels and `## Model fit` blocks remain applied — only the assign step is deferred).
+>
+>    **Hard rules.**
+>    - Never call `gh project item-add` in `--dry-run`.
+>    - Missing file in `autospec` / `autosplit` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
+>
+> 7. **Dependency-edge sanity checks.** After labeling, validate the dep graph
+>    of the just-created children:
+>    - **closed-dep warning** — emit `WARN: child #<N> depends on closed issue #<M>` for each `Depends on #M` line where `gh issue view #<M> --json state` is `CLOSED`.
+>    - **child-less tracker dep warning** — emit `WARN: child #<N> depends on tracker #<M> with no children` when `#<M>` carries `type:tracker` and has no other open `auto-implement` deps pointing at it.
+>    - **circular sibling-dep hard fail** — exit non-zero if any cycle exists among the just-created children's `Depends on #N` edges.
+>
+> 8. **Post-filing quality audit.** For each child issue (skip `type:tracker`):
+>    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
+>    - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+>    - On non-zero exit (lint fails):
+>      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
+>      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:
+>        ```markdown
+>        ## Quality lint
+>
+>        - **GOAL** — <1-line finding>.
+>        - **AC#<n>** — <1-line finding>.
+>        - **SMOKE** — <1-line finding>.
+>
+>        <!-- autospec-quality:begin -->
+>        *Auto-linted by Phase 3.5 on YYYY-MM-DD.*
+>        <!-- autospec-quality:end -->
+>        ```
+>      - Comment findings: `gh issue comment <N> --body "<findings>" --repo {repo}`
+>    - Do NOT remove `auto-implement` label. Operator decides whether to proceed.
+>
+> 9. **Run-end summary.** Print to stdout:
+>    ```
+>    Phase 3.5 summary on {repo}
+>    - classified: N
+>    - skipped (needs-autospec-template): M
+>    - ctx:32k=A  ctx:64k=B  ctx:120k=C
+>    - reasoning:shallow=X  reasoning:medium=Y  reasoning:deep=Z
+>    - boards assigned: <K> (or "skipped — no project-map.yml")
+>    - dep warnings: <count>; circular cycles: <count>
+>    ```
+
+
+## Phase 3 pre-impl gate
+
+After Phase 3 decomposition completes (and Phase 3.5 review-and-label has
+applied `ctx:*` / `reasoning:*` labels), end Phase 3 by asking the user
+this verbatim question (no auto-launch — always ask explicitly, per spec
+§3.3):
+
+> `"Spec written, N issues filed. Start /autospec-run now, defer to your external daemon, or keep refining? [run / defer / refine]"`
+
+Substitute `N` with the actual issue count from Phase 3. Default highlight
+is **`defer`** for `/autosplit` (the plan-only skill — the user
+invoked `/autosplit` expecting plan-only behavior, so the gate
+defaults to `defer`).
+
+- **`run`** — invoke `/autospec-run` in the current session.
+- **`defer`** (default for `/autosplit`) — print
+  `"Issues are ready. Your external monitor will pick them up. Exiting."`
+  and stop without launching `/autospec-run`. The just-filed `auto-implement`
+  queue persists on the GitHub side so an external daemon (or a later
+  `/autospec-run` invocation) can pick it up.
+- **`refine`** — re-enter Phase 2 from question 1 (Architecture).
+
+No daemon auto-detection — always ask explicitly.
+
+## Handoff
+
+If the gate answer was `run`, hand off to `/autospec-run --profile <name>`
+to begin implementation. If the answer was `defer`, the run ends here and
+the queue is left for an external monitor.

--- a/skills/autosplit/uninstall.sh
+++ b/skills/autosplit/uninstall.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autosplit"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        # Try to remove an empty parent skill directory (Claude only — its layout
+        # has a per-skill subdir).
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+# ---------- remove ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,7 +12,7 @@
 #   ./uninstall.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-define | autospec-run | autospec-classify | autospec-listen | all
+#   --skill   one of: autospec | autosplit | autospec-define | autospec-run | autospec-classify | autospec-listen | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -24,7 +24,7 @@
 
 set -eu
 
-ALL_SKILLS="autospec autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
+ALL_SKILLS="autospec autosplit autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -67,7 +67,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$SKILL_ARG" in
-    all|autospec|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-stop) ;;
+    all|autospec|autosplit|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-stop) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
         exit 2


### PR DESCRIPTION
## Summary
- add the multi-harness autosplit skill and local installer/uninstaller wrappers
- include autosplit in suite install/uninstall, docs, and skill index
- extend validation so startup self-update and Codex skill-dir checks cover autosplit

## Validation
- bash scripts/validate.sh
- ./install.sh --skill autosplit --harness all --update

## Review notes
- .omx runtime state is ignored so local OMX files are not accidentally staged
- live GitHub issue filing through autosplit was not exercised