### PR TITLE
[autospec-review] T17: Bats: skill body byte-identity lock-step test

### DIFF
--- a/tests/test_autospec_review_skill_lockstep.bats
+++ b/tests/test_autospec_review_skill_lockstep.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+# Verify autospec-review skill body is byte-identical across SKILL.md,
+# opencode/agent.md, and codex/prompt.md.
+
+@test "skill body byte-identity: SKILL.md vs opencode/agent.md" {
+  diff <(awk '/^---$/{c++; next} c>=2' skills/autospec-review/SKILL.md) \
+       <(awk '/^---$/{c++; next} c>=2' skills/autospec-review/opencode/agent.md)
+}
+
+@test "skill body byte-identity: SKILL.md vs codex/prompt.md" {
+  diff <(awk '/^---$/{c++; next} c>=2' skills/autospec-review/SKILL.md) \
+       <(cat skills/autospec-review/codex/prompt.md)
+}


### PR DESCRIPTION
Closes #258

## Summary

- Creates `tests/test_autospec_review_skill_lockstep.bats` with two tests verifying byte-identity of autospec-review skill body across SKILL.md, opencode/agent.md, and codex/prompt.md
- Both bats tests pass
- `bash scripts/validate.sh` passes

## Note on codex comparison

The plan specified `sed '1{/^$/d;}'` for the codex comparison, but `scripts/validate.sh` uses `cat codex/prompt.md` directly (since `strip_body(SKILL.md)` already starts with `\n`, which equals the full content of codex/prompt.md). The test uses the `cat` form to stay consistent with validate.sh.