### PR TITLE
feat(monitor): batch self-termination + orchestrator relaunch loop

### DIFF
--- a/docs/specs/2026-05-07-monitor-session-reset-design.md
+++ b/docs/specs/2026-05-07-monitor-session-reset-design.md
@@ -1,0 +1,170 @@
+# autospec-run Monitor Session Reset (Batch Self-Termination)
+
+**Date:** 2026-05-07  
+**Status:** Draft  
+**Scope:** `skills/autospec-run/SKILL.md`, `skills/autospec/SKILL.md` (Phase 4), `scripts/validate.sh`, `tests/`
+
+---
+
+## 1. Problem
+
+The Phase 4 background monitor runs as a single long-lived background subagent. Foreground subagent transcripts (process(ISSUE) calls) accumulate in the monitor's context window. Empirically this causes context overflow at ~185 tool calls (~4-5 issues), manifesting as either a silent exit or a literal "Prompt is too long" error. The current SKILL.md has no self-termination logic — the monitor either finishes the whole queue or crashes.
+
+## 2. Solution
+
+The monitor self-terminates after processing a configurable batch of issues (default: 3) by writing a status file `~/.autospec/batch-done.json`. The orchestrator's Phase 4 block becomes a relaunch loop: it reads the file after each task-notification and relaunches the monitor with fresh context until the queue is fully drained. All persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
+
+---
+
+## 3. Architecture
+
+### 3.1 Monitor outer loop change
+
+Add a `batch_issue_count` counter (initialized to 0) and a `batch_num` parameter (passed in from the orchestrator). After each successful `process(ISSUE)` call, increment `batch_issue_count`. When `batch_issue_count >= AUTOSPEC_BATCH_SIZE` (default 3), write `batch-done.json` and exit.
+
+```
+batch_issue_count = 0
+
+while true:
+  [existing scan + stop-flag + watchdog logic]
+  
+  if ready is empty:
+    if all issues CLOSED: write ALL_DONE → exit
+    else: sleep 300, continue
+  
+  ISSUE = ready[0]
+  claim(ISSUE)
+  process(ISSUE)    # foreground subagent
+  batch_issue_count += 1
+  
+  if batch_issue_count >= AUTOSPEC_BATCH_SIZE:
+    write BATCH_COMPLETE → exit
+  
+  # else continue to next iteration immediately
+```
+
+The batch counter increments **after each completed `process(ISSUE)` call** (regardless of merge or failure outcome), not on empty scans or blocked-queue sleeps. A fully-blocked queue still reaches the normal 2h idle HARD SHUTDOWN.
+
+The monitor prints the following before writing the file and exiting:
+```
+[monitor] batch N: processed K/AUTOSPEC_BATCH_SIZE issues — writing batch-done.json and exiting for fresh context
+```
+
+### 3.2 Batch-done file
+
+**Path:** `~/.autospec/batch-done.json`
+
+**Schema:**
+```json
+{
+  "batch": 2,
+  "processed": 3,
+  "repo": "berlinguyinca/autospec",
+  "ts": 1234567890,
+  "status": "BATCH_COMPLETE"
+}
+```
+
+`status` is either `BATCH_COMPLETE` (hit batch limit; more issues may remain) or `ALL_DONE` (queue fully drained).
+
+**Lifecycle:**
+1. Monitor **deletes** the file at startup (clears stale state from prior crashes).
+2. Monitor **writes** it on any intentional exit (batch limit or queue drained).
+3. Orchestrator **reads then deletes** it after task-notification, before deciding to relaunch.
+4. If the file is **absent** when the orchestrator checks (monitor crashed or overflowed): treat as `BATCH_COMPLETE` and relaunch.
+
+### 3.3 Orchestrator relaunch loop (Phase 4)
+
+Replace the current single-launch Phase 4 with:
+
+```
+batch_num = 1
+
+while true:
+  launch background monitor (pass batch_num, AUTOSPEC_BATCH_SIZE)
+  wait for task-notification
+
+  if ~/.autospec/batch-done.json exists:
+    status = read .status from file
+    delete ~/.autospec/batch-done.json
+  else:
+    status = "BATCH_COMPLETE"   # crash/overflow — safe to relaunch
+
+  if status == "ALL_DONE":
+    break   # proceed to Phase 6
+  else:
+    batch_num += 1
+    print "[orchestrator] batch N complete — relaunching monitor with fresh context (batch N+1)"
+    continue   # immediate relaunch, no sleep
+```
+
+### 3.4 Configuration
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `AUTOSPEC_BATCH_SIZE` | `3` | Max issues per monitor session |
+
+Values ≤ 0 or unset default to 3.
+
+---
+
+## 4. Error handling
+
+| Scenario | Behaviour |
+|---|---|
+| Monitor crashes / overflows without writing file | Orchestrator finds no file → status = `BATCH_COMPLETE` → relaunch |
+| Stale `batch-done.json` from prior session | Monitor deletes at startup → never confuses orchestrator |
+| All issues blocked (unmet deps) | Batch counter does not increment on empty scans; normal 2h idle HARD SHUTDOWN fires |
+| `AUTOSPEC_BATCH_SIZE` ≥ queue size | Monitor exits with `ALL_DONE` on first batch — no unnecessary relaunch |
+| `in-progress-by-bot` left by crashed monitor | Watchdog reconciliation at monitor startup reclaims stale claims normally |
+
+---
+
+## 5. Affected files
+
+| File | Change |
+|---|---|
+| `skills/autospec-run/SKILL.md` | Add `batch_issue_count` counter to outer loop; add `batch-done.json` write logic; replace single-launch Phase 4 with relaunch loop |
+| `skills/autospec/SKILL.md` | Same Phase 4 changes (autospec embeds the full Phase 4 monitor prompt) |
+| `skills/autospec-run/codex/prompt.md` | Lock-step sync with SKILL.md body |
+| `skills/autospec-run/opencode/agent.md` | Lock-step sync with SKILL.md body |
+| `skills/autospec/codex/prompt.md` | Lock-step sync with SKILL.md body |
+| `skills/autospec/opencode/agent.md` | Lock-step sync with SKILL.md body |
+| `scripts/validate.sh` | No changes — existing bats runner picks up new test file automatically |
+| `tests/unit/test_monitor_batch_exit.bats` | New bats test file (see §6) |
+
+---
+
+## 6. Testing
+
+### Bats tests (`tests/unit/test_monitor_batch_exit.bats`)
+
+1. **BATCH_COMPLETE signal:** mock monitor writes `batch-done.json` with `status=BATCH_COMPLETE`; verify orchestrator loop re-enters (reads, deletes, increments batch_num).
+2. **ALL_DONE signal:** mock monitor writes `status=ALL_DONE`; verify orchestrator breaks and proceeds to Phase 6.
+3. **Missing file (crash):** no `batch-done.json` present; verify orchestrator treats as `BATCH_COMPLETE` and relaunches.
+4. **Stale file cleanup:** seed a stale `batch-done.json` before monitor start; verify monitor deletes it at startup (file absent after startup hook).
+5. **AUTOSPEC_BATCH_SIZE=0 defaults to 3:** verify env-var parsing.
+
+### Smoke test
+
+Run `/autospec-run` against a 4-issue test queue with `AUTOSPEC_BATCH_SIZE=2`. Verify:
+- Two monitor launches occur.
+- `batch-done.json` is written, read, and deleted between launches.
+- All 4 issues close with merged PRs.
+- No orphan `in-progress-by-bot` labels or stale heartbeat files.
+
+### Crash recovery test
+
+Kill a monitor mid-batch (no file written). Verify:
+- Orchestrator relaunches.
+- Watchdog reclaims the `in-progress-by-bot` label.
+- The previously claimed issue gets re-processed cleanly.
+
+---
+
+## 7. Out of scope
+
+- ScheduleWakeup-based polling relaunch (Approach C, rejected: event-driven is cleaner).
+- Summary-string signal (Approach A, rejected: Approach B is harness-neutral).
+- Per-batch partial report aggregation (Phase 6 already collects from GitHub state; no new log needed).
+- Changes to `process(ISSUE)` internals — batch logic is purely in the outer loop and orchestrator.

--- a/docs/specs/2026-05-07-monitor-session-reset-design.md
+++ b/docs/specs/2026-05-07-monitor-session-reset-design.md
@@ -130,7 +130,7 @@ Values ≤ 0 or unset default to 3.
 | `skills/autospec-run/opencode/agent.md` | Lock-step sync with SKILL.md body |
 | `skills/autospec/codex/prompt.md` | Lock-step sync with SKILL.md body |
 | `skills/autospec/opencode/agent.md` | Lock-step sync with SKILL.md body |
-| `scripts/validate.sh` | No changes — existing bats runner picks up new test file automatically |
+| `scripts/validate.sh` | Add `check_monitor_batch_exit()` function + call in per-skill validation loop |
 | `tests/unit/test_monitor_batch_exit.bats` | New bats test file (see §6) |
 
 ---

--- a/docs/superpowers/plans/2026-05-07-monitor-session-reset.md
+++ b/docs/superpowers/plans/2026-05-07-monitor-session-reset.md
@@ -1,0 +1,484 @@
+# Monitor Session Reset (Batch Self-Termination) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Phase 4 autospec-run monitor self-terminate after processing `AUTOSPEC_BATCH_SIZE` issues (default 3), write `~/.autospec/batch-done.json`, and let the orchestrator relaunch it with fresh context.
+
+**Architecture:** The monitor's outer loop gains a `batch_issue_count` counter that increments after every `process(ISSUE)` call (merge or failure). At the batch limit it writes `batch-done.json` with `status=BATCH_COMPLETE` and exits. The orchestrator's Phase 4 launch block becomes a `while` loop that relaunches the monitor until it sees `ALL_DONE` (or the file is absent, treating a crash as `BATCH_COMPLETE`). All persistent state remains in GitHub labels and heartbeat files — relaunches are always safe.
+
+**Tech Stack:** Markdown (SKILL.md prompt files), Bash (validate.sh, bats tests), JSON (batch-done.json), lock-step trio sync (SKILL.md = codex/prompt.md = opencode/agent.md body).
+
+---
+
+## File Map
+
+| Action | Path | What changes |
+|---|---|---|
+| Modify | `scripts/validate.sh` | Add `check_monitor_batch_exit()` function + call it in main loop |
+| Create | `tests/unit/test_monitor_batch_exit.bats` | 5 bats tests covering batch-done.json protocol |
+| Modify | `skills/autospec-run/SKILL.md` | Orchestrator relaunch loop + monitor outer loop batch logic |
+| Modify | `skills/autospec-run/codex/prompt.md` | Lock-step sync (body = SKILL.md body stripped of frontmatter) |
+| Modify | `skills/autospec-run/opencode/agent.md` | Lock-step sync (frontmatter preserved, body replaced) |
+| Modify | `skills/autospec/SKILL.md` | Same Phase 4 changes as autospec-run |
+| Modify | `skills/autospec/codex/prompt.md` | Lock-step sync |
+| Modify | `skills/autospec/opencode/agent.md` | Lock-step sync |
+
+---
+
+## Task 1: Add `check_monitor_batch_exit()` to validate.sh
+
+**Files:**
+- Modify: `scripts/validate.sh`
+
+- [ ] **Step 1: Find the insertion point in validate.sh**
+
+Run:
+```bash
+grep -n "^check_harness_detection_block\|^check_subagent_model_tier\|^main(" scripts/validate.sh | head -10
+```
+Expected: line numbers for existing check functions and the main call loop.
+
+- [ ] **Step 2: Add the function after `check_harness_detection_block`**
+
+Insert this function in `scripts/validate.sh` immediately after the closing `}` of `check_harness_detection_block`:
+
+```bash
+check_monitor_batch_exit() {
+    local file="$1"
+    # Only enforce on skills that contain a Phase 4 monitor outer loop.
+    # Detect by presence of "batch_issue_count" or "AUTOSPEC_BATCH_SIZE".
+    # Skills without Phase 4 (e.g. autospec-classify) are silently skipped.
+    if ! grep -q "Phase 4" "$file" 2>/dev/null; then
+        return 0
+    fi
+    local missing=()
+    grep -q "batch_issue_count" "$file"    || missing+=("batch_issue_count")
+    grep -q "AUTOSPEC_BATCH_SIZE"  "$file" || missing+=("AUTOSPEC_BATCH_SIZE")
+    grep -q "batch-done.json"      "$file" || missing+=("batch-done.json")
+    grep -q "BATCH_COMPLETE"       "$file" || missing+=("BATCH_COMPLETE")
+    grep -q "ALL_DONE"             "$file" || missing+=("ALL_DONE")
+    if [ "${#missing[@]}" -gt 0 ]; then
+        fail "$file: monitor batch-exit missing: ${missing[*]}"
+    fi
+    info "monitor-batch-exit: $(basename "$(dirname "$file")")"
+}
+```
+
+- [ ] **Step 3: Call it from the per-skill validation loop**
+
+Find the line in validate.sh that calls `check_harness_detection_block "$skill_dir/SKILL.md"` (or similar per-file check loop). Add the new call immediately after:
+
+```bash
+check_monitor_batch_exit "$skill_dir/SKILL.md"
+```
+
+- [ ] **Step 4: Verify validate.sh is parseable**
+
+```bash
+bash -n scripts/validate.sh
+```
+Expected: no output (no syntax errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/validate.sh
+git commit -m "feat(validate): add check_monitor_batch_exit() for batch self-termination"
+```
+
+---
+
+## Task 2: Write failing bats tests (TDD red phase)
+
+**Files:**
+- Create: `tests/unit/test_monitor_batch_exit.bats`
+
+- [ ] **Step 1: Create the test file**
+
+```bash
+cat > tests/unit/test_monitor_batch_exit.bats << 'BATS'
+#!/usr/bin/env bats
+# tests/unit/test_monitor_batch_exit.bats — verify check_monitor_batch_exit()
+# in scripts/validate.sh detects missing/present batch self-termination logic.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    VALIDATE="$REPO_ROOT/scripts/validate.sh"
+    SCRATCH="$(mktemp -d)"
+    export SCRATCH REPO_ROOT VALIDATE
+
+    # Build an isolated helper that exposes only check_monitor_batch_exit.
+    HELPER="$SCRATCH/helper.sh"
+    cat > "$HELPER" <<'HELPER_SCRIPT'
+#!/usr/bin/env bash
+set -eu
+fail() { printf 'validate: FAIL — %s\n' "$*" >&2; exit 1; }
+info() { printf 'validate: %s\n' "$*"; }
+HELPER_SCRIPT
+    sed -n '/^check_monitor_batch_exit()/,/^}/p' "$VALIDATE" >> "$HELPER"
+    chmod +x "$HELPER"
+    export HELPER
+}
+
+teardown() {
+    rm -rf "$SCRATCH"
+}
+
+# Helper: write a minimal SKILL.md body with Phase 4 marker and all required tokens.
+_full_batch_skill() {
+    cat <<'MD'
+## Phase 4 — Background autonomous monitor
+
+> batch_issue_count=0
+> AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3}
+> batch-done.json
+> BATCH_COMPLETE
+> ALL_DONE
+MD
+}
+
+# Helper: write a Phase 4 skill missing one token.
+_missing_token_skill() {
+    local missing="$1"
+    _full_batch_skill | grep -v "$missing"
+}
+
+@test "SKILL.md with all batch-exit tokens passes" {
+    local f="$SCRATCH/SKILL.md"
+    _full_batch_skill > "$f"
+    run bash "$HELPER" check_monitor_batch_exit "$f"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "monitor-batch-exit"
+}
+
+@test "SKILL.md missing batch_issue_count fails" {
+    local f="$SCRATCH/SKILL.md"
+    _missing_token_skill "batch_issue_count" > "$f"
+    run bash "$HELPER" check_monitor_batch_exit "$f"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "batch_issue_count"
+}
+
+@test "SKILL.md missing batch-done.json fails" {
+    local f="$SCRATCH/SKILL.md"
+    _missing_token_skill "batch-done.json" > "$f"
+    run bash "$HELPER" check_monitor_batch_exit "$f"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "batch-done.json"
+}
+
+@test "SKILL.md without Phase 4 marker is silently skipped" {
+    local f="$SCRATCH/SKILL.md"
+    echo "# autospec-classify — no Phase 4 here" > "$f"
+    run bash "$HELPER" check_monitor_batch_exit "$f"
+    [ "$status" -eq 0 ]
+}
+
+@test "SKILL.md missing ALL_DONE fails" {
+    local f="$SCRATCH/SKILL.md"
+    _missing_token_skill "ALL_DONE" > "$f"
+    run bash "$HELPER" check_monitor_batch_exit "$f"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "ALL_DONE"
+}
+BATS
+```
+
+- [ ] **Step 2: Run the tests — expect failures (red phase)**
+
+```bash
+bats tests/unit/test_monitor_batch_exit.bats
+```
+Expected: tests 1, 2, 3, 5 fail (function doesn't exist yet in helper); test 4 may pass. This confirms TDD setup is correct.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add tests/unit/test_monitor_batch_exit.bats
+git commit -m "test(monitor): add failing bats for batch self-termination (TDD red)"
+```
+
+---
+
+## Task 3: Update autospec-run/SKILL.md — orchestrator relaunch loop
+
+**Files:**
+- Modify: `skills/autospec-run/SKILL.md`
+
+- [ ] **Step 1: Replace the single-launch sentence with the relaunch loop**
+
+Find this text (around line 204):
+```
+Then launch a **background subagent** with this prompt verbatim:
+```
+
+Replace it with:
+```
+Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
+
+```
+batch_num = 1
+while true:
+  launch background subagent (pass batch_num; set AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3})
+  wait for task-notification (monitor agent completes)
+
+  # Read and consume the batch-done signal.
+  if [ -f "$HOME/.autospec/batch-done.json" ]; then
+    status=$(jq -r .status "$HOME/.autospec/batch-done.json" 2>/dev/null || echo "BATCH_COMPLETE")
+    rm -f "$HOME/.autospec/batch-done.json"
+  else
+    status="BATCH_COMPLETE"   # monitor crashed / overflowed — safe to relaunch
+  fi
+
+  if [ "$status" = "ALL_DONE" ]; then
+    break   # proceed to Phase 6 final report
+  fi
+
+  batch_num=$((batch_num + 1))
+  echo "[orchestrator] batch $((batch_num - 1)) complete — relaunching monitor with fresh context (batch ${batch_num})"
+  # continue immediately, no sleep
+```
+
+Pass the following prompt verbatim to each background subagent:
+```
+
+- [ ] **Step 2: Update the "Never exit after one issue" warning**
+
+Find:
+```
+> **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
+```
+
+Replace with:
+```
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator will relaunch you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
+```
+
+- [ ] **Step 3: Add batch initialization at the top of the outer loop**
+
+Find the outer loop start (around line 229):
+```
+> while true:
+>   deferred = []   # issues skipped because they exceed the active profile
+```
+
+Replace with:
+```
+> while true:
+>   deferred = []   # issues skipped because they exceed the active profile
+>
+>   # Batch self-termination setup (run-once, at first iteration only via shell init before loop).
+>   # These vars are initialized before the loop:
+>   #   batch_issue_count=0
+>   #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+>   #   rm -f "$HOME/.autospec/batch-done.json"   # clear any stale file from prior crash
+```
+
+- [ ] **Step 4: Add batch counter increment and exit after process(ISSUE)**
+
+Find (around line 370-372):
+```
+>   process(ISSUE)   # foreground subagent — see template below
+>   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
+>   # of this loop immediately so the fresh queue scan can pick any issue unblocked
+```
+
+Replace with:
+```
+>   process(ISSUE)   # foreground subagent — see template below
+>   batch_issue_count=$((batch_issue_count + 1))
+>   if [ "$batch_issue_count" -ge "$BATCH_SIZE" ]; then
+>     printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"BATCH_COMPLETE"}\n' \
+>       "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>       > "$HOME/.autospec/batch-done.json"
+>     echo "[monitor] batch ${batch_num:-1}: processed $batch_issue_count/$BATCH_SIZE issues — writing batch-done.json and exiting for fresh context"
+>     exit 0
+>   fi
+>   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
+>   # of this loop immediately so the fresh queue scan can pick any issue unblocked
+```
+
+- [ ] **Step 5: Add ALL_DONE write to the HARD SHUTDOWN path**
+
+Find (around line 283):
+```
+>     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
+```
+
+Replace with:
+```
+>     if open_count == 0 AND latest_close > 2h ago:
+>       printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"ALL_DONE"}\n' \
+>         "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>         > "$HOME/.autospec/batch-done.json"
+>       echo "[monitor] all issues processed — writing ALL_DONE and exiting"
+>       HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
+```
+
+- [ ] **Step 6: Verify validate.sh now passes on autospec-run SKILL.md**
+
+```bash
+bash scripts/validate.sh 2>&1 | grep -E "FAIL|PASS|monitor-batch"
+```
+Expected: `monitor-batch-exit: autospec-run` line (PASS); no FAIL for autospec-run.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add skills/autospec-run/SKILL.md
+git commit -m "feat(autospec-run): add batch self-termination + orchestrator relaunch loop"
+```
+
+---
+
+## Task 4: Lock-step sync autospec-run trio
+
+**Files:**
+- Modify: `skills/autospec-run/codex/prompt.md`
+- Modify: `skills/autospec-run/opencode/agent.md`
+
+- [ ] **Step 1: Strip frontmatter from SKILL.md to get raw body**
+
+```bash
+awk 'BEGIN{f=0} /^---/{f++; next} f>=2{print}' \
+  skills/autospec-run/SKILL.md > /tmp/autospec-run-body.md
+wc -l /tmp/autospec-run-body.md
+```
+Expected: line count matches SKILL.md minus its frontmatter lines.
+
+- [ ] **Step 2: Overwrite codex/prompt.md**
+
+```bash
+cp /tmp/autospec-run-body.md skills/autospec-run/codex/prompt.md
+```
+
+- [ ] **Step 3: Update opencode/agent.md (keep frontmatter, replace body)**
+
+```bash
+# Extract frontmatter (up to and including the second ---):
+awk 'BEGIN{f=0} /^---/{f++; print; if(f==2) exit} f>0{print}' \
+  skills/autospec-run/opencode/agent.md > /tmp/ocode-front.md
+# Combine: frontmatter + blank line + body:
+{ cat /tmp/ocode-front.md; echo ""; cat /tmp/autospec-run-body.md; } \
+  > skills/autospec-run/opencode/agent.md
+```
+
+- [ ] **Step 4: Run validate.sh to confirm lock-step passes**
+
+```bash
+bash scripts/validate.sh 2>&1 | grep -E "lock-step|FAIL"
+```
+Expected: no FAIL; `lock-step: autospec-run` printed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/autospec-run/codex/prompt.md skills/autospec-run/opencode/agent.md
+git commit -m "chore(autospec-run): lock-step sync codex/prompt.md and opencode/agent.md"
+```
+
+---
+
+## Task 5: Apply same Phase 4 changes to autospec/SKILL.md + lock-step sync
+
+**Files:**
+- Modify: `skills/autospec/SKILL.md`
+- Modify: `skills/autospec/codex/prompt.md`
+- Modify: `skills/autospec/opencode/agent.md`
+
+- [ ] **Step 1: Apply identical Phase 4 text changes to autospec/SKILL.md**
+
+Repeat every edit from Task 3 Steps 1–5, targeting `skills/autospec/SKILL.md`. The Phase 4 section in autospec/SKILL.md is a verbatim copy of the one in autospec-run/SKILL.md (they share the same monitor prompt text). Use grep to find the equivalent line numbers:
+
+```bash
+grep -n "Then launch a \*\*background subagent\|Never exit after processing\|while true:\|HARD SHUTDOWN\|process(ISSUE)   # foreground" \
+  skills/autospec/SKILL.md
+```
+
+Apply the same five substitutions from Task 3 at the lines found above.
+
+- [ ] **Step 2: Verify validate.sh passes for autospec**
+
+```bash
+bash scripts/validate.sh 2>&1 | grep -E "FAIL|monitor-batch"
+```
+Expected: `monitor-batch-exit: autospec` printed; no FAIL.
+
+- [ ] **Step 3: Commit autospec/SKILL.md**
+
+```bash
+git add skills/autospec/SKILL.md
+git commit -m "feat(autospec): add batch self-termination + orchestrator relaunch loop"
+```
+
+- [ ] **Step 4: Strip frontmatter and sync autospec codex/opencode trios**
+
+```bash
+awk 'BEGIN{f=0} /^---/{f++; next} f>=2{print}' \
+  skills/autospec/SKILL.md > /tmp/autospec-body.md
+
+cp /tmp/autospec-body.md skills/autospec/codex/prompt.md
+
+awk 'BEGIN{f=0} /^---/{f++; print; if(f==2) exit} f>0{print}' \
+  skills/autospec/opencode/agent.md > /tmp/ocode-autospec-front.md
+{ cat /tmp/ocode-autospec-front.md; echo ""; cat /tmp/autospec-body.md; } \
+  > skills/autospec/opencode/agent.md
+```
+
+- [ ] **Step 5: Validate lock-step for autospec**
+
+```bash
+bash scripts/validate.sh 2>&1 | grep -E "lock-step|FAIL"
+```
+Expected: `lock-step: autospec` printed; no FAIL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/autospec/codex/prompt.md skills/autospec/opencode/agent.md
+git commit -m "chore(autospec): lock-step sync codex/prompt.md and opencode/agent.md"
+```
+
+---
+
+## Task 6: Green phase — run all tests
+
+**Files:** none new
+
+- [ ] **Step 1: Run the bats test suite**
+
+```bash
+bats tests/unit/test_monitor_batch_exit.bats -v
+```
+Expected: all 5 tests PASS.
+
+- [ ] **Step 2: Run the full validate.sh**
+
+```bash
+bash scripts/validate.sh
+```
+Expected: exit 0; no FAIL lines; `monitor-batch-exit: autospec` and `monitor-batch-exit: autospec-run` both printed.
+
+- [ ] **Step 3: Run full bats suite to catch regressions**
+
+```bash
+bats tests/unit/ --timing
+```
+Expected: all tests pass; `test_monitor_batch_exit.bats` shows 5 passing.
+
+- [ ] **Step 4: Final commit if anything was fixed**
+
+```bash
+git add -p   # review any fixup changes
+git commit -m "fix(monitor): green phase — all batch-exit tests passing"
+```
+Skip if nothing changed since last commit.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §3.1 (batch counter) → Task 3 Steps 3–4. §3.2 (file schema) → Task 3 Step 4. §3.3 (orchestrator loop) → Task 3 Step 1. §3.4 (config) → Task 3 Steps 3–4. §4 (error handling) → Task 3 Step 5 (crash recovery) + Task 3 Step 3 (stale file). §5 (affected files) → Tasks 3–5. §6 (bats tests) → Task 2.
+- **Lock-step:** Explicitly handled in Tasks 4 and 5 for all 6 trio files.
+- **TDD:** Task 2 writes and commits failing tests before Task 3 writes the implementation.
+- **Type consistency:** `batch_issue_count`, `AUTOSPEC_BATCH_SIZE`, `batch-done.json`, `BATCH_COMPLETE`, `ALL_DONE` — used consistently across validate.sh function (Task 1), bats tests (Task 2), and SKILL.md prose (Tasks 3, 5).

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -259,6 +259,27 @@ check_harness_detection_block() {
         || fail "$name: ## Harness detection section present but missing 'silently' fallback reference"
 }
 
+check_monitor_batch_exit() {
+    local file="$1"
+    # Only enforce on skills that contain a Phase 4 monitor outer loop.
+    # Skills without Phase 4 (e.g. autospec-classify, autospec-review) are silently skipped.
+    if ! grep -q "Phase 4" "$file" 2>/dev/null; then
+        return 0
+    fi
+    local name
+    name="$(basename "$(dirname "$file")")"
+    local missing=()
+    grep -q "batch_issue_count" "$file"   || missing+=("batch_issue_count")
+    grep -q "AUTOSPEC_BATCH_SIZE"  "$file" || missing+=("AUTOSPEC_BATCH_SIZE")
+    grep -q "batch-done.json"      "$file" || missing+=("batch-done.json")
+    grep -q "BATCH_COMPLETE"       "$file" || missing+=("BATCH_COMPLETE")
+    grep -q "ALL_DONE"             "$file" || missing+=("ALL_DONE")
+    if [ "${#missing[@]}" -gt 0 ]; then
+        fail "$name: monitor batch-exit missing: ${missing[*]}"
+    fi
+    info "monitor-batch-exit: $name"
+}
+
 # AGENTS.md must document the two-tier subagent model selection policy with
 # both Tier A and Tier B subsection headings.
 check_agents_md_subagent_section() {
@@ -519,6 +540,7 @@ main() {
         check_self_update "$skill_dir"
         check_subagent_model_tier "$skill_dir"
         check_harness_detection_block "$skill_dir/SKILL.md"
+        check_monitor_batch_exit "$skill_dir/SKILL.md"
     done
 
     check_startup_preflight

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -263,7 +263,7 @@ check_monitor_batch_exit() {
     local file="$1"
     # Only enforce on skills that contain a Phase 4 monitor outer loop.
     # Skills without Phase 4 (e.g. autospec-classify, autospec-review) are silently skipped.
-    if ! grep -q "Phase 4" "$file" 2>/dev/null; then
+    if ! grep -q "^## Phase 4 — Background autonomous monitor" "$file" 2>/dev/null; then
         return 0
     fi
     local name

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -201,9 +201,34 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
-Then launch a **background subagent** with this prompt verbatim:
+Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
-> You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+```
+batch_num=1
+while true:
+  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3})
+  wait for task-notification (monitor agent completes)
+
+  # Read and consume the batch-done signal.
+  if [ -f "$HOME/.autospec/batch-done.json" ]; then
+    status=$(jq -r .status "$HOME/.autospec/batch-done.json" 2>/dev/null || echo "BATCH_COMPLETE")
+    rm -f "$HOME/.autospec/batch-done.json"
+  else
+    status="BATCH_COMPLETE"   # monitor crashed / overflowed — safe to relaunch
+  fi
+
+  if [ "$status" = "ALL_DONE" ]; then
+    break   # proceed to Phase 6 final report
+  fi
+
+  batch_num=$((batch_num + 1))
+  echo "[orchestrator] batch $((batch_num - 1)) complete — relaunching monitor with fresh context (batch ${batch_num})"
+  # continue immediately, no sleep
+```
+
+Pass the following prompt verbatim to each background subagent:
+
+> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
 
 > **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
 > 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
@@ -215,7 +240,7 @@ Then launch a **background subagent** with this prompt verbatim:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Profile load (run-start, once).** If `--profile <name>` was passed, look it up in `~/.autospec/model-profiles.yml`; if `<name>` is not a key under `profiles:`, exit non-zero and print the available names. If no flag was passed, load the file's `default:` profile. If the file is missing, run auto-init and exit (per the Invocation section).
@@ -226,6 +251,11 @@ Then launch a **background subagent** with this prompt verbatim:
 >
 > Outer loop:
 > ```
+> # Before the loop (run-once init):
+> #   batch_issue_count=0
+> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
+>
 > while true:
 >   deferred = []   # issues skipped because they exceed the active profile
 >
@@ -280,7 +310,12 @@ issues unblock the queue before continuing with normal feature work.
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
->     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
+>     if open_count == 0 AND latest_close > 2h ago:
+>       printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"ALL_DONE"}\n' \
+>         "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>         > "$HOME/.autospec/batch-done.json"
+>       echo "[monitor] all issues processed — writing ALL_DONE and exiting"
+>       HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
 >     else: print state ("blocked: N unmet deps" / "deferred: M off-profile" / "drained, waiting 2h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then
@@ -368,6 +403,14 @@ issues unblock the queue before continuing with normal feature work.
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
+>   batch_issue_count=$((batch_issue_count + 1))
+>   if [ "$batch_issue_count" -ge "$BATCH_SIZE" ]; then
+>     printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"BATCH_COMPLETE"}\n' \
+>       "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>       > "$HOME/.autospec/batch-done.json"
+>     echo "[monitor] batch ${batch_num:-1}: processed $batch_issue_count/$BATCH_SIZE issues — writing batch-done.json and exiting for fresh context"
+>     exit 0
+>   fi
 >   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
 >   # of this loop immediately so the fresh queue scan can pick any issue unblocked
 >   # by the merge or failure cleanup that just completed.

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -254,6 +254,7 @@ Pass the following prompt verbatim to each background subagent:
 > # Before the loop (run-once init):
 > #   batch_issue_count=0
 > #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3   # guard against 0 or negative
 > #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
 >
 > while true:
@@ -326,6 +327,9 @@ issues unblock the queue before continuing with normal feature work.
 >     if [ "$AGE_SECS" -gt 86400 ]; then
 >       echo "WARN: stale stop.flag ($AGE_SECS s old); ignoring" >&2
 >     elif [ "$MODE" = "graceful" ] || [ "$MODE" = "immediate" ]; then
+>       printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"ALL_DONE"}\n' \
+>         "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>         > "$HOME/.autospec/batch-done.json"
 >       echo "[monitor] stop signal received: $MODE — exiting"
 >       # HARD SHUTDOWN with final report
 >       exit 0

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -196,9 +196,34 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
-Then launch a **background subagent** with this prompt verbatim:
+Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
-> You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+```
+batch_num=1
+while true:
+  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3})
+  wait for task-notification (monitor agent completes)
+
+  # Read and consume the batch-done signal.
+  if [ -f "$HOME/.autospec/batch-done.json" ]; then
+    status=$(jq -r .status "$HOME/.autospec/batch-done.json" 2>/dev/null || echo "BATCH_COMPLETE")
+    rm -f "$HOME/.autospec/batch-done.json"
+  else
+    status="BATCH_COMPLETE"   # monitor crashed / overflowed — safe to relaunch
+  fi
+
+  if [ "$status" = "ALL_DONE" ]; then
+    break   # proceed to Phase 6 final report
+  fi
+
+  batch_num=$((batch_num + 1))
+  echo "[orchestrator] batch $((batch_num - 1)) complete — relaunching monitor with fresh context (batch ${batch_num})"
+  # continue immediately, no sleep
+```
+
+Pass the following prompt verbatim to each background subagent:
+
+> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
 
 > **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
 > 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
@@ -210,7 +235,7 @@ Then launch a **background subagent** with this prompt verbatim:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Profile load (run-start, once).** If `--profile <name>` was passed, look it up in `~/.autospec/model-profiles.yml`; if `<name>` is not a key under `profiles:`, exit non-zero and print the available names. If no flag was passed, load the file's `default:` profile. If the file is missing, run auto-init and exit (per the Invocation section).
@@ -221,6 +246,11 @@ Then launch a **background subagent** with this prompt verbatim:
 >
 > Outer loop:
 > ```
+> # Before the loop (run-once init):
+> #   batch_issue_count=0
+> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
+>
 > while true:
 >   deferred = []   # issues skipped because they exceed the active profile
 >
@@ -275,7 +305,12 @@ issues unblock the queue before continuing with normal feature work.
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
->     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
+>     if open_count == 0 AND latest_close > 2h ago:
+>       printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"ALL_DONE"}\n' \
+>         "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>         > "$HOME/.autospec/batch-done.json"
+>       echo "[monitor] all issues processed — writing ALL_DONE and exiting"
+>       HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
 >     else: print state ("blocked: N unmet deps" / "deferred: M off-profile" / "drained, waiting 2h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then
@@ -363,6 +398,14 @@ issues unblock the queue before continuing with normal feature work.
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
+>   batch_issue_count=$((batch_issue_count + 1))
+>   if [ "$batch_issue_count" -ge "$BATCH_SIZE" ]; then
+>     printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"BATCH_COMPLETE"}\n' \
+>       "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>       > "$HOME/.autospec/batch-done.json"
+>     echo "[monitor] batch ${batch_num:-1}: processed $batch_issue_count/$BATCH_SIZE issues — writing batch-done.json and exiting for fresh context"
+>     exit 0
+>   fi
 >   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
 >   # of this loop immediately so the fresh queue scan can pick any issue unblocked
 >   # by the merge or failure cleanup that just completed.

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -249,6 +249,7 @@ Pass the following prompt verbatim to each background subagent:
 > # Before the loop (run-once init):
 > #   batch_issue_count=0
 > #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3   # guard against 0 or negative
 > #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
 >
 > while true:
@@ -321,6 +322,9 @@ issues unblock the queue before continuing with normal feature work.
 >     if [ "$AGE_SECS" -gt 86400 ]; then
 >       echo "WARN: stale stop.flag ($AGE_SECS s old); ignoring" >&2
 >     elif [ "$MODE" = "graceful" ] || [ "$MODE" = "immediate" ]; then
+>       printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"ALL_DONE"}\n' \
+>         "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>         > "$HOME/.autospec/batch-done.json"
 >       echo "[monitor] stop signal received: $MODE — exiting"
 >       # HARD SHUTDOWN with final report
 >       exit 0

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -200,9 +200,34 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
-Then launch a **background subagent** with this prompt verbatim:
+Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
-> You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+```
+batch_num=1
+while true:
+  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3})
+  wait for task-notification (monitor agent completes)
+
+  # Read and consume the batch-done signal.
+  if [ -f "$HOME/.autospec/batch-done.json" ]; then
+    status=$(jq -r .status "$HOME/.autospec/batch-done.json" 2>/dev/null || echo "BATCH_COMPLETE")
+    rm -f "$HOME/.autospec/batch-done.json"
+  else
+    status="BATCH_COMPLETE"   # monitor crashed / overflowed — safe to relaunch
+  fi
+
+  if [ "$status" = "ALL_DONE" ]; then
+    break   # proceed to Phase 6 final report
+  fi
+
+  batch_num=$((batch_num + 1))
+  echo "[orchestrator] batch $((batch_num - 1)) complete — relaunching monitor with fresh context (batch ${batch_num})"
+  # continue immediately, no sleep
+```
+
+Pass the following prompt verbatim to each background subagent:
+
+> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
 
 > **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
 > 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
@@ -214,7 +239,7 @@ Then launch a **background subagent** with this prompt verbatim:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Profile load (run-start, once).** If `--profile <name>` was passed, look it up in `~/.autospec/model-profiles.yml`; if `<name>` is not a key under `profiles:`, exit non-zero and print the available names. If no flag was passed, load the file's `default:` profile. If the file is missing, run auto-init and exit (per the Invocation section).
@@ -225,6 +250,11 @@ Then launch a **background subagent** with this prompt verbatim:
 >
 > Outer loop:
 > ```
+> # Before the loop (run-once init):
+> #   batch_issue_count=0
+> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
+>
 > while true:
 >   deferred = []   # issues skipped because they exceed the active profile
 >
@@ -279,7 +309,12 @@ issues unblock the queue before continuing with normal feature work.
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
->     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
+>     if open_count == 0 AND latest_close > 2h ago:
+>       printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"ALL_DONE"}\n' \
+>         "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>         > "$HOME/.autospec/batch-done.json"
+>       echo "[monitor] all issues processed — writing ALL_DONE and exiting"
+>       HARD SHUTDOWN — emit final report (incl. deferred summary, see Phase 6)
 >     else: print state ("blocked: N unmet deps" / "deferred: M off-profile" / "drained, waiting 2h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then
@@ -367,6 +402,14 @@ issues unblock the queue before continuing with normal feature work.
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
+>   batch_issue_count=$((batch_issue_count + 1))
+>   if [ "$batch_issue_count" -ge "$BATCH_SIZE" ]; then
+>     printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"BATCH_COMPLETE"}\n' \
+>       "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>       > "$HOME/.autospec/batch-done.json"
+>     echo "[monitor] batch ${batch_num:-1}: processed $batch_issue_count/$BATCH_SIZE issues — writing batch-done.json and exiting for fresh context"
+>     exit 0
+>   fi
 >   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
 >   # of this loop immediately so the fresh queue scan can pick any issue unblocked
 >   # by the merge or failure cleanup that just completed.

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -253,6 +253,7 @@ Pass the following prompt verbatim to each background subagent:
 > # Before the loop (run-once init):
 > #   batch_issue_count=0
 > #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3   # guard against 0 or negative
 > #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
 >
 > while true:
@@ -325,6 +326,9 @@ issues unblock the queue before continuing with normal feature work.
 >     if [ "$AGE_SECS" -gt 86400 ]; then
 >       echo "WARN: stale stop.flag ($AGE_SECS s old); ignoring" >&2
 >     elif [ "$MODE" = "graceful" ] || [ "$MODE" = "immediate" ]; then
+>       printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"ALL_DONE"}\n' \
+>         "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>         > "$HOME/.autospec/batch-done.json"
 >       echo "[monitor] stop signal received: $MODE — exiting"
 >       # HARD SHUTDOWN with final report
 >       exit 0

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -547,6 +547,7 @@ Pass the following prompt verbatim to each background subagent:
 > # Before the loop (run-once init):
 > #   batch_issue_count=0
 > #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3   # guard against 0 or negative
 > #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
 >
 > while true:
@@ -590,6 +591,9 @@ Pass the following prompt verbatim to each background subagent:
 >     if [ "$AGE_SECS" -gt 86400 ]; then
 >       echo "WARN: stale stop.flag ($AGE_SECS s old); ignoring" >&2
 >     elif [ "$MODE" = "graceful" ] || [ "$MODE" = "immediate" ]; then
+>       printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"ALL_DONE"}\n' \
+>         "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>         > "$HOME/.autospec/batch-done.json"
 >       echo "[monitor] stop signal received: $MODE — exiting"
 >       # HARD SHUTDOWN with final report
 >       exit 0

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -498,9 +498,34 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
-Then launch a **background subagent** with this prompt verbatim:
+Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
-> You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+```
+batch_num=1
+while true:
+  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3})
+  wait for task-notification (monitor agent completes)
+
+  # Read and consume the batch-done signal.
+  if [ -f "$HOME/.autospec/batch-done.json" ]; then
+    status=$(jq -r .status "$HOME/.autospec/batch-done.json" 2>/dev/null || echo "BATCH_COMPLETE")
+    rm -f "$HOME/.autospec/batch-done.json"
+  else
+    status="BATCH_COMPLETE"   # monitor crashed / overflowed — safe to relaunch
+  fi
+
+  if [ "$status" = "ALL_DONE" ]; then
+    break   # proceed to Phase 6 final report
+  fi
+
+  batch_num=$((batch_num + 1))
+  echo "[orchestrator] batch $((batch_num - 1)) complete — relaunching monitor with fresh context (batch ${batch_num})"
+  # continue immediately, no sleep
+```
+
+Pass the following prompt verbatim to each background subagent:
+
+> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
 
 > **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
 > 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
@@ -512,13 +537,18 @@ Then launch a **background subagent** with this prompt verbatim:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Shared helper scripts.** Helper scripts live at `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}` after installation. Do not assume the target repository has an autospec `scripts/` directory.
 >
 > Outer loop:
 > ```
+> # Before the loop (run-once init):
+> #   batch_issue_count=0
+> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
+>
 > while true:
 >   # Startup/per-scan heartbeat reconciliation — run before candidate selection.
 >   # This deletes closed/merged/orphaned heartbeats, rejects old schemas like
@@ -544,7 +574,12 @@ Then launch a **background subagent** with this prompt verbatim:
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
->     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — return final report
+>     if open_count == 0 AND latest_close > 2h ago:
+>       printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"ALL_DONE"}\n' \
+>         "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>         > "$HOME/.autospec/batch-done.json"
+>       echo "[monitor] all issues processed — writing ALL_DONE and exiting"
+>       HARD SHUTDOWN — return final report
 >     else: print state ("blocked: N unmet deps" / "drained, waiting 2h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then
@@ -632,6 +667,14 @@ Then launch a **background subagent** with this prompt verbatim:
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
+>   batch_issue_count=$((batch_issue_count + 1))
+>   if [ "$batch_issue_count" -ge "$BATCH_SIZE" ]; then
+>     printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"BATCH_COMPLETE"}\n' \
+>       "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>       > "$HOME/.autospec/batch-done.json"
+>     echo "[monitor] batch ${batch_num:-1}: processed $batch_issue_count/$BATCH_SIZE issues — writing batch-done.json and exiting for fresh context"
+>     exit 0
+>   fi
 >   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
 >   # of this loop immediately so the fresh queue scan can pick any issue unblocked
 >   # by the merge or failure cleanup that just completed.

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -492,9 +492,34 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
-Then launch a **background subagent** with this prompt verbatim:
+Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
-> You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+```
+batch_num=1
+while true:
+  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3})
+  wait for task-notification (monitor agent completes)
+
+  # Read and consume the batch-done signal.
+  if [ -f "$HOME/.autospec/batch-done.json" ]; then
+    status=$(jq -r .status "$HOME/.autospec/batch-done.json" 2>/dev/null || echo "BATCH_COMPLETE")
+    rm -f "$HOME/.autospec/batch-done.json"
+  else
+    status="BATCH_COMPLETE"   # monitor crashed / overflowed — safe to relaunch
+  fi
+
+  if [ "$status" = "ALL_DONE" ]; then
+    break   # proceed to Phase 6 final report
+  fi
+
+  batch_num=$((batch_num + 1))
+  echo "[orchestrator] batch $((batch_num - 1)) complete — relaunching monitor with fresh context (batch ${batch_num})"
+  # continue immediately, no sleep
+```
+
+Pass the following prompt verbatim to each background subagent:
+
+> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
 
 > **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
 > 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
@@ -506,13 +531,18 @@ Then launch a **background subagent** with this prompt verbatim:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Shared helper scripts.** Helper scripts live at `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}` after installation. Do not assume the target repository has an autospec `scripts/` directory.
 >
 > Outer loop:
 > ```
+> # Before the loop (run-once init):
+> #   batch_issue_count=0
+> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
+>
 > while true:
 >   # Startup/per-scan heartbeat reconciliation — run before candidate selection.
 >   # This deletes closed/merged/orphaned heartbeats, rejects old schemas like
@@ -538,7 +568,12 @@ Then launch a **background subagent** with this prompt verbatim:
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
->     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — return final report
+>     if open_count == 0 AND latest_close > 2h ago:
+>       printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"ALL_DONE"}\n' \
+>         "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>         > "$HOME/.autospec/batch-done.json"
+>       echo "[monitor] all issues processed — writing ALL_DONE and exiting"
+>       HARD SHUTDOWN — return final report
 >     else: print state ("blocked: N unmet deps" / "drained, waiting 2h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then
@@ -626,6 +661,14 @@ Then launch a **background subagent** with this prompt verbatim:
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
+>   batch_issue_count=$((batch_issue_count + 1))
+>   if [ "$batch_issue_count" -ge "$BATCH_SIZE" ]; then
+>     printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"BATCH_COMPLETE"}\n' \
+>       "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>       > "$HOME/.autospec/batch-done.json"
+>     echo "[monitor] batch ${batch_num:-1}: processed $batch_issue_count/$BATCH_SIZE issues — writing batch-done.json and exiting for fresh context"
+>     exit 0
+>   fi
 >   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
 >   # of this loop immediately so the fresh queue scan can pick any issue unblocked
 >   # by the merge or failure cleanup that just completed.

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -541,6 +541,7 @@ Pass the following prompt verbatim to each background subagent:
 > # Before the loop (run-once init):
 > #   batch_issue_count=0
 > #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3   # guard against 0 or negative
 > #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
 >
 > while true:
@@ -584,6 +585,9 @@ Pass the following prompt verbatim to each background subagent:
 >     if [ "$AGE_SECS" -gt 86400 ]; then
 >       echo "WARN: stale stop.flag ($AGE_SECS s old); ignoring" >&2
 >     elif [ "$MODE" = "graceful" ] || [ "$MODE" = "immediate" ]; then
+>       printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"ALL_DONE"}\n' \
+>         "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>         > "$HOME/.autospec/batch-done.json"
 >       echo "[monitor] stop signal received: $MODE — exiting"
 >       # HARD SHUTDOWN with final report
 >       exit 0

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -545,6 +545,7 @@ Pass the following prompt verbatim to each background subagent:
 > # Before the loop (run-once init):
 > #   batch_issue_count=0
 > #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3   # guard against 0 or negative
 > #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
 >
 > while true:
@@ -588,6 +589,9 @@ Pass the following prompt verbatim to each background subagent:
 >     if [ "$AGE_SECS" -gt 86400 ]; then
 >       echo "WARN: stale stop.flag ($AGE_SECS s old); ignoring" >&2
 >     elif [ "$MODE" = "graceful" ] || [ "$MODE" = "immediate" ]; then
+>       printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"ALL_DONE"}\n' \
+>         "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>         > "$HOME/.autospec/batch-done.json"
 >       echo "[monitor] stop signal received: $MODE — exiting"
 >       # HARD SHUTDOWN with final report
 >       exit 0

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -496,9 +496,34 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
-Then launch a **background subagent** with this prompt verbatim:
+Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
-> You are the auto-implement monitor for `{repo}`. Process every open `auto-implement` issue autonomously and auto-merge each PR. **You MUST stay running across many iterations. Do NOT exit after one issue.**
+```
+batch_num=1
+while true:
+  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3})
+  wait for task-notification (monitor agent completes)
+
+  # Read and consume the batch-done signal.
+  if [ -f "$HOME/.autospec/batch-done.json" ]; then
+    status=$(jq -r .status "$HOME/.autospec/batch-done.json" 2>/dev/null || echo "BATCH_COMPLETE")
+    rm -f "$HOME/.autospec/batch-done.json"
+  else
+    status="BATCH_COMPLETE"   # monitor crashed / overflowed — safe to relaunch
+  fi
+
+  if [ "$status" = "ALL_DONE" ]; then
+    break   # proceed to Phase 6 final report
+  fi
+
+  batch_num=$((batch_num + 1))
+  echo "[orchestrator] batch $((batch_num - 1)) complete — relaunching monitor with fresh context (batch ${batch_num})"
+  # continue immediately, no sleep
+```
+
+Pass the following prompt verbatim to each background subagent:
+
+> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
 
 > **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
 > 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
@@ -510,13 +535,18 @@ Then launch a **background subagent** with this prompt verbatim:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Never exit after processing one issue** — the loop must persist until shutdown (idle timeout, stop.flag, or all issues resolved).
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Shared helper scripts.** Helper scripts live at `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}` after installation. Do not assume the target repository has an autospec `scripts/` directory.
 >
 > Outer loop:
 > ```
+> # Before the loop (run-once init):
+> #   batch_issue_count=0
+> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
+>
 > while true:
 >   # Startup/per-scan heartbeat reconciliation — run before candidate selection.
 >   # This deletes closed/merged/orphaned heartbeats, rejects old schemas like
@@ -542,7 +572,12 @@ Then launch a **background subagent** with this prompt verbatim:
 >   if ready is empty:
 >     latest_close = most recent closedAt of any auto-implement issue
 >     open_count   = count of open auto-implement issues
->     if open_count == 0 AND latest_close > 2h ago: HARD SHUTDOWN — return final report
+>     if open_count == 0 AND latest_close > 2h ago:
+>       printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"ALL_DONE"}\n' \
+>         "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>         > "$HOME/.autospec/batch-done.json"
+>       echo "[monitor] all issues processed — writing ALL_DONE and exiting"
+>       HARD SHUTDOWN — return final report
 >     else: print state ("blocked: N unmet deps" / "drained, waiting 2h idle"), sleep 300, continue
 >   # autospec-stop sentinel check — outer loop, top of each iteration
 >   if [ -f "$HOME/.autospec/stop.flag" ]; then
@@ -630,6 +665,14 @@ Then launch a **background subagent** with this prompt verbatim:
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
+>   batch_issue_count=$((batch_issue_count + 1))
+>   if [ "$batch_issue_count" -ge "$BATCH_SIZE" ]; then
+>     printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"BATCH_COMPLETE"}\n' \
+>       "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
+>       > "$HOME/.autospec/batch-done.json"
+>     echo "[monitor] batch ${batch_num:-1}: processed $batch_issue_count/$BATCH_SIZE issues — writing batch-done.json and exiting for fresh context"
+>     exit 0
+>   fi
 >   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top
 >   # of this loop immediately so the fresh queue scan can pick any issue unblocked
 >   # by the merge or failure cleanup that just completed.

--- a/tests/unit/test_monitor_batch_exit.bats
+++ b/tests/unit/test_monitor_batch_exit.bats
@@ -45,11 +45,10 @@ version: 1.0.0
 
 ## Phase 4 — Background autonomous monitor
 
-> batch_issue_count=0
-> AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3}
+> batch_issue_count=0; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3}
 >
 > Write "$HOME/.autospec/batch-done.json" with status BATCH_COMPLETE after batch limit.
-> When queue drained write ALL_DONE.
+> When queue drained write status ALL_DONE instead.
 EOF
 }
 

--- a/tests/unit/test_monitor_batch_exit.bats
+++ b/tests/unit/test_monitor_batch_exit.bats
@@ -128,3 +128,29 @@ EOF
     [ "$status" -ne 0 ]
     echo "$output" | grep -q "ALL_DONE"
 }
+
+# ===========================================================================
+# Test 6: AUTOSPEC_BATCH_SIZE=0 guard (guard against <=0 defaulting to batch-of-1)
+# ===========================================================================
+@test "check_monitor_batch_exit: SKILL.md with BATCH_SIZE guard for <=0 passes" {
+    local f="$SCRATCH/SKILL.md"
+    # Build a skill that has all required tokens including the guard line
+    cat > "$f" <<'EOF'
+---
+name: autospec-run
+version: 1.0.0
+---
+
+## Phase 4 — Background autonomous monitor
+
+> batch_issue_count=0; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3}
+> [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3
+>
+> Write "$HOME/.autospec/batch-done.json" with status BATCH_COMPLETE after batch limit.
+> When queue drained write status ALL_DONE instead.
+EOF
+
+    run bash -c "source '$HELPER' && check_monitor_batch_exit '$f'" 2>&1
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "monitor-batch-exit"
+}

--- a/tests/unit/test_monitor_batch_exit.bats
+++ b/tests/unit/test_monitor_batch_exit.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# tests/unit/test_monitor_batch_exit.bats — verify check_monitor_batch_exit()
+# in scripts/validate.sh detects missing/present batch self-termination logic.
+#
+# Five cases per spec docs/specs/2026-05-07-monitor-session-reset-design.md:
+#   1. SKILL.md with all required batch-exit tokens passes
+#   2. SKILL.md missing batch_issue_count fails
+#   3. SKILL.md missing batch-done.json token fails
+#   4. SKILL.md without Phase 4 marker is silently skipped (exit 0)
+#   5. SKILL.md missing ALL_DONE fails
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    VALIDATE="$REPO_ROOT/scripts/validate.sh"
+    SCRATCH="$(mktemp -d)"
+    export SCRATCH REPO_ROOT VALIDATE
+
+    # Build an isolated helper that exposes only check_monitor_batch_exit.
+    HELPER="$SCRATCH/helper.sh"
+    cat > "$HELPER" <<'HELPER_SCRIPT'
+#!/usr/bin/env bash
+set -eu
+fail() { printf 'validate: FAIL — %s\n' "$*" >&2; exit 1; }
+info() { printf 'validate: %s\n' "$*"; }
+HELPER_SCRIPT
+
+    sed -n '/^check_monitor_batch_exit()/,/^}/p' "$VALIDATE" >> "$HELPER"
+    export HELPER
+}
+
+teardown() {
+    if [ -n "${SCRATCH:-}" ] && [ -d "$SCRATCH" ]; then
+        rm -rf "$SCRATCH"
+    fi
+}
+
+# Helper: write a SKILL.md body with Phase 4 marker and all required tokens.
+_full_batch_skill() {
+    local f="$1"
+    cat > "$f" <<'EOF'
+---
+name: autospec-run
+version: 1.0.0
+---
+
+## Phase 4 — Background autonomous monitor
+
+> batch_issue_count=0
+> AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3}
+>
+> Write "$HOME/.autospec/batch-done.json" with status BATCH_COMPLETE after batch limit.
+> When queue drained write ALL_DONE.
+EOF
+}
+
+# ===========================================================================
+# Test 1: All tokens present → passes
+# ===========================================================================
+@test "check_monitor_batch_exit: SKILL.md with all batch-exit tokens passes" {
+    local f="$SCRATCH/SKILL.md"
+    _full_batch_skill "$f"
+
+    run bash -c "source '$HELPER' && check_monitor_batch_exit '$f'" 2>&1
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "monitor-batch-exit"
+}
+
+# ===========================================================================
+# Test 2: Missing batch_issue_count → fails
+# ===========================================================================
+@test "check_monitor_batch_exit: SKILL.md missing batch_issue_count fails" {
+    local f="$SCRATCH/SKILL.md"
+    _full_batch_skill "$f"
+    # Remove the batch_issue_count line
+    sed -i '' '/batch_issue_count/d' "$f" 2>/dev/null \
+        || sed -i '/batch_issue_count/d' "$f"
+
+    run bash -c "source '$HELPER' && check_monitor_batch_exit '$f'" 2>&1
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "batch_issue_count"
+}
+
+# ===========================================================================
+# Test 3: Missing batch-done.json → fails
+# ===========================================================================
+@test "check_monitor_batch_exit: SKILL.md missing batch-done.json fails" {
+    local f="$SCRATCH/SKILL.md"
+    _full_batch_skill "$f"
+    sed -i '' '/batch-done\.json/d' "$f" 2>/dev/null \
+        || sed -i '/batch-done\.json/d' "$f"
+
+    run bash -c "source '$HELPER' && check_monitor_batch_exit '$f'" 2>&1
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "batch-done.json"
+}
+
+# ===========================================================================
+# Test 4: No Phase 4 marker → silently skipped (exit 0)
+# ===========================================================================
+@test "check_monitor_batch_exit: SKILL.md without Phase 4 is silently skipped" {
+    local f="$SCRATCH/SKILL.md"
+    cat > "$f" <<'EOF'
+---
+name: autospec-classify
+version: 1.0.0
+---
+
+# autospec-classify
+
+This skill has no background autonomous monitor outer loop.
+EOF
+
+    run bash -c "source '$HELPER' && check_monitor_batch_exit '$f'" 2>&1
+    [ "$status" -eq 0 ]
+    # Must NOT print the monitor-batch-exit info line (skipped silently)
+    ! echo "$output" | grep -q "monitor-batch-exit"
+}
+
+# ===========================================================================
+# Test 5: Missing ALL_DONE → fails
+# ===========================================================================
+@test "check_monitor_batch_exit: SKILL.md missing ALL_DONE fails" {
+    local f="$SCRATCH/SKILL.md"
+    _full_batch_skill "$f"
+    sed -i '' '/ALL_DONE/d' "$f" 2>/dev/null \
+        || sed -i '/ALL_DONE/d' "$f"
+
+    run bash -c "source '$HELPER' && check_monitor_batch_exit '$f'" 2>&1
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "ALL_DONE"
+}


### PR DESCRIPTION
## Summary

- Adds `batch_issue_count` counter to the Phase 4 monitor outer loop in both `autospec` and `autospec-run` skills — exits after `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`
- Replaces single-launch Phase 4 block with an orchestrator relaunch loop that reads the file, relaunches on `BATCH_COMPLETE`, and stops on `ALL_DONE`
- If monitor crashes without writing the file, orchestrator treats it as `BATCH_COMPLETE` (safe crash recovery via GitHub labels + heartbeat files)
- Adds `check_monitor_batch_exit()` to `scripts/validate.sh` + 5 bats tests in `tests/unit/test_monitor_batch_exit.bats`
- Lock-step syncs all 6 trio files (SKILL.md + codex/prompt.md + opencode/agent.md) for both skills

## Why

Context overflow at ~185 tool calls (~4-5 issues) caused silent exits and "Prompt is too long" errors. This makes session length bounded and predictable.

## Test Plan

- [ ] `bash scripts/validate.sh` exits 0
- [ ] `bats tests/unit/test_monitor_batch_exit.bats` — all 5 pass
- [ ] `AUTOSPEC_BATCH_SIZE=2` run against a 4-issue queue produces 2 monitor launches with `batch-done.json` written and deleted between them
- [ ] Monitor crash (no file written) triggers orchestrator relaunch

🤖 Generated with [Claude Code](https://claude.ai/claude-code)