### PR TITLE
[codex] Ensure autospec immediately picks next ready issue

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -374,6 +374,21 @@ check_phase4_issue_start_summary() {
     done
 }
 
+# Phase 4 cascade latency: after `process(ISSUE)` returns, the monitor must
+# immediately re-enter candidate selection. Sleeping after a completed issue
+# delays unblocked follow-up issues and slows recovery from failures.
+check_phase4_immediate_next_issue_pickup() {
+    info "phase4 immediate next-issue pickup: autospec + autospec-run trio"
+    for s in autospec autospec-run; do
+        for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
+            grep -q 'Immediate next-issue pickup: NO SLEEP after process(ISSUE)' "$f" \
+                || fail "$f missing immediate next-issue pickup directive"
+            grep -q 'fresh queue scan can pick any issue unblocked' "$f" \
+                || fail "$f missing fresh queue scan/unblocked issue rationale"
+        done
+    done
+}
+
 # Governance copy: the listener lifecycle and anti-loop guardrails must be
 # documented in AGENTS.md, and the listener skill must appear in both the
 # top-level README.md and SKILLS.md skill index. Spec §6.1, §7.1.
@@ -447,6 +462,7 @@ main() {
     check_lint_implementation_helpers
     check_phase4_guardian_block_lockstep
     check_phase4_issue_start_summary
+    check_phase4_immediate_next_issue_pickup
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -335,7 +335,9 @@ Then launch a **background subagent** with this prompt verbatim:
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
->   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
+>   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
+>   # of this loop immediately so the fresh queue scan can pick any issue unblocked
+>   # by the merge or failure cleanup that just completed.
 > ```
 >
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -330,7 +330,9 @@ Then launch a **background subagent** with this prompt verbatim:
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
->   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
+>   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
+>   # of this loop immediately so the fresh queue scan can pick any issue unblocked
+>   # by the merge or failure cleanup that just completed.
 > ```
 >
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -334,7 +334,9 @@ Then launch a **background subagent** with this prompt verbatim:
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
->   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
+>   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
+>   # of this loop immediately so the fresh queue scan can pick any issue unblocked
+>   # by the merge or failure cleanup that just completed.
 > ```
 >
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -612,7 +612,9 @@ Then launch a **background subagent** with this prompt verbatim:
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
->   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
+>   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
+>   # of this loop immediately so the fresh queue scan can pick any issue unblocked
+>   # by the merge or failure cleanup that just completed.
 > ```
 >
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -606,7 +606,9 @@ Then launch a **background subagent** with this prompt verbatim:
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
->   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
+>   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
+>   # of this loop immediately so the fresh queue scan can pick any issue unblocked
+>   # by the merge or failure cleanup that just completed.
 > ```
 >
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -610,7 +610,9 @@ Then launch a **background subagent** with this prompt verbatim:
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
->   # NO SLEEP — go straight to the next iteration; the merge may have unblocked another issue
+>   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
+>   # of this loop immediately so the fresh queue scan can pick any issue unblocked
+>   # by the merge or failure cleanup that just completed.
 > ```
 >
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:


### PR DESCRIPTION
## What changed

- Tightened the `/autospec` and `/autospec-run` monitor prompts so the outer loop immediately re-enters candidate selection after `process(ISSUE)` returns.
- Applied the directive across Claude Code, OpenCode, and Codex CLI prompt bodies for both monitor surfaces.
- Added `scripts/validate.sh` coverage to fail if either monitor trio loses the immediate next-issue pickup directive.

## Why

When an issue is merged or failure cleanup restores labels, another issue may become ready immediately. The monitor should not delay recovery or downstream work after completing one issue.

## Validation

- `bash scripts/validate.sh`
- `bats tests/unit tests/smoke`
- `git diff --check`
