### PR TITLE
docs: target-repo setup guide (Change γ, #307)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/
   | sh -s -- --harness all
 ```
 
+### Target repo setup
+
+If you run autospec against your own codebase, see
+[`docs/target-repo-setup.md`](docs/target-repo-setup.md) for the
+operator-side opt-ins that pair with the Phase 4 implementer's
+cross-session safety gates: branch protection on `main` plus a
+migration-replay test convention. Both are voluntary; without them
+autospec keeps working but loses the safety net for issue #307's
+cross-session CI rot.
+
 ### Turbo integration
 
 `install.sh` also bootstraps [tobihagemann/turbo](https://github.com/tobihagemann/turbo) as a peer skill family:

--- a/docs/target-repo-setup.md
+++ b/docs/target-repo-setup.md
@@ -1,0 +1,129 @@
+# Target repo setup
+
+This guide is for repository operators who want to run autospec
+(`/autospec-define` + `/autospec-run`) against their own codebase. It
+documents the two pre-merge gates that close the cross-session CI rot
+documented in [issue #307] and the design spec
+[`docs/specs/2026-05-17-cross-session-ci-rot-design.md`].
+
+[issue #307]: https://github.com/berlinguyinca/autospec/issues/307
+[`docs/specs/2026-05-17-cross-session-ci-rot-design.md`]: ../docs/specs/2026-05-17-cross-session-ci-rot-design.md
+
+Both gates are opt-in. autospec keeps working against repos that have
+not enabled them — you just lose the cross-session safety net.
+
+## 1. Required branch protection on `main`
+
+The Phase 4 implementer's rebase-and-retest gate
+(`docs/specs/2026-05-17-cross-session-ci-rot-design.md` § Change α)
+re-proves each PR against post-merge `main` before admin-merging. Pair
+it with branch protection so GitHub also refuses to merge a stale
+branch even if `--admin` is used: belt-and-suspenders.
+
+Required settings on `main`:
+
+- **Require status checks to pass before merging** — enabled.
+- **Require branches to be up to date before merging** — enabled.
+  Forces GitHub to refuse merges of stale branches even when an admin
+  override is in play. This is the kernel of the cross-session
+  protection.
+- **List required status checks** — every check that must pass for an
+  admin-merge to proceed. Project-specific; common examples:
+  `build`, `unit-tests`, `lint`, `integration-tests`.
+
+The protection is wired via GitHub's branch-protection API — the
+operator-facing flag is `required_status_checks.strict = true` plus the
+list under `required_status_checks.contexts`. The verification one-liner
+below queries both.
+
+## 2. Migration-replay test convention
+
+The Phase 4 implementer's migration-replay hook
+(`docs/specs/2026-05-17-cross-session-ci-rot-design.md` § Change β,
+landed as PR #315) runs your target repo's migration-replay test before
+opening a PR whose diff touches a migration path. If the test exits
+non-zero, the implementer comments the failure on the issue and aborts
+before `gh pr create` — the regression must be fixed first.
+
+Opt in by providing exactly **one** of the following test invocations.
+The implementer probes them in this order and uses the first hit:
+
+1. **`make migrate-test`** — if `Makefile` exists and contains a
+   `^migrate-test:` target.
+2. **`npm run migrate:test`** — if `package.json` exists and
+   `.scripts."migrate:test"` is non-null.
+3. **`bin/migrate-test`** — if the script exists at `bin/migrate-test`
+   and is executable.
+4. **`pytest tests/migrations`** — if a `tests/migrations/` directory
+   exists; invoked as `pytest tests/migrations -x`.
+
+The test you provide MUST:
+
+- Exit non-zero on regression.
+- Run **all** migrations on a fresh database (not against a
+  pre-migrated state). Replay-order regressions only surface when the
+  full migration chain is exercised end-to-end.
+
+Recommended skeletons:
+
+- **Postgres + Goose**: spin a throwaway container, run `goose -dir
+  <migrations_dir> up`, run a schema or smoke assertion, then
+  `goose -dir <migrations_dir> reset`.
+- **Postgres + Alembic**: same pattern with `alembic upgrade head`
+  followed by `alembic downgrade base` (or a fresh DB per run).
+- **Node + Knex**: `knex migrate:latest` on a throwaway DB, then assert
+  the resulting schema.
+
+If none of the four conventions is detected, the implementer logs an
+informational line and continues without the replay check — the gate
+is voluntary.
+
+## 3. Why this matters
+
+The cross-session CI rot incidents documented in [issue #307] are not
+detectable by per-PR CI alone. Two PRs can each pass independently
+against pre-merge `main` and still leave `main` broken after both
+squash-merge:
+
+- **Incident #1** (duplicate `:=`): stale branch at merge — `main`
+  moved underneath PR B between its CI and its squash. PR B's CI was
+  never run against PR A's already-merged state.
+- **Incident #2** (`CHECK` constraint allow-list dropped by a
+  later-timestamped migration): semantic conflict invisible to static
+  per-PR CI. The two migration files don't textually conflict; the
+  regression only appears when Goose runs them in timestamp order on a
+  fresh DB.
+- **Incident #3** (settings-tabs refactor + unrelated failing test): a
+  duplicate of #1 in test-fixture territory. The refactor and the
+  broken tests live in the same suite, but no single PR ever ran with
+  both diffs applied.
+
+Branch protection + the rebase-and-retest gate close #1 and #3. The
+migration-replay hook closes #2.
+
+## 4. Verification
+
+After enabling the settings above, paste this one-liner to confirm both
+gates are wired:
+
+```bash
+# Branch protection check
+gh api repos/<owner>/<repo>/branches/main/protection \
+  --jq '.required_status_checks.strict, .required_status_checks.contexts' \
+  && echo "branch protection OK"
+
+# Migration-replay target check
+make -n migrate-test 2>/dev/null \
+  || npm run --silent migrate:test --dry-run 2>/dev/null \
+  || test -x bin/migrate-test \
+  || test -d tests/migrations \
+  && echo "migration-replay target detected"
+```
+
+The first command exits zero only when `required_status_checks.strict`
+is `true` and lists at least one context. The second exits zero only
+when at least one of the four migration-replay conventions is present.
+
+Once both lines print their `OK`/`detected` strings, autospec's
+Phase 4 implementer will run both gates against PRs targeting your
+`main`.

--- a/docs/target-repo-setup.md
+++ b/docs/target-repo-setup.md
@@ -107,22 +107,39 @@ After enabling the settings above, paste this one-liner to confirm both
 gates are wired:
 
 ```bash
-# Branch protection check
-gh api repos/<owner>/<repo>/branches/main/protection \
-  --jq '.required_status_checks.strict, .required_status_checks.contexts' \
-  && echo "branch protection OK"
+# Branch protection check — exits 0 only when strict=true AND at least
+# one required context is configured. `--jq` evaluates a predicate and
+# returns the boolean as text; gh exits non-zero when --jq's expression
+# raises, but `select` may emit nothing without raising, so we test the
+# stdout instead.
+strict_ok=$(gh api repos/<owner>/<repo>/branches/main/protection \
+  --jq '(.required_status_checks.strict == true) and ((.required_status_checks.contexts | length) > 0)' \
+  2>/dev/null)
+if [ "$strict_ok" = "true" ]; then
+  echo "branch protection OK"
+else
+  echo "branch protection NOT OK (need strict=true AND at least one required context)" >&2
+fi
 
-# Migration-replay target check
-make -n migrate-test 2>/dev/null \
-  || npm run --silent migrate:test --dry-run 2>/dev/null \
-  || test -x bin/migrate-test \
-  || test -d tests/migrations \
-  && echo "migration-replay target detected"
+# Migration-replay target check. Use metadata-only inspections — never
+# execute the migration test as part of detection. `npm run ... --dry-run`
+# does NOT mean "don't execute the script" — it still invokes node and
+# may fire the script's side effects. Inspect package.json with jq instead.
+{
+  ( [ -f Makefile ]    && grep -qE '^migrate-test:' Makefile ) \
+  || ( [ -f package.json ] && command -v jq >/dev/null 2>&1 \
+       && [ "$(jq -r '.scripts."migrate:test" // empty' package.json)" != "" ] ) \
+  || [ -x bin/migrate-test ] \
+  || [ -d tests/migrations ];
+} && echo "migration-replay target detected" \
+  || echo "migration-replay target NOT detected (target repo has not opted in)" >&2
 ```
 
-The first command exits zero only when `required_status_checks.strict`
-is `true` and lists at least one context. The second exits zero only
-when at least one of the four migration-replay conventions is present.
+The first block exits the `strict_ok == true` branch only when
+`required_status_checks.strict` is `true` AND at least one required
+context is listed. The second block uses metadata-only inspections
+(`grep`, `jq`, `test -x`, `test -d`) — it never invokes `make`, `npm`,
+or `pytest`, so running it against a target repo is side-effect-free.
 
 Once both lines print their `OK`/`detected` strings, autospec's
 Phase 4 implementer will run both gates against PRs targeting your

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -574,16 +574,28 @@ main() {
 
 # tests/phase4/*.sh — exercise the v2-flow Phase 4 implementer prompt
 # (structure check, rebase-gate fixtures, migration-replay fixtures).
+# tests/docs/*.sh — content checks for operator-facing docs
+# (target-repo setup guide, etc.).
 # Each script is self-contained and exits 0 on PASS.
 check_phase4_tests() {
     info "phase4 tests: tests/phase4/*.sh"
-    [ -d tests/phase4 ] || return 0
-    for t in tests/phase4/*.sh; do
-        [ -f "$t" ] || continue
-        info "  running: $t"
-        bash "$t" >/tmp/validate-phase4.log 2>&1 \
-            || { cat /tmp/validate-phase4.log >&2; fail "$t: failed"; }
-    done
+    if [ -d tests/phase4 ]; then
+        for t in tests/phase4/*.sh; do
+            [ -f "$t" ] || continue
+            info "  running: $t"
+            bash "$t" >/tmp/validate-phase4.log 2>&1 \
+                || { cat /tmp/validate-phase4.log >&2; fail "$t: failed"; }
+        done
+    fi
+    info "docs tests: tests/docs/*.sh"
+    if [ -d tests/docs ]; then
+        for t in tests/docs/*.sh; do
+            [ -f "$t" ] || continue
+            info "  running: $t"
+            bash "$t" >/tmp/validate-docs.log 2>&1 \
+                || { cat /tmp/validate-docs.log >&2; fail "$t: failed"; }
+        done
+    fi
 }
 
 main "$@"

--- a/tests/docs/test_target_repo_setup_guide.sh
+++ b/tests/docs/test_target_repo_setup_guide.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Verifies docs/target-repo-setup.md (Change γ from
+# docs/specs/2026-05-17-cross-session-ci-rot-design.md) exists and contains
+# the required content elements: a reference to issue #307, the 4
+# migration-replay convention strings verbatim, the verification one-liner
+# (required_status_checks predicate), and a Verification block.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+DOC="$SCRIPT_DIR/docs/target-repo-setup.md"
+README="$SCRIPT_DIR/README.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$DOC" ] || fail "doc missing at $DOC"
+
+# Required content elements.
+grep -qF "issue #307" "$DOC" || fail "doc must reference issue #307"
+grep -qF "make migrate-test" "$DOC"      || fail "doc must include 'make migrate-test' verbatim"
+grep -qF "npm run migrate:test" "$DOC"   || fail "doc must include 'npm run migrate:test' verbatim"
+grep -qF "bin/migrate-test" "$DOC"       || fail "doc must include 'bin/migrate-test' verbatim"
+grep -qF "pytest tests/migrations" "$DOC" || fail "doc must include 'pytest tests/migrations' verbatim"
+grep -qF "required_status_checks" "$DOC" || fail "doc must include 'required_status_checks' for the verification block"
+
+# Verification one-liner must include the gh api branch-protection call.
+grep -qF "gh api repos/" "$DOC" \
+    || fail "doc must include the gh api branch-protection one-liner"
+
+# Four numbered sections per spec § Change γ outline.
+for heading in \
+    "Required branch protection on" \
+    "Migration-replay test convention" \
+    "Why this matters" \
+    "Verification"; do
+    grep -qF "$heading" "$DOC" || fail "doc missing section: '$heading'"
+done
+
+# README link.
+[ -f "$README" ] || fail "README.md missing"
+grep -qF "target-repo-setup" "$README" \
+    || fail "README must link to docs/target-repo-setup.md"
+
+# The README link must appear inside the Install section (i.e. after the
+# '## Install' heading and before the next '## ' heading).
+install_line=$(grep -n "^## Install" "$README" | head -1 | cut -d: -f1)
+[ -n "$install_line" ] || fail "README missing '## Install' heading"
+next_h2_line=$(awk -v start="$install_line" 'NR>start && /^## / {print NR; exit}' "$README")
+link_line=$(grep -n "target-repo-setup" "$README" | head -1 | cut -d: -f1)
+[ -n "$link_line" ] || fail "README must link to docs/target-repo-setup.md"
+[ "$link_line" -gt "$install_line" ] || fail "README link must appear after '## Install'"
+if [ -n "$next_h2_line" ]; then
+    [ "$link_line" -lt "$next_h2_line" ] \
+        || fail "README link must appear inside the Install section (before next '## ' heading)"
+fi
+
+echo "PASS"


### PR DESCRIPTION
## Summary

Implements **Change γ** from `docs/specs/2026-05-17-cross-session-ci-rot-design.md`: a `docs/target-repo-setup.md` guide for operators who run autospec against their own codebase, covering the two opt-ins that pair with the Phase 4 implementer's cross-session safety gates landed in PRs #314 and #315.

Sections:

1. **Required branch protection on `main`** — `required_status_checks.strict = true` plus required contexts. Pairs with the change-α rebase-and-retest gate so GitHub also refuses stale merges even under `--admin`.
2. **Migration-replay test convention** — lists the 4 first-hit detection targets verbatim (`make migrate-test`, `npm run migrate:test`, `bin/migrate-test`, `pytest tests/migrations`) plus skeleton recommendations for Postgres/Goose, Alembic, and Knex.
3. **Why this matters** — one paragraph per documented incident class, linking issue #307 and the design spec.
4. **Verification** — a side-effect-free one-liner the operator can paste to confirm both gates are wired.

Adds a "Target repo setup" subsection under `## Install` in `README.md` linking to the new doc.

## Peer-review (Codex CLI)

Codex flagged four findings; the two in-scope must-fix items against my new doc are addressed in the second commit:

- The branch-protection check now uses a single boolean jq predicate `(strict == true) and (contexts length > 0)` whose stdout is tested explicitly, so it correctly fails when strict is false or no contexts are required.
- The migration-replay detection block is now metadata-only (`grep`, `jq`, `test -x`, `test -d`) — `npm run ... --dry-run` is NOT a safe existence check (the underlying script still executes), so operators can now paste the one-liner without triggering migration side effects.

The two remaining findings are pre-existing in the already-merged change-α gate (UNSTABLE-as-merge-ready state; UNSTABLE-pending test fixture gap). They are out of scope for a docs PR and explicitly tolerated by autospec policy; a separate refinement issue can address them if operational data shows they bite.

Codex output captured to `.autospec/peer-review-313.txt` (gitignored).

## Test plan

- [x] `bash tests/docs/test_target_repo_setup_guide.sh` — asserts the doc exists with all 4 sections, references issue #307, contains all 4 migration-replay convention strings verbatim, contains the `required_status_checks` predicate, contains the `gh api repos/` one-liner, and that README.md links to it from inside the Install section.
- [x] `bash scripts/validate.sh` — full validation including new `check_phase4_tests` step that also exercises `tests/docs/*.sh`.

Closes #313