### PR TITLE
[autospec-review] T22: Bats: lock-step byte-identity tests for autospec-run blocks

### DIFF
--- a/tests/test_autospec_run_priority_sort_lockstep.bats
+++ b/tests/test_autospec_run_priority_sort_lockstep.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+@test "priority sort block exists in SKILL.md" {
+  grep -q "Queue priority sort" skills/autospec-run/SKILL.md
+}
+@test "priority sort block byte-identical: SKILL.md vs opencode" {
+  diff <(sed -n '/Queue priority sort/,/^---/p' skills/autospec-run/SKILL.md | head -20) \
+       <(sed -n '/Queue priority sort/,/^---/p' skills/autospec-run/opencode/agent.md | head -20)
+}
+@test "priority sort block byte-identical: SKILL.md vs codex" {
+  diff <(sed -n '/Queue priority sort/,/^---/p' skills/autospec-run/SKILL.md | head -20) \
+       <(sed -n '/Queue priority sort/,/^---/p' skills/autospec-run/codex/prompt.md | head -20)
+}

--- a/tests/test_autospec_run_regression_review_lockstep.bats
+++ b/tests/test_autospec_run_regression_review_lockstep.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+@test "regression review escalation block exists in SKILL.md" {
+  grep -q "Regression review escalation" skills/autospec-run/SKILL.md
+}
+@test "regression review escalation block byte-identical: SKILL.md vs opencode" {
+  diff <(sed -n '/Regression review escalation/,/^---/p' skills/autospec-run/SKILL.md | head -20) \
+       <(sed -n '/Regression review escalation/,/^---/p' skills/autospec-run/opencode/agent.md | head -20)
+}
+@test "regression review escalation block byte-identical: SKILL.md vs codex" {
+  diff <(sed -n '/Regression review escalation/,/^---/p' skills/autospec-run/SKILL.md | head -20) \
+       <(sed -n '/Regression review escalation/,/^---/p' skills/autospec-run/codex/prompt.md | head -20)
+}


### PR DESCRIPTION
Closes #263

Implements Task 22 of the autospec-review plan: bats lock-step byte-identity tests for autospec-run blocks.

- Creates `tests/test_autospec_run_priority_sort_lockstep.bats` with 3 tests verifying Queue priority sort block exists and is byte-identical across SKILL.md/opencode/codex
- Creates `tests/test_autospec_run_regression_review_lockstep.bats` with 3 tests verifying Regression review escalation block exists and is byte-identical across SKILL.md/opencode/codex
- All 6 bats tests pass
- `bash scripts/validate.sh` passes