### PR TITLE
feat(autospec-run): rebase-and-retest pre-merge gate (Change α, #307)

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -530,7 +530,33 @@ issues unblock the queue before continuing with normal feature work.
 >      exit 0
 >    fi
 >    ```
-> 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
+> 8. SUCCESS: Run the **rebase-and-retest pre-merge gate** before admin-merging. Addresses cross-session CI rot (issue #307): two PRs each green against pre-merge main can together break main, so we re-prove this PR against post-merge main. Cap is `AUTOSPEC_REBASE_MAX_ATTEMPTS` (default 3).
+>    ```bash
+>    max_attempts="${AUTOSPEC_REBASE_MAX_ATTEMPTS:-3}"
+>    attempt=0
+>    while [ "$attempt" -lt "$max_attempts" ]; do
+>        state=$(gh pr view <PR> --json mergeStateStatus --jq .mergeStateStatus)
+>        # mergeStateStatus values: CLEAN | BEHIND | BLOCKED | DIRTY | HAS_HOOKS | UNKNOWN | UNSTABLE
+>        case "$state" in
+>            CLEAN|HAS_HOOKS|UNSTABLE) break ;;
+>            BEHIND) gh pr update-branch <PR> 2>&1 || true ;;
+>            DIRTY)
+>                gh issue comment <ISSUE> --body "PR #<PR> has a merge conflict against main; needs human resolution."
+>                exit 1
+>                ;;
+>            BLOCKED) sleep 30 ;;
+>            *) sleep 15 ;;
+>        esac
+>        until [ "$(gh pr view <PR> --json statusCheckRollup --jq '[.statusCheckRollup[]?.conclusion] | all(. == "SUCCESS" or . == null)')" = "true" ]; do sleep 30; done
+>        attempt=$((attempt + 1))
+>    done
+>    if [ "$attempt" -ge "$max_attempts" ]; then
+>        gh issue comment <ISSUE> --body "PR #<PR>: rebase-and-retest stalled after $max_attempts attempts; main is moving faster than CI completes. Pausing for operator review."
+>        exit 1
+>    fi
+>    gh pr merge <PR> --admin --squash --delete-branch
+>    ```
+>    Then admin-merge: `gh pr merge <PR> --admin --squash --delete-branch`. Merge auto-closes the issue.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -530,24 +530,43 @@ issues unblock the queue before continuing with normal feature work.
 >      exit 0
 >    fi
 >    ```
-> 8. SUCCESS: Run the **rebase-and-retest pre-merge gate** before admin-merging. Addresses cross-session CI rot (issue #307): two PRs each green against pre-merge main can together break main, so we re-prove this PR against post-merge main. Cap is `AUTOSPEC_REBASE_MAX_ATTEMPTS` (default 3).
+> 8. SUCCESS: Run the **rebase-and-retest pre-merge gate** before admin-merging. Addresses cross-session CI rot (issue #307): two PRs each green against pre-merge main can together break main, so we re-prove this PR against post-merge main. Cap is `AUTOSPEC_REBASE_MAX_ATTEMPTS` (default 3). The gate ends with the admin-merge, so do NOT issue a second merge after the block.
 >    ```bash
 >    max_attempts="${AUTOSPEC_REBASE_MAX_ATTEMPTS:-3}"
 >    attempt=0
+>    wait_for_ci_green() {
+>        while :; do
+>            rollup=$(gh pr view <PR> --json statusCheckRollup --jq '.statusCheckRollup // []')
+>            pending=$(printf '%s' "$rollup" | jq '[.[] | select(.conclusion == null)] | length')
+>            bad=$(printf '%s' "$rollup" | jq '[.[] | select(.conclusion=="FAILURE" or .conclusion=="CANCELLED" or .conclusion=="TIMED_OUT" or .conclusion=="ACTION_REQUIRED")] | length')
+>            total=$(printf '%s' "$rollup" | jq 'length')
+>            if [ "$bad" != "0" ]; then
+>                gh issue comment <ISSUE> --body "PR #<PR>: a required check failed after rebase-and-retest. Pausing for operator review."
+>                exit 1
+>            fi
+>            if [ "$total" != "0" ] && [ "$pending" = "0" ]; then return 0; fi
+>            sleep 30
+>        done
+>    }
 >    while [ "$attempt" -lt "$max_attempts" ]; do
 >        state=$(gh pr view <PR> --json mergeStateStatus --jq .mergeStateStatus)
 >        # mergeStateStatus values: CLEAN | BEHIND | BLOCKED | DIRTY | HAS_HOOKS | UNKNOWN | UNSTABLE
 >        case "$state" in
 >            CLEAN|HAS_HOOKS|UNSTABLE) break ;;
->            BEHIND) gh pr update-branch <PR> 2>&1 || true ;;
+>            BEHIND)
+>                if ! gh pr update-branch <PR>; then
+>                    gh issue comment <ISSUE> --body "PR #<PR>: \`gh pr update-branch\` failed (auth/api/conflict). Pausing for operator review."
+>                    exit 1
+>                fi
+>                wait_for_ci_green
+>                ;;
 >            DIRTY)
 >                gh issue comment <ISSUE> --body "PR #<PR> has a merge conflict against main; needs human resolution."
 >                exit 1
 >                ;;
->            BLOCKED) sleep 30 ;;
+>            BLOCKED) sleep 30; wait_for_ci_green ;;
 >            *) sleep 15 ;;
 >        esac
->        until [ "$(gh pr view <PR> --json statusCheckRollup --jq '[.statusCheckRollup[]?.conclusion] | all(. == "SUCCESS" or . == null)')" = "true" ]; do sleep 30; done
 >        attempt=$((attempt + 1))
 >    done
 >    if [ "$attempt" -ge "$max_attempts" ]; then
@@ -556,7 +575,7 @@ issues unblock the queue before continuing with normal feature work.
 >    fi
 >    gh pr merge <PR> --admin --squash --delete-branch
 >    ```
->    Then admin-merge: `gh pr merge <PR> --admin --squash --delete-branch`. Merge auto-closes the issue.
+>    The block ends with the admin-merge; merge auto-closes the issue.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -525,7 +525,33 @@ issues unblock the queue before continuing with normal feature work.
 >      exit 0
 >    fi
 >    ```
-> 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
+> 8. SUCCESS: Run the **rebase-and-retest pre-merge gate** before admin-merging. Addresses cross-session CI rot (issue #307): two PRs each green against pre-merge main can together break main, so we re-prove this PR against post-merge main. Cap is `AUTOSPEC_REBASE_MAX_ATTEMPTS` (default 3).
+>    ```bash
+>    max_attempts="${AUTOSPEC_REBASE_MAX_ATTEMPTS:-3}"
+>    attempt=0
+>    while [ "$attempt" -lt "$max_attempts" ]; do
+>        state=$(gh pr view <PR> --json mergeStateStatus --jq .mergeStateStatus)
+>        # mergeStateStatus values: CLEAN | BEHIND | BLOCKED | DIRTY | HAS_HOOKS | UNKNOWN | UNSTABLE
+>        case "$state" in
+>            CLEAN|HAS_HOOKS|UNSTABLE) break ;;
+>            BEHIND) gh pr update-branch <PR> 2>&1 || true ;;
+>            DIRTY)
+>                gh issue comment <ISSUE> --body "PR #<PR> has a merge conflict against main; needs human resolution."
+>                exit 1
+>                ;;
+>            BLOCKED) sleep 30 ;;
+>            *) sleep 15 ;;
+>        esac
+>        until [ "$(gh pr view <PR> --json statusCheckRollup --jq '[.statusCheckRollup[]?.conclusion] | all(. == "SUCCESS" or . == null)')" = "true" ]; do sleep 30; done
+>        attempt=$((attempt + 1))
+>    done
+>    if [ "$attempt" -ge "$max_attempts" ]; then
+>        gh issue comment <ISSUE> --body "PR #<PR>: rebase-and-retest stalled after $max_attempts attempts; main is moving faster than CI completes. Pausing for operator review."
+>        exit 1
+>    fi
+>    gh pr merge <PR> --admin --squash --delete-branch
+>    ```
+>    Then admin-merge: `gh pr merge <PR> --admin --squash --delete-branch`. Merge auto-closes the issue.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -525,24 +525,43 @@ issues unblock the queue before continuing with normal feature work.
 >      exit 0
 >    fi
 >    ```
-> 8. SUCCESS: Run the **rebase-and-retest pre-merge gate** before admin-merging. Addresses cross-session CI rot (issue #307): two PRs each green against pre-merge main can together break main, so we re-prove this PR against post-merge main. Cap is `AUTOSPEC_REBASE_MAX_ATTEMPTS` (default 3).
+> 8. SUCCESS: Run the **rebase-and-retest pre-merge gate** before admin-merging. Addresses cross-session CI rot (issue #307): two PRs each green against pre-merge main can together break main, so we re-prove this PR against post-merge main. Cap is `AUTOSPEC_REBASE_MAX_ATTEMPTS` (default 3). The gate ends with the admin-merge, so do NOT issue a second merge after the block.
 >    ```bash
 >    max_attempts="${AUTOSPEC_REBASE_MAX_ATTEMPTS:-3}"
 >    attempt=0
+>    wait_for_ci_green() {
+>        while :; do
+>            rollup=$(gh pr view <PR> --json statusCheckRollup --jq '.statusCheckRollup // []')
+>            pending=$(printf '%s' "$rollup" | jq '[.[] | select(.conclusion == null)] | length')
+>            bad=$(printf '%s' "$rollup" | jq '[.[] | select(.conclusion=="FAILURE" or .conclusion=="CANCELLED" or .conclusion=="TIMED_OUT" or .conclusion=="ACTION_REQUIRED")] | length')
+>            total=$(printf '%s' "$rollup" | jq 'length')
+>            if [ "$bad" != "0" ]; then
+>                gh issue comment <ISSUE> --body "PR #<PR>: a required check failed after rebase-and-retest. Pausing for operator review."
+>                exit 1
+>            fi
+>            if [ "$total" != "0" ] && [ "$pending" = "0" ]; then return 0; fi
+>            sleep 30
+>        done
+>    }
 >    while [ "$attempt" -lt "$max_attempts" ]; do
 >        state=$(gh pr view <PR> --json mergeStateStatus --jq .mergeStateStatus)
 >        # mergeStateStatus values: CLEAN | BEHIND | BLOCKED | DIRTY | HAS_HOOKS | UNKNOWN | UNSTABLE
 >        case "$state" in
 >            CLEAN|HAS_HOOKS|UNSTABLE) break ;;
->            BEHIND) gh pr update-branch <PR> 2>&1 || true ;;
+>            BEHIND)
+>                if ! gh pr update-branch <PR>; then
+>                    gh issue comment <ISSUE> --body "PR #<PR>: \`gh pr update-branch\` failed (auth/api/conflict). Pausing for operator review."
+>                    exit 1
+>                fi
+>                wait_for_ci_green
+>                ;;
 >            DIRTY)
 >                gh issue comment <ISSUE> --body "PR #<PR> has a merge conflict against main; needs human resolution."
 >                exit 1
 >                ;;
->            BLOCKED) sleep 30 ;;
+>            BLOCKED) sleep 30; wait_for_ci_green ;;
 >            *) sleep 15 ;;
 >        esac
->        until [ "$(gh pr view <PR> --json statusCheckRollup --jq '[.statusCheckRollup[]?.conclusion] | all(. == "SUCCESS" or . == null)')" = "true" ]; do sleep 30; done
 >        attempt=$((attempt + 1))
 >    done
 >    if [ "$attempt" -ge "$max_attempts" ]; then
@@ -551,7 +570,7 @@ issues unblock the queue before continuing with normal feature work.
 >    fi
 >    gh pr merge <PR> --admin --squash --delete-branch
 >    ```
->    Then admin-merge: `gh pr merge <PR> --admin --squash --delete-branch`. Merge auto-closes the issue.
+>    The block ends with the admin-merge; merge auto-closes the issue.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -529,24 +529,43 @@ issues unblock the queue before continuing with normal feature work.
 >      exit 0
 >    fi
 >    ```
-> 8. SUCCESS: Run the **rebase-and-retest pre-merge gate** before admin-merging. Addresses cross-session CI rot (issue #307): two PRs each green against pre-merge main can together break main, so we re-prove this PR against post-merge main. Cap is `AUTOSPEC_REBASE_MAX_ATTEMPTS` (default 3).
+> 8. SUCCESS: Run the **rebase-and-retest pre-merge gate** before admin-merging. Addresses cross-session CI rot (issue #307): two PRs each green against pre-merge main can together break main, so we re-prove this PR against post-merge main. Cap is `AUTOSPEC_REBASE_MAX_ATTEMPTS` (default 3). The gate ends with the admin-merge, so do NOT issue a second merge after the block.
 >    ```bash
 >    max_attempts="${AUTOSPEC_REBASE_MAX_ATTEMPTS:-3}"
 >    attempt=0
+>    wait_for_ci_green() {
+>        while :; do
+>            rollup=$(gh pr view <PR> --json statusCheckRollup --jq '.statusCheckRollup // []')
+>            pending=$(printf '%s' "$rollup" | jq '[.[] | select(.conclusion == null)] | length')
+>            bad=$(printf '%s' "$rollup" | jq '[.[] | select(.conclusion=="FAILURE" or .conclusion=="CANCELLED" or .conclusion=="TIMED_OUT" or .conclusion=="ACTION_REQUIRED")] | length')
+>            total=$(printf '%s' "$rollup" | jq 'length')
+>            if [ "$bad" != "0" ]; then
+>                gh issue comment <ISSUE> --body "PR #<PR>: a required check failed after rebase-and-retest. Pausing for operator review."
+>                exit 1
+>            fi
+>            if [ "$total" != "0" ] && [ "$pending" = "0" ]; then return 0; fi
+>            sleep 30
+>        done
+>    }
 >    while [ "$attempt" -lt "$max_attempts" ]; do
 >        state=$(gh pr view <PR> --json mergeStateStatus --jq .mergeStateStatus)
 >        # mergeStateStatus values: CLEAN | BEHIND | BLOCKED | DIRTY | HAS_HOOKS | UNKNOWN | UNSTABLE
 >        case "$state" in
 >            CLEAN|HAS_HOOKS|UNSTABLE) break ;;
->            BEHIND) gh pr update-branch <PR> 2>&1 || true ;;
+>            BEHIND)
+>                if ! gh pr update-branch <PR>; then
+>                    gh issue comment <ISSUE> --body "PR #<PR>: \`gh pr update-branch\` failed (auth/api/conflict). Pausing for operator review."
+>                    exit 1
+>                fi
+>                wait_for_ci_green
+>                ;;
 >            DIRTY)
 >                gh issue comment <ISSUE> --body "PR #<PR> has a merge conflict against main; needs human resolution."
 >                exit 1
 >                ;;
->            BLOCKED) sleep 30 ;;
+>            BLOCKED) sleep 30; wait_for_ci_green ;;
 >            *) sleep 15 ;;
 >        esac
->        until [ "$(gh pr view <PR> --json statusCheckRollup --jq '[.statusCheckRollup[]?.conclusion] | all(. == "SUCCESS" or . == null)')" = "true" ]; do sleep 30; done
 >        attempt=$((attempt + 1))
 >    done
 >    if [ "$attempt" -ge "$max_attempts" ]; then
@@ -555,7 +574,7 @@ issues unblock the queue before continuing with normal feature work.
 >    fi
 >    gh pr merge <PR> --admin --squash --delete-branch
 >    ```
->    Then admin-merge: `gh pr merge <PR> --admin --squash --delete-branch`. Merge auto-closes the issue.
+>    The block ends with the admin-merge; merge auto-closes the issue.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -529,7 +529,33 @@ issues unblock the queue before continuing with normal feature work.
 >      exit 0
 >    fi
 >    ```
-> 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
+> 8. SUCCESS: Run the **rebase-and-retest pre-merge gate** before admin-merging. Addresses cross-session CI rot (issue #307): two PRs each green against pre-merge main can together break main, so we re-prove this PR against post-merge main. Cap is `AUTOSPEC_REBASE_MAX_ATTEMPTS` (default 3).
+>    ```bash
+>    max_attempts="${AUTOSPEC_REBASE_MAX_ATTEMPTS:-3}"
+>    attempt=0
+>    while [ "$attempt" -lt "$max_attempts" ]; do
+>        state=$(gh pr view <PR> --json mergeStateStatus --jq .mergeStateStatus)
+>        # mergeStateStatus values: CLEAN | BEHIND | BLOCKED | DIRTY | HAS_HOOKS | UNKNOWN | UNSTABLE
+>        case "$state" in
+>            CLEAN|HAS_HOOKS|UNSTABLE) break ;;
+>            BEHIND) gh pr update-branch <PR> 2>&1 || true ;;
+>            DIRTY)
+>                gh issue comment <ISSUE> --body "PR #<PR> has a merge conflict against main; needs human resolution."
+>                exit 1
+>                ;;
+>            BLOCKED) sleep 30 ;;
+>            *) sleep 15 ;;
+>        esac
+>        until [ "$(gh pr view <PR> --json statusCheckRollup --jq '[.statusCheckRollup[]?.conclusion] | all(. == "SUCCESS" or . == null)')" = "true" ]; do sleep 30; done
+>        attempt=$((attempt + 1))
+>    done
+>    if [ "$attempt" -ge "$max_attempts" ]; then
+>        gh issue comment <ISSUE> --body "PR #<PR>: rebase-and-retest stalled after $max_attempts attempts; main is moving faster than CI completes. Pausing for operator review."
+>        exit 1
+>    fi
+>    gh pr merge <PR> --admin --squash --delete-branch
+>    ```
+>    Then admin-merge: `gh pr merge <PR> --admin --squash --delete-branch`. Merge auto-closes the issue.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec-run/prompts/phase4-implementer.md
+++ b/skills/autospec-run/prompts/phase4-implementer.md
@@ -84,6 +84,25 @@ The cap defaults to 3 attempts but is configurable via the
 ```bash
 max_attempts="${AUTOSPEC_REBASE_MAX_ATTEMPTS:-3}"
 attempt=0
+wait_for_ci_green() {
+    # Block until every check in the rollup has a non-null conclusion AND none
+    # is a FAILURE/CANCELLED/TIMED_OUT. A null conclusion means "still running"
+    # — counting nulls as SUCCESS would let the gate exit while CI is pending.
+    # An empty rollup also waits (a brand-new update-branch may not have
+    # registered its checks yet).
+    while :; do
+        rollup=$(gh pr view <PR> --json statusCheckRollup --jq '.statusCheckRollup // []')
+        pending=$(printf '%s' "$rollup" | jq '[.[] | select(.conclusion == null)] | length')
+        bad=$(printf '%s' "$rollup" | jq '[.[] | select(.conclusion=="FAILURE" or .conclusion=="CANCELLED" or .conclusion=="TIMED_OUT" or .conclusion=="ACTION_REQUIRED")] | length')
+        total=$(printf '%s' "$rollup" | jq 'length')
+        if [ "$bad" != "0" ]; then
+            gh issue comment <issue> --body "PR #<PR>: a required check failed after rebase-and-retest (FAILURE/CANCELLED/TIMED_OUT). Pausing for operator review."
+            exit 1
+        fi
+        if [ "$total" != "0" ] && [ "$pending" = "0" ]; then return 0; fi
+        sleep 30
+    done
+}
 while [ "$attempt" -lt "$max_attempts" ]; do
     state=$(gh pr view <PR> --json mergeStateStatus --jq .mergeStateStatus)
     # mergeStateStatus values: CLEAN | BEHIND | BLOCKED | DIRTY | HAS_HOOKS | UNKNOWN | UNSTABLE
@@ -92,7 +111,11 @@ while [ "$attempt" -lt "$max_attempts" ]; do
             break                                                       # ready to merge
             ;;
         BEHIND)
-            gh pr update-branch <PR> 2>&1 || true
+            if ! gh pr update-branch <PR>; then
+                gh issue comment <issue> --body "PR #<PR>: \`gh pr update-branch\` failed (auth/api/conflict). Pausing for operator review."
+                exit 1
+            fi
+            wait_for_ci_green                                           # CI re-triggers after update; settle before re-querying state
             ;;
         DIRTY)
             gh issue comment <issue> --body "PR #<PR> has a merge conflict against main; needs human resolution."
@@ -100,15 +123,12 @@ while [ "$attempt" -lt "$max_attempts" ]; do
             ;;
         BLOCKED)
             sleep 30                                                    # required check still pending
+            wait_for_ci_green
             ;;
         *)
             sleep 15                                                    # UNKNOWN / transient
             ;;
     esac
-    # After update-branch (or BLOCKED wait), CI re-triggers. Wait for it to settle.
-    until [ "$(gh pr view <PR> --json statusCheckRollup --jq '[.statusCheckRollup[]?.conclusion] | all(. == "SUCCESS" or . == null)')" = "true" ]; do
-        sleep 30
-    done
     attempt=$((attempt + 1))
 done
 if [ "$attempt" -ge "$max_attempts" ]; then

--- a/skills/autospec-run/prompts/phase4-implementer.md
+++ b/skills/autospec-run/prompts/phase4-implementer.md
@@ -69,6 +69,73 @@ Immediately before `gh pr create`:
 2. If any lockstep dep is not yet merged: do NOT open the PR. Comment on the issue noting which dep is blocking, and exit. The monitor will pick this issue up again later.
 3. If all deps are merged: open the PR with `gh pr create`. PR body must include `Closes #<issue-N>`.
 
+## Rebase-and-retest gate
+
+Immediately before `gh pr merge --admin --squash --delete-branch`, run the
+following loop. It addresses cross-session CI rot (issue #307): when two
+PRs are individually green but their combination breaks main, a stale
+branch at merge time silently corrupts main. By asking GitHub to update
+the branch when it is `BEHIND` main and waiting for CI to re-pass, the
+PR is proven against post-merge main before we admin-merge.
+
+The cap defaults to 3 attempts but is configurable via the
+`AUTOSPEC_REBASE_MAX_ATTEMPTS` env var.
+
+```bash
+max_attempts="${AUTOSPEC_REBASE_MAX_ATTEMPTS:-3}"
+attempt=0
+while [ "$attempt" -lt "$max_attempts" ]; do
+    state=$(gh pr view <PR> --json mergeStateStatus --jq .mergeStateStatus)
+    # mergeStateStatus values: CLEAN | BEHIND | BLOCKED | DIRTY | HAS_HOOKS | UNKNOWN | UNSTABLE
+    case "$state" in
+        CLEAN|HAS_HOOKS|UNSTABLE)
+            break                                                       # ready to merge
+            ;;
+        BEHIND)
+            gh pr update-branch <PR> 2>&1 || true
+            ;;
+        DIRTY)
+            gh issue comment <issue> --body "PR #<PR> has a merge conflict against main; needs human resolution."
+            exit 1
+            ;;
+        BLOCKED)
+            sleep 30                                                    # required check still pending
+            ;;
+        *)
+            sleep 15                                                    # UNKNOWN / transient
+            ;;
+    esac
+    # After update-branch (or BLOCKED wait), CI re-triggers. Wait for it to settle.
+    until [ "$(gh pr view <PR> --json statusCheckRollup --jq '[.statusCheckRollup[]?.conclusion] | all(. == "SUCCESS" or . == null)')" = "true" ]; do
+        sleep 30
+    done
+    attempt=$((attempt + 1))
+done
+if [ "$attempt" -ge "$max_attempts" ]; then
+    gh issue comment <issue> --body "PR #<PR>: rebase-and-retest stalled after $max_attempts attempts; main is moving faster than CI completes. Pausing for operator review."
+    exit 1
+fi
+gh pr merge <PR> --admin --squash --delete-branch
+```
+
+Notes:
+
+- `gh pr view --json mergeStateStatus` is the merge-state predicate.
+  `CLEAN`, `HAS_HOOKS`, and `UNSTABLE` all mean "safe to merge"
+  (UNSTABLE = optional checks pending, which autospec already tolerates).
+- `gh pr update-branch` is GitHub's first-party rebase mechanism — no
+  local checkout/rebase/force-push dance required.
+- `DIRTY` (merge conflict) → comment + exit immediately. Operator
+  resolves; autospec's auto-loop is the wrong tool for conflicts.
+- Three full CI cycles is the upper bound on reasonable wait. On the
+  4th `BEHIND` state, comment on the issue and exit — the queue has too
+  much churn for this PR to merge cleanly, and an operator should
+  intervene.
+- Lock-step deps are already checked immediately before `gh pr create`.
+  If a lock-step dep merges into main during the rebase window, that's
+  already-merged state being absorbed into this PR via update-branch —
+  the desired behavior.
+
 ## Exit conditions
 
 - **Success** — PR opened, all CI checks green, auto-merge enabled.

--- a/tests/phase4/test_rebase_loop.sh
+++ b/tests/phase4/test_rebase_loop.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Verifies the Phase 4 implementer prompts contain a rebase-and-retest
+# pre-merge gate (change α from docs/specs/2026-05-17-cross-session-ci-rot-design.md).
+#
+# Strategy: this is a prompt-text test (the gate is executed by an LLM
+# following the documented shell). We assert:
+#   1. Both v2-flow prompt and legacy SKILL.md prompt contain the gate
+#      keywords (mergeStateStatus, gh pr update-branch, BEHIND, DIRTY,
+#      CLEAN, AUTOSPEC_REBASE_MAX_ATTEMPTS).
+#   2. The gate is documented before gh pr merge --admin --squash.
+#   3. The exact shell block extracted from the v2-flow prompt, when
+#      executed under a fake `gh` shim, exhibits the documented control
+#      flow for three scenarios:
+#         (a) BEHIND on attempt 1 → CLEAN on attempt 2 → reaches merge.
+#         (b) DIRTY → exits non-zero, posts an issue comment, no merge.
+#         (c) BEHIND on three consecutive attempts → escalation comment,
+#             non-zero exit, no merge.
+#
+# Test design follows tests/phase4/test_prompt_structure.sh conventions.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+V2_PROMPT="$SCRIPT_DIR/skills/autospec-run/prompts/phase4-implementer.md"
+LEGACY_PROMPT="$SCRIPT_DIR/skills/autospec-run/SKILL.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$V2_PROMPT" ] || fail "v2-flow prompt missing at $V2_PROMPT"
+[ -f "$LEGACY_PROMPT" ] || fail "legacy prompt missing at $LEGACY_PROMPT"
+
+# --- 1. Keyword presence in both prompts -----------------------------------
+
+for prompt in "$V2_PROMPT" "$LEGACY_PROMPT"; do
+    name="$(basename "$(dirname "$prompt")")/$(basename "$prompt")"
+    for kw in "mergeStateStatus" "gh pr update-branch" "BEHIND" "DIRTY" "CLEAN" "AUTOSPEC_REBASE_MAX_ATTEMPTS"; do
+        grep -qF "$kw" "$prompt" || fail "$name: missing rebase-gate keyword '$kw'"
+    done
+done
+
+# --- 2. Gate must appear before gh pr merge --admin --squash ---------------
+
+for prompt in "$V2_PROMPT" "$LEGACY_PROMPT"; do
+    name="$(basename "$(dirname "$prompt")")/$(basename "$prompt")"
+    # Find the first gate occurrence and the last admin-squash merge invocation
+    # (the prose may mention `gh pr merge --admin --squash` before the gate to
+    # introduce it; the executable merge call lives after the gate block).
+    gate_line=$(grep -n "mergeStateStatus" "$prompt" | head -1 | cut -d: -f1)
+    merge_line=$(grep -n "gh pr merge .*--admin --squash" "$prompt" | tail -1 | cut -d: -f1)
+    [ -n "$gate_line" ] || fail "$name: no gate line found"
+    [ -n "$merge_line" ] || fail "$name: no admin-squash merge line found"
+    [ "$gate_line" -lt "$merge_line" ] || fail "$name: gate must appear before admin-squash merge (gate=$gate_line, merge=$merge_line)"
+done
+
+# --- 3. Execute the gate shell block under a fake gh shim ------------------
+# Extract the first fenced ```bash block in the v2-flow prompt that contains
+# 'mergeStateStatus' AND a while loop — that's the gate.
+
+extract_gate_block() {
+    awk '
+        /^```bash[[:space:]]*$/   { in_fence=1; buf=""; next }
+        /^```[[:space:]]*$/ && in_fence {
+            if (buf ~ /mergeStateStatus/ && buf ~ /while/) { print buf; exit }
+            in_fence=0; buf=""; next
+        }
+        in_fence { buf = buf $0 "\n" }
+    ' "$V2_PROMPT"
+}
+
+GATE_BLOCK="$(extract_gate_block)"
+[ -n "$GATE_BLOCK" ] || fail "could not extract rebase-gate shell block from $V2_PROMPT"
+
+# Make a tmp dir for shims and state files.
+TMPDIR_GATE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_GATE"' EXIT
+
+# Scenario runner: writes a fake `gh` to PATH, expands <PR>/<issue>
+# placeholders to concrete values, and executes the gate. The fake gh emits
+# a deterministic mergeStateStatus per call based on a counter, records
+# every call to a log, and stubs the auxiliary commands the gate uses.
+run_scenario() {
+    sequence="$1"   # space-separated list, e.g. "BEHIND CLEAN"
+    expect_exit="$2"
+    expect_merge_count="$3"
+    expect_comment_substr="$4"
+
+    workdir="$TMPDIR_GATE/$5"
+    mkdir -p "$workdir/bin"
+    : > "$workdir/gh.log"
+    : > "$workdir/comments.log"
+    printf '%s\n' $sequence > "$workdir/state-sequence"
+
+    cat > "$workdir/bin/gh" <<'GHSHIM'
+#!/usr/bin/env bash
+# fake gh — services these subcommands needed by the rebase gate:
+#   gh pr view <PR> --json mergeStateStatus --jq .mergeStateStatus
+#   gh pr view <PR> --json statusCheckRollup --jq ...
+#   gh pr update-branch <PR>
+#   gh pr merge <PR> --admin --squash --delete-branch
+#   gh issue comment <N> --body ...
+log="$WORKDIR/gh.log"
+printf '%s\n' "gh $*" >> "$log"
+
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+    # Differentiate the mergeStateStatus query from the rollup query
+    case "$*" in
+        *mergeStateStatus*)
+            seqfile="$WORKDIR/state-sequence"
+            idxfile="$WORKDIR/state-index"
+            idx=$(cat "$idxfile" 2>/dev/null || echo 0)
+            states=($(cat "$seqfile"))
+            value="${states[$idx]:-CLEAN}"
+            echo $((idx + 1)) > "$idxfile"
+            printf '%s\n' "$value"
+            exit 0
+            ;;
+        *statusCheckRollup*)
+            # Always green so the inner CI-wait loop terminates immediately.
+            printf 'true\n'
+            exit 0
+            ;;
+    esac
+fi
+if [ "$1" = "pr" ] && [ "$2" = "update-branch" ]; then
+    exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then
+    echo "MERGED" >> "$WORKDIR/merge.log"
+    exit 0
+fi
+if [ "$1" = "issue" ] && [ "$2" = "comment" ]; then
+    shift 2
+    # capture the --body argument
+    while [ "$#" -gt 0 ]; do
+        if [ "$1" = "--body" ]; then shift; printf '%s\n' "$1" >> "$WORKDIR/comments.log"; fi
+        shift
+    done
+    exit 0
+fi
+exit 0
+GHSHIM
+    chmod +x "$workdir/bin/gh"
+
+    # Stub `sleep` to a no-op so the test runs instantly.
+    cat > "$workdir/bin/sleep" <<'SLEEPSHIM'
+#!/usr/bin/env bash
+exit 0
+SLEEPSHIM
+    chmod +x "$workdir/bin/sleep"
+
+    # Substitute placeholders <PR> and <issue> with concrete values so the
+    # extracted block is executable shell.
+    runner="$workdir/run.sh"
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'set +e\n'
+        printf 'export WORKDIR=%s\n' "$workdir"
+        printf 'export PATH=%s/bin:$PATH\n' "$workdir"
+        # Allow shorter cap for the third scenario via env var.
+        if [ -n "${AUTOSPEC_REBASE_MAX_ATTEMPTS:-}" ]; then
+            printf 'export AUTOSPEC_REBASE_MAX_ATTEMPTS=%s\n' "$AUTOSPEC_REBASE_MAX_ATTEMPTS"
+        fi
+        printf '%s\n' "$GATE_BLOCK" | sed -e 's/<PR>/123/g' -e 's/<issue>/311/g'
+    } > "$runner"
+    chmod +x "$runner"
+
+    set +e
+    bash "$runner" > "$workdir/run.out" 2>&1
+    actual_exit=$?
+    set -e
+
+    if [ -f "$workdir/merge.log" ]; then
+        merge_count=$(wc -l < "$workdir/merge.log" | tr -d ' ')
+    else
+        merge_count=0
+    fi
+    [ -z "$merge_count" ] && merge_count=0
+
+    if [ "$actual_exit" != "$expect_exit" ]; then
+        echo "--- run.out ---" >&2
+        cat "$workdir/run.out" >&2
+        echo "--- gh.log ---" >&2
+        cat "$workdir/gh.log" >&2
+        fail "scenario $5: expected exit=$expect_exit got $actual_exit"
+    fi
+    if [ "$merge_count" != "$expect_merge_count" ]; then
+        echo "--- gh.log ---" >&2
+        cat "$workdir/gh.log" >&2
+        fail "scenario $5: expected merge invocations=$expect_merge_count got $merge_count"
+    fi
+    if [ -n "$expect_comment_substr" ]; then
+        grep -qF "$expect_comment_substr" "$workdir/comments.log" \
+            || { echo "--- comments.log ---" >&2; cat "$workdir/comments.log" >&2;
+                 fail "scenario $5: expected issue comment containing '$expect_comment_substr'"; }
+    fi
+}
+
+# (a) BEHIND → CLEAN → merge
+run_scenario "BEHIND CLEAN" 0 1 "" "behind_then_clean"
+
+# (b) DIRTY → comment + non-zero exit, no merge
+run_scenario "DIRTY" 1 0 "conflict" "dirty"
+
+# (c) 3 × BEHIND → escalation comment, non-zero exit, no merge.
+# AUTOSPEC_REBASE_MAX_ATTEMPTS=3 is the documented default; the gate must
+# escalate after 3 BEHIND results without ever reaching CLEAN.
+run_scenario "BEHIND BEHIND BEHIND BEHIND" 1 0 "stalled" "three_behind"
+
+# (d) Honor AUTOSPEC_REBASE_MAX_ATTEMPTS=1: a single BEHIND should already
+# escalate.
+AUTOSPEC_REBASE_MAX_ATTEMPTS=1 run_scenario "BEHIND BEHIND" 1 0 "stalled" "env_cap_one"
+
+echo "PASS"

--- a/tests/phase4/test_rebase_loop.sh
+++ b/tests/phase4/test_rebase_loop.sh
@@ -83,12 +83,25 @@ run_scenario() {
     expect_exit="$2"
     expect_merge_count="$3"
     expect_comment_substr="$4"
+    name="$5"
+    # Optional 6th arg: update-branch exit code (default 0).
+    UPDATE_BRANCH_RC="${6:-0}"
+    # Optional 7th arg: a rollup JSON to serve. Defaults to one SUCCESS check.
+    # (Note: brace-default expansion stumbles on `}` inside the value, so set
+    # the default with a plain if.)
+    if [ "$#" -ge 7 ] && [ -n "$7" ]; then
+        ROLLUP_JSON="$7"
+    else
+        ROLLUP_JSON='[{"conclusion":"SUCCESS"}]'
+    fi
 
-    workdir="$TMPDIR_GATE/$5"
+    workdir="$TMPDIR_GATE/$name"
     mkdir -p "$workdir/bin"
     : > "$workdir/gh.log"
     : > "$workdir/comments.log"
     printf '%s\n' $sequence > "$workdir/state-sequence"
+    echo "$UPDATE_BRANCH_RC" > "$workdir/update-rc"
+    printf '%s' "$ROLLUP_JSON" > "$workdir/rollup.json"
 
     cat > "$workdir/bin/gh" <<'GHSHIM'
 #!/usr/bin/env bash
@@ -115,14 +128,15 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
             exit 0
             ;;
         *statusCheckRollup*)
-            # Always green so the inner CI-wait loop terminates immediately.
-            printf 'true\n'
+            # The real gate now does: --jq '.statusCheckRollup // []' and
+            # post-processes with jq. Return the rollup array verbatim.
+            cat "$WORKDIR/rollup.json"
             exit 0
             ;;
     esac
 fi
 if [ "$1" = "pr" ] && [ "$2" = "update-branch" ]; then
-    exit 0
+    exit "$(cat "$WORKDIR/update-rc" 2>/dev/null || echo 0)"
 fi
 if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then
     echo "MERGED" >> "$WORKDIR/merge.log"
@@ -209,5 +223,11 @@ run_scenario "BEHIND BEHIND BEHIND BEHIND" 1 0 "stalled" "three_behind"
 # (d) Honor AUTOSPEC_REBASE_MAX_ATTEMPTS=1: a single BEHIND should already
 # escalate.
 AUTOSPEC_REBASE_MAX_ATTEMPTS=1 run_scenario "BEHIND BEHIND" 1 0 "stalled" "env_cap_one"
+
+# (e) update-branch fails: comment + non-zero exit, no merge.
+run_scenario "BEHIND" 1 0 "update-branch" "update_branch_fail" 1
+
+# (f) CI re-run reports FAILURE conclusion: comment + non-zero exit, no merge.
+run_scenario "BEHIND CLEAN" 1 0 "required check failed" "ci_failure" 0 '[{"conclusion":"FAILURE"}]'
 
 echo "PASS"


### PR DESCRIPTION
## Summary

Implements **Change α** from `docs/specs/2026-05-17-cross-session-ci-rot-design.md`: before admin-merging an auto-implement PR, loop `gh pr update-branch` + CI re-wait up to `AUTOSPEC_REBASE_MAX_ATTEMPTS` (default 3) when `mergeStateStatus` is `BEHIND`.

This re-proves each PR against post-merge `main` before the squash, closing the documented cross-session CI-rot incidents #1 (duplicate `:=` after stale merge) and #3 (test rename + stale branch) from issue #307.

The gate ships to both the v2-flow prompt (`skills/autospec-run/prompts/phase4-implementer.md`) and the legacy inline prompt in `SKILL.md` (lock-step mirrored to `opencode/agent.md` + `codex/prompt.md`), so every in-flight `auto-implement` issue benefits.

## Gate behavior

- `CLEAN | HAS_HOOKS | UNSTABLE` → break to merge (UNSTABLE = optional checks pending; already tolerated by autospec).
- `BEHIND` → `gh pr update-branch`; on failure (auth/api/conflict), comment + exit. Then `wait_for_ci_green` blocks until the rollup is non-empty AND every check has a non-null conclusion AND none is `FAILURE/CANCELLED/TIMED_OUT`.
- `DIRTY` → comment + exit (conflicts need human resolution).
- `BLOCKED` → sleep, then wait for CI to settle.
- Cap at `AUTOSPEC_REBASE_MAX_ATTEMPTS` (default 3) — after that, escalation comment + exit.

## Peer-review

Codex CLI reviewed the initial commit and flagged three must-fix issues (silent `update-branch` failure, `null`-as-SUCCESS predicate bug, prose duplication causing double-merge risk). All three are addressed in the second commit. Codex output captured to `.autospec/peer-review-311.txt` (gitignored).

## Test plan

- [x] `bash tests/phase4/test_rebase_loop.sh` — asserts keyword presence in both prompts, asserts gate precedes the admin-squash merge invocation, and executes the v2-flow gate block under a fake `gh` shim across 6 scenarios: BEHIND→CLEAN, DIRTY, 3×BEHIND escalation, `AUTOSPEC_REBASE_MAX_ATTEMPTS=1` honored, `update-branch` failure escalation, and CI-rollup FAILURE escalation.
- [x] `bash tests/phase4/test_prompt_structure.sh` — existing prompt structure check still passes.
- [x] `bash scripts/validate.sh` — full repo lock-step + frontmatter validation passes.

Closes #311