### PR TITLE
[autospec-review] T24: Update SKILLS.md and top-level README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ selected model and harness to execute reliably.
 | [`autospec-listen`](skills/autospec-listen/README.md) | You want chat phrases like "file an issue" to become tracked work. | Drafts issues for approval or routes spec requests into `/autospec-define`. |
 | [`autospec-story`](skills/autospec-story/README.md) | You need a repo-level product and implementation-state overview. | Produces a cited Markdown story from local specs, docs, issues, PRs, and git history. |
 | [`autospec-stop`](skills/autospec-stop/README.md) | You need to halt or resume an active monitor. | Writes the shared stop sentinel, pauses issues safely, reports status, or resumes paused work. |
+| [`autospec-review`](skills/autospec-review/README.md) | You want to close the spec-vs-code feedback loop. | Audits specs against issues, finds gaps, files `[REGRESSION]` issues with `priority:high`. |
 
 See [`SKILLS.md`](SKILLS.md) for activation keywords and per-skill routing
 details.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -24,6 +24,14 @@
 - Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
 - Status: read-only synthesis mode. Produces a cited Markdown report that separates evidence, inference, open work, completed work, and unknowns. See [`skills/autospec-story/README.md`](skills/autospec-story/README.md).
 
+## autospec-review
+
+- Path: [`skills/autospec-review`](skills/autospec-review)
+- Trigger: use when a user wants to audit design specs against open and closed issues to find gaps, file high-priority regression issues, and feed them back through autospec. Auto-fires after each autospec-run batch unless `~/.autospec/no-review.flag` exists.
+- Activation keywords: `autospec-review`, `audit specs`, `find spec gaps`, `regression review`, `spec vs issues`, `find missing coverage`
+- Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
+- Status: closes the spec-vs-code feedback loop; renders regression specs, dispatches Tier A reviewer subagent, and hands off to `/autospec-split` to file `[REGRESSION]` issues with `priority:high`.
+
 ## autospec-split
 
 - Path: [`skills/autospec-split`](skills/autospec-split)


### PR DESCRIPTION
Closes #265

## Summary

- Adds `autospec-review` section to `SKILLS.md` with path, trigger description, activation keywords, harnesses, and status
- Adds `autospec-review` row to the skill table in `README.md`
- Primary smoke test passes: `grep -q autospec-review SKILLS.md`
- `bash scripts/validate.sh` passes