### PR TITLE
fix: Surface autospec issue summaries before execution

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -351,6 +351,27 @@ check_phase4_guardian_block_lockstep() {
     info "guardian lockstep: all 6 trio files byte-identical"
 }
 
+# Phase 4 issue-start visibility: every monitor surface that can process
+# auto-implement issues must print a concise issue summary after claim and
+# before `process(ISSUE)` dispatch. This keeps long-running monitors observable.
+check_phase4_issue_start_summary() {
+    info "phase4 issue-start summary: autospec + autospec-run trio"
+    for s in autospec autospec-run; do
+        for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
+            grep -q 'Issue start summary' "$f" \
+                || fail "$f missing Issue start summary directive"
+            grep -q '\[monitor\] starting #\$ISSUE:' "$f" \
+                || fail "$f missing [monitor] starting issue summary line"
+            grep -q '\[monitor\] goal:' "$f" \
+                || fail "$f missing [monitor] goal summary line"
+            grep -q '\[monitor\] smoke:' "$f" \
+                || fail "$f missing [monitor] smoke summary line"
+            grep -q '\[monitor\] scope:' "$f" \
+                || fail "$f missing [monitor] scope summary line"
+        done
+    done
+}
+
 # Governance copy: the listener lifecycle and anti-loop guardrails must be
 # documented in AGENTS.md, and the listener skill must appear in both the
 # top-level README.md and SKILLS.md skill index. Spec §6.1, §7.1.
@@ -419,6 +440,7 @@ main() {
     check_lint_issue_helpers
     check_lint_implementation_helpers
     check_phase4_guardian_block_lockstep
+    check_phase4_issue_start_summary
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -305,6 +305,35 @@ Then launch a **background subagent** with this prompt verbatim:
 >   fi
 >   mkdir -p "$HOME/.autospec/process-heartbeats"
 >   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
+>   # Issue start summary — print before dispatching process(ISSUE) so the operator
+>   # knows exactly what the monitor is about to work on.
+>   ISSUE_TITLE=$(gh issue view ISSUE --json title --jq .title 2>/dev/null || echo "")
+>   ISSUE_URL=$(gh issue view ISSUE --json url --jq .url 2>/dev/null || echo "")
+>   ISSUE_LABELS=$(gh issue view ISSUE --json labels --jq -r '[.labels[].name] | join(", ")' 2>/dev/null || echo "")
+>   ISSUE_BODY=$(gh issue view ISSUE --json body --jq .body 2>/dev/null || echo "")
+>   ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     BEGIN{in_goal=0}
+>     /^## Goal[[:space:]]*$/ {in_goal=1; next}
+>     /^## / && in_goal {exit}
+>     in_goal && NF {print; exit}
+>   ')
+>   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk 'NF && $0 !~ /^#/ {print; exit}')
+>   ISSUE_SMOKE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     /### Primary smoke test/ {seen=1; next}
+>     seen && /^```/ {fence++; next}
+>     seen && fence==1 && NF && $0 !~ /^[[:space:]]*#/ {print; exit}
+>   ')
+>   ISSUE_SCOPE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     /^## Implementation outline[[:space:]]*$/ {in_scope=1; next}
+>     /^## / && in_scope {exit}
+>     in_scope && /^- / {gsub(/^- /,""); print; count++; if (count>=3) exit}
+>   ' | paste -sd '; ' -)
+>   echo "[monitor] starting #$ISSUE: ${ISSUE_TITLE:-<untitled>}"
+>   echo "[monitor] url: ${ISSUE_URL:-<unknown>}"
+>   echo "[monitor] labels: ${ISSUE_LABELS:-<none>}"
+>   echo "[monitor] goal: ${ISSUE_GOAL:-<not provided>}"
+>   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
+>   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -300,6 +300,35 @@ Then launch a **background subagent** with this prompt verbatim:
 >   fi
 >   mkdir -p "$HOME/.autospec/process-heartbeats"
 >   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
+>   # Issue start summary — print before dispatching process(ISSUE) so the operator
+>   # knows exactly what the monitor is about to work on.
+>   ISSUE_TITLE=$(gh issue view ISSUE --json title --jq .title 2>/dev/null || echo "")
+>   ISSUE_URL=$(gh issue view ISSUE --json url --jq .url 2>/dev/null || echo "")
+>   ISSUE_LABELS=$(gh issue view ISSUE --json labels --jq -r '[.labels[].name] | join(", ")' 2>/dev/null || echo "")
+>   ISSUE_BODY=$(gh issue view ISSUE --json body --jq .body 2>/dev/null || echo "")
+>   ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     BEGIN{in_goal=0}
+>     /^## Goal[[:space:]]*$/ {in_goal=1; next}
+>     /^## / && in_goal {exit}
+>     in_goal && NF {print; exit}
+>   ')
+>   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk 'NF && $0 !~ /^#/ {print; exit}')
+>   ISSUE_SMOKE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     /### Primary smoke test/ {seen=1; next}
+>     seen && /^```/ {fence++; next}
+>     seen && fence==1 && NF && $0 !~ /^[[:space:]]*#/ {print; exit}
+>   ')
+>   ISSUE_SCOPE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     /^## Implementation outline[[:space:]]*$/ {in_scope=1; next}
+>     /^## / && in_scope {exit}
+>     in_scope && /^- / {gsub(/^- /,""); print; count++; if (count>=3) exit}
+>   ' | paste -sd '; ' -)
+>   echo "[monitor] starting #$ISSUE: ${ISSUE_TITLE:-<untitled>}"
+>   echo "[monitor] url: ${ISSUE_URL:-<unknown>}"
+>   echo "[monitor] labels: ${ISSUE_LABELS:-<none>}"
+>   echo "[monitor] goal: ${ISSUE_GOAL:-<not provided>}"
+>   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
+>   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -304,6 +304,35 @@ Then launch a **background subagent** with this prompt verbatim:
 >   fi
 >   mkdir -p "$HOME/.autospec/process-heartbeats"
 >   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
+>   # Issue start summary — print before dispatching process(ISSUE) so the operator
+>   # knows exactly what the monitor is about to work on.
+>   ISSUE_TITLE=$(gh issue view ISSUE --json title --jq .title 2>/dev/null || echo "")
+>   ISSUE_URL=$(gh issue view ISSUE --json url --jq .url 2>/dev/null || echo "")
+>   ISSUE_LABELS=$(gh issue view ISSUE --json labels --jq -r '[.labels[].name] | join(", ")' 2>/dev/null || echo "")
+>   ISSUE_BODY=$(gh issue view ISSUE --json body --jq .body 2>/dev/null || echo "")
+>   ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     BEGIN{in_goal=0}
+>     /^## Goal[[:space:]]*$/ {in_goal=1; next}
+>     /^## / && in_goal {exit}
+>     in_goal && NF {print; exit}
+>   ')
+>   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk 'NF && $0 !~ /^#/ {print; exit}')
+>   ISSUE_SMOKE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     /### Primary smoke test/ {seen=1; next}
+>     seen && /^```/ {fence++; next}
+>     seen && fence==1 && NF && $0 !~ /^[[:space:]]*#/ {print; exit}
+>   ')
+>   ISSUE_SCOPE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     /^## Implementation outline[[:space:]]*$/ {in_scope=1; next}
+>     /^## / && in_scope {exit}
+>     in_scope && /^- / {gsub(/^- /,""); print; count++; if (count>=3) exit}
+>   ' | paste -sd '; ' -)
+>   echo "[monitor] starting #$ISSUE: ${ISSUE_TITLE:-<untitled>}"
+>   echo "[monitor] url: ${ISSUE_URL:-<unknown>}"
+>   echo "[monitor] labels: ${ISSUE_LABELS:-<none>}"
+>   echo "[monitor] goal: ${ISSUE_GOAL:-<not provided>}"
+>   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
+>   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -582,6 +582,35 @@ Then launch a **background subagent** with this prompt verbatim:
 >   fi
 >   mkdir -p "$HOME/.autospec/process-heartbeats"
 >   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
+>   # Issue start summary — print before dispatching process(ISSUE) so the operator
+>   # knows exactly what the monitor is about to work on.
+>   ISSUE_TITLE=$(gh issue view ISSUE --json title --jq .title 2>/dev/null || echo "")
+>   ISSUE_URL=$(gh issue view ISSUE --json url --jq .url 2>/dev/null || echo "")
+>   ISSUE_LABELS=$(gh issue view ISSUE --json labels --jq -r '[.labels[].name] | join(", ")' 2>/dev/null || echo "")
+>   ISSUE_BODY=$(gh issue view ISSUE --json body --jq .body 2>/dev/null || echo "")
+>   ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     BEGIN{in_goal=0}
+>     /^## Goal[[:space:]]*$/ {in_goal=1; next}
+>     /^## / && in_goal {exit}
+>     in_goal && NF {print; exit}
+>   ')
+>   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk 'NF && $0 !~ /^#/ {print; exit}')
+>   ISSUE_SMOKE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     /### Primary smoke test/ {seen=1; next}
+>     seen && /^```/ {fence++; next}
+>     seen && fence==1 && NF && $0 !~ /^[[:space:]]*#/ {print; exit}
+>   ')
+>   ISSUE_SCOPE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     /^## Implementation outline[[:space:]]*$/ {in_scope=1; next}
+>     /^## / && in_scope {exit}
+>     in_scope && /^- / {gsub(/^- /,""); print; count++; if (count>=3) exit}
+>   ' | paste -sd '; ' -)
+>   echo "[monitor] starting #$ISSUE: ${ISSUE_TITLE:-<untitled>}"
+>   echo "[monitor] url: ${ISSUE_URL:-<unknown>}"
+>   echo "[monitor] labels: ${ISSUE_LABELS:-<none>}"
+>   echo "[monitor] goal: ${ISSUE_GOAL:-<not provided>}"
+>   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
+>   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -576,6 +576,35 @@ Then launch a **background subagent** with this prompt verbatim:
 >   fi
 >   mkdir -p "$HOME/.autospec/process-heartbeats"
 >   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
+>   # Issue start summary — print before dispatching process(ISSUE) so the operator
+>   # knows exactly what the monitor is about to work on.
+>   ISSUE_TITLE=$(gh issue view ISSUE --json title --jq .title 2>/dev/null || echo "")
+>   ISSUE_URL=$(gh issue view ISSUE --json url --jq .url 2>/dev/null || echo "")
+>   ISSUE_LABELS=$(gh issue view ISSUE --json labels --jq -r '[.labels[].name] | join(", ")' 2>/dev/null || echo "")
+>   ISSUE_BODY=$(gh issue view ISSUE --json body --jq .body 2>/dev/null || echo "")
+>   ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     BEGIN{in_goal=0}
+>     /^## Goal[[:space:]]*$/ {in_goal=1; next}
+>     /^## / && in_goal {exit}
+>     in_goal && NF {print; exit}
+>   ')
+>   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk 'NF && $0 !~ /^#/ {print; exit}')
+>   ISSUE_SMOKE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     /### Primary smoke test/ {seen=1; next}
+>     seen && /^```/ {fence++; next}
+>     seen && fence==1 && NF && $0 !~ /^[[:space:]]*#/ {print; exit}
+>   ')
+>   ISSUE_SCOPE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     /^## Implementation outline[[:space:]]*$/ {in_scope=1; next}
+>     /^## / && in_scope {exit}
+>     in_scope && /^- / {gsub(/^- /,""); print; count++; if (count>=3) exit}
+>   ' | paste -sd '; ' -)
+>   echo "[monitor] starting #$ISSUE: ${ISSUE_TITLE:-<untitled>}"
+>   echo "[monitor] url: ${ISSUE_URL:-<unknown>}"
+>   echo "[monitor] labels: ${ISSUE_LABELS:-<none>}"
+>   echo "[monitor] goal: ${ISSUE_GOAL:-<not provided>}"
+>   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
+>   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -580,6 +580,35 @@ Then launch a **background subagent** with this prompt verbatim:
 >   fi
 >   mkdir -p "$HOME/.autospec/process-heartbeats"
 >   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
+>   # Issue start summary — print before dispatching process(ISSUE) so the operator
+>   # knows exactly what the monitor is about to work on.
+>   ISSUE_TITLE=$(gh issue view ISSUE --json title --jq .title 2>/dev/null || echo "")
+>   ISSUE_URL=$(gh issue view ISSUE --json url --jq .url 2>/dev/null || echo "")
+>   ISSUE_LABELS=$(gh issue view ISSUE --json labels --jq -r '[.labels[].name] | join(", ")' 2>/dev/null || echo "")
+>   ISSUE_BODY=$(gh issue view ISSUE --json body --jq .body 2>/dev/null || echo "")
+>   ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     BEGIN{in_goal=0}
+>     /^## Goal[[:space:]]*$/ {in_goal=1; next}
+>     /^## / && in_goal {exit}
+>     in_goal && NF {print; exit}
+>   ')
+>   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk 'NF && $0 !~ /^#/ {print; exit}')
+>   ISSUE_SMOKE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     /### Primary smoke test/ {seen=1; next}
+>     seen && /^```/ {fence++; next}
+>     seen && fence==1 && NF && $0 !~ /^[[:space:]]*#/ {print; exit}
+>   ')
+>   ISSUE_SCOPE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>     /^## Implementation outline[[:space:]]*$/ {in_scope=1; next}
+>     /^## / && in_scope {exit}
+>     in_scope && /^- / {gsub(/^- /,""); print; count++; if (count>=3) exit}
+>   ' | paste -sd '; ' -)
+>   echo "[monitor] starting #$ISSUE: ${ISSUE_TITLE:-<untitled>}"
+>   echo "[monitor] url: ${ISSUE_URL:-<unknown>}"
+>   echo "[monitor] labels: ${ISSUE_LABELS:-<none>}"
+>   echo "[monitor] goal: ${ISSUE_GOAL:-<not provided>}"
+>   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
+>   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
 >   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
 > ```


### PR DESCRIPTION
## Summary

- print a concise `[monitor] starting #...` block after autospec claims an issue and before `process(ISSUE)` dispatches
- include title, URL, labels, goal, primary smoke command, and implementation scope snippets
- mirror the behavior across `/autospec-run` and full `/autospec` for SKILL, Codex, and OpenCode surfaces
- add a `scripts/validate.sh` invariant so the summary block cannot silently disappear

## Verification

- `bash scripts/validate.sh`
- `bats tests/unit tests/smoke` (229 tests)
