### PR TITLE
[autospec-review] T18: Modify autospec-run/SKILL.md: queue priority sort

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -224,6 +224,19 @@ Then launch a **background subagent** with this prompt verbatim:
 >       echo "[watchdog] neither bash nor powershell found; skipping heartbeat reconciliation."
 >     fi
 >   fi
+
+### Queue priority sort (autospec-review interlock)
+
+When selecting the next `auto-implement` issue, sort:
+
+1. First: issues with label `priority:high` (e.g. `[REGRESSION]`
+   issues filed by autospec-review). Within `priority:high`, oldest
+   first.
+2. Then: all other `auto-implement` issues, oldest first.
+
+`priority:high` always wins over age. This guarantees regression
+issues unblock the queue before continuing with normal feature work.
+
 >   all_open = [open auto-implement issues, sorted ascending by issue number]
 >   candidates = [all_open issues whose Depends-on deps are all CLOSED, sorted ascending]
 >   blocked = [all_open issues with unmet Depends-on deps]

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -219,6 +219,19 @@ Then launch a **background subagent** with this prompt verbatim:
 >       echo "[watchdog] neither bash nor powershell found; skipping heartbeat reconciliation."
 >     fi
 >   fi
+
+### Queue priority sort (autospec-review interlock)
+
+When selecting the next `auto-implement` issue, sort:
+
+1. First: issues with label `priority:high` (e.g. `[REGRESSION]`
+   issues filed by autospec-review). Within `priority:high`, oldest
+   first.
+2. Then: all other `auto-implement` issues, oldest first.
+
+`priority:high` always wins over age. This guarantees regression
+issues unblock the queue before continuing with normal feature work.
+
 >   all_open = [open auto-implement issues, sorted ascending by issue number]
 >   candidates = [all_open issues whose Depends-on deps are all CLOSED, sorted ascending]
 >   blocked = [all_open issues with unmet Depends-on deps]

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -223,6 +223,19 @@ Then launch a **background subagent** with this prompt verbatim:
 >       echo "[watchdog] neither bash nor powershell found; skipping heartbeat reconciliation."
 >     fi
 >   fi
+
+### Queue priority sort (autospec-review interlock)
+
+When selecting the next `auto-implement` issue, sort:
+
+1. First: issues with label `priority:high` (e.g. `[REGRESSION]`
+   issues filed by autospec-review). Within `priority:high`, oldest
+   first.
+2. Then: all other `auto-implement` issues, oldest first.
+
+`priority:high` always wins over age. This guarantees regression
+issues unblock the queue before continuing with normal feature work.
+
 >   all_open = [open auto-implement issues, sorted ascending by issue number]
 >   candidates = [all_open issues whose Depends-on deps are all CLOSED, sorted ascending]
 >   blocked = [all_open issues with unmet Depends-on deps]


### PR DESCRIPTION
Closes #259

Implements Task 18 of the autospec-review plan: adds queue priority sort interlock to autospec-run.

- Inserts `### Queue priority sort (autospec-review interlock)` section before the existing queue scan logic
- `priority:high` issues (e.g. regression issues from autospec-review) always sort before normal issues
- Updates all three lock-step variants (SKILL.md, opencode/agent.md, codex/prompt.md) identically
- Primary smoke test passes: `grep -q 'Queue priority sort' skills/autospec-run/SKILL.md`
- `bash scripts/validate.sh` passes