### PR TITLE
[autospec-review] T10: TDD: issue linkage matrix

### DIFF
--- a/scripts/autospec_review_audit.py
+++ b/scripts/autospec_review_audit.py
@@ -10,7 +10,7 @@ import hashlib
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Sequence
+from typing import Iterable, Sequence
 
 
 def compute_gap_id(spec_path: str, spec_anchor: str, gap_type: str) -> str:
@@ -63,3 +63,48 @@ def discover_specs(
                 spec_path=rel, spec_topic=topic, spec_date=date, abs_path=abs_path
             )
     return list(seen.values())
+
+_INLINE_ISSUE = re.compile(r"#(\d+)")
+
+
+def link_issues(
+    spec_text: str,
+    spec_path: str,
+    spec_topic: str,
+    all_issues: Iterable[dict],
+) -> list[dict]:
+    """Return issues linked to a spec by any of three signals.
+
+    1. Inline ``#nnn`` references in spec_text.
+    2. Spec path or its filename appearing in issue body.
+    3. Topic slug appearing in issue title (case-insensitive substring)
+       or in any of the issue's labels.
+
+    Order: stable, deduplicated, sorted by issue number.
+    """
+    inline_nums = {int(m) for m in _INLINE_ISSUE.findall(spec_text)}
+    spec_filename = spec_path.rsplit("/", 1)[-1]
+    topic_lc = spec_topic.lower()
+
+    matched: dict[int, dict] = {}
+    for issue in all_issues:
+        num = issue["number"]
+        if num in inline_nums:
+            matched[num] = issue
+            continue
+        body = issue.get("body") or ""
+        if spec_path in body or spec_filename in body:
+            matched[num] = issue
+            continue
+        if topic_lc and topic_lc in (issue.get("title") or "").lower():
+            matched[num] = issue
+            continue
+        labels = issue.get("labels") or []
+        label_names = {
+            (lbl["name"] if isinstance(lbl, dict) else lbl).lower()
+            for lbl in labels
+        }
+        if topic_lc in label_names:
+            matched[num] = issue
+            continue
+    return [matched[n] for n in sorted(matched)]

--- a/tests/test_autospec_review.py
+++ b/tests/test_autospec_review.py
@@ -72,3 +72,42 @@ def test_discover_specs_honors_glob_override(tmp_path):
         repo_root=tmp_path, globs=("weird/**/*.md",)
     )
     assert [p.spec_path for p in found] == ["weird/place/spec.md"]
+
+
+def test_link_issues_by_inline_number():
+    spec_text = "Tracker #260, fix #472, see also (#488)."
+    issues = [
+        {"number": 260, "state": "open",   "title": "x", "body": "", "labels": []},
+        {"number": 472, "state": "closed", "title": "y", "body": "", "labels": []},
+        {"number": 488, "state": "closed", "title": "z", "body": "", "labels": []},
+        {"number": 999, "state": "open",   "title": "irrelevant", "body": "", "labels": []},
+    ]
+    linked = ara.link_issues(spec_text=spec_text, spec_path="docs/specs/foo.md",
+                             spec_topic="foo", all_issues=issues)
+    nums = sorted(i["number"] for i in linked)
+    assert nums == [260, 472, 488]
+
+
+def test_link_issues_by_spec_path_in_body():
+    spec_text = ""
+    issues = [
+        {"number": 1, "state": "open", "title": "a", "body": "", "labels": []},
+        {"number": 2, "state": "open", "title": "b",
+         "body": "implements docs/specs/foo.md§3", "labels": []},
+    ]
+    linked = ara.link_issues(spec_text=spec_text, spec_path="docs/specs/foo.md",
+                             spec_topic="foo", all_issues=issues)
+    assert [i["number"] for i in linked] == [2]
+
+
+def test_link_issues_by_topic_label_or_title():
+    spec_text = ""
+    issues = [
+        {"number": 1, "state": "open", "title": "Add foo bar",      "body": "", "labels": []},
+        {"number": 2, "state": "open", "title": "Unrelated",        "body": "",
+         "labels": [{"name": "foo"}]},
+        {"number": 3, "state": "open", "title": "totally other",    "body": "", "labels": []},
+    ]
+    linked = ara.link_issues(spec_text=spec_text, spec_path="docs/specs/x.md",
+                             spec_topic="foo", all_issues=issues)
+    assert sorted(i["number"] for i in linked) == [1, 2]


### PR DESCRIPTION
Closes #250

Implements Task 10 of the autospec-review plan: TDD for issue linkage matrix.

- Appends 3 new tests covering inline #nnn references, spec path in issue body, and topic slug in title/label
- Implements `link_issues()` using three-signal matching (inline refs, path match, topic slug)
- Adds `Iterable` to typing imports
- All 8 tests pass; `bash scripts/validate.sh` passes