### PR TITLE
feat(autospec-review): regression-spec template

### DIFF
--- a/skills/autospec-review/templates/regression-spec.md.tmpl
+++ b/skills/autospec-review/templates/regression-spec.md.tmpl
@@ -1,0 +1,39 @@
+---
+date: {{audit_date}}
+parent_spec: {{spec_path}}
+audit_run_id: {{run_id}}
+priority: high
+---
+# [REGRESSION] {{spec_topic}} — audit gaps {{audit_date}}
+
+This spec enumerates gaps found by autospec-review on {{audit_date}}
+against the parent spec. Each section corresponds to one row in
+`reports/autospec-review/gaps.csv` (`gap_id` shown).
+
+## Background
+
+{{parent_spec_summary}}
+
+## Gaps to remediate
+
+{{#each gaps}}
+### Gap {{gap_id}} — `{{gap_type}}` — {{severity}}
+
+**Parent spec anchor:** {{spec_anchor}}
+**Suspected closed issues:** {{suspected_issues}}
+**Evidence:**
+> {{evidence}}
+
+**What needs to ship:** {{remediation_hint}}
+
+**Acceptance criteria:**
+{{ac_bullets}}
+- [ ] Verification: {{verification_target}}
+
+{{/each}}
+
+## Verification
+
+- [ ] Test suite for affected modules passes.
+- [ ] Each gap_id's evidence no longer reproduces (verified via re-grep).
+- [ ] CSV rows flip from `status=filed` to `status=fixed` on next audit.


### PR DESCRIPTION
Closes #247

Adds the regression-spec markdown template at `skills/autospec-review/templates/regression-spec.md.tmpl` per Task 7 of the autospec-review plan. The template defines frontmatter (date, parent_spec, audit_run_id, priority), a Background section, a per-gap iteration block (gap_id / gap_type / severity / spec_anchor / suspected_issues / evidence / remediation_hint / acceptance criteria / verification_target), and a top-level Verification checklist.

Smoke: `test -s skills/autospec-review/templates/regression-spec.md.tmpl` -> green
Validate: `bash scripts/validate.sh` -> green