### PR TITLE
[autospec-review] T11: TDD: JSON validation for subagent output

### DIFF
--- a/scripts/autospec_review_audit.py
+++ b/scripts/autospec_review_audit.py
@@ -108,3 +108,91 @@ def link_issues(
             matched[num] = issue
             continue
     return [matched[n] for n in sorted(matched)]
+
+GAP_TYPES = frozenset({
+    "ac_no_issue", "closed_missing_code",
+    "closed_unchecked_ac", "section_no_coverage",
+})
+SEVERITIES = frozenset({"blocker", "major", "minor"})
+GAP_REQUIRED_FIELDS = (
+    "gap_type", "severity", "title", "spec_anchor",
+    "evidence", "suspected_issues", "remediation_hint",
+)
+EVIDENCE_MAX_CHARS = 500
+
+
+class SubagentSchemaError(ValueError):
+    """Raised when a subagent's JSON output fails the contract."""
+
+
+def validate_subagent_output(
+    payload: dict,
+    *,
+    expected_spec_path: str,
+    spec_text: str,
+    linked_numbers: set[int],
+) -> dict:
+    """Validate + normalise; return cleaned payload (truncated evidence).
+
+    Raises ``SubagentSchemaError`` on contract violations.
+    """
+    if not isinstance(payload, dict):
+        raise SubagentSchemaError("payload must be an object")
+
+    if payload.get("spec_path") != expected_spec_path:
+        raise SubagentSchemaError(
+            f"spec_path mismatch: expected {expected_spec_path!r}, "
+            f"got {payload.get('spec_path')!r}"
+        )
+
+    gaps = payload.get("gaps")
+    if not isinstance(gaps, list):
+        raise SubagentSchemaError("gaps must be a list")
+
+    cleaned_gaps: list[dict] = []
+    for idx, gap in enumerate(gaps):
+        if not isinstance(gap, dict):
+            raise SubagentSchemaError(f"gap[{idx}] must be object")
+        for field in GAP_REQUIRED_FIELDS:
+            if field not in gap:
+                raise SubagentSchemaError(
+                    f"gap[{idx}] missing field {field!r}"
+                )
+        if gap["gap_type"] not in GAP_TYPES:
+            raise SubagentSchemaError(
+                f"gap[{idx}] gap_type {gap['gap_type']!r} not in taxonomy"
+            )
+        if gap["severity"] not in SEVERITIES:
+            raise SubagentSchemaError(
+                f"gap[{idx}] severity {gap['severity']!r} unknown"
+            )
+        if gap["spec_anchor"] not in spec_text:
+            raise SubagentSchemaError(
+                f"gap[{idx}] spec_anchor {gap['spec_anchor']!r} "
+                "not found in spec_text"
+            )
+        if not isinstance(gap["suspected_issues"], list):
+            raise SubagentSchemaError(
+                f"gap[{idx}] suspected_issues must be a list"
+            )
+        for ref in gap["suspected_issues"]:
+            try:
+                num = int(str(ref).lstrip("#"))
+            except ValueError as e:
+                raise SubagentSchemaError(
+                    f"gap[{idx}] suspected_issues item {ref!r} not parseable"
+                ) from e
+            if num not in linked_numbers:
+                raise SubagentSchemaError(
+                    f"gap[{idx}] suspected_issues #{num} not in linked set"
+                )
+
+        cleaned_gap = dict(gap)
+        ev = cleaned_gap.get("evidence", "")
+        if len(ev) > EVIDENCE_MAX_CHARS:
+            cleaned_gap["evidence"] = ev[: EVIDENCE_MAX_CHARS - 1] + "…"
+        cleaned_gaps.append(cleaned_gap)
+
+    cleaned = dict(payload)
+    cleaned["gaps"] = cleaned_gaps
+    return cleaned

--- a/tests/test_autospec_review.py
+++ b/tests/test_autospec_review.py
@@ -2,6 +2,7 @@
 """Unit tests for scripts/autospec_review_audit.py."""
 import sys
 from pathlib import Path
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
@@ -111,3 +112,64 @@ def test_link_issues_by_topic_label_or_title():
     linked = ara.link_issues(spec_text=spec_text, spec_path="docs/specs/x.md",
                              spec_topic="foo", all_issues=issues)
     assert sorted(i["number"] for i in linked) == [1, 2]
+
+
+VALID_GAP = {
+    "gap_type": "closed_missing_code",
+    "severity": "blocker",
+    "title": "x",
+    "spec_anchor": "## H",
+    "evidence": "...",
+    "suspected_issues": ["#472"],
+    "remediation_hint": "ship it",
+}
+
+
+def test_validate_subagent_output_accepts_minimal():
+    payload = {"spec_path": "docs/specs/foo.md", "gaps": [VALID_GAP]}
+    ara.validate_subagent_output(
+        payload,
+        expected_spec_path="docs/specs/foo.md",
+        spec_text="## H\n",
+        linked_numbers={472},
+    )
+
+
+def test_validate_subagent_output_rejects_unknown_severity():
+    bad = {**VALID_GAP, "severity": "wat"}
+    payload = {"spec_path": "docs/specs/foo.md", "gaps": [bad]}
+    with pytest.raises(ara.SubagentSchemaError, match="severity"):
+        ara.validate_subagent_output(
+            payload, expected_spec_path="docs/specs/foo.md",
+            spec_text="## H\n", linked_numbers={472},
+        )
+
+
+def test_validate_subagent_output_rejects_unknown_anchor():
+    payload = {"spec_path": "docs/specs/foo.md", "gaps": [VALID_GAP]}
+    with pytest.raises(ara.SubagentSchemaError, match="spec_anchor"):
+        ara.validate_subagent_output(
+            payload, expected_spec_path="docs/specs/foo.md",
+            spec_text="## DIFFERENT\n", linked_numbers={472},
+        )
+
+
+def test_validate_subagent_output_rejects_unknown_issue():
+    payload = {"spec_path": "docs/specs/foo.md", "gaps": [VALID_GAP]}
+    with pytest.raises(ara.SubagentSchemaError, match="suspected_issues"):
+        ara.validate_subagent_output(
+            payload, expected_spec_path="docs/specs/foo.md",
+            spec_text="## H\n", linked_numbers={1},
+        )
+
+
+def test_validate_subagent_output_truncates_evidence():
+    long = "x" * 600
+    gap = {**VALID_GAP, "evidence": long}
+    payload = {"spec_path": "docs/specs/foo.md", "gaps": [gap]}
+    cleaned = ara.validate_subagent_output(
+        payload, expected_spec_path="docs/specs/foo.md",
+        spec_text="## H\n", linked_numbers={472},
+    )
+    assert len(cleaned["gaps"][0]["evidence"]) <= 500
+    assert cleaned["gaps"][0]["evidence"].endswith("…")


### PR DESCRIPTION
Closes #251

Implements Task 11 of the autospec-review plan: TDD for JSON contract validation of subagent output.

- Adds `import pytest` to test file header
- Appends 5 new tests covering: minimal valid payload, unknown severity, unknown anchor, unknown issue reference, and evidence truncation
- Implements `SubagentSchemaError`, `validate_subagent_output()` with full field/type/taxonomy checks and 500-char evidence truncation
- All 13 tests pass; `bash scripts/validate.sh` passes