### PR TITLE
refactor: align split skill naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Multi-harness skill suite for shipping a feature end-to-end across many GitHub
 issues — design spec → decomposed `auto-implement` queue → autonomous
-implementation loop with admin auto-merge — split across six cooperating
+implementation loop with admin auto-merge — split across focused workflow
 skills so each invocation runs only the phases you need. Works on **Claude
 Code**, **OpenCode**, and **Codex CLI**.
 
@@ -11,11 +11,12 @@ Code**, **OpenCode**, and **Codex CLI**.
 | Skill | Phases | Purpose |
 | --- | --- | --- |
 | [`autospec`](skills/autospec/README.md) | 0–6 (incl. **Phase 3.5**) | Full pipeline. Bootstrap repo if missing, design spec, decompose into issues, **review-and-label children with `ctx:*`/`reasoning:*` rubric (Phase 3.5)**, then run autonomous monitor with admin auto-merge. Also supports splitting an existing tracked `docs/specs/*.md` into issues. |
-| [`autosplit`](skills/autosplit/README.md) | 3–3.5 | Shortcut for splitting an existing tracked `docs/specs/*.md` into the same EPIC plus `auto-implement` child issue queue. Runs startup self-update before selecting the spec. |
+| [`autospec-split`](skills/autospec-split/README.md) | 3–3.5 | Shortcut for splitting an existing tracked `docs/specs/*.md` into the same EPIC plus `auto-implement` child issue queue. Runs startup self-update before selecting the spec. |
 | [`autospec-define`](skills/autospec-define/README.md) | 0–3.5 | Planning half. Stops after Phase 3.5 review-and-label step and hands off to `/autospec-run`. Also supports splitting an existing tracked `docs/specs/*.md` into issues. |
 | [`autospec-run`](skills/autospec-run/README.md) | 4–6 | Implementation half. Picks up the populated `auto-implement` queue and runs the autonomous monitor. Supports `--profile <name>` filtering against `~/.autospec/model-profiles.yml`. |
 | [`autospec-classify`](skills/autospec-classify/README.md) | retro | Standalone retro-labeler for already-existing `auto-implement` issues; applies the Phase 3.5 rubric to a queue that pre-dates Phase 3.5. |
 | [`autospec-listen`](skills/autospec-listen/README.md) | passive | Passive listener for chat-driven issue / spec triggers. On a phrase like "file an issue" or "write a spec", drafts a GitHub issue body for confirmation or routes to `/autospec-define`. |
+| [`autospec-stop`](skills/autospec-stop/README.md) | control | Stop/resume utility for active autospec monitors. Supports graceful, immediate, status, and resume flows through the shared stop sentinel. |
 
 Cost-aware **two-tier** subagent dispatch: spec/research/decompose/review subagents use the top model with extended thinking (Tier A — Claude Code: `opus` + `ultrathink`; Codex: top GPT + `reasoning_effort=high`; OpenCode: top task tier); implementer + LGTM-review subagents use the cheaper model with medium thinking (Tier B — Claude Code: `sonnet`; Codex: `gpt-5.1-codex-spark`; OpenCode: smaller task tier). Both tiers fall back UP on unavailability. The orchestrator runs whatever model you invoked the skill with — invoke it on top tier for best spec quality. See `AGENTS.md` for the full policy.
 
@@ -56,7 +57,7 @@ Or pick a subset:
 
 ```bash
 ./install.sh --skill autospec-run --harness claude   # one skill, one harness
-./install.sh --skill autosplit    --harness all      # install the split shortcut
+./install.sh --skill autospec-split    --harness all      # install the split shortcut
 ./install.sh --skill all          --harness opencode # every skill, one harness
 ./install.sh --skill autospec     --harness all      # one skill, every harness
 ./uninstall.sh --skill all --harness all             # symmetric uninstall
@@ -73,7 +74,7 @@ Honors `CLAUDE_CONFIG_DIR`, `OPENCODE_CONFIG_DIR`, and `CODEX_HOME` if set.
 
 ### Auto-update
 
-Each `/autospec*` skill checks `main` for a newer commit at most once per 24 hours at
+Each installed suite skill checks `main` for a newer commit at most once per 24 hours at
 startup and reinstalls in place if there is one. The check is fail-open: any network
 or install error logs one `WARN:` line to stderr and proceeds normally.
 Set `AUTOSPEC_NO_SELF_UPDATE=1` to skip the check entirely. For the full contract
@@ -88,10 +89,12 @@ stops without entering the normal pipeline:
 
 ```
 /autospec update
-/autosplit update
+/autospec-split update
 /autospec-define update
 /autospec-run update
 /autospec-classify update
+/autospec-listen update
+/autospec-stop update
 ```
 
 You can also re-run the suite installer with `--update`:
@@ -142,14 +145,14 @@ Every issue filed by autospec is linted by `scripts/lint-issue.sh` before it rea
 
 ## Existing Specs
 
-`/autospec` and `/autospec-define` can split an already-written spec into the
-same EPIC + `auto-implement` child issue queue used by the normal pipeline.
-Invoke with phrases such as `split existing spec`, `split latest spec`, or
-`turn docs/specs/2026-05-01-example-design.md into GitHub issues`. When no path
-is provided, the skills choose the newest `docs/specs/*.md` by filename date as
-the default; if multiple specs are available, they ask before filing issues.
-The selected spec must already be tracked on `origin/main` so child issues can
-cite a stable GitHub URL.
+`/autospec-split`, `/autospec`, and `/autospec-define` can split an already-written
+spec into the same EPIC + `auto-implement` child issue queue used by the normal
+pipeline. Invoke with phrases such as `split existing spec`, `split latest spec`,
+or `turn docs/specs/2026-05-01-example-design.md into GitHub issues`. When no
+path is provided, the skills choose the newest `docs/specs/*.md` by filename
+date as the default; if multiple specs are available, they ask before filing
+issues. The selected spec must already be tracked on `origin/main` so child
+issues can cite a stable GitHub URL.
 
 ## Stopping a run
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -16,11 +16,11 @@
 - Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
 - Status: trigger-listener for chat-driven issue / spec creation. Files issues with `needs-classify` label so `/autospec-classify` can transition them onto the `auto-implement` queue. See [`skills/autospec-listen/README.md`](skills/autospec-listen/README.md).
 
-## autosplit
+## autospec-split
 
-- Path: [`skills/autosplit`](skills/autosplit)
+- Path: [`skills/autospec-split`](skills/autospec-split)
 - Trigger: use when a user asks to split, materialize, roadmap, decompose, or turn an existing tracked `docs/specs/*.md` design spec into GitHub issues.
-- Activation keywords: `autosplit`, `split existing spec`, `split latest spec`, `turn this spec into GitHub issues`, `roadmap this spec`, `materialize this spec`
+- Activation keywords: `autospec-split`, `split existing spec`, `split latest spec`, `turn this spec into GitHub issues`, `roadmap this spec`, `materialize this spec`
 - Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
 - Status: existing-spec shortcut for Phase 3 plus Phase 3.5 with startup self-update before normal execution.
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -69,18 +69,18 @@ external daemon, or keep refining? [run / defer / refine] (default: defer)
 Issues are ready. Your external monitor will pick them up. Exiting.
 ```
 
-## autosplit
+## autospec-split
 
 ### What it does
 
-`/autosplit` is the existing-spec shortcut: it selects a tracked
+`/autospec-split` is the existing-spec shortcut: it selects a tracked
 `docs/specs/*.md` file, skips Phases 1–2, decomposes that spec into an
 EPIC plus `auto-implement` child issues, runs Phase 3.5 review-and-label,
 then stops with the `/autospec-run` handoff.
 
 ### When to use it
 
-Use `/autosplit` when the design spec already exists on `origin/main`
+Use `/autospec-split` when the design spec already exists on `origin/main`
 and you only need to materialize it into GitHub issues. Use
 `/autospec-define` instead when the spec still needs to be written or
 landed.
@@ -88,7 +88,7 @@ landed.
 ### Example output
 
 ```
-/autosplit split latest spec
+/autospec-split split latest spec
 selected docs/specs/2026-05-01-example-design.md
 Phase 3: decompose — 6 child issues filed (#130…#135)
 Phase 3.5: classify — labeled with ctx:* and reasoning:*

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
 #   ./install.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autosplit | autospec-define | autospec-run | autospec-classify | autospec-listen | all
+#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-classify | autospec-listen | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -27,7 +27,7 @@ set -eu
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$REPO_ROOT/skills"
 
-ALL_SKILLS="autospec autosplit autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
+ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -75,10 +75,10 @@ done
 
 # Validate --skill
 case "$SKILL_ARG" in
-    all|autospec|autosplit|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-stop) ;;
+    all|autospec|autospec-split|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-stop) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
-        err "must be one of: autospec | autosplit | autospec-define | autospec-run | autospec-classify | autospec-listen | autospec-stop | all"
+        err "must be one of: autospec | autospec-split | autospec-define | autospec-run | autospec-classify | autospec-listen | autospec-stop | all"
         exit 2
         ;;
 esac

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -135,7 +135,7 @@ check_startup_preflight() {
     }
     canonical=$(extract_block skills/autospec/SKILL.md)
     [ -n "$canonical" ] || fail "autospec SKILL.md missing ## Startup self-update section"
-    for s in autospec autosplit autospec-define autospec-run autospec-listen autospec-classify autospec-stop; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-stop; do
         for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
             body=$(extract_block "$f")
             [ -n "$body" ] || fail "$f missing ## Startup self-update section"
@@ -152,7 +152,7 @@ check_startup_preflight() {
 # prompts/ path AND the new skills/ slash-command registry path.
 check_codex_skills_install() {
     info "codex skills-dir install: all skills"
-    for s in autospec autosplit autospec-define autospec-run autospec-listen autospec-classify autospec-stop; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-stop; do
         f="skills/$s/install.sh"
         grep -q 'skills/\$SKILL_NAME/SKILL\.md' "$f" \
             || fail "$f missing Codex skills-dir install (skills/\$SKILL_NAME/SKILL.md)"
@@ -193,7 +193,7 @@ check_subagent_model_tier() {
     case "$name" in
         autospec)
             expected_a=4; expected_b=2 ;;
-        autospec-define|autosplit)
+        autospec-define|autospec-split)
             expected_a=3; expected_b=0 ;;
         autospec-run)
             expected_a=1; expected_b=2 ;;
@@ -352,12 +352,12 @@ check_governance_headings() {
         || fail "SKILLS.md: missing 'autospec-listen' reference"
 }
 
-# Existing spec mode invariants: autospec, autosplit, and autospec-define must expose the
+# Existing spec mode invariants: autospec, autospec-split, and autospec-define must expose the
 # shortcut that skips Phase 1/2 and reuses Phase 3 + Phase 3.5 for a tracked
 # docs/specs/*.md file. Enforce all trio files so harness variants cannot drift.
 check_existing_spec_mode() {
-    info "existing-spec mode: autospec + autosplit + autospec-define"
-    for s in autospec autosplit autospec-define; do
+    info "existing-spec mode: autospec + autospec-split + autospec-define"
+    for s in autospec autospec-split autospec-define; do
         for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
             grep -q '^## Existing spec mode' "$f" \
                 || fail "$f missing '## Existing spec mode' section"

--- a/skills/autospec-split/README.md
+++ b/skills/autospec-split/README.md
@@ -1,4 +1,4 @@
-# autosplit
+# autospec-split
 
 Existing-spec split shortcut for the **autospec** suite. It splits an already-written, tracked `docs/specs/*.md` into the same
 EPIC plus `auto-implement` child issue queue. Invoke with `split existing spec`,
@@ -10,30 +10,30 @@ Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
 ## Quick install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh | sh -s -- --harness all
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-split/install.sh | sh -s -- --harness all
 ```
 
 Per-harness:
 
 ```bash
 # Claude Code only
-curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh | sh -s -- --harness claude
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-split/install.sh | sh -s -- --harness claude
 # OpenCode only
-curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh | sh -s -- --harness opencode
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-split/install.sh | sh -s -- --harness opencode
 # Codex CLI only
-curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh | sh -s -- --harness codex
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-split/install.sh | sh -s -- --harness codex
 ```
 
 From a clone:
 
 ```bash
-cd skills/autosplit
+cd skills/autospec-split
 ./install.sh --harness all
 ```
 
 ## What it does
 
-- **Startup self-update** — Refreshes the installed `autosplit` copy from `main`
+- **Startup self-update** — Refreshes the installed `autospec-split` copy from `main`
   before normal execution, using the same fail-open preflight as the other
   autospec skills.
 - **Phase 0** — Verifies the current directory is a GitHub-backed git repo.
@@ -68,7 +68,7 @@ The Tier B (cheaper + medium thinking) tier is **not used** by this skill; it's 
 | Skill | Purpose |
 | --- | --- |
 | [`autospec`](../autospec/README.md) | The full pipeline (Phases 0–6) when you want one skill that plans **and** ships. |
-| [`autospec-run`](../autospec-run/README.md) | Implementation half (Phases 4–6). Picks up where `autosplit` stops; supports `--profile <name>` filtering against `~/.autospec/model-profiles.yml`. |
+| [`autospec-run`](../autospec-run/README.md) | Implementation half (Phases 4–6). Picks up where `autospec-split` stops; supports `--profile <name>` filtering against `~/.autospec/model-profiles.yml`. |
 | [`autospec-classify`](../autospec-classify/README.md) | Standalone retro-labeler for already-existing `auto-implement` issues; applies the Phase 3.5 `ctx:*` / `reasoning:*` rubric. |
 
 ## Self-update
@@ -78,7 +78,7 @@ place. The skill detects its harness, re-runs the canonical install one-liner
 with `--update`, shows the diff, and stops without entering Phase 0:
 
 ```
-/autosplit update
+/autospec-split update
 ```
 
 Or re-run the per-skill installer with `--update`:
@@ -90,8 +90,8 @@ Or re-run the per-skill installer with `--update`:
 ## Usage
 
 ```
-/autosplit split latest spec
-/autosplit turn docs/specs/2026-05-01-example-design.md into GitHub issues
+/autospec-split split latest spec
+/autospec-split turn docs/specs/2026-05-01-example-design.md into GitHub issues
 ```
 
 (Replace `/` with `@` for OpenCode, or invoke through Codex CLI as a slash command.)

--- a/skills/autospec-split/SKILL.md
+++ b/skills/autospec-split/SKILL.md
@@ -1,9 +1,13 @@
+---
+name: autospec-split
+description: Use when the user wants to split an existing tracked docs/specs/*.md design spec into GitHub issues, then stop after Phase 3.5 and hand off to /autospec-run.
+---
 
-# autosplit workflow (harness-neutral)
+# autospec-split workflow (harness-neutral)
 
 Take the following request and run the autospec existing-spec split shortcut: select a tracked `docs/specs/*.md` file, skip Phases 1-2, run Phase 3 and Phase 3.5 against that spec, then stop with the `/autospec-run` handoff.
 
-If the request does not identify an existing spec to split, resolve the newest `docs/specs/*.md` candidate using **Existing spec mode** below. Do not brainstorm or write a new spec from `/autosplit`; tell the user to use `/autospec-define` for new feature planning.
+If the request does not identify an existing spec to split, resolve the newest `docs/specs/*.md` candidate using **Existing spec mode** below. Do not brainstorm or write a new spec from `/autospec-split`; tell the user to use `/autospec-define` for new feature planning.
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
@@ -13,7 +17,7 @@ Manage your own context — never exceed 60%. Delegate to subagents whenever you
 #!/usr/bin/env bash
 # autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
 set +e
-SKILL_NAME=autosplit   # per-skill: autosplit / autospec-run / autospec-listen / autospec-classify
+SKILL_NAME=autospec-split   # per-skill: autospec-split / autospec-run / autospec-listen / autospec-classify
 if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
 mkdir -p "$HOME/.autospec"
 LOCKDIR="$HOME/.autospec/.update.lock.d"
@@ -54,23 +58,24 @@ echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
 
 1. **Detect harness** by checking which install path exists for this skill:
-   - Claude Code: `~/.claude/skills/autosplit/SKILL.md`
-   - OpenCode:    `~/.config/opencode/agent/autosplit.md`
-   - Codex CLI:   `~/.codex/prompts/autosplit.md`
+   - Claude Code: `~/.claude/skills/autospec-split/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-split.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-split.md`
 2. **Re-install from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh) --harness <detected> --update
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-split/install.sh) --harness <detected> --update
    ```
    If multiple harness paths exist, run the one-liner once per detected harness.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 
-If no install path is detected, print `Self-update: no installed copy of autosplit found; run install.sh first.` and exit.
+If no install path is detected, print `Self-update: no installed copy of autospec-split found; run install.sh first.` and exit.
 
 ## Feature request
 
 {FEATURE_DESCRIPTION}
 
+---
 
 ## Existing spec mode
 
@@ -129,6 +134,7 @@ This workflow assumes five capabilities. Map each one to your harness's actual t
 
 **Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work (research, decompose, review/label); Tier B (cheaper model + medium thinking) for implementation work (Phase 4 implementer + LGTM review — not used by this skill). The orchestrator keeps the user's invoked model. Fall back UP the tier on unavailability.
 
+---
 
 ## Phase 0 — Bootstrap repo (if missing)
 
@@ -373,7 +379,7 @@ labels and patches each body with a `## Model fit` block.
 >
 >    **Hard rules.**
 >    - Never call `gh project item-add` in `--dry-run`.
->    - Missing file in `autospec` / `autosplit` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
+>    - Missing file in `autospec` / `autospec-split` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
 >
 > 7. **Dependency-edge sanity checks.** After labeling, validate the dep graph
 >    of the just-created children:
@@ -412,6 +418,7 @@ labels and patches each body with a `## Model fit` block.
 >    - dep warnings: <count>; circular cycles: <count>
 >    ```
 
+---
 
 ## Phase 3 pre-impl gate
 
@@ -423,12 +430,12 @@ this verbatim question (no auto-launch — always ask explicitly, per spec
 > `"Spec written, N issues filed. Start /autospec-run now, defer to your external daemon, or keep refining? [run / defer / refine]"`
 
 Substitute `N` with the actual issue count from Phase 3. Default highlight
-is **`defer`** for `/autosplit` (the plan-only skill — the user
-invoked `/autosplit` expecting plan-only behavior, so the gate
+is **`defer`** for `/autospec-split` (the plan-only skill — the user
+invoked `/autospec-split` expecting plan-only behavior, so the gate
 defaults to `defer`).
 
 - **`run`** — invoke `/autospec-run` in the current session.
-- **`defer`** (default for `/autosplit`) — print
+- **`defer`** (default for `/autospec-split`) — print
   `"Issues are ready. Your external monitor will pick them up. Exiting."`
   and stop without launching `/autospec-run`. The just-filed `auto-implement`
   queue persists on the GitHub side so an external daemon (or a later

--- a/skills/autospec-split/codex/prompt.md
+++ b/skills/autospec-split/codex/prompt.md
@@ -1,13 +1,9 @@
----
-name: autosplit
-description: Use when the user wants to split an existing tracked docs/specs/*.md design spec into GitHub issues, then stop after Phase 3.5 and hand off to /autospec-run.
----
 
-# autosplit workflow (harness-neutral)
+# autospec-split workflow (harness-neutral)
 
 Take the following request and run the autospec existing-spec split shortcut: select a tracked `docs/specs/*.md` file, skip Phases 1-2, run Phase 3 and Phase 3.5 against that spec, then stop with the `/autospec-run` handoff.
 
-If the request does not identify an existing spec to split, resolve the newest `docs/specs/*.md` candidate using **Existing spec mode** below. Do not brainstorm or write a new spec from `/autosplit`; tell the user to use `/autospec-define` for new feature planning.
+If the request does not identify an existing spec to split, resolve the newest `docs/specs/*.md` candidate using **Existing spec mode** below. Do not brainstorm or write a new spec from `/autospec-split`; tell the user to use `/autospec-define` for new feature planning.
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
@@ -17,7 +13,7 @@ Manage your own context — never exceed 60%. Delegate to subagents whenever you
 #!/usr/bin/env bash
 # autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
 set +e
-SKILL_NAME=autosplit   # per-skill: autosplit / autospec-run / autospec-listen / autospec-classify
+SKILL_NAME=autospec-split   # per-skill: autospec-split / autospec-run / autospec-listen / autospec-classify
 if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
 mkdir -p "$HOME/.autospec"
 LOCKDIR="$HOME/.autospec/.update.lock.d"
@@ -58,24 +54,23 @@ echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
 
 1. **Detect harness** by checking which install path exists for this skill:
-   - Claude Code: `~/.claude/skills/autosplit/SKILL.md`
-   - OpenCode:    `~/.config/opencode/agent/autosplit.md`
-   - Codex CLI:   `~/.codex/prompts/autosplit.md`
+   - Claude Code: `~/.claude/skills/autospec-split/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-split.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-split.md`
 2. **Re-install from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh) --harness <detected> --update
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-split/install.sh) --harness <detected> --update
    ```
    If multiple harness paths exist, run the one-liner once per detected harness.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 
-If no install path is detected, print `Self-update: no installed copy of autosplit found; run install.sh first.` and exit.
+If no install path is detected, print `Self-update: no installed copy of autospec-split found; run install.sh first.` and exit.
 
 ## Feature request
 
 {FEATURE_DESCRIPTION}
 
----
 
 ## Existing spec mode
 
@@ -134,7 +129,6 @@ This workflow assumes five capabilities. Map each one to your harness's actual t
 
 **Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work (research, decompose, review/label); Tier B (cheaper model + medium thinking) for implementation work (Phase 4 implementer + LGTM review — not used by this skill). The orchestrator keeps the user's invoked model. Fall back UP the tier on unavailability.
 
----
 
 ## Phase 0 — Bootstrap repo (if missing)
 
@@ -379,7 +373,7 @@ labels and patches each body with a `## Model fit` block.
 >
 >    **Hard rules.**
 >    - Never call `gh project item-add` in `--dry-run`.
->    - Missing file in `autospec` / `autosplit` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
+>    - Missing file in `autospec` / `autospec-split` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
 >
 > 7. **Dependency-edge sanity checks.** After labeling, validate the dep graph
 >    of the just-created children:
@@ -418,7 +412,6 @@ labels and patches each body with a `## Model fit` block.
 >    - dep warnings: <count>; circular cycles: <count>
 >    ```
 
----
 
 ## Phase 3 pre-impl gate
 
@@ -430,12 +423,12 @@ this verbatim question (no auto-launch — always ask explicitly, per spec
 > `"Spec written, N issues filed. Start /autospec-run now, defer to your external daemon, or keep refining? [run / defer / refine]"`
 
 Substitute `N` with the actual issue count from Phase 3. Default highlight
-is **`defer`** for `/autosplit` (the plan-only skill — the user
-invoked `/autosplit` expecting plan-only behavior, so the gate
+is **`defer`** for `/autospec-split` (the plan-only skill — the user
+invoked `/autospec-split` expecting plan-only behavior, so the gate
 defaults to `defer`).
 
 - **`run`** — invoke `/autospec-run` in the current session.
-- **`defer`** (default for `/autosplit`) — print
+- **`defer`** (default for `/autospec-split`) — print
   `"Issues are ready. Your external monitor will pick them up. Exiting."`
   and stop without launching `/autospec-run`. The just-filed `auto-implement`
   queue persists on the GitHub side so an external daemon (or a later

--- a/skills/autospec-split/install.sh
+++ b/skills/autospec-split/install.sh
@@ -9,7 +9,7 @@
 #   ./install.sh --dry-run           # print what would be done; do nothing
 #
 # Can also be piped from curl:
-#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh \
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-split/install.sh \
 #     | sh -s -- --harness all
 # When piped, the script auto-downloads the skill files from the same branch.
 #
@@ -17,16 +17,16 @@
 #   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
 #   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
 #   CODEX_HOME           (default: $HOME/.codex)
-#   AUTOSPLIT_REF         (default: main) — git ref to fetch from when piped
-#   AUTOSPLIT_RAW_BASE    (override the raw URL base entirely)
+#   AUTOSPEC_SPLIT_REF         (default: main) — git ref to fetch from when piped
+#   AUTOSPEC_SPLIT_RAW_BASE    (override the raw URL base entirely)
 #
 # Idempotent: re-running upgrades the install. Exits non-zero on hard failure;
 # exits zero with warnings on missing optional deps.
 
 set -eu
 
-SKILL_NAME="autosplit"
-SKILL_RAW_BASE="${AUTOSPLIT_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPLIT_REF:-main}/skills/autosplit}"
+SKILL_NAME="autospec-split"
+SKILL_RAW_BASE="${AUTOSPEC_SPLIT_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_SPLIT_REF:-main}/skills/autospec-split}"
 
 # Resolve the directory containing this script. When piped through stdin (e.g.
 # `curl ... | sh`), $0 will not be a real file — detect that and fall back to

--- a/skills/autospec-split/opencode/agent.md
+++ b/skills/autospec-split/opencode/agent.md
@@ -3,11 +3,11 @@ description: Use when the user wants to split an existing tracked docs/specs/*.m
 mode: primary
 ---
 
-# autosplit workflow (harness-neutral)
+# autospec-split workflow (harness-neutral)
 
 Take the following request and run the autospec existing-spec split shortcut: select a tracked `docs/specs/*.md` file, skip Phases 1-2, run Phase 3 and Phase 3.5 against that spec, then stop with the `/autospec-run` handoff.
 
-If the request does not identify an existing spec to split, resolve the newest `docs/specs/*.md` candidate using **Existing spec mode** below. Do not brainstorm or write a new spec from `/autosplit`; tell the user to use `/autospec-define` for new feature planning.
+If the request does not identify an existing spec to split, resolve the newest `docs/specs/*.md` candidate using **Existing spec mode** below. Do not brainstorm or write a new spec from `/autospec-split`; tell the user to use `/autospec-define` for new feature planning.
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it; do not investigate, write code, or design directly in the main conversation when a subagent can do it.
 
@@ -17,7 +17,7 @@ Manage your own context — never exceed 60%. Delegate to subagents whenever you
 #!/usr/bin/env bash
 # autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
 set +e
-SKILL_NAME=autosplit   # per-skill: autosplit / autospec-run / autospec-listen / autospec-classify
+SKILL_NAME=autospec-split   # per-skill: autospec-split / autospec-run / autospec-listen / autospec-classify
 if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
 mkdir -p "$HOME/.autospec"
 LOCKDIR="$HOME/.autospec/.update.lock.d"
@@ -58,18 +58,18 @@ echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
 
 1. **Detect harness** by checking which install path exists for this skill:
-   - Claude Code: `~/.claude/skills/autosplit/SKILL.md`
-   - OpenCode:    `~/.config/opencode/agent/autosplit.md`
-   - Codex CLI:   `~/.codex/prompts/autosplit.md`
+   - Claude Code: `~/.claude/skills/autospec-split/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-split.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-split.md`
 2. **Re-install from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autosplit/install.sh) --harness <detected> --update
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-split/install.sh) --harness <detected> --update
    ```
    If multiple harness paths exist, run the one-liner once per detected harness.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 
-If no install path is detected, print `Self-update: no installed copy of autosplit found; run install.sh first.` and exit.
+If no install path is detected, print `Self-update: no installed copy of autospec-split found; run install.sh first.` and exit.
 
 ## Feature request
 
@@ -377,7 +377,7 @@ labels and patches each body with a `## Model fit` block.
 >
 >    **Hard rules.**
 >    - Never call `gh project item-add` in `--dry-run`.
->    - Missing file in `autospec` / `autosplit` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
+>    - Missing file in `autospec` / `autospec-split` is non-fatal at run time once auto-init has populated it; if auto-init itself fails (e.g. `gh project list` denied), warn and skip board assignment for the rest of the run.
 >
 > 7. **Dependency-edge sanity checks.** After labeling, validate the dep graph
 >    of the just-created children:
@@ -427,12 +427,12 @@ this verbatim question (no auto-launch — always ask explicitly, per spec
 > `"Spec written, N issues filed. Start /autospec-run now, defer to your external daemon, or keep refining? [run / defer / refine]"`
 
 Substitute `N` with the actual issue count from Phase 3. Default highlight
-is **`defer`** for `/autosplit` (the plan-only skill — the user
-invoked `/autosplit` expecting plan-only behavior, so the gate
+is **`defer`** for `/autospec-split` (the plan-only skill — the user
+invoked `/autospec-split` expecting plan-only behavior, so the gate
 defaults to `defer`).
 
 - **`run`** — invoke `/autospec-run` in the current session.
-- **`defer`** (default for `/autosplit`) — print
+- **`defer`** (default for `/autospec-split`) — print
   `"Issues are ready. Your external monitor will pick them up. Exiting."`
   and stop without launching `/autospec-run`. The just-filed `auto-implement`
   queue persists on the GitHub side so an external daemon (or a later

--- a/skills/autospec-split/uninstall.sh
+++ b/skills/autospec-split/uninstall.sh
@@ -16,7 +16,7 @@
 
 set -eu
 
-SKILL_NAME="autosplit"
+SKILL_NAME="autospec-split"
 
 HARNESS=""
 DRY_RUN=0

--- a/tests/smoke/test_install_all_skills.bats
+++ b/tests/smoke/test_install_all_skills.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 # tests/smoke/test_install_all_skills.bats — round-trip the top-level
 # install.sh --skill all into a per-test tmpdir HOME and assert that all
-# 5 skill bodies land for every harness, and uninstall removes them.
+# all suite skill bodies land for every harness, and uninstall removes them.
 #
 # Spec ref: docs/specs/2026-05-01-autospec-meta-improvements-design.md §6.2, §6.3.
 
@@ -17,7 +17,7 @@ setup() {
     export OPENCODE_CONFIG_DIR="$FAKE_HOME/.config/opencode"
     export CODEX_HOME="$FAKE_HOME/.codex"
 
-    SKILLS="autospec autospec-define autospec-run autospec-classify autospec-listen"
+    SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
 }
 
 teardown() {
@@ -31,9 +31,9 @@ _claude_path() { printf '%s/.claude/skills/%s/SKILL.md' "$FAKE_HOME" "$1"; }
 _opencode_path() { printf '%s/.config/opencode/agent/%s.md' "$FAKE_HOME" "$1"; }
 _codex_path() { printf '%s/.codex/prompts/%s.md' "$FAKE_HOME" "$1"; }
 
-# ---- install all 5 skills -----------------------------------------------
+# ---- install all skills --------------------------------------------------
 
-@test "install --skill all places 5 skill bodies (one per skill, each harness)" {
+@test "install --skill all places every suite skill body in each harness" {
     run bash "$INSTALL" --skill all --harness all
     [ "$status" -eq 0 ]
     for s in $SKILLS; do

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,7 +12,7 @@
 #   ./uninstall.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autosplit | autospec-define | autospec-run | autospec-classify | autospec-listen | all
+#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-classify | autospec-listen | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -24,7 +24,7 @@
 
 set -eu
 
-ALL_SKILLS="autospec autosplit autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
+ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -67,7 +67,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$SKILL_ARG" in
-    all|autospec|autosplit|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-stop) ;;
+    all|autospec|autospec-split|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-stop) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
         exit 2


### PR DESCRIPTION
## Summary
- rename the split-only skill from autosplit to autospec-split across all harness files
- update install/uninstall selectors, validation lists, docs, and smoke test expectations
- refresh README skill/self-update/existing-spec references for the full suite

## Validation
- bash scripts/dev-bootstrap.sh && bash scripts/validate.sh
- bats tests/unit tests/smoke
- GH_TOKEN=*** E2E=1 bats tests/e2e
- GH_TOKEN=*** bash tests/integration/test_guardian_flow.sh

## Review notes
- local installed autosplit copies were removed and autospec-split was installed for Claude, OpenCode, and Codex
- no backward-compatible autosplit alias is included