### PR TITLE
[codex] Add autospec-story repo narrative mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Code**, **OpenCode**, and **Codex CLI**.
 | [`autospec-run`](skills/autospec-run/README.md) | 4–6 | Implementation half. Picks up the populated `auto-implement` queue and runs the autonomous monitor. Supports `--profile <name>` filtering against `~/.autospec/model-profiles.yml`. |
 | [`autospec-classify`](skills/autospec-classify/README.md) | retro | Standalone retro-labeler for already-existing `auto-implement` issues; applies the Phase 3.5 rubric to a queue that pre-dates Phase 3.5. |
 | [`autospec-listen`](skills/autospec-listen/README.md) | passive | Passive listener for chat-driven issue / spec triggers. On a phrase like "file an issue" or "write a spec", drafts a GitHub issue body for confirmation or routes to `/autospec-define`. |
+| [`autospec-story`](skills/autospec-story/README.md) | story | Read-only repo narrative. Synthesizes local specs, GitHub issues/PRs, and recent git history into a cited application story and implementation-state overview. |
 | [`autospec-stop`](skills/autospec-stop/README.md) | control | Stop/resume utility for active autospec monitors. Supports graceful, immediate, status, and resume flows through the shared stop sentinel. |
 
 Cost-aware **two-tier** subagent dispatch: spec/research/decompose/review subagents use the top model with extended thinking (Tier A — Claude Code: `opus` + `ultrathink`; Codex: top GPT + `reasoning_effort=high`; OpenCode: top task tier); implementer + LGTM-review subagents use the cheaper model with medium thinking (Tier B — Claude Code: `sonnet`; Codex: `gpt-5.1-codex-spark`; OpenCode: smaller task tier). Both tiers fall back UP on unavailability. The orchestrator runs whatever model you invoked the skill with — invoke it on top tier for best spec quality. See `AGENTS.md` for the full policy.
@@ -94,6 +95,7 @@ stops without entering the normal pipeline:
 /autospec-run update
 /autospec-classify update
 /autospec-listen update
+/autospec-story update
 /autospec-stop update
 ```
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -16,6 +16,14 @@
 - Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
 - Status: trigger-listener for chat-driven issue / spec creation. Files issues with `needs-classify` label so `/autospec-classify` can transition them onto the `auto-implement` queue. See [`skills/autospec-listen/README.md`](skills/autospec-listen/README.md).
 
+## autospec-story
+
+- Path: [`skills/autospec-story`](skills/autospec-story)
+- Trigger: use when a user asks for a complete repo story, implementation overview, product history, or state report from local specs plus GitHub issues and PRs.
+- Activation keywords: `autospec-story`, `repo story`, `application story`, `implementation state`, `what has been built`, `complete overview`, `state of the application`
+- Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
+- Status: read-only synthesis mode. Produces a cited Markdown report that separates evidence, inference, open work, completed work, and unknowns. See [`skills/autospec-story/README.md`](skills/autospec-story/README.md).
+
 ## autospec-split
 
 - Path: [`skills/autospec-split`](skills/autospec-split)

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
 #   ./install.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-classify | autospec-listen | all
+#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-classify | autospec-listen | autospec-story | autospec-stop | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -27,7 +27,7 @@ set -eu
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$REPO_ROOT/skills"
 
-ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
+ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-story autospec-stop"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -75,10 +75,10 @@ done
 
 # Validate --skill
 case "$SKILL_ARG" in
-    all|autospec|autospec-split|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-stop) ;;
+    all|autospec|autospec-split|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-story|autospec-stop) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
-        err "must be one of: autospec | autospec-split | autospec-define | autospec-run | autospec-classify | autospec-listen | autospec-stop | all"
+        err "must be one of: autospec | autospec-split | autospec-define | autospec-run | autospec-classify | autospec-listen | autospec-story | autospec-stop | all"
         exit 2
         ;;
 esac

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -135,7 +135,7 @@ check_startup_preflight() {
     }
     canonical=$(extract_block skills/autospec/SKILL.md)
     [ -n "$canonical" ] || fail "autospec SKILL.md missing ## Startup self-update section"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-stop; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop; do
         for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
             body=$(extract_block "$f")
             [ -n "$body" ] || fail "$f missing ## Startup self-update section"
@@ -152,7 +152,7 @@ check_startup_preflight() {
 # prompts/ path AND the new skills/ slash-command registry path.
 check_codex_skills_install() {
     info "codex skills-dir install: all skills"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-stop; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop; do
         f="skills/$s/install.sh"
         grep -q 'skills/\$SKILL_NAME/SKILL\.md' "$f" \
             || fail "$f missing Codex skills-dir install (skills/\$SKILL_NAME/SKILL.md)"
@@ -167,7 +167,7 @@ check_codex_skills_install() {
 check_shared_script_install() {
     info "shared helper install: all skills"
     helpers="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-stop; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop; do
         f="skills/$s/install.sh"
         grep -q 'install_shared_scripts' "$f" \
             || fail "$f missing install_shared_scripts function/call"
@@ -217,6 +217,8 @@ check_subagent_model_tier() {
         autospec-run)
             expected_a=1; expected_b=2 ;;
         autospec-classify)
+            expected_a=1; expected_b=0 ;;
+        autospec-story)
             expected_a=1; expected_b=0 ;;
         *)
             expected_a=""; expected_b="" ;;
@@ -386,10 +388,14 @@ check_governance_headings() {
     [ -f README.md ] || fail "README.md: file missing at repo root"
     grep -q 'autospec-listen' README.md \
         || fail "README.md: missing 'autospec-listen' reference"
+    grep -q 'autospec-story' README.md \
+        || fail "README.md: missing 'autospec-story' reference"
 
     [ -f SKILLS.md ] || fail "SKILLS.md: file missing at repo root"
     grep -q 'autospec-listen' SKILLS.md \
         || fail "SKILLS.md: missing 'autospec-listen' reference"
+    grep -q 'autospec-story' SKILLS.md \
+        || fail "SKILLS.md: missing 'autospec-story' reference"
 }
 
 # Existing spec mode invariants: autospec, autospec-split, and autospec-define must expose the

--- a/skills/autospec-story/README.md
+++ b/skills/autospec-story/README.md
@@ -1,0 +1,45 @@
+# autospec-story
+
+Read-only story mode for an existing GitHub repository. It reconciles local specs,
+docs, GitHub issues, GitHub PRs, and recent git history into a complete product
+story and implementation-state report.
+
+Use it when you need to answer:
+
+- What is this application trying to become?
+- Which capabilities are implemented, in progress, planned, or unknown?
+- Which specs, issues, PRs, and commits support that conclusion?
+- What should the team inspect next?
+
+## Usage
+
+```bash
+/autospec-story
+/autospec-story --output docs/autospec-story.md
+/autospec-story --since 2026-05-01 --limit 200 --output docs/autospec-story.md
+```
+
+The workflow is read-only against GitHub and the target repo unless `--output` is
+provided, in which case it writes the requested Markdown report path.
+
+## Evidence Sources
+
+- Local docs and specs, including `docs/specs/*.md`, `docs/superpowers/specs/*.md`, `.omx/plans/*.md`, `README.md`, `AGENTS.md`, and architecture/runbook docs.
+- GitHub issues in both open and closed states.
+- GitHub PRs in open, merged, and closed states.
+- Recent git history and dirty worktree status.
+
+## Output
+
+The report is grouped by product capability, not just by issue number. It
+separates direct evidence from inference and unknowns, and every major claim is
+expected to cite a local path, issue, PR, or commit id.
+
+## Self-update
+
+Once installed, run the skill with the literal argument `update` to refresh in
+place:
+
+```bash
+/autospec-story update
+```

--- a/skills/autospec-story/SKILL.md
+++ b/skills/autospec-story/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: autospec-story
+description: Use when the user wants a repo-level product story, implementation-state overview, or narrative synthesis from local specs plus GitHub issues and PRs for the current repository.
+---
+
+# autospec-story (harness-neutral)
+
+Read-only repo storyteller. Build a complete overview of the current GitHub
+repository by reconciling local specs, docs, GitHub issues, GitHub PRs, and
+recent git history into one cited Markdown narrative: what the application is,
+why it exists, what has been implemented, what remains open, and which parts
+are evidence versus inference.
+
+Manage your own context — never exceed 60%. Delegate the final synthesis to a
+Tier A subagent whenever your harness supports it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-story   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$`
+(case-insensitive, whitespace-padded), this skill enters self-update mode and
+does not run the normal story workflow:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-story/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-story.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-story.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-story/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched
+   copy.
+4. **Stop.** Do not gather repo state or write a story report. Print the upgrade
+   summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of
+autospec-story found; run install.sh first.` and exit.
+
+## Invocation
+
+```
+/autospec-story [--since <date>] [--output <path>] [--limit <N>]
+```
+
+- `--since <date>` — limit GitHub issue, PR, and git-history collection to
+  items created or updated since the date. Accepts GitHub search date syntax
+  such as `2026-05-01`.
+- `--output <path>` — write the report to a local Markdown file in addition to
+  printing the summary. Default: print only.
+- `--limit <N>` — cap GitHub issue and PR collection per state bucket. Default:
+  `500`.
+
+This skill is read-only with respect to the target repo and GitHub: do not edit
+issues, labels, projects, branches, commits, or pull requests.
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your
+harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                              | Codex CLI                              | Fallback if missing                                |
+|-----------------------------|--------------------------------------|---------------------------------------|----------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode        | shell `rg`, `git`, `gh`                | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output  | spawn nested CLI session               | Do the synthesis in-thread                         |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                         | inline prompt                          | Ask in the response and wait for the next turn     |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; fall back UP on unavailability |
+
+**Persistent project notes**: read durable preferences from **`AGENTS.md`** in
+the repo root. If multiple scoped AGENTS files exist, honor the deepest one for
+files under that scope. Per AGENTS.md, the synthesis subagent uses **Tier A
+(spec work)** because the output is a spec-adjacent reasoning artifact. The
+orchestrator keeps the user's invoked model. Fall back UP the tier on
+unavailability.
+
+## Pre-flight
+
+1. Verify the current directory is inside a git worktree:
+   `git rev-parse --show-toplevel`.
+2. Verify the repo is connected to GitHub:
+   `gh repo view --json nameWithOwner,url -q '.nameWithOwner + " " + .url'`.
+3. Verify `gh auth status` is authenticated. If unavailable, continue with local
+   evidence only and mark GitHub state as missing evidence.
+4. Parse flags. Default `LIMIT=500`; if `--since` is present, add
+   `--search "created:>=<date> OR updated:>=<date>"` only where the GitHub CLI
+   command supports it.
+
+## Evidence collection
+
+Collect evidence into a temporary working directory under `${TMPDIR:-/tmp}`.
+Use structured JSON where possible and keep raw command output so the final
+report can cite sources.
+
+### Local repository evidence
+
+Run from the repo root:
+
+```bash
+git rev-parse --show-toplevel
+git branch --show-current
+git status --short --branch
+git log --date=short --pretty=format:'%h%x09%ad%x09%s' --max-count 200
+rg --files docs .github examples skills scripts tests | sort
+```
+
+Read only the files that help establish product story or implementation state:
+
+- `README.md`, `AGENTS.md`, `SKILLS.md`, `CONTRIBUTING.md`.
+- `docs/specs/*.md`, `docs/superpowers/specs/*.md`, `.omx/plans/*.md`.
+- `docs/architecture.md`, `docs/user-manual.md`, `docs/runbooks/*.md`.
+- Repo-specific package manifests, service entry points, and top-level
+  architecture docs discovered by `rg --files`.
+
+Do not bulk-paste entire large files into the final answer. Extract titles,
+section headings, decisions, acceptance criteria, and completion markers.
+
+### GitHub issue evidence
+
+Collect both open and closed issues; closed issues are the primary source for
+completed work.
+
+```bash
+gh issue list --state open --limit "$LIMIT" --json number,title,state,labels,assignees,createdAt,updatedAt,url,body
+gh issue list --state closed --limit "$LIMIT" --json number,title,state,labels,assignees,createdAt,updatedAt,closedAt,url,body
+```
+
+If `--since` is present, prefer GitHub search filters; if a command cannot
+express the filter, collect first and filter by timestamp during synthesis.
+
+### GitHub PR evidence
+
+Collect open, merged, and closed PRs:
+
+```bash
+gh pr list --state open --limit "$LIMIT" --json number,title,state,labels,createdAt,updatedAt,url,body,headRefName,baseRefName
+gh pr list --state merged --limit "$LIMIT" --json number,title,state,labels,createdAt,updatedAt,mergedAt,url,body,headRefName,baseRefName
+gh pr list --state closed --limit "$LIMIT" --json number,title,state,labels,createdAt,updatedAt,closedAt,url,body,headRefName,baseRefName
+```
+
+Map PRs back to issues by parsing `Closes #N`, `Fixes #N`, `Refs #N`, branch
+names, labels, and issue URLs in PR bodies. Treat this mapping as inference
+unless the PR body has an explicit close/reference line.
+
+## Story synthesis
+
+> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking
+> per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT +
+> `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on
+> unavailability.
+
+Synthesize a cited report. Preserve the distinction between evidence and
+inference:
+
+- Evidence: direct local file paths, issue numbers, PR numbers, labels, commit
+  subjects, spec section titles, and explicit close/reference lines.
+- Inference: likely component state, intent that is implied by multiple related
+  issues, and PR-to-issue mappings without explicit closing syntax.
+- Unknown: anything not supported by current local files, GitHub artifacts, or
+  git history.
+
+Prioritize a complete overview over chronological exhaustiveness. Cluster work
+by product capability or application subsystem, not by issue number alone.
+
+## Report format
+
+When `--output` is provided, write this exact Markdown shape to that path. When
+printing in chat, include the executive summary plus the most important state
+tables and cite the report path if one was written.
+
+```markdown
+# Autospec Story: <owner/repo>
+
+Generated: <ISO8601 timestamp>
+Repo root: `<absolute path>`
+GitHub: <repo url or "unavailable">
+Evidence window: <all available evidence or --since date>
+
+## Executive Summary
+
+<5-8 bullets describing what the application is, current implementation state,
+and the highest-signal open gaps. Each bullet cites at least one source.>
+
+## Application Story
+
+<Narrative of the problem, product direction, and major design decisions.>
+
+## Evidence Map
+
+| Evidence type | Count | Primary sources |
+| --- | ---: | --- |
+| Specs | N | `docs/specs/...` |
+| Open issues | N | #1, #2 |
+| Closed issues | N | #3, #4 |
+| Open PRs | N | #5 |
+| Merged PRs | N | #6 |
+| Recent commits | N | `abc1234` |
+
+## Implementation State
+
+| Area | State | Evidence | Notes |
+| --- | --- | --- | --- |
+| <capability> | Implemented / In progress / Planned / Unknown | <paths, #issues, #PRs> | <short note> |
+
+## Completed Work
+
+<Grouped closed issues, merged PRs, and specs that appear implemented.>
+
+## Open Work
+
+<Open issues and unmerged PRs grouped by capability, with blockers called out.>
+
+## Specs and Decisions
+
+<Specs written, key decisions, superseded plans, and active design contracts.>
+
+## Risks, Gaps, and Unknowns
+
+<Explicitly separate missing evidence from known defects.>
+
+## Next Recommended Questions
+
+<Questions the team should ask next, grounded in current state.>
+
+## Source References
+
+<Local paths, issue URLs, PR URLs, and commit ids used as evidence.>
+```
+
+## Quality bar
+
+- Every major claim cites at least one source.
+- Closed issue heartbeats, stale labels, and old specs are treated as historical
+  evidence, not proof of current implementation.
+- Do not claim a feature is implemented solely because an issue exists. Prefer
+  `Planned` unless there is a merged PR, closed issue with implementation
+  detail, or local code/docs evidence.
+- Call out dirty worktree state in the report header so readers know whether
+  the local repo includes uncommitted changes.
+- If GitHub is unavailable, say so clearly and produce a local-only story.
+- If the report is too long for chat, write it to `docs/autospec-story.md` only
+  when the user passed `--output docs/autospec-story.md`; otherwise print a
+  concise story and recommend an output path.

--- a/skills/autospec-story/codex/prompt.md
+++ b/skills/autospec-story/codex/prompt.md
@@ -1,0 +1,280 @@
+
+# autospec-story (harness-neutral)
+
+Read-only repo storyteller. Build a complete overview of the current GitHub
+repository by reconciling local specs, docs, GitHub issues, GitHub PRs, and
+recent git history into one cited Markdown narrative: what the application is,
+why it exists, what has been implemented, what remains open, and which parts
+are evidence versus inference.
+
+Manage your own context — never exceed 60%. Delegate the final synthesis to a
+Tier A subagent whenever your harness supports it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-story   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$`
+(case-insensitive, whitespace-padded), this skill enters self-update mode and
+does not run the normal story workflow:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-story/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-story.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-story.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-story/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched
+   copy.
+4. **Stop.** Do not gather repo state or write a story report. Print the upgrade
+   summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of
+autospec-story found; run install.sh first.` and exit.
+
+## Invocation
+
+```
+/autospec-story [--since <date>] [--output <path>] [--limit <N>]
+```
+
+- `--since <date>` — limit GitHub issue, PR, and git-history collection to
+  items created or updated since the date. Accepts GitHub search date syntax
+  such as `2026-05-01`.
+- `--output <path>` — write the report to a local Markdown file in addition to
+  printing the summary. Default: print only.
+- `--limit <N>` — cap GitHub issue and PR collection per state bucket. Default:
+  `500`.
+
+This skill is read-only with respect to the target repo and GitHub: do not edit
+issues, labels, projects, branches, commits, or pull requests.
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your
+harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                              | Codex CLI                              | Fallback if missing                                |
+|-----------------------------|--------------------------------------|---------------------------------------|----------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode        | shell `rg`, `git`, `gh`                | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output  | spawn nested CLI session               | Do the synthesis in-thread                         |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                         | inline prompt                          | Ask in the response and wait for the next turn     |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; fall back UP on unavailability |
+
+**Persistent project notes**: read durable preferences from **`AGENTS.md`** in
+the repo root. If multiple scoped AGENTS files exist, honor the deepest one for
+files under that scope. Per AGENTS.md, the synthesis subagent uses **Tier A
+(spec work)** because the output is a spec-adjacent reasoning artifact. The
+orchestrator keeps the user's invoked model. Fall back UP the tier on
+unavailability.
+
+## Pre-flight
+
+1. Verify the current directory is inside a git worktree:
+   `git rev-parse --show-toplevel`.
+2. Verify the repo is connected to GitHub:
+   `gh repo view --json nameWithOwner,url -q '.nameWithOwner + " " + .url'`.
+3. Verify `gh auth status` is authenticated. If unavailable, continue with local
+   evidence only and mark GitHub state as missing evidence.
+4. Parse flags. Default `LIMIT=500`; if `--since` is present, add
+   `--search "created:>=<date> OR updated:>=<date>"` only where the GitHub CLI
+   command supports it.
+
+## Evidence collection
+
+Collect evidence into a temporary working directory under `${TMPDIR:-/tmp}`.
+Use structured JSON where possible and keep raw command output so the final
+report can cite sources.
+
+### Local repository evidence
+
+Run from the repo root:
+
+```bash
+git rev-parse --show-toplevel
+git branch --show-current
+git status --short --branch
+git log --date=short --pretty=format:'%h%x09%ad%x09%s' --max-count 200
+rg --files docs .github examples skills scripts tests | sort
+```
+
+Read only the files that help establish product story or implementation state:
+
+- `README.md`, `AGENTS.md`, `SKILLS.md`, `CONTRIBUTING.md`.
+- `docs/specs/*.md`, `docs/superpowers/specs/*.md`, `.omx/plans/*.md`.
+- `docs/architecture.md`, `docs/user-manual.md`, `docs/runbooks/*.md`.
+- Repo-specific package manifests, service entry points, and top-level
+  architecture docs discovered by `rg --files`.
+
+Do not bulk-paste entire large files into the final answer. Extract titles,
+section headings, decisions, acceptance criteria, and completion markers.
+
+### GitHub issue evidence
+
+Collect both open and closed issues; closed issues are the primary source for
+completed work.
+
+```bash
+gh issue list --state open --limit "$LIMIT" --json number,title,state,labels,assignees,createdAt,updatedAt,url,body
+gh issue list --state closed --limit "$LIMIT" --json number,title,state,labels,assignees,createdAt,updatedAt,closedAt,url,body
+```
+
+If `--since` is present, prefer GitHub search filters; if a command cannot
+express the filter, collect first and filter by timestamp during synthesis.
+
+### GitHub PR evidence
+
+Collect open, merged, and closed PRs:
+
+```bash
+gh pr list --state open --limit "$LIMIT" --json number,title,state,labels,createdAt,updatedAt,url,body,headRefName,baseRefName
+gh pr list --state merged --limit "$LIMIT" --json number,title,state,labels,createdAt,updatedAt,mergedAt,url,body,headRefName,baseRefName
+gh pr list --state closed --limit "$LIMIT" --json number,title,state,labels,createdAt,updatedAt,closedAt,url,body,headRefName,baseRefName
+```
+
+Map PRs back to issues by parsing `Closes #N`, `Fixes #N`, `Refs #N`, branch
+names, labels, and issue URLs in PR bodies. Treat this mapping as inference
+unless the PR body has an explicit close/reference line.
+
+## Story synthesis
+
+> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking
+> per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT +
+> `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on
+> unavailability.
+
+Synthesize a cited report. Preserve the distinction between evidence and
+inference:
+
+- Evidence: direct local file paths, issue numbers, PR numbers, labels, commit
+  subjects, spec section titles, and explicit close/reference lines.
+- Inference: likely component state, intent that is implied by multiple related
+  issues, and PR-to-issue mappings without explicit closing syntax.
+- Unknown: anything not supported by current local files, GitHub artifacts, or
+  git history.
+
+Prioritize a complete overview over chronological exhaustiveness. Cluster work
+by product capability or application subsystem, not by issue number alone.
+
+## Report format
+
+When `--output` is provided, write this exact Markdown shape to that path. When
+printing in chat, include the executive summary plus the most important state
+tables and cite the report path if one was written.
+
+```markdown
+# Autospec Story: <owner/repo>
+
+Generated: <ISO8601 timestamp>
+Repo root: `<absolute path>`
+GitHub: <repo url or "unavailable">
+Evidence window: <all available evidence or --since date>
+
+## Executive Summary
+
+<5-8 bullets describing what the application is, current implementation state,
+and the highest-signal open gaps. Each bullet cites at least one source.>
+
+## Application Story
+
+<Narrative of the problem, product direction, and major design decisions.>
+
+## Evidence Map
+
+| Evidence type | Count | Primary sources |
+| --- | ---: | --- |
+| Specs | N | `docs/specs/...` |
+| Open issues | N | #1, #2 |
+| Closed issues | N | #3, #4 |
+| Open PRs | N | #5 |
+| Merged PRs | N | #6 |
+| Recent commits | N | `abc1234` |
+
+## Implementation State
+
+| Area | State | Evidence | Notes |
+| --- | --- | --- | --- |
+| <capability> | Implemented / In progress / Planned / Unknown | <paths, #issues, #PRs> | <short note> |
+
+## Completed Work
+
+<Grouped closed issues, merged PRs, and specs that appear implemented.>
+
+## Open Work
+
+<Open issues and unmerged PRs grouped by capability, with blockers called out.>
+
+## Specs and Decisions
+
+<Specs written, key decisions, superseded plans, and active design contracts.>
+
+## Risks, Gaps, and Unknowns
+
+<Explicitly separate missing evidence from known defects.>
+
+## Next Recommended Questions
+
+<Questions the team should ask next, grounded in current state.>
+
+## Source References
+
+<Local paths, issue URLs, PR URLs, and commit ids used as evidence.>
+```
+
+## Quality bar
+
+- Every major claim cites at least one source.
+- Closed issue heartbeats, stale labels, and old specs are treated as historical
+  evidence, not proof of current implementation.
+- Do not claim a feature is implemented solely because an issue exists. Prefer
+  `Planned` unless there is a merged PR, closed issue with implementation
+  detail, or local code/docs evidence.
+- Call out dirty worktree state in the report header so readers know whether
+  the local repo includes uncommitted changes.
+- If GitHub is unavailable, say so clearly and produce a local-only story.
+- If the report is too long for chat, write it to `docs/autospec-story.md` only
+  when the user passed `--output docs/autospec-story.md`; otherwise print a
+  concise story and recommend an output path.

--- a/skills/autospec-story/install.sh
+++ b/skills/autospec-story/install.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --symlink           # symlink instead of copy (updates propagate)
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-story/install.sh \
+#     | sh -s -- --harness all
+# When piped, the script auto-downloads the skill files from the same branch.
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPEC_STORY_REF         (default: main) — git ref to fetch from when piped
+#   AUTOSPEC_STORY_RAW_BASE    (override the raw URL base entirely)
+#
+# Idempotent: re-running upgrades the install. Exits non-zero on hard failure;
+# exits zero with warnings on missing optional deps.
+
+set -eu
+
+SKILL_NAME="autospec-story"
+SKILL_RAW_BASE="${AUTOSPEC_STORY_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_STORY_REF:-main}/skills/autospec-story}"
+
+# Resolve the directory containing this script. When piped through stdin (e.g.
+# `curl ... | sh`), $0 will not be a real file — detect that and fall back to
+# downloading the source files from the raw GitHub URL.
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+UPDATE_MODE=0
+TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
+
+# ---------- helpers --------------------------------------------------------
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
+
+Installs the ${SKILL_NAME} skill into the chosen harness's standard
+skill/agent/prompt directory.
+
+Examples:
+  $0                          # interactive
+  $0 --harness all            # install everywhere
+  $0 --harness claude         # Claude Code only
+  $0 --harness opencode       # OpenCode only
+  $0 --harness codex          # Codex CLI only
+  $0 --harness all --symlink  # symlink instead of copy
+  $0 --dry-run --harness all  # print plan, change nothing
+  $0 --harness claude --update  # idempotent re-install (overwrite existing)
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    # Download the files we need into a temp dir and set SKILL_DIR to it.
+    if ! command -v curl >/dev/null 2>&1; then
+        err "curl is required when running from stdin (e.g. piped via 'curl | sh')."
+        exit 1
+    fi
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/$rel"
+            exit 1
+        fi
+    done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autospec helper scripts"
+        return 1
+    fi
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    dest_dir="$(dirname "$dest")"
+
+    if [ ! -f "$src" ]; then
+        err "missing source file: $src"
+        return 1
+    fi
+
+    run "mkdir -p \"$dest_dir\""
+
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --symlink)
+            USE_SYMLINK=1
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        --update)
+            UPDATE_MODE=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# ---------- harness prompt -------------------------------------------------
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- ensure source files are available ------------------------------
+
+# If we couldn't resolve a local SKILL_DIR (piped from curl) OR the local dir
+# doesn't actually contain the skill files, fall back to remote fetch.
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+
+if [ "$need_fetch" -eq 1 ]; then
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        err "--symlink requires running from a checkout of the codex-skills repo (no local files to symlink to)."
+        exit 2
+    fi
+    fetch_source_files
+fi
+
+# ---------- dependency checks ---------------------------------------------
+
+dep_warnings=0
+
+check_dep() {
+    name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        warn "$name not found on PATH (required by the skill at runtime)"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+}
+
+check_dep git
+check_dep gh
+check_dep jq
+
+if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+        warn "gh is installed but not authenticated. Run: gh auth login"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+fi
+
+if [ "$dep_warnings" -gt 0 ]; then
+    warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
+fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+CLAUDE_SRC="$SKILL_DIR/SKILL.md"
+OPENCODE_SRC="$SKILL_DIR/opencode/agent.md"
+CODEX_SRC="$SKILL_DIR/codex/prompt.md"
+
+# ---------- install --------------------------------------------------------
+
+installed_paths=""
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_SRC" "$CLAUDE_DEST"
+    installed_paths="${installed_paths}  Claude Code: ${CLAUDE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_SRC" "$OPENCODE_DEST"
+    installed_paths="${installed_paths}  OpenCode:    ${OPENCODE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+    installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
+fi
+
+# ---------- final summary --------------------------------------------------
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    if [ "$UPDATE_MODE" -eq 1 ]; then
+        info "Updated (idempotent overwrite):"
+    else
+        info "Installed:"
+    fi
+    printf '%b' "$installed_paths"
+    info ""
+    info "Invoke with:"
+    info "  Claude Code:  /${SKILL_NAME} <feature description>"
+    info "  OpenCode:     @${SKILL_NAME} <feature description>"
+    info "  Codex CLI:    /${SKILL_NAME} <feature description>"
+fi
+
+exit 0

--- a/skills/autospec-story/opencode/agent.md
+++ b/skills/autospec-story/opencode/agent.md
@@ -1,0 +1,284 @@
+---
+name: autospec-story
+description: Use when the user wants a repo-level product story, implementation-state overview, or narrative synthesis from local specs plus GitHub issues and PRs for the current repository.
+---
+
+# autospec-story (harness-neutral)
+
+Read-only repo storyteller. Build a complete overview of the current GitHub
+repository by reconciling local specs, docs, GitHub issues, GitHub PRs, and
+recent git history into one cited Markdown narrative: what the application is,
+why it exists, what has been implemented, what remains open, and which parts
+are evidence versus inference.
+
+Manage your own context — never exceed 60%. Delegate the final synthesis to a
+Tier A subagent whenever your harness supports it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-story   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$`
+(case-insensitive, whitespace-padded), this skill enters self-update mode and
+does not run the normal story workflow:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-story/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-story.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-story.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-story/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched
+   copy.
+4. **Stop.** Do not gather repo state or write a story report. Print the upgrade
+   summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of
+autospec-story found; run install.sh first.` and exit.
+
+## Invocation
+
+```
+/autospec-story [--since <date>] [--output <path>] [--limit <N>]
+```
+
+- `--since <date>` — limit GitHub issue, PR, and git-history collection to
+  items created or updated since the date. Accepts GitHub search date syntax
+  such as `2026-05-01`.
+- `--output <path>` — write the report to a local Markdown file in addition to
+  printing the summary. Default: print only.
+- `--limit <N>` — cap GitHub issue and PR collection per state bucket. Default:
+  `500`.
+
+This skill is read-only with respect to the target repo and GitHub: do not edit
+issues, labels, projects, branches, commits, or pull requests.
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your
+harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                              | Codex CLI                              | Fallback if missing                                |
+|-----------------------------|--------------------------------------|---------------------------------------|----------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode        | shell `rg`, `git`, `gh`                | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output  | spawn nested CLI session               | Do the synthesis in-thread                         |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                         | inline prompt                          | Ask in the response and wait for the next turn     |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; fall back UP on unavailability |
+
+**Persistent project notes**: read durable preferences from **`AGENTS.md`** in
+the repo root. If multiple scoped AGENTS files exist, honor the deepest one for
+files under that scope. Per AGENTS.md, the synthesis subagent uses **Tier A
+(spec work)** because the output is a spec-adjacent reasoning artifact. The
+orchestrator keeps the user's invoked model. Fall back UP the tier on
+unavailability.
+
+## Pre-flight
+
+1. Verify the current directory is inside a git worktree:
+   `git rev-parse --show-toplevel`.
+2. Verify the repo is connected to GitHub:
+   `gh repo view --json nameWithOwner,url -q '.nameWithOwner + " " + .url'`.
+3. Verify `gh auth status` is authenticated. If unavailable, continue with local
+   evidence only and mark GitHub state as missing evidence.
+4. Parse flags. Default `LIMIT=500`; if `--since` is present, add
+   `--search "created:>=<date> OR updated:>=<date>"` only where the GitHub CLI
+   command supports it.
+
+## Evidence collection
+
+Collect evidence into a temporary working directory under `${TMPDIR:-/tmp}`.
+Use structured JSON where possible and keep raw command output so the final
+report can cite sources.
+
+### Local repository evidence
+
+Run from the repo root:
+
+```bash
+git rev-parse --show-toplevel
+git branch --show-current
+git status --short --branch
+git log --date=short --pretty=format:'%h%x09%ad%x09%s' --max-count 200
+rg --files docs .github examples skills scripts tests | sort
+```
+
+Read only the files that help establish product story or implementation state:
+
+- `README.md`, `AGENTS.md`, `SKILLS.md`, `CONTRIBUTING.md`.
+- `docs/specs/*.md`, `docs/superpowers/specs/*.md`, `.omx/plans/*.md`.
+- `docs/architecture.md`, `docs/user-manual.md`, `docs/runbooks/*.md`.
+- Repo-specific package manifests, service entry points, and top-level
+  architecture docs discovered by `rg --files`.
+
+Do not bulk-paste entire large files into the final answer. Extract titles,
+section headings, decisions, acceptance criteria, and completion markers.
+
+### GitHub issue evidence
+
+Collect both open and closed issues; closed issues are the primary source for
+completed work.
+
+```bash
+gh issue list --state open --limit "$LIMIT" --json number,title,state,labels,assignees,createdAt,updatedAt,url,body
+gh issue list --state closed --limit "$LIMIT" --json number,title,state,labels,assignees,createdAt,updatedAt,closedAt,url,body
+```
+
+If `--since` is present, prefer GitHub search filters; if a command cannot
+express the filter, collect first and filter by timestamp during synthesis.
+
+### GitHub PR evidence
+
+Collect open, merged, and closed PRs:
+
+```bash
+gh pr list --state open --limit "$LIMIT" --json number,title,state,labels,createdAt,updatedAt,url,body,headRefName,baseRefName
+gh pr list --state merged --limit "$LIMIT" --json number,title,state,labels,createdAt,updatedAt,mergedAt,url,body,headRefName,baseRefName
+gh pr list --state closed --limit "$LIMIT" --json number,title,state,labels,createdAt,updatedAt,closedAt,url,body,headRefName,baseRefName
+```
+
+Map PRs back to issues by parsing `Closes #N`, `Fixes #N`, `Refs #N`, branch
+names, labels, and issue URLs in PR bodies. Treat this mapping as inference
+unless the PR body has an explicit close/reference line.
+
+## Story synthesis
+
+> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking
+> per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT +
+> `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on
+> unavailability.
+
+Synthesize a cited report. Preserve the distinction between evidence and
+inference:
+
+- Evidence: direct local file paths, issue numbers, PR numbers, labels, commit
+  subjects, spec section titles, and explicit close/reference lines.
+- Inference: likely component state, intent that is implied by multiple related
+  issues, and PR-to-issue mappings without explicit closing syntax.
+- Unknown: anything not supported by current local files, GitHub artifacts, or
+  git history.
+
+Prioritize a complete overview over chronological exhaustiveness. Cluster work
+by product capability or application subsystem, not by issue number alone.
+
+## Report format
+
+When `--output` is provided, write this exact Markdown shape to that path. When
+printing in chat, include the executive summary plus the most important state
+tables and cite the report path if one was written.
+
+```markdown
+# Autospec Story: <owner/repo>
+
+Generated: <ISO8601 timestamp>
+Repo root: `<absolute path>`
+GitHub: <repo url or "unavailable">
+Evidence window: <all available evidence or --since date>
+
+## Executive Summary
+
+<5-8 bullets describing what the application is, current implementation state,
+and the highest-signal open gaps. Each bullet cites at least one source.>
+
+## Application Story
+
+<Narrative of the problem, product direction, and major design decisions.>
+
+## Evidence Map
+
+| Evidence type | Count | Primary sources |
+| --- | ---: | --- |
+| Specs | N | `docs/specs/...` |
+| Open issues | N | #1, #2 |
+| Closed issues | N | #3, #4 |
+| Open PRs | N | #5 |
+| Merged PRs | N | #6 |
+| Recent commits | N | `abc1234` |
+
+## Implementation State
+
+| Area | State | Evidence | Notes |
+| --- | --- | --- | --- |
+| <capability> | Implemented / In progress / Planned / Unknown | <paths, #issues, #PRs> | <short note> |
+
+## Completed Work
+
+<Grouped closed issues, merged PRs, and specs that appear implemented.>
+
+## Open Work
+
+<Open issues and unmerged PRs grouped by capability, with blockers called out.>
+
+## Specs and Decisions
+
+<Specs written, key decisions, superseded plans, and active design contracts.>
+
+## Risks, Gaps, and Unknowns
+
+<Explicitly separate missing evidence from known defects.>
+
+## Next Recommended Questions
+
+<Questions the team should ask next, grounded in current state.>
+
+## Source References
+
+<Local paths, issue URLs, PR URLs, and commit ids used as evidence.>
+```
+
+## Quality bar
+
+- Every major claim cites at least one source.
+- Closed issue heartbeats, stale labels, and old specs are treated as historical
+  evidence, not proof of current implementation.
+- Do not claim a feature is implemented solely because an issue exists. Prefer
+  `Planned` unless there is a merged PR, closed issue with implementation
+  detail, or local code/docs evidence.
+- Call out dirty worktree state in the report header so readers know whether
+  the local repo includes uncommitted changes.
+- If GitHub is unavailable, say so clearly and produce a local-only story.
+- If the report is too long for chat, write it to `docs/autospec-story.md` only
+  when the user passed `--output docs/autospec-story.md`; otherwise print a
+  concise story and recommend an output path.

--- a/skills/autospec-story/uninstall.sh
+++ b/skills/autospec-story/uninstall.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autospec-story"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        # Try to remove an empty parent skill directory (Claude only — its layout
+        # has a per-skill subdir).
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+# ---------- remove ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0

--- a/skills/autospec/README.md
+++ b/skills/autospec/README.md
@@ -15,6 +15,7 @@ Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
 | [`autospec-define`](../autospec-define/README.md) | Planning half (Phases 0–3.5). Stops after the review-and-label step and hands off to `autospec-run`. |
 | [`autospec-run`](../autospec-run/README.md) | Implementation half (Phases 4–6). Consumes the populated `auto-implement` queue; supports `--profile <name>` filtering. |
 | [`autospec-classify`](../autospec-classify/README.md) | Standalone retro-labeler. Applies the Phase 3.5 `ctx:*` / `reasoning:*` rubric to issues that pre-date Phase 3.5. |
+| [`autospec-story`](../autospec-story/README.md) | Read-only story mode. Synthesizes local specs, GitHub issues/PRs, and git history into a cited product story and implementation-state overview. |
 
 ## Self-update
 

--- a/tests/smoke/test_install_all_skills.bats
+++ b/tests/smoke/test_install_all_skills.bats
@@ -17,7 +17,7 @@ setup() {
     export OPENCODE_CONFIG_DIR="$FAKE_HOME/.config/opencode"
     export CODEX_HOME="$FAKE_HOME/.codex"
 
-    SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
+    SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-story autospec-stop"
     HELPERS="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
 }
 

--- a/tests/unit/test_validate_extension.bats
+++ b/tests/unit/test_validate_extension.bats
@@ -185,10 +185,28 @@ _run_scratch_validate() {
     echo "$output" | grep -F 'README.md'
 }
 
+@test "validate.sh: fails when README.md does not mention autospec-story" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    grep -v 'autospec-story' "$REPO_ROOT/README.md" > "$SCRATCH/README.md"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'README.md'
+}
+
 @test "validate.sh: fails when SKILLS.md does not mention autospec-listen" {
     cp -R "$REPO_ROOT"/. "$SCRATCH"/
     rm -rf "$SCRATCH/.git"
     grep -v 'autospec-listen' "$REPO_ROOT/SKILLS.md" > "$SCRATCH/SKILLS.md"
+    run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -F 'SKILLS.md'
+}
+
+@test "validate.sh: fails when SKILLS.md does not mention autospec-story" {
+    cp -R "$REPO_ROOT"/. "$SCRATCH"/
+    rm -rf "$SCRATCH/.git"
+    grep -v 'autospec-story' "$REPO_ROOT/SKILLS.md" > "$SCRATCH/SKILLS.md"
     run bash -c "cd '$SCRATCH' && bash scripts/validate.sh 2>&1"
     [ "$status" -ne 0 ]
     echo "$output" | grep -F 'SKILLS.md'

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,7 +12,7 @@
 #   ./uninstall.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-classify | autospec-listen | all
+#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-classify | autospec-listen | autospec-story | autospec-stop | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -24,7 +24,7 @@
 
 set -eu
 
-ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-stop"
+ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-story autospec-stop"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -67,7 +67,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$SKILL_ARG" in
-    all|autospec|autospec-split|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-stop) ;;
+    all|autospec|autospec-split|autospec-define|autospec-run|autospec-classify|autospec-listen|autospec-story|autospec-stop) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
         exit 2


### PR DESCRIPTION
## What changed

- Added `autospec-story`, a read-only multi-harness skill that synthesizes local specs, docs, GitHub issues, GitHub PRs, and recent git history into a cited application story and implementation-state report.
- Wired `autospec-story` into top-level install/uninstall, validation, smoke install coverage, README, SKILLS index, and autospec related-skill docs.
- Added validation coverage so README/SKILLS references cannot drift out of the shipped skill set.

## Why

Autospec has enough durable knowledge in specs, issues, PRs, and local docs to explain the product history and current implementation state. This gives users a first-class mode to generate that overview without entering the implementation pipeline or mutating GitHub state.

## Validation

- `bash scripts/validate.sh`
- `bats tests/unit tests/smoke`
- `git diff --check`
