### PR TITLE
feat(autospec-test): contract loader + JSON schema (phase 1)

### DIFF
--- a/schemas/autospec-test-contract.schema.json
+++ b/schemas/autospec-test-contract.schema.json
@@ -1,0 +1,221 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-test-contract.schema.json",
+  "title": "autospec-test contract",
+  "description": "Schema for .autospec/test.yml — the autospec-test skill contract file. Shared by Skills A (autospec-test), C (clone provisioner), and D (suite bootstrap).",
+  "type": "object",
+  "required": ["mode"],
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["strict_isolation", "scoped_production"],
+      "description": "Isolation mode. strict_isolation (default): all tests run against an isolated clone. scoped_production: opt-in to tightly scoped production access with mandatory backup/restore."
+    },
+    "i_understand_this_writes_to_production": {
+      "type": "boolean",
+      "description": "Required literal acknowledgement for Mode II (scoped_production). Must be true."
+    },
+    "unit": {
+      "type": "object",
+      "description": "Unit test gate configuration.",
+      "properties": {
+        "test_cmd": {
+          "type": "string",
+          "description": "Command to run unit tests. Auto-detected if omitted."
+        },
+        "coverage_collector": {
+          "type": "string",
+          "enum": ["istanbul", "c8", "coverage-py", "jacoco", "go-cover", "cargo-llvm-cov"],
+          "description": "Coverage collector adapter. Auto-detected from language markers if omitted."
+        },
+        "coverage_thresholds": {
+          "type": "object",
+          "properties": {
+            "lines": { "type": "number", "minimum": 0, "maximum": 100 },
+            "branches": { "type": "number", "minimum": 0, "maximum": 100 },
+            "functions": { "type": "number", "minimum": 0, "maximum": 100 }
+          },
+          "additionalProperties": false
+        },
+        "function_presence_check": {
+          "type": "boolean",
+          "description": "When true, every exported/public function must have at least one unit test."
+        },
+        "coverage_exclude_globs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Glob patterns for files to exclude from coverage measurement."
+        }
+      },
+      "additionalProperties": false
+    },
+    "e2e": {
+      "type": "object",
+      "description": "E2E test gate configuration.",
+      "properties": {
+        "clone_url_env": {
+          "type": "string",
+          "description": "Environment variable name that holds the base URL for the isolated clone. Auto-detected from E2E_BASE_URL, PLAYWRIGHT_BASE_URL, BASE_URL."
+        },
+        "start_cmd": {
+          "type": "string",
+          "description": "Command to start the application for E2E testing. Auto-detected from package.json scripts."
+        },
+        "playwright_cmd": {
+          "type": "string",
+          "description": "Command to run Playwright tests. Auto-detected."
+        },
+        "playwright_config": {
+          "type": "string",
+          "description": "Path to Playwright config file. Auto-detected via glob."
+        },
+        "coverage_cmd": {
+          "type": "string",
+          "description": "Command to run E2E tests with coverage enabled."
+        },
+        "coverage_collector": {
+          "type": "string",
+          "enum": ["istanbul", "c8", "coverage-py", "jacoco", "go-cover", "cargo-llvm-cov"],
+          "description": "Coverage collector for E2E runs."
+        },
+        "coverage_thresholds": {
+          "type": "object",
+          "properties": {
+            "lines": { "type": "number", "minimum": 0, "maximum": 100 },
+            "branches": { "type": "number", "minimum": 0, "maximum": 100 },
+            "functions": { "type": "number", "minimum": 0, "maximum": 100 },
+            "ui_elements": { "type": "number", "minimum": 0, "maximum": 100 },
+            "behavior_categories": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["sort", "scroll", "upload", "download", "filter", "paginate", "bulk_select", "keyboard_nav", "drag_drop"]
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "forbidden_url_patterns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Regex patterns for URLs that must never be contacted during tests. MANDATORY — fail-closed if missing or empty without explicit ack."
+        },
+        "forbidden_url_patterns_intentionally_empty": {
+          "type": "boolean",
+          "description": "Set to true to explicitly acknowledge that forbidden_url_patterns is intentionally empty (no URL restrictions). Requires deliberate operator action."
+        },
+        "egress_allowlist": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional egress allowlist for Layer C enforcement."
+        },
+        "production_scoped_access": {
+          "type": "object",
+          "description": "Mode II: production access scope tokens.",
+          "properties": {
+            "scope_tokens": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["kind"],
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": ["row_filter", "method_allowlist", "route_filter"]
+                  },
+                  "table": { "type": "string" },
+                  "column": { "type": "string" },
+                  "allowed_values": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "out_of_scope_action": {
+                    "type": "string",
+                    "enum": ["hard_fail", "warn"]
+                  },
+                  "module": { "type": "string" },
+                  "allowed_methods": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "others_must_be": { "type": "string" },
+                  "methods": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "allowed_path_patterns": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "action_on_violation": {
+                    "type": "string",
+                    "enum": ["hard_fail", "warn"]
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "backup": {
+          "type": "object",
+          "description": "Mode II: backup/restore configuration. Required for scoped_production mode.",
+          "required": ["driver", "restore_cmd"],
+          "properties": {
+            "driver": {
+              "type": "string",
+              "enum": ["zfs", "pgdump", "mysqldump", "custom_cmd"],
+              "description": "Backup driver to use."
+            },
+            "dataset": { "type": "string" },
+            "pre_test_snapshot": { "type": "boolean" },
+            "verify_snapshot_cmd": { "type": "string" },
+            "restore_cmd": {
+              "type": "string",
+              "description": "Command to restore from backup. Required."
+            },
+            "on_test_catastrophe": {
+              "type": "string",
+              "enum": ["restore_and_halt", "halt_only"]
+            },
+            "refuse_to_run_without_backup": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "budgets": {
+      "type": "object",
+      "description": "Self-heal loop budget configuration.",
+      "properties": {
+        "coding_time_minutes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Wall-clock minutes allowed for coding during self-heal (pauses while tests run)."
+        },
+        "max_loop_iterations": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum number of self-heal loop iterations before blocking."
+        },
+        "same_error_halt_threshold": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of consecutive iterations with the same error before halting."
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "if": {
+    "properties": { "mode": { "const": "scoped_production" } }
+  },
+  "then": {
+    "required": ["i_understand_this_writes_to_production"],
+    "properties": {
+      "i_understand_this_writes_to_production": { "const": true }
+    }
+  }
+}

--- a/skills/autospec-test/scripts/autodetect.sh
+++ b/skills/autospec-test/scripts/autodetect.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# autodetect.sh — probe a target repo for autospec-test contract defaults.
+#
+# Usage: autodetect <repo_root>
+#   Outputs per-field defaults as JSON to stdout.
+#   Exit 0 on success, exit 1 on fatal error.
+#
+# Probes performed:
+#   - package.json scripts (test, test:e2e, e2e, start:e2e, dev)
+#   - playwright.config.* glob
+#   - env vars: E2E_BASE_URL, PLAYWRIGHT_BASE_URL, BASE_URL
+#   - language markers: go.mod, Cargo.toml, pyproject.toml, pom.xml, build.gradle
+#
+# stdout: JSON with keys for any detected values; missing keys = not detected.
+# stdin/stdout JSON convention: this script outputs JSON to stdout only.
+
+set -eu
+
+autodetect() {
+    local repo_root="${1:-.}"
+
+    if [ ! -d "$repo_root" ]; then
+        printf '{"error":"repo_root not found: %s"}\n' "$repo_root" >&2
+        exit 1
+    fi
+
+    # ── Language detection ─────────────────────────────────────────────────────
+    local language=""
+    local coverage_collector=""
+    local unit_test_cmd=""
+
+    if [ -f "$repo_root/go.mod" ]; then
+        language="go"
+        coverage_collector="go-cover"
+        unit_test_cmd="go test ./... -cover"
+    elif [ -f "$repo_root/Cargo.toml" ]; then
+        language="rust"
+        coverage_collector="cargo-llvm-cov"
+        unit_test_cmd="cargo test"
+    elif [ -f "$repo_root/pyproject.toml" ] || [ -f "$repo_root/setup.py" ] || [ -f "$repo_root/setup.cfg" ]; then
+        language="python"
+        coverage_collector="coverage-py"
+        unit_test_cmd="pytest"
+    elif [ -f "$repo_root/pom.xml" ]; then
+        language="java"
+        coverage_collector="jacoco"
+        unit_test_cmd="mvn test"
+    elif [ -f "$repo_root/build.gradle" ] || [ -f "$repo_root/build.gradle.kts" ]; then
+        language="java"
+        coverage_collector="jacoco"
+        unit_test_cmd="./gradlew test"
+    elif [ -f "$repo_root/package.json" ]; then
+        language="node"
+    fi
+
+    # ── Node: probe package.json scripts ──────────────────────────────────────
+    local e2e_start_cmd=""
+    local playwright_cmd=""
+    local e2e_test_cmd=""
+
+    if [ -f "$repo_root/package.json" ] && command -v jq >/dev/null 2>&1; then
+        # Unit test cmd from package.json
+        if [ -z "$unit_test_cmd" ]; then
+            local pkg_test
+            pkg_test=$(jq -r '.scripts.test // empty' "$repo_root/package.json" 2>/dev/null || true)
+            if [ -n "$pkg_test" ]; then
+                unit_test_cmd="${pkg_test} --coverage"
+            fi
+        fi
+
+        # Coverage collector for node
+        if [ -z "$coverage_collector" ]; then
+            # Prefer c8 if listed, else istanbul
+            if jq -e '.devDependencies.c8 // .dependencies.c8' "$repo_root/package.json" >/dev/null 2>&1; then
+                coverage_collector="c8"
+            else
+                coverage_collector="istanbul"
+            fi
+        fi
+
+        # E2E start cmd
+        local start_e2e
+        start_e2e=$(jq -r '(.scripts["start:e2e"] // .scripts.dev // empty)' "$repo_root/package.json" 2>/dev/null || true)
+        if [ -n "$start_e2e" ]; then
+            e2e_start_cmd="$start_e2e"
+        fi
+
+        # E2E test cmd
+        local e2e_pkg
+        e2e_pkg=$(jq -r '(.scripts["test:e2e"] // .scripts.e2e // empty)' "$repo_root/package.json" 2>/dev/null || true)
+        if [ -n "$e2e_pkg" ]; then
+            e2e_test_cmd="$e2e_pkg"
+            playwright_cmd="$e2e_pkg"
+        fi
+    fi
+
+    # ── Playwright config detection ────────────────────────────────────────────
+    local playwright_config=""
+    for ext in ts js mjs cjs; do
+        local cfg_path="$repo_root/playwright.config.$ext"
+        if [ -f "$cfg_path" ]; then
+            playwright_config="playwright.config.$ext"
+            if [ -z "$playwright_cmd" ]; then
+                playwright_cmd="npx playwright test"
+            fi
+            break
+        fi
+    done
+
+    # ── Clone URL env detection ────────────────────────────────────────────────
+    local clone_url_env=""
+    if [ -n "${E2E_BASE_URL:-}" ]; then
+        clone_url_env="E2E_BASE_URL"
+    elif [ -n "${PLAYWRIGHT_BASE_URL:-}" ]; then
+        clone_url_env="PLAYWRIGHT_BASE_URL"
+    elif [ -n "${BASE_URL:-}" ]; then
+        clone_url_env="BASE_URL"
+    else
+        # Check if any of these vars are referenced in package.json or playwright config
+        if [ -f "$repo_root/package.json" ] && grep -q "E2E_BASE_URL" "$repo_root/package.json" 2>/dev/null; then
+            clone_url_env="E2E_BASE_URL"
+        elif [ -f "$repo_root/package.json" ] && grep -q "PLAYWRIGHT_BASE_URL" "$repo_root/package.json" 2>/dev/null; then
+            clone_url_env="PLAYWRIGHT_BASE_URL"
+        else
+            clone_url_env="E2E_BASE_URL"
+        fi
+    fi
+
+    # ── Emit JSON ──────────────────────────────────────────────────────────────
+    # Build JSON output carefully; strip null/empty values at all levels
+    # so downstream merge does not inject null into the schema-validated contract.
+    jq -n \
+        --arg language "$language" \
+        --arg coverage_collector "$coverage_collector" \
+        --arg unit_test_cmd "$unit_test_cmd" \
+        --arg e2e_start_cmd "$e2e_start_cmd" \
+        --arg playwright_cmd "$playwright_cmd" \
+        --arg playwright_config "$playwright_config" \
+        --arg clone_url_env "$clone_url_env" \
+        '
+        def nonempty(v): if v != "" and v != null then v else null end;
+        def compact: with_entries(select(.value != null and .value != {}));
+
+        {
+            unit: ({
+                test_cmd: nonempty($unit_test_cmd),
+                coverage_collector: nonempty($coverage_collector)
+            } | compact),
+            e2e: ({
+                clone_url_env: nonempty($clone_url_env),
+                start_cmd: nonempty($e2e_start_cmd),
+                playwright_cmd: nonempty($playwright_cmd),
+                playwright_config: nonempty($playwright_config)
+            } | compact)
+        } | compact
+        '
+}
+
+autodetect "${1:-}"

--- a/skills/autospec-test/scripts/load-contract.sh
+++ b/skills/autospec-test/scripts/load-contract.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# load-contract.sh — load, merge with autodetect defaults, and validate
+# the autospec-test contract for a target repository.
+#
+# Usage: load_contract <repo_root>
+#   Outputs resolved contract JSON to stdout.
+#
+# Exit codes (shared stdin/stdout JSON convention for all downstream phases):
+#   0 = ok — resolved contract JSON on stdout
+#   1 = fatal error — tool missing, unreadable file, internal error
+#   2 = refuse-to-run — contract invalid or missing required safety fields
+#       (operator-actionable; stderr explains what to fix)
+#
+# Resolution order per field: explicit yml → autodetect → fail-closed if neither.
+#
+# Dependencies: yq (YAML→JSON), jq (JSON merge), ajv (schema validation)
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+load_contract() {
+    local repo_root="${1:-.}"
+
+    if [ ! -d "$repo_root" ]; then
+        printf 'load-contract: fatal: repo_root not found: %s\n' "$repo_root" >&2
+        exit 1
+    fi
+
+    # ── Dependency checks ──────────────────────────────────────────────────────
+    if ! command -v yq >/dev/null 2>&1; then
+        printf 'load-contract: fatal: yq not found. Install with: brew install yq\n' >&2
+        exit 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        printf 'load-contract: fatal: jq not found. Install with: brew install jq\n' >&2
+        exit 1
+    fi
+
+    # ── Step 1: Parse .autospec/test.yml if present ────────────────────────────
+    local explicit_json="{}"
+    local contract_file="$repo_root/.autospec/test.yml"
+    if [ -f "$contract_file" ]; then
+        # yq converts YAML to JSON; exit non-zero on parse error
+        if ! explicit_json=$(yq -o=json '.' "$contract_file" 2>/tmp/load-contract-yq-err.txt); then
+            printf 'load-contract: fatal: failed to parse %s:\n' "$contract_file" >&2
+            cat /tmp/load-contract-yq-err.txt >&2
+            exit 1
+        fi
+        # Verify it's valid JSON (yq can emit "null" for empty files)
+        if [ "$explicit_json" = "null" ] || [ -z "$explicit_json" ]; then
+            explicit_json="{}"
+        fi
+    fi
+
+    # ── Step 2: Run autodetect to fill missing fields ──────────────────────────
+    local detect_json="{}"
+    if ! detect_json=$("$SCRIPT_DIR/autodetect.sh" "$repo_root" 2>/dev/null); then
+        detect_json="{}"
+    fi
+
+    # ── Step 3: Deep-merge explicit over autodetect defaults ──────────────────
+    # Strategy: for each top-level key, explicit wins; for nested objects,
+    # merge one level deep (explicit nested keys override autodetect nested keys).
+    local merged_json
+    merged_json=$(jq -n \
+        --argjson explicit "$explicit_json" \
+        --argjson detect "$detect_json" \
+        '
+        # merge two objects one level deep: a wins over b
+        def deep_merge(a; b):
+            if (a | type) == "object" and (b | type) == "object"
+            then b + a
+            else a
+            end;
+
+        # Start from detect defaults
+        $detect
+        # Overlay each explicit key (deep-merge for objects)
+        | . + (
+            $explicit | to_entries | map(
+                .value = deep_merge(.value; ($detect[.key] // null))
+            ) | from_entries
+          )
+        '
+    )
+
+    # ── Step 4: Validate merged contract ──────────────────────────────────────
+    local tmpfile
+    tmpfile=$(mktemp /tmp/autospec-test-merged-XXXXXX.json)
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmpfile'" EXIT
+    printf '%s' "$merged_json" > "$tmpfile"
+
+    # Pass the schema path explicitly
+    local schema_file="$SCRIPT_DIR/../../../schemas/autospec-test-contract.schema.json"
+    # Capture validate exit code explicitly — do not use `if !` which can swallow
+    # the exit code under set -e.
+    local validate_rc=0
+    "$SCRIPT_DIR/validate-contract.sh" "$tmpfile" "$schema_file" || validate_rc=$?
+    if [ "$validate_rc" -ne 0 ]; then
+        exit "$validate_rc"
+    fi
+
+    # ── Step 5: Emit resolved contract JSON ────────────────────────────────────
+    printf '%s\n' "$merged_json"
+}
+
+load_contract "${1:-.}"

--- a/skills/autospec-test/scripts/validate-contract.sh
+++ b/skills/autospec-test/scripts/validate-contract.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# validate-contract.sh — validate a resolved autospec-test contract JSON.
+#
+# Usage:  validate_contract <json_file> [<schema_file>]
+#   OR:   echo '{"mode":"strict_isolation",...}' | validate_contract - [<schema_file>]
+#
+# Exit codes:
+#   0 = valid contract
+#   1 = fatal error (missing tool, unreadable file, internal error)
+#   2 = refuse-to-run: contract is invalid or missing required fields (operator-actionable)
+#
+# Validation steps:
+#   1. JSON Schema validation via `ajv validate`
+#   2. Higher-level rules not expressible in JSON Schema:
+#      a. Mode II conjunction: scoped_production requires i_understand_this_writes_to_production=true
+#         AND e2e.backup.driver AND e2e.backup.restore_cmd
+#      b. Fail-closed rule: e2e.forbidden_url_patterns=[] without
+#         e2e.forbidden_url_patterns_intentionally_empty=true → exit 2
+
+set -eu
+
+# Resolve schema path
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DEFAULT_SCHEMA="$REPO_ROOT/schemas/autospec-test-contract.schema.json"
+
+validate_contract() {
+    local input_file="${1:--}"
+    local schema_file="${2:-$DEFAULT_SCHEMA}"
+
+    # ── Dependency checks ──────────────────────────────────────────────────────
+    if ! command -v ajv >/dev/null 2>&1; then
+        printf 'validate-contract: fatal: ajv CLI not found. Install with: npm install -g ajv-cli\n' >&2
+        exit 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        printf 'validate-contract: fatal: jq not found. Install with: brew install jq\n' >&2
+        exit 1
+    fi
+    if [ ! -f "$schema_file" ]; then
+        printf 'validate-contract: fatal: schema not found: %s\n' "$schema_file" >&2
+        exit 1
+    fi
+
+    # ── Read input ─────────────────────────────────────────────────────────────
+    local json_data
+    if [ "$input_file" = "-" ]; then
+        json_data=$(cat)
+    else
+        if [ ! -f "$input_file" ]; then
+            printf 'validate-contract: fatal: input file not found: %s\n' "$input_file" >&2
+            exit 1
+        fi
+        json_data=$(cat "$input_file")
+    fi
+
+    # Write to temp file for ajv (which needs a file argument)
+    local tmpfile
+    tmpfile=$(mktemp /tmp/autospec-test-contract-XXXXXX.json)
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmpfile'" EXIT
+    printf '%s' "$json_data" > "$tmpfile"
+
+    # ── Step 1: JSON Schema validation ────────────────────────────────────────
+    local ajv_out
+    if ! ajv_out=$(ajv validate -s "$schema_file" -d "$tmpfile" --spec=draft2020 2>&1); then
+        printf 'validate-contract: schema validation failed:\n%s\n' "$ajv_out" >&2
+        exit 2
+    fi
+
+    # ── Step 2a: Mode II conjunction check ────────────────────────────────────
+    local mode
+    mode=$(printf '%s' "$json_data" | jq -r '.mode // "strict_isolation"')
+    if [ "$mode" = "scoped_production" ]; then
+        # Check i_understand_this_writes_to_production
+        local ack
+        ack=$(printf '%s' "$json_data" | jq -r '.i_understand_this_writes_to_production // false')
+        if [ "$ack" != "true" ]; then
+            printf 'validate-contract: refuse-to-run: mode=scoped_production requires i_understand_this_writes_to_production=true\n' >&2
+            exit 2
+        fi
+
+        # Check backup.driver
+        local backup_driver
+        backup_driver=$(printf '%s' "$json_data" | jq -r '.e2e.backup.driver // empty')
+        if [ -z "$backup_driver" ]; then
+            printf 'validate-contract: refuse-to-run: mode=scoped_production requires e2e.backup.driver (backup configuration missing)\n' >&2
+            exit 2
+        fi
+
+        # Check backup.restore_cmd
+        local restore_cmd
+        restore_cmd=$(printf '%s' "$json_data" | jq -r '.e2e.backup.restore_cmd // empty')
+        if [ -z "$restore_cmd" ]; then
+            printf 'validate-contract: refuse-to-run: mode=scoped_production requires e2e.backup.restore_cmd\n' >&2
+            exit 2
+        fi
+    fi
+
+    # ── Step 2b: Fail-closed forbidden_url_patterns rule ─────────────────────
+    local forbidden_count
+    forbidden_count=$(printf '%s' "$json_data" | jq '.e2e.forbidden_url_patterns | length // 0')
+    if [ "$forbidden_count" = "0" ]; then
+        # Check for explicit ack
+        local ack_empty
+        ack_empty=$(printf '%s' "$json_data" | jq -r '.e2e.forbidden_url_patterns_intentionally_empty // false')
+        if [ "$ack_empty" != "true" ]; then
+            printf 'validate-contract: refuse-to-run: e2e.forbidden_url_patterns is empty or missing without explicit ack. Set forbidden_url_patterns to at least one pattern, or set forbidden_url_patterns_intentionally_empty=true to acknowledge no URL restrictions apply.\n' >&2
+            exit 2
+        fi
+    fi
+
+    # ── All checks passed ──────────────────────────────────────────────────────
+    exit 0
+}
+
+validate_contract "${1:--}" "${2:-}"

--- a/skills/autospec-test/tests/fixtures/contracts/autodetect-only.yml
+++ b/skills/autospec-test/tests/fixtures/contracts/autodetect-only.yml
@@ -1,0 +1,5 @@
+mode: strict_isolation
+
+e2e:
+  forbidden_url_patterns:
+    - "^https?://app\\.acme\\.com"

--- a/skills/autospec-test/tests/fixtures/contracts/empty-forbidden-no-ack.yml
+++ b/skills/autospec-test/tests/fixtures/contracts/empty-forbidden-no-ack.yml
@@ -1,0 +1,17 @@
+mode: strict_isolation
+
+unit:
+  test_cmd: "npm test -- --coverage"
+  coverage_thresholds:
+    lines: 95
+    branches: 90
+    functions: 95
+
+e2e:
+  forbidden_url_patterns: []
+  clone_url_env: E2E_BASE_URL
+
+budgets:
+  coding_time_minutes: 60
+  max_loop_iterations: 5
+  same_error_halt_threshold: 3

--- a/skills/autospec-test/tests/fixtures/contracts/minimal-valid.yml
+++ b/skills/autospec-test/tests/fixtures/contracts/minimal-valid.yml
@@ -1,0 +1,18 @@
+mode: strict_isolation
+
+unit:
+  test_cmd: "npm test -- --coverage"
+  coverage_thresholds:
+    lines: 95
+    branches: 90
+    functions: 95
+
+e2e:
+  forbidden_url_patterns:
+    - "^https?://app\\.acme\\.com"
+  clone_url_env: E2E_BASE_URL
+
+budgets:
+  coding_time_minutes: 60
+  max_loop_iterations: 5
+  same_error_halt_threshold: 3

--- a/skills/autospec-test/tests/fixtures/contracts/mode-ii-missing-backup.yml
+++ b/skills/autospec-test/tests/fixtures/contracts/mode-ii-missing-backup.yml
@@ -1,0 +1,27 @@
+mode: scoped_production
+i_understand_this_writes_to_production: true
+
+unit:
+  test_cmd: "npm test -- --coverage"
+  coverage_thresholds:
+    lines: 95
+    branches: 90
+    functions: 95
+
+e2e:
+  forbidden_url_patterns:
+    - "^https?://app\\.acme\\.com"
+  clone_url_env: E2E_BASE_URL
+  production_scoped_access:
+    scope_tokens:
+      - kind: row_filter
+        table: families
+        column: id
+        allowed_values:
+          - "test-family-7a3f9c"
+        out_of_scope_action: hard_fail
+
+budgets:
+  coding_time_minutes: 60
+  max_loop_iterations: 5
+  same_error_halt_threshold: 3

--- a/skills/autospec-test/tests/fixtures/contracts/mode-ii-valid.yml
+++ b/skills/autospec-test/tests/fixtures/contracts/mode-ii-valid.yml
@@ -1,0 +1,32 @@
+mode: scoped_production
+i_understand_this_writes_to_production: true
+
+unit:
+  test_cmd: "npm test -- --coverage"
+  coverage_thresholds:
+    lines: 95
+    branches: 90
+    functions: 95
+
+e2e:
+  forbidden_url_patterns:
+    - "^https?://app\\.acme\\.com"
+  clone_url_env: E2E_BASE_URL
+  production_scoped_access:
+    scope_tokens:
+      - kind: row_filter
+        table: families
+        column: id
+        allowed_values:
+          - "test-family-7a3f9c"
+        out_of_scope_action: hard_fail
+
+  backup:
+    driver: pgdump
+    pre_test_snapshot: true
+    restore_cmd: "pg_restore -d prod /tmp/pre-test.dump"
+
+budgets:
+  coding_time_minutes: 60
+  max_loop_iterations: 5
+  same_error_halt_threshold: 3

--- a/skills/autospec-test/tests/fixtures/contracts/unparseable.yml
+++ b/skills/autospec-test/tests/fixtures/contracts/unparseable.yml
@@ -1,0 +1,4 @@
+mode: strict_isolation
+  this is: [invalid yaml
+  because: the indentation is wrong
+  and the bracket is unclosed

--- a/skills/autospec-test/tests/fixtures/repos/minimal-valid/.autospec/test.yml
+++ b/skills/autospec-test/tests/fixtures/repos/minimal-valid/.autospec/test.yml
@@ -1,0 +1,18 @@
+mode: strict_isolation
+
+unit:
+  test_cmd: "npm test -- --coverage"
+  coverage_thresholds:
+    lines: 95
+    branches: 90
+    functions: 95
+
+e2e:
+  forbidden_url_patterns:
+    - "^https?://app\\.acme\\.com"
+  clone_url_env: E2E_BASE_URL
+
+budgets:
+  coding_time_minutes: 60
+  max_loop_iterations: 5
+  same_error_halt_threshold: 3

--- a/skills/autospec-test/tests/fixtures/repos/mode-ii-missing-backup/.autospec/test.yml
+++ b/skills/autospec-test/tests/fixtures/repos/mode-ii-missing-backup/.autospec/test.yml
@@ -1,0 +1,27 @@
+mode: scoped_production
+i_understand_this_writes_to_production: true
+
+unit:
+  test_cmd: "npm test -- --coverage"
+  coverage_thresholds:
+    lines: 95
+    branches: 90
+    functions: 95
+
+e2e:
+  forbidden_url_patterns:
+    - "^https?://app\\.acme\\.com"
+  clone_url_env: E2E_BASE_URL
+  production_scoped_access:
+    scope_tokens:
+      - kind: row_filter
+        table: families
+        column: id
+        allowed_values:
+          - "test-family-7a3f9c"
+        out_of_scope_action: hard_fail
+
+budgets:
+  coding_time_minutes: 60
+  max_loop_iterations: 5
+  same_error_halt_threshold: 3

--- a/skills/autospec-test/tests/unit/contract-loader.bats
+++ b/skills/autospec-test/tests/unit/contract-loader.bats
@@ -1,0 +1,250 @@
+#!/usr/bin/env bats
+# skills/autospec-test/tests/unit/contract-loader.bats
+#
+# TDD tests for the Phase 1 contract loader:
+#   - load-contract.sh (load_contract)
+#   - autodetect.sh
+#   - validate-contract.sh
+#   - schemas/autospec-test-contract.schema.json
+#
+# Exit code contract:
+#   0 = ok
+#   1 = fatal error
+#   2 = refuse-to-run (operator-actionable)
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../../.." && pwd)"
+    SCRIPTS_DIR="$REPO_ROOT/skills/autospec-test/scripts"
+    FIXTURES_DIR="$REPO_ROOT/skills/autospec-test/tests/fixtures/contracts"
+    SCHEMA="$REPO_ROOT/schemas/autospec-test-contract.schema.json"
+
+    # Create a temp dir for per-test fake repos
+    TEST_TMPDIR="$(mktemp -d /tmp/autospec-test-bats-XXXXXX)"
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+# ── Helper: make a minimal fake repo with a given contract file ───────────────
+make_fake_repo() {
+    local contract_src="$1"
+    local fake_repo="$TEST_TMPDIR/repo"
+    mkdir -p "$fake_repo/.autospec"
+    cp "$contract_src" "$fake_repo/.autospec/test.yml"
+    printf '%s\n' "$fake_repo"
+}
+
+# ── Schema compilation ────────────────────────────────────────────────────────
+
+@test "schema compiles with ajv" {
+    run ajv compile -s "$SCHEMA" --spec=draft2020
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"is valid"* ]]
+}
+
+# ── validate-contract.sh: fixture acceptance/rejection ───────────────────────
+
+@test "validate-contract: minimal-valid contract exits 0" {
+    # Convert YAML fixture to JSON for validate-contract
+    run bash -c "yq -o=json '.' '$FIXTURES_DIR/minimal-valid.yml' | '$SCRIPTS_DIR/validate-contract.sh' - '$SCHEMA'"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate-contract: mode-ii-valid contract exits 0" {
+    run bash -c "yq -o=json '.' '$FIXTURES_DIR/mode-ii-valid.yml' | '$SCRIPTS_DIR/validate-contract.sh' - '$SCHEMA'"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate-contract: empty forbidden_url_patterns without ack exits 2" {
+    run bash -c "yq -o=json '.' '$FIXTURES_DIR/empty-forbidden-no-ack.yml' | '$SCRIPTS_DIR/validate-contract.sh' - '$SCHEMA'"
+    [ "$status" -eq 2 ]
+}
+
+@test "validate-contract: empty forbidden_url_patterns stderr mentions the field" {
+    run bash -c "yq -o=json '.' '$FIXTURES_DIR/empty-forbidden-no-ack.yml' | '$SCRIPTS_DIR/validate-contract.sh' - '$SCHEMA' 2>&1"
+    [[ "$output" == *"forbidden_url_patterns"* ]]
+}
+
+@test "validate-contract: mode-ii-missing-backup exits 2" {
+    run bash -c "yq -o=json '.' '$FIXTURES_DIR/mode-ii-missing-backup.yml' | '$SCRIPTS_DIR/validate-contract.sh' - '$SCHEMA'"
+    [ "$status" -eq 2 ]
+}
+
+@test "validate-contract: mode-ii-missing-backup stderr mentions backup" {
+    run bash -c "yq -o=json '.' '$FIXTURES_DIR/mode-ii-missing-backup.yml' | '$SCRIPTS_DIR/validate-contract.sh' - '$SCHEMA' 2>&1"
+    [[ "$output" == *"backup"* ]]
+}
+
+@test "validate-contract: missing required field mode exits 2" {
+    run bash -c "echo '{\"unit\":{}}' | '$SCRIPTS_DIR/validate-contract.sh' - '$SCHEMA'"
+    [ "$status" -eq 2 ]
+}
+
+@test "validate-contract: invalid mode value exits 2" {
+    run bash -c "echo '{\"mode\":\"invalid_mode\"}' | '$SCRIPTS_DIR/validate-contract.sh' - '$SCHEMA'"
+    [ "$status" -eq 2 ]
+}
+
+@test "validate-contract: missing schema file exits 1" {
+    run bash -c "echo '{}' | '$SCRIPTS_DIR/validate-contract.sh' - '/nonexistent/schema.json'"
+    [ "$status" -eq 1 ]
+}
+
+# ── load-contract.sh: full pipeline ──────────────────────────────────────────
+
+@test "load-contract: minimal-valid repo exits 0 and emits JSON" {
+    local fake_repo
+    fake_repo=$(make_fake_repo "$FIXTURES_DIR/minimal-valid.yml")
+    run "$SCRIPTS_DIR/load-contract.sh" "$fake_repo"
+    [ "$status" -eq 0 ]
+    # Output should be valid JSON with mode field
+    local mode
+    mode=$(printf '%s' "$output" | jq -r '.mode')
+    [ "$mode" = "strict_isolation" ]
+}
+
+@test "load-contract: empty forbidden_url_patterns without ack exits 2" {
+    local fake_repo
+    fake_repo=$(make_fake_repo "$FIXTURES_DIR/empty-forbidden-no-ack.yml")
+    run "$SCRIPTS_DIR/load-contract.sh" "$fake_repo"
+    [ "$status" -eq 2 ]
+}
+
+@test "load-contract: mode-ii-missing-backup exits 2" {
+    local fake_repo
+    fake_repo=$(make_fake_repo "$FIXTURES_DIR/mode-ii-missing-backup.yml")
+    run "$SCRIPTS_DIR/load-contract.sh" "$fake_repo"
+    [ "$status" -eq 2 ]
+}
+
+@test "load-contract: mode-ii-valid exits 0" {
+    local fake_repo
+    fake_repo=$(make_fake_repo "$FIXTURES_DIR/mode-ii-valid.yml")
+    run "$SCRIPTS_DIR/load-contract.sh" "$fake_repo"
+    [ "$status" -eq 0 ]
+}
+
+@test "load-contract: unparseable YAML exits 1" {
+    local fake_repo="$TEST_TMPDIR/bad-repo"
+    mkdir -p "$fake_repo/.autospec"
+    # Write a YAML file that yq cannot parse
+    printf 'mode: strict_isolation\n  bad: [unclosed\n' > "$fake_repo/.autospec/test.yml"
+    run "$SCRIPTS_DIR/load-contract.sh" "$fake_repo"
+    [ "$status" -ne 0 ]
+}
+
+@test "load-contract: nonexistent repo_root exits 1" {
+    run "$SCRIPTS_DIR/load-contract.sh" "/nonexistent/path/$$"
+    [ "$status" -eq 1 ]
+}
+
+@test "load-contract: autodetect-only (no test.yml) still validates forbidden_url_patterns fail-closed" {
+    # Without a .autospec/test.yml, autodetect fills in empty e2e
+    # and validate-contract should refuse-to-run since no forbidden_url_patterns
+    local fake_repo="$TEST_TMPDIR/autodetect-repo"
+    mkdir -p "$fake_repo"
+    run "$SCRIPTS_DIR/load-contract.sh" "$fake_repo"
+    # Should refuse to run: no forbidden_url_patterns
+    [ "$status" -eq 2 ]
+}
+
+@test "load-contract: output JSON has mode field" {
+    local fake_repo
+    fake_repo=$(make_fake_repo "$FIXTURES_DIR/minimal-valid.yml")
+    run "$SCRIPTS_DIR/load-contract.sh" "$fake_repo"
+    [ "$status" -eq 0 ]
+    run bash -c "printf '%s' '$output' | jq -e '.mode'"
+    [ "$status" -eq 0 ]
+}
+
+# ── autodetect.sh ─────────────────────────────────────────────────────────────
+
+@test "autodetect: Go repo detects go-cover collector" {
+    local fake_repo="$TEST_TMPDIR/go-repo"
+    mkdir -p "$fake_repo"
+    printf 'module example.com/myapp\n\ngo 1.21\n' > "$fake_repo/go.mod"
+    run "$SCRIPTS_DIR/autodetect.sh" "$fake_repo"
+    [ "$status" -eq 0 ]
+    local collector
+    collector=$(printf '%s' "$output" | jq -r '.unit.coverage_collector // empty')
+    [ "$collector" = "go-cover" ]
+}
+
+@test "autodetect: Python repo detects coverage-py collector" {
+    local fake_repo="$TEST_TMPDIR/py-repo"
+    mkdir -p "$fake_repo"
+    printf '[build-system]\nrequires = ["setuptools"]\n' > "$fake_repo/pyproject.toml"
+    run "$SCRIPTS_DIR/autodetect.sh" "$fake_repo"
+    [ "$status" -eq 0 ]
+    local collector
+    collector=$(printf '%s' "$output" | jq -r '.unit.coverage_collector // empty')
+    [ "$collector" = "coverage-py" ]
+}
+
+@test "autodetect: Rust repo detects cargo-llvm-cov collector" {
+    local fake_repo="$TEST_TMPDIR/rust-repo"
+    mkdir -p "$fake_repo"
+    printf '[package]\nname = "myapp"\nversion = "0.1.0"\n' > "$fake_repo/Cargo.toml"
+    run "$SCRIPTS_DIR/autodetect.sh" "$fake_repo"
+    [ "$status" -eq 0 ]
+    local collector
+    collector=$(printf '%s' "$output" | jq -r '.unit.coverage_collector // empty')
+    [ "$collector" = "cargo-llvm-cov" ]
+}
+
+@test "autodetect: Playwright config detected when file exists" {
+    local fake_repo="$TEST_TMPDIR/pw-repo"
+    mkdir -p "$fake_repo"
+    printf 'export default { use: { baseURL: "http://localhost:3000" } };\n' > "$fake_repo/playwright.config.ts"
+    run "$SCRIPTS_DIR/autodetect.sh" "$fake_repo"
+    [ "$status" -eq 0 ]
+    local cfg
+    cfg=$(printf '%s' "$output" | jq -r '.e2e.playwright_config // empty')
+    [ "$cfg" = "playwright.config.ts" ]
+}
+
+@test "autodetect: nonexistent repo exits 1" {
+    run "$SCRIPTS_DIR/autodetect.sh" "/nonexistent/path/$$"
+    [ "$status" -eq 1 ]
+}
+
+@test "autodetect: empty repo emits valid JSON" {
+    local fake_repo="$TEST_TMPDIR/empty-repo"
+    mkdir -p "$fake_repo"
+    run "$SCRIPTS_DIR/autodetect.sh" "$fake_repo"
+    [ "$status" -eq 0 ]
+    # Output must be valid JSON
+    run bash -c "printf '%s' '$output' | jq . > /dev/null"
+    [ "$status" -eq 0 ]
+}
+
+# ── schema: acceptance of valid fixtures ──────────────────────────────────────
+
+@test "schema: accepts minimal-valid fixture JSON" {
+    local json_file="$TEST_TMPDIR/minimal-valid.json"
+    yq -o=json '.' "$FIXTURES_DIR/minimal-valid.yml" > "$json_file"
+    run ajv validate -s "$SCHEMA" -d "$json_file" --spec=draft2020
+    [ "$status" -eq 0 ]
+}
+
+@test "schema: accepts mode-ii-valid fixture JSON" {
+    local json_file="$TEST_TMPDIR/mode-ii-valid.json"
+    yq -o=json '.' "$FIXTURES_DIR/mode-ii-valid.yml" > "$json_file"
+    run ajv validate -s "$SCHEMA" -d "$json_file" --spec=draft2020
+    [ "$status" -eq 0 ]
+}
+
+@test "schema: rejects object with unknown top-level properties" {
+    local json_file="$TEST_TMPDIR/unknown-props.json"
+    printf '{"mode":"strict_isolation","unknown_field":"bad","e2e":{"forbidden_url_patterns":["^https?://bad\\.com"]}}\n' > "$json_file"
+    run ajv validate -s "$SCHEMA" -d "$json_file" --spec=draft2020
+    [ "$status" -ne 0 ]
+}
+
+@test "schema: rejects mode=scoped_production without i_understand flag" {
+    local json_file="$TEST_TMPDIR/mode-ii-no-ack.json"
+    printf '{"mode":"scoped_production","e2e":{"forbidden_url_patterns":["^https?://bad\\.com"]}}\n' > "$json_file"
+    run ajv validate -s "$SCHEMA" -d "$json_file" --spec=draft2020
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Closes #319

## Summary

Ships the Phase 1 contract loader infrastructure for the `autospec-test` skill:

- **`schemas/autospec-test-contract.schema.json`** — JSON Schema Draft 2020-12 covering `mode` enum, `unit`, `e2e`, `budgets`; Mode II conditional requirements (`i_understand_this_writes_to_production`, `backup.driver`, `backup.restore_cmd`)
- **`skills/autospec-test/scripts/load-contract.sh`** — full YAML→JSON pipeline: `yq` parse of `.autospec/test.yml`, autodetect defaults merge, schema + higher-level validation; exit code contract: 0=ok, 1=fatal, 2=refuse-to-run
- **`skills/autospec-test/scripts/autodetect.sh`** — probes `package.json` scripts, `playwright.config.*` glob, env vars (`E2E_BASE_URL`/`PLAYWRIGHT_BASE_URL`/`BASE_URL`), language markers (`go.mod`, `Cargo.toml`, `pyproject.toml`, `pom.xml`, `build.gradle`)
- **`skills/autospec-test/scripts/validate-contract.sh`** — `ajv validate` + higher-level rules: Mode II conjunction check, fail-closed `forbidden_url_patterns` rule
- **28 bats tests** covering all 6 fixture types; all 28 pass

## Test results

```
1..28
ok 1 schema compiles with ajv
ok 2 validate-contract: minimal-valid contract exits 0
ok 3 validate-contract: mode-ii-valid contract exits 0
ok 4 validate-contract: empty forbidden_url_patterns without ack exits 2
ok 5 validate-contract: empty forbidden_url_patterns stderr mentions the field
ok 6 validate-contract: mode-ii-missing-backup exits 2
ok 7 validate-contract: mode-ii-missing-backup stderr mentions backup
...
ok 28 schema: rejects mode=scoped_production without i_understand flag
```

## Verification

```bash
# Smoke test
bats skills/autospec-test/tests/unit/contract-loader.bats

# Operator verification
bash skills/autospec-test/scripts/load-contract.sh skills/autospec-test/tests/fixtures/repos/minimal-valid
bash skills/autospec-test/scripts/load-contract.sh skills/autospec-test/tests/fixtures/repos/mode-ii-missing-backup ; echo "exit=$?"
ajv compile -s schemas/autospec-test-contract.schema.json --spec=draft2020
```