### PR TITLE
[autospec-review] T20: Modify autospec-run/SKILL.md: Phase 6 post-batch /autospec-review trigger

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -526,7 +526,26 @@ Re-run with --profile <larger> to pick these up, or run /autospec-run on a host 
 
 If `deferred[]` is empty, omit the section.
 
----
+## Post-batch audit (autospec-review interlock)
+
+Runs after the last issue in this batch closes/merges, before printing
+the final report.
+
+Skip when:
+
+- `~/.autospec/no-review.flag` exists, OR
+- `--no-postreview` was passed to autospec-run.
+
+Otherwise:
+
+```bash
+/autospec-review --since "${BATCH_START_DATE}"
+```
+
+On gaps found: post a comment to the autospec-run status thread
+summarising gap counts by spec. Do NOT block batch completion.
+Failures from `/autospec-review` log a warning but do not fail the
+overall run.
 
 ## Constraints (apply throughout)
 

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -521,6 +521,26 @@ Re-run with --profile <larger> to pick these up, or run /autospec-run on a host 
 
 If `deferred[]` is empty, omit the section.
 
+## Post-batch audit (autospec-review interlock)
+
+Runs after the last issue in this batch closes/merges, before printing
+the final report.
+
+Skip when:
+
+- `~/.autospec/no-review.flag` exists, OR
+- `--no-postreview` was passed to autospec-run.
+
+Otherwise:
+
+```bash
+/autospec-review --since "${BATCH_START_DATE}"
+```
+
+On gaps found: post a comment to the autospec-run status thread
+summarising gap counts by spec. Do NOT block batch completion.
+Failures from `/autospec-review` log a warning but do not fail the
+overall run.
 
 ## Constraints (apply throughout)
 

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -525,6 +525,26 @@ Re-run with --profile <larger> to pick these up, or run /autospec-run on a host 
 
 If `deferred[]` is empty, omit the section.
 
+## Post-batch audit (autospec-review interlock)
+
+Runs after the last issue in this batch closes/merges, before printing
+the final report.
+
+Skip when:
+
+- `~/.autospec/no-review.flag` exists, OR
+- `--no-postreview` was passed to autospec-run.
+
+Otherwise:
+
+```bash
+/autospec-review --since "${BATCH_START_DATE}"
+```
+
+On gaps found: post a comment to the autospec-run status thread
+summarising gap counts by spec. Do NOT block batch completion.
+Failures from `/autospec-review` log a warning but do not fail the
+overall run.
 
 ## Constraints (apply throughout)
 


### PR DESCRIPTION
Closes #261

Implements Task 20 of the autospec-review plan: post-batch /autospec-review trigger in autospec-run.

- Appends `## Post-batch audit (autospec-review interlock)` section after Phase 6 Final report
- Skippable via `~/.autospec/no-review.flag` or `--no-postreview` flag
- Non-blocking: failures log a warning but don't fail the overall run
- Updates all three lock-step variants (SKILL.md, opencode/agent.md, codex/prompt.md) identically
- Primary smoke test: `grep -q 'Post-batch audit' skills/autospec-run/SKILL.md`
- `bash scripts/validate.sh` passes