### PR TITLE
[autospec-review] T13: TDD: run_id generator + gh issue list adapter

### DIFF
--- a/scripts/autospec_review_audit.py
+++ b/scripts/autospec_review_audit.py
@@ -253,3 +253,40 @@ def merge_into_ledger(ledger_path: Path, new_rows: Iterable[dict]) -> None:
         for row in existing.values():
             writer.writerow({k: row.get(k, "") for k in CSV_COLUMNS})
     os.replace(tmp_path, ledger_path)
+
+import datetime as _dt
+import shutil
+import subprocess
+
+
+def generate_run_id(short_sha: str | None = None) -> str:
+    """``<UTC compact ISO>-<short_git_sha>`` — sortable + traceable."""
+    if short_sha is None:
+        short_sha = current_git_short_sha()
+    ts = _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%MZ")
+    return f"{ts}-{short_sha}"
+
+
+def current_git_short_sha() -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "--short", "HEAD"], text=True
+    ).strip()
+
+
+def gh_issue_list(repo: str, *, state: str = "all", limit: int = 1000) -> list[dict]:
+    """Wrapper around ``gh issue list --json ...``.
+
+    Returns the parsed JSON list.  Raises ``RuntimeError`` if ``gh`` is
+    not on PATH.
+    """
+    if shutil.which("gh") is None:
+        raise RuntimeError("gh CLI not on PATH; install GitHub CLI")
+    out = subprocess.check_output([
+        "gh", "issue", "list",
+        "--repo", repo,
+        "--state", state,
+        "--limit", str(limit),
+        "--json", "number,state,title,body,labels,closedAt,url",
+    ], text=True)
+    import json
+    return json.loads(out)

--- a/tests/test_autospec_review.py
+++ b/tests/test_autospec_review.py
@@ -1,6 +1,7 @@
 # tests/test_autospec_review.py
 """Unit tests for scripts/autospec_review_audit.py."""
 import csv
+import re
 import sys
 from pathlib import Path
 import pytest
@@ -231,3 +232,12 @@ def test_merge_into_ledger_atomic_via_tmp(tmp_path):
     ara.write_per_run_csv(ledger, [_row()])
     ara.merge_into_ledger(ledger, [_row(gap_id="another")])
     assert not (tmp_path / "gaps.csv.tmp").exists()
+
+
+def test_run_id_format():
+    rid = ara.generate_run_id(short_sha="6c2e3a4")
+    assert re.match(r"^\d{8}T\d{4}Z-6c2e3a4$", rid)
+
+
+def test_run_id_includes_provided_sha():
+    assert ara.generate_run_id(short_sha="abc1234").endswith("-abc1234")


### PR DESCRIPTION
Closes #253

Implements Task 13 of the autospec-review plan: TDD for run_id generation and gh issue list adapter.

- Adds `import re` to test file header
- Appends 2 tests: run_id format regex match and SHA inclusion
- Implements `generate_run_id()`, `current_git_short_sha()`, `gh_issue_list()` with PATH check
- All 18 tests pass; `bash scripts/validate.sh` passes