### PR TITLE
feat(autospec-test): SKILL.md + lockstep validation + docs (phase 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ selected model and harness to execute reliably.
 | [`autospec-story`](skills/autospec-story/README.md) | You need a repo-level product and implementation-state overview. | Produces a cited Markdown story from local specs, docs, issues, PRs, and git history. |
 | [`autospec-stop`](skills/autospec-stop/README.md) | You need to halt or resume an active monitor. | Writes the shared stop sentinel, pauses issues safely, reports status, or resumes paused work. |
 | [`autospec-review`](skills/autospec-review/README.md) | You want to close the spec-vs-code feedback loop. | Audits specs against issues, finds gaps, files `[REGRESSION]` issues with `priority:high`. |
+| [`autospec-test`](skills/autospec-test/README.md) | You want every Phase 4 PR gated on unit + E2E coverage with auto-heal. | Runs a two-stage coverage gate, auto-heals gaps within a 60-min budget, and blocks assertion-loosening rewrites before auto-merge. |
 
 See [`SKILLS.md`](SKILLS.md) for activation keywords and per-skill routing
 details.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -41,6 +41,14 @@
 - Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
 - Status: existing-spec shortcut for Phase 3 plus Phase 3.5 with startup self-update before normal execution.
 
+## autospec-test
+
+- Path: [`skills/autospec-test`](skills/autospec-test)
+- Trigger: use when you want every Phase 4 PR gated on unit + E2E test coverage with an auto-heal loop, or to run ad-hoc coverage validation against any branch.
+- Activation keywords: `autospec-test`, `coverage gate`, `e2e gate`, `unit coverage`, `test gate`, `auto-heal tests`, `enforce test coverage`, `coverage enforcement`
+- Harnesses: Claude Code (`SKILL.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
+- Status: inline Phase 4 gate (runs after build + lint, before auto-merge) plus standalone `/autospec-test [PR#]` invocation. Two-stage: unit coverage → E2E coverage. Self-heal loop up to 5 iterations / 60 min coding time. Assertion-shift guardrail blocks LOOSENING rewrites. Mode II (scoped production) opt-in with mandatory backup/restore.
+
 ## Future Skill Checklist
 
 1. Create `skills/<skill-name>/SKILL.md`.

--- a/docs/target-repo-setup.md
+++ b/docs/target-repo-setup.md
@@ -144,3 +144,74 @@ or `pytest`, so running it against a target repo is side-effect-free.
 Once both lines print their `OK`/`detected` strings, autospec's
 Phase 4 implementer will run both gates against PRs targeting your
 `main`.
+
+## How to enable autospec-test
+
+`autospec-test` gates every Phase 4 PR on unit + E2E coverage and
+auto-heals gaps within a 60-minute coding budget. Enabling it requires
+three steps: install Playwright (if not already present), write
+`.autospec/test.yml`, and optionally run the wizard.
+
+### 1. Install Playwright in your target repo
+
+```bash
+npm init playwright@latest
+# Accept defaults; choose TypeScript if your repo uses it.
+# Commit playwright.config.ts and the generated test skeleton.
+```
+
+If your repo uses a different test framework for E2E (e.g. Cypress),
+the skill gates on Playwright only. Cypress repos should set
+`forbidden_url_patterns_intentionally_empty: true` and omit E2E stage
+until a Playwright suite is added.
+
+### 2. Write `.autospec/test.yml`
+
+Create `.autospec/test.yml` in your target repo with at minimum:
+
+```yaml
+# .autospec/test.yml
+mode: strict_isolation          # default; safe for all repos
+
+e2e:
+  clone_url_env: E2E_BASE_URL   # env var pointing at your isolated clone
+  forbidden_url_patterns:
+    - "^https?://app\\.example\\.com"      # your production URL(s)
+    - "^https?://.*\\.prod\\.example\\.internal"
+
+budgets:
+  coding_time_minutes: 60       # LLM coding time; test runtime is unbounded
+  max_loop_iterations: 5
+  same_error_halt_threshold: 3
+```
+
+**Fail-closed rule:** if `forbidden_url_patterns` is missing or empty
+(without `forbidden_url_patterns_intentionally_empty: true`), the skill
+refuses to run and labels the PR `e2e:contract-error`. Always declare
+at least one forbidden pattern covering your production URL.
+
+Commit `.autospec/test.yml` to your repo's default branch.
+
+### 3. Run the wizard (optional but recommended)
+
+```bash
+/autospec-test --init
+```
+
+The wizard walks through mode selection, detects backup drivers for
+Mode II (scoped production), prints a dry-run preview of constraints,
+and requires you to type `I UNDERSTAND` before writing any files.
+
+### What the labels mean
+
+| Label | Meaning |
+|---|---|
+| `e2e:passed` | Both stages green; auto-merge proceeds |
+| `e2e:healed` | Gate was red; self-heal loop fixed it; auto-merge proceeds (subject to assertion-shift guardrail) |
+| `e2e:blocked` | Loop exhausted budget or iteration cap; needs human review |
+| `e2e:stuck-error` | Same error in 3 consecutive iterations; needs human review |
+| `e2e:refused` | Skill refused to run (missing contract or forbidden URL check); fix `.autospec/test.yml` |
+| `e2e:contract-error` | Contract validation failed (missing `forbidden_url_patterns`, Playwright not found, etc.) |
+| `e2e:assertion-loosening` | Loop weakened a test assertion; needs human review before merge |
+| `needs-human-review` | Combined with any of the above blocked states |
+| `e2e:scoped-prod` | Mode II run (touches production under declared scope tokens) |

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -523,6 +523,21 @@ check_existing_spec_mode() {
     done
 }
 
+# autospec-test skill structural check (Phase 10): run per-skill validate.sh
+# to verify SKILL.md, codex/prompt.md, and structural section presence.
+check_autospec_test_skill_present() {
+    info "autospec-test skill structural lint"
+    local skill_dir="skills/autospec-test"
+    local validate_sh="$skill_dir/validate.sh"
+    [ -d "$skill_dir" ] || fail "$skill_dir: directory missing"
+    [ -f "$skill_dir/SKILL.md" ] || fail "$skill_dir/SKILL.md: required file missing"
+    [ -f "$skill_dir/codex/prompt.md" ] || fail "$skill_dir/codex/prompt.md: required file missing"
+    [ -f "$validate_sh" ] || fail "$validate_sh: per-skill validate.sh missing"
+    bash -n "$validate_sh" || fail "$validate_sh: bash syntax error"
+    bash "$validate_sh" >/dev/null 2>&1 \
+        || { bash "$validate_sh" >&2; fail "$validate_sh: structural lint failed"; }
+}
+
 main() {
     info "scanning multi-harness skills under skills/ ..."
     skills="$(discover_skills)"
@@ -562,6 +577,7 @@ main() {
     check_autospec_run_regression_review_lockstep
     check_autospec_review_skill_present
     check_autospec_review_tier_a_directives
+    check_autospec_test_skill_present
     check_phase4_tests
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax

--- a/skills/autospec-test/SKILL.md
+++ b/skills/autospec-test/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: autospec-test
+description: Use when you want to gate every Phase 4 PR on unit + E2E test coverage against an isolated environment, auto-heal coverage gaps within a 60-minute coding budget, and block assertion-loosening rewrites before auto-merge.
+---
+
+# autospec-test — Unit + E2E Coverage Gate with Self-Heal Loop
+
+Enforce that every PR produced by `/autospec-run` ships with thorough, passing unit + E2E test coverage against an isolated environment, and that any gaps the gate finds get auto-healed by a bounded LLM loop within the same PR.
+
+## Self-update
+
+Decide this purely from the request text the harness handed you. Do NOT
+shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
+test the user's free-form request — passing it through a shell is what
+historically tripped harness permission engines. Read the request, normalize
+it in your reasoning (collapse whitespace, trim, lowercase), and if the result is
+exactly `update`, this skill enters self-update mode and does NOT run the
+normal pipeline.
+
+1. Detect harness by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-test/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-test.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-test.md`
+2. Re-install from `main` by piping the canonical installer:
+   ```
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-test/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. Show the diff between the prior installed file(s) and the freshly fetched copy.
+4. Stop. Do not enter any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-test found; run install.sh first.` and exit.
+
+## Model tier
+
+`reasoning:standard, ctx:120k`
+
+This skill runs inline inside the Phase 4 implementer worktree (same model tier as the outer implementer) or standalone against a specified PR branch. No Tier A dispatch required for normal operation; the coverage gate and self-heal loop are deterministic or LLM-light.
+
+## When to use
+
+- Automatically: `/autospec-run` Phase 4 invokes this skill after the build + lint gate passes and before admin auto-merge, for every PR that closes an `auto-implement` issue.
+- Standalone: `/autospec-test [PR#]` for ad-hoc validation of any branch or PR against main — useful before filing an issue or after a manual hot-fix.
+- First-time setup: `/autospec-test --init` to interactively configure `.autospec/test.yml` in a target repo.
+
+## When not to use
+
+- When the target repo has no test suite at all (no jest/vitest/mocha/pytest/go test/cargo test found, no Playwright). Use Skill D (suite bootstrapper) first.
+- When clone provisioning is not yet in place and no `E2E_BASE_URL` / `PLAYWRIGHT_BASE_URL` / `BASE_URL` env var is set. The gate will refuse to run (exit 2) rather than silently hit production.
+- When `~/.autospec/no-test.flag` exists (operator opt-out for repos where testing is handled by an external CI system).
+- For repos in the autospec family itself (autospec is a bash/markdown skill repo with no Playwright suite). The skill self-detects and skips gracefully.
+
+## How it works
+
+Two-stage gate runs sequentially inside the Phase 4 worktree:
+
+```
+Phase 4 existing: build + lint
+        │
+        ▼
+Stage 1: unit tests + unit-coverage gate
+        │ (must pass before Stage 2 starts)
+        ▼
+Stage 2: E2E tests + E2E coverage gate
+        │
+        ▼
+Assertion-shift guardrail (covers both stages' test diffs)
+        │
+        ▼
+Auto-merge or block
+```
+
+**Stage 1 — Unit (Metric E):** Code coverage thresholds (defaults 95/90/95 lines/branches/functions), function-presence check (every exported/public function has at least one unit test), and all unit tests pass with no `.only`, `.skip`, or `xit`.
+
+**Stage 2 — E2E:** Three metrics: code coverage from E2E run (Metric A, thresholds 90/85/90), UI element coverage (Metric B — every reachable `button/a/input/select/textarea/[contenteditable]` touched by Playwright), and behavior taxonomy (Metric D — at least one passing test per declared category: sort, scroll, upload, download, filter, paginate, bulk_select, keyboard_nav, drag_drop).
+
+**Self-heal loop:** Up to 5 iterations, 60 minutes of coding time (paused while tests run). Each iteration classifies failures (missing_unit_test, missing_test, failing_unit_test, failing_test, flaky_test, selector_brittle, product_bug) and picks the highest-priority cluster that fits remaining budget. Loop state persisted in `.autospec/test-loop-state.json` in the worktree so monitor relaunches resume rather than reset.
+
+**Assertion-shift guardrail:** AST + regex pass over all modified test files. LOOSENING changes block auto-merge (adds `needs-human-review` + `e2e:assertion-loosening`). SHIFTING is conditionally allowed if the same commit also modifies a non-test source file and includes `JUSTIFICATION:` in the commit message. STRENGTHENING always allowed.
+
+## Contract file
+
+`.autospec/test.yml` in the target repo. Most fields autodetected; the file's primary purpose is declaring **forbidden URLs** (mandatory) and any Mode II opt-in.
+
+Minimal valid contract:
+
+```yaml
+# .autospec/test.yml
+mode: strict_isolation
+
+e2e:
+  clone_url_env: E2E_BASE_URL
+  forbidden_url_patterns:
+    - "^https?://app\\.acme\\.com"
+    - "^https?://.*\\.prod\\.acme\\.internal"
+
+budgets:
+  coding_time_minutes: 60
+  max_loop_iterations: 5
+  same_error_halt_threshold: 3
+```
+
+**Fail-closed:** missing or empty `forbidden_url_patterns` (without `forbidden_url_patterns_intentionally_empty: true`) causes the skill to refuse to run (exit 2, operator-actionable).
+
+**Loop-immutable fields:** the self-heal loop may not edit `.autospec/test.yml`, `.autospec/.scoped-prod-acked-*.lock`, or Playwright config safety-related fields. A pre-commit hook in the worktree enforces this.
+
+Full schema at `schemas/autospec-test-contract.schema.json` in this repo.
+
+## Modes I and II
+
+**Mode I — strict isolation (default):** All test traffic is confined to a clone URL (`E2E_BASE_URL` or equivalent). Three enforcement layers:
+
+1. Pre-flight URL check: every URL-shaped value in Playwright config is matched against `forbidden_url_patterns` before any test runs. Match → hard fail, no tests run.
+2. Runtime network intercept: Playwright global setup injects `context.route('**/*', handler)` that aborts requests whose final URL (post-redirect) matches a forbidden pattern.
+3. Egress allowlist (optional): if `egress_allowlist` declared, runner enforces at netns/container level.
+
+**Mode II — scoped production (opt-in):** Requires `mode: scoped_production` plus `i_understand_this_writes_to_production: true` in the contract, plus `backup:` with a verified pre-suite snapshot and `restore_cmd`. Scope tokens constrain which rows, methods, and routes the test suite may touch. Scope violations trigger immediate restore and batch halt. Two consecutive scope violations across runs auto-quarantine Mode II and require manual re-acknowledgement.
+
+Hard non-negotiables for Mode II (encoded in skill, not user-overridable): no `backup:` → refuse to run; no verified pre-suite snapshot → refuse to run; no `restore_cmd` → refuse to run; scope violation → restore + halt; 2 consecutive violations → quarantine.
+
+## Safety rails
+
+The skill enforces these rails regardless of operator configuration:
+
+- **Fail-closed forbidden URL check:** no `forbidden_url_patterns` → refuse to run (exit 2).
+- **Loop-immutable contract:** self-heal loop cannot weaken safety config files.
+- **LOOSENING block:** any test assertion that becomes less strict blocks auto-merge.
+- **Mode II backup invariants:** see Modes I and II above.
+- **Stop flag respects existing convention:** if `~/.autospec/stop.flag` is present, the skill exits gracefully using the same sentinel path as autospec-stop.
+- **Pre-commit hook:** installed in the worktree before the self-heal loop starts; blocks any loop commit that modifies `.autospec/test.yml` or Playwright safety fields.
+
+## Self-heal loop
+
+Loop anatomy for each iteration:
+
+1. Read gate JSON + `.autospec/test-findings.md` + last 3 iterations' summaries.
+2. Classify each failure: missing_unit_test, missing_test, failing_unit_test, failing_test, flaky_test, selector_brittle, product_bug.
+3. Prioritize: product_bug > missing_unit_test > missing_test > selector_brittle > failing_unit_test > failing_test > flaky_test.
+4. Pick the highest-priority cluster that fits remaining coding budget.
+5. Edit allowed surfaces: unit test files, Playwright test files, product source code, `playwright.config.*` (timeouts/retries/projects only — not safety fields).
+6. Commit with structured message: `test-heal(iter N): <one-line>` plus `CLASSIFICATION:` and `JUSTIFICATION:` lines (required for assertion-shift compliance).
+7. Re-run gate. Green → exit. Red → next iteration.
+
+**Termination conditions (any one exits the loop):**
+- Gate passes → proceed to assertion-shift guardrail.
+- 60 min coding time exhausted → PR blocked (`e2e:blocked`, `needs-human-review`).
+- 5 iterations completed → PR blocked.
+- Same error signature in 3 consecutive iterations → PR blocked + `e2e:stuck-error`.
+- `~/.autospec/stop.flag` present → graceful exit.
+- Loop classifier produces empty action 2 iterations in a row → PR blocked + `e2e:no-action`.
+
+Loop state schema:
+```json
+{
+  "pr_number": 1234,
+  "started_at": "2026-05-21T12:00:00Z",
+  "coding_time_used_seconds": 1842,
+  "iterations": [
+    { "n": 1, "started_at": "...", "ended_at": "...",
+      "classification": "missing_test",
+      "files_changed": ["tests/dashboard.spec.ts"],
+      "gate_passed": false,
+      "error_signature": "sha256:abc..." }
+  ],
+  "last_error_signature": "sha256:abc...",
+  "same_error_consecutive": 2
+}
+```
+
+## Wizard
+
+`/autospec-test --init` walks the operator through first-time setup:
+
+1. Mode selection (strict isolation vs scoped production; strict is the default).
+2. If scoped: scope-token kinds, identifiers, prod URL.
+3. Backup driver detection (probe for `zfs`, `pg_dump`, `mysqldump`, `custom_cmd`). If none detected and Mode II selected, refuse to write `.autospec/test.yml`.
+4. Dry-run preview — print the constraints that will apply; require operator to type `I UNDERSTAND` before writing any files.
+5. Write `.autospec/test.yml` and, for Mode II, the initial `.autospec/.scoped-prod-acked-<sha>.lock`. Operator handles `git add` and push.
+
+The wizard does not run tests. It only produces config. Run `/autospec-test [PR#]` or let `/autospec-run` invoke the gate to exercise the configuration.
+
+## Required capabilities & harness adapter
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                              | Fallback if missing                         |
+|-----------------------------|-----------------------------------------|---------------------------------------|----------------------------------------|---------------------------------------------|
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session               | Run inline (more context cost)              |
+| Shell execution             | `Bash` tool                             | shell tool                            | `apply_patch` + shell                  | Required; skill cannot run without shell    |
+| Read-only codebase research | `Agent` (subagent_type=Explore)         | `task` agent in read-only mode        | shell `grep` / `rg`                    | In-thread grep                              |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                          | Ask in the response and wait               |
+| Subagent model tier         | TIER_B: `sonnet`; TIER_A: `opus` + ultrathink | TIER_B: smaller task model       | TIER_B: `gpt-5.1-codex-spark`          | Fall back UP to TIER_A on unavailability    |
+
+## Stop mode
+
+When the user's request (normalized: collapsed whitespace, trimmed, lowercased) is exactly `stop`, or `stop` followed by one or more `--<word>` flags, this skill enters stop mode and does NOT run the normal pipeline.
+
+Dispatch to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`, print the helper's stdout, then stop.
+
+Inside the self-heal loop, the skill checks `~/.autospec/stop.flag` after each iteration. If present, it writes the current loop state to `.autospec/test-loop-state.json`, comments on the PR with the current iteration summary, and exits without blocking or labeling. The next monitor relaunch will resume from the saved state.

--- a/skills/autospec-test/codex/prompt.md
+++ b/skills/autospec-test/codex/prompt.md
@@ -1,0 +1,194 @@
+
+# autospec-test — Unit + E2E Coverage Gate with Self-Heal Loop
+
+Enforce that every PR produced by `/autospec-run` ships with thorough, passing unit + E2E test coverage against an isolated environment, and that any gaps the gate finds get auto-healed by a bounded LLM loop within the same PR.
+
+## Self-update
+
+Decide this purely from the request text the harness handed you. Do NOT
+shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
+test the user's free-form request — passing it through a shell is what
+historically tripped harness permission engines. Read the request, normalize
+it in your reasoning (collapse whitespace, trim, lowercase), and if the result is
+exactly `update`, this skill enters self-update mode and does NOT run the
+normal pipeline.
+
+1. Detect harness by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-test/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-test.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-test.md`
+2. Re-install from `main` by piping the canonical installer:
+   ```
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-test/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. Show the diff between the prior installed file(s) and the freshly fetched copy.
+4. Stop. Do not enter any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-test found; run install.sh first.` and exit.
+
+## Model tier
+
+`reasoning:standard, ctx:120k`
+
+This skill runs inline inside the Phase 4 implementer worktree (same model tier as the outer implementer) or standalone against a specified PR branch. No Tier A dispatch required for normal operation; the coverage gate and self-heal loop are deterministic or LLM-light.
+
+## When to use
+
+- Automatically: `/autospec-run` Phase 4 invokes this skill after the build + lint gate passes and before admin auto-merge, for every PR that closes an `auto-implement` issue.
+- Standalone: `/autospec-test [PR#]` for ad-hoc validation of any branch or PR against main — useful before filing an issue or after a manual hot-fix.
+- First-time setup: `/autospec-test --init` to interactively configure `.autospec/test.yml` in a target repo.
+
+## When not to use
+
+- When the target repo has no test suite at all (no jest/vitest/mocha/pytest/go test/cargo test found, no Playwright). Use Skill D (suite bootstrapper) first.
+- When clone provisioning is not yet in place and no `E2E_BASE_URL` / `PLAYWRIGHT_BASE_URL` / `BASE_URL` env var is set. The gate will refuse to run (exit 2) rather than silently hit production.
+- When `~/.autospec/no-test.flag` exists (operator opt-out for repos where testing is handled by an external CI system).
+- For repos in the autospec family itself (autospec is a bash/markdown skill repo with no Playwright suite). The skill self-detects and skips gracefully.
+
+## How it works
+
+Two-stage gate runs sequentially inside the Phase 4 worktree:
+
+```
+Phase 4 existing: build + lint
+        │
+        ▼
+Stage 1: unit tests + unit-coverage gate
+        │ (must pass before Stage 2 starts)
+        ▼
+Stage 2: E2E tests + E2E coverage gate
+        │
+        ▼
+Assertion-shift guardrail (covers both stages' test diffs)
+        │
+        ▼
+Auto-merge or block
+```
+
+**Stage 1 — Unit (Metric E):** Code coverage thresholds (defaults 95/90/95 lines/branches/functions), function-presence check (every exported/public function has at least one unit test), and all unit tests pass with no `.only`, `.skip`, or `xit`.
+
+**Stage 2 — E2E:** Three metrics: code coverage from E2E run (Metric A, thresholds 90/85/90), UI element coverage (Metric B — every reachable `button/a/input/select/textarea/[contenteditable]` touched by Playwright), and behavior taxonomy (Metric D — at least one passing test per declared category: sort, scroll, upload, download, filter, paginate, bulk_select, keyboard_nav, drag_drop).
+
+**Self-heal loop:** Up to 5 iterations, 60 minutes of coding time (paused while tests run). Each iteration classifies failures (missing_unit_test, missing_test, failing_unit_test, failing_test, flaky_test, selector_brittle, product_bug) and picks the highest-priority cluster that fits remaining budget. Loop state persisted in `.autospec/test-loop-state.json` in the worktree so monitor relaunches resume rather than reset.
+
+**Assertion-shift guardrail:** AST + regex pass over all modified test files. LOOSENING changes block auto-merge (adds `needs-human-review` + `e2e:assertion-loosening`). SHIFTING is conditionally allowed if the same commit also modifies a non-test source file and includes `JUSTIFICATION:` in the commit message. STRENGTHENING always allowed.
+
+## Contract file
+
+`.autospec/test.yml` in the target repo. Most fields autodetected; the file's primary purpose is declaring **forbidden URLs** (mandatory) and any Mode II opt-in.
+
+Minimal valid contract:
+
+```yaml
+# .autospec/test.yml
+mode: strict_isolation
+
+e2e:
+  clone_url_env: E2E_BASE_URL
+  forbidden_url_patterns:
+    - "^https?://app\\.acme\\.com"
+    - "^https?://.*\\.prod\\.acme\\.internal"
+
+budgets:
+  coding_time_minutes: 60
+  max_loop_iterations: 5
+  same_error_halt_threshold: 3
+```
+
+**Fail-closed:** missing or empty `forbidden_url_patterns` (without `forbidden_url_patterns_intentionally_empty: true`) causes the skill to refuse to run (exit 2, operator-actionable).
+
+**Loop-immutable fields:** the self-heal loop may not edit `.autospec/test.yml`, `.autospec/.scoped-prod-acked-*.lock`, or Playwright config safety-related fields. A pre-commit hook in the worktree enforces this.
+
+Full schema at `schemas/autospec-test-contract.schema.json` in this repo.
+
+## Modes I and II
+
+**Mode I — strict isolation (default):** All test traffic is confined to a clone URL (`E2E_BASE_URL` or equivalent). Three enforcement layers:
+
+1. Pre-flight URL check: every URL-shaped value in Playwright config is matched against `forbidden_url_patterns` before any test runs. Match → hard fail, no tests run.
+2. Runtime network intercept: Playwright global setup injects `context.route('**/*', handler)` that aborts requests whose final URL (post-redirect) matches a forbidden pattern.
+3. Egress allowlist (optional): if `egress_allowlist` declared, runner enforces at netns/container level.
+
+**Mode II — scoped production (opt-in):** Requires `mode: scoped_production` plus `i_understand_this_writes_to_production: true` in the contract, plus `backup:` with a verified pre-suite snapshot and `restore_cmd`. Scope tokens constrain which rows, methods, and routes the test suite may touch. Scope violations trigger immediate restore and batch halt. Two consecutive scope violations across runs auto-quarantine Mode II and require manual re-acknowledgement.
+
+Hard non-negotiables for Mode II (encoded in skill, not user-overridable): no `backup:` → refuse to run; no verified pre-suite snapshot → refuse to run; no `restore_cmd` → refuse to run; scope violation → restore + halt; 2 consecutive violations → quarantine.
+
+## Safety rails
+
+The skill enforces these rails regardless of operator configuration:
+
+- **Fail-closed forbidden URL check:** no `forbidden_url_patterns` → refuse to run (exit 2).
+- **Loop-immutable contract:** self-heal loop cannot weaken safety config files.
+- **LOOSENING block:** any test assertion that becomes less strict blocks auto-merge.
+- **Mode II backup invariants:** see Modes I and II above.
+- **Stop flag respects existing convention:** if `~/.autospec/stop.flag` is present, the skill exits gracefully using the same sentinel path as autospec-stop.
+- **Pre-commit hook:** installed in the worktree before the self-heal loop starts; blocks any loop commit that modifies `.autospec/test.yml` or Playwright safety fields.
+
+## Self-heal loop
+
+Loop anatomy for each iteration:
+
+1. Read gate JSON + `.autospec/test-findings.md` + last 3 iterations' summaries.
+2. Classify each failure: missing_unit_test, missing_test, failing_unit_test, failing_test, flaky_test, selector_brittle, product_bug.
+3. Prioritize: product_bug > missing_unit_test > missing_test > selector_brittle > failing_unit_test > failing_test > flaky_test.
+4. Pick the highest-priority cluster that fits remaining coding budget.
+5. Edit allowed surfaces: unit test files, Playwright test files, product source code, `playwright.config.*` (timeouts/retries/projects only — not safety fields).
+6. Commit with structured message: `test-heal(iter N): <one-line>` plus `CLASSIFICATION:` and `JUSTIFICATION:` lines (required for assertion-shift compliance).
+7. Re-run gate. Green → exit. Red → next iteration.
+
+**Termination conditions (any one exits the loop):**
+- Gate passes → proceed to assertion-shift guardrail.
+- 60 min coding time exhausted → PR blocked (`e2e:blocked`, `needs-human-review`).
+- 5 iterations completed → PR blocked.
+- Same error signature in 3 consecutive iterations → PR blocked + `e2e:stuck-error`.
+- `~/.autospec/stop.flag` present → graceful exit.
+- Loop classifier produces empty action 2 iterations in a row → PR blocked + `e2e:no-action`.
+
+Loop state schema:
+```json
+{
+  "pr_number": 1234,
+  "started_at": "2026-05-21T12:00:00Z",
+  "coding_time_used_seconds": 1842,
+  "iterations": [
+    { "n": 1, "started_at": "...", "ended_at": "...",
+      "classification": "missing_test",
+      "files_changed": ["tests/dashboard.spec.ts"],
+      "gate_passed": false,
+      "error_signature": "sha256:abc..." }
+  ],
+  "last_error_signature": "sha256:abc...",
+  "same_error_consecutive": 2
+}
+```
+
+## Wizard
+
+`/autospec-test --init` walks the operator through first-time setup:
+
+1. Mode selection (strict isolation vs scoped production; strict is the default).
+2. If scoped: scope-token kinds, identifiers, prod URL.
+3. Backup driver detection (probe for `zfs`, `pg_dump`, `mysqldump`, `custom_cmd`). If none detected and Mode II selected, refuse to write `.autospec/test.yml`.
+4. Dry-run preview — print the constraints that will apply; require operator to type `I UNDERSTAND` before writing any files.
+5. Write `.autospec/test.yml` and, for Mode II, the initial `.autospec/.scoped-prod-acked-<sha>.lock`. Operator handles `git add` and push.
+
+The wizard does not run tests. It only produces config. Run `/autospec-test [PR#]` or let `/autospec-run` invoke the gate to exercise the configuration.
+
+## Required capabilities & harness adapter
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                              | Fallback if missing                         |
+|-----------------------------|-----------------------------------------|---------------------------------------|----------------------------------------|---------------------------------------------|
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session               | Run inline (more context cost)              |
+| Shell execution             | `Bash` tool                             | shell tool                            | `apply_patch` + shell                  | Required; skill cannot run without shell    |
+| Read-only codebase research | `Agent` (subagent_type=Explore)         | `task` agent in read-only mode        | shell `grep` / `rg`                    | In-thread grep                              |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                          | Ask in the response and wait               |
+| Subagent model tier         | TIER_B: `sonnet`; TIER_A: `opus` + ultrathink | TIER_B: smaller task model       | TIER_B: `gpt-5.1-codex-spark`          | Fall back UP to TIER_A on unavailability    |
+
+## Stop mode
+
+When the user's request (normalized: collapsed whitespace, trimmed, lowercased) is exactly `stop`, or `stop` followed by one or more `--<word>` flags, this skill enters stop mode and does NOT run the normal pipeline.
+
+Dispatch to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`, print the helper's stdout, then stop.
+
+Inside the self-heal loop, the skill checks `~/.autospec/stop.flag` after each iteration. If present, it writes the current loop state to `.autospec/test-loop-state.json`, comments on the PR with the current iteration summary, and exits without blocking or labeling. The next monitor relaunch will resume from the saved state.

--- a/skills/autospec-test/tests/unit/validate-skill-structure.bats
+++ b/skills/autospec-test/tests/unit/validate-skill-structure.bats
@@ -1,0 +1,356 @@
+#!/usr/bin/env bats
+# skills/autospec-test/tests/unit/validate-skill-structure.bats
+#
+# TDD tests for Phase 10 deliverables:
+#   - skills/autospec-test/validate.sh — structural lint
+#   - skills/autospec-test/SKILL.md — required sections present
+#   - skills/autospec-test/codex/prompt.md — leading blank line
+#
+# Run: bats skills/autospec-test/tests/unit/validate-skill-structure.bats
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../../.." && pwd)"
+    SKILL_DIR="$REPO_ROOT/skills/autospec-test"
+    VALIDATE_SH="$SKILL_DIR/validate.sh"
+    SKILL_MD="$SKILL_DIR/SKILL.md"
+    CODEX_PROMPT="$SKILL_DIR/codex/prompt.md"
+    TMPDIR_TEST="$(mktemp -d /tmp/autospec-validate-bats-XXXXXX)"
+}
+
+teardown() {
+    rm -rf "$TMPDIR_TEST"
+}
+
+# ── validate.sh exists and passes bash -n ─────────────────────────────────────
+
+@test "validate.sh exists" {
+    [ -f "$VALIDATE_SH" ]
+}
+
+@test "validate.sh passes bash syntax check" {
+    bash -n "$VALIDATE_SH"
+}
+
+# ── SKILL.md structural sections ──────────────────────────────────────────────
+
+@test "SKILL.md exists" {
+    [ -f "$SKILL_MD" ]
+}
+
+@test "SKILL.md contains ## Self-update section" {
+    grep -q '^## Self-update' "$SKILL_MD"
+}
+
+@test "SKILL.md contains ## Model tier section" {
+    grep -q '^## Model tier' "$SKILL_MD"
+}
+
+@test "SKILL.md Model tier declares reasoning:standard" {
+    grep -q 'reasoning:standard' "$SKILL_MD"
+}
+
+@test "SKILL.md Model tier declares ctx:120k" {
+    grep -q 'ctx:120k' "$SKILL_MD"
+}
+
+@test "SKILL.md contains ## When to use section" {
+    grep -q '^## When to use' "$SKILL_MD"
+}
+
+@test "SKILL.md contains ## When not to use section" {
+    grep -q '^## When not to use' "$SKILL_MD"
+}
+
+@test "SKILL.md contains ## How it works section" {
+    grep -q '^## How it works' "$SKILL_MD"
+}
+
+@test "SKILL.md contains ## Contract file section" {
+    grep -q '^## Contract file' "$SKILL_MD"
+}
+
+@test "SKILL.md contains ## Modes I and II section" {
+    grep -q '^## Modes I and II' "$SKILL_MD"
+}
+
+@test "SKILL.md contains ## Safety rails section" {
+    grep -q '^## Safety rails' "$SKILL_MD"
+}
+
+@test "SKILL.md contains ## Self-heal loop section" {
+    grep -q '^## Self-heal loop' "$SKILL_MD"
+}
+
+@test "SKILL.md contains ## Wizard section" {
+    grep -q '^## Wizard' "$SKILL_MD"
+}
+
+@test "SKILL.md contains ## Stop mode section (pure prose)" {
+    grep -q '^## Stop mode' "$SKILL_MD"
+}
+
+@test "SKILL.md Stop mode section has no FEATURE_DESCRIPTION heredoc" {
+    # Pure prose: no shell-out of user text (saved-memory lockstep rule 4)
+    # Check for the actual forbidden placeholder form: {FEATURE_DESCRIPTION}
+    run grep '{FEATURE_DESCRIPTION}' "$SKILL_MD"
+    [ "$status" -ne 0 ]
+}
+
+@test "SKILL.md contains forbidden_url_patterns example block (adapter row)" {
+    grep -q 'forbidden_url_patterns' "$SKILL_MD"
+}
+
+@test "SKILL.md has YAML frontmatter with name field" {
+    # Check frontmatter exists with name: autospec-test
+    head -5 "$SKILL_MD" | grep -q '^---'
+    awk '/^---$/{c++; next} c==1{print}' "$SKILL_MD" | grep -q '^name:'
+}
+
+# ── codex/prompt.md leading blank line ───────────────────────────────────────
+
+@test "codex/prompt.md exists" {
+    [ -f "$CODEX_PROMPT" ]
+}
+
+@test "codex/prompt.md starts with a leading blank line (byte-precise)" {
+    # The very first byte of the file must be a newline (leading blank line convention)
+    first_char="$(head -c 1 "$CODEX_PROMPT" | xxd -p)"
+    [ "$first_char" = "0a" ]
+}
+
+@test "codex/prompt.md is not empty after blank line" {
+    line_count="$(wc -l < "$CODEX_PROMPT" | tr -d ' ')"
+    [ "$line_count" -gt 5 ]
+}
+
+# ── validate.sh rejects SKILL.md with missing sections ───────────────────────
+
+@test "validate.sh rejects a SKILL.md missing ## Self-update section" {
+    # Create a fake skill dir with a SKILL.md missing Self-update
+    fake_dir="$TMPDIR_TEST/fake-skill"
+    mkdir -p "$fake_dir/codex"
+    # Write SKILL.md without ## Self-update
+    cat > "$fake_dir/SKILL.md" <<'EOF'
+---
+name: fake-skill
+description: fake
+---
+
+## Model tier
+
+reasoning:standard, ctx:120k
+
+## When to use
+
+Something.
+
+## When not to use
+
+Something.
+
+## How it works
+
+Something.
+
+## Contract file
+
+Something.
+
+## Modes I and II
+
+Something.
+
+## Safety rails
+
+Something.
+
+## Self-heal loop
+
+Something.
+
+## Wizard
+
+Something.
+
+## Stop mode
+
+Pure prose stop mode.
+EOF
+    # Write a valid codex/prompt.md with leading blank line
+    printf '\n# fake-skill\n\nContent.\n' > "$fake_dir/codex/prompt.md"
+    # Run validate.sh against this dir — must exit non-zero
+    run bash "$VALIDATE_SH" --skill-dir "$fake_dir"
+    [ "$status" -ne 0 ]
+}
+
+@test "validate.sh rejects a SKILL.md missing ## Model tier section" {
+    fake_dir="$TMPDIR_TEST/fake-skill-no-model-tier"
+    mkdir -p "$fake_dir/codex"
+    cat > "$fake_dir/SKILL.md" <<'EOF'
+---
+name: fake-skill
+description: fake
+---
+
+## Self-update
+
+Pure prose.
+
+## When to use
+
+Something.
+
+## When not to use
+
+Something.
+
+## How it works
+
+Something.
+
+## Contract file
+
+Something.
+
+## Modes I and II
+
+Something.
+
+## Safety rails
+
+Something.
+
+## Self-heal loop
+
+Something.
+
+## Wizard
+
+Something.
+
+## Stop mode
+
+Pure prose stop mode.
+EOF
+    printf '\n# fake-skill\n\nContent.\n' > "$fake_dir/codex/prompt.md"
+    run bash "$VALIDATE_SH" --skill-dir "$fake_dir"
+    [ "$status" -ne 0 ]
+}
+
+@test "validate.sh rejects codex/prompt.md without leading blank line" {
+    fake_dir="$TMPDIR_TEST/fake-skill-no-blank"
+    mkdir -p "$fake_dir/codex"
+    # Full valid SKILL.md
+    cat > "$fake_dir/SKILL.md" <<'EOF'
+---
+name: fake-skill
+description: fake
+---
+
+## Self-update
+
+Pure prose.
+
+## Model tier
+
+reasoning:standard, ctx:120k
+
+## When to use
+
+Something.
+
+## When not to use
+
+Something.
+
+## How it works
+
+Something.
+
+## Contract file
+
+Something.
+
+## Modes I and II
+
+Something.
+
+## Safety rails
+
+Something.
+
+## Self-heal loop
+
+Something.
+
+## Wizard
+
+Something.
+
+## Stop mode
+
+Pure prose stop mode.
+EOF
+    # codex/prompt.md WITHOUT leading blank line
+    printf '# fake-skill\n\nContent.\n' > "$fake_dir/codex/prompt.md"
+    run bash "$VALIDATE_SH" --skill-dir "$fake_dir"
+    [ "$status" -ne 0 ]
+}
+
+@test "validate.sh accepts valid SKILL.md and codex/prompt.md" {
+    fake_dir="$TMPDIR_TEST/fake-skill-valid"
+    mkdir -p "$fake_dir/codex"
+    cat > "$fake_dir/SKILL.md" <<'EOF'
+---
+name: fake-skill
+description: fake
+---
+
+## Self-update
+
+Pure prose self-update section.
+
+## Model tier
+
+reasoning:standard, ctx:120k
+
+## When to use
+
+Something.
+
+## When not to use
+
+Something.
+
+## How it works
+
+Something.
+
+## Contract file
+
+forbidden_url_patterns example block here.
+
+## Modes I and II
+
+Something.
+
+## Safety rails
+
+Something.
+
+## Self-heal loop
+
+Something.
+
+## Wizard
+
+Something.
+
+## Stop mode
+
+Pure prose stop mode. No shell-out placeholders.
+EOF
+    printf '\n# fake-skill\n\nContent.\n' > "$fake_dir/codex/prompt.md"
+    run bash "$VALIDATE_SH" --skill-dir "$fake_dir"
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-test/validate.sh
+++ b/skills/autospec-test/validate.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# skills/autospec-test/validate.sh — per-skill structural lint for autospec-test.
+#
+# Checks:
+#   1. SKILL.md contains every required structural section in correct order.
+#   2. SKILL.md frontmatter is valid YAML with a `name:` field.
+#   3. SKILL.md has no {FEATURE_DESCRIPTION} shell-out placeholders (pure-prose rule).
+#   4. codex/prompt.md starts with a leading blank line (byte-precise).
+#   5. SKILL.md contains a forbidden_url_patterns example block (adapter row).
+#   6. SKILL.md Model tier declares reasoning:standard and ctx:120k.
+#
+# Usage:
+#   bash skills/autospec-test/validate.sh [--skill-dir <path>]
+#
+# Exit 0 = all checks pass.
+# Exit 1 = at least one check failed (diagnostic printed to stderr).
+
+set -eu
+
+fail() {
+    printf 'autospec-test/validate: FAIL — %s\n' "$*" >&2
+    exit 1
+}
+
+info() {
+    printf 'autospec-test/validate: %s\n' "$*"
+}
+
+# Resolve skill dir: --skill-dir <path> overrides the default (this script's parent).
+SKILL_DIR=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --skill-dir)
+            SKILL_DIR="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+if [ -z "$SKILL_DIR" ]; then
+    SKILL_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
+
+SKILL_MD="$SKILL_DIR/SKILL.md"
+CODEX_PROMPT="$SKILL_DIR/codex/prompt.md"
+
+# ── 1. Required files exist ───────────────────────────────────────────────────
+info "checking required files exist"
+[ -f "$SKILL_MD" ]      || fail "SKILL.md missing at $SKILL_MD"
+[ -f "$CODEX_PROMPT" ]  || fail "codex/prompt.md missing at $CODEX_PROMPT"
+
+# ── 2. SKILL.md: required structural sections (in order) ─────────────────────
+info "checking required structural sections in SKILL.md"
+
+REQUIRED_SECTIONS=(
+    "## Self-update"
+    "## Model tier"
+    "## When to use"
+    "## When not to use"
+    "## How it works"
+    "## Contract file"
+    "## Modes I and II"
+    "## Safety rails"
+    "## Self-heal loop"
+    "## Wizard"
+    "## Stop mode"
+)
+
+last_line=0
+for section in "${REQUIRED_SECTIONS[@]}"; do
+    line_num=$(grep -n "^${section}" "$SKILL_MD" | head -1 | cut -d: -f1)
+    if [ -z "$line_num" ]; then
+        fail "SKILL.md missing required section: '$section'"
+    fi
+    if [ "$line_num" -le "$last_line" ]; then
+        fail "SKILL.md section '$section' appears out of order (line $line_num, expected after $last_line)"
+    fi
+    last_line="$line_num"
+done
+info "all required sections present and in order"
+
+# ── 3. SKILL.md: Model tier declares reasoning:standard and ctx:120k ─────────
+info "checking Model tier declarations in SKILL.md"
+grep -q 'reasoning:standard' "$SKILL_MD" \
+    || fail "SKILL.md Model tier missing 'reasoning:standard' declaration"
+grep -q 'ctx:120k' "$SKILL_MD" \
+    || fail "SKILL.md Model tier missing 'ctx:120k' declaration"
+
+# ── 4. SKILL.md: No {FEATURE_DESCRIPTION} shell-out (pure-prose rule) ────────
+info "checking for forbidden FEATURE_DESCRIPTION placeholder in SKILL.md"
+if grep -q '{FEATURE_DESCRIPTION}' "$SKILL_MD"; then
+    fail "SKILL.md contains forbidden '{FEATURE_DESCRIPTION}' placeholder (Stop/Self-update sections must be pure prose)"
+fi
+
+# ── 5. SKILL.md: forbidden_url_patterns example block (adapter row) ──────────
+info "checking forbidden_url_patterns example block in SKILL.md"
+grep -q 'forbidden_url_patterns' "$SKILL_MD" \
+    || fail "SKILL.md missing forbidden_url_patterns example block (required adapter row content)"
+
+# ── 6. SKILL.md: YAML frontmatter with name: field ───────────────────────────
+info "checking SKILL.md frontmatter"
+fm="$(awk 'BEGIN{in_fm=0} /^---$/{in_fm++; if(in_fm==1) next; if(in_fm==2) exit} in_fm==1{print}' "$SKILL_MD")"
+if [ -z "$fm" ]; then
+    fail "SKILL.md missing or empty YAML frontmatter"
+fi
+printf '%s\n' "$fm" | grep -q '^name:' \
+    || fail "SKILL.md frontmatter missing 'name:' field"
+if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" 2>/dev/null; then
+    printf '%s\n' "$fm" | python3 -c "import sys, yaml; yaml.safe_load(sys.stdin.read())" \
+        || fail "SKILL.md frontmatter is not valid YAML"
+fi
+
+# ── 7. codex/prompt.md: leading blank line (byte-precise) ────────────────────
+info "checking codex/prompt.md leading blank line"
+first_char="$(head -c 1 "$CODEX_PROMPT" | xxd -p 2>/dev/null || od -An -tx1 -N1 "$CODEX_PROMPT" | tr -d ' \n')"
+if [ "$first_char" != "0a" ]; then
+    fail "codex/prompt.md does not start with a leading blank line (first byte: $first_char, expected 0a)"
+fi
+
+info "OK — all autospec-test structural checks passed."


### PR DESCRIPTION
Closes #328

## Summary

Ships the final Phase 10 deliverables that register `autospec-test` as a top-level autospec skill:

- **`skills/autospec-test/SKILL.md`** — full structural sections in required order: `## Self-update`, `## Model tier` (declaring `reasoning:standard, ctx:120k`), `## When to use`, `## When not to use`, `## How it works`, `## Contract file`, `## Modes I and II`, `## Safety rails`, `## Self-heal loop`, `## Wizard`, adapter row block, `## Stop mode` (pure prose — no `{FEATURE_DESCRIPTION}` heredocs).
- **`skills/autospec-test/codex/prompt.md`** — leading blank line (byte `0x0a`); mirrors SKILL.md body in codex tone.
- **`skills/autospec-test/validate.sh`** — per-skill structural lint: checks section presence/order, `reasoning:standard`/`ctx:120k` declarations, forbidden `{FEATURE_DESCRIPTION}` placeholder, `forbidden_url_patterns` adapter row, frontmatter validity, and codex/prompt.md leading blank line byte-precisely.
- **`skills/autospec-test/tests/unit/validate-skill-structure.bats`** — 26 TDD bats tests (all passing) covering each structural check including accept/reject cases.
- **`scripts/validate.sh`** — extended with `check_autospec_test_skill_present()` so top-level validate invokes the per-skill lint on every CI run.
- **`README.md`** — `autospec-test` added to the skills table.
- **`SKILLS.md`** — `autospec-test` entry with trigger, activation keywords, harness list, and status.
- **`docs/target-repo-setup.md`** — "How to enable autospec-test" section covering Playwright install, `.autospec/test.yml` authoring, wizard usage, and label semantics.

## Lockstep compliance

All 5 saved-memory lockstep rules honored:
1. SKILL.md has all structural sections; `## Self-update` and `## Stop mode` are pure prose.
2. `codex/prompt.md` first byte is `0x0a` (verified by `xxd`).
3. `validate.sh` named-content checks updated — `check_autospec_test_skill_present` added.
4. No `{FEATURE_DESCRIPTION}` heredocs in any section.
5. No RETURN traps; no `[ test ] && action` one-sided conditionals under `set -e`.

## Test plan

- [x] `bash scripts/validate.sh` — all checks pass including new `autospec-test skill structural lint`
- [x] `bash skills/autospec-test/validate.sh` — OK
- [x] `bats skills/autospec-test/tests/unit/validate-skill-structure.bats` — 26/26 pass
- [x] `grep -n "autospec-test" README.md docs/target-repo-setup.md` — both present
- [x] `head -1 skills/autospec-test/codex/prompt.md | xxd` — first byte `0a`