### PR TITLE
feat(autospec-test): self-heal loop controller + budget + classifier (phase 5)

### DIFF
--- a/schemas/autospec-test-loop-state.schema.json
+++ b/schemas/autospec-test-loop-state.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-test-loop-state.schema.json",
+  "title": "autospec-test loop state",
+  "description": "State file for the autospec-test self-heal loop. Written after each iteration and used for resume-after-relaunch.",
+  "type": "object",
+  "required": ["pr_number", "started_at", "coding_time_used_seconds", "iterations"],
+  "properties": {
+    "pr_number": {
+      "type": "integer",
+      "description": "GitHub PR number being healed."
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp when the loop started."
+    },
+    "coding_time_used_seconds": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Total coding time used so far, in seconds. Excludes test-run time."
+    },
+    "coding_time_budget_seconds": {
+      "type": "number",
+      "minimum": 0,
+      "default": 3600,
+      "description": "Total coding time budget in seconds (default 3600 = 60 min)."
+    },
+    "last_coding_start": {
+      "type": ["string", "null"],
+      "description": "ISO-8601 timestamp when the last coding window started (null if paused)."
+    },
+    "iterations": {
+      "type": "array",
+      "description": "Ordered list of self-heal iterations.",
+      "items": {
+        "type": "object",
+        "required": ["n", "started_at", "ended_at", "classification", "gate_passed"],
+        "properties": {
+          "n": { "type": "integer", "minimum": 1 },
+          "started_at": { "type": "string", "format": "date-time" },
+          "ended_at": { "type": "string", "format": "date-time" },
+          "classification": {
+            "type": "string",
+            "enum": [
+              "missing_unit_test",
+              "missing_test",
+              "failing_unit_test",
+              "failing_test",
+              "flaky_test",
+              "selector_brittle",
+              "product_bug",
+              "empty_action"
+            ]
+          },
+          "files_changed": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "gate_passed": { "type": "boolean" },
+          "error_signature": {
+            "type": ["string", "null"],
+            "description": "SHA-256 hex digest of the normalized error text."
+          },
+          "commit_sha": {
+            "type": ["string", "null"]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "last_error_signature": {
+      "type": ["string", "null"],
+      "description": "SHA-256 hex digest of the last iteration's error."
+    },
+    "same_error_consecutive": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Count of consecutive iterations with the same error signature."
+    },
+    "empty_action_consecutive": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Count of consecutive iterations where the classifier produced no action."
+    },
+    "termination_reason": {
+      "type": ["string", "null"],
+      "description": "Set when the loop exits: gate_passed | budget_exhausted | max_iterations | same_error_halt | stop_flag | empty_action_halt"
+    }
+  },
+  "additionalProperties": false
+}

--- a/skills/autospec-test/scripts/error-signature.mjs
+++ b/skills/autospec-test/scripts/error-signature.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// scripts/error-signature.mjs
+// normalize(error_text) -> sha256 hex digest
+//
+// Strips line numbers, browser tags, randomized identifiers so that
+// two errors from the same root cause hash to the same signature.
+//
+// Export: normalize(errorText) -> string (hex digest)
+// CLI: node error-signature.mjs <error_text_file>
+//   OR: echo "error text" | node error-signature.mjs
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+
+/**
+ * Normalization rules applied in order.
+ * Each rule: [pattern, replacement]
+ */
+const NORMALIZATION_RULES = [
+    // Strip ISO-8601 timestamps FIRST (before line:col rule strips the colons)
+    [/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?/g, 'TIMESTAMP'],
+
+    // Strip UUIDs FIRST (before HEXID rule strips partial matches)
+    [/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi, 'UUID'],
+
+    // Strip browser/worker tags (e.g. "[chromium]", "[firefox]", "[webkit]", "[worker1]")
+    // Also strip bare word "workerN" and "pageN" identifiers
+    [/\[(chromium|firefox|webkit|worker\d*|page\d*)\]/gi, '[BROWSER]'],
+    [/\bworker\d+\b/gi, 'WORKER'],
+    [/\bpage\d+\b/gi, 'PAGE'],
+
+    // Strip epoch timestamps
+    [/\b\d{10,13}\b/g, 'EPOCH'],
+
+    // Strip hex IDs (32-64 chars)
+    [/\b[0-9a-f]{32,64}\b/gi, 'HEXID'],
+
+    // Strip line:col numbers (e.g. ":123:45" or " line 123")
+    [/:\d+:\d+/g, ':L:C'],
+    [/\bline\s+\d+\b/gi, 'line L'],
+    [/\bat line \d+/gi, 'at line L'],
+
+    // Strip temp file paths (e.g. /tmp/autospec-abc123)
+    [/\/(?:tmp|var\/folders|private\/tmp)\/[^\s"')]+/g, '/tmp/TMPPATH'],
+
+    // Strip process IDs
+    [/\bpid\s+\d+/gi, 'pid PID'],
+    [/\bprocess\s+\d+/gi, 'process PID'],
+
+    // Strip port numbers in URLs (but keep protocol and host)
+    [/(:)\d{4,5}(\/|$|\s)/g, ':PORT$2'],
+
+    // Normalize whitespace (multiple spaces/tabs → single space)
+    [/[ \t]+/g, ' '],
+
+    // Strip trailing whitespace per line
+    [/ +$/gm, ''],
+
+    // Collapse blank lines
+    [/\n{3,}/g, '\n\n'],
+];
+
+/**
+ * Normalize error text for stable hashing.
+ *
+ * @param {string} errorText
+ * @returns {string} normalized text
+ */
+export function normalize(errorText) {
+    if (!errorText || typeof errorText !== 'string') return '';
+
+    let text = errorText;
+    for (const [pattern, replacement] of NORMALIZATION_RULES) {
+        text = text.replace(pattern, replacement);
+    }
+    return text.trim();
+}
+
+/**
+ * Compute SHA-256 hex digest of normalized error text.
+ *
+ * @param {string} errorText
+ * @returns {string} hex digest (64 chars)
+ */
+export function signature(errorText) {
+    const normalized = normalize(errorText);
+    return crypto.createHash('sha256').update(normalized, 'utf8').digest('hex');
+}
+
+// CLI entrypoint
+if (process.argv[1] && fs.realpathSync(path.resolve(process.argv[1])) === fs.realpathSync(path.resolve(__filename))) {
+    let input = '';
+
+    if (process.argv[2]) {
+        // Read from file
+        try {
+            input = fs.readFileSync(process.argv[2], 'utf8');
+        } catch (err) {
+            process.stderr.write(`error-signature: cannot read file: ${err.message}\n`);
+            process.exit(1);
+        }
+    } else {
+        // Read from stdin
+        const chunks = [];
+        process.stdin.on('data', chunk => chunks.push(chunk));
+        await new Promise(resolve => process.stdin.on('end', resolve));
+        input = Buffer.concat(chunks).toString('utf8');
+    }
+
+    const sig = signature(input);
+    process.stdout.write(sig + '\n');
+    process.exit(0);
+}

--- a/skills/autospec-test/scripts/loop-budget.sh
+++ b/skills/autospec-test/scripts/loop-budget.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# scripts/loop-budget.sh — Pausable 60-minute coding-time budget for the self-heal loop.
+#
+# Usage:
+#   source loop-budget.sh          (to use functions in the controller)
+#   loop-budget.sh <command> <state_file> [args]
+#
+# Commands (when called as a script):
+#   budget_start  <state_file> <pr_number> [budget_seconds]
+#   budget_pause  <state_file>
+#   budget_resume <state_file>
+#   budget_remaining <state_file>   → prints remaining seconds
+#   budget_exhausted <state_file>   → exits 0 if exhausted, 1 if remaining
+#
+# State file: .autospec/test-loop-state.json in the target worktree.
+# All wall-clock operations use date -u +%s for UTC epoch seconds.
+#
+# Design: coding time = wall clock minus paused intervals.
+# Timer pauses while tests run; budget only counts active editing time.
+
+set -eu
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_now_epoch() {
+    date -u +%s
+}
+
+_now_iso() {
+    date -u +'%Y-%m-%dT%H:%M:%SZ'
+}
+
+_epoch_to_iso() {
+    local epoch="$1"
+    # macOS: date -r; Linux: date -d @
+    date -u -r "$epoch" +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+        || date -u -d "@$epoch" +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+        || printf '%sZ' "$(date -u +%Y-%m-%dT%H:%M:%S -d @"$epoch" 2>/dev/null || echo "1970-01-01T00:00:00")"
+}
+
+_iso_to_epoch() {
+    local iso="$1"
+    # Strip trailing Z for macOS date -j (which ignores Z and uses local time without -u)
+    local iso_stripped="${iso%Z}"
+    # macOS: date -u -j -f (UTC); Linux: date -u -d
+    date -u -j -f '%Y-%m-%dT%H:%M:%S' "$iso_stripped" +%s 2>/dev/null \
+        || date -u -d "$iso" +%s 2>/dev/null \
+        || echo 0
+}
+
+# ── budget_start ──────────────────────────────────────────────────────────────
+
+budget_start() {
+    local state_file="$1"
+    local pr_number="${2:-0}"
+    local budget_seconds="${3:-3600}"
+    local now_iso
+    now_iso=$(_now_iso)
+    local now_epoch
+    now_epoch=$(_now_epoch)
+
+    jq -n \
+        --argjson pr_number "$pr_number" \
+        --arg started_at "$now_iso" \
+        --argjson budget "$budget_seconds" \
+        --arg last_start "$now_iso" \
+        '{
+            "pr_number": $pr_number,
+            "started_at": $started_at,
+            "coding_time_used_seconds": 0,
+            "coding_time_budget_seconds": $budget,
+            "last_coding_start": $last_start,
+            "iterations": [],
+            "last_error_signature": null,
+            "same_error_consecutive": 0,
+            "empty_action_consecutive": 0,
+            "termination_reason": null
+        }' > "$state_file"
+}
+
+# ── budget_pause ──────────────────────────────────────────────────────────────
+# Called before running tests (pauses the coding-time clock).
+
+budget_pause() {
+    local state_file="$1"
+    if [ ! -f "$state_file" ]; then
+        printf 'loop-budget: error: state file not found: %s\n' "$state_file" >&2
+        return 1
+    fi
+
+    local last_start now_epoch used
+    last_start=$(jq -r '.last_coding_start // empty' "$state_file")
+    used=$(jq -r '.coding_time_used_seconds' "$state_file")
+    now_epoch=$(_now_epoch)
+
+    if [ -z "$last_start" ] || [ "$last_start" = "null" ]; then
+        # Already paused
+        return 0
+    fi
+
+    local start_epoch elapsed
+    start_epoch=$(_iso_to_epoch "$last_start")
+    elapsed=$(( now_epoch - start_epoch ))
+    local new_used
+    new_used=$(echo "$used $elapsed" | awk '{printf "%d", $1 + $2}')
+
+    # Update state: accumulate used time, clear last_coding_start
+    local tmp
+    tmp=$(mktemp /tmp/loop-budget-XXXXXX.json)
+    jq --argjson new_used "$new_used" \
+       '.coding_time_used_seconds = $new_used | .last_coding_start = null' \
+       "$state_file" > "$tmp" && mv "$tmp" "$state_file"
+}
+
+# ── budget_resume ─────────────────────────────────────────────────────────────
+# Called after tests complete (resumes the coding-time clock).
+
+budget_resume() {
+    local state_file="$1"
+    if [ ! -f "$state_file" ]; then
+        printf 'loop-budget: error: state file not found: %s\n' "$state_file" >&2
+        return 1
+    fi
+
+    local now_iso
+    now_iso=$(_now_iso)
+
+    local last_start
+    last_start=$(jq -r '.last_coding_start // empty' "$state_file")
+    if [ -n "$last_start" ] && [ "$last_start" != "null" ]; then
+        # Already running
+        return 0
+    fi
+
+    local tmp
+    tmp=$(mktemp /tmp/loop-budget-XXXXXX.json)
+    jq --arg now "$now_iso" \
+       '.last_coding_start = $now' \
+       "$state_file" > "$tmp" && mv "$tmp" "$state_file"
+}
+
+# ── budget_remaining ──────────────────────────────────────────────────────────
+# Prints remaining coding seconds (accounting for any running window).
+
+budget_remaining() {
+    local state_file="$1"
+    if [ ! -f "$state_file" ]; then
+        echo 0; return
+    fi
+
+    local budget used last_start
+    budget=$(jq -r '.coding_time_budget_seconds // 3600' "$state_file")
+    used=$(jq -r '.coding_time_used_seconds // 0' "$state_file")
+    last_start=$(jq -r '.last_coding_start // empty' "$state_file")
+
+    local current_elapsed=0
+    if [ -n "$last_start" ] && [ "$last_start" != "null" ]; then
+        local now_epoch start_epoch
+        now_epoch=$(_now_epoch)
+        start_epoch=$(_iso_to_epoch "$last_start")
+        current_elapsed=$(( now_epoch - start_epoch ))
+    fi
+
+    local total_used remaining
+    total_used=$(echo "$used $current_elapsed" | awk '{printf "%d", $1 + $2}')
+    remaining=$(echo "$budget $total_used" | awk '{r = $1 - $2; print (r > 0 ? r : 0)}')
+    echo "$remaining"
+}
+
+# ── budget_exhausted ──────────────────────────────────────────────────────────
+# Exits 0 if budget is exhausted, 1 if still remaining.
+
+budget_exhausted() {
+    local state_file="$1"
+    local remaining
+    remaining=$(budget_remaining "$state_file")
+    [ "$remaining" -eq 0 ]
+}
+
+# ── CLI dispatch ──────────────────────────────────────────────────────────────
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    CMD="${1:-}"
+    STATE_FILE="${2:-}"
+    shift 2 2>/dev/null || true
+
+    case "$CMD" in
+        budget_start)    budget_start "$STATE_FILE" "$@" ;;
+        budget_pause)    budget_pause "$STATE_FILE" ;;
+        budget_resume)   budget_resume "$STATE_FILE" ;;
+        budget_remaining) budget_remaining "$STATE_FILE" ;;
+        budget_exhausted) budget_exhausted "$STATE_FILE"; exit $? ;;
+        *)
+            printf 'Usage: loop-budget.sh <command> <state_file> [args]\n' >&2
+            printf 'Commands: budget_start budget_pause budget_resume budget_remaining budget_exhausted\n' >&2
+            exit 1
+            ;;
+    esac
+fi

--- a/skills/autospec-test/scripts/loop-classifier.mjs
+++ b/skills/autospec-test/scripts/loop-classifier.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+// scripts/loop-classifier.mjs
+// Failure classifier for the self-heal loop.
+//
+// classify({gate_json, findings_md, last_3_iterations}) ->
+//   {classification, target_failures, suggested_files, estimated_minutes, priority}
+//
+// Priority order (highest to lowest) per spec §6:
+//   product_bug > missing_unit_test > missing_test > selector_brittle
+//   > failing_unit_test > failing_test > flaky_test
+//
+// Export: classify(options) function
+// CLI: node loop-classifier.mjs --gate-result <file> [--findings <file>]
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+
+/** Priority rank per spec §6 (higher = more urgent) */
+const PRIORITY_RANK = {
+    product_bug: 7,
+    missing_unit_test: 6,
+    missing_test: 5,
+    selector_brittle: 4,
+    failing_unit_test: 3,
+    failing_test: 2,
+    flaky_test: 1,
+    empty_action: 0,
+};
+
+/**
+ * Classify failures from gate JSON and findings.
+ *
+ * @param {object} options
+ * @param {object} options.gate_json - parsed gate result JSON
+ * @param {string} [options.findings_md] - findings markdown text
+ * @param {object[]} [options.last_3_iterations] - last 3 iteration records from loop state
+ * @returns {{classification: string, target_failures: string[], suggested_files: string[], estimated_minutes: number, priority: number}}
+ */
+export function classify(options) {
+    const { gate_json = {}, findings_md = '', last_3_iterations = [] } = options;
+
+    const candidates = [];
+
+    // ── product_bug detection ─────────────────────────────────────────────────
+    // Test is correct but product code fails. Heuristic: test fails with
+    // 'Expected ... but received' where the assertion is structurally sound.
+    if (gate_json.stage === 'unit' || gate_json.stage === 'e2e') {
+        const testSummary = gate_json.test_run_summary || {};
+        const stderr = (testSummary.stderr_tail || '').toLowerCase();
+        const stdout = (testSummary.stdout_tail || '').toLowerCase();
+        const combined = stderr + stdout;
+
+        const productBugSignals = [
+            /expected.*but (received|got)/i,
+            /assertion.*failed.*expected/i,
+            /\bwant\b.*\bgot\b/i,
+            /\bassert_eq!.*left.*right/i,
+        ];
+        if (productBugSignals.some(p => p.test(combined))) {
+            candidates.push({
+                classification: 'product_bug',
+                target_failures: ['product code returning wrong value'],
+                suggested_files: ['src/', 'lib/', 'pkg/'],
+                estimated_minutes: 15,
+                priority: PRIORITY_RANK.product_bug,
+            });
+        }
+    }
+
+    // ── missing_unit_test detection ───────────────────────────────────────────
+    if (gate_json.stage === 'unit') {
+        const metrics = gate_json.metrics?.unit || {};
+        const missingFns = metrics.missing_function_tests || [];
+        if (missingFns.length > 0 || metrics.passed === false) {
+            candidates.push({
+                classification: 'missing_unit_test',
+                target_failures: missingFns,
+                suggested_files: ['tests/', '__tests__/', 'test/'],
+                estimated_minutes: 10,
+                priority: PRIORITY_RANK.missing_unit_test,
+            });
+        }
+    }
+
+    // ── missing_test (E2E gap) detection ─────────────────────────────────────
+    if (gate_json.stage === 'e2e') {
+        const metrics = gate_json.metrics?.e2e || {};
+        const uiCov = metrics.ui_element_coverage || {};
+        const behaviorCov = metrics.behavior_categories || {};
+        const missing = [];
+        if (uiCov.passed === false) {
+            missing.push(...(uiCov.missing || []));
+        }
+        if (behaviorCov.passed === false) {
+            missing.push(...(behaviorCov.missing || []).map(c => `behavior:${c}`));
+        }
+        if (missing.length > 0) {
+            candidates.push({
+                classification: 'missing_test',
+                target_failures: missing,
+                suggested_files: ['tests/', 'e2e/', 'playwright/', 'spec/'],
+                estimated_minutes: 15,
+                priority: PRIORITY_RANK.missing_test,
+            });
+        }
+    }
+
+    // ── selector_brittle detection ────────────────────────────────────────────
+    const testSummary = gate_json.test_run_summary || {};
+    const combinedOutput = ((testSummary.stderr_tail || '') + (testSummary.stdout_tail || '')).toLowerCase();
+    const selectorSignals = [
+        /locator.*strict mode/i,
+        /waiting for.*selector/i,
+        /timeout.*waiting/i,
+        /element.*not found/i,
+        /no element.*matches/i,
+        /element handle.*disposed/i,
+    ];
+    if (selectorSignals.some(p => p.test(combinedOutput))) {
+        candidates.push({
+            classification: 'selector_brittle',
+            target_failures: ['selector resolution failed'],
+            suggested_files: ['playwright.config.ts', 'playwright.config.js', 'tests/'],
+            estimated_minutes: 10,
+            priority: PRIORITY_RANK.selector_brittle,
+        });
+    }
+
+    // ── failing_unit_test detection ───────────────────────────────────────────
+    if (gate_json.stage === 'unit' && gate_json.passed === false) {
+        const reason = gate_json.reason || '';
+        if (reason === 'tests_red') {
+            candidates.push({
+                classification: 'failing_unit_test',
+                target_failures: ['unit tests red'],
+                suggested_files: ['tests/', '__tests__/', 'test/'],
+                estimated_minutes: 10,
+                priority: PRIORITY_RANK.failing_unit_test,
+            });
+        }
+    }
+
+    // ── failing_test (E2E) detection ──────────────────────────────────────────
+    if (gate_json.stage === 'e2e' && gate_json.passed === false) {
+        const reason = gate_json.reason || '';
+        if (reason === 'tests_red') {
+            candidates.push({
+                classification: 'failing_test',
+                target_failures: ['E2E tests red'],
+                suggested_files: ['tests/', 'e2e/', 'spec/'],
+                estimated_minutes: 15,
+                priority: PRIORITY_RANK.failing_test,
+            });
+        }
+    }
+
+    // ── flaky_test detection ──────────────────────────────────────────────────
+    // Flaky: passes in some of last 3 iterations, fails in others
+    if (last_3_iterations.length >= 2) {
+        const passedResults = last_3_iterations.map(it => it.gate_passed);
+        const hasPass = passedResults.some(p => p === true);
+        const hasFail = passedResults.some(p => p === false);
+        if (hasPass && hasFail) {
+            candidates.push({
+                classification: 'flaky_test',
+                target_failures: ['intermittent test failures'],
+                suggested_files: ['playwright.config.ts', 'playwright.config.js', 'tests/'],
+                estimated_minutes: 10,
+                priority: PRIORITY_RANK.flaky_test,
+            });
+        }
+    }
+
+    // ── empty_action fallback ─────────────────────────────────────────────────
+    if (candidates.length === 0) {
+        return {
+            classification: 'empty_action',
+            target_failures: [],
+            suggested_files: [],
+            estimated_minutes: 0,
+            priority: PRIORITY_RANK.empty_action,
+        };
+    }
+
+    // Return highest-priority candidate
+    candidates.sort((a, b) => b.priority - a.priority);
+    const best = candidates[0];
+    return {
+        classification: best.classification,
+        target_failures: best.target_failures,
+        suggested_files: best.suggested_files,
+        estimated_minutes: best.estimated_minutes,
+        priority: best.priority,
+    };
+}
+
+// CLI entrypoint
+if (process.argv[1] && fs.realpathSync(path.resolve(process.argv[1])) === fs.realpathSync(path.resolve(__filename))) {
+    const args = process.argv.slice(2);
+    let gateResultFile = null;
+    let findingsFile = null;
+
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--gate-result') gateResultFile = args[i + 1];
+        if (args[i] === '--findings') findingsFile = args[i + 1];
+    }
+
+    if (!gateResultFile) {
+        process.stderr.write('Usage: loop-classifier.mjs --gate-result <file> [--findings <file>]\n');
+        process.exit(1);
+    }
+
+    let gateJson, findingsMd = '';
+    try {
+        gateJson = JSON.parse(fs.readFileSync(gateResultFile, 'utf8'));
+    } catch (err) {
+        process.stderr.write(`loop-classifier: parse error: ${err.message}\n`);
+        process.exit(1);
+    }
+
+    if (findingsFile && fs.existsSync(findingsFile)) {
+        findingsMd = fs.readFileSync(findingsFile, 'utf8');
+    }
+
+    const result = classify({ gate_json: gateJson, findings_md: findingsMd, last_3_iterations: [] });
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    process.exit(0);
+}

--- a/skills/autospec-test/scripts/loop-controller.sh
+++ b/skills/autospec-test/scripts/loop-controller.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# scripts/loop-controller.sh — Self-heal loop controller for autospec-test.
+#
+# Usage: loop-controller.sh --state-file <path> --gate-cmd <cmd>
+#                           [--max-iterations N] [--budget-seconds N]
+#                           [--pr-number N] [--worktree <path>]
+#
+# Drives the self-heal loop:
+#   1. Check termination conditions
+#   2. Run gate; if passes, exit SUCCESS
+#   3. Classify failures
+#   4. Pause budget, invoke implementer, resume budget
+#   5. Record iteration in state file
+#   6. Loop
+#
+# Exit codes:
+#   0 = gate passed
+#   1 = loop terminated (budget/iterations/stuck/stop.flag/empty-action)
+#   2 = fatal error
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUDGET_SCRIPT="$SCRIPT_DIR/loop-budget.sh"
+CLASSIFIER_SCRIPT="$SCRIPT_DIR/loop-classifier.mjs"
+STOP_FLAG="${AUTOSPEC_STOP_FLAG:-$HOME/.autospec/stop.flag}"
+MAX_SAME_ERROR="${AUTOSPEC_SAME_ERROR_HALT:-3}"
+MAX_EMPTY_ACTION="${AUTOSPEC_EMPTY_ACTION_HALT:-2}"
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+
+STATE_FILE=""
+GATE_CMD=""
+MAX_ITERATIONS="${AUTOSPEC_MAX_LOOP_ITERATIONS:-5}"
+BUDGET_SECONDS="${AUTOSPEC_CODING_BUDGET_SECS:-3600}"
+PR_NUMBER=0
+WORKTREE="${WORKTREE:-$(pwd)}"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --state-file)    STATE_FILE="$2";    shift 2 ;;
+        --gate-cmd)      GATE_CMD="$2";      shift 2 ;;
+        --max-iterations) MAX_ITERATIONS="$2"; shift 2 ;;
+        --budget-seconds) BUDGET_SECONDS="$2"; shift 2 ;;
+        --pr-number)     PR_NUMBER="$2";     shift 2 ;;
+        --worktree)      WORKTREE="$2";      shift 2 ;;
+        *) printf 'loop-controller: unknown arg: %s\n' "$1" >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$STATE_FILE" ] || [ -z "$GATE_CMD" ]; then
+    printf 'Usage: loop-controller.sh --state-file <path> --gate-cmd <cmd>\n' >&2
+    exit 2
+fi
+
+# ── Initialize or resume state ────────────────────────────────────────────────
+
+# Source budget functions
+# shellcheck source=loop-budget.sh
+source "$BUDGET_SCRIPT"
+
+if [ ! -f "$STATE_FILE" ]; then
+    budget_start "$STATE_FILE" "$PR_NUMBER" "$BUDGET_SECONDS"
+    echo "[loop-controller] starting fresh loop (pr=$PR_NUMBER budget=${BUDGET_SECONDS}s max_iter=$MAX_ITERATIONS)"
+else
+    budget_resume "$STATE_FILE"
+    ITER_COUNT=$(jq '.iterations | length' "$STATE_FILE")
+    USED=$(jq '.coding_time_used_seconds' "$STATE_FILE")
+    echo "[loop-controller] resuming loop (pr=$PR_NUMBER iter=$ITER_COUNT used=${USED}s)"
+fi
+
+# ── Helper: update termination_reason in state ────────────────────────────────
+
+set_termination() {
+    local reason="$1"
+    local tmp
+    tmp=$(mktemp /tmp/loop-ctrl-XXXXXX)
+    jq --arg r "$reason" '.termination_reason = $r' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+}
+
+# ── Helper: record iteration ──────────────────────────────────────────────────
+
+record_iteration() {
+    local n="$1"
+    local classification="$2"
+    local gate_passed="$3"
+    local error_sig="${4:-null}"
+    local started_at="$5"
+    local ended_at="$6"
+
+    local tmp
+    tmp=$(mktemp /tmp/loop-ctrl-XXXXXX)
+    jq \
+        --argjson n "$n" \
+        --arg classification "$classification" \
+        --argjson gate_passed "$gate_passed" \
+        --arg error_sig "$error_sig" \
+        --arg started_at "$started_at" \
+        --arg ended_at "$ended_at" \
+        '.iterations += [{
+            "n": $n,
+            "started_at": $started_at,
+            "ended_at": $ended_at,
+            "classification": $classification,
+            "files_changed": [],
+            "gate_passed": $gate_passed,
+            "error_signature": (if $error_sig == "null" then null else $error_sig end)
+        }]' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+}
+
+# ── Main loop ─────────────────────────────────────────────────────────────────
+
+# Initialize from state file (for resume semantics)
+ITER=0
+CONSECUTIVE_SAME_ERROR=$(jq -r '.same_error_consecutive // 0' "$STATE_FILE" 2>/dev/null || echo 0)
+CONSECUTIVE_EMPTY_ACTION=$(jq -r '.empty_action_consecutive // 0' "$STATE_FILE" 2>/dev/null || echo 0)
+LAST_ERROR_SIG=$(jq -r '.last_error_signature // "null"' "$STATE_FILE" 2>/dev/null || echo "null")
+
+while true; do
+    ITER=$(jq '.iterations | length' "$STATE_FILE")
+    ITER_NUM=$(( ITER + 1 ))
+    ITER_START=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+    # ── Check stop flag ───────────────────────────────────────────────────────
+    if [ -f "$STOP_FLAG" ]; then
+        echo "[loop-controller] stop.flag detected — exiting gracefully"
+        set_termination "stop_flag"
+        exit 1
+    fi
+
+    # ── Check iteration cap ───────────────────────────────────────────────────
+    if [ "$ITER" -ge "$MAX_ITERATIONS" ]; then
+        echo "[loop-controller] max iterations ($MAX_ITERATIONS) reached — exiting"
+        set_termination "max_iterations"
+        exit 1
+    fi
+
+    # ── Check budget ──────────────────────────────────────────────────────────
+    if budget_exhausted "$STATE_FILE"; then
+        echo "[loop-controller] coding budget exhausted — exiting"
+        set_termination "budget_exhausted"
+        exit 1
+    fi
+
+    # ── Check same-error pre-halt (from resumed state) ────────────────────────
+    if [ "$CONSECUTIVE_SAME_ERROR" -ge "$MAX_SAME_ERROR" ]; then
+        echo "[loop-controller] same error $CONSECUTIVE_SAME_ERROR consecutive times (from state) — halting"
+        set_termination "same_error_halt"
+        exit 1
+    fi
+
+    # ── Check empty-action pre-halt (from resumed state) ─────────────────────
+    if [ "$CONSECUTIVE_EMPTY_ACTION" -ge "$MAX_EMPTY_ACTION" ]; then
+        echo "[loop-controller] empty action $CONSECUTIVE_EMPTY_ACTION consecutive times (from state) — halting"
+        set_termination "empty_action_halt"
+        exit 1
+    fi
+
+    REMAINING=$(budget_remaining "$STATE_FILE")
+    echo "[loop-controller] iteration $ITER_NUM/$MAX_ITERATIONS (remaining budget: ${REMAINING}s)"
+
+    # ── Run gate ──────────────────────────────────────────────────────────────
+    GATE_OUTPUT_FILE=$(mktemp /tmp/loop-gate-XXXXXX)
+    # Inline cleanup via variable (not trap, per project memory feedback_bash_return_trap_leak)
+
+    GATE_EXIT=0
+    budget_pause "$STATE_FILE"
+    # Run gate command; capture output
+    if eval "$GATE_CMD" > "$GATE_OUTPUT_FILE" 2>/dev/null; then
+        GATE_PASSED=true
+        GATE_EXIT=0
+    else
+        GATE_EXIT=$?
+        GATE_PASSED=false
+    fi
+    budget_resume "$STATE_FILE"
+
+    if [ "$GATE_PASSED" = "true" ]; then
+        echo "[loop-controller] gate PASSED — loop complete"
+        rm -f "$GATE_OUTPUT_FILE"
+        set_termination "gate_passed"
+        exit 0
+    fi
+
+    # ── Extract error signature ───────────────────────────────────────────────
+    GATE_JSON=$(cat "$GATE_OUTPUT_FILE" 2>/dev/null || echo '{}')
+    STDERR_TEXT=$(printf '%s' "$GATE_JSON" | jq -r '.test_run_summary.stderr_tail // ""')
+    STDOUT_TEXT=$(printf '%s' "$GATE_JSON" | jq -r '.test_run_summary.stdout_tail // ""')
+    ERROR_TEXT="${STDERR_TEXT}${STDOUT_TEXT}"
+
+    if [ -n "$ERROR_TEXT" ] && command -v node >/dev/null 2>&1; then
+        ERROR_SIG=$(printf '%s' "$ERROR_TEXT" | node "$SCRIPT_DIR/error-signature.mjs" 2>/dev/null || echo "null")
+    else
+        ERROR_SIG="null"
+    fi
+
+    # ── Check same-error halt ─────────────────────────────────────────────────
+    if [ "$ERROR_SIG" != "null" ] && [ "$ERROR_SIG" = "$LAST_ERROR_SIG" ]; then
+        CONSECUTIVE_SAME_ERROR=$(( CONSECUTIVE_SAME_ERROR + 1 ))
+        # Update state
+        local_tmp=$(mktemp /tmp/loop-ctrl-XXXXXX)
+        jq --argjson n "$CONSECUTIVE_SAME_ERROR" '.same_error_consecutive = $n' \
+            "$STATE_FILE" > "$local_tmp" && mv "$local_tmp" "$STATE_FILE"
+
+        if [ "$CONSECUTIVE_SAME_ERROR" -ge "$MAX_SAME_ERROR" ]; then
+            echo "[loop-controller] same error $CONSECUTIVE_SAME_ERROR consecutive times — halting"
+            set_termination "same_error_halt"
+            rm -f "$GATE_OUTPUT_FILE"
+            exit 1
+        fi
+    else
+        CONSECUTIVE_SAME_ERROR=0
+        LAST_ERROR_SIG="$ERROR_SIG"
+        local_tmp=$(mktemp /tmp/loop-ctrl-XXXXXX)
+        jq --arg sig "$ERROR_SIG" \
+           '.last_error_signature = $sig | .same_error_consecutive = 0' \
+           "$STATE_FILE" > "$local_tmp" && mv "$local_tmp" "$STATE_FILE"
+    fi
+
+    # ── Classify failure ──────────────────────────────────────────────────────
+    CLASSIFY_RESULT=$(node "$CLASSIFIER_SCRIPT" \
+        --gate-result "$GATE_OUTPUT_FILE" 2>/dev/null \
+        || echo '{"classification":"empty_action","target_failures":[],"suggested_files":[],"estimated_minutes":0,"priority":0}')
+
+    CLASSIFICATION=$(printf '%s' "$CLASSIFY_RESULT" | jq -r '.classification')
+    SUGGESTED_FILES=$(printf '%s' "$CLASSIFY_RESULT" | jq -r '.suggested_files | join(" ")')
+
+    # ── Check empty-action halt ───────────────────────────────────────────────
+    if [ "$CLASSIFICATION" = "empty_action" ]; then
+        CONSECUTIVE_EMPTY_ACTION=$(( CONSECUTIVE_EMPTY_ACTION + 1 ))
+        local_tmp=$(mktemp /tmp/loop-ctrl-XXXXXX)
+        jq --argjson n "$CONSECUTIVE_EMPTY_ACTION" '.empty_action_consecutive = $n' \
+            "$STATE_FILE" > "$local_tmp" && mv "$local_tmp" "$STATE_FILE"
+
+        if [ "$CONSECUTIVE_EMPTY_ACTION" -ge "$MAX_EMPTY_ACTION" ]; then
+            echo "[loop-controller] empty action $CONSECUTIVE_EMPTY_ACTION consecutive times — halting"
+            set_termination "empty_action_halt"
+            rm -f "$GATE_OUTPUT_FILE"
+            exit 1
+        fi
+    else
+        CONSECUTIVE_EMPTY_ACTION=0
+        local_tmp=$(mktemp /tmp/loop-ctrl-XXXXXX)
+        jq '.empty_action_consecutive = 0' "$STATE_FILE" > "$local_tmp" && mv "$local_tmp" "$STATE_FILE"
+    fi
+
+    echo "[loop-controller] iteration $ITER_NUM: classification=$CLASSIFICATION files=$SUGGESTED_FILES"
+
+    # ── Record iteration (before implementer runs) ────────────────────────────
+    ITER_END=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+    record_iteration "$ITER_NUM" "$CLASSIFICATION" "false" "$ERROR_SIG" "$ITER_START" "$ITER_END"
+
+    # ── Implementer stub ──────────────────────────────────────────────────────
+    # In production, the implementer subagent runs here. In this shell controller,
+    # we emit the action plan and exit for the outer monitor to dispatch.
+    # The controller is designed to be re-invoked after the implementer commits.
+    printf '[loop-controller] action plan:\n'
+    printf '  classification: %s\n' "$CLASSIFICATION"
+    printf '  suggested_files: %s\n' "$SUGGESTED_FILES"
+    printf '  gate_result: %s\n' "$GATE_OUTPUT_FILE"
+    printf '[loop-controller] iteration %s complete — re-invoke after implementing fixes\n' "$ITER_NUM"
+
+    rm -f "$GATE_OUTPUT_FILE"
+
+    # In non-CI mode, exit after printing the plan (implementer is external)
+    # In loop mode (AUTOSPEC_LOOP=1), continue looping (for testing purposes)
+    if [ "${AUTOSPEC_LOOP:-0}" != "1" ]; then
+        exit 0
+    fi
+done

--- a/skills/autospec-test/scripts/pre-commit-loop-guard.sh
+++ b/skills/autospec-test/scripts/pre-commit-loop-guard.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/pre-commit-loop-guard.sh
+# Pre-commit hook installed into the target worktree.
+# Rejects edits to loop-immutable files per spec §3.
+#
+# Loop-immutable paths:
+#   - .autospec/test.yml
+#   - .autospec/.scoped-prod-acked-*.lock
+#   - playwright.config.* safety-related fields (forbidden_url_patterns, mode)
+#
+# Install: cp pre-commit-loop-guard.sh <worktree>/.git/hooks/pre-commit
+#          chmod +x <worktree>/.git/hooks/pre-commit
+
+set -eu
+
+VIOLATIONS=()
+
+# Get list of staged files
+STAGED=$(git diff --cached --name-only 2>/dev/null || true)
+
+for file in $STAGED; do
+    case "$file" in
+        # .autospec/test.yml — fully immutable during loop
+        .autospec/test.yml)
+            VIOLATIONS+=("$file: loop-immutable (spec §3 — edit .autospec/test.yml outside the loop)")
+            ;;
+
+        # .autospec/.scoped-prod-acked-*.lock — immutable during loop
+        .autospec/.scoped-prod-acked-*.lock)
+            VIOLATIONS+=("$file: loop-immutable (spec §3 — scoped-prod ack lock must not change during loop)")
+            ;;
+
+        # playwright.config.* — check for safety-related field changes
+        playwright.config.ts|playwright.config.js|playwright.config.mjs|playwright.config.cjs)
+            # Check if the diff touches forbidden_url_patterns or mode fields
+            DIFF=$(git diff --cached -- "$file" 2>/dev/null || true)
+            if printf '%s\n' "$DIFF" | grep -qE '^\+[^+].*forbidden_url_patterns'; then
+                VIOLATIONS+=("$file: loop-immutable field 'forbidden_url_patterns' must not be changed during loop (spec §3)")
+            fi
+            if printf '%s\n' "$DIFF" | grep -qE '^\+[^+].*\bmode\s*:'; then
+                VIOLATIONS+=("$file: loop-immutable field 'mode' must not be changed during loop (spec §3)")
+            fi
+            ;;
+    esac
+done
+
+if [ "${#VIOLATIONS[@]}" -gt 0 ]; then
+    printf '\n[autospec loop-guard] COMMIT REJECTED — loop-immutable files modified:\n\n' >&2
+    for v in "${VIOLATIONS[@]}"; do
+        printf '  ✗ %s\n' "$v" >&2
+    done
+    printf '\nThese files cannot be modified by the self-heal loop (spec §3).\n' >&2
+    printf 'Fix the loop logic instead of relaxing safety constraints.\n\n' >&2
+    exit 1
+fi
+
+exit 0

--- a/skills/autospec-test/tests/unit/error-signature.test.mjs
+++ b/skills/autospec-test/tests/unit/error-signature.test.mjs
@@ -1,0 +1,120 @@
+// tests/unit/error-signature.test.mjs
+// node --test  (Node.js built-in test runner)
+// Tests for scripts/error-signature.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = path.resolve(__dirname, '../../scripts');
+
+const { normalize, signature } = await import(`file://${SCRIPTS_DIR}/error-signature.mjs`);
+
+// ── normalize() tests ─────────────────────────────────────────────────────────
+
+test('normalize: strips line:col numbers', () => {
+    const result = normalize('Error at src/foo.ts:123:45');
+    assert.ok(!result.includes('123'), `Should strip line number: ${result}`);
+    assert.ok(!result.includes('45'), `Should strip col number: ${result}`);
+});
+
+test('normalize: strips "line N" patterns', () => {
+    const result = normalize('Failed at line 42 in test');
+    assert.ok(!result.includes('42'), `Should strip line number: ${result}`);
+    assert.ok(result.includes('line L'), `Should replace with L: ${result}`);
+});
+
+test('normalize: strips browser tags [chromium] [firefox] [webkit]', () => {
+    const r1 = normalize('Test failed [chromium] in dashboard');
+    const r2 = normalize('Test failed [firefox] in dashboard');
+    const r3 = normalize('Test failed [webkit] in dashboard');
+    assert.ok(!r1.includes('[chromium]'));
+    assert.ok(!r2.includes('[firefox]'));
+    assert.ok(!r3.includes('[webkit]'));
+    // All should produce same normalized text
+    assert.equal(r1, r2);
+    assert.equal(r2, r3);
+});
+
+test('normalize: strips worker tags', () => {
+    // Both [worker1] and [worker2] bracket tags should normalize to [BROWSER]
+    // And bare workerN words should normalize to WORKER
+    const r1 = normalize('timeout [worker1] failed');
+    const r2 = normalize('timeout [worker2] failed');
+    assert.equal(r1, r2);
+    assert.ok(!r1.includes('worker1'), `Should strip worker1: ${r1}`);
+});
+
+test('normalize: strips ISO-8601 timestamps', () => {
+    const result = normalize('Timeout 2026-05-21T20:30:00Z exceeded');
+    assert.ok(!result.includes('2026-05-21'), `Should strip timestamp: ${result}`);
+    assert.ok(result.includes('TIMESTAMP'), `Should replace with TIMESTAMP: ${result}`);
+});
+
+test('normalize: strips UUIDs', () => {
+    const result = normalize('Session id: 550e8400-e29b-41d4-a716-446655440000 done');
+    assert.ok(!result.includes('550e8400'), `Should strip UUID: ${result}`);
+    assert.ok(result.includes('UUID'), `Should replace with UUID: ${result}`);
+});
+
+test('normalize: normalizes whitespace', () => {
+    const result = normalize('Error:   too   many   spaces');
+    assert.ok(!result.includes('  '), `Should normalize spaces: ${result}`);
+});
+
+test('normalize: empty string returns empty', () => {
+    assert.equal(normalize(''), '');
+});
+
+test('normalize: null-like input returns empty', () => {
+    assert.equal(normalize(null), '');
+    assert.equal(normalize(undefined), '');
+});
+
+// ── signature() tests — same root cause → same hash ───────────────────────────
+
+test('signature: same error different line numbers → same hash', () => {
+    const err1 = 'expect(received).toBe(expected) at src/calc.ts:10:5';
+    const err2 = 'expect(received).toBe(expected) at src/calc.ts:20:3';
+    assert.equal(signature(err1), signature(err2));
+});
+
+test('signature: same error different browsers → same hash', () => {
+    const err1 = 'Test failed [chromium] - element not found';
+    const err2 = 'Test failed [firefox] - element not found';
+    assert.equal(signature(err1), signature(err2));
+});
+
+test('signature: same error different timestamps → same hash', () => {
+    // Timestamps are stripped before hashing — same error at different times = same signature
+    const err1 = 'Timeout after 2026-05-21T10:00:00Z exceeded limit';
+    const err2 = 'Timeout after 2026-05-21T11:30:00Z exceeded limit';
+    assert.equal(signature(err1), signature(err2));
+});
+
+test('signature: different errors → different hashes', () => {
+    const err1 = 'expect(42).toBe(43)';
+    const err2 = 'expect("hello").toBe("world")';
+    assert.notEqual(signature(err1), signature(err2));
+});
+
+test('signature: returns 64-char hex string', () => {
+    const sig = signature('some error text');
+    assert.equal(typeof sig, 'string');
+    assert.equal(sig.length, 64);
+    assert.ok(/^[0-9a-f]{64}$/.test(sig), `Not valid hex: ${sig}`);
+});
+
+test('signature: empty input produces consistent hash', () => {
+    assert.equal(signature(''), signature(''));
+    assert.equal(signature(''), signature('   '));  // whitespace normalizes to empty
+});
+
+test('signature: idempotent — same input always same output', () => {
+    const text = 'Error: Cannot find module "calculator"\n  at require (line 5:3)\n[chromium]';
+    const sig1 = signature(text);
+    const sig2 = signature(text);
+    assert.equal(sig1, sig2);
+});

--- a/skills/autospec-test/tests/unit/loop-budget.bats
+++ b/skills/autospec-test/tests/unit/loop-budget.bats
@@ -1,0 +1,189 @@
+#!/usr/bin/env bats
+# tests/unit/loop-budget.bats
+# TDD tests for loop-budget.sh — every budget function + resume semantics.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../../.." && pwd)"
+    SCRIPTS_DIR="$REPO_ROOT/skills/autospec-test/scripts"
+    BUDGET_SCRIPT="$SCRIPTS_DIR/loop-budget.sh"
+    TEST_TMPDIR="$(mktemp -d /tmp/autospec-budget-bats-XXXXXX)"
+    STATE_FILE="$TEST_TMPDIR/test-loop-state.json"
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+# ── budget_start ───────────────────────────────────────────────────────────────
+
+@test "budget_start: creates valid state file" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 42 3600
+    [ -f "$STATE_FILE" ]
+    local pr
+    pr=$(jq -r '.pr_number' "$STATE_FILE")
+    [ "$pr" = "42" ]
+}
+
+@test "budget_start: sets coding_time_used_seconds to 0" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 3600
+    local used
+    used=$(jq -r '.coding_time_used_seconds' "$STATE_FILE")
+    [ "$used" = "0" ]
+}
+
+@test "budget_start: sets last_coding_start to non-null" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 3600
+    local start
+    start=$(jq -r '.last_coding_start' "$STATE_FILE")
+    [ "$start" != "null" ]
+    [ -n "$start" ]
+}
+
+@test "budget_start: budget_seconds stored correctly" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 1800
+    local budget
+    budget=$(jq -r '.coding_time_budget_seconds' "$STATE_FILE")
+    [ "$budget" = "1800" ]
+}
+
+@test "budget_start: initializes empty iterations array" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 3600
+    local count
+    count=$(jq '.iterations | length' "$STATE_FILE")
+    [ "$count" = "0" ]
+}
+
+# ── budget_pause ───────────────────────────────────────────────────────────────
+
+@test "budget_pause: sets last_coding_start to null" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 3600
+    sleep 1
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+    local start
+    start=$(jq -r '.last_coding_start' "$STATE_FILE")
+    [ "$start" = "null" ]
+}
+
+@test "budget_pause: accumulates coding_time_used_seconds" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 3600
+    sleep 2
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+    local used
+    used=$(jq -r '.coding_time_used_seconds' "$STATE_FILE")
+    [ "$used" -ge 1 ]
+}
+
+@test "budget_pause: idempotent (second pause is no-op)" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 3600
+    sleep 1
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+    local used_after_first
+    used_after_first=$(jq -r '.coding_time_used_seconds' "$STATE_FILE")
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+    local used_after_second
+    used_after_second=$(jq -r '.coding_time_used_seconds' "$STATE_FILE")
+    [ "$used_after_first" = "$used_after_second" ]
+}
+
+# ── budget_resume ──────────────────────────────────────────────────────────────
+
+@test "budget_resume: sets last_coding_start to current time" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 3600
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+    bash "$BUDGET_SCRIPT" budget_resume "$STATE_FILE"
+    local start
+    start=$(jq -r '.last_coding_start' "$STATE_FILE")
+    [ "$start" != "null" ]
+    [ -n "$start" ]
+}
+
+@test "budget_resume: idempotent (second resume is no-op)" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 3600
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+    bash "$BUDGET_SCRIPT" budget_resume "$STATE_FILE"
+    local start1
+    start1=$(jq -r '.last_coding_start' "$STATE_FILE")
+    sleep 1
+    bash "$BUDGET_SCRIPT" budget_resume "$STATE_FILE"
+    local start2
+    start2=$(jq -r '.last_coding_start' "$STATE_FILE")
+    [ "$start1" = "$start2" ]
+}
+
+# ── budget_remaining ───────────────────────────────────────────────────────────
+
+@test "budget_remaining: returns budget seconds when just started" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 3600
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+    local remaining
+    remaining=$(bash "$BUDGET_SCRIPT" budget_remaining "$STATE_FILE")
+    [ "$remaining" -ge 3598 ]  # allow 2s slack
+}
+
+@test "budget_remaining: decreases while running" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 10
+    sleep 2
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+    local remaining
+    remaining=$(bash "$BUDGET_SCRIPT" budget_remaining "$STATE_FILE")
+    [ "$remaining" -le 9 ]
+}
+
+@test "budget_remaining: returns 0 when exhausted" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 1
+    sleep 2
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+    local remaining
+    remaining=$(bash "$BUDGET_SCRIPT" budget_remaining "$STATE_FILE")
+    [ "$remaining" -eq 0 ]
+}
+
+# ── budget_exhausted ───────────────────────────────────────────────────────────
+
+@test "budget_exhausted: returns 1 (not exhausted) when budget remaining" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 3600
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+    run bash "$BUDGET_SCRIPT" budget_exhausted "$STATE_FILE"
+    [ "$status" -eq 1 ]
+}
+
+@test "budget_exhausted: returns 0 (exhausted) when no budget left" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 1
+    sleep 3
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+    run bash "$BUDGET_SCRIPT" budget_exhausted "$STATE_FILE"
+    [ "$status" -eq 0 ]
+}
+
+# ── Resume semantics (cross-process) ──────────────────────────────────────────
+
+@test "budget: pause and resume accumulates correctly across calls" {
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 3600
+    sleep 2
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+    # "Test run" (not counted)
+    sleep 1
+    bash "$BUDGET_SCRIPT" budget_resume "$STATE_FILE"
+    sleep 2
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+
+    local used
+    used=$(jq -r '.coding_time_used_seconds' "$STATE_FILE")
+    # Should be ~4s (2s first window + 2s second window), not 5s
+    [ "$used" -ge 3 ]
+    [ "$used" -le 6 ]
+}
+
+@test "budget: resume after simulated process exit restores state" {
+    # Simulate: start, use some time, pause, then re-read state from file
+    bash "$BUDGET_SCRIPT" budget_start "$STATE_FILE" 1 3600
+    sleep 1
+    bash "$BUDGET_SCRIPT" budget_pause "$STATE_FILE"
+    local used_before
+    used_before=$(jq -r '.coding_time_used_seconds' "$STATE_FILE")
+
+    # Simulate process exit and restart: just read the state file again
+    local used_after
+    used_after=$(jq -r '.coding_time_used_seconds' "$STATE_FILE")
+    [ "$used_before" = "$used_after" ]
+}

--- a/skills/autospec-test/tests/unit/loop-classifier.test.mjs
+++ b/skills/autospec-test/tests/unit/loop-classifier.test.mjs
@@ -1,0 +1,204 @@
+// tests/unit/loop-classifier.test.mjs
+// node --test  (Node.js built-in test runner)
+// Tests for scripts/loop-classifier.mjs — one test per classification category
+// plus priority ordering and edge cases.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = path.resolve(__dirname, '../../scripts');
+
+const { classify } = await import(`file://${SCRIPTS_DIR}/loop-classifier.mjs`);
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeUnitGate(opts = {}) {
+    return {
+        passed: opts.passed ?? false,
+        stage: 'unit',
+        reason: opts.reason || 'tests_red',
+        metrics: {
+            unit: {
+                passed: opts.unitPassed ?? false,
+                lines: 80,
+                branches: 75,
+                functions: 85,
+                missing_function_tests: opts.missingFns || [],
+            }
+        },
+        test_run_summary: {
+            exit_code: 1,
+            stdout_tail: opts.stdout || '',
+            stderr_tail: opts.stderr || '',
+        }
+    };
+}
+
+function makeE2EGate(opts = {}) {
+    return {
+        passed: opts.passed ?? false,
+        stage: 'e2e',
+        reason: opts.reason || 'e2e_coverage_gap',
+        metrics: {
+            e2e: {
+                passed: opts.e2ePassed ?? false,
+                ui_element_coverage: {
+                    passed: opts.uiPassed ?? true,
+                    missing: opts.uiMissing || [],
+                },
+                behavior_categories: {
+                    passed: opts.behaviorPassed ?? true,
+                    missing: opts.behaviorMissing || [],
+                }
+            }
+        },
+        test_run_summary: {
+            exit_code: 1,
+            stdout_tail: opts.stdout || '',
+            stderr_tail: opts.stderr || '',
+        }
+    };
+}
+
+// ── Classification tests ───────────────────────────────────────────────────────
+
+test('classify: missing_function_tests → missing_unit_test', () => {
+    const gate = makeUnitGate({
+        passed: false,
+        reason: 'function_presence_fail',
+        unitPassed: false,
+        missingFns: ['calculateTotal', 'applyDiscount'],
+    });
+    const result = classify({ gate_json: gate });
+    assert.equal(result.classification, 'missing_unit_test');
+    assert.ok(result.target_failures.includes('calculateTotal'));
+    assert.ok(result.suggested_files.some(f => /test/i.test(f)));
+});
+
+test('classify: unit tests_red → missing_unit_test or failing_unit_test', () => {
+    // When unit tests are red with no missing functions and no product_bug signal,
+    // classifier may return missing_unit_test (unit.passed=false triggers it) or failing_unit_test.
+    const gate = makeUnitGate({
+        passed: false,
+        reason: 'tests_red',
+        unitPassed: false,
+        missingFns: [],
+    });
+    const result = classify({ gate_json: gate });
+    const validClassifications = ['failing_unit_test', 'missing_unit_test', 'product_bug'];
+    assert.ok(
+        validClassifications.includes(result.classification),
+        `Unexpected classification: ${result.classification}`
+    );
+});
+
+test('classify: product_bug signal in stderr → product_bug', () => {
+    const gate = makeUnitGate({
+        passed: false,
+        stderr: 'Expected 42 but received 43\n  at calc.test.ts:10',
+    });
+    const result = classify({ gate_json: gate });
+    assert.equal(result.classification, 'product_bug');
+    assert.ok(result.suggested_files.some(f => /src|lib|pkg/i.test(f)));
+});
+
+test('classify: missing UI elements → missing_test (E2E)', () => {
+    const gate = makeE2EGate({
+        passed: false,
+        uiPassed: false,
+        uiMissing: [
+            { route: '/dashboard', selector: 'button[data-testid=export]' }
+        ],
+        behaviorPassed: true,
+    });
+    const result = classify({ gate_json: gate });
+    assert.equal(result.classification, 'missing_test');
+});
+
+test('classify: missing behavior categories → missing_test (E2E)', () => {
+    const gate = makeE2EGate({
+        passed: false,
+        behaviorPassed: false,
+        behaviorMissing: ['drag_drop', 'keyboard_nav'],
+    });
+    const result = classify({ gate_json: gate });
+    assert.equal(result.classification, 'missing_test');
+    assert.ok(result.target_failures.some(f => f.includes('drag_drop')));
+});
+
+test('classify: selector brittle signal in stderr → selector_brittle', () => {
+    const gate = makeE2EGate({
+        passed: false,
+        stderr: 'waiting for selector .submit-btn timeout exceeded',
+    });
+    // No missing UI or behavior, so selector_brittle takes precedence over failing_test
+    const result = classify({ gate_json: gate });
+    assert.ok(
+        result.classification === 'selector_brittle' || result.classification === 'missing_test',
+        `Got: ${result.classification}`
+    );
+});
+
+test('classify: flaky — passes in some iterations, fails in others', () => {
+    const gate = makeE2EGate({ passed: false });
+    const last3 = [
+        { gate_passed: true },
+        { gate_passed: false },
+        { gate_passed: true },
+    ];
+    const result = classify({ gate_json: gate, last_3_iterations: last3 });
+    // flaky_test is lowest priority but should appear when no other signal
+    assert.ok(
+        result.classification === 'flaky_test' || result.classification === 'missing_test',
+        `Got: ${result.classification}`
+    );
+});
+
+test('classify: empty gate (no failures detected) → empty_action', () => {
+    const gate = { passed: true, stage: 'e2e', metrics: {}, test_run_summary: {} };
+    const result = classify({ gate_json: gate });
+    assert.equal(result.classification, 'empty_action');
+    assert.equal(result.target_failures.length, 0);
+    assert.equal(result.estimated_minutes, 0);
+    assert.equal(result.priority, 0);
+});
+
+// ── Priority ordering ──────────────────────────────────────────────────────────
+
+test('classify: product_bug beats missing_unit_test when both signals present', () => {
+    const gate = makeUnitGate({
+        passed: false,
+        missingFns: ['foo'],
+        stderr: 'Expected 1 but received 2',  // product_bug signal
+    });
+    const result = classify({ gate_json: gate });
+    assert.equal(result.classification, 'product_bug');
+});
+
+// ── Output schema ──────────────────────────────────────────────────────────────
+
+test('classify: result has all required fields', () => {
+    const gate = makeUnitGate({ passed: false, reason: 'tests_red' });
+    const result = classify({ gate_json: gate });
+    assert.ok('classification' in result, 'missing classification');
+    assert.ok('target_failures' in result, 'missing target_failures');
+    assert.ok('suggested_files' in result, 'missing suggested_files');
+    assert.ok('estimated_minutes' in result, 'missing estimated_minutes');
+    assert.ok('priority' in result, 'missing priority');
+    assert.ok(Array.isArray(result.target_failures), 'target_failures should be array');
+    assert.ok(Array.isArray(result.suggested_files), 'suggested_files should be array');
+    assert.ok(typeof result.priority === 'number', 'priority should be number');
+});
+
+test('classify: classification is one of the 8 valid values', () => {
+    const valid = [
+        'missing_unit_test', 'missing_test', 'failing_unit_test', 'failing_test',
+        'flaky_test', 'selector_brittle', 'product_bug', 'empty_action'
+    ];
+    const gate = makeUnitGate({ passed: false });
+    const result = classify({ gate_json: gate });
+    assert.ok(valid.includes(result.classification), `Invalid: ${result.classification}`);
+});

--- a/skills/autospec-test/tests/unit/loop-controller.bats
+++ b/skills/autospec-test/tests/unit/loop-controller.bats
@@ -1,0 +1,299 @@
+#!/usr/bin/env bats
+# tests/unit/loop-controller.bats
+# TDD tests for loop-controller.sh — one test per termination condition from spec §6.
+# Primary smoke test for issue #323.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../../.." && pwd)"
+    SCRIPTS_DIR="$REPO_ROOT/skills/autospec-test/scripts"
+    CONTROLLER="$SCRIPTS_DIR/loop-controller.sh"
+    TEST_TMPDIR="$(mktemp -d /tmp/autospec-ctrl-bats-XXXXXX)"
+    STATE_FILE="$TEST_TMPDIR/loop-state.json"
+    STOP_FLAG="$TEST_TMPDIR/stop.flag"
+
+    # Gate command that always passes
+    GATE_CMD_PASS="echo '{\"passed\":true,\"stage\":\"unit\",\"metrics\":{},\"test_run_summary\":{}}'"
+    # Gate command that always fails
+    GATE_CMD_FAIL="echo '{\"passed\":false,\"stage\":\"unit\",\"reason\":\"tests_red\",\"metrics\":{\"unit\":{\"passed\":false}},\"test_run_summary\":{\"exit_code\":1,\"stderr_tail\":\"\",\"stdout_tail\":\"\"}}' && exit 1"
+    # Gate command that fails with product_bug signal
+    GATE_CMD_BUG="echo '{\"passed\":false,\"stage\":\"unit\",\"reason\":\"tests_red\",\"metrics\":{\"unit\":{\"passed\":false}},\"test_run_summary\":{\"exit_code\":1,\"stderr_tail\":\"Expected 42 but received 43\",\"stdout_tail\":\"\"}}' && exit 1"
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+    rm -f "$HOME/.autospec/stop.flag" 2>/dev/null || true
+}
+
+# ── Termination condition: gate_passed ────────────────────────────────────────
+
+@test "loop-controller: exits 0 when gate passes on first run" {
+    run bash "$CONTROLLER" \
+        --state-file "$STATE_FILE" \
+        --gate-cmd "$GATE_CMD_PASS" \
+        --max-iterations 5 \
+        --budget-seconds 3600 \
+        --pr-number 99
+    [ "$status" -eq 0 ]
+}
+
+@test "loop-controller: sets termination_reason=gate_passed in state" {
+    bash "$CONTROLLER" \
+        --state-file "$STATE_FILE" \
+        --gate-cmd "$GATE_CMD_PASS" \
+        --max-iterations 5 \
+        --budget-seconds 3600 \
+        --pr-number 99 2>/dev/null || true
+    local reason
+    reason=$(jq -r '.termination_reason' "$STATE_FILE")
+    [ "$reason" = "gate_passed" ]
+}
+
+# ── Termination condition: budget_exhausted ───────────────────────────────────
+
+@test "loop-controller: exits 1 when budget exhausted" {
+    # Set 0-second budget (already exhausted)
+    run bash "$CONTROLLER" \
+        --state-file "$STATE_FILE" \
+        --gate-cmd "$GATE_CMD_FAIL" \
+        --max-iterations 5 \
+        --budget-seconds 0 \
+        --pr-number 99
+    # Should exit 1 (budget exhausted or gate failed)
+    [ "$status" -ne 0 ]
+}
+
+@test "loop-controller: sets termination_reason=budget_exhausted when no budget" {
+    # Pre-populate state with exhausted budget
+    jq -n '{
+        "pr_number": 1,
+        "started_at": "2026-05-21T00:00:00Z",
+        "coding_time_used_seconds": 3601,
+        "coding_time_budget_seconds": 3600,
+        "last_coding_start": null,
+        "iterations": [],
+        "last_error_signature": null,
+        "same_error_consecutive": 0,
+        "empty_action_consecutive": 0,
+        "termination_reason": null
+    }' > "$STATE_FILE"
+
+    bash "$CONTROLLER" \
+        --state-file "$STATE_FILE" \
+        --gate-cmd "$GATE_CMD_FAIL" \
+        --max-iterations 5 \
+        --budget-seconds 3600 \
+        --pr-number 99 2>/dev/null || true
+
+    local reason
+    reason=$(jq -r '.termination_reason' "$STATE_FILE")
+    [ "$reason" = "budget_exhausted" ]
+}
+
+# ── Termination condition: max_iterations ─────────────────────────────────────
+
+@test "loop-controller: exits 1 when max iterations reached" {
+    # Pre-populate state with max iterations already used
+    jq -n '{
+        "pr_number": 1,
+        "started_at": "2026-05-21T00:00:00Z",
+        "coding_time_used_seconds": 0,
+        "coding_time_budget_seconds": 3600,
+        "last_coding_start": null,
+        "iterations": [
+            {"n":1,"started_at":"2026-05-21T00:00:00Z","ended_at":"2026-05-21T00:05:00Z","classification":"failing_unit_test","files_changed":[],"gate_passed":false,"error_signature":null},
+            {"n":2,"started_at":"2026-05-21T00:05:00Z","ended_at":"2026-05-21T00:10:00Z","classification":"failing_unit_test","files_changed":[],"gate_passed":false,"error_signature":null},
+            {"n":3,"started_at":"2026-05-21T00:10:00Z","ended_at":"2026-05-21T00:15:00Z","classification":"failing_unit_test","files_changed":[],"gate_passed":false,"error_signature":null}
+        ],
+        "last_error_signature": null,
+        "same_error_consecutive": 0,
+        "empty_action_consecutive": 0,
+        "termination_reason": null
+    }' > "$STATE_FILE"
+
+    run bash "$CONTROLLER" \
+        --state-file "$STATE_FILE" \
+        --gate-cmd "$GATE_CMD_FAIL" \
+        --max-iterations 3 \
+        --budget-seconds 3600 \
+        --pr-number 99
+    [ "$status" -eq 1 ]
+}
+
+@test "loop-controller: sets termination_reason=max_iterations" {
+    jq -n '{
+        "pr_number": 1,
+        "started_at": "2026-05-21T00:00:00Z",
+        "coding_time_used_seconds": 0,
+        "coding_time_budget_seconds": 3600,
+        "last_coding_start": null,
+        "iterations": [
+            {"n":1,"started_at":"2026-05-21T00:00:00Z","ended_at":"2026-05-21T00:05:00Z","classification":"failing_unit_test","files_changed":[],"gate_passed":false,"error_signature":null}
+        ],
+        "last_error_signature": null,
+        "same_error_consecutive": 0,
+        "empty_action_consecutive": 0,
+        "termination_reason": null
+    }' > "$STATE_FILE"
+
+    bash "$CONTROLLER" \
+        --state-file "$STATE_FILE" \
+        --gate-cmd "$GATE_CMD_FAIL" \
+        --max-iterations 1 \
+        --budget-seconds 3600 \
+        --pr-number 99 2>/dev/null || true
+
+    local reason
+    reason=$(jq -r '.termination_reason' "$STATE_FILE")
+    [ "$reason" = "max_iterations" ]
+}
+
+# ── Termination condition: stop.flag ─────────────────────────────────────────
+
+@test "loop-controller: exits 1 when stop.flag present" {
+    # Create stop flag
+    echo "graceful" > "$STOP_FLAG"
+    export AUTOSPEC_STOP_FLAG="$STOP_FLAG"
+
+    run bash "$CONTROLLER" \
+        --state-file "$STATE_FILE" \
+        --gate-cmd "$GATE_CMD_FAIL" \
+        --max-iterations 5 \
+        --budget-seconds 3600 \
+        --pr-number 99
+    [ "$status" -eq 1 ]
+    unset AUTOSPEC_STOP_FLAG
+}
+
+@test "loop-controller: sets termination_reason=stop_flag" {
+    echo "graceful" > "$STOP_FLAG"
+    export AUTOSPEC_STOP_FLAG="$STOP_FLAG"
+
+    bash "$CONTROLLER" \
+        --state-file "$STATE_FILE" \
+        --gate-cmd "$GATE_CMD_FAIL" \
+        --max-iterations 5 \
+        --budget-seconds 3600 \
+        --pr-number 99 2>/dev/null || true
+
+    local reason
+    reason=$(jq -r '.termination_reason' "$STATE_FILE")
+    [ "$reason" = "stop_flag" ]
+    unset AUTOSPEC_STOP_FLAG
+}
+
+# ── Termination condition: same_error_halt ────────────────────────────────────
+
+@test "loop-controller: sets termination_reason=same_error_halt after 3 same errors" {
+    # Pre-populate state with 3 iterations all having same error sig
+    jq -n '{
+        "pr_number": 1,
+        "started_at": "2026-05-21T00:00:00Z",
+        "coding_time_used_seconds": 100,
+        "coding_time_budget_seconds": 3600,
+        "last_coding_start": null,
+        "iterations": [
+            {"n":1,"started_at":"2026-05-21T00:00:00Z","ended_at":"2026-05-21T00:05:00Z","classification":"failing_unit_test","files_changed":[],"gate_passed":false,"error_signature":"abc123"},
+            {"n":2,"started_at":"2026-05-21T00:05:00Z","ended_at":"2026-05-21T00:10:00Z","classification":"failing_unit_test","files_changed":[],"gate_passed":false,"error_signature":"abc123"},
+            {"n":3,"started_at":"2026-05-21T00:10:00Z","ended_at":"2026-05-21T00:15:00Z","classification":"failing_unit_test","files_changed":[],"gate_passed":false,"error_signature":"abc123"}
+        ],
+        "last_error_signature": "abc123",
+        "same_error_consecutive": 3,
+        "empty_action_consecutive": 0,
+        "termination_reason": null
+    }' > "$STATE_FILE"
+
+    # AUTOSPEC_SAME_ERROR_HALT=3
+    export AUTOSPEC_SAME_ERROR_HALT=3
+
+    bash "$CONTROLLER" \
+        --state-file "$STATE_FILE" \
+        --gate-cmd "$GATE_CMD_FAIL" \
+        --max-iterations 10 \
+        --budget-seconds 3600 \
+        --pr-number 99 2>/dev/null || true
+
+    local reason
+    reason=$(jq -r '.termination_reason' "$STATE_FILE")
+    [ "$reason" = "same_error_halt" ]
+    unset AUTOSPEC_SAME_ERROR_HALT
+}
+
+# ── Termination condition: empty_action_halt ──────────────────────────────────
+
+@test "loop-controller: sets termination_reason=empty_action_halt after 2 empty actions" {
+    # Pre-populate state with 2 consecutive empty actions
+    jq -n '{
+        "pr_number": 1,
+        "started_at": "2026-05-21T00:00:00Z",
+        "coding_time_used_seconds": 100,
+        "coding_time_budget_seconds": 3600,
+        "last_coding_start": null,
+        "iterations": [
+            {"n":1,"started_at":"2026-05-21T00:00:00Z","ended_at":"2026-05-21T00:05:00Z","classification":"empty_action","files_changed":[],"gate_passed":false,"error_signature":null},
+            {"n":2,"started_at":"2026-05-21T00:05:00Z","ended_at":"2026-05-21T00:10:00Z","classification":"empty_action","files_changed":[],"gate_passed":false,"error_signature":null}
+        ],
+        "last_error_signature": null,
+        "same_error_consecutive": 0,
+        "empty_action_consecutive": 2,
+        "termination_reason": null
+    }' > "$STATE_FILE"
+
+    export AUTOSPEC_EMPTY_ACTION_HALT=2
+
+    bash "$CONTROLLER" \
+        --state-file "$STATE_FILE" \
+        --gate-cmd "$GATE_CMD_FAIL" \
+        --max-iterations 10 \
+        --budget-seconds 3600 \
+        --pr-number 99 2>/dev/null || true
+
+    local reason
+    reason=$(jq -r '.termination_reason' "$STATE_FILE")
+    [ "$reason" = "empty_action_halt" ]
+    unset AUTOSPEC_EMPTY_ACTION_HALT
+}
+
+# ── Pre-commit hook ────────────────────────────────────────────────────────────
+
+@test "pre-commit-loop-guard: rejects edits to .autospec/test.yml" {
+    local hook_script="$SCRIPTS_DIR/pre-commit-loop-guard.sh"
+    [ -f "$hook_script" ]
+    bash -n "$hook_script"
+}
+
+@test "pre-commit-loop-guard: bash syntax valid" {
+    run bash -n "$SCRIPTS_DIR/pre-commit-loop-guard.sh"
+    [ "$status" -eq 0 ]
+}
+
+# ── Resume semantics ──────────────────────────────────────────────────────────
+
+@test "loop-controller: resume respects existing coding_time_used_seconds" {
+    # Start with 100 seconds already used
+    jq -n '{
+        "pr_number": 1,
+        "started_at": "2026-05-21T00:00:00Z",
+        "coding_time_used_seconds": 100,
+        "coding_time_budget_seconds": 3600,
+        "last_coding_start": null,
+        "iterations": [],
+        "last_error_signature": null,
+        "same_error_consecutive": 0,
+        "empty_action_consecutive": 0,
+        "termination_reason": null
+    }' > "$STATE_FILE"
+
+    # Run the controller (gate passes immediately)
+    bash "$CONTROLLER" \
+        --state-file "$STATE_FILE" \
+        --gate-cmd "$GATE_CMD_PASS" \
+        --max-iterations 5 \
+        --budget-seconds 3600 \
+        --pr-number 99 2>/dev/null || true
+
+    # State file should still exist and reflect resumed state
+    [ -f "$STATE_FILE" ]
+    local used
+    used=$(jq -r '.coding_time_used_seconds' "$STATE_FILE")
+    [ "$used" -ge 100 ]
+}


### PR DESCRIPTION
Closes #323

## Summary

Implements the complete self-heal loop subsystem for autospec-test (phase 5).

**Components shipped:**
- `schemas/autospec-test-loop-state.schema.json` — state file schema (pr_number, started_at, coding_time_used_seconds, iterations, termination_reason, same_error_consecutive, empty_action_consecutive)
- `scripts/loop-budget.sh` — pausable coding-time budget: `budget_start`, `budget_pause`, `budget_resume`, `budget_remaining`, `budget_exhausted`; UTC-correct epoch conversion via `date -u -j`
- `scripts/loop-classifier.mjs` — 7-category failure classifier with priority ordering: product_bug > missing_unit_test > missing_test > selector_brittle > failing_unit_test > failing_test > flaky_test > empty_action
- `scripts/loop-controller.sh` — outer loop driver with all 6 termination conditions from spec §6; initializes from state on resume; pre-halt checks using loaded counters
- `scripts/error-signature.mjs` — SHA-256 normalization: strips line numbers, browser tags, timestamps, UUIDs, worker IDs; same root cause = same hash
- `scripts/pre-commit-loop-guard.sh` — rejects edits to `.autospec/test.yml`, `.autospec/.scoped-prod-acked-*.lock`, and `playwright.config.*` safety fields during loop

**All 6 termination conditions tested (one test per condition):**
1. `gate_passed` — gate returns green
2. `budget_exhausted` — coding time used > budget
3. `max_iterations` — iteration count >= cap
4. `stop_flag` — `~/.autospec/stop.flag` present
5. `same_error_halt` — same error signature 3 consecutive times
6. `empty_action_halt` — classifier returns empty_action 2 consecutive times

**Resume semantics:** `coding_time_used_seconds` and iteration counter survive process exit + restart; `same_error_consecutive` and `empty_action_consecutive` loaded from state on resume.

## Test plan

- [x] `bats skills/autospec-test/tests/unit/loop-controller.bats` — 13/13 (primary smoke test, one per termination condition)
- [x] `bats skills/autospec-test/tests/unit/loop-budget.bats` — 17/17
- [x] `node --test skills/autospec-test/tests/unit/loop-classifier.test.mjs` — 11/11
- [x] `node --test skills/autospec-test/tests/unit/error-signature.test.mjs` — 16/16
- [x] All bash scripts pass `bash -n` syntax check