### PR TITLE
fix: install autospec helpers and reconcile heartbeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ See [`examples/README.md`](examples/README.md) for the full schema and the auto-
 
 ## Quality gate
 
-Every issue filed by autospec is linted by `scripts/lint-issue.sh` before it reaches the implementation queue. The Phase 3 decomposer runs an adaptive retry loop (up to `MAX_LINT_RETRIES=5` attempts) that accumulates lint findings as prompt directives, skipping a child only if attempt 5 still fails. Phase 3.5 and `/autospec-classify` run a one-shot post-filing audit: issues that fail the lint get the `needs-quality-bar` label (color `#fbca04`), an idempotent `## Quality lint` block inserted into their body, and a comment with the findings. The `auto-implement` label is never removed — the operator decides whether to proceed or hand-fix. See [`docs/specs/2026-05-01-autospec-issue-quality-gate-design.md`](docs/specs/2026-05-01-autospec-issue-quality-gate-design.md) for the full contract.
+Every issue filed by autospec is linted by the installed `lint-issue.sh` helper before it reaches the implementation queue. Skill installers copy shared helpers into `~/.autospec/scripts` (`AUTOSPEC_SCRIPTS_DIR` overrides this path), so target repositories do not need to carry autospec's `scripts/` directory. The Phase 3 decomposer runs an adaptive retry loop (up to `MAX_LINT_RETRIES=5` attempts) that accumulates lint findings as prompt directives, skipping a child only if attempt 5 still fails. Phase 3.5 and `/autospec-classify` run a one-shot post-filing audit: issues that fail the lint get the `needs-quality-bar` label (color `#fbca04`), an idempotent `## Quality lint` block inserted into their body, and a comment with the findings. The `auto-implement` label is never removed — the operator decides whether to proceed or hand-fix. See [`docs/specs/2026-05-01-autospec-issue-quality-gate-design.md`](docs/specs/2026-05-01-autospec-issue-quality-gate-design.md) for the full contract.
 
 ## Existing Specs
 
@@ -164,4 +164,4 @@ To halt a running autospec monitor, use the `/autospec-stop` skill or the inline
 /autospec-run stop --status         # check current stop sentinel state
 ```
 
-All three paths route through `scripts/autospec-stop.sh`. Use `--resume` to strip the `paused-by-user` label from paused issues and restart the queue. See [`AGENTS.md` § Stop mode authority](AGENTS.md) for the full contract.
+All three paths route through the installed `autospec-stop.sh` helper in `~/.autospec/scripts` (or `AUTOSPEC_SCRIPTS_DIR`). Use `--resume` to strip the `paused-by-user` label from paused issues and restart the queue. See [`AGENTS.md` § Stop mode authority](AGENTS.md) for the full contract.

--- a/scripts/autospec-watchdog.ps1
+++ b/scripts/autospec-watchdog.ps1
@@ -1,15 +1,18 @@
 <# autospec-watchdog.ps1 — reclaim and nudge stalled autospec workers.
 
-The monitor should call this every 12 iterations (or on similar cadence) to
-detect stale `process-heartbeats/*.json` entries and:
-  1) nudge the issue
-  2) reclaim when stall time exceeds reclaim threshold
+The monitor calls this before queue selection and on its regular service-watch
+cadence to reconcile `process-heartbeats/*.json` entries:
+  1) garbage-collect closed/orphaned heartbeats
+  2) release stuck claimed heartbeats
+  3) nudge stale active work
+  4) reclaim when stall time exceeds reclaim threshold
 
 Environment overrides:
   AUTOSPEC_WATCHDOG_DIR: heartbeat directory (default: $HOME/.autospec/process-heartbeats)
   AUTOSPEC_WATCHDOG_REPO: override repo for gh calls (default: gh repo context)
   AUTOSPEC_WATCHDOG_STALE_SECS: stale threshold (default: 1800)
   AUTOSPEC_WATCHDOG_RECLAIM_SECS: reclaim threshold (default: 10800)
+  AUTOSPEC_WATCHDOG_CLAIMED_TIMEOUT_SECS: claimed timeout (default: 300)
   AUTOSPEC_WATCHDOG_NUDGE_COOLDOWN_SECS: nudge cooldown (default: 900)
   AUTOSPEC_WATCHDOG_STATE_FILE: state file for nudge cooldown (default: $HOME/.autospec/watchdog-state.tsv)
 #>
@@ -46,6 +49,7 @@ if ([string]::IsNullOrWhiteSpace($watchdogRepo)) {
 }
 $staleSecs = Get-EnvInt "AUTOSPEC_WATCHDOG_STALE_SECS" 1800
 $reclaimSecs = Get-EnvInt "AUTOSPEC_WATCHDOG_RECLAIM_SECS" 10800
+$claimedTimeoutSecs = Get-EnvInt "AUTOSPEC_WATCHDOG_CLAIMED_TIMEOUT_SECS" 300
 $nudgeCooldownSecs = Get-EnvInt "AUTOSPEC_WATCHDOG_NUDGE_COOLDOWN_SECS" 900
 $stateFile = [Environment]::GetEnvironmentVariable("AUTOSPEC_WATCHDOG_STATE_FILE")
 if ([string]::IsNullOrWhiteSpace($stateFile)) {
@@ -53,7 +57,7 @@ if ([string]::IsNullOrWhiteSpace($stateFile)) {
 }
 
 if (-not (Test-Path $watchdogDir)) {
-    Write-Output "service-watch: nudged=0 reclaimed=0 skipped=0"
+    Write-Output "service-watch: nudged=0 reclaimed=0 claimed_released=0 garbage_collected=0 invalid_schema=0 skipped=0"
     exit 0
 }
 
@@ -76,10 +80,55 @@ function Reclaim-Issue {
     & gh @commentArgs 1>$null 2>$null
 }
 
+function Release-Claim {
+    param([string]$IssueNumber, [int64]$Age)
+    $editArgs = @("issue", "edit", $IssueNumber, "--remove-label", "in-progress-by-bot", "--add-label", "auto-implement") + $repoArgs
+    $commentArgs = @("issue", "comment", $IssueNumber, "--body", "autospec watchdog released this claim after $Age s without reaching worktree_ready.") + $repoArgs
+    & gh @editArgs 1>$null 2>$null
+    & gh @commentArgs 1>$null 2>$null
+}
+
 function Nudge-Issue {
     param([string]$IssueNumber)
     $commentArgs = @("issue", "comment", $IssueNumber, "--body", "autospec watchdog: please check in; if stuck, post blocker and clear in-progress-by-bot.") + $repoArgs
     & gh @commentArgs 1>$null 2>$null
+}
+
+function Get-HeartbeatValue {
+    param([object]$Heartbeat, [string]$Name)
+    $prop = $Heartbeat.PSObject.Properties[$Name]
+    if ($null -eq $prop -or $null -eq $prop.Value) { return "" }
+    return [string]$prop.Value
+}
+
+function Test-HeartbeatSchema {
+    param([object]$Heartbeat, [string]$IssueNumber)
+    $step = Get-HeartbeatValue $Heartbeat "step"
+    $issueValue = Get-HeartbeatValue $Heartbeat "issue"
+    $tsRaw = Get-HeartbeatValue $Heartbeat "ts"
+    $tsValue = 0L
+    $validSteps = @("claimed", "worktree_ready", "tests_started", "tests_passed", "pr_created", "smoke_retry", "reviewed", "merged", "failed")
+
+    if ($issueValue -ne $IssueNumber) { return $false }
+    if (-not [int64]::TryParse($tsRaw, [ref]$tsValue)) { return $false }
+    if ($validSteps -notcontains $step) { return $false }
+    return $true
+}
+
+function Normalize-Heartbeat {
+    param([object]$Heartbeat, [string]$IssueNumber, [string]$Path)
+    $tsRaw = Get-HeartbeatValue $Heartbeat "ts"
+    $tsValue = 0L
+    [void][int64]::TryParse($tsRaw, [ref]$tsValue)
+    $normalized = [ordered]@{
+        issue = $IssueNumber
+        branch = Get-HeartbeatValue $Heartbeat "branch"
+        step = Get-HeartbeatValue $Heartbeat "step"
+        ts = $tsValue
+        pr = Get-HeartbeatValue $Heartbeat "pr"
+        repo = Get-HeartbeatValue $Heartbeat "repo"
+    }
+    $normalized | ConvertTo-Json -Compress | Set-Content -Path $Path -NoNewline
 }
 
 $lastNudge = @{}
@@ -93,6 +142,9 @@ if (Test-Path $stateFile) {
 
 $nudged = 0
 $reclaimed = 0
+$claimedReleased = 0
+$garbageCollected = 0
+$invalidSchema = 0
 $skipped = 0
 $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
 
@@ -106,19 +158,10 @@ Get-ChildItem -Path $watchdogDir -Filter '*.json' -File | ForEach-Object {
     try {
         $heartbeat = Get-Content $_.FullName -Raw | ConvertFrom-Json -ErrorAction Stop
     } catch {
-        $skipped++
+        Remove-Item $_.FullName -Force
+        $invalidSchema++
         return
     }
-
-    if ($null -eq $heartbeat.ts -or -not ($heartbeat.ts -is [int64])) {
-        $skipped++
-        return
-    }
-
-    $ts = [int64]$heartbeat.ts
-    $age = [int64]($now - $ts)
-    if ($age -lt 0) { $age = 0 }
-    if ($age -lt $staleSecs) { return }
 
     $meta = GhIssueMeta -IssueNumber $issue
     if ([string]::IsNullOrWhiteSpace($meta)) {
@@ -139,9 +182,32 @@ Get-ChildItem -Path $watchdogDir -Filter '*.json' -File | ForEach-Object {
     if ($state -ne "OPEN" -or (",${labels}," -notmatch ",in-progress-by-bot,") ) {
         Remove-Item $_.FullName -Force
         $lastNudge.Remove($issue) | Out-Null
-        $skipped++
+        $garbageCollected++
         return
     }
+
+    if (-not (Test-HeartbeatSchema -Heartbeat $heartbeat -IssueNumber $issue)) {
+        Remove-Item $_.FullName -Force
+        $lastNudge.Remove($issue) | Out-Null
+        $invalidSchema++
+        return
+    }
+
+    Normalize-Heartbeat -Heartbeat $heartbeat -IssueNumber $issue -Path $_.FullName
+
+    $ts = [int64](Get-HeartbeatValue $heartbeat "ts")
+    $age = [int64]($now - $ts)
+    if ($age -lt 0) { $age = 0 }
+
+    if ((Get-HeartbeatValue $heartbeat "step") -eq "claimed" -and $age -ge $claimedTimeoutSecs) {
+        Release-Claim -IssueNumber $issue -Age $age
+        $claimedReleased++
+        Remove-Item $_.FullName -Force
+        $lastNudge.Remove($issue) | Out-Null
+        return
+    }
+
+    if ($age -lt $staleSecs) { return }
 
     if ($age -ge $reclaimSecs) {
         Reclaim-Issue -IssueNumber $issue -Age $age
@@ -176,4 +242,4 @@ if ($lastNudge.Count -eq 0) {
     Move-Item $tmp $stateFile -Force
 }
 
-Write-Output ("service-watch: nudged={0} reclaimed={1} skipped={2}" -f $nudged, $reclaimed, $skipped)
+Write-Output ("service-watch: nudged={0} reclaimed={1} claimed_released={2} garbage_collected={3} invalid_schema={4} skipped={5}" -f $nudged, $reclaimed, $claimedReleased, $garbageCollected, $invalidSchema, $skipped)

--- a/scripts/autospec-watchdog.sh
+++ b/scripts/autospec-watchdog.sh
@@ -36,6 +36,12 @@ if [ ! -d "$WATCHDOG_DIR" ]; then
     exit 0
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+    echo "$WATCHDOG_LOG_PREFIX WARN: jq CLI not found; skipping heartbeat reconciliation" >&2
+    printf '%s\n' "service-watch: nudged=0 reclaimed=0 claimed_released=0 garbage_collected=0 invalid_schema=0 skipped=0"
+    exit 0
+fi
+
 now_ts="$(date -u +%s)"
 nudged=0
 reclaimed=0

--- a/scripts/autospec-watchdog.sh
+++ b/scripts/autospec-watchdog.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 # autospec-watchdog.sh — reclaim and nudge stalled autospec workers.
 #
-# The monitor should call this every 12 iterations (or on the same cadence) to
-# detect stalled `process-heartbeats/*.json` files and:
-# 1) leave a reminder comment
-# 2) reclaim the issue (if stalled beyond reclaim threshold)
+# The monitor should call this at startup, before candidate selection, and on
+# its regular service-watch cadence to reconcile `process-heartbeats/*.json`
+# files and detect stalled workers.
 #
 # Environment overrides:
 #   AUTOSPEC_WATCHDOG_DIR              heartbeat directory (default: ~/.autospec/process-heartbeats)
 #   AUTOSPEC_WATCHDOG_REPO              override repo for gh calls (default: gh repo context)
 #   AUTOSPEC_WATCHDOG_STALE_SECS         stale threshold (default: 1800)
 #   AUTOSPEC_WATCHDOG_RECLAIM_SECS       reclaim threshold (default: 10800)
+#   AUTOSPEC_WATCHDOG_CLAIMED_TIMEOUT_SECS claimed-step release threshold (default: 300)
 #   AUTOSPEC_WATCHDOG_NUDGE_COOLDOWN_SECS nudge cooldown (default: 900)
 #   AUTOSPEC_WATCHDOG_STATE_FILE         state file for nudge cooldown (default: ~/.autospec/watchdog-state.tsv)
 
@@ -20,6 +20,7 @@ WATCHDOG_DIR="${AUTOSPEC_WATCHDOG_DIR:-$HOME/.autospec/process-heartbeats}"
 WATCHDOG_REPO="${AUTOSPEC_WATCHDOG_REPO:-${AUTOSPEC_REPO:-}}"
 WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
 WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"
+WATCHDOG_CLAIMED_TIMEOUT_SECS="${AUTOSPEC_WATCHDOG_CLAIMED_TIMEOUT_SECS:-300}"
 WATCHDOG_NUDGE_COOLDOWN_SECS="${AUTOSPEC_WATCHDOG_NUDGE_COOLDOWN_SECS:-900}"
 STATE_FILE="${AUTOSPEC_WATCHDOG_STATE_FILE:-$HOME/.autospec/watchdog-state.tsv}"
 
@@ -31,48 +32,56 @@ if ! command -v gh >/dev/null 2>&1; then
 fi
 
 if [ ! -d "$WATCHDOG_DIR" ]; then
-    printf '%s\n' "service-watch: nudged=0 reclaimed=0 skipped=0"
+    printf '%s\n' "service-watch: nudged=0 reclaimed=0 claimed_released=0 garbage_collected=0 invalid_schema=0 skipped=0"
     exit 0
 fi
 
 now_ts="$(date -u +%s)"
 nudged=0
 reclaimed=0
+claimed_released=0
+garbage_collected=0
+invalid_schema=0
 skipped=0
 
 if [ -n "$WATCHDOG_REPO" ]; then
-    repo_args=(--repo "$WATCHDOG_REPO")
+    REPO_ARGS="--repo $WATCHDOG_REPO"
 else
-    repo_args=()
+    REPO_ARGS=""
 fi
 
-declare -A LAST_NUDGE_TS
+STATE_LINES=""
 
 load_state() {
     if [ -f "$STATE_FILE" ]; then
-        while IFS=$'\t' read -r issue ts; do
-            if [[ "$issue" =~ ^[0-9]+$ ]] && [[ "$ts" =~ ^[0-9]+$ ]]; then
-                LAST_NUDGE_TS["$issue"]="$ts"
-            fi
-        done < "$STATE_FILE"
+        STATE_LINES="$(awk '$1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ { print $1 "\t" $2 }' "$STATE_FILE")"
     fi
 }
 
-extract_ts() {
-    awk -F: '
-        /"ts"[[:space:]]*:/ {
-            line=$0
-            gsub(/^[[:space:]]*/, "", line)
-            if (match(line, /"ts"[[:space:]]*:[[:space:]]*([0-9]+)/, m)) {
-                print m[1]
-                exit
-            }
-        }
-    ' "$1"
+state_get() {
+    printf '%s\n' "$STATE_LINES" | awk -v issue="$1" '$1 == issue { print $2; exit }'
+}
+
+state_set() {
+    issue="$1"
+    ts="$2"
+    STATE_LINES="$(printf '%s\n' "$STATE_LINES" | awk -v issue="$issue" 'NF && $1 != issue { print }')"
+    if [ -n "$STATE_LINES" ]; then
+        STATE_LINES="${STATE_LINES}
+${issue}	${ts}"
+    else
+        STATE_LINES="${issue}	${ts}"
+    fi
+}
+
+state_unset() {
+    issue="$1"
+    STATE_LINES="$(printf '%s\n' "$STATE_LINES" | awk -v issue="$issue" 'NF && $1 != issue { print }')"
 }
 
 issue_meta() {
-    gh issue view "$1" "${repo_args[@]}" \
+    # shellcheck disable=SC2086
+    gh issue view "$1" $REPO_ARGS \
         --json state,labels \
         --jq '.state + " " + ([.labels[].name] | join(","))' \
         2>/dev/null || true
@@ -82,32 +91,82 @@ reclaim_issue() {
     local issue="$1"
     local age="$2"
 
-    gh issue edit "$issue" "${repo_args[@]}" \
+    # shellcheck disable=SC2086
+    gh issue edit "$issue" $REPO_ARGS \
         --remove-label in-progress-by-bot \
         --add-label auto-implement >/dev/null 2>&1 || true
-    gh issue comment "$issue" "${repo_args[@]}" \
+    # shellcheck disable=SC2086
+    gh issue comment "$issue" $REPO_ARGS \
         --body "autospec watchdog reclaimed this issue after ${age}s of no check-in." >/dev/null 2>&1 || true
 }
 
 nudge_issue() {
     local issue="$1"
 
-    gh issue comment "$issue" "${repo_args[@]}" \
+    # shellcheck disable=SC2086
+    gh issue comment "$issue" $REPO_ARGS \
         --body "autospec watchdog: please check in; if stuck, post blocker and clear in-progress-by-bot." \
         >/dev/null 2>&1 || return 1
 }
 
 save_state() {
     mkdir -p "$HOME/.autospec"
-    if [ "${#LAST_NUDGE_TS[@]}" -eq 0 ]; then
+    if [ -z "$STATE_LINES" ]; then
         rm -f "$STATE_FILE"
         return
     fi
     tmp="$(mktemp "$HOME/.autospec/.watchdog-state.XXXXXX")"
-    for issue in "${!LAST_NUDGE_TS[@]}"; do
-        printf '%s\t%s\n' "$issue" "${LAST_NUDGE_TS[$issue]}" >> "$tmp"
-    done
+    printf '%s\n' "$STATE_LINES" > "$tmp"
     mv "$tmp" "$STATE_FILE"
+}
+
+json_value() {
+    key="$1"
+    file="$2"
+    jq -r --arg key "$key" '.[$key] // empty' "$file" 2>/dev/null || true
+}
+
+heartbeat_schema_valid() {
+    file="$1"
+    issue="$2"
+
+    hb_issue="$(json_value issue "$file")"
+    hb_step="$(json_value step "$file")"
+    hb_ts="$(json_value ts "$file")"
+
+    case "$hb_issue" in
+        "$issue") ;;
+        *) return 1 ;;
+    esac
+    case "$hb_ts" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    case "$hb_step" in
+        claimed|worktree_ready|tests_started|tests_passed|pr_created|smoke_retry|reviewed|merged|failed) ;;
+        *) return 1 ;;
+    esac
+    return 0
+}
+
+normalize_heartbeat() {
+    file="$1"
+    issue="$2"
+
+    branch="$(json_value branch "$file")"
+    step="$(json_value step "$file")"
+    ts="$(json_value ts "$file")"
+    pr="$(json_value pr "$file")"
+    repo="$(json_value repo "$file")"
+    tmp="${file}.tmp"
+    jq -n \
+        --arg issue "$issue" \
+        --arg branch "$branch" \
+        --arg step "$step" \
+        --argjson ts "$ts" \
+        --arg pr "$pr" \
+        --arg repo "$repo" \
+        '{issue:$issue,branch:$branch,step:$step,ts:$ts,pr:$pr,repo:$repo}' > "$tmp" \
+        && mv "$tmp" "$file"
 }
 
 load_state
@@ -122,25 +181,11 @@ for hb in "$WATCHDOG_DIR"/*.json; do
         continue
     fi
 
-    ts="$(extract_ts "$hb")"
-    if [[ ! "$ts" =~ ^[0-9]+$ ]]; then
-        skipped=$((skipped + 1))
-        continue
-    fi
-
-    age=$(( now_ts - ts ))
-    if [ "$age" -lt 0 ]; then
-        age=0
-    fi
-    if [ "$age" -lt "$WATCHDOG_STALE_SECS" ]; then
-        continue
-    fi
-
     meta="$(issue_meta "$issue")"
     if [ -z "$meta" ]; then
         skipped=$((skipped + 1))
         rm -f "$hb"
-        unset "LAST_NUDGE_TS[$issue]"
+        state_unset "$issue"
         continue
     fi
 
@@ -152,26 +197,55 @@ for hb in "$WATCHDOG_DIR"/*.json; do
     fi
 
     if [ "$state" != "OPEN" ] || [ "$in_progress" != "true" ]; then
-        skipped=$((skipped + 1))
+        garbage_collected=$((garbage_collected + 1))
         rm -f "$hb"
-        unset "LAST_NUDGE_TS[$issue]"
+        state_unset "$issue"
+        continue
+    fi
+
+    if ! heartbeat_schema_valid "$hb" "$issue"; then
+        invalid_schema=$((invalid_schema + 1))
+        rm -f "$hb"
+        state_unset "$issue"
+        continue
+    fi
+
+    normalize_heartbeat "$hb" "$issue"
+    ts="$(json_value ts "$hb")"
+    step="$(json_value step "$hb")"
+
+    age=$(( now_ts - ts ))
+    if [ "$age" -lt 0 ]; then
+        age=0
+    fi
+
+    if [ "$step" = "claimed" ] && [ "$age" -ge "$WATCHDOG_CLAIMED_TIMEOUT_SECS" ]; then
+        reclaim_issue "$issue" "$age"
+        claimed_released=$((claimed_released + 1))
+        state_unset "$issue"
+        rm -f "$hb"
+        continue
+    fi
+
+    if [ "$age" -lt "$WATCHDOG_STALE_SECS" ]; then
         continue
     fi
 
     if [ "$age" -ge "$WATCHDOG_RECLAIM_SECS" ]; then
         reclaim_issue "$issue" "$age"
         reclaimed=$((reclaimed + 1))
-        unset "LAST_NUDGE_TS[$issue]"
+        state_unset "$issue"
         rm -f "$hb"
         continue
     fi
 
-    last_nudge="${LAST_NUDGE_TS[$issue]:-0}"
+    last_nudge="$(state_get "$issue")"
+    last_nudge="${last_nudge:-0}"
     since_last_nudge=$((now_ts - last_nudge))
     if [ "$last_nudge" -eq 0 ] || [ "$since_last_nudge" -ge "$WATCHDOG_NUDGE_COOLDOWN_SECS" ]; then
         if nudge_issue "$issue"; then
             nudged=$((nudged + 1))
-            LAST_NUDGE_TS["$issue"]="$now_ts"
+            state_set "$issue" "$now_ts"
         else
             skipped=$((skipped + 1))
         fi
@@ -181,4 +255,5 @@ for hb in "$WATCHDOG_DIR"/*.json; do
 done
 
 save_state
-printf 'service-watch: nudged=%s reclaimed=%s skipped=%s\n' "$nudged" "$reclaimed" "$skipped"
+printf 'service-watch: nudged=%s reclaimed=%s claimed_released=%s garbage_collected=%s invalid_schema=%s skipped=%s\n' \
+    "$nudged" "$reclaimed" "$claimed_released" "$garbage_collected" "$invalid_schema" "$skipped"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -161,6 +161,25 @@ check_codex_skills_install() {
     done
 }
 
+# Every per-skill installer must install shared helper scripts into
+# ~/.autospec/scripts so runtime commands work in target repositories that do
+# not contain this repo's scripts/ directory.
+check_shared_script_install() {
+    info "shared helper install: all skills"
+    helpers="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-stop; do
+        f="skills/$s/install.sh"
+        grep -q 'install_shared_scripts' "$f" \
+            || fail "$f missing install_shared_scripts function/call"
+        grep -q '\.autospec/scripts' "$f" \
+            || fail "$f missing ~/.autospec/scripts install target"
+        for helper in $helpers; do
+            grep -q "$helper" "$f" \
+                || fail "$f missing shared helper install entry: $helper"
+        done
+    done
+}
+
 # Two-tier subagent model selection invariants: every dispatching SKILL.md
 # must include the literal "**Model tier:**" directive at least once, every
 # such directive must specify either "Tier A (spec work)" or
@@ -390,6 +409,7 @@ main() {
     check_startup_preflight
     check_stop_mode_section
     check_codex_skills_install
+    check_shared_script_install
 
     check_agents_md_subagent_section
     check_autospec_listen_files

--- a/skills/autospec-classify/SKILL.md
+++ b/skills/autospec-classify/SKILL.md
@@ -247,7 +247,7 @@ For each candidate issue:
 
 6. **Quality audit.** After patching the `## Model fit` block:
    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
-   - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+   - Run: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/audit-<N>.md`
    - On non-zero exit (lint fails):
      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:

--- a/skills/autospec-classify/codex/prompt.md
+++ b/skills/autospec-classify/codex/prompt.md
@@ -243,7 +243,7 @@ For each candidate issue:
 
 6. **Quality audit.** After patching the `## Model fit` block:
    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
-   - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+   - Run: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/audit-<N>.md`
    - On non-zero exit (lint fails):
      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:

--- a/skills/autospec-classify/install.sh
+++ b/skills/autospec-classify/install.sh
@@ -43,6 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
 
 # ---------- helpers --------------------------------------------------------
 
@@ -92,14 +93,46 @@ fetch_source_files() {
     fi
     TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
     info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
-    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex"
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
     for rel in SKILL.md opencode/agent.md codex/prompt.md; do
         if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
             err "failed to download $SKILL_RAW_BASE/$rel"
             exit 1
         fi
     done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
     SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autospec helper scripts"
+        return 1
+    fi
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
 }
 
 install_one() {
@@ -231,6 +264,12 @@ fi
 if [ "$dep_warnings" -gt 0 ]; then
     warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
 fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
 
 # ---------- per-harness paths ---------------------------------------------
 

--- a/skills/autospec-classify/opencode/agent.md
+++ b/skills/autospec-classify/opencode/agent.md
@@ -247,7 +247,7 @@ For each candidate issue:
 
 6. **Quality audit.** After patching the `## Model fit` block:
    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
-   - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+   - Run: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/audit-<N>.md`
    - On non-zero exit (lint fails):
      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -247,7 +247,7 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Self-check each issue against the caps **before** calling `gh issue create`. If a cap is violated and a split is not feasible, surface the issue inline (print the over-cap body to the operator) instead of filing it.
 >
-> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash scripts/lint-issue.sh /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
+> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
 >
 > | Finding | Directive appended to next prompt |
 > |---|---|
@@ -393,7 +393,7 @@ labels and patches each body with a `## Model fit` block.
 >
 > 8. **Post-filing quality audit.** For each child issue (skip `type:tracker`):
 >    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
->    - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+>    - Run: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/audit-<N>.md`
 >    - On non-zero exit (lint fails):
 >      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
 >      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -241,7 +241,7 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Self-check each issue against the caps **before** calling `gh issue create`. If a cap is violated and a split is not feasible, surface the issue inline (print the over-cap body to the operator) instead of filing it.
 >
-> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash scripts/lint-issue.sh /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
+> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
 >
 > | Finding | Directive appended to next prompt |
 > |---|---|
@@ -387,7 +387,7 @@ labels and patches each body with a `## Model fit` block.
 >
 > 8. **Post-filing quality audit.** For each child issue (skip `type:tracker`):
 >    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
->    - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+>    - Run: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/audit-<N>.md`
 >    - On non-zero exit (lint fails):
 >      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
 >      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:

--- a/skills/autospec-define/install.sh
+++ b/skills/autospec-define/install.sh
@@ -43,6 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
 
 # ---------- helpers --------------------------------------------------------
 
@@ -92,14 +93,46 @@ fetch_source_files() {
     fi
     TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
     info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
-    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex"
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
     for rel in SKILL.md opencode/agent.md codex/prompt.md; do
         if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
             err "failed to download $SKILL_RAW_BASE/$rel"
             exit 1
         fi
     done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
     SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autospec helper scripts"
+        return 1
+    fi
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
 }
 
 install_one() {
@@ -231,6 +264,12 @@ fi
 if [ "$dep_warnings" -gt 0 ]; then
     warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
 fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
 
 # ---------- per-harness paths ---------------------------------------------
 

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -245,7 +245,7 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Self-check each issue against the caps **before** calling `gh issue create`. If a cap is violated and a split is not feasible, surface the issue inline (print the over-cap body to the operator) instead of filing it.
 >
-> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash scripts/lint-issue.sh /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
+> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
 >
 > | Finding | Directive appended to next prompt |
 > |---|---|
@@ -391,7 +391,7 @@ labels and patches each body with a `## Model fit` block.
 >
 > 8. **Post-filing quality audit.** For each child issue (skip `type:tracker`):
 >    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
->    - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+>    - Run: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/audit-<N>.md`
 >    - On non-zero exit (lint fails):
 >      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
 >      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:

--- a/skills/autospec-listen/install.sh
+++ b/skills/autospec-listen/install.sh
@@ -43,6 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
 
 # ---------- helpers --------------------------------------------------------
 
@@ -92,14 +93,46 @@ fetch_source_files() {
     fi
     TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
     info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
-    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex"
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
     for rel in SKILL.md opencode/agent.md codex/prompt.md; do
         if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
             err "failed to download $SKILL_RAW_BASE/$rel"
             exit 1
         fi
     done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
     SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autospec helper scripts"
+        return 1
+    fi
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
 }
 
 install_one() {
@@ -231,6 +264,12 @@ fi
 if [ "$dep_warnings" -gt 0 ]; then
     warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
 fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
 
 # ---------- per-harness paths ---------------------------------------------
 

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -89,7 +89,7 @@ NOT shell out the user's request). If the normalized request is exactly
 mode and does NOT run the normal pipeline. When dispatching, pass any
 `--<flag>` tokens the user provided as separate words to the helper.
 
-1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+1. Dispatch to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`.
 2. Print the helper's stdout to the user.
 3. Stop. Do not enter Phase 0 or any pipeline phase.
 
@@ -202,12 +202,31 @@ Then launch a **background subagent** with this prompt verbatim:
 >
 > **Missing-label warning (run-start, once).** Count open `auto-implement` issues that lack either a `ctx:*` or a `reasoning:*` label. If non-zero, print `WARN: N issues lack model-fit labels (ctx:* / reasoning:*); they will be treated as ctx:64k, reasoning:medium. Run /autospec-classify to backfill.` Exactly once at run start.
 >
+> **Shared helper scripts.** Helper scripts live at `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}` after installation. Do not assume the target repository has an autospec `scripts/` directory.
+>
 > Outer loop:
 > ```
-> deferred = []   # issues skipped because they exceed the active profile
->
 > while true:
->   candidates = [open auto-implement issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   deferred = []   # issues skipped because they exceed the active profile
+>
+>   # Startup/per-scan heartbeat reconciliation — run before candidate selection.
+>   # This deletes closed/merged/orphaned heartbeats, rejects old schemas like
+>   # {"issue":407,"status":"in_progress"}, normalizes current schemas, and
+>   # releases any `claimed` heartbeat older than AUTOSPEC_WATCHDOG_CLAIMED_TIMEOUT_SECS (default: 300).
+>   if [ -d "$HOME/.autospec/process-heartbeats" ]; then
+>     if command -v bash >/dev/null 2>&1; then
+>       bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.sh"
+>     elif command -v pwsh >/dev/null 2>&1; then
+>       pwsh -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
+>     elif command -v powershell >/dev/null 2>&1; then
+>       powershell -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
+>     else
+>       echo "[watchdog] neither bash nor powershell found; skipping heartbeat reconciliation."
+>     fi
+>   fi
+>   all_open = [open auto-implement issues, sorted ascending by issue number]
+>   candidates = [all_open issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   blocked = [all_open issues with unmet Depends-on deps]
 >
 >   ready = []
 >   for I in candidates:
@@ -220,6 +239,10 @@ Then launch a **background subagent** with this prompt verbatim:
 >       if ctx_lbl > profile.ctx:             reason.append(f"{ctx_lbl} > profile.ctx={profile.ctx}")
 >       if reasoning_lbl > profile.reasoning: reason.append(f"{reasoning_lbl} > profile.reasoning={profile.reasoning}")
 >       deferred.append({"issue": I.number, "reason": ", ".join(reason)})
+>
+>   claimed_issue, claimed_step = [newest valid heartbeat issue/step, or "-" / "-"]
+>   print "[monitor] queue scan: open=N ready=N blocked=N deferred=N claimed=#X step=Y order=ascending(oldest-first)"
+>   # GitHub may display newer/high-numbered issues first; autospec intentionally processes ready issues ascending.
 >
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
@@ -240,25 +263,25 @@ Then launch a **background subagent** with this prompt verbatim:
 >       exit 0
 >     fi
 >   fi
->   # Service watch: check for stuck workers every 12 iterations so monitors don't hang indefinitely.
+>   # Service watch: heartbeat reconciliation already runs before each candidate scan; every 12 iterations also runs a cheap nudge/reclaim pass for long-lived workers.
 >   monitor_tick=$((monitor_tick + 1))
 >   if [ "$monitor_tick" -ge 12 ]; then
 >     monitor_tick=0
 >     if [ -d "$HOME/.autospec/process-heartbeats" ]; then
 >       # Default reclaim window: 10800s (3h). For local single-threaded workers set
 >       # AUTOSPEC_WATCHDOG_RECLAIM_SECS=43200 (12h) before launch.
->       WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"
->       WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
+>       export AUTOSPEC_WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"
+>       export AUTOSPEC_WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
 >       # Cheap service wake-up pass: use low-cost model only.
 >       if command -v bash >/dev/null 2>&1; then
 >         # Dispatch one background watchdog helper (cheap model) to iterate stale entries.
->         bash scripts/autospec-watchdog.sh
+>         bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.sh"
 >       elif command -v pwsh >/dev/null 2>&1; then
 >         # Windows fallback: PowerShell helper.
->         pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/autospec-watchdog.ps1
+>         pwsh -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
 >       elif command -v powershell >/dev/null 2>&1; then
 >         # Windows fallback: classic PowerShell fallback.
->         powershell -NoProfile -ExecutionPolicy Bypass -File scripts/autospec-watchdog.ps1
+>         powershell -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
 >       else
 >         echo "[watchdog] neither bash nor powershell found; skipping service-watch pass."
 >       fi
@@ -280,6 +303,8 @@ Then launch a **background subagent** with this prompt verbatim:
 >     echo "[monitor] ISSUE $ISSUE claim failed (another monitor claimed it); skipping"
 >     continue
 >   fi
+>   mkdir -p "$HOME/.autospec/process-heartbeats"
+>   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```
@@ -313,7 +338,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -322,7 +347,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -332,7 +357,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >      If `AUTOSPEC_NO_GUARDIAN=1` is set: log `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN` and skip to LGTM dispatch.
 >      Otherwise:
 >        rm -f /tmp/guardian-<PR>.md
->        bash scripts/lint-implementation.sh <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
+>        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
 >        det_exit=$?
 >        Dispatch a **foreground subagent** (Tier A) with this brief verbatim:
 >        > **Model tier:** Tier A (spec work) — guardian audit. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
@@ -375,7 +400,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -383,7 +408,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -85,7 +85,7 @@ NOT shell out the user's request). If the normalized request is exactly
 mode and does NOT run the normal pipeline. When dispatching, pass any
 `--<flag>` tokens the user provided as separate words to the helper.
 
-1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+1. Dispatch to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`.
 2. Print the helper's stdout to the user.
 3. Stop. Do not enter Phase 0 or any pipeline phase.
 
@@ -197,12 +197,31 @@ Then launch a **background subagent** with this prompt verbatim:
 >
 > **Missing-label warning (run-start, once).** Count open `auto-implement` issues that lack either a `ctx:*` or a `reasoning:*` label. If non-zero, print `WARN: N issues lack model-fit labels (ctx:* / reasoning:*); they will be treated as ctx:64k, reasoning:medium. Run /autospec-classify to backfill.` Exactly once at run start.
 >
+> **Shared helper scripts.** Helper scripts live at `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}` after installation. Do not assume the target repository has an autospec `scripts/` directory.
+>
 > Outer loop:
 > ```
-> deferred = []   # issues skipped because they exceed the active profile
->
 > while true:
->   candidates = [open auto-implement issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   deferred = []   # issues skipped because they exceed the active profile
+>
+>   # Startup/per-scan heartbeat reconciliation — run before candidate selection.
+>   # This deletes closed/merged/orphaned heartbeats, rejects old schemas like
+>   # {"issue":407,"status":"in_progress"}, normalizes current schemas, and
+>   # releases any `claimed` heartbeat older than AUTOSPEC_WATCHDOG_CLAIMED_TIMEOUT_SECS (default: 300).
+>   if [ -d "$HOME/.autospec/process-heartbeats" ]; then
+>     if command -v bash >/dev/null 2>&1; then
+>       bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.sh"
+>     elif command -v pwsh >/dev/null 2>&1; then
+>       pwsh -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
+>     elif command -v powershell >/dev/null 2>&1; then
+>       powershell -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
+>     else
+>       echo "[watchdog] neither bash nor powershell found; skipping heartbeat reconciliation."
+>     fi
+>   fi
+>   all_open = [open auto-implement issues, sorted ascending by issue number]
+>   candidates = [all_open issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   blocked = [all_open issues with unmet Depends-on deps]
 >
 >   ready = []
 >   for I in candidates:
@@ -215,6 +234,10 @@ Then launch a **background subagent** with this prompt verbatim:
 >       if ctx_lbl > profile.ctx:             reason.append(f"{ctx_lbl} > profile.ctx={profile.ctx}")
 >       if reasoning_lbl > profile.reasoning: reason.append(f"{reasoning_lbl} > profile.reasoning={profile.reasoning}")
 >       deferred.append({"issue": I.number, "reason": ", ".join(reason)})
+>
+>   claimed_issue, claimed_step = [newest valid heartbeat issue/step, or "-" / "-"]
+>   print "[monitor] queue scan: open=N ready=N blocked=N deferred=N claimed=#X step=Y order=ascending(oldest-first)"
+>   # GitHub may display newer/high-numbered issues first; autospec intentionally processes ready issues ascending.
 >
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
@@ -235,25 +258,25 @@ Then launch a **background subagent** with this prompt verbatim:
 >       exit 0
 >     fi
 >   fi
->   # Service watch: check for stuck workers every 12 iterations so monitors don't hang indefinitely.
+>   # Service watch: heartbeat reconciliation already runs before each candidate scan; every 12 iterations also runs a cheap nudge/reclaim pass for long-lived workers.
 >   monitor_tick=$((monitor_tick + 1))
 >   if [ "$monitor_tick" -ge 12 ]; then
 >     monitor_tick=0
 >     if [ -d "$HOME/.autospec/process-heartbeats" ]; then
 >       # Default reclaim window: 10800s (3h). For local single-threaded workers set
 >       # AUTOSPEC_WATCHDOG_RECLAIM_SECS=43200 (12h) before launch.
->       WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"
->       WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
+>       export AUTOSPEC_WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"
+>       export AUTOSPEC_WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
 >       # Cheap service wake-up pass: use low-cost model only.
 >       if command -v bash >/dev/null 2>&1; then
 >         # Dispatch one background watchdog helper (cheap model) to iterate stale entries.
->         bash scripts/autospec-watchdog.sh
+>         bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.sh"
 >       elif command -v pwsh >/dev/null 2>&1; then
 >         # Windows fallback: PowerShell helper.
->         pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/autospec-watchdog.ps1
+>         pwsh -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
 >       elif command -v powershell >/dev/null 2>&1; then
 >         # Windows fallback: classic PowerShell fallback.
->         powershell -NoProfile -ExecutionPolicy Bypass -File scripts/autospec-watchdog.ps1
+>         powershell -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
 >       else
 >         echo "[watchdog] neither bash nor powershell found; skipping service-watch pass."
 >       fi
@@ -275,6 +298,8 @@ Then launch a **background subagent** with this prompt verbatim:
 >     echo "[monitor] ISSUE $ISSUE claim failed (another monitor claimed it); skipping"
 >     continue
 >   fi
+>   mkdir -p "$HOME/.autospec/process-heartbeats"
+>   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```
@@ -308,7 +333,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -317,7 +342,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -327,7 +352,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >      If `AUTOSPEC_NO_GUARDIAN=1` is set: log `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN` and skip to LGTM dispatch.
 >      Otherwise:
 >        rm -f /tmp/guardian-<PR>.md
->        bash scripts/lint-implementation.sh <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
+>        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
 >        det_exit=$?
 >        Dispatch a **foreground subagent** (Tier A) with this brief verbatim:
 >        > **Model tier:** Tier A (spec work) — guardian audit. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
@@ -370,7 +395,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -378,7 +403,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```

--- a/skills/autospec-run/install.sh
+++ b/skills/autospec-run/install.sh
@@ -43,6 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
 
 # ---------- helpers --------------------------------------------------------
 
@@ -92,14 +93,46 @@ fetch_source_files() {
     fi
     TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
     info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
-    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex"
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
     for rel in SKILL.md opencode/agent.md codex/prompt.md; do
         if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
             err "failed to download $SKILL_RAW_BASE/$rel"
             exit 1
         fi
     done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
     SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autospec helper scripts"
+        return 1
+    fi
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
 }
 
 install_one() {
@@ -231,6 +264,12 @@ fi
 if [ "$dep_warnings" -gt 0 ]; then
     warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
 fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
 
 # ---------- per-harness paths ---------------------------------------------
 

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -89,7 +89,7 @@ NOT shell out the user's request). If the normalized request is exactly
 mode and does NOT run the normal pipeline. When dispatching, pass any
 `--<flag>` tokens the user provided as separate words to the helper.
 
-1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+1. Dispatch to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`.
 2. Print the helper's stdout to the user.
 3. Stop. Do not enter Phase 0 or any pipeline phase.
 
@@ -201,12 +201,31 @@ Then launch a **background subagent** with this prompt verbatim:
 >
 > **Missing-label warning (run-start, once).** Count open `auto-implement` issues that lack either a `ctx:*` or a `reasoning:*` label. If non-zero, print `WARN: N issues lack model-fit labels (ctx:* / reasoning:*); they will be treated as ctx:64k, reasoning:medium. Run /autospec-classify to backfill.` Exactly once at run start.
 >
+> **Shared helper scripts.** Helper scripts live at `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}` after installation. Do not assume the target repository has an autospec `scripts/` directory.
+>
 > Outer loop:
 > ```
-> deferred = []   # issues skipped because they exceed the active profile
->
 > while true:
->   candidates = [open auto-implement issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   deferred = []   # issues skipped because they exceed the active profile
+>
+>   # Startup/per-scan heartbeat reconciliation — run before candidate selection.
+>   # This deletes closed/merged/orphaned heartbeats, rejects old schemas like
+>   # {"issue":407,"status":"in_progress"}, normalizes current schemas, and
+>   # releases any `claimed` heartbeat older than AUTOSPEC_WATCHDOG_CLAIMED_TIMEOUT_SECS (default: 300).
+>   if [ -d "$HOME/.autospec/process-heartbeats" ]; then
+>     if command -v bash >/dev/null 2>&1; then
+>       bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.sh"
+>     elif command -v pwsh >/dev/null 2>&1; then
+>       pwsh -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
+>     elif command -v powershell >/dev/null 2>&1; then
+>       powershell -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
+>     else
+>       echo "[watchdog] neither bash nor powershell found; skipping heartbeat reconciliation."
+>     fi
+>   fi
+>   all_open = [open auto-implement issues, sorted ascending by issue number]
+>   candidates = [all_open issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   blocked = [all_open issues with unmet Depends-on deps]
 >
 >   ready = []
 >   for I in candidates:
@@ -219,6 +238,10 @@ Then launch a **background subagent** with this prompt verbatim:
 >       if ctx_lbl > profile.ctx:             reason.append(f"{ctx_lbl} > profile.ctx={profile.ctx}")
 >       if reasoning_lbl > profile.reasoning: reason.append(f"{reasoning_lbl} > profile.reasoning={profile.reasoning}")
 >       deferred.append({"issue": I.number, "reason": ", ".join(reason)})
+>
+>   claimed_issue, claimed_step = [newest valid heartbeat issue/step, or "-" / "-"]
+>   print "[monitor] queue scan: open=N ready=N blocked=N deferred=N claimed=#X step=Y order=ascending(oldest-first)"
+>   # GitHub may display newer/high-numbered issues first; autospec intentionally processes ready issues ascending.
 >
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
@@ -239,25 +262,25 @@ Then launch a **background subagent** with this prompt verbatim:
 >       exit 0
 >     fi
 >   fi
->   # Service watch: check for stuck workers every 12 iterations so monitors don't hang indefinitely.
+>   # Service watch: heartbeat reconciliation already runs before each candidate scan; every 12 iterations also runs a cheap nudge/reclaim pass for long-lived workers.
 >   monitor_tick=$((monitor_tick + 1))
 >   if [ "$monitor_tick" -ge 12 ]; then
 >     monitor_tick=0
 >     if [ -d "$HOME/.autospec/process-heartbeats" ]; then
 >       # Default reclaim window: 10800s (3h). For local single-threaded workers set
 >       # AUTOSPEC_WATCHDOG_RECLAIM_SECS=43200 (12h) before launch.
->       WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"
->       WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
+>       export AUTOSPEC_WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"
+>       export AUTOSPEC_WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
 >       # Cheap service wake-up pass: use low-cost model only.
 >       if command -v bash >/dev/null 2>&1; then
 >         # Dispatch one background watchdog helper (cheap model) to iterate stale entries.
->         bash scripts/autospec-watchdog.sh
+>         bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.sh"
 >       elif command -v pwsh >/dev/null 2>&1; then
 >         # Windows fallback: PowerShell helper.
->         pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/autospec-watchdog.ps1
+>         pwsh -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
 >       elif command -v powershell >/dev/null 2>&1; then
 >         # Windows fallback: classic PowerShell fallback.
->         powershell -NoProfile -ExecutionPolicy Bypass -File scripts/autospec-watchdog.ps1
+>         powershell -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
 >       else
 >         echo "[watchdog] neither bash nor powershell found; skipping service-watch pass."
 >       fi
@@ -279,6 +302,8 @@ Then launch a **background subagent** with this prompt verbatim:
 >     echo "[monitor] ISSUE $ISSUE claim failed (another monitor claimed it); skipping"
 >     continue
 >   fi
+>   mkdir -p "$HOME/.autospec/process-heartbeats"
+>   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```
@@ -312,7 +337,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -321,7 +346,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -331,7 +356,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >      If `AUTOSPEC_NO_GUARDIAN=1` is set: log `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN` and skip to LGTM dispatch.
 >      Otherwise:
 >        rm -f /tmp/guardian-<PR>.md
->        bash scripts/lint-implementation.sh <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
+>        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
 >        det_exit=$?
 >        Dispatch a **foreground subagent** (Tier A) with this brief verbatim:
 >        > **Model tier:** Tier A (spec work) — guardian audit. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
@@ -374,7 +399,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -382,7 +407,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```

--- a/skills/autospec-split/SKILL.md
+++ b/skills/autospec-split/SKILL.md
@@ -243,7 +243,7 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Self-check each issue against the caps **before** calling `gh issue create`. If a cap is violated and a split is not feasible, surface the issue inline (print the over-cap body to the operator) instead of filing it.
 >
-> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash scripts/lint-issue.sh /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
+> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
 >
 > | Finding | Directive appended to next prompt |
 > |---|---|
@@ -389,7 +389,7 @@ labels and patches each body with a `## Model fit` block.
 >
 > 8. **Post-filing quality audit.** For each child issue (skip `type:tracker`):
 >    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
->    - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+>    - Run: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/audit-<N>.md`
 >    - On non-zero exit (lint fails):
 >      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
 >      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:

--- a/skills/autospec-split/codex/prompt.md
+++ b/skills/autospec-split/codex/prompt.md
@@ -237,7 +237,7 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Self-check each issue against the caps **before** calling `gh issue create`. If a cap is violated and a split is not feasible, surface the issue inline (print the over-cap body to the operator) instead of filing it.
 >
-> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash scripts/lint-issue.sh /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
+> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
 >
 > | Finding | Directive appended to next prompt |
 > |---|---|
@@ -383,7 +383,7 @@ labels and patches each body with a `## Model fit` block.
 >
 > 8. **Post-filing quality audit.** For each child issue (skip `type:tracker`):
 >    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
->    - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+>    - Run: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/audit-<N>.md`
 >    - On non-zero exit (lint fails):
 >      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
 >      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:

--- a/skills/autospec-split/install.sh
+++ b/skills/autospec-split/install.sh
@@ -43,6 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
 
 # ---------- helpers --------------------------------------------------------
 
@@ -92,14 +93,46 @@ fetch_source_files() {
     fi
     TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
     info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
-    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex"
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
     for rel in SKILL.md opencode/agent.md codex/prompt.md; do
         if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
             err "failed to download $SKILL_RAW_BASE/$rel"
             exit 1
         fi
     done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
     SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autospec helper scripts"
+        return 1
+    fi
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
 }
 
 install_one() {
@@ -231,6 +264,12 @@ fi
 if [ "$dep_warnings" -gt 0 ]; then
     warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
 fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
 
 # ---------- per-harness paths ---------------------------------------------
 

--- a/skills/autospec-split/opencode/agent.md
+++ b/skills/autospec-split/opencode/agent.md
@@ -241,7 +241,7 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Self-check each issue against the caps **before** calling `gh issue create`. If a cap is violated and a split is not feasible, surface the issue inline (print the over-cap body to the operator) instead of filing it.
 >
-> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash scripts/lint-issue.sh /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
+> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
 >
 > | Finding | Directive appended to next prompt |
 > |---|---|
@@ -387,7 +387,7 @@ labels and patches each body with a `## Model fit` block.
 >
 > 8. **Post-filing quality audit.** For each child issue (skip `type:tracker`):
 >    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
->    - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+>    - Run: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/audit-<N>.md`
 >    - On non-zero exit (lint fails):
 >      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
 >      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:

--- a/skills/autospec-stop/README.md
+++ b/skills/autospec-stop/README.md
@@ -45,7 +45,7 @@ cd skills/autospec-stop
 /autospec-run stop --graceful       # inline sub-mode in monitor skill
 ```
 
-All three paths route through `scripts/autospec-stop.sh`.
+All three paths route through the installed `autospec-stop.sh` helper in `~/.autospec/scripts` (or `AUTOSPEC_SCRIPTS_DIR`).
 
 ## Spec
 

--- a/skills/autospec-stop/SKILL.md
+++ b/skills/autospec-stop/SKILL.md
@@ -6,7 +6,7 @@ description: Use when the user wants to halt a running autospec monitor graceful
 # autospec-stop (harness-neutral)
 
 Halt a running autospec monitor gracefully or immediately. All paths route
-through `bash scripts/autospec-stop.sh "$@"`.
+through `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"`.
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
 
@@ -76,7 +76,7 @@ If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
 (case-insensitive), this skill enters stop mode and does not run the normal
 pipeline:
 
-1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+1. Dispatch to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`.
 2. Print the helper's stdout to the user.
 3. Stop. Do not enter Phase 0 or any pipeline phase.
 
@@ -86,7 +86,7 @@ pipeline:
 /autospec-stop [--graceful|--immediate|--status|--resume|--help]
 ```
 
-Dispatches directly to `bash scripts/autospec-stop.sh "$@"`. All logic lives
+Dispatches directly to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"`. All logic lives
 in the helper script.
 
 | Flag | Behaviour |
@@ -113,18 +113,18 @@ This workflow assumes a small set of capabilities. Map each one to your harness'
 
 1. Run startup self-update block above.
 2. Parse the user's invocation arguments (default to `--graceful` if no flag given).
-3. Execute: `bash scripts/autospec-stop.sh "$@"`
+3. Execute: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"`
 4. Print stdout to user and exit.
 
-If `scripts/autospec-stop.sh` is not found, print:
+If `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh` is not found, print:
 ```
-autospec-stop: helper not found at scripts/autospec-stop.sh.
-Run from the autospec repo root, or re-install the skill.
+autospec-stop: helper not found at ${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh.
+Reinstall autospec-stop from the autospec repo, then retry.
 ```
 and exit non-zero.
 
 ## Hard rules
 
-- Never call `scripts/autospec-stop.sh --abort-current-issue` from user invocation. That flag is internal.
+- Never call `autospec-stop.sh --abort-current-issue` from user invocation. That flag is internal.
 - Never modify issue bodies, labels, or PRs directly — the helper script owns all GitHub mutations.
 - This skill is a thin wrapper. All behaviour is in the helper script.

--- a/skills/autospec-stop/codex/prompt.md
+++ b/skills/autospec-stop/codex/prompt.md
@@ -2,7 +2,7 @@
 # autospec-stop (harness-neutral)
 
 Halt a running autospec monitor gracefully or immediately. All paths route
-through `bash scripts/autospec-stop.sh "$@"`.
+through `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"`.
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
 
@@ -72,7 +72,7 @@ If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
 (case-insensitive), this skill enters stop mode and does not run the normal
 pipeline:
 
-1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+1. Dispatch to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`.
 2. Print the helper's stdout to the user.
 3. Stop. Do not enter Phase 0 or any pipeline phase.
 
@@ -82,7 +82,7 @@ pipeline:
 /autospec-stop [--graceful|--immediate|--status|--resume|--help]
 ```
 
-Dispatches directly to `bash scripts/autospec-stop.sh "$@"`. All logic lives
+Dispatches directly to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"`. All logic lives
 in the helper script.
 
 | Flag | Behaviour |
@@ -109,18 +109,18 @@ This workflow assumes a small set of capabilities. Map each one to your harness'
 
 1. Run startup self-update block above.
 2. Parse the user's invocation arguments (default to `--graceful` if no flag given).
-3. Execute: `bash scripts/autospec-stop.sh "$@"`
+3. Execute: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"`
 4. Print stdout to user and exit.
 
-If `scripts/autospec-stop.sh` is not found, print:
+If `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh` is not found, print:
 ```
-autospec-stop: helper not found at scripts/autospec-stop.sh.
-Run from the autospec repo root, or re-install the skill.
+autospec-stop: helper not found at ${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh.
+Reinstall autospec-stop from the autospec repo, then retry.
 ```
 and exit non-zero.
 
 ## Hard rules
 
-- Never call `scripts/autospec-stop.sh --abort-current-issue` from user invocation. That flag is internal.
+- Never call `autospec-stop.sh --abort-current-issue` from user invocation. That flag is internal.
 - Never modify issue bodies, labels, or PRs directly — the helper script owns all GitHub mutations.
 - This skill is a thin wrapper. All behaviour is in the helper script.

--- a/skills/autospec-stop/install.sh
+++ b/skills/autospec-stop/install.sh
@@ -37,6 +37,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
 
 # ---------- helpers --------------------------------------------------------
 
@@ -75,14 +76,46 @@ fetch_source_files() {
     fi
     TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
     info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
-    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex"
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
     for rel in SKILL.md opencode/agent.md codex/prompt.md; do
         if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
             err "failed to download $SKILL_RAW_BASE/$rel"
             exit 1
         fi
     done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
     SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autospec helper scripts"
+        return 1
+    fi
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
 }
 
 install_one() {
@@ -185,6 +218,12 @@ if [ "$need_fetch" -eq 1 ]; then
     fi
     fetch_source_files
 fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
 
 # ---------- per-harness paths ---------------------------------------------
 

--- a/skills/autospec-stop/opencode/agent.md
+++ b/skills/autospec-stop/opencode/agent.md
@@ -6,7 +6,7 @@ mode: primary
 # autospec-stop (harness-neutral)
 
 Halt a running autospec monitor gracefully or immediately. All paths route
-through `bash scripts/autospec-stop.sh "$@"`.
+through `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"`.
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
 
@@ -76,7 +76,7 @@ If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
 (case-insensitive), this skill enters stop mode and does not run the normal
 pipeline:
 
-1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+1. Dispatch to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`.
 2. Print the helper's stdout to the user.
 3. Stop. Do not enter Phase 0 or any pipeline phase.
 
@@ -86,7 +86,7 @@ pipeline:
 /autospec-stop [--graceful|--immediate|--status|--resume|--help]
 ```
 
-Dispatches directly to `bash scripts/autospec-stop.sh "$@"`. All logic lives
+Dispatches directly to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"`. All logic lives
 in the helper script.
 
 | Flag | Behaviour |
@@ -113,18 +113,18 @@ This workflow assumes a small set of capabilities. Map each one to your harness'
 
 1. Run startup self-update block above.
 2. Parse the user's invocation arguments (default to `--graceful` if no flag given).
-3. Execute: `bash scripts/autospec-stop.sh "$@"`
+3. Execute: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"`
 4. Print stdout to user and exit.
 
-If `scripts/autospec-stop.sh` is not found, print:
+If `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh` is not found, print:
 ```
-autospec-stop: helper not found at scripts/autospec-stop.sh.
-Run from the autospec repo root, or re-install the skill.
+autospec-stop: helper not found at ${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh.
+Reinstall autospec-stop from the autospec repo, then retry.
 ```
 and exit non-zero.
 
 ## Hard rules
 
-- Never call `scripts/autospec-stop.sh --abort-current-issue` from user invocation. That flag is internal.
+- Never call `autospec-stop.sh --abort-current-issue` from user invocation. That flag is internal.
 - Never modify issue bodies, labels, or PRs directly — the helper script owns all GitHub mutations.
 - This skill is a thin wrapper. All behaviour is in the helper script.

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -92,7 +92,7 @@ NOT shell out the user's request). If the normalized request is exactly
 mode and does NOT run the normal pipeline. When dispatching, pass any
 `--<flag>` tokens the user provided as separate words to the helper.
 
-1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+1. Dispatch to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`.
 2. Print the helper's stdout to the user.
 3. Stop. Do not enter Phase 0 or any pipeline phase.
 
@@ -270,7 +270,7 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Self-check each issue against the caps **before** calling `gh issue create`. If a cap is violated and a split is not feasible, surface the issue inline (print the over-cap body to the operator) instead of filing it.
 >
-> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash scripts/lint-issue.sh /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
+> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
 >
 > | Finding | Directive appended to next prompt |
 > |---|---|
@@ -416,7 +416,7 @@ labels and patches each body with a `## Model fit` block.
 >
 > 8. **Post-filing quality audit.** For each child issue (skip `type:tracker`):
 >    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
->    - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+>    - Run: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/audit-<N>.md`
 >    - On non-zero exit (lint fails):
 >      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
 >      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:
@@ -495,10 +495,32 @@ Then launch a **background subagent** with this prompt verbatim:
 > **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
 
 >
+> **Shared helper scripts.** Helper scripts live at `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}` after installation. Do not assume the target repository has an autospec `scripts/` directory.
+>
 > Outer loop:
 > ```
 > while true:
->   ready = [open auto-implement issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   # Startup/per-scan heartbeat reconciliation — run before candidate selection.
+>   # This deletes closed/merged/orphaned heartbeats, rejects old schemas like
+>   # {"issue":407,"status":"in_progress"}, normalizes current schemas, and
+>   # releases any `claimed` heartbeat older than AUTOSPEC_WATCHDOG_CLAIMED_TIMEOUT_SECS (default: 300).
+>   if [ -d "$HOME/.autospec/process-heartbeats" ]; then
+>     if command -v bash >/dev/null 2>&1; then
+>       bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.sh"
+>     elif command -v pwsh >/dev/null 2>&1; then
+>       pwsh -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
+>     elif command -v powershell >/dev/null 2>&1; then
+>       powershell -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
+>     else
+>       echo "[watchdog] neither bash nor powershell found; skipping heartbeat reconciliation."
+>     fi
+>   fi
+>   all_open = [open auto-implement issues, sorted ascending by issue number]
+>   ready = [all_open issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   blocked = [all_open issues with unmet Depends-on deps]
+>   claimed_issue, claimed_step = [newest valid heartbeat issue/step, or "-" / "-"]
+>   print "[monitor] queue scan: open=N ready=N blocked=N deferred=0 claimed=#X step=Y order=ascending(oldest-first)"
+>   # GitHub may display newer/high-numbered issues first; autospec intentionally processes ready issues ascending.
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
@@ -518,25 +540,25 @@ Then launch a **background subagent** with this prompt verbatim:
 >       exit 0
 >     fi
 >   fi
->   # Service watch: check for stuck workers every 12 iterations so monitors don't hang indefinitely.
+>   # Service watch: heartbeat reconciliation already runs before each candidate scan; every 12 iterations also runs a cheap nudge/reclaim pass for long-lived workers.
 >   monitor_tick=$((monitor_tick + 1))
 >   if [ "$monitor_tick" -ge 12 ]; then
 >     monitor_tick=0
 >     if [ -d "$HOME/.autospec/process-heartbeats" ]; then
 >       # Default reclaim window: 10800s (3h). For local single-threaded workers set
 >       # AUTOSPEC_WATCHDOG_RECLAIM_SECS=43200 (12h) before launch.
->       WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"
->       WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
+>       export AUTOSPEC_WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"
+>       export AUTOSPEC_WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
 >       # Cheap service wake-up pass: use low-cost model only.
 >       if command -v bash >/dev/null 2>&1; then
 >         # Dispatch one background watchdog helper (cheap model) to iterate stale entries.
->         bash scripts/autospec-watchdog.sh
+>         bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.sh"
 >       elif command -v pwsh >/dev/null 2>&1; then
 >         # Windows fallback: PowerShell helper.
->         pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/autospec-watchdog.ps1
+>         pwsh -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
 >       elif command -v powershell >/dev/null 2>&1; then
 >         # Windows fallback: classic PowerShell fallback.
->         powershell -NoProfile -ExecutionPolicy Bypass -File scripts/autospec-watchdog.ps1
+>         powershell -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
 >       else
 >         echo "[watchdog] neither bash nor powershell found; skipping service-watch pass."
 >       fi
@@ -558,6 +580,8 @@ Then launch a **background subagent** with this prompt verbatim:
 >     echo "[monitor] ISSUE $ISSUE claim failed (another monitor claimed it); skipping"
 >     continue
 >   fi
+>   mkdir -p "$HOME/.autospec/process-heartbeats"
+>   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```
@@ -591,7 +615,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -600,7 +624,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -610,7 +634,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >      If `AUTOSPEC_NO_GUARDIAN=1` is set: log `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN` and skip to LGTM dispatch.
 >      Otherwise:
 >        rm -f /tmp/guardian-<PR>.md
->        bash scripts/lint-implementation.sh <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
+>        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
 >        det_exit=$?
 >        Dispatch a **foreground subagent** (Tier A) with this brief verbatim:
 >        > **Model tier:** Tier A (spec work) — guardian audit. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
@@ -653,7 +677,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -661,7 +685,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -88,7 +88,7 @@ NOT shell out the user's request). If the normalized request is exactly
 mode and does NOT run the normal pipeline. When dispatching, pass any
 `--<flag>` tokens the user provided as separate words to the helper.
 
-1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+1. Dispatch to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`.
 2. Print the helper's stdout to the user.
 3. Stop. Do not enter Phase 0 or any pipeline phase.
 
@@ -264,7 +264,7 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Self-check each issue against the caps **before** calling `gh issue create`. If a cap is violated and a split is not feasible, surface the issue inline (print the over-cap body to the operator) instead of filing it.
 >
-> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash scripts/lint-issue.sh /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
+> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
 >
 > | Finding | Directive appended to next prompt |
 > |---|---|
@@ -410,7 +410,7 @@ labels and patches each body with a `## Model fit` block.
 >
 > 8. **Post-filing quality audit.** For each child issue (skip `type:tracker`):
 >    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
->    - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+>    - Run: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/audit-<N>.md`
 >    - On non-zero exit (lint fails):
 >      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
 >      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:
@@ -489,10 +489,32 @@ Then launch a **background subagent** with this prompt verbatim:
 > **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
 
 >
+> **Shared helper scripts.** Helper scripts live at `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}` after installation. Do not assume the target repository has an autospec `scripts/` directory.
+>
 > Outer loop:
 > ```
 > while true:
->   ready = [open auto-implement issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   # Startup/per-scan heartbeat reconciliation — run before candidate selection.
+>   # This deletes closed/merged/orphaned heartbeats, rejects old schemas like
+>   # {"issue":407,"status":"in_progress"}, normalizes current schemas, and
+>   # releases any `claimed` heartbeat older than AUTOSPEC_WATCHDOG_CLAIMED_TIMEOUT_SECS (default: 300).
+>   if [ -d "$HOME/.autospec/process-heartbeats" ]; then
+>     if command -v bash >/dev/null 2>&1; then
+>       bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.sh"
+>     elif command -v pwsh >/dev/null 2>&1; then
+>       pwsh -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
+>     elif command -v powershell >/dev/null 2>&1; then
+>       powershell -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
+>     else
+>       echo "[watchdog] neither bash nor powershell found; skipping heartbeat reconciliation."
+>     fi
+>   fi
+>   all_open = [open auto-implement issues, sorted ascending by issue number]
+>   ready = [all_open issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   blocked = [all_open issues with unmet Depends-on deps]
+>   claimed_issue, claimed_step = [newest valid heartbeat issue/step, or "-" / "-"]
+>   print "[monitor] queue scan: open=N ready=N blocked=N deferred=0 claimed=#X step=Y order=ascending(oldest-first)"
+>   # GitHub may display newer/high-numbered issues first; autospec intentionally processes ready issues ascending.
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
@@ -512,25 +534,25 @@ Then launch a **background subagent** with this prompt verbatim:
 >       exit 0
 >     fi
 >   fi
->   # Service watch: check for stuck workers every 12 iterations so monitors don't hang indefinitely.
+>   # Service watch: heartbeat reconciliation already runs before each candidate scan; every 12 iterations also runs a cheap nudge/reclaim pass for long-lived workers.
 >   monitor_tick=$((monitor_tick + 1))
 >   if [ "$monitor_tick" -ge 12 ]; then
 >     monitor_tick=0
 >     if [ -d "$HOME/.autospec/process-heartbeats" ]; then
 >       # Default reclaim window: 10800s (3h). For local single-threaded workers set
 >       # AUTOSPEC_WATCHDOG_RECLAIM_SECS=43200 (12h) before launch.
->       WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"
->       WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
+>       export AUTOSPEC_WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"
+>       export AUTOSPEC_WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
 >       # Cheap service wake-up pass: use low-cost model only.
 >       if command -v bash >/dev/null 2>&1; then
 >         # Dispatch one background watchdog helper (cheap model) to iterate stale entries.
->         bash scripts/autospec-watchdog.sh
+>         bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.sh"
 >       elif command -v pwsh >/dev/null 2>&1; then
 >         # Windows fallback: PowerShell helper.
->         pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/autospec-watchdog.ps1
+>         pwsh -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
 >       elif command -v powershell >/dev/null 2>&1; then
 >         # Windows fallback: classic PowerShell fallback.
->         powershell -NoProfile -ExecutionPolicy Bypass -File scripts/autospec-watchdog.ps1
+>         powershell -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
 >       else
 >         echo "[watchdog] neither bash nor powershell found; skipping service-watch pass."
 >       fi
@@ -552,6 +574,8 @@ Then launch a **background subagent** with this prompt verbatim:
 >     echo "[monitor] ISSUE $ISSUE claim failed (another monitor claimed it); skipping"
 >     continue
 >   fi
+>   mkdir -p "$HOME/.autospec/process-heartbeats"
+>   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```
@@ -585,7 +609,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -594,7 +618,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -604,7 +628,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >      If `AUTOSPEC_NO_GUARDIAN=1` is set: log `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN` and skip to LGTM dispatch.
 >      Otherwise:
 >        rm -f /tmp/guardian-<PR>.md
->        bash scripts/lint-implementation.sh <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
+>        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
 >        det_exit=$?
 >        Dispatch a **foreground subagent** (Tier A) with this brief verbatim:
 >        > **Model tier:** Tier A (spec work) — guardian audit. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
@@ -647,7 +671,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -655,7 +679,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```

--- a/skills/autospec/install.sh
+++ b/skills/autospec/install.sh
@@ -43,6 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
 
 # ---------- helpers --------------------------------------------------------
 
@@ -92,14 +93,46 @@ fetch_source_files() {
     fi
     TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
     info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
-    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex"
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
     for rel in SKILL.md opencode/agent.md codex/prompt.md; do
         if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
             err "failed to download $SKILL_RAW_BASE/$rel"
             exit 1
         fi
     done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
     SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autospec helper scripts"
+        return 1
+    fi
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
 }
 
 install_one() {
@@ -231,6 +264,12 @@ fi
 if [ "$dep_warnings" -gt 0 ]; then
     warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
 fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
 
 # ---------- per-harness paths ---------------------------------------------
 

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -92,7 +92,7 @@ NOT shell out the user's request). If the normalized request is exactly
 mode and does NOT run the normal pipeline. When dispatching, pass any
 `--<flag>` tokens the user provided as separate words to the helper.
 
-1. Dispatch to `bash scripts/autospec-stop.sh <args>`.
+1. Dispatch to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`.
 2. Print the helper's stdout to the user.
 3. Stop. Do not enter Phase 0 or any pipeline phase.
 
@@ -268,7 +268,7 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Self-check each issue against the caps **before** calling `gh issue create`. If a cap is violated and a split is not feasible, surface the issue inline (print the over-cap body to the operator) instead of filing it.
 >
-> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash scripts/lint-issue.sh /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
+> **Pre-filing lint loop (adaptive, MAX_LINT_RETRIES=5):** For each candidate child body, before calling `gh issue create`, write the body to `/tmp/draft-<slug>.md` and run `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/draft-<slug>.md`. If the exit code is non-zero, map each `RULE_ID: <desc>` finding to an actionable directive using the table below, append all directives to the next generation prompt as cumulative context, and regenerate. Repeat up to `MAX_LINT_RETRIES=5` attempts. If attempt 5 still fails, print all 5 drafts plus accumulated findings inline and **skip** that child (do not file); continue to the next child. On pass (exit 0), proceed to `gh issue create` as normal.
 >
 > | Finding | Directive appended to next prompt |
 > |---|---|
@@ -414,7 +414,7 @@ labels and patches each body with a `## Model fit` block.
 >
 > 8. **Post-filing quality audit.** For each child issue (skip `type:tracker`):
 >    - Pull body: `gh issue view <N> --repo {repo} --json body -q .body > /tmp/audit-<N>.md`
->    - Run: `bash scripts/lint-issue.sh /tmp/audit-<N>.md`
+>    - Run: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-issue.sh" /tmp/audit-<N>.md`
 >    - On non-zero exit (lint fails):
 >      - Apply label: `gh issue edit <N> --add-label needs-quality-bar --repo {repo}`
 >      - Insert `## Quality lint` block (idempotent, between `<!-- autospec-quality:begin -->` and `<!-- autospec-quality:end -->` markers) via `gh issue edit <N> --body-file <tmp>`. Block format:
@@ -493,10 +493,32 @@ Then launch a **background subagent** with this prompt verbatim:
 > **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
 
 >
+> **Shared helper scripts.** Helper scripts live at `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}` after installation. Do not assume the target repository has an autospec `scripts/` directory.
+>
 > Outer loop:
 > ```
 > while true:
->   ready = [open auto-implement issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   # Startup/per-scan heartbeat reconciliation — run before candidate selection.
+>   # This deletes closed/merged/orphaned heartbeats, rejects old schemas like
+>   # {"issue":407,"status":"in_progress"}, normalizes current schemas, and
+>   # releases any `claimed` heartbeat older than AUTOSPEC_WATCHDOG_CLAIMED_TIMEOUT_SECS (default: 300).
+>   if [ -d "$HOME/.autospec/process-heartbeats" ]; then
+>     if command -v bash >/dev/null 2>&1; then
+>       bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.sh"
+>     elif command -v pwsh >/dev/null 2>&1; then
+>       pwsh -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
+>     elif command -v powershell >/dev/null 2>&1; then
+>       powershell -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
+>     else
+>       echo "[watchdog] neither bash nor powershell found; skipping heartbeat reconciliation."
+>     fi
+>   fi
+>   all_open = [open auto-implement issues, sorted ascending by issue number]
+>   ready = [all_open issues whose Depends-on deps are all CLOSED, sorted ascending]
+>   blocked = [all_open issues with unmet Depends-on deps]
+>   claimed_issue, claimed_step = [newest valid heartbeat issue/step, or "-" / "-"]
+>   print "[monitor] queue scan: open=N ready=N blocked=N deferred=0 claimed=#X step=Y order=ascending(oldest-first)"
+>   # GitHub may display newer/high-numbered issues first; autospec intentionally processes ready issues ascending.
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
@@ -516,25 +538,25 @@ Then launch a **background subagent** with this prompt verbatim:
 >       exit 0
 >     fi
 >   fi
->   # Service watch: check for stuck workers every 12 iterations so monitors don't hang indefinitely.
+>   # Service watch: heartbeat reconciliation already runs before each candidate scan; every 12 iterations also runs a cheap nudge/reclaim pass for long-lived workers.
 >   monitor_tick=$((monitor_tick + 1))
 >   if [ "$monitor_tick" -ge 12 ]; then
 >     monitor_tick=0
 >     if [ -d "$HOME/.autospec/process-heartbeats" ]; then
 >       # Default reclaim window: 10800s (3h). For local single-threaded workers set
 >       # AUTOSPEC_WATCHDOG_RECLAIM_SECS=43200 (12h) before launch.
->       WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"
->       WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
+>       export AUTOSPEC_WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"
+>       export AUTOSPEC_WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
 >       # Cheap service wake-up pass: use low-cost model only.
 >       if command -v bash >/dev/null 2>&1; then
 >         # Dispatch one background watchdog helper (cheap model) to iterate stale entries.
->         bash scripts/autospec-watchdog.sh
+>         bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.sh"
 >       elif command -v pwsh >/dev/null 2>&1; then
 >         # Windows fallback: PowerShell helper.
->         pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/autospec-watchdog.ps1
+>         pwsh -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
 >       elif command -v powershell >/dev/null 2>&1; then
 >         # Windows fallback: classic PowerShell fallback.
->         powershell -NoProfile -ExecutionPolicy Bypass -File scripts/autospec-watchdog.ps1
+>         powershell -NoProfile -ExecutionPolicy Bypass -File "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-watchdog.ps1"
 >       else
 >         echo "[watchdog] neither bash nor powershell found; skipping service-watch pass."
 >       fi
@@ -556,6 +578,8 @@ Then launch a **background subagent** with this prompt verbatim:
 >     echo "[monitor] ISSUE $ISSUE claim failed (another monitor claimed it); skipping"
 >     continue
 >   fi
+>   mkdir -p "$HOME/.autospec/process-heartbeats"
+>   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```
@@ -589,7 +613,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -598,7 +622,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -608,7 +632,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >      If `AUTOSPEC_NO_GUARDIAN=1` is set: log `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN` and skip to LGTM dispatch.
 >      Otherwise:
 >        rm -f /tmp/guardian-<PR>.md
->        bash scripts/lint-implementation.sh <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
+>        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
 >        det_exit=$?
 >        Dispatch a **foreground subagent** (Tier A) with this brief verbatim:
 >        > **Model tier:** Tier A (spec work) — guardian audit. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
@@ -651,7 +675,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```
@@ -659,7 +683,7 @@ Then launch a **background subagent** with this prompt verbatim:
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then
->      bash scripts/autospec-stop.sh --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" --abort-current-issue "$ISSUE" "$BRANCH" "$LAST_STEP"
 >      exit 0
 >    fi
 >    ```

--- a/tests/smoke/test_install_all_skills.bats
+++ b/tests/smoke/test_install_all_skills.bats
@@ -18,6 +18,7 @@ setup() {
     export CODEX_HOME="$FAKE_HOME/.codex"
 
     SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
+    HELPERS="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
 }
 
 teardown() {
@@ -30,6 +31,7 @@ teardown() {
 _claude_path() { printf '%s/.claude/skills/%s/SKILL.md' "$FAKE_HOME" "$1"; }
 _opencode_path() { printf '%s/.config/opencode/agent/%s.md' "$FAKE_HOME" "$1"; }
 _codex_path() { printf '%s/.codex/prompts/%s.md' "$FAKE_HOME" "$1"; }
+_helper_path() { printf '%s/.autospec/scripts/%s' "$FAKE_HOME" "$1"; }
 
 # ---- install all skills --------------------------------------------------
 
@@ -40,6 +42,12 @@ _codex_path() { printf '%s/.codex/prompts/%s.md' "$FAKE_HOME" "$1"; }
         [ -f "$(_claude_path "$s")" ]
         [ -f "$(_opencode_path "$s")" ]
         [ -f "$(_codex_path "$s")" ]
+    done
+    for h in $HELPERS; do
+        [ -f "$(_helper_path "$h")" ]
+        case "$h" in
+            *.sh) [ -x "$(_helper_path "$h")" ] ;;
+        esac
     done
 }
 
@@ -70,5 +78,11 @@ _codex_path() { printf '%s/.codex/prompts/%s.md' "$FAKE_HOME" "$1"; }
         [ -f "$(_claude_path "$s")" ]
         [ -f "$(_opencode_path "$s")" ]
         [ -f "$(_codex_path "$s")" ]
+    done
+    for h in $HELPERS; do
+        [ -f "$(_helper_path "$h")" ]
+        case "$h" in
+            *.sh) [ -x "$(_helper_path "$h")" ] ;;
+        esac
     done
 }

--- a/tests/unit/test_autospec_watchdog.bats
+++ b/tests/unit/test_autospec_watchdog.bats
@@ -102,3 +102,12 @@ EOF
     [ -f "$AUTOSPEC_WATCHDOG_DIR/410.json" ]
     jq -e '.issue == "410" and .pr == "" and .repo == ""' "$AUTOSPEC_WATCHDOG_DIR/410.json" >/dev/null
 }
+
+@test "missing jq fails open without deleting heartbeats" {
+    write_hb 410 tests_started 10
+    PATH="$STUB_BIN:/usr/bin:/bin" run bash "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ -f "$AUTOSPEC_WATCHDOG_DIR/410.json" ]
+    echo "$output" | grep -q 'invalid_schema=0'
+}

--- a/tests/unit/test_autospec_watchdog.bats
+++ b/tests/unit/test_autospec_watchdog.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_watchdog.bats — heartbeat reconciliation and
+# timeout behavior for scripts/autospec-watchdog.sh.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/autospec-watchdog.sh"
+
+    export HOME="$(mktemp -d)"
+    export AUTOSPEC_WATCHDOG_DIR="$HOME/.autospec/process-heartbeats"
+    export AUTOSPEC_WATCHDOG_STATE_FILE="$HOME/.autospec/watchdog-state.tsv"
+    export AUTOSPEC_WATCHDOG_STALE_SECS=1800
+    export AUTOSPEC_WATCHDOG_RECLAIM_SECS=10800
+    export AUTOSPEC_WATCHDOG_CLAIMED_TIMEOUT_SECS=300
+    mkdir -p "$AUTOSPEC_WATCHDOG_DIR"
+
+    STUB_BIN="$(mktemp -d)"
+    GH_LOG="$HOME/gh.log"
+    export GH_LOG
+    cat > "$STUB_BIN/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$*" >> "$GH_LOG"
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+    case "$3" in
+        406) printf 'CLOSED \n' ;;
+        407) printf 'OPEN auto-implement\n' ;;
+        408) printf 'OPEN in-progress-by-bot\n' ;;
+        409) printf 'OPEN in-progress-by-bot\n' ;;
+        410) printf 'OPEN in-progress-by-bot\n' ;;
+        *) printf 'OPEN in-progress-by-bot\n' ;;
+    esac
+    exit 0
+fi
+exit 0
+GHSTUB
+    chmod +x "$STUB_BIN/gh"
+    export PATH="$STUB_BIN:$PATH"
+
+    NOW="$(date -u +%s)"
+    export NOW
+}
+
+teardown() {
+    rm -rf "$HOME" "$STUB_BIN"
+}
+
+write_hb() {
+    issue="$1"
+    step="$2"
+    age="$3"
+    ts=$((NOW - age))
+    cat > "$AUTOSPEC_WATCHDOG_DIR/$issue.json" <<EOF
+{"issue":$issue,"branch":"feat/$issue","step":"$step","ts":$ts,"pr":"","repo":"owner/repo"}
+EOF
+}
+
+@test "startup reconciliation garbage-collects closed and orphaned heartbeats" {
+    write_hb 406 worktree_ready 10
+    write_hb 407 worktree_ready 10
+
+    run bash "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ ! -f "$AUTOSPEC_WATCHDOG_DIR/406.json" ]
+    [ ! -f "$AUTOSPEC_WATCHDOG_DIR/407.json" ]
+    echo "$output" | grep -q 'garbage_collected=2'
+}
+
+@test "old heartbeat schemas are rejected before issue processing" {
+    cat > "$AUTOSPEC_WATCHDOG_DIR/408.json" <<EOF
+{"issue":408,"status":"in_progress","ts":$((NOW - 10))}
+EOF
+
+    run bash "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ ! -f "$AUTOSPEC_WATCHDOG_DIR/408.json" ]
+    echo "$output" | grep -q 'invalid_schema=1'
+    ! grep -q 'issue edit 408' "$GH_LOG"
+}
+
+@test "claimed heartbeat older than timeout is released immediately" {
+    write_hb 409 claimed 360
+
+    run bash "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ ! -f "$AUTOSPEC_WATCHDOG_DIR/409.json" ]
+    echo "$output" | grep -q 'claimed_released=1'
+    grep -q 'issue edit 409 --remove-label in-progress-by-bot --add-label auto-implement' "$GH_LOG"
+}
+
+@test "current schema is normalized without deleting active heartbeat" {
+    cat > "$AUTOSPEC_WATCHDOG_DIR/410.json" <<EOF
+{"issue":410,"branch":"feat/410","step":"tests_started","ts":$((NOW - 10))}
+EOF
+
+    run bash "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ -f "$AUTOSPEC_WATCHDOG_DIR/410.json" ]
+    jq -e '.issue == "410" and .pr == "" and .repo == ""' "$AUTOSPEC_WATCHDOG_DIR/410.json" >/dev/null
+}

--- a/tests/unit/test_phase3_lint_integration.bats
+++ b/tests/unit/test_phase3_lint_integration.bats
@@ -2,7 +2,7 @@
 # tests/unit/test_phase3_lint_integration.bats — grep assertions verifying that
 # every trio file in skills/autospec, skills/autospec-define, and
 # skills/autospec-classify mentions the Phase 3 lint loop and Phase 3.5 audit
-# keywords (scripts/lint-issue.sh, needs-quality-bar, ## Quality lint).
+# keywords (installed lint-issue.sh helper path, needs-quality-bar, ## Quality lint).
 
 setup() {
     REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
@@ -10,16 +10,16 @@ setup() {
 
 # ── skills/autospec ────────────────────────────────────────────────────────────
 
-@test "autospec Phase 3 trio: SKILL.md mentions scripts/lint-issue.sh" {
-    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec/SKILL.md"
+@test "autospec Phase 3 trio: SKILL.md mentions installed lint-issue.sh" {
+    grep -q 'AUTOSPEC_SCRIPTS_DIR.*lint-issue.sh' "$REPO_ROOT/skills/autospec/SKILL.md"
 }
 
-@test "autospec Phase 3 trio: codex/prompt.md mentions scripts/lint-issue.sh" {
-    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec/codex/prompt.md"
+@test "autospec Phase 3 trio: codex/prompt.md mentions installed lint-issue.sh" {
+    grep -q 'AUTOSPEC_SCRIPTS_DIR.*lint-issue.sh' "$REPO_ROOT/skills/autospec/codex/prompt.md"
 }
 
-@test "autospec Phase 3 trio: opencode/agent.md mentions scripts/lint-issue.sh" {
-    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec/opencode/agent.md"
+@test "autospec Phase 3 trio: opencode/agent.md mentions installed lint-issue.sh" {
+    grep -q 'AUTOSPEC_SCRIPTS_DIR.*lint-issue.sh' "$REPO_ROOT/skills/autospec/opencode/agent.md"
 }
 
 @test "autospec Phase 3.5 trio: SKILL.md mentions needs-quality-bar" {
@@ -40,16 +40,16 @@ setup() {
 
 # ── skills/autospec-define ────────────────────────────────────────────────────
 
-@test "autospec-define Phase 3 trio: SKILL.md mentions scripts/lint-issue.sh" {
-    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec-define/SKILL.md"
+@test "autospec-define Phase 3 trio: SKILL.md mentions installed lint-issue.sh" {
+    grep -q 'AUTOSPEC_SCRIPTS_DIR.*lint-issue.sh' "$REPO_ROOT/skills/autospec-define/SKILL.md"
 }
 
-@test "autospec-define Phase 3 trio: codex/prompt.md mentions scripts/lint-issue.sh" {
-    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec-define/codex/prompt.md"
+@test "autospec-define Phase 3 trio: codex/prompt.md mentions installed lint-issue.sh" {
+    grep -q 'AUTOSPEC_SCRIPTS_DIR.*lint-issue.sh' "$REPO_ROOT/skills/autospec-define/codex/prompt.md"
 }
 
-@test "autospec-define Phase 3 trio: opencode/agent.md mentions scripts/lint-issue.sh" {
-    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec-define/opencode/agent.md"
+@test "autospec-define Phase 3 trio: opencode/agent.md mentions installed lint-issue.sh" {
+    grep -q 'AUTOSPEC_SCRIPTS_DIR.*lint-issue.sh' "$REPO_ROOT/skills/autospec-define/opencode/agent.md"
 }
 
 @test "autospec-define Phase 3.5 trio: SKILL.md mentions needs-quality-bar" {
@@ -70,8 +70,8 @@ setup() {
 
 # ── skills/autospec-classify ──────────────────────────────────────────────────
 
-@test "autospec-classify audit trio: SKILL.md mentions scripts/lint-issue.sh" {
-    grep -q 'scripts/lint-issue.sh' "$REPO_ROOT/skills/autospec-classify/SKILL.md"
+@test "autospec-classify audit trio: SKILL.md mentions installed lint-issue.sh" {
+    grep -q 'AUTOSPEC_SCRIPTS_DIR.*lint-issue.sh' "$REPO_ROOT/skills/autospec-classify/SKILL.md"
 }
 
 @test "autospec-classify audit trio: SKILL.md mentions needs-quality-bar" {
@@ -92,8 +92,8 @@ setup() {
 
 # ── cross-skill lock-step parity ──────────────────────────────────────────────
 
-@test "lock-step: all 3 autospec-define harness files mention scripts/lint-issue.sh" {
-    COUNT=$(grep -rl 'scripts/lint-issue.sh' \
+@test "lock-step: all 3 autospec-define harness files mention installed lint-issue.sh" {
+    COUNT=$(grep -rl 'AUTOSPEC_SCRIPTS_DIR.*lint-issue.sh' \
         "$REPO_ROOT/skills/autospec-define/SKILL.md" \
         "$REPO_ROOT/skills/autospec-define/codex/prompt.md" \
         "$REPO_ROOT/skills/autospec-define/opencode/agent.md" | wc -l | tr -d ' ')


### PR DESCRIPTION
## Summary
- install shared autospec helper scripts into `~/.autospec/scripts` from every skill installer
- route skill prompt helper calls through `AUTOSPEC_SCRIPTS_DIR` instead of target repo-local `scripts/`
- reconcile autospec monitor heartbeats before candidate selection, including closed/orphan cleanup, schema validation, and claimed-timeout release

## Tests
- `bash scripts/dev-bootstrap.sh`
- `bash scripts/validate.sh`
- `bats tests/unit tests/smoke`
- `bats tests/e2e` (2 E2E-gated tests skipped)
- `bash tests/integration/test_guardian_flow.sh` (skips cleanly without `GH_TOKEN`)
- `git diff --check`

## Notes
- PowerShell watchdog parity was updated, but local `pwsh` is unavailable, so runtime execution was not locally tested.
