### PR TITLE
[autospec-review] T8: TDD: compute_gap_id deterministic hash

### DIFF
--- a/scripts/autospec_review_audit.py
+++ b/scripts/autospec_review_audit.py
@@ -1,0 +1,20 @@
+# scripts/autospec_review_audit.py
+"""Deterministic helpers for the autospec-review skill.
+
+Public functions are called both from skill body (via shell) and from
+unit tests.  No LLM calls; no network calls except `gh`.
+"""
+from __future__ import annotations
+
+import hashlib
+
+
+def compute_gap_id(spec_path: str, spec_anchor: str, gap_type: str) -> str:
+    """Stable 10-hex-char primary key for a gap.
+
+    Renaming a section header creates a new ``gap_id`` (treated as a new
+    gap).  Stability across audit runs is what protects manual ledger
+    annotations.
+    """
+    payload = f"{spec_path}\n{spec_anchor}\n{gap_type}".encode("utf-8")
+    return hashlib.sha1(payload).hexdigest()[:10]

--- a/tests/test_autospec_review.py
+++ b/tests/test_autospec_review.py
@@ -1,0 +1,31 @@
+# tests/test_autospec_review.py
+"""Unit tests for scripts/autospec_review_audit.py."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import autospec_review_audit as ara
+
+
+def test_gap_id_is_deterministic():
+    a = ara.compute_gap_id(
+        spec_path="docs/specs/2026-04-30-foo.md",
+        spec_anchor="## 4.2 NLM source schema",
+        gap_type="closed_missing_code",
+    )
+    b = ara.compute_gap_id(
+        spec_path="docs/specs/2026-04-30-foo.md",
+        spec_anchor="## 4.2 NLM source schema",
+        gap_type="closed_missing_code",
+    )
+    assert a == b
+    assert len(a) == 10
+    assert all(c in "0123456789abcdef" for c in a)
+
+
+def test_gap_id_changes_on_input_change():
+    base = ara.compute_gap_id("a.md", "## H", "ac_no_issue")
+    assert ara.compute_gap_id("b.md", "## H", "ac_no_issue") != base
+    assert ara.compute_gap_id("a.md", "## I", "ac_no_issue") != base
+    assert ara.compute_gap_id("a.md", "## H", "section_no_coverage") != base


### PR DESCRIPTION
Closes #248

Implements Task 8 of the autospec-review plan: creates `tests/test_autospec_review.py` with two TDD tests for `compute_gap_id`, and `scripts/autospec_review_audit.py` with the deterministic SHA-1-based 10-hex-char gap ID implementation. Both tests pass; `bash scripts/validate.sh` passes.