### PR TITLE
feat(autospec-classify,autospec-review): add harness detection block + simplify tier briefs

### DIFF
--- a/skills/autospec-classify/SKILL.md
+++ b/skills/autospec-classify/SKILL.md
@@ -95,6 +95,26 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 The skill exits non-zero if `gh auth status` fails or the current cwd is not a
 GitHub-tracked repo.
 
+## Harness detection (run once at skill start, before Phase 0)
+
+Detect your harness by checking available tools before any phase:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness (model unknown, tool absent, or tool call returns an error for that model), silently use `TIER_A` instead. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
 ## Required capabilities & harness adapter
 
 This workflow assumes a small set of capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
@@ -166,7 +186,7 @@ Default for issues that lack any of these signals: `ctx:64k`, `reasoning:medium`
 
 ## Per-issue procedure
 
-> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+> **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
 
 For each candidate issue:
 

--- a/skills/autospec-classify/codex/prompt.md
+++ b/skills/autospec-classify/codex/prompt.md
@@ -91,6 +91,26 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 The skill exits non-zero if `gh auth status` fails or the current cwd is not a
 GitHub-tracked repo.
 
+## Harness detection (run once at skill start, before Phase 0)
+
+Detect your harness by checking available tools before any phase:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness (model unknown, tool absent, or tool call returns an error for that model), silently use `TIER_A` instead. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
 ## Required capabilities & harness adapter
 
 This workflow assumes a small set of capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
@@ -162,7 +182,7 @@ Default for issues that lack any of these signals: `ctx:64k`, `reasoning:medium`
 
 ## Per-issue procedure
 
-> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+> **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
 
 For each candidate issue:
 

--- a/skills/autospec-classify/opencode/agent.md
+++ b/skills/autospec-classify/opencode/agent.md
@@ -95,6 +95,26 @@ If no install path is detected, print `Self-update: no installed copy of autospe
 The skill exits non-zero if `gh auth status` fails or the current cwd is not a
 GitHub-tracked repo.
 
+## Harness detection (run once at skill start, before Phase 0)
+
+Detect your harness by checking available tools before any phase:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness (model unknown, tool absent, or tool call returns an error for that model), silently use `TIER_A` instead. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
 ## Required capabilities & harness adapter
 
 This workflow assumes a small set of capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
@@ -166,7 +186,7 @@ Default for issues that lack any of these signals: `ctx:64k`, `reasoning:medium`
 
 ## Per-issue procedure
 
-> **Model tier:** Tier A (spec work) — top model with extended/maximum thinking per AGENTS.md. Claude Code: `opus` + `ultrathink`; Codex: current top GPT + `reasoning_effort=high`; OpenCode: top task tier. Fall back UP on unavailability.
+> **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
 
 For each candidate issue:
 

--- a/skills/autospec-review/SKILL.md
+++ b/skills/autospec-review/SKILL.md
@@ -55,6 +55,26 @@ CSV ledger, and route regressions back through `/autospec-split` with
 | `--since DATE` | Only audit specs whose date prefix ≥ DATE |
 | `--spec-glob PATTERN` | Override default spec discovery globs |
 
+## Harness detection (run once at skill start, before Phase 0)
+
+Detect your harness by checking available tools before any phase:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness (model unknown, tool absent, or tool call returns an error for that model), silently use `TIER_A` instead. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
 ## Phase 0 — Preflight
 
 1. Read repo state. Resolve `repo` from `gh repo view --json

--- a/skills/autospec-review/codex/prompt.md
+++ b/skills/autospec-review/codex/prompt.md
@@ -51,6 +51,26 @@ CSV ledger, and route regressions back through `/autospec-split` with
 | `--since DATE` | Only audit specs whose date prefix ≥ DATE |
 | `--spec-glob PATTERN` | Override default spec discovery globs |
 
+## Harness detection (run once at skill start, before Phase 0)
+
+Detect your harness by checking available tools before any phase:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness (model unknown, tool absent, or tool call returns an error for that model), silently use `TIER_A` instead. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
 ## Phase 0 — Preflight
 
 1. Read repo state. Resolve `repo` from `gh repo view --json

--- a/skills/autospec-review/opencode/agent.md
+++ b/skills/autospec-review/opencode/agent.md
@@ -55,6 +55,26 @@ CSV ledger, and route regressions back through `/autospec-split` with
 | `--since DATE` | Only audit specs whose date prefix ≥ DATE |
 | `--spec-glob PATTERN` | Override default spec discovery globs |
 
+## Harness detection (run once at skill start, before Phase 0)
+
+Detect your harness by checking available tools before any phase:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness (model unknown, tool absent, or tool call returns an error for that model), silently use `TIER_A` instead. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
 ## Phase 0 — Preflight
 
 1. Read repo state. Resolve `repo` from `gh repo view --json


### PR DESCRIPTION
Closes #297

Adds ## Harness detection block to skills/autospec-classify/SKILL.md and skills/autospec-review/SKILL.md (+ codex/prompt.md + opencode/agent.md lock-step sync for both). Replaces verbose multi-harness tier briefs with TIER_A/TIER_B references per 2026-05-07-harness-aware-model-tier-design.md.

For autospec-review, preserves "Tier A (spec work)" text in inline phase annotations (required by validate.sh check_autospec_review_tier_a_directives ≥2 occurrences).