### PR TITLE
[autospec-review] T9: TDD: spec discovery

### DIFF
--- a/scripts/autospec_review_audit.py
+++ b/scripts/autospec_review_audit.py
@@ -7,6 +7,10 @@ unit tests.  No LLM calls; no network calls except `gh`.
 from __future__ import annotations
 
 import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
 
 
 def compute_gap_id(spec_path: str, spec_anchor: str, gap_type: str) -> str:
@@ -18,3 +22,44 @@ def compute_gap_id(spec_path: str, spec_anchor: str, gap_type: str) -> str:
     """
     payload = f"{spec_path}\n{spec_anchor}\n{gap_type}".encode("utf-8")
     return hashlib.sha1(payload).hexdigest()[:10]
+
+
+DEFAULT_SPEC_GLOBS: tuple[str, ...] = (
+    "docs/specs/**/*.md",
+    "docs/superpowers/specs/**/*.md",
+)
+
+_DATE_PREFIX = re.compile(r"^(?P<date>\d{4}-\d{2}-\d{2})-(?P<rest>.+?)(?:-design)?$")
+
+
+@dataclass(frozen=True)
+class SpecRef:
+    spec_path: str             # repo-relative path
+    spec_topic: str            # filename slug, date-prefix and -design suffix stripped
+    spec_date: str | None      # yyyy-mm-dd or None
+    abs_path: Path             # absolute path, useful for callers
+
+
+def discover_specs(
+    repo_root: Path,
+    globs: Sequence[str] = DEFAULT_SPEC_GLOBS,
+) -> list[SpecRef]:
+    repo_root = Path(repo_root)
+    seen: dict[str, SpecRef] = {}
+    for pattern in globs:
+        for abs_path in sorted(repo_root.glob(pattern)):
+            if not abs_path.is_file():
+                continue
+            rel = abs_path.relative_to(repo_root).as_posix()
+            stem = abs_path.stem
+            m = _DATE_PREFIX.match(stem)
+            if m:
+                topic = m.group("rest")
+                date = m.group("date")
+            else:
+                topic = stem.removesuffix("-design")
+                date = None
+            seen[rel] = SpecRef(
+                spec_path=rel, spec_topic=topic, spec_date=date, abs_path=abs_path
+            )
+    return list(seen.values())

--- a/tests/test_autospec_review.py
+++ b/tests/test_autospec_review.py
@@ -29,3 +29,46 @@ def test_gap_id_changes_on_input_change():
     assert ara.compute_gap_id("b.md", "## H", "ac_no_issue") != base
     assert ara.compute_gap_id("a.md", "## I", "ac_no_issue") != base
     assert ara.compute_gap_id("a.md", "## H", "section_no_coverage") != base
+
+
+def test_discover_specs_default_globs(tmp_path):
+    (tmp_path / "docs/specs").mkdir(parents=True)
+    (tmp_path / "docs/superpowers/specs").mkdir(parents=True)
+    a = tmp_path / "docs/specs/2026-04-30-alpha-design.md"
+    b = tmp_path / "docs/superpowers/specs/2026-04-23-beta-design.md"
+    c = tmp_path / "docs/specs/notes.txt"   # NOT a spec
+    a.write_text("# Alpha\n")
+    b.write_text("# Beta\n")
+    c.write_text("just notes\n")
+
+    found = ara.discover_specs(repo_root=tmp_path)
+    paths = sorted(p.spec_path for p in found)
+    assert paths == [
+        "docs/specs/2026-04-30-alpha-design.md",
+        "docs/superpowers/specs/2026-04-23-beta-design.md",
+    ]
+
+
+def test_discover_specs_extracts_topic_and_date(tmp_path):
+    (tmp_path / "docs/specs").mkdir(parents=True)
+    (tmp_path / "docs/specs/2026-04-30-alpha-beta-design.md").write_text("# x")
+    (tmp_path / "docs/specs/no-date-design.md").write_text("# y")
+
+    found = {p.spec_path: p for p in ara.discover_specs(repo_root=tmp_path)}
+    p1 = found["docs/specs/2026-04-30-alpha-beta-design.md"]
+    assert p1.spec_topic == "alpha-beta"
+    assert p1.spec_date == "2026-04-30"
+
+    p2 = found["docs/specs/no-date-design.md"]
+    assert p2.spec_topic == "no-date"
+    assert p2.spec_date is None
+
+
+def test_discover_specs_honors_glob_override(tmp_path):
+    (tmp_path / "weird/place").mkdir(parents=True)
+    (tmp_path / "weird/place/spec.md").write_text("# z")
+
+    found = ara.discover_specs(
+        repo_root=tmp_path, globs=("weird/**/*.md",)
+    )
+    assert [p.spec_path for p in found] == ["weird/place/spec.md"]


### PR DESCRIPTION
Closes #249

Implements Task 9 of the autospec-review plan: TDD for spec discovery.

- Appends 3 new tests to `tests/test_autospec_review.py` covering default globs, topic/date extraction, and glob override
- Implements `SpecRef` dataclass and `discover_specs()` function in `scripts/autospec_review_audit.py`
- All 5 tests pass; `bash scripts/validate.sh` passes