### PR TITLE
feat(monitor): fuse guardian + LGTM into single review subagent

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -478,9 +478,9 @@ check_autospec_run_priority_sort_lockstep() {
 check_autospec_run_regression_review_lockstep() {
     info "autospec-run regression review lockstep"
     for variant in "skills/autospec-run/opencode/agent.md" "skills/autospec-run/codex/prompt.md"; do
-        grep -q "Regression review escalation" "$variant" \
+        grep -qE "Regression (review escalation|meta-review)" "$variant" \
             || fail "regression review block missing in $variant"
-        grep -q "Tier A (spec work)" "$variant" \
+        grep -qE "Tier A \(spec work\)|TIER_A" "$variant" \
             || fail "Tier A annotation missing in $variant"
     done
 }

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -201,6 +201,8 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
+**Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
+
 Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
 ```
@@ -462,77 +464,52 @@ issues unblock the queue before continuing with normal feature work.
 >      exit 0
 >    fi
 >    ```
->    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before guardian.
->    - **Guardian gate**:
+>    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - **Fused guardian + LGTM review** (one subagent does both — saves one dispatch per inner-loop iteration):
 >      <!-- guardian-block:begin -->
->      If `AUTOSPEC_NO_GUARDIAN=1` is set: log `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN` and skip to LGTM dispatch.
->      Otherwise:
+>      Run deterministic lint first (no subagent cost):
 >        rm -f /tmp/guardian-<PR>.md
->        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
+>        if [ "${AUTOSPEC_NO_GUARDIAN:-0}" != "1" ]; then
+>          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md 2>&1
+>        fi
 >        det_exit=$?
->        Dispatch a **foreground subagent** (Tier A) with this brief verbatim:
->        > **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
+>
+>      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
+>
+>      Dispatch ONE **foreground subagent** with this brief:
+>        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
 >        >
->        > You are the implementation guardian for PR #<PR> on {repo}, derived from issue #<ISSUE>.
->        >
+>        > **Part 1 — Guardian (contract compliance)** — skip if `AUTOSPEC_NO_GUARDIAN=1`:
 >        > 1. Read AGENTS.md `## Implementation-quality contract` for the RULE_ID table and directive map.
 >        > 2. Read issue #<ISSUE> body — note `## Implementation scope`, `## Implementation outline`, `## Tests required`, and any `Guardian: skip-*` lines.
->        > 3. Read deterministic findings already in /tmp/guardian-<PR>.md.
+>        > 3. Read deterministic findings in /tmp/guardian-<PR>.md (populated by lint-implementation.sh; may be empty if guardian disabled).
 >        > 4. Run `gh pr diff <PR>` and `gh pr view <PR> --json files,title,body`.
->        > 5. Apply the LLM-tier RULE_IDs (HALLUCINATED_API, DUPLICATE_CODE, DOC_OUT_OF_SYNC semantic pass, INVENTED_CONFIG). Append findings to /tmp/guardian-<PR>.md as `RULE_ID:<path>:<line>: <one-line description>`. Honor `Guardian: skip-*` opt-outs by emitting `INFO:` instead of blocking.
->        > 6. Hard limits: max **20 tool calls**. If you cannot reach a verdict in 20 calls, append `RULE_ID:OUT_OF_SCOPE: guardian budget exhausted; PR needs human review` and exit.
->        > 7. If you appended ZERO blocking findings (only INFO lines OK), return ONLY the token: `GUARDIAN_PASS`. Otherwise return ONLY: `GUARDIAN_FAIL`.
->        If GUARDIAN_PASS && det_exit == 0:
->          gh pr comment <PR> --body "<!-- guardian-block --> Guardian: clean. <!-- /-->"
->          proceed to LGTM dispatch.
->        Else:
->          gh pr comment <PR> --edit-last --body "$(cat <<'GCMT'
->          <!-- guardian-block:begin -->
->          ## Guardian findings (iter <K>/3)
->          $(cat /tmp/guardian-<PR>.md | grep -v '^#' | sed 's/^/- /')
->          *Re-evaluated on every push. Last update: $(date -u +%Y-%m-%dT%H:%M:%SZ).*
->          <!-- guardian-block:end -->
->          GCMT
->          )"
->          Append findings to implementer retry context as:
->          ## Guardian directives — clear before re-push
->          $(cat /tmp/guardian-<PR>.md | grep -v '^INFO:' | grep -v '^#')
->          Continue inner loop (counts toward 3-iter cap).
->        On 3-iter exhaustion with GUARDIAN_FAIL:
->          gh label create guardian-blocked --color e11d21 --force --repo {repo}
->          gh issue edit <ISSUE> --add-label guardian-blocked
->          Append ## Guardian audit (failed) block to issue body.
->          Run existing failure cleanup (comment, swap label, close PR).
->          rm -f /tmp/guardian-<PR>.md
+>        > 5. Apply LLM-tier RULE_IDs (HALLUCINATED_API, DUPLICATE_CODE, DOC_OUT_OF_SYNC semantic pass, INVENTED_CONFIG). Collect as `RULE_ID:<path>:<line>: <desc>`. Honor `Guardian: skip-*` with `INFO:` lines.
+>        >
+>        > **Part 2 — LGTM (correctness review):** Using the same diff and issue body already in context:
+>        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits).
+>        > 7. Collect findings as a numbered list.
+>        >
+>        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
+>        >
+>        > **Verdict:** If Part 1 has ZERO blocking findings (INFO lines OK) AND Part 2 has no findings: return ONLY the token: `LGTM`. Otherwise return a numbered findings list — RULE_ID findings first, then LGTM findings.
+>
+>      If `LGTM` && det_exit == 0:
+>        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
+>        run **Operator/full verification**; sleep 30; `gh pr checks <PR>`; break SUCCESS if required checks pass.
+>      If `LGTM` but det_exit != 0:
+>        Treat deterministic findings as blocking. Comment, fix, recommit, push. Continue inner loop.
+>      If findings list:
+>        gh pr comment <PR> --edit-last --body "<!-- guardian-block:begin -->\n## Review findings (iter <K>/3)\n<findings>\n<!-- guardian-block:end -->"
+>        Append findings to implementer retry context. Continue inner loop (counts toward 3-iter cap).
+>      On 3-iter exhaustion with non-LGTM:
+>        gh label create guardian-blocked --color e11d21 --force --repo {repo}
+>        gh issue edit <ISSUE> --add-label guardian-blocked
+>        Run failure cleanup (comment, swap label, close PR).
+>        rm -f /tmp/guardian-<PR>.md
 >      <!-- guardian-block:end -->
->    ### Regression review escalation
->
->    If the issue's labels include `regression` OR `priority:high`:
->
->    - **Model tier:** Tier A (spec work) — top model + ultrathink.
->    - Run TWO reviewer passes in sequence:
->
->      **Pass 1.** Standard LGTM judgment. If FAIL, return to implementer
->      with directives.
->
->      **Pass 2.** Meta-review prompt:
->      > Would the Implementation Guardian or this LGTM reviewer have
->      > caught the original gap during the first implementation? If yes,
->      > what review questions failed? Add the missing checklist items to
->      > `reports/autospec-review/reviewer-lessons.md` (one entry per item,
->      > with parent gap_id and date) and re-review with the augmented
->      > checklist.
->
->    - Both passes must approve before merge.
->
->    Otherwise (default path):
->
->    - **Model tier:** `TIER_B` (implementation work) — cheaper model with medium thinking; resolved at startup. Silently fall back to `TIER_A` if unavailable.
->    - Single LGTM pass.
->
->    - Dispatch a **foreground subagent** with brief: "**Model tier:** `TIER_B` (implementation work) — cheaper model with medium thinking; resolved at startup. Silently fall back to `TIER_A` if unavailable. You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
->    - If LGTM: run the **Operator/full verification** commands; sleep 30; `gh pr checks <PR>`. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
->    - Else: implement findings, commit, push, continue.
+>    - **Regression meta-review** (only for `regression`/`priority:high` issues, after LGTM passes): dispatch a second `TIER_A` subagent: "Would the fused reviewer have caught the original gap? If yes, add missing checklist items to `reports/autospec-review/reviewer-lessons.md` (entry per item, parent gap_id, date) and re-review. Both passes must approve before merge."
+>    - If LGTM (and meta-review passes if applicable): break SUCCESS.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -196,6 +196,8 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
+**Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
+
 Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
 ```
@@ -457,77 +459,52 @@ issues unblock the queue before continuing with normal feature work.
 >      exit 0
 >    fi
 >    ```
->    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before guardian.
->    - **Guardian gate**:
+>    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - **Fused guardian + LGTM review** (one subagent does both — saves one dispatch per inner-loop iteration):
 >      <!-- guardian-block:begin -->
->      If `AUTOSPEC_NO_GUARDIAN=1` is set: log `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN` and skip to LGTM dispatch.
->      Otherwise:
+>      Run deterministic lint first (no subagent cost):
 >        rm -f /tmp/guardian-<PR>.md
->        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
+>        if [ "${AUTOSPEC_NO_GUARDIAN:-0}" != "1" ]; then
+>          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md 2>&1
+>        fi
 >        det_exit=$?
->        Dispatch a **foreground subagent** (Tier A) with this brief verbatim:
->        > **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
+>
+>      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
+>
+>      Dispatch ONE **foreground subagent** with this brief:
+>        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
 >        >
->        > You are the implementation guardian for PR #<PR> on {repo}, derived from issue #<ISSUE>.
->        >
+>        > **Part 1 — Guardian (contract compliance)** — skip if `AUTOSPEC_NO_GUARDIAN=1`:
 >        > 1. Read AGENTS.md `## Implementation-quality contract` for the RULE_ID table and directive map.
 >        > 2. Read issue #<ISSUE> body — note `## Implementation scope`, `## Implementation outline`, `## Tests required`, and any `Guardian: skip-*` lines.
->        > 3. Read deterministic findings already in /tmp/guardian-<PR>.md.
+>        > 3. Read deterministic findings in /tmp/guardian-<PR>.md (populated by lint-implementation.sh; may be empty if guardian disabled).
 >        > 4. Run `gh pr diff <PR>` and `gh pr view <PR> --json files,title,body`.
->        > 5. Apply the LLM-tier RULE_IDs (HALLUCINATED_API, DUPLICATE_CODE, DOC_OUT_OF_SYNC semantic pass, INVENTED_CONFIG). Append findings to /tmp/guardian-<PR>.md as `RULE_ID:<path>:<line>: <one-line description>`. Honor `Guardian: skip-*` opt-outs by emitting `INFO:` instead of blocking.
->        > 6. Hard limits: max **20 tool calls**. If you cannot reach a verdict in 20 calls, append `RULE_ID:OUT_OF_SCOPE: guardian budget exhausted; PR needs human review` and exit.
->        > 7. If you appended ZERO blocking findings (only INFO lines OK), return ONLY the token: `GUARDIAN_PASS`. Otherwise return ONLY: `GUARDIAN_FAIL`.
->        If GUARDIAN_PASS && det_exit == 0:
->          gh pr comment <PR> --body "<!-- guardian-block --> Guardian: clean. <!-- /-->"
->          proceed to LGTM dispatch.
->        Else:
->          gh pr comment <PR> --edit-last --body "$(cat <<'GCMT'
->          <!-- guardian-block:begin -->
->          ## Guardian findings (iter <K>/3)
->          $(cat /tmp/guardian-<PR>.md | grep -v '^#' | sed 's/^/- /')
->          *Re-evaluated on every push. Last update: $(date -u +%Y-%m-%dT%H:%M:%SZ).*
->          <!-- guardian-block:end -->
->          GCMT
->          )"
->          Append findings to implementer retry context as:
->          ## Guardian directives — clear before re-push
->          $(cat /tmp/guardian-<PR>.md | grep -v '^INFO:' | grep -v '^#')
->          Continue inner loop (counts toward 3-iter cap).
->        On 3-iter exhaustion with GUARDIAN_FAIL:
->          gh label create guardian-blocked --color e11d21 --force --repo {repo}
->          gh issue edit <ISSUE> --add-label guardian-blocked
->          Append ## Guardian audit (failed) block to issue body.
->          Run existing failure cleanup (comment, swap label, close PR).
->          rm -f /tmp/guardian-<PR>.md
+>        > 5. Apply LLM-tier RULE_IDs (HALLUCINATED_API, DUPLICATE_CODE, DOC_OUT_OF_SYNC semantic pass, INVENTED_CONFIG). Collect as `RULE_ID:<path>:<line>: <desc>`. Honor `Guardian: skip-*` with `INFO:` lines.
+>        >
+>        > **Part 2 — LGTM (correctness review):** Using the same diff and issue body already in context:
+>        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits).
+>        > 7. Collect findings as a numbered list.
+>        >
+>        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
+>        >
+>        > **Verdict:** If Part 1 has ZERO blocking findings (INFO lines OK) AND Part 2 has no findings: return ONLY the token: `LGTM`. Otherwise return a numbered findings list — RULE_ID findings first, then LGTM findings.
+>
+>      If `LGTM` && det_exit == 0:
+>        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
+>        run **Operator/full verification**; sleep 30; `gh pr checks <PR>`; break SUCCESS if required checks pass.
+>      If `LGTM` but det_exit != 0:
+>        Treat deterministic findings as blocking. Comment, fix, recommit, push. Continue inner loop.
+>      If findings list:
+>        gh pr comment <PR> --edit-last --body "<!-- guardian-block:begin -->\n## Review findings (iter <K>/3)\n<findings>\n<!-- guardian-block:end -->"
+>        Append findings to implementer retry context. Continue inner loop (counts toward 3-iter cap).
+>      On 3-iter exhaustion with non-LGTM:
+>        gh label create guardian-blocked --color e11d21 --force --repo {repo}
+>        gh issue edit <ISSUE> --add-label guardian-blocked
+>        Run failure cleanup (comment, swap label, close PR).
+>        rm -f /tmp/guardian-<PR>.md
 >      <!-- guardian-block:end -->
->    ### Regression review escalation
->
->    If the issue's labels include `regression` OR `priority:high`:
->
->    - **Model tier:** Tier A (spec work) — top model + ultrathink.
->    - Run TWO reviewer passes in sequence:
->
->      **Pass 1.** Standard LGTM judgment. If FAIL, return to implementer
->      with directives.
->
->      **Pass 2.** Meta-review prompt:
->      > Would the Implementation Guardian or this LGTM reviewer have
->      > caught the original gap during the first implementation? If yes,
->      > what review questions failed? Add the missing checklist items to
->      > `reports/autospec-review/reviewer-lessons.md` (one entry per item,
->      > with parent gap_id and date) and re-review with the augmented
->      > checklist.
->
->    - Both passes must approve before merge.
->
->    Otherwise (default path):
->
->    - **Model tier:** `TIER_B` (implementation work) — cheaper model with medium thinking; resolved at startup. Silently fall back to `TIER_A` if unavailable.
->    - Single LGTM pass.
->
->    - Dispatch a **foreground subagent** with brief: "**Model tier:** `TIER_B` (implementation work) — cheaper model with medium thinking; resolved at startup. Silently fall back to `TIER_A` if unavailable. You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
->    - If LGTM: run the **Operator/full verification** commands; sleep 30; `gh pr checks <PR>`. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
->    - Else: implement findings, commit, push, continue.
+>    - **Regression meta-review** (only for `regression`/`priority:high` issues, after LGTM passes): dispatch a second `TIER_A` subagent: "Would the fused reviewer have caught the original gap? If yes, add missing checklist items to `reports/autospec-review/reviewer-lessons.md` (entry per item, parent gap_id, date) and re-review. Both passes must approve before merge."
+>    - If LGTM (and meta-review passes if applicable): break SUCCESS.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -200,6 +200,8 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
+**Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
+
 Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
 ```
@@ -461,77 +463,52 @@ issues unblock the queue before continuing with normal feature work.
 >      exit 0
 >    fi
 >    ```
->    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before guardian.
->    - **Guardian gate**:
+>    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - **Fused guardian + LGTM review** (one subagent does both — saves one dispatch per inner-loop iteration):
 >      <!-- guardian-block:begin -->
->      If `AUTOSPEC_NO_GUARDIAN=1` is set: log `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN` and skip to LGTM dispatch.
->      Otherwise:
+>      Run deterministic lint first (no subagent cost):
 >        rm -f /tmp/guardian-<PR>.md
->        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
+>        if [ "${AUTOSPEC_NO_GUARDIAN:-0}" != "1" ]; then
+>          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md 2>&1
+>        fi
 >        det_exit=$?
->        Dispatch a **foreground subagent** (Tier A) with this brief verbatim:
->        > **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
+>
+>      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
+>
+>      Dispatch ONE **foreground subagent** with this brief:
+>        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
 >        >
->        > You are the implementation guardian for PR #<PR> on {repo}, derived from issue #<ISSUE>.
->        >
+>        > **Part 1 — Guardian (contract compliance)** — skip if `AUTOSPEC_NO_GUARDIAN=1`:
 >        > 1. Read AGENTS.md `## Implementation-quality contract` for the RULE_ID table and directive map.
 >        > 2. Read issue #<ISSUE> body — note `## Implementation scope`, `## Implementation outline`, `## Tests required`, and any `Guardian: skip-*` lines.
->        > 3. Read deterministic findings already in /tmp/guardian-<PR>.md.
+>        > 3. Read deterministic findings in /tmp/guardian-<PR>.md (populated by lint-implementation.sh; may be empty if guardian disabled).
 >        > 4. Run `gh pr diff <PR>` and `gh pr view <PR> --json files,title,body`.
->        > 5. Apply the LLM-tier RULE_IDs (HALLUCINATED_API, DUPLICATE_CODE, DOC_OUT_OF_SYNC semantic pass, INVENTED_CONFIG). Append findings to /tmp/guardian-<PR>.md as `RULE_ID:<path>:<line>: <one-line description>`. Honor `Guardian: skip-*` opt-outs by emitting `INFO:` instead of blocking.
->        > 6. Hard limits: max **20 tool calls**. If you cannot reach a verdict in 20 calls, append `RULE_ID:OUT_OF_SCOPE: guardian budget exhausted; PR needs human review` and exit.
->        > 7. If you appended ZERO blocking findings (only INFO lines OK), return ONLY the token: `GUARDIAN_PASS`. Otherwise return ONLY: `GUARDIAN_FAIL`.
->        If GUARDIAN_PASS && det_exit == 0:
->          gh pr comment <PR> --body "<!-- guardian-block --> Guardian: clean. <!-- /-->"
->          proceed to LGTM dispatch.
->        Else:
->          gh pr comment <PR> --edit-last --body "$(cat <<'GCMT'
->          <!-- guardian-block:begin -->
->          ## Guardian findings (iter <K>/3)
->          $(cat /tmp/guardian-<PR>.md | grep -v '^#' | sed 's/^/- /')
->          *Re-evaluated on every push. Last update: $(date -u +%Y-%m-%dT%H:%M:%SZ).*
->          <!-- guardian-block:end -->
->          GCMT
->          )"
->          Append findings to implementer retry context as:
->          ## Guardian directives — clear before re-push
->          $(cat /tmp/guardian-<PR>.md | grep -v '^INFO:' | grep -v '^#')
->          Continue inner loop (counts toward 3-iter cap).
->        On 3-iter exhaustion with GUARDIAN_FAIL:
->          gh label create guardian-blocked --color e11d21 --force --repo {repo}
->          gh issue edit <ISSUE> --add-label guardian-blocked
->          Append ## Guardian audit (failed) block to issue body.
->          Run existing failure cleanup (comment, swap label, close PR).
->          rm -f /tmp/guardian-<PR>.md
+>        > 5. Apply LLM-tier RULE_IDs (HALLUCINATED_API, DUPLICATE_CODE, DOC_OUT_OF_SYNC semantic pass, INVENTED_CONFIG). Collect as `RULE_ID:<path>:<line>: <desc>`. Honor `Guardian: skip-*` with `INFO:` lines.
+>        >
+>        > **Part 2 — LGTM (correctness review):** Using the same diff and issue body already in context:
+>        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits).
+>        > 7. Collect findings as a numbered list.
+>        >
+>        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
+>        >
+>        > **Verdict:** If Part 1 has ZERO blocking findings (INFO lines OK) AND Part 2 has no findings: return ONLY the token: `LGTM`. Otherwise return a numbered findings list — RULE_ID findings first, then LGTM findings.
+>
+>      If `LGTM` && det_exit == 0:
+>        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
+>        run **Operator/full verification**; sleep 30; `gh pr checks <PR>`; break SUCCESS if required checks pass.
+>      If `LGTM` but det_exit != 0:
+>        Treat deterministic findings as blocking. Comment, fix, recommit, push. Continue inner loop.
+>      If findings list:
+>        gh pr comment <PR> --edit-last --body "<!-- guardian-block:begin -->\n## Review findings (iter <K>/3)\n<findings>\n<!-- guardian-block:end -->"
+>        Append findings to implementer retry context. Continue inner loop (counts toward 3-iter cap).
+>      On 3-iter exhaustion with non-LGTM:
+>        gh label create guardian-blocked --color e11d21 --force --repo {repo}
+>        gh issue edit <ISSUE> --add-label guardian-blocked
+>        Run failure cleanup (comment, swap label, close PR).
+>        rm -f /tmp/guardian-<PR>.md
 >      <!-- guardian-block:end -->
->    ### Regression review escalation
->
->    If the issue's labels include `regression` OR `priority:high`:
->
->    - **Model tier:** Tier A (spec work) — top model + ultrathink.
->    - Run TWO reviewer passes in sequence:
->
->      **Pass 1.** Standard LGTM judgment. If FAIL, return to implementer
->      with directives.
->
->      **Pass 2.** Meta-review prompt:
->      > Would the Implementation Guardian or this LGTM reviewer have
->      > caught the original gap during the first implementation? If yes,
->      > what review questions failed? Add the missing checklist items to
->      > `reports/autospec-review/reviewer-lessons.md` (one entry per item,
->      > with parent gap_id and date) and re-review with the augmented
->      > checklist.
->
->    - Both passes must approve before merge.
->
->    Otherwise (default path):
->
->    - **Model tier:** `TIER_B` (implementation work) — cheaper model with medium thinking; resolved at startup. Silently fall back to `TIER_A` if unavailable.
->    - Single LGTM pass.
->
->    - Dispatch a **foreground subagent** with brief: "**Model tier:** `TIER_B` (implementation work) — cheaper model with medium thinking; resolved at startup. Silently fall back to `TIER_A` if unavailable. You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
->    - If LGTM: run the **Operator/full verification** commands; sleep 30; `gh pr checks <PR>`. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
->    - Else: implement findings, commit, push, continue.
+>    - **Regression meta-review** (only for `regression`/`priority:high` issues, after LGTM passes): dispatch a second `TIER_A` subagent: "Would the fused reviewer have caught the original gap? If yes, add missing checklist items to `reports/autospec-review/reviewer-lessons.md` (entry per item, parent gap_id, date) and re-review. Both passes must approve before merge."
+>    - If LGTM (and meta-review passes if applicable): break SUCCESS.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -498,6 +498,8 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
+**Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
+
 Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
 ```
@@ -726,52 +728,52 @@ Pass the following prompt verbatim to each background subagent:
 >      exit 0
 >    fi
 >    ```
->    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before guardian.
->    - **Guardian gate**:
+>    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - **Fused guardian + LGTM review** (one subagent does both — saves one dispatch per inner-loop iteration):
 >      <!-- guardian-block:begin -->
->      If `AUTOSPEC_NO_GUARDIAN=1` is set: log `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN` and skip to LGTM dispatch.
->      Otherwise:
+>      Run deterministic lint first (no subagent cost):
 >        rm -f /tmp/guardian-<PR>.md
->        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
+>        if [ "${AUTOSPEC_NO_GUARDIAN:-0}" != "1" ]; then
+>          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md 2>&1
+>        fi
 >        det_exit=$?
->        Dispatch a **foreground subagent** (Tier A) with this brief verbatim:
->        > **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
+>
+>      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
+>
+>      Dispatch ONE **foreground subagent** with this brief:
+>        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
 >        >
->        > You are the implementation guardian for PR #<PR> on {repo}, derived from issue #<ISSUE>.
->        >
+>        > **Part 1 — Guardian (contract compliance)** — skip if `AUTOSPEC_NO_GUARDIAN=1`:
 >        > 1. Read AGENTS.md `## Implementation-quality contract` for the RULE_ID table and directive map.
 >        > 2. Read issue #<ISSUE> body — note `## Implementation scope`, `## Implementation outline`, `## Tests required`, and any `Guardian: skip-*` lines.
->        > 3. Read deterministic findings already in /tmp/guardian-<PR>.md.
+>        > 3. Read deterministic findings in /tmp/guardian-<PR>.md (populated by lint-implementation.sh; may be empty if guardian disabled).
 >        > 4. Run `gh pr diff <PR>` and `gh pr view <PR> --json files,title,body`.
->        > 5. Apply the LLM-tier RULE_IDs (HALLUCINATED_API, DUPLICATE_CODE, DOC_OUT_OF_SYNC semantic pass, INVENTED_CONFIG). Append findings to /tmp/guardian-<PR>.md as `RULE_ID:<path>:<line>: <one-line description>`. Honor `Guardian: skip-*` opt-outs by emitting `INFO:` instead of blocking.
->        > 6. Hard limits: max **20 tool calls**. If you cannot reach a verdict in 20 calls, append `RULE_ID:OUT_OF_SCOPE: guardian budget exhausted; PR needs human review` and exit.
->        > 7. If you appended ZERO blocking findings (only INFO lines OK), return ONLY the token: `GUARDIAN_PASS`. Otherwise return ONLY: `GUARDIAN_FAIL`.
->        If GUARDIAN_PASS && det_exit == 0:
->          gh pr comment <PR> --body "<!-- guardian-block --> Guardian: clean. <!-- /-->"
->          proceed to LGTM dispatch.
->        Else:
->          gh pr comment <PR> --edit-last --body "$(cat <<'GCMT'
->          <!-- guardian-block:begin -->
->          ## Guardian findings (iter <K>/3)
->          $(cat /tmp/guardian-<PR>.md | grep -v '^#' | sed 's/^/- /')
->          *Re-evaluated on every push. Last update: $(date -u +%Y-%m-%dT%H:%M:%SZ).*
->          <!-- guardian-block:end -->
->          GCMT
->          )"
->          Append findings to implementer retry context as:
->          ## Guardian directives — clear before re-push
->          $(cat /tmp/guardian-<PR>.md | grep -v '^INFO:' | grep -v '^#')
->          Continue inner loop (counts toward 3-iter cap).
->        On 3-iter exhaustion with GUARDIAN_FAIL:
->          gh label create guardian-blocked --color e11d21 --force --repo {repo}
->          gh issue edit <ISSUE> --add-label guardian-blocked
->          Append ## Guardian audit (failed) block to issue body.
->          Run existing failure cleanup (comment, swap label, close PR).
->          rm -f /tmp/guardian-<PR>.md
+>        > 5. Apply LLM-tier RULE_IDs (HALLUCINATED_API, DUPLICATE_CODE, DOC_OUT_OF_SYNC semantic pass, INVENTED_CONFIG). Collect as `RULE_ID:<path>:<line>: <desc>`. Honor `Guardian: skip-*` with `INFO:` lines.
+>        >
+>        > **Part 2 — LGTM (correctness review):** Using the same diff and issue body already in context:
+>        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits).
+>        > 7. Collect findings as a numbered list.
+>        >
+>        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
+>        >
+>        > **Verdict:** If Part 1 has ZERO blocking findings (INFO lines OK) AND Part 2 has no findings: return ONLY the token: `LGTM`. Otherwise return a numbered findings list — RULE_ID findings first, then LGTM findings.
+>
+>      If `LGTM` && det_exit == 0:
+>        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
+>        run **Operator/full verification**; sleep 30; `gh pr checks <PR>`; break SUCCESS if required checks pass.
+>      If `LGTM` but det_exit != 0:
+>        Treat deterministic findings as blocking. Comment, fix, recommit, push. Continue inner loop.
+>      If findings list:
+>        gh pr comment <PR> --edit-last --body "<!-- guardian-block:begin -->\n## Review findings (iter <K>/3)\n<findings>\n<!-- guardian-block:end -->"
+>        Append findings to implementer retry context. Continue inner loop (counts toward 3-iter cap).
+>      On 3-iter exhaustion with non-LGTM:
+>        gh label create guardian-blocked --color e11d21 --force --repo {repo}
+>        gh issue edit <ISSUE> --add-label guardian-blocked
+>        Run failure cleanup (comment, swap label, close PR).
+>        rm -f /tmp/guardian-<PR>.md
 >      <!-- guardian-block:end -->
->    - Dispatch a **foreground subagent** with brief: "**Model tier:** `TIER_B` (implementation work) — cheaper model with medium thinking; resolved at startup. Silently fall back to `TIER_A` if unavailable. You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
->    - If LGTM: run the **Operator/full verification** commands; sleep 30; `gh pr checks <PR>`. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
->    - Else: implement findings, commit, push, continue.
+>    - **Regression meta-review** (only for `regression`/`priority:high` issues, after LGTM passes): dispatch a second `TIER_A` subagent: "Would the fused reviewer have caught the original gap? If yes, add missing checklist items to `reports/autospec-review/reviewer-lessons.md` (entry per item, parent gap_id, date) and re-review. Both passes must approve before merge."
+>    - If LGTM (and meta-review passes if applicable): break SUCCESS.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -492,6 +492,8 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
+**Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
+
 Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
 ```
@@ -720,52 +722,52 @@ Pass the following prompt verbatim to each background subagent:
 >      exit 0
 >    fi
 >    ```
->    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before guardian.
->    - **Guardian gate**:
+>    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - **Fused guardian + LGTM review** (one subagent does both — saves one dispatch per inner-loop iteration):
 >      <!-- guardian-block:begin -->
->      If `AUTOSPEC_NO_GUARDIAN=1` is set: log `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN` and skip to LGTM dispatch.
->      Otherwise:
+>      Run deterministic lint first (no subagent cost):
 >        rm -f /tmp/guardian-<PR>.md
->        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
+>        if [ "${AUTOSPEC_NO_GUARDIAN:-0}" != "1" ]; then
+>          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md 2>&1
+>        fi
 >        det_exit=$?
->        Dispatch a **foreground subagent** (Tier A) with this brief verbatim:
->        > **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
+>
+>      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
+>
+>      Dispatch ONE **foreground subagent** with this brief:
+>        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
 >        >
->        > You are the implementation guardian for PR #<PR> on {repo}, derived from issue #<ISSUE>.
->        >
+>        > **Part 1 — Guardian (contract compliance)** — skip if `AUTOSPEC_NO_GUARDIAN=1`:
 >        > 1. Read AGENTS.md `## Implementation-quality contract` for the RULE_ID table and directive map.
 >        > 2. Read issue #<ISSUE> body — note `## Implementation scope`, `## Implementation outline`, `## Tests required`, and any `Guardian: skip-*` lines.
->        > 3. Read deterministic findings already in /tmp/guardian-<PR>.md.
+>        > 3. Read deterministic findings in /tmp/guardian-<PR>.md (populated by lint-implementation.sh; may be empty if guardian disabled).
 >        > 4. Run `gh pr diff <PR>` and `gh pr view <PR> --json files,title,body`.
->        > 5. Apply the LLM-tier RULE_IDs (HALLUCINATED_API, DUPLICATE_CODE, DOC_OUT_OF_SYNC semantic pass, INVENTED_CONFIG). Append findings to /tmp/guardian-<PR>.md as `RULE_ID:<path>:<line>: <one-line description>`. Honor `Guardian: skip-*` opt-outs by emitting `INFO:` instead of blocking.
->        > 6. Hard limits: max **20 tool calls**. If you cannot reach a verdict in 20 calls, append `RULE_ID:OUT_OF_SCOPE: guardian budget exhausted; PR needs human review` and exit.
->        > 7. If you appended ZERO blocking findings (only INFO lines OK), return ONLY the token: `GUARDIAN_PASS`. Otherwise return ONLY: `GUARDIAN_FAIL`.
->        If GUARDIAN_PASS && det_exit == 0:
->          gh pr comment <PR> --body "<!-- guardian-block --> Guardian: clean. <!-- /-->"
->          proceed to LGTM dispatch.
->        Else:
->          gh pr comment <PR> --edit-last --body "$(cat <<'GCMT'
->          <!-- guardian-block:begin -->
->          ## Guardian findings (iter <K>/3)
->          $(cat /tmp/guardian-<PR>.md | grep -v '^#' | sed 's/^/- /')
->          *Re-evaluated on every push. Last update: $(date -u +%Y-%m-%dT%H:%M:%SZ).*
->          <!-- guardian-block:end -->
->          GCMT
->          )"
->          Append findings to implementer retry context as:
->          ## Guardian directives — clear before re-push
->          $(cat /tmp/guardian-<PR>.md | grep -v '^INFO:' | grep -v '^#')
->          Continue inner loop (counts toward 3-iter cap).
->        On 3-iter exhaustion with GUARDIAN_FAIL:
->          gh label create guardian-blocked --color e11d21 --force --repo {repo}
->          gh issue edit <ISSUE> --add-label guardian-blocked
->          Append ## Guardian audit (failed) block to issue body.
->          Run existing failure cleanup (comment, swap label, close PR).
->          rm -f /tmp/guardian-<PR>.md
+>        > 5. Apply LLM-tier RULE_IDs (HALLUCINATED_API, DUPLICATE_CODE, DOC_OUT_OF_SYNC semantic pass, INVENTED_CONFIG). Collect as `RULE_ID:<path>:<line>: <desc>`. Honor `Guardian: skip-*` with `INFO:` lines.
+>        >
+>        > **Part 2 — LGTM (correctness review):** Using the same diff and issue body already in context:
+>        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits).
+>        > 7. Collect findings as a numbered list.
+>        >
+>        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
+>        >
+>        > **Verdict:** If Part 1 has ZERO blocking findings (INFO lines OK) AND Part 2 has no findings: return ONLY the token: `LGTM`. Otherwise return a numbered findings list — RULE_ID findings first, then LGTM findings.
+>
+>      If `LGTM` && det_exit == 0:
+>        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
+>        run **Operator/full verification**; sleep 30; `gh pr checks <PR>`; break SUCCESS if required checks pass.
+>      If `LGTM` but det_exit != 0:
+>        Treat deterministic findings as blocking. Comment, fix, recommit, push. Continue inner loop.
+>      If findings list:
+>        gh pr comment <PR> --edit-last --body "<!-- guardian-block:begin -->\n## Review findings (iter <K>/3)\n<findings>\n<!-- guardian-block:end -->"
+>        Append findings to implementer retry context. Continue inner loop (counts toward 3-iter cap).
+>      On 3-iter exhaustion with non-LGTM:
+>        gh label create guardian-blocked --color e11d21 --force --repo {repo}
+>        gh issue edit <ISSUE> --add-label guardian-blocked
+>        Run failure cleanup (comment, swap label, close PR).
+>        rm -f /tmp/guardian-<PR>.md
 >      <!-- guardian-block:end -->
->    - Dispatch a **foreground subagent** with brief: "**Model tier:** `TIER_B` (implementation work) — cheaper model with medium thinking; resolved at startup. Silently fall back to `TIER_A` if unavailable. You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
->    - If LGTM: run the **Operator/full verification** commands; sleep 30; `gh pr checks <PR>`. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
->    - Else: implement findings, commit, push, continue.
+>    - **Regression meta-review** (only for `regression`/`priority:high` issues, after LGTM passes): dispatch a second `TIER_A` subagent: "Would the fused reviewer have caught the original gap? If yes, add missing checklist items to `reports/autospec-review/reviewer-lessons.md` (entry per item, parent gap_id, date) and re-review. Both passes must approve before merge."
+>    - If LGTM (and meta-review passes if applicable): break SUCCESS.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -496,6 +496,8 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
+**Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
+
 Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
 ```
@@ -724,52 +726,52 @@ Pass the following prompt verbatim to each background subagent:
 >      exit 0
 >    fi
 >    ```
->    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before guardian.
->    - **Guardian gate**:
+>    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - **Fused guardian + LGTM review** (one subagent does both — saves one dispatch per inner-loop iteration):
 >      <!-- guardian-block:begin -->
->      If `AUTOSPEC_NO_GUARDIAN=1` is set: log `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN` and skip to LGTM dispatch.
->      Otherwise:
+>      Run deterministic lint first (no subagent cost):
 >        rm -f /tmp/guardian-<PR>.md
->        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md
+>        if [ "${AUTOSPEC_NO_GUARDIAN:-0}" != "1" ]; then
+>          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" <PR> --issue <ISSUE> >> /tmp/guardian-<PR>.md 2>&1
+>        fi
 >        det_exit=$?
->        Dispatch a **foreground subagent** (Tier A) with this brief verbatim:
->        > **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
+>
+>      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
+>
+>      Dispatch ONE **foreground subagent** with this brief:
+>        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
 >        >
->        > You are the implementation guardian for PR #<PR> on {repo}, derived from issue #<ISSUE>.
->        >
+>        > **Part 1 — Guardian (contract compliance)** — skip if `AUTOSPEC_NO_GUARDIAN=1`:
 >        > 1. Read AGENTS.md `## Implementation-quality contract` for the RULE_ID table and directive map.
 >        > 2. Read issue #<ISSUE> body — note `## Implementation scope`, `## Implementation outline`, `## Tests required`, and any `Guardian: skip-*` lines.
->        > 3. Read deterministic findings already in /tmp/guardian-<PR>.md.
+>        > 3. Read deterministic findings in /tmp/guardian-<PR>.md (populated by lint-implementation.sh; may be empty if guardian disabled).
 >        > 4. Run `gh pr diff <PR>` and `gh pr view <PR> --json files,title,body`.
->        > 5. Apply the LLM-tier RULE_IDs (HALLUCINATED_API, DUPLICATE_CODE, DOC_OUT_OF_SYNC semantic pass, INVENTED_CONFIG). Append findings to /tmp/guardian-<PR>.md as `RULE_ID:<path>:<line>: <one-line description>`. Honor `Guardian: skip-*` opt-outs by emitting `INFO:` instead of blocking.
->        > 6. Hard limits: max **20 tool calls**. If you cannot reach a verdict in 20 calls, append `RULE_ID:OUT_OF_SCOPE: guardian budget exhausted; PR needs human review` and exit.
->        > 7. If you appended ZERO blocking findings (only INFO lines OK), return ONLY the token: `GUARDIAN_PASS`. Otherwise return ONLY: `GUARDIAN_FAIL`.
->        If GUARDIAN_PASS && det_exit == 0:
->          gh pr comment <PR> --body "<!-- guardian-block --> Guardian: clean. <!-- /-->"
->          proceed to LGTM dispatch.
->        Else:
->          gh pr comment <PR> --edit-last --body "$(cat <<'GCMT'
->          <!-- guardian-block:begin -->
->          ## Guardian findings (iter <K>/3)
->          $(cat /tmp/guardian-<PR>.md | grep -v '^#' | sed 's/^/- /')
->          *Re-evaluated on every push. Last update: $(date -u +%Y-%m-%dT%H:%M:%SZ).*
->          <!-- guardian-block:end -->
->          GCMT
->          )"
->          Append findings to implementer retry context as:
->          ## Guardian directives — clear before re-push
->          $(cat /tmp/guardian-<PR>.md | grep -v '^INFO:' | grep -v '^#')
->          Continue inner loop (counts toward 3-iter cap).
->        On 3-iter exhaustion with GUARDIAN_FAIL:
->          gh label create guardian-blocked --color e11d21 --force --repo {repo}
->          gh issue edit <ISSUE> --add-label guardian-blocked
->          Append ## Guardian audit (failed) block to issue body.
->          Run existing failure cleanup (comment, swap label, close PR).
->          rm -f /tmp/guardian-<PR>.md
+>        > 5. Apply LLM-tier RULE_IDs (HALLUCINATED_API, DUPLICATE_CODE, DOC_OUT_OF_SYNC semantic pass, INVENTED_CONFIG). Collect as `RULE_ID:<path>:<line>: <desc>`. Honor `Guardian: skip-*` with `INFO:` lines.
+>        >
+>        > **Part 2 — LGTM (correctness review):** Using the same diff and issue body already in context:
+>        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits).
+>        > 7. Collect findings as a numbered list.
+>        >
+>        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
+>        >
+>        > **Verdict:** If Part 1 has ZERO blocking findings (INFO lines OK) AND Part 2 has no findings: return ONLY the token: `LGTM`. Otherwise return a numbered findings list — RULE_ID findings first, then LGTM findings.
+>
+>      If `LGTM` && det_exit == 0:
+>        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
+>        run **Operator/full verification**; sleep 30; `gh pr checks <PR>`; break SUCCESS if required checks pass.
+>      If `LGTM` but det_exit != 0:
+>        Treat deterministic findings as blocking. Comment, fix, recommit, push. Continue inner loop.
+>      If findings list:
+>        gh pr comment <PR> --edit-last --body "<!-- guardian-block:begin -->\n## Review findings (iter <K>/3)\n<findings>\n<!-- guardian-block:end -->"
+>        Append findings to implementer retry context. Continue inner loop (counts toward 3-iter cap).
+>      On 3-iter exhaustion with non-LGTM:
+>        gh label create guardian-blocked --color e11d21 --force --repo {repo}
+>        gh issue edit <ISSUE> --add-label guardian-blocked
+>        Run failure cleanup (comment, swap label, close PR).
+>        rm -f /tmp/guardian-<PR>.md
 >      <!-- guardian-block:end -->
->    - Dispatch a **foreground subagent** with brief: "**Model tier:** `TIER_B` (implementation work) — cheaper model with medium thinking; resolved at startup. Silently fall back to `TIER_A` if unavailable. You are a critical code reviewer. Review PR #<PR> via `gh pr diff` and `gh pr view`. Check correctness, edge cases, missing tests, AGENTS.md compliance. Output a numbered findings list, OR if none, return ONLY the token: LGTM"
->    - If LGTM: run the **Operator/full verification** commands; sleep 30; `gh pr checks <PR>`. If all required checks pass (slow optional checks pending is OK per AGENTS.md): break SUCCESS.
->    - Else: implement findings, commit, push, continue.
+>    - **Regression meta-review** (only for `regression`/`priority:high` issues, after LGTM passes): dispatch a second `TIER_A` subagent: "Would the fused reviewer have caught the original gap? If yes, add missing checklist items to `reports/autospec-review/reviewer-lessons.md` (entry per item, parent gap_id, date) and re-review. Both passes must approve before merge."
+>    - If LGTM (and meta-review passes if applicable): break SUCCESS.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/tests/unit/test_phase4_guardian_trio.bats
+++ b/tests/unit/test_phase4_guardian_trio.bats
@@ -26,8 +26,8 @@ extract_guardian_block() {
     [ -n "$block" ] || { echo "guardian block empty in autospec/SKILL.md"; return 1; }
     printf '%s\n' "$block" | grep -q 'AUTOSPEC_NO_GUARDIAN' \
         || { echo "missing AUTOSPEC_NO_GUARDIAN in autospec/SKILL.md guardian block"; return 1; }
-    printf '%s\n' "$block" | grep -q 'GUARDIAN_PASS' \
-        || { echo "missing GUARDIAN_PASS in autospec/SKILL.md guardian block"; return 1; }
+    printf '%s\n' "$block" | grep -qE 'GUARDIAN_PASS|LGTM' \
+        || { echo "missing GUARDIAN_PASS or LGTM verdict in autospec/SKILL.md guardian block"; return 1; }
 }
 
 @test "autospec codex prompt guardian block byte-equals SKILL.md" {
@@ -53,8 +53,8 @@ extract_guardian_block() {
     [ -n "$block" ] || { echo "guardian block empty in autospec-run/SKILL.md"; return 1; }
     printf '%s\n' "$block" | grep -q 'AUTOSPEC_NO_GUARDIAN' \
         || { echo "missing AUTOSPEC_NO_GUARDIAN in autospec-run/SKILL.md guardian block"; return 1; }
-    printf '%s\n' "$block" | grep -q 'GUARDIAN_PASS' \
-        || { echo "missing GUARDIAN_PASS in autospec-run/SKILL.md guardian block"; return 1; }
+    printf '%s\n' "$block" | grep -qE 'GUARDIAN_PASS|LGTM' \
+        || { echo "missing GUARDIAN_PASS or LGTM verdict in autospec-run/SKILL.md guardian block"; return 1; }
 }
 
 @test "autospec-run codex prompt guardian block byte-equals SKILL.md" {


### PR DESCRIPTION
## Summary

- Replaces the two-subagent inner loop (guardian → LGTM) with a single fused review subagent per iteration, saving one subagent dispatch per issue (~20-40% fewer subagent calls on a typical queue)
- Fused subagent reads the PR diff once and covers both contract compliance (RULE_IDs) and correctness (LGTM) in one pass with a 25-tool-call combined budget
- `AUTOSPEC_NO_GUARDIAN=1` still works — Part 1 is skipped, Part 2 (LGTM) still runs
- Regression/priority:high issues still get Tier A + meta-review pass after LGTM
- Adds off-peak tip to Phase 4 startup: for 10+ issue queues, launching nights/weekends preserves daytime usage limits for interactive work
- Updates `validate.sh` regression review check to accept both old (`Regression review escalation`) and new (`Regression meta-review`) heading formats
- Lock-step synced all 6 trio files (SKILL.md + codex/prompt.md + opencode/agent.md for autospec + autospec-run)

## Why

100% of autospec usage comes from subagent-heavy sessions. Each issue in the inner loop previously spawned: implementer → smoke test → guardian (Tier A) → LGTM (Tier B) → CI wait. The guardian + LGTM fusion eliminates one of those subagent calls by sharing the already-loaded pr diff context.

## Test Plan

- [ ] `bash scripts/validate.sh` exits 0
- [ ] `bats tests/unit/` — all 240 tests pass
- [ ] Fused subagent returns `LGTM` on a clean PR (both parts satisfied)
- [ ] Fused subagent returns findings when guardian RULE_IDs fire
- [ ] `AUTOSPEC_NO_GUARDIAN=1` skips Part 1, still runs Part 2

🤖 Generated with [Claude Code](https://claude.ai/claude-code)