### PR TITLE
feat(autospec-test): assertion-shift AST classifier (phase 4)

### DIFF
--- a/skills/autospec-test/scripts/adapters/cargo-test.mjs
+++ b/skills/autospec-test/scripts/adapters/cargo-test.mjs
@@ -1,0 +1,117 @@
+// adapters/cargo-test.mjs
+// Assertion-shift adapter for Rust test files (cargo test).
+// Export: bucket(fileDiff, filePath) -> Verdict[]
+
+// Rust assertion patterns
+const RUST_ASSERT_PATTERNS = [
+    /\bassert!\s*\(/,
+    /\bassert_eq!\s*\(/,
+    /\bassert_ne!\s*\(/,
+    /\bassert_matches!\s*\(/,
+    /\bpanic!\s*\(/,
+    /\bunwrap\s*\(\)/,
+    /\bexpect\s*\(/,
+];
+
+// Rust assertion strictness rank
+const RUST_ASSERT_RANK = {
+    'assert_eq!': 5,
+    'assert_ne!': 4,
+    'assert_matches!': 4,
+    'assert!': 3,
+    'expect(': 2,
+    'unwrap()': 1,
+};
+
+// Rust skip patterns
+const RUST_SKIP = [
+    /\#\[ignore\]/,
+    /\/\/\s*assert/,  // commented-out assertion
+];
+
+function isRustAssertion(line) {
+    return RUST_ASSERT_PATTERNS.some(p => p.test(line));
+}
+
+function detectRustAssertOp(line) {
+    return Object.keys(RUST_ASSERT_RANK).find(op => line.includes(op));
+}
+
+function classifyRustChange(removedLine, addedLine) {
+    // Check #[ignore] FIRST — it appears on its own line with no assertion keyword
+    if (RUST_SKIP.some(p => p.test(addedLine)) && !RUST_SKIP.some(p => p.test(removedLine))) {
+        return 'LOOSENING';
+    }
+    if (RUST_SKIP.some(p => p.test(removedLine)) && !RUST_SKIP.some(p => p.test(addedLine))) {
+        return 'STRENGTHENING';
+    }
+
+    const wasAssert = isRustAssertion(removedLine);
+    const isAssert = isRustAssertion(addedLine);
+
+    if (wasAssert && !isAssert) return 'LOOSENING';
+    if (!wasAssert && isAssert) return 'STRENGTHENING';
+
+    // Operator rank change
+    const beforeOp = detectRustAssertOp(removedLine);
+    const afterOp = detectRustAssertOp(addedLine);
+    if (beforeOp && afterOp && beforeOp !== afterOp) {
+        const delta = RUST_ASSERT_RANK[afterOp] - RUST_ASSERT_RANK[beforeOp];
+        if (delta < 0) return 'LOOSENING';
+        if (delta > 0) return 'STRENGTHENING';
+    }
+
+    if (wasAssert && isAssert && removedLine.trim() !== addedLine.trim()) {
+        return 'SHIFTING';
+    }
+
+    return null;
+}
+
+export function bucket(fileDiff, filePath) {
+    const verdicts = [];
+
+    for (const hunk of (fileDiff.hunks || [])) {
+        const removed = hunk.removed || [];
+        const added = hunk.added || [];
+        const maxPairs = Math.max(removed.length, added.length);
+
+        for (let i = 0; i < maxPairs; i++) {
+            const rem = removed[i];
+            const add = added[i];
+
+            if (rem && add) {
+                const b = classifyRustChange(rem.content, add.content);
+                if (b) {
+                    verdicts.push({
+                        file: filePath,
+                        line: add.line || hunk.startLine || 0,
+                        bucket: b,
+                        framework: 'cargo-test',
+                        detail: `${rem.content.trim()} → ${add.content.trim()}`,
+                    });
+                }
+            } else if (rem && !add && (isRustAssertion(rem.content) || RUST_SKIP.some(p => p.test(rem.content)))) {
+                // Removal of assertion OR skip decorator
+                const isSkipRemoval = !isRustAssertion(rem.content) && RUST_SKIP.some(p => p.test(rem.content));
+                verdicts.push({
+                    file: filePath,
+                    line: hunk.startLine || 0,
+                    bucket: isSkipRemoval ? 'STRENGTHENING' : 'LOOSENING',
+                    framework: 'cargo-test',
+                    detail: isSkipRemoval ? `skip removed: ${rem.content.trim()}` : `assertion removed: ${rem.content.trim()}`,
+                });
+            } else if (!rem && add && (isRustAssertion(add.content) || RUST_SKIP.some(p => p.test(add.content)))) {
+                verdicts.push({
+                    file: filePath,
+                    line: add.line || hunk.startLine || 0,
+                    bucket: 'STRENGTHENING',
+                    framework: 'cargo-test',
+                    detail: `assertion added: ${add.content.trim()}`,
+                });
+            }
+        }
+    }
+
+    return verdicts;
+}

--- a/skills/autospec-test/scripts/adapters/generic.mjs
+++ b/skills/autospec-test/scripts/adapters/generic.mjs
@@ -1,0 +1,204 @@
+// adapters/generic.mjs
+// Generic assertion-shift adapter — text/regex based (no AST).
+// Used as fallback when no framework-specific adapter is available,
+// and as shared logic for JS/TS adapters.
+//
+// Export: bucket(fileDiff, filePath) -> Verdict[]
+
+/**
+ * Assertion patterns for generic detection.
+ * Each entry: { pattern, type }
+ *   type: 'assert' | 'tolerance'
+ */
+const ASSERTION_PATTERNS = [
+    // Jest/Vitest/Mocha expect style
+    /\bexpect\s*\(.+\)\s*\./,
+    // Chai assert
+    /\bassert\s*\.\w+\s*\(/,
+    // Node assert
+    /\bassert(?:\.strict)?\s*\(/,
+    // Python assert
+    /^\s*assert\s+/,
+    // Go testing
+    /\bt\.(?:Error|Fatal|Fail|Equal|NotEqual|True|False|Nil|NotNil)\b/,
+    // Rust assert
+    /\bassert(?:_eq|_ne|_matches|!)?\s*!/,
+    // Playwright expect
+    /\bexpect\s*\(.+\)\.to(?:Be|Have|Match|Contain|Equal|Pass|Throw)/,
+];
+
+const TOLERANCE_PATTERNS = [
+    // numeric tolerance widening: toBeCloseTo, toAlmostEqual, delta
+    /\btoBeCloseTo\s*\([^,]+,\s*(\d+)\)/,
+    /\bdelta\s*[=:]\s*([\d.]+)/,
+    /\bprecision\s*[=:]\s*([\d.]+)/,
+    /\balmost\s*(?:equal|equals)\s*\([^,]+,\s*([\d.]+)/i,
+];
+
+const SKIP_PATTERNS = [
+    /\btest\.skip\b/,
+    /\bit\.skip\b/,
+    /\bdescribe\.skip\b/,
+    /\bxtest\b/,
+    /\bxit\b/,
+    /\bxdescribe\b/,
+    /\b@pytest\.mark\.skip\b/,
+    /\bt\.Skip\b/,
+    /\b#\[ignore\]/,
+];
+
+const ONLY_PATTERNS = [
+    /\btest\.only\b/,
+    /\bit\.only\b/,
+    /\bdescribe\.only\b/,
+    /\bftest\b/,
+    /\bfit\b/,
+];
+
+/**
+ * Check if a line contains an assertion.
+ */
+function isAssertion(line) {
+    return ASSERTION_PATTERNS.some(p => p.test(line));
+}
+
+/**
+ * Classify a pair of (removed, added) assertion lines.
+ * Returns 'LOOSENING' | 'SHIFTING' | 'STRENGTHENING' | null
+ */
+function classifyChange(removedLine, addedLine) {
+    // Check skip/only patterns FIRST — these affect test coverage regardless of assertion presence.
+    // e.g. test('x') → test.skip('x') has no assertion keywords but is still LOOSENING.
+    const wasSkipped = SKIP_PATTERNS.some(p => p.test(removedLine));
+    const isSkipped = SKIP_PATTERNS.some(p => p.test(addedLine));
+    if (!wasSkipped && isSkipped) return 'LOOSENING';  // skip added
+    if (wasSkipped && !isSkipped) return 'STRENGTHENING';  // skip removed
+
+    // .only added: LOOSENING (reduces test coverage)
+    const hadOnly = ONLY_PATTERNS.some(p => p.test(removedLine));
+    const hasOnly = ONLY_PATTERNS.some(p => p.test(addedLine));
+    if (!hadOnly && hasOnly) return 'LOOSENING';
+    if (hadOnly && !hasOnly) return 'STRENGTHENING';
+
+    // Pure selector / comment fix — no assertion keyword on either side
+    if (!isAssertion(removedLine) && !isAssertion(addedLine)) return null;
+
+    // Assertion removed → LOOSENING
+    if (isAssertion(removedLine) && !isAssertion(addedLine)) {
+        return 'LOOSENING';
+    }
+
+    // Assertion added → STRENGTHENING
+    if (!isAssertion(removedLine) && isAssertion(addedLine)) {
+        return 'STRENGTHENING';
+    }
+
+    // Check tolerance changes
+    for (const tp of TOLERANCE_PATTERNS) {
+        const removedMatch = removedLine.match(tp);
+        const addedMatch = addedLine.match(tp);
+        if (removedMatch && addedMatch) {
+            const oldVal = parseFloat(removedMatch[1]);
+            const newVal = parseFloat(addedMatch[1]);
+            if (isNaN(oldVal) || isNaN(newVal)) break;
+            if (newVal > oldVal) return 'LOOSENING';  // wider tolerance
+            if (newVal < oldVal) return 'STRENGTHENING';  // tighter tolerance
+        }
+    }
+
+    // Operator weakening patterns
+    // e.g. toStrictEqual → toEqual (looser), toBe → toEqual (looser)
+    const operatorRank = {
+        'toStrictEqual': 3, 'toBe': 3,
+        'toEqual': 2,
+        'toMatchObject': 1, 'toContain': 1, 'toMatch': 1,
+        'toBeTruthy': 0, 'toBeDefined': 0,
+    };
+    const removedOp = Object.keys(operatorRank).find(op => removedLine.includes(op));
+    const addedOp = Object.keys(operatorRank).find(op => addedLine.includes(op));
+    if (removedOp && addedOp && removedOp !== addedOp) {
+        const oldRank = operatorRank[removedOp];
+        const newRank = operatorRank[addedOp];
+        if (newRank < oldRank) return 'LOOSENING';
+        if (newRank > oldRank) return 'STRENGTHENING';
+    }
+
+    // Same operator/type — value-only change → SHIFTING
+    if (removedLine.trim() !== addedLine.trim()) {
+        return 'SHIFTING';
+    }
+
+    return null;
+}
+
+/**
+ * Bucket assertion changes from a file diff.
+ *
+ * @param {{added: {line: number, content: string}[], removed: {line: number, content: string}[], hunks: any[]}} fileDiff
+ * @param {string} filePath
+ * @returns {import('../assertion-shift-classifier.mjs').Verdict[]}
+ */
+export function bucket(fileDiff, filePath) {
+    const verdicts = [];
+    const framework = detectFramework(filePath);
+
+    // Match removed/added lines within each hunk
+    for (const hunk of (fileDiff.hunks || [])) {
+        const removed = hunk.removed || [];
+        const added = hunk.added || [];
+
+        // Simple pairing: match removed↔added lines within hunk
+        const maxPairs = Math.max(removed.length, added.length);
+
+        for (let i = 0; i < maxPairs; i++) {
+            const rem = removed[i];
+            const add = added[i];
+
+            if (rem && add) {
+                // Changed line
+                const bucket = classifyChange(rem.content, add.content);
+                if (bucket) {
+                    verdicts.push({
+                        file: filePath,
+                        line: add.line || hunk.startLine || 0,
+                        bucket,
+                        framework,
+                        detail: `${rem.content.trim()} → ${add.content.trim()}`,
+                    });
+                }
+            } else if (rem && !add) {
+                // Purely removed line
+                if (isAssertion(rem.content)) {
+                    verdicts.push({
+                        file: filePath,
+                        line: hunk.startLine || 0,
+                        bucket: 'LOOSENING',
+                        framework,
+                        detail: `assertion removed: ${rem.content.trim()}`,
+                    });
+                }
+            } else if (!rem && add) {
+                // Purely added line
+                if (isAssertion(add.content)) {
+                    verdicts.push({
+                        file: filePath,
+                        line: add.line || hunk.startLine || 0,
+                        bucket: 'STRENGTHENING',
+                        framework,
+                        detail: `assertion added: ${add.content.trim()}`,
+                    });
+                }
+            }
+        }
+    }
+
+    return verdicts;
+}
+
+function detectFramework(filePath) {
+    if (/\.(spec|test)\.(ts|tsx)$/.test(filePath)) return 'playwright';
+    if (/test_.*\.py$|.*_test\.py$/.test(filePath)) return 'pytest';
+    if (/_test\.go$/.test(filePath)) return 'go-test';
+    if (/\.rs$/.test(filePath)) return 'cargo-test';
+    return 'jest';
+}

--- a/skills/autospec-test/scripts/adapters/go-test.mjs
+++ b/skills/autospec-test/scripts/adapters/go-test.mjs
@@ -1,0 +1,141 @@
+// adapters/go-test.mjs
+// Assertion-shift adapter for Go test files (*_test.go).
+// Export: bucket(fileDiff, filePath) -> Verdict[]
+
+// Go testing assertion patterns
+const GO_ASSERT_PATTERNS = [
+    /\bt\.(?:Error|Errorf|Fatal|Fatalf|Fail|FailNow)\s*\(/,
+    /\bt\.(?:Equal|NotEqual|True|False|Nil|NotNil|Contains|Len)\s*\(/,
+    /\brequire\.(?:Equal|NotEqual|True|False|Nil|NotNil|Contains|Error|NoError)\s*\(/,
+    /\bassert\.(?:Equal|NotEqual|True|False|Nil|NotNil|Contains|Error|NoError)\s*\(/,
+    /\bif\s+.*!=.*\{\s*t\.(?:Error|Fatal)/,
+];
+
+// Go assertion strictness rank
+const GO_ASSERT_RANK = {
+    'require.Equal': 5,
+    'assert.Equal': 4,
+    'require.True': 3,
+    'assert.True': 3,
+    'require.Contains': 2,
+    'assert.Contains': 2,
+    'require.Error': 3,
+    'assert.Error': 3,
+    't.Fatal': 4,
+    't.Error': 2,
+    't.Fail': 1,
+};
+
+// Go skip patterns → LOOSENING
+const GO_SKIP = [
+    /\bt\.Skip\s*\(/,
+    /\bt\.Skipf\s*\(/,
+    /\/\/ t\.Errorf/,  // commented-out assertions
+];
+
+function isGoAssertion(line) {
+    return GO_ASSERT_PATTERNS.some(p => p.test(line));
+}
+
+function detectGoAssertOp(line) {
+    return Object.keys(GO_ASSERT_RANK).find(op => line.includes(op));
+}
+
+function classifyGoChange(removedLine, addedLine) {
+    // Check skip FIRST — t.Skip() lines are not assertions
+    if (GO_SKIP.some(p => p.test(addedLine)) && !GO_SKIP.some(p => p.test(removedLine))) {
+        return 'LOOSENING';
+    }
+    if (GO_SKIP.some(p => p.test(removedLine)) && !GO_SKIP.some(p => p.test(addedLine))) {
+        return 'STRENGTHENING';
+    }
+
+    const wasAssert = isGoAssertion(removedLine);
+    const isAssert = isGoAssertion(addedLine);
+
+    if (wasAssert && !isAssert) {
+        return 'LOOSENING';
+    }
+    if (!wasAssert && isAssert) return 'STRENGTHENING';
+
+    // Operator rank change
+    const beforeOp = detectGoAssertOp(removedLine);
+    const afterOp = detectGoAssertOp(addedLine);
+    if (beforeOp && afterOp && beforeOp !== afterOp) {
+        const delta = GO_ASSERT_RANK[afterOp] - GO_ASSERT_RANK[beforeOp];
+        if (delta < 0) return 'LOOSENING';
+        if (delta > 0) return 'STRENGTHENING';
+    }
+
+    if (wasAssert && isAssert && removedLine.trim() !== addedLine.trim()) {
+        return 'SHIFTING';
+    }
+
+    return null;
+}
+
+export function bucket(fileDiff, filePath) {
+    const verdicts = [];
+
+    for (const hunk of (fileDiff.hunks || [])) {
+        const removed = hunk.removed || [];
+        const added = hunk.added || [];
+        const maxPairs = Math.max(removed.length, added.length);
+
+        for (let i = 0; i < maxPairs; i++) {
+            const rem = removed[i];
+            const add = added[i];
+
+            if (rem && add) {
+                const b = classifyGoChange(rem.content, add.content);
+                if (b) {
+                    verdicts.push({
+                        file: filePath,
+                        line: add.line || hunk.startLine || 0,
+                        bucket: b,
+                        framework: 'go-test',
+                        detail: `${rem.content.trim()} → ${add.content.trim()}`,
+                    });
+                }
+            } else if (rem && !add) {
+                if (isGoAssertion(rem.content)) {
+                    verdicts.push({
+                        file: filePath,
+                        line: hunk.startLine || 0,
+                        bucket: 'LOOSENING',
+                        framework: 'go-test',
+                        detail: `assertion removed: ${rem.content.trim()}`,
+                    });
+                } else if (GO_SKIP.some(p => p.test(rem.content))) {
+                    verdicts.push({
+                        file: filePath,
+                        line: hunk.startLine || 0,
+                        bucket: 'STRENGTHENING',
+                        framework: 'go-test',
+                        detail: `skip removed: ${rem.content.trim()}`,
+                    });
+                }
+            } else if (!rem && add) {
+                if (isGoAssertion(add.content)) {
+                    verdicts.push({
+                        file: filePath,
+                        line: add.line || hunk.startLine || 0,
+                        bucket: 'STRENGTHENING',
+                        framework: 'go-test',
+                        detail: `assertion added: ${add.content.trim()}`,
+                    });
+                } else if (GO_SKIP.some(p => p.test(add.content))) {
+                    verdicts.push({
+                        file: filePath,
+                        line: add.line || hunk.startLine || 0,
+                        bucket: 'LOOSENING',
+                        framework: 'go-test',
+                        detail: `skip added: ${add.content.trim()}`,
+                    });
+                }
+            }
+        }
+    }
+
+    return verdicts;
+}

--- a/skills/autospec-test/scripts/adapters/jest.mjs
+++ b/skills/autospec-test/scripts/adapters/jest.mjs
@@ -1,0 +1,9 @@
+// adapters/jest.mjs
+// Assertion-shift adapter for Jest test files.
+// Export: bucket(fileDiff, filePath) -> Verdict[]
+
+import { bucket as genericBucket } from './generic.mjs';
+
+export function bucket(fileDiff, filePath) {
+    return genericBucket(fileDiff, filePath);
+}

--- a/skills/autospec-test/scripts/adapters/mocha.mjs
+++ b/skills/autospec-test/scripts/adapters/mocha.mjs
@@ -1,0 +1,49 @@
+// adapters/mocha.mjs
+// Assertion-shift adapter for Mocha test files (Chai assertions).
+// Export: bucket(fileDiff, filePath) -> Verdict[]
+
+import { bucket as genericBucket } from './generic.mjs';
+
+// Chai BDD operator rank
+const CHAI_OPERATOR_RANK = {
+    'deep.equal': 4,
+    'equal': 3,
+    'include': 2,
+    'match': 1,
+    'exist': 0,
+    'ok': 0,
+    'true': 3,
+    'false': 3,
+    'null': 3,
+    'undefined': 3,
+    'eql': 3,
+};
+
+function detectChaiOperator(line) {
+    return Object.keys(CHAI_OPERATOR_RANK).find(op => {
+        const pattern = new RegExp(`\\.${op.replace('.', '\\.')}\\b`);
+        return pattern.test(line);
+    });
+}
+
+export function bucket(fileDiff, filePath) {
+    const verdicts = genericBucket(fileDiff, filePath);
+
+    // Refine with Chai operator ranks
+    for (const v of verdicts) {
+        if (v.bucket === 'SHIFTING') {
+            const [before, after] = v.detail.split(' → ');
+            if (before && after) {
+                const beforeOp = detectChaiOperator(before);
+                const afterOp = detectChaiOperator(after);
+                if (beforeOp && afterOp && beforeOp !== afterOp) {
+                    const delta = CHAI_OPERATOR_RANK[afterOp] - CHAI_OPERATOR_RANK[beforeOp];
+                    if (delta < 0) v.bucket = 'LOOSENING';
+                    else if (delta > 0) v.bucket = 'STRENGTHENING';
+                }
+            }
+        }
+    }
+
+    return verdicts;
+}

--- a/skills/autospec-test/scripts/adapters/playwright.mjs
+++ b/skills/autospec-test/scripts/adapters/playwright.mjs
@@ -1,0 +1,78 @@
+// adapters/playwright.mjs
+// Assertion-shift adapter for Playwright test files (.spec.ts, .test.ts, etc.)
+// Export: bucket(fileDiff, filePath) -> Verdict[]
+
+import { bucket as genericBucket } from './generic.mjs';
+
+// Playwright-specific assertion operators ranked by strictness
+const PW_OPERATOR_RANK = {
+    'toStrictEqual': 5,
+    'toBe': 4,
+    'toEqual': 3,
+    'toMatchObject': 2,
+    'toContain': 2,
+    'toHaveText': 2,
+    'toHaveValue': 2,
+    'toMatch': 1,
+    'toBeTruthy': 0,
+    'toBeDefined': 0,
+    'toBeVisible': 2,
+    'toBeEnabled': 2,
+    'toBeChecked': 2,
+    'toBeDisabled': 1,
+    'toBeHidden': 1,
+};
+
+// Playwright-specific LOOSENING patterns
+const PW_LOOSENING = [
+    // Removing timeout (makes test flakier)
+    /timeout\s*:\s*\d+/,
+    // Adding { timeout: large } to expect
+    /\.toHave.*\{\s*timeout\s*:\s*(\d+)/,
+];
+
+/**
+ * Playwright-specific bucket function.
+ * Extends generic with Playwright operator rankings.
+ */
+export function bucket(fileDiff, filePath) {
+    // Use generic bucketing as base
+    const verdicts = genericBucket(fileDiff, filePath);
+
+    // Post-process: refine verdicts using Playwright-specific operator ranks
+    for (const v of verdicts) {
+        if (v.bucket === 'SHIFTING') {
+            // Check if operator changed rank
+            const [before, after] = v.detail.split(' → ');
+            if (before && after) {
+                const beforeOp = Object.keys(PW_OPERATOR_RANK).find(op => before.includes(op));
+                const afterOp = Object.keys(PW_OPERATOR_RANK).find(op => after.includes(op));
+                if (beforeOp && afterOp && beforeOp !== afterOp) {
+                    const delta = PW_OPERATOR_RANK[afterOp] - PW_OPERATOR_RANK[beforeOp];
+                    if (delta < 0) v.bucket = 'LOOSENING';
+                    else if (delta > 0) v.bucket = 'STRENGTHENING';
+                }
+            }
+        }
+    }
+
+    // Check for timeout increases in added lines (LOOSENING)
+    for (const hunk of (fileDiff.hunks || [])) {
+        for (const add of (hunk.added || [])) {
+            if (PW_LOOSENING[1].test(add.content)) {
+                const timeoutMatch = add.content.match(/timeout\s*:\s*(\d+)/);
+                if (timeoutMatch && parseInt(timeoutMatch[1], 10) > 30000) {
+                    verdicts.push({
+                        file: filePath,
+                        line: add.line || hunk.startLine || 0,
+                        bucket: 'LOOSENING',
+                        framework: 'playwright',
+                        detail: `timeout increased to ${timeoutMatch[1]}ms in expect`,
+                    });
+                }
+            }
+        }
+    }
+
+    return verdicts;
+}

--- a/skills/autospec-test/scripts/adapters/pytest.mjs
+++ b/skills/autospec-test/scripts/adapters/pytest.mjs
@@ -1,0 +1,145 @@
+// adapters/pytest.mjs
+// Assertion-shift adapter for pytest test files.
+// Invokes Python-level analysis via text patterns (no subprocess needed for basic detection).
+// Export: bucket(fileDiff, filePath) -> Verdict[]
+
+// Python assertion patterns
+const PY_ASSERT_PATTERNS = [
+    /^\s*assert\s+/,
+    /\bpytest\.raises\s*\(/,
+    /\bpytest\.warns\s*\(/,
+    /\bassert_called(?:_once)?(?:_with)?\s*\(/,
+    /\bassertEqual\s*\(/,
+    /\bassertRaises\s*\(/,
+    /\bassertAlmostEqual\s*\(/,
+];
+
+const PY_TOLERANCE_PATTERNS = [
+    /\babs\s*=\s*([\d.e+-]+)/,
+    /\brel\s*=\s*([\d.e+-]+)/,
+    /\bapprox\s*\([^,)]+,\s*(?:abs|rel)\s*=\s*([\d.e+-]+)/,
+    /\bplaces\s*=\s*(\d+)/,
+    /\bdelta\s*=\s*([\d.e+-]+)/,
+];
+
+const PY_LOOSENING = [
+    // Adding pytest.mark.skip
+    /\bpytest\.mark\.skip\b/,
+    /\bpytest\.mark\.xfail\b/,
+    // Weakening assert to assertTrue (any truth check)
+    /\bassertTrue\b/,
+];
+
+function isPyAssertion(line) {
+    return PY_ASSERT_PATTERNS.some(p => p.test(line));
+}
+
+function classifyPyChange(removedLine, addedLine) {
+    // Check skip/xfail FIRST (before assertion guard) — decorator lines contain no assertion keyword
+    if (PY_LOOSENING.some(p => p.test(addedLine)) && !PY_LOOSENING.some(p => p.test(removedLine))) {
+        return 'LOOSENING';
+    }
+    if (PY_LOOSENING.some(p => p.test(removedLine)) && !PY_LOOSENING.some(p => p.test(addedLine))) {
+        return 'STRENGTHENING';
+    }
+
+    const wasAssert = isPyAssertion(removedLine);
+    const isAssert = isPyAssertion(addedLine);
+
+    if (wasAssert && !isAssert) return 'LOOSENING';
+    if (!wasAssert && isAssert) return 'STRENGTHENING';
+
+    // Tolerance changes
+    for (const tp of PY_TOLERANCE_PATTERNS) {
+        const rm = removedLine.match(tp);
+        const am = addedLine.match(tp);
+        if (rm && am) {
+            const oldVal = parseFloat(rm[1]);
+            const newVal = parseFloat(am[1]);
+            if (!isNaN(oldVal) && !isNaN(newVal)) {
+                // For 'places': higher = stricter
+                if (tp.source.includes('places')) {
+                    if (newVal < oldVal) return 'LOOSENING';
+                    if (newVal > oldVal) return 'STRENGTHENING';
+                } else {
+                    if (newVal > oldVal) return 'LOOSENING';
+                    if (newVal < oldVal) return 'STRENGTHENING';
+                }
+            }
+        }
+    }
+
+    if (wasAssert && isAssert && removedLine.trim() !== addedLine.trim()) {
+        return 'SHIFTING';
+    }
+
+    return null;
+}
+
+export function bucket(fileDiff, filePath) {
+    const verdicts = [];
+
+    for (const hunk of (fileDiff.hunks || [])) {
+        const removed = hunk.removed || [];
+        const added = hunk.added || [];
+        const maxPairs = Math.max(removed.length, added.length);
+
+        for (let i = 0; i < maxPairs; i++) {
+            const rem = removed[i];
+            const add = added[i];
+
+            if (rem && add) {
+                const b = classifyPyChange(rem.content, add.content);
+                if (b) {
+                    verdicts.push({
+                        file: filePath,
+                        line: add.line || hunk.startLine || 0,
+                        bucket: b,
+                        framework: 'pytest',
+                        detail: `${rem.content.trim()} → ${add.content.trim()}`,
+                    });
+                }
+            } else if (rem && !add) {
+                if (isPyAssertion(rem.content)) {
+                    verdicts.push({
+                        file: filePath,
+                        line: hunk.startLine || 0,
+                        bucket: 'LOOSENING',
+                        framework: 'pytest',
+                        detail: `assertion removed: ${rem.content.trim()}`,
+                    });
+                } else if (PY_LOOSENING.some(p => p.test(rem.content))) {
+                    // skip/xfail decorator removed → STRENGTHENING
+                    verdicts.push({
+                        file: filePath,
+                        line: hunk.startLine || 0,
+                        bucket: 'STRENGTHENING',
+                        framework: 'pytest',
+                        detail: `skip removed: ${rem.content.trim()}`,
+                    });
+                }
+            } else if (!rem && add) {
+                if (isPyAssertion(add.content)) {
+                    verdicts.push({
+                        file: filePath,
+                        line: add.line || hunk.startLine || 0,
+                        bucket: 'STRENGTHENING',
+                        framework: 'pytest',
+                        detail: `assertion added: ${add.content.trim()}`,
+                    });
+                } else if (PY_LOOSENING.some(p => p.test(add.content))) {
+                    // skip/xfail decorator added → LOOSENING
+                    verdicts.push({
+                        file: filePath,
+                        line: add.line || hunk.startLine || 0,
+                        bucket: 'LOOSENING',
+                        framework: 'pytest',
+                        detail: `skip added: ${add.content.trim()}`,
+                    });
+                }
+            }
+        }
+    }
+
+    return verdicts;
+}

--- a/skills/autospec-test/scripts/adapters/vitest.mjs
+++ b/skills/autospec-test/scripts/adapters/vitest.mjs
@@ -1,0 +1,40 @@
+// adapters/vitest.mjs
+// Assertion-shift adapter for Vitest test files.
+// Export: bucket(fileDiff, filePath) -> Verdict[]
+
+import { bucket as genericBucket } from './generic.mjs';
+
+// Vitest-specific operator rank (subset differs from jest)
+const VT_OPERATOR_RANK = {
+    'toStrictEqual': 5,
+    'toBe': 4,
+    'toEqual': 3,
+    'toMatchObject': 2,
+    'toContain': 2,
+    'toMatch': 1,
+    'toBeTruthy': 0,
+    'toBeDefined': 0,
+    'toSatisfy': 2,
+};
+
+export function bucket(fileDiff, filePath) {
+    const verdicts = genericBucket(fileDiff, filePath);
+
+    // Refine SHIFTING verdicts using Vitest operator ranks
+    for (const v of verdicts) {
+        if (v.bucket === 'SHIFTING') {
+            const [before, after] = v.detail.split(' → ');
+            if (before && after) {
+                const beforeOp = Object.keys(VT_OPERATOR_RANK).find(op => before.includes(op));
+                const afterOp = Object.keys(VT_OPERATOR_RANK).find(op => after.includes(op));
+                if (beforeOp && afterOp && beforeOp !== afterOp) {
+                    const delta = VT_OPERATOR_RANK[afterOp] - VT_OPERATOR_RANK[beforeOp];
+                    if (delta < 0) v.bucket = 'LOOSENING';
+                    else if (delta > 0) v.bucket = 'STRENGTHENING';
+                }
+            }
+        }
+    }
+
+    return verdicts;
+}

--- a/skills/autospec-test/scripts/assertion-shift-classifier.mjs
+++ b/skills/autospec-test/scripts/assertion-shift-classifier.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+// scripts/assertion-shift-classifier.mjs
+// AST-based assertion-shift classifier for autospec-test.
+//
+// Buckets every modified test-file assertion as:
+//   LOOSENING   — tolerance widened, type weakened, assertion removed
+//   SHIFTING    — value-only shift, same operator/type
+//   STRENGTHENING — tolerance tightened, check added
+//
+// Per-bucket policy (spec §5c):
+//   LOOSENING   → blocks gate (label needs-human-review + e2e:assertion-loosening)
+//   SHIFTING    → blocks unless (co-edited non-test file AND JUSTIFICATION: in commit message)
+//   STRENGTHENING → always passes
+//
+// Export: classify(options) async function
+// CLI: node assertion-shift-classifier.mjs --repo <dir> --base <ref> --head <ref>
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __filename = fileURLToPath(import.meta.url);
+const ADAPTERS_DIR = path.join(path.dirname(__filename), 'adapters');
+
+/**
+ * @typedef {Object} Verdict
+ * @property {string} file       - relative path to the test file
+ * @property {number} line       - line number of the assertion change (1-based)
+ * @property {'LOOSENING'|'SHIFTING'|'STRENGTHENING'} bucket
+ * @property {string} framework  - detected test framework
+ * @property {string} detail     - human-readable description of the change
+ */
+
+/**
+ * @typedef {Object} GateResult
+ * @property {boolean} passed
+ * @property {string} reason     - machine-readable reason code (when !passed)
+ * @property {Verdict[]} verdicts
+ * @property {string[]} loosening_files
+ * @property {string[]} shifting_unjustified_files
+ */
+
+// Framework detection patterns
+const FRAMEWORK_PATTERNS = {
+    playwright: /\.(spec|test)\.(ts|js|mjs)$/,
+    jest:       /\.(test|spec)\.(ts|js|tsx|jsx)$/,
+    vitest:     /\.(test|spec)\.(ts|js|mjs|tsx|jsx)$/,
+    mocha:      /\.(test|spec)\.js$/,
+    pytest:     /test_.*\.py$|.*_test\.py$/,
+    'go-test':  /_test\.go$/,
+    'cargo-test': /\.rs$/,
+};
+
+// Framework detection order (more specific first)
+const FRAMEWORK_ORDER = ['playwright', 'pytest', 'go-test', 'cargo-test', 'vitest', 'jest', 'mocha'];
+
+/**
+ * Detect which test framework a file belongs to.
+ * @param {string} filePath
+ * @returns {string} framework name
+ */
+function detectFramework(filePath) {
+    for (const fw of FRAMEWORK_ORDER) {
+        if (FRAMEWORK_PATTERNS[fw].test(filePath)) {
+            return fw;
+        }
+    }
+    return 'jest'; // default
+}
+
+/**
+ * Run git diff to get modified lines for a file.
+ * Returns {added: string[], removed: string[], hunks: Array<{added, removed, startLine}>}
+ */
+async function getFileDiff(repoRoot, baseRef, headRef, filePath) {
+    try {
+        const { stdout } = await execFileAsync('git', [
+            '-C', repoRoot,
+            'diff', `${baseRef}..${headRef}`, '--', filePath
+        ], { maxBuffer: 10 * 1024 * 1024 });
+        return parseDiff(stdout);
+    } catch {
+        return { added: [], removed: [], hunks: [] };
+    }
+}
+
+/**
+ * Parse unified diff output into added/removed lines with line numbers.
+ */
+function parseDiff(diffText) {
+    const added = [];
+    const removed = [];
+    const hunks = [];
+
+    let currentHunk = null;
+    let newLineNum = 0;
+
+    for (const line of diffText.split('\n')) {
+        if (line.startsWith('@@')) {
+            // @@ -old_start,old_count +new_start,new_count @@
+            const match = line.match(/\+(\d+)/);
+            newLineNum = match ? parseInt(match[1], 10) : 0;
+            currentHunk = { added: [], removed: [], startLine: newLineNum };
+            hunks.push(currentHunk);
+        } else if (line.startsWith('+') && !line.startsWith('+++')) {
+            const content = line.slice(1);
+            added.push({ line: newLineNum, content });
+            if (currentHunk) currentHunk.added.push({ line: newLineNum, content });
+            newLineNum++;
+        } else if (line.startsWith('-') && !line.startsWith('---')) {
+            const content = line.slice(1);
+            removed.push({ line: 0, content }); // removed lines don't have new line numbers
+            if (currentHunk) currentHunk.removed.push({ line: 0, content });
+        } else if (!line.startsWith('\\')) {
+            newLineNum++;
+        }
+    }
+
+    return { added, removed, hunks };
+}
+
+/**
+ * Get the list of files changed between two refs.
+ * @returns {Promise<{testFiles: string[], nonTestFiles: string[]}>}
+ */
+async function getChangedFiles(repoRoot, baseRef, headRef) {
+    try {
+        const { stdout } = await execFileAsync('git', [
+            '-C', repoRoot,
+            'diff', '--name-only', `${baseRef}..${headRef}`
+        ]);
+        const files = stdout.trim().split('\n').filter(Boolean);
+        const testFiles = files.filter(f => isTestFile(f));
+        const nonTestFiles = files.filter(f => !isTestFile(f));
+        return { testFiles, nonTestFiles };
+    } catch {
+        return { testFiles: [], nonTestFiles: [] };
+    }
+}
+
+/**
+ * Determine if a file is a test file.
+ */
+function isTestFile(filePath) {
+    return Object.values(FRAMEWORK_PATTERNS).some(pat => pat.test(filePath)) ||
+        /[/\\]tests?[/\\]/.test(filePath) ||
+        /[/\\]__tests?__[/\\]/.test(filePath) ||
+        /[/\\]spec[/\\]/.test(filePath);
+}
+
+/**
+ * Get commit messages between base and head refs.
+ */
+async function getCommitMessages(repoRoot, baseRef, headRef) {
+    try {
+        const { stdout } = await execFileAsync('git', [
+            '-C', repoRoot,
+            'log', '--format=%B', `${baseRef}..${headRef}`
+        ]);
+        return stdout;
+    } catch {
+        return '';
+    }
+}
+
+/**
+ * Main classifier entry point.
+ *
+ * @param {object} options
+ * @param {string} options.repoRoot  - absolute path to the target repo
+ * @param {string} options.baseRef   - base git ref (e.g. 'main', 'origin/main')
+ * @param {string} options.headRef   - head git ref (e.g. 'HEAD', 'pr-branch')
+ * @param {string} [options.diffText] - pre-computed diff text (for unit tests)
+ * @returns {Promise<{verdicts: Verdict[], gate: GateResult}>}
+ */
+export async function classify(options) {
+    const { repoRoot, baseRef = 'HEAD~1', headRef = 'HEAD', diffText } = options;
+
+    // Get changed files — in diffText (unit test) mode, also accept nonTestFilesChanged override
+    let testFiles, nonTestFiles;
+    if (diffText !== undefined) {
+        const parsed = parseFilesFromDiff(diffText);
+        testFiles = parsed.testFiles;
+        // Accept explicit nonTestFilesChanged for unit tests (avoids git calls)
+        nonTestFiles = Array.isArray(options.nonTestFilesChanged)
+            ? options.nonTestFilesChanged
+            : parsed.nonTestFiles;
+    } else {
+        ({ testFiles, nonTestFiles } = await getChangedFiles(repoRoot, baseRef, headRef));
+    }
+
+    // Get commit messages to check for JUSTIFICATION:
+    const commitMessages = diffText !== undefined
+        ? (options.commitMessages || '')
+        : await getCommitMessages(repoRoot, baseRef, headRef);
+
+    const hasJustification = /JUSTIFICATION:\s*.+/m.test(commitMessages);
+    const hasCoEdit = nonTestFiles.length > 0;
+
+    const allVerdicts = [];
+
+    for (const testFile of testFiles) {
+        const framework = detectFramework(testFile);
+        let fileDiff;
+
+        if (diffText) {
+            // Extract per-file diff from combined diff text
+            fileDiff = extractFileDiff(diffText, testFile);
+        } else {
+            fileDiff = await getFileDiff(repoRoot, baseRef, headRef, testFile);
+        }
+
+        // Load framework adapter
+        let adapter;
+        try {
+            const adapterPath = path.join(ADAPTERS_DIR, `${framework}.mjs`);
+            adapter = await import(`file://${adapterPath}`);
+        } catch {
+            // Fall back to generic adapter
+            try {
+                const genericPath = path.join(ADAPTERS_DIR, 'generic.mjs');
+                adapter = await import(`file://${genericPath}`);
+            } catch {
+                continue;
+            }
+        }
+
+        // Run adapter
+        const verdicts = adapter.bucket(fileDiff, testFile);
+        allVerdicts.push(...verdicts);
+    }
+
+    // Compute gate decision
+    const looseningVerdicts = allVerdicts.filter(v => v.bucket === 'LOOSENING');
+    const shiftingVerdicts = allVerdicts.filter(v => v.bucket === 'SHIFTING');
+
+    const looseningFiles = [...new Set(looseningVerdicts.map(v => v.file))];
+    const shiftingFiles = [...new Set(shiftingVerdicts.map(v => v.file))];
+
+    // SHIFTING passes only when co-edit AND JUSTIFICATION: both present
+    const shiftingJustified = hasJustification && hasCoEdit;
+    const shiftingUnjustifiedFiles = shiftingJustified ? [] : shiftingFiles;
+
+    const passed = looseningFiles.length === 0 && shiftingUnjustifiedFiles.length === 0;
+
+    let reason = '';
+    if (!passed) {
+        if (looseningFiles.length > 0 && shiftingUnjustifiedFiles.length > 0) {
+            reason = 'loosening_and_unjustified_shift';
+        } else if (looseningFiles.length > 0) {
+            reason = 'assertion_loosening';
+        } else {
+            reason = 'unjustified_assertion_shift';
+        }
+    }
+
+    const gate = {
+        passed,
+        reason,
+        verdicts: allVerdicts,
+        loosening_files: looseningFiles,
+        shifting_unjustified_files: shiftingUnjustifiedFiles,
+        has_justification: hasJustification,
+        has_co_edit: hasCoEdit,
+    };
+
+    return { verdicts: allVerdicts, gate };
+}
+
+/**
+ * Parse test/non-test files from a combined diff string.
+ */
+function parseFilesFromDiff(diffText) {
+    const testFiles = [];
+    const nonTestFiles = [];
+    const filePattern = /^diff --git a\/(.+) b\//gm;
+    let match;
+    while ((match = filePattern.exec(diffText)) !== null) {
+        const f = match[1];
+        if (isTestFile(f)) testFiles.push(f);
+        else nonTestFiles.push(f);
+    }
+    return { testFiles, nonTestFiles };
+}
+
+/**
+ * Extract the diff section for a specific file from a combined diff.
+ */
+function extractFileDiff(diffText, filePath) {
+    const escaped = filePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const fileStart = new RegExp(`^diff --git a/${escaped}`, 'm');
+    const startIdx = diffText.search(fileStart);
+    if (startIdx === -1) return { added: [], removed: [], hunks: [] };
+
+    const nextDiff = diffText.indexOf('\ndiff --git', startIdx + 1);
+    const section = nextDiff === -1 ? diffText.slice(startIdx) : diffText.slice(startIdx, nextDiff);
+    return parseDiff(section);
+}
+
+// CLI entrypoint
+if (process.argv[1] && fs.realpathSync(path.resolve(process.argv[1])) === fs.realpathSync(path.resolve(__filename))) {
+    const args = process.argv.slice(2);
+    let repoRoot = process.cwd();
+    let baseRef = 'HEAD~1';
+    let headRef = 'HEAD';
+
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--repo') repoRoot = args[i + 1];
+        if (args[i] === '--base') baseRef = args[i + 1];
+        if (args[i] === '--head') headRef = args[i + 1];
+    }
+
+    try {
+        const result = await classify({ repoRoot, baseRef, headRef });
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+        process.exit(result.gate.passed ? 0 : 1);
+    } catch (err) {
+        process.stderr.write(`assertion-shift-classifier: error: ${err.message}\n`);
+        process.exit(2);
+    }
+}

--- a/skills/autospec-test/tests/fixtures/repos/greenwash-bait/README.md
+++ b/skills/autospec-test/tests/fixtures/repos/greenwash-bait/README.md
@@ -1,0 +1,8 @@
+# greenwash-bait fixture
+
+Synthetic target repo that contains a real regression with tempting assertion-weakening tests.
+Used by the assertion-shift classifier for operator/full verification.
+
+## Structure
+- `tests/calc.test.js` — test file with LOOSENING and SHIFTING changes
+- `src/calc.js` — source file (non-test, for co-edit testing)

--- a/skills/autospec-test/tests/fixtures/repos/greenwash-bait/src/calc.js
+++ b/skills/autospec-test/tests/fixtures/repos/greenwash-bait/src/calc.js
@@ -1,0 +1,4 @@
+// greenwash-bait fixture: calc.js
+// Source file deliberately has a regression (returns wrong value)
+function add(a, b) { return a + b + 1; }  // BUG: off-by-one
+module.exports = { add };

--- a/skills/autospec-test/tests/fixtures/repos/greenwash-bait/tests/calc.test.js
+++ b/skills/autospec-test/tests/fixtures/repos/greenwash-bait/tests/calc.test.js
@@ -1,0 +1,6 @@
+// greenwash-bait fixture: calc.test.js
+// Tempting assertion weakening: changes toStrictEqual → toEqual to hide regression
+const { add } = require('../src/calc');
+test('add returns correct value', () => {
+    expect(add(1, 1)).toEqual(2);  // WEAKENED from toStrictEqual — hides regression
+});

--- a/skills/autospec-test/tests/unit/assertion-shift/fixtures.mjs
+++ b/skills/autospec-test/tests/unit/assertion-shift/fixtures.mjs
@@ -1,0 +1,508 @@
+// fixtures.mjs — fixture corpus for assertion-shift classifier tests.
+// Each fixture: { id, description, diff, filePath, commitMessages, nonTestFilesChanged, expected }
+// expected: { gate_passed, verdicts: [{bucket}] } (verdicts may be partial)
+
+export const FIXTURES = [
+
+    // ── LOOSENING fixtures ────────────────────────────────────────────────────
+
+    {
+        id: 'jest-01',
+        description: 'jest: assertion removed → LOOSENING',
+        filePath: 'src/__tests__/calc.test.js',
+        commitMessages: 'fix: update test\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -5,7 +5,6 @@ test('add', () => {
+-  expect(result).toBe(42);
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+
+    {
+        id: 'jest-02',
+        description: 'jest: toStrictEqual → toEqual → LOOSENING',
+        filePath: 'src/__tests__/calc.test.js',
+        commitMessages: 'fix: relax check\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -5,7 +5,7 @@ test('add', () => {
+-  expect(result).toStrictEqual({a: 1});
++  expect(result).toEqual({a: 1});
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+
+    {
+        id: 'jest-03',
+        description: 'jest: test.skip added → LOOSENING',
+        filePath: 'src/__tests__/calc.test.js',
+        commitMessages: 'fix: skip flaky\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -1,7 +1,7 @@
+-test('add', () => {
++test.skip('add', () => {
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+
+    {
+        id: 'playwright-01',
+        description: 'playwright: toStrictEqual → toMatchObject → LOOSENING',
+        filePath: 'e2e/dashboard.spec.ts',
+        commitMessages: 'fix: relax assertion\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/e2e/dashboard.spec.ts b/e2e/dashboard.spec.ts
+@@ -10,7 +10,7 @@ test('dashboard', async ({ page }) => {
+-  expect(data).toStrictEqual({ id: 1, name: 'Alice' });
++  expect(data).toMatchObject({ id: 1 });
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+
+    {
+        id: 'playwright-02',
+        description: 'playwright: assertion removed from test block → LOOSENING',
+        filePath: 'e2e/login.spec.ts',
+        commitMessages: 'fix: remove assertion\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/e2e/login.spec.ts b/e2e/login.spec.ts
+@@ -8,7 +8,6 @@ test('login', async ({ page }) => {
+-  await expect(page).toHaveURL('/dashboard');
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+
+    {
+        id: 'pytest-01',
+        description: 'pytest: assert removed → LOOSENING',
+        filePath: 'tests/test_api.py',
+        commitMessages: 'fix: remove check\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/tests/test_api.py b/tests/test_api.py
+@@ -10,7 +10,6 @@ def test_status():
+-    assert response.status_code == 200
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+
+    {
+        id: 'pytest-02',
+        description: 'pytest: pytest.mark.skip added → LOOSENING',
+        filePath: 'tests/test_api.py',
+        commitMessages: 'fix: skip\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/tests/test_api.py b/tests/test_api.py
+@@ -1,4 +1,5 @@
++@pytest.mark.skip
+ def test_status():
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+
+    {
+        id: 'go-01',
+        description: 'go-test: require.Equal → assert.Contains → LOOSENING',
+        filePath: 'pkg/calc/calc_test.go',
+        commitMessages: 'fix: relax\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/pkg/calc/calc_test.go b/pkg/calc/calc_test.go
+@@ -5,7 +5,7 @@ func TestAdd(t *testing.T) {
+-\trequire.Equal(t, 42, result)
++\tassert.Contains(t, []int{42}, result)
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+
+    {
+        id: 'go-02',
+        description: 'go-test: t.Skip added → LOOSENING',
+        filePath: 'pkg/calc/calc_test.go',
+        commitMessages: 'fix: skip\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/pkg/calc/calc_test.go b/pkg/calc/calc_test.go
+@@ -3,6 +3,7 @@ func TestAdd(t *testing.T) {
++\tt.Skip("not ready")
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+
+    {
+        id: 'cargo-01',
+        description: 'cargo-test: assert_eq! removed → LOOSENING',
+        filePath: 'src/lib_test.rs',
+        commitMessages: 'fix: remove\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/lib_test.rs b/src/lib_test.rs
+@@ -5,7 +5,6 @@ fn test_add() {
+-    assert_eq!(result, 42);
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+
+    {
+        id: 'cargo-02',
+        description: 'cargo-test: assert_eq! → assert! → LOOSENING (weaker operator)',
+        filePath: 'src/lib_test.rs',
+        commitMessages: 'fix: weaken\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/lib_test.rs b/src/lib_test.rs
+@@ -5,7 +5,7 @@ fn test_add() {
+-    assert_eq!(result, 42);
++    assert!(result > 0);
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+
+    {
+        id: 'mocha-01',
+        description: 'mocha: assertion removed → LOOSENING',
+        filePath: 'test/api.test.js',
+        commitMessages: 'fix: remove check\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/test/api.test.js b/test/api.test.js
+@@ -5,7 +5,6 @@ it('api', () => {
+-  expect(result).to.deep.equal({ id: 1, name: 'Alice' });
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+
+    // ── SHIFTING fixtures ─────────────────────────────────────────────────────
+
+    {
+        id: 'jest-04',
+        description: 'jest: value-only change, no justification → SHIFTING (blocks)',
+        filePath: 'src/__tests__/calc.test.js',
+        commitMessages: 'fix: update expected value\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -5,7 +5,7 @@ test('add', () => {
+-  expect(result).toBe(42);
++  expect(result).toBe(43);
+`,
+        expected: { gate_passed: false, reason: 'unjustified_assertion_shift', any_bucket: 'SHIFTING' },
+    },
+
+    {
+        id: 'jest-05',
+        description: 'jest: SHIFTING with JUSTIFICATION + co-edit → passes',
+        filePath: 'src/__tests__/calc.test.js',
+        commitMessages: 'fix: update expected value\nJUSTIFICATION: upstream API now returns 43 as documented in changelog\n',
+        nonTestFilesChanged: ['src/calc.js'],
+        diff: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -5,7 +5,7 @@ test('add', () => {
+-  expect(result).toBe(42);
++  expect(result).toBe(43);
+`,
+        expected: { gate_passed: true, any_bucket: 'SHIFTING' },
+    },
+
+    {
+        id: 'jest-06',
+        description: 'jest: SHIFTING with JUSTIFICATION but no co-edit → blocks',
+        filePath: 'src/__tests__/calc.test.js',
+        commitMessages: 'fix: update expected\nJUSTIFICATION: value changed\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -5,7 +5,7 @@ test('add', () => {
+-  expect(result).toBe(42);
++  expect(result).toBe(43);
+`,
+        expected: { gate_passed: false, reason: 'unjustified_assertion_shift', any_bucket: 'SHIFTING' },
+    },
+
+    {
+        id: 'jest-07',
+        description: 'jest: SHIFTING with co-edit but no JUSTIFICATION → blocks',
+        filePath: 'src/__tests__/calc.test.js',
+        commitMessages: 'fix: update expected value\n',
+        nonTestFilesChanged: ['src/calc.js'],
+        diff: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -5,7 +5,7 @@ test('add', () => {
+-  expect(result).toBe(42);
++  expect(result).toBe(43);
+`,
+        expected: { gate_passed: false, reason: 'unjustified_assertion_shift', any_bucket: 'SHIFTING' },
+    },
+
+    {
+        id: 'playwright-03',
+        description: 'playwright: URL value shift no justification → SHIFTING (blocks)',
+        filePath: 'e2e/login.spec.ts',
+        commitMessages: 'fix: update URL\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/e2e/login.spec.ts b/e2e/login.spec.ts
+@@ -8,7 +8,7 @@ test('login', async ({ page }) => {
+-  await expect(page).toHaveURL('/dashboard');
++  await expect(page).toHaveURL('/home');
+`,
+        expected: { gate_passed: false, reason: 'unjustified_assertion_shift', any_bucket: 'SHIFTING' },
+    },
+
+    {
+        id: 'playwright-04',
+        description: 'playwright: SHIFTING with both JUSTIFICATION + co-edit → passes',
+        filePath: 'e2e/login.spec.ts',
+        commitMessages: 'fix: update redirect\nJUSTIFICATION: redirect changed to /home per product decision\n',
+        nonTestFilesChanged: ['src/router.ts'],
+        diff: `diff --git a/e2e/login.spec.ts b/e2e/login.spec.ts
+@@ -8,7 +8,7 @@ test('login', async ({ page }) => {
+-  await expect(page).toHaveURL('/dashboard');
++  await expect(page).toHaveURL('/home');
+`,
+        expected: { gate_passed: true, any_bucket: 'SHIFTING' },
+    },
+
+    {
+        id: 'pytest-03',
+        description: 'pytest: value shift no justification → SHIFTING (blocks)',
+        filePath: 'tests/test_api.py',
+        commitMessages: 'fix: update value\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/tests/test_api.py b/tests/test_api.py
+@@ -10,7 +10,7 @@ def test_status():
+-    assert response.json()['count'] == 10
++    assert response.json()['count'] == 11
+`,
+        expected: { gate_passed: false, reason: 'unjustified_assertion_shift', any_bucket: 'SHIFTING' },
+    },
+
+    {
+        id: 'go-03',
+        description: 'go-test: value shift with JUSTIFICATION + co-edit → passes',
+        filePath: 'pkg/calc/calc_test.go',
+        commitMessages: 'fix: update expected\nJUSTIFICATION: algorithm now returns 43\n',
+        nonTestFilesChanged: ['pkg/calc/calc.go'],
+        diff: `diff --git a/pkg/calc/calc_test.go b/pkg/calc/calc_test.go
+@@ -5,7 +5,7 @@ func TestAdd(t *testing.T) {
+-\trequire.Equal(t, 42, result)
++\trequire.Equal(t, 43, result)
+`,
+        expected: { gate_passed: true, any_bucket: 'SHIFTING' },
+    },
+
+    // ── STRENGTHENING fixtures ────────────────────────────────────────────────
+
+    {
+        id: 'jest-08',
+        description: 'jest: assertion added → STRENGTHENING (passes)',
+        filePath: 'src/__tests__/calc.test.js',
+        commitMessages: 'test: add assertion\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -5,6 +5,7 @@ test('add', () => {
++  expect(result).toBe(42);
+`,
+        expected: { gate_passed: true, any_bucket: 'STRENGTHENING' },
+    },
+
+    {
+        id: 'jest-09',
+        description: 'jest: toEqual → toStrictEqual → STRENGTHENING',
+        filePath: 'src/__tests__/calc.test.js',
+        commitMessages: 'test: tighten check\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -5,7 +5,7 @@ test('add', () => {
+-  expect(result).toEqual({a: 1});
++  expect(result).toStrictEqual({a: 1});
+`,
+        expected: { gate_passed: true, any_bucket: 'STRENGTHENING' },
+    },
+
+    {
+        id: 'jest-10',
+        description: 'jest: test.skip removed → STRENGTHENING',
+        filePath: 'src/__tests__/calc.test.js',
+        commitMessages: 'test: unskip\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -1,7 +1,7 @@
+-test.skip('add', () => {
++test('add', () => {
+`,
+        expected: { gate_passed: true, any_bucket: 'STRENGTHENING' },
+    },
+
+    {
+        id: 'playwright-05',
+        description: 'playwright: assertion added → STRENGTHENING',
+        filePath: 'e2e/dashboard.spec.ts',
+        commitMessages: 'test: add assertion\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/e2e/dashboard.spec.ts b/e2e/dashboard.spec.ts
+@@ -10,6 +10,7 @@ test('dashboard', async ({ page }) => {
++  await expect(page.locator('h1')).toHaveText('Dashboard');
+`,
+        expected: { gate_passed: true, any_bucket: 'STRENGTHENING' },
+    },
+
+    {
+        id: 'pytest-04',
+        description: 'pytest: assert added → STRENGTHENING',
+        filePath: 'tests/test_api.py',
+        commitMessages: 'test: add check\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/tests/test_api.py b/tests/test_api.py
+@@ -10,6 +10,7 @@ def test_status():
++    assert response.json()['success'] == True
+`,
+        expected: { gate_passed: true, any_bucket: 'STRENGTHENING' },
+    },
+
+    {
+        id: 'pytest-05',
+        description: 'pytest: pytest.mark.skip removed → STRENGTHENING',
+        filePath: 'tests/test_api.py',
+        commitMessages: 'test: unskip\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/tests/test_api.py b/tests/test_api.py
+@@ -1,4 +1,3 @@
+-@pytest.mark.skip
+ def test_status():
+`,
+        expected: { gate_passed: true, any_bucket: 'STRENGTHENING' },
+    },
+
+    {
+        id: 'go-04',
+        description: 'go-test: assertion added → STRENGTHENING',
+        filePath: 'pkg/calc/calc_test.go',
+        commitMessages: 'test: add check\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/pkg/calc/calc_test.go b/pkg/calc/calc_test.go
+@@ -5,6 +5,7 @@ func TestAdd(t *testing.T) {
++\trequire.Equal(t, 42, result)
+`,
+        expected: { gate_passed: true, any_bucket: 'STRENGTHENING' },
+    },
+
+    {
+        id: 'cargo-03',
+        description: 'cargo-test: assert! → assert_eq! → STRENGTHENING',
+        filePath: 'src/lib_test.rs',
+        commitMessages: 'test: strengthen\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/lib_test.rs b/src/lib_test.rs
+@@ -5,7 +5,7 @@ fn test_add() {
+-    assert!(result == 42);
++    assert_eq!(result, 42);
+`,
+        expected: { gate_passed: true, any_bucket: 'STRENGTHENING' },
+    },
+
+    {
+        id: 'cargo-04',
+        description: 'cargo-test: #[ignore] removed → STRENGTHENING',
+        filePath: 'src/lib_test.rs',
+        commitMessages: 'test: unignore\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/lib_test.rs b/src/lib_test.rs
+@@ -3,7 +3,6 @@ mod tests {
+-    #[ignore]
+     fn test_add() {
+`,
+        expected: { gate_passed: true, any_bucket: 'STRENGTHENING' },
+    },
+
+    // ── No-verdict fixtures (pure selector / non-assertion changes) ───────────
+
+    {
+        id: 'playwright-06',
+        description: 'playwright: pure selector fix — no assertion change → no verdicts, passes',
+        filePath: 'e2e/dashboard.spec.ts',
+        commitMessages: 'fix: update selector\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/e2e/dashboard.spec.ts b/e2e/dashboard.spec.ts
+@@ -5,7 +5,7 @@ test('dashboard', async ({ page }) => {
+-  await page.click('.old-btn');
++  await page.click('[data-testid="submit"]');
+`,
+        expected: { gate_passed: true, any_bucket: null },
+    },
+
+    {
+        id: 'jest-11',
+        description: 'jest: comment-only change → no verdicts, passes',
+        filePath: 'src/__tests__/calc.test.js',
+        commitMessages: 'docs: update comment\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -1,4 +1,4 @@
+-// old comment
++// new comment
+`,
+        expected: { gate_passed: true, any_bucket: null },
+    },
+
+    {
+        id: 'pytest-06',
+        description: 'pytest: tolerance tightened → STRENGTHENING (passes)',
+        filePath: 'tests/test_math.py',
+        commitMessages: 'test: tighten tolerance\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/tests/test_math.py b/tests/test_math.py
+@@ -5,7 +5,7 @@ def test_pi():
+-    assert result == approx(3.14, abs=0.01)
++    assert result == approx(3.14159, abs=0.001)
+`,
+        expected: { gate_passed: true, any_bucket: 'STRENGTHENING' },
+    },
+
+    {
+        id: 'mocha-02',
+        description: 'mocha: assertion added → STRENGTHENING',
+        filePath: 'test/api.test.js',
+        commitMessages: 'test: add assertion\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/test/api.test.js b/test/api.test.js
+@@ -5,6 +5,7 @@ it('api', () => {
++  expect(result).to.deep.equal({ id: 1, name: 'Alice' });
+`,
+        expected: { gate_passed: true, any_bucket: 'STRENGTHENING' },
+    },
+
+    {
+        id: 'vitest-01',
+        description: 'vitest: toMatchObject → toStrictEqual → STRENGTHENING',
+        filePath: 'src/utils.test.ts',
+        commitMessages: 'test: strengthen\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/utils.test.ts b/src/utils.test.ts
+@@ -5,7 +5,7 @@ test('util', () => {
+-  expect(result).toMatchObject({a: 1});
++  expect(result).toStrictEqual({a: 1, b: 2});
+`,
+        expected: { gate_passed: true, any_bucket: 'STRENGTHENING' },
+    },
+
+    {
+        id: 'vitest-02',
+        description: 'vitest: toStrictEqual → toMatchObject → LOOSENING',
+        filePath: 'src/utils.test.ts',
+        commitMessages: 'fix: relax\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/src/utils.test.ts b/src/utils.test.ts
+@@ -5,7 +5,7 @@ test('util', () => {
+-  expect(result).toStrictEqual({a: 1, b: 2});
++  expect(result).toMatchObject({a: 1});
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+
+    {
+        id: 'go-05',
+        description: 'go-test: assert.Equal removed entirely → LOOSENING',
+        filePath: 'pkg/api/api_test.go',
+        commitMessages: 'fix: remove check\n',
+        nonTestFilesChanged: [],
+        diff: `diff --git a/pkg/api/api_test.go b/pkg/api/api_test.go
+@@ -7,7 +7,6 @@ func TestStatus(t *testing.T) {
+-\tassert.Equal(t, 200, resp.StatusCode)
+`,
+        expected: { gate_passed: false, reason: 'assertion_loosening', any_bucket: 'LOOSENING' },
+    },
+];
+
+export default FIXTURES;

--- a/skills/autospec-test/tests/unit/assertion-shift/run-parameterized.mjs
+++ b/skills/autospec-test/tests/unit/assertion-shift/run-parameterized.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// tests/unit/assertion-shift/run-parameterized.mjs
+// Parameterized test runner for the assertion-shift classifier fixture corpus.
+// Run via: node --test skills/autospec-test/tests/unit/assertion-shift/
+// Or directly: node skills/autospec-test/tests/unit/assertion-shift/run-parameterized.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+const SCRIPTS_DIR = path.join(REPO_ROOT, 'skills/autospec-test/scripts');
+
+// Import classifier and fixtures
+const { classify } = await import(`file://${SCRIPTS_DIR}/assertion-shift-classifier.mjs`);
+const { FIXTURES } = await import(`file://${__dirname}/fixtures.mjs`);
+
+// ── Parameterized tests ────────────────────────────────────────────────────────
+
+for (const fixture of FIXTURES) {
+    test(`[${fixture.id}] ${fixture.description}`, async () => {
+        const result = await classify({
+            repoRoot: REPO_ROOT,
+            baseRef: 'HEAD~1',
+            headRef: 'HEAD',
+            // Use pre-computed diff to avoid git dependency in unit tests
+            diffText: fixture.diff,
+            commitMessages: fixture.commitMessages,
+            nonTestFilesChanged: fixture.nonTestFilesChanged,
+        });
+
+        const { gate } = result;
+
+        // Check gate pass/fail
+        assert.equal(
+            gate.passed,
+            fixture.expected.gate_passed,
+            `[${fixture.id}] gate.passed expected ${fixture.expected.gate_passed}, got ${gate.passed}. reason=${gate.reason}, verdicts=${JSON.stringify(result.verdicts)}`
+        );
+
+        // Check reason code when gate fails
+        if (!fixture.expected.gate_passed && fixture.expected.reason) {
+            assert.equal(
+                gate.reason,
+                fixture.expected.reason,
+                `[${fixture.id}] gate.reason expected '${fixture.expected.reason}', got '${gate.reason}'`
+            );
+        }
+
+        // Check at least one verdict has the expected bucket (when specified)
+        if (fixture.expected.any_bucket !== null && fixture.expected.any_bucket !== undefined) {
+            const hasBucket = result.verdicts.some(v => v.bucket === fixture.expected.any_bucket);
+            assert.ok(
+                hasBucket,
+                `[${fixture.id}] Expected at least one verdict with bucket='${fixture.expected.any_bucket}'. Got: ${JSON.stringify(result.verdicts.map(v => v.bucket))}`
+            );
+        } else if (fixture.expected.any_bucket === null) {
+            // Expect zero verdicts
+            assert.equal(
+                result.verdicts.length,
+                0,
+                `[${fixture.id}] Expected zero verdicts but got: ${JSON.stringify(result.verdicts)}`
+            );
+        }
+    });
+}
+
+// ── Additional edge case tests ─────────────────────────────────────────────────
+
+test('classify: pure non-test file changes produce no verdicts', async () => {
+    const result = await classify({
+        repoRoot: REPO_ROOT,
+        baseRef: 'HEAD~1',
+        headRef: 'HEAD',
+        diffText: `diff --git a/src/utils.js b/src/utils.js
+@@ -5,7 +5,7 @@
+-  return 42;
++  return 43;
+`,
+        commitMessages: 'fix: update return value\n',
+        nonTestFilesChanged: ['src/utils.js'],
+    });
+    assert.equal(result.verdicts.length, 0, 'Non-test files should produce no verdicts');
+    assert.equal(result.gate.passed, true);
+});
+
+test('classify: empty diff produces no verdicts and passes gate', async () => {
+    const result = await classify({
+        repoRoot: REPO_ROOT,
+        baseRef: 'HEAD~1',
+        headRef: 'HEAD',
+        diffText: '',
+        commitMessages: '',
+        nonTestFilesChanged: [],
+    });
+    assert.equal(result.verdicts.length, 0);
+    assert.equal(result.gate.passed, true);
+});
+
+test('classify: LOOSENING + SHIFTING together → loosening_and_unjustified_shift', async () => {
+    const result = await classify({
+        repoRoot: REPO_ROOT,
+        baseRef: 'HEAD~1',
+        headRef: 'HEAD',
+        diffText: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -5,8 +5,8 @@ test('add', () => {
+-  expect(result).toStrictEqual({a: 1});
++  expect(result).toEqual({a: 1});
+-  expect(count).toBe(10);
++  expect(count).toBe(11);
+`,
+        commitMessages: 'fix: update\n',
+        nonTestFilesChanged: [],
+    });
+    assert.equal(result.gate.passed, false);
+    // Should have both loosening and shifting verdicts
+    const hasLoosening = result.verdicts.some(v => v.bucket === 'LOOSENING');
+    const hasShifting = result.verdicts.some(v => v.bucket === 'SHIFTING');
+    assert.ok(hasLoosening || hasShifting, 'Should have LOOSENING or SHIFTING verdicts');
+});
+
+test('classify: STRENGTHENING-only changes pass gate', async () => {
+    const result = await classify({
+        repoRoot: REPO_ROOT,
+        baseRef: 'HEAD~1',
+        headRef: 'HEAD',
+        diffText: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -5,6 +5,7 @@ test('add', () => {
++  expect(result).toStrictEqual({a: 1, b: 2});
+`,
+        commitMessages: 'test: add stricter check\n',
+        nonTestFilesChanged: [],
+    });
+    assert.equal(result.gate.passed, true);
+    assert.equal(result.gate.loosening_files.length, 0);
+    assert.equal(result.gate.shifting_unjustified_files.length, 0);
+});
+
+test('classify: gate result includes has_justification and has_co_edit fields', async () => {
+    const result = await classify({
+        repoRoot: REPO_ROOT,
+        baseRef: 'HEAD~1',
+        headRef: 'HEAD',
+        diffText: '',
+        commitMessages: 'fix: update\nJUSTIFICATION: reason here\n',
+        nonTestFilesChanged: ['src/app.js'],
+    });
+    assert.ok('has_justification' in result.gate, 'gate should have has_justification');
+    assert.ok('has_co_edit' in result.gate, 'gate should have has_co_edit');
+    assert.equal(result.gate.has_justification, true);
+    assert.equal(result.gate.has_co_edit, true);
+});
+
+test('classify: verdicts have required schema fields', async () => {
+    const result = await classify({
+        repoRoot: REPO_ROOT,
+        baseRef: 'HEAD~1',
+        headRef: 'HEAD',
+        diffText: `diff --git a/src/__tests__/calc.test.js b/src/__tests__/calc.test.js
+@@ -5,7 +5,7 @@ test('add', () => {
+-  expect(result).toBe(42);
++  expect(result).toBe(43);
+`,
+        commitMessages: 'fix: update\n',
+        nonTestFilesChanged: [],
+    });
+    for (const v of result.verdicts) {
+        assert.ok('file' in v, 'verdict missing file');
+        assert.ok('line' in v, 'verdict missing line');
+        assert.ok('bucket' in v, 'verdict missing bucket');
+        assert.ok('framework' in v, 'verdict missing framework');
+        assert.ok('detail' in v, 'verdict missing detail');
+        assert.ok(['LOOSENING', 'SHIFTING', 'STRENGTHENING'].includes(v.bucket),
+            `invalid bucket: ${v.bucket}`);
+    }
+});


### PR DESCRIPTION
Closes #322

## Summary

Implements the assertion-shift classifier for autospec-test (phase 4), which buckets every modified test-file assertion as LOOSENING, SHIFTING, or STRENGTHENING and gates auto-merge accordingly.

**Components shipped:**
- `scripts/assertion-shift-classifier.mjs` — main classifier: detects changed test files, dispatches per-framework adapter, aggregates verdicts, applies JUSTIFICATION+co-edit policy
- `scripts/adapters/generic.mjs` — base text/regex adapter (shared logic for JS/TS)
- `scripts/adapters/playwright.mjs` — Playwright operator rank refinement
- `scripts/adapters/jest.mjs`, `vitest.mjs`, `mocha.mjs` — JS framework adapters
- `scripts/adapters/pytest.mjs` — Python assert/decorator handling
- `scripts/adapters/go-test.mjs` — Go require/assert library support
- `scripts/adapters/cargo-test.mjs` — Rust assert_eq!/assert!/ignore support
- `tests/unit/assertion-shift/fixtures.mjs` — 36 parameterized fixture diffs spanning all 7 frameworks
- `tests/unit/assertion-shift/run-parameterized.mjs` — 42 tests total (36 fixture + 6 edge cases)
- `tests/fixtures/repos/greenwash-bait/` — operator/full verification fixture

**Gate policy:**
- LOOSENING → blocks (label `needs-human-review + e2e:assertion-loosening`)
- SHIFTING without JUSTIFICATION+co-edit → blocks
- SHIFTING with both JUSTIFICATION: commit msg AND co-edited non-test file → passes
- STRENGTHENING → always passes

**Edge cases handled:**
- test.skip/xfail decorator lines (standalone, not assertions)
- pytest.mark.skip added/removed (standalone decorator lines)
- t.Skip() in Go (standalone call lines)
- #[ignore] in Rust (attribute lines)
- Unpaired add/remove hunks (insertions and deletions without counterpart)

## Test plan

- [x] `node --test skills/autospec-test/tests/unit/assertion-shift/run-parameterized.mjs` — 42/42 passing
- [x] All 7 framework adapters covered in fixture corpus
- [x] All 3 buckets + all gate policy branches tested
- [x] node syntax check clean on all adapters