### PR TITLE
[autospec-review] T12: TDD: CSV writer with manual-edit preservation

### DIFF
--- a/scripts/autospec_review_audit.py
+++ b/scripts/autospec_review_audit.py
@@ -196,3 +196,60 @@ def validate_subagent_output(
     cleaned = dict(payload)
     cleaned["gaps"] = cleaned_gaps
     return cleaned
+
+import csv
+import os
+
+CSV_COLUMNS: tuple[str, ...] = (
+    "gap_id", "run_id", "audit_date", "repo",
+    "spec_path", "spec_topic", "gap_type", "severity",
+    "title", "spec_anchor", "evidence", "suspected_issues",
+    "remediation_issue", "remediation_pr", "status", "notes",
+)
+PRESERVED_STATUSES = frozenset({"wontfix", "false_positive"})
+
+
+def write_per_run_csv(out_path: Path, rows: Iterable[dict]) -> None:
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS, lineterminator="\n")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k, "") for k in CSV_COLUMNS})
+
+
+def merge_into_ledger(ledger_path: Path, new_rows: Iterable[dict]) -> None:
+    """Merge new_rows into ledger keyed by gap_id, preserving manual edits.
+
+    Manual edits = rows whose existing ``status`` is in ``PRESERVED_STATUSES``,
+    OR whose ``notes`` field is non-empty.  Those rows' ``status`` and
+    ``notes`` columns are NOT overwritten by new_rows.  All other columns
+    are refreshed from new_rows.
+    """
+    ledger_path = Path(ledger_path)
+    existing: dict[str, dict] = {}
+    if ledger_path.exists():
+        with ledger_path.open(encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                existing[row["gap_id"]] = row
+
+    for new in new_rows:
+        gid = new["gap_id"]
+        prior = existing.get(gid)
+        if prior is None:
+            existing[gid] = {k: new.get(k, "") for k in CSV_COLUMNS}
+            continue
+        merged = {k: new.get(k, "") for k in CSV_COLUMNS}
+        if prior.get("status") in PRESERVED_STATUSES or prior.get("notes"):
+            merged["status"] = prior.get("status", merged["status"])
+            merged["notes"] = prior.get("notes", merged["notes"])
+        existing[gid] = merged
+
+    tmp_path = ledger_path.with_suffix(ledger_path.suffix + ".tmp")
+    with tmp_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS, lineterminator="\n")
+        writer.writeheader()
+        for row in existing.values():
+            writer.writerow({k: row.get(k, "") for k in CSV_COLUMNS})
+    os.replace(tmp_path, ledger_path)

--- a/tests/test_autospec_review.py
+++ b/tests/test_autospec_review.py
@@ -1,5 +1,6 @@
 # tests/test_autospec_review.py
 """Unit tests for scripts/autospec_review_audit.py."""
+import csv
 import sys
 from pathlib import Path
 import pytest
@@ -173,3 +174,60 @@ def test_validate_subagent_output_truncates_evidence():
     )
     assert len(cleaned["gaps"][0]["evidence"]) <= 500
     assert cleaned["gaps"][0]["evidence"].endswith("…")
+
+
+def _row(**overrides):
+    base = {
+        "gap_id": "abc123def0",
+        "run_id": "20260506T1430Z-deadbee",
+        "audit_date": "2026-05-06",
+        "repo": "owner/repo",
+        "spec_path": "docs/specs/foo.md",
+        "spec_topic": "foo",
+        "gap_type": "closed_missing_code",
+        "severity": "blocker",
+        "title": "missing thing",
+        "spec_anchor": "## H",
+        "evidence": "ev",
+        "suspected_issues": "#1 #2",
+        "remediation_issue": "",
+        "remediation_pr": "",
+        "status": "open",
+        "notes": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_write_per_run_csv_round_trip(tmp_path):
+    rows = [_row(), _row(gap_id="0000000000", title="other")]
+    out = tmp_path / "snapshot.csv"
+    ara.write_per_run_csv(out, rows)
+    with out.open() as f:
+        loaded = list(csv.DictReader(f))
+    assert len(loaded) == 2
+    assert loaded[0]["gap_id"] == "abc123def0"
+    assert list(loaded[0].keys()) == list(ara.CSV_COLUMNS)
+
+
+def test_merge_into_ledger_preserves_manual_status(tmp_path):
+    ledger = tmp_path / "gaps.csv"
+    existing = _row(gap_id="keep1", status="wontfix",
+                    notes="manual: not applicable for v1")
+    ara.write_per_run_csv(ledger, [existing])
+
+    new = _row(gap_id="keep1", status="open", notes="")
+    ara.merge_into_ledger(ledger, [new, _row(gap_id="newrow")])
+
+    with ledger.open() as f:
+        merged = {r["gap_id"]: r for r in csv.DictReader(f)}
+    assert merged["keep1"]["status"] == "wontfix"
+    assert merged["keep1"]["notes"] == "manual: not applicable for v1"
+    assert merged["newrow"]["status"] == "open"
+
+
+def test_merge_into_ledger_atomic_via_tmp(tmp_path):
+    ledger = tmp_path / "gaps.csv"
+    ara.write_per_run_csv(ledger, [_row()])
+    ara.merge_into_ledger(ledger, [_row(gap_id="another")])
+    assert not (tmp_path / "gaps.csv.tmp").exists()


### PR DESCRIPTION
Closes #252

Implements Task 12 of the autospec-review plan: TDD for CSV writer with manual-edit preservation.

- Adds `import csv` to test file header
- Appends `_row()` helper and 3 new tests: round-trip, manual status preservation, atomic write via .tmp
- Implements `write_per_run_csv()` and `merge_into_ledger()` with `CSV_COLUMNS`, `PRESERVED_STATUSES`, and atomic os.replace
- All 16 tests pass; `bash scripts/validate.sh` passes