### PR TITLE
feat(autospec-test): v2 contract extension + JSON Schema (phase 1)

### DIFF
--- a/schemas/autospec-test-contract.schema.json
+++ b/schemas/autospec-test-contract.schema.json
@@ -181,6 +181,272 @@
             "refuse_to_run_without_backup": { "type": "boolean" }
           },
           "additionalProperties": false
+        },
+        "invariants_v2": {
+          "type": "object",
+          "description": "v2 Stage 2.5 invariants, window contracts, extended crawler, and contract symmetry. All v2 fields nest here to avoid clobbering v1 e2e.* fields.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Master switch. When false, Stage 2.5 is skipped entirely."
+            },
+            "invariants": {
+              "type": "array",
+              "description": "Metric F — Structural invariants. Each entry is a kind-tagged invariant declaration.",
+              "items": {
+                "type": "object",
+                "required": ["id", "kind", "apply_on_routes"],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Unique identifier for this invariant."
+                  },
+                  "kind": {
+                    "type": "string",
+                    "description": "Invariant kind. Built-in: every_visible_X_is_Y, every_foldout_opens_all_nested, every_row_has_required_actions, every_visible_X_has_accessible_name, every_modal_returns_to_body_scroll. Custom kinds registered via .autospec/invariant-kinds/<name>.mjs."
+                  },
+                  "apply_on_routes": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "minItems": 1,
+                    "description": "Routes where this invariant is enforced. Each entry must start with /."
+                  },
+                  "require_count_at_least": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Minimum number of elements the selector must match. Prevents vacuous truth."
+                  },
+                  "visible": {
+                    "type": "string",
+                    "description": "CSS/Playwright selector for the visible element (every_visible_X_is_Y)."
+                  },
+                  "action": {
+                    "type": "string",
+                    "description": "Selector for the action element within the visible element."
+                  },
+                  "verifies_open": {
+                    "type": "string",
+                    "description": "Selector that must be visible after clicking action."
+                  },
+                  "verifies_close": {
+                    "type": "string",
+                    "description": "Selector to click to close the opened element."
+                  },
+                  "foldout": {
+                    "type": "string",
+                    "description": "Selector for foldout elements (every_foldout_opens_all_nested)."
+                  },
+                  "nested_must_be_visible_after_open": {
+                    "type": "string",
+                    "description": "Selector for nested elements that must be visible after opening the foldout."
+                  },
+                  "row": {
+                    "type": "string",
+                    "description": "Selector for row elements (every_row_has_required_actions)."
+                  },
+                  "required_actions": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "List of action selectors that must be present on each row."
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "window_contracts": {
+              "type": "array",
+              "description": "Metric G — Window-contract symmetry declarations.",
+              "items": {
+                "type": "object",
+                "required": ["id", "ui_display", "api_query", "mismatch_action"],
+                "properties": {
+                  "id": { "type": "string" },
+                  "ui_display": {
+                    "type": "object",
+                    "required": ["route", "widget", "window_days_attr"],
+                    "properties": {
+                      "route": { "type": "string" },
+                      "widget": { "type": "string" },
+                      "window_days_attr": { "type": "string" }
+                    },
+                    "additionalProperties": false
+                  },
+                  "api_query": {
+                    "type": "object",
+                    "required": ["method", "path_pattern", "recorded_via"],
+                    "properties": {
+                      "method": { "type": "string" },
+                      "path_pattern": { "type": "string" },
+                      "window_params": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "type": { "type": "string" },
+                            "must_be": { "type": "string" },
+                            "tolerance_days": { "type": "integer", "minimum": 0 }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "recorded_via": {
+                        "type": "string",
+                        "enum": ["network_intercept"]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "mismatch_action": {
+                    "type": "string",
+                    "enum": ["hard_fail", "warn_only"]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "crawler": {
+              "type": "object",
+              "description": "Metric H — Extended crawler configuration.",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "bfs_max_routes": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Maximum number of routes to crawl via BFS."
+                },
+                "open_all_foldouts": {
+                  "type": "boolean",
+                  "description": "When true, all foldouts are opened before checking affordances."
+                },
+                "affordance_patterns": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["element"],
+                    "properties": {
+                      "element": { "type": "string" },
+                      "opens": { "type": "string" },
+                      "closes_via": { "type": "string" }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "failure_threshold": {
+                  "type": "object",
+                  "properties": {
+                    "max_unaffordable_elements": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "contract_symmetry": {
+              "type": "array",
+              "description": "Metric I — Data-source contract symmetry declarations.",
+              "items": {
+                "type": "object",
+                "required": ["id", "ui_source", "api_target", "mismatch_action"],
+                "properties": {
+                  "id": { "type": "string" },
+                  "ui_source": {
+                    "type": "object",
+                    "required": ["route", "extract"],
+                    "properties": {
+                      "route": { "type": "string" },
+                      "extract": { "type": "string" },
+                      "per_match": {
+                        "type": "object",
+                        "additionalProperties": { "type": "string" }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "api_target": {
+                    "type": "object",
+                    "required": ["method", "path_template"],
+                    "properties": {
+                      "method": { "type": "string" },
+                      "path_template": { "type": "string" },
+                      "must_contain": { "type": "string" },
+                      "must_be_editable": { "type": "string" }
+                    },
+                    "additionalProperties": false
+                  },
+                  "mismatch_action": {
+                    "type": "string",
+                    "enum": ["hard_fail", "warn_only"]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "edge_case_seeds": {
+              "type": "object",
+              "description": "Edge-case seed declarations. Named entity keys hold require_shapes arrays. enforcement key controls behavior when seeds are missing.",
+              "properties": {
+                "enforcement": {
+                  "type": "string",
+                  "enum": ["refuse_to_run_if_missing", "warn_if_missing", "skip_if_missing"],
+                  "description": "What to do when declared seed shapes are not provisioned."
+                }
+              },
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "require_shapes": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["name", "count_min"],
+                          "properties": {
+                            "name": { "type": "string" },
+                            "count_min": { "type": "integer", "minimum": 0 }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  { "type": "string" }
+                ]
+              }
+            },
+            "thresholds": {
+              "type": "object",
+              "description": "Pass-rate thresholds for each metric (0-100).",
+              "properties": {
+                "invariants_required_pass_rate": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "window_contracts_required_pass_rate": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "crawler_required_pass_rate": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "contract_symmetry_required_pass_rate": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/skills/autospec-test/scripts/validate-contract.sh
+++ b/skills/autospec-test/scripts/validate-contract.sh
@@ -32,6 +32,45 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 DEFAULT_SCHEMA="$REPO_ROOT/schemas/autospec-test-contract.schema.json"
 
+# _v2_route_covered_by_patterns <route> <patterns_newline_sep>
+# Returns 0 if route matches at least one pattern (anchors stripped), 1 otherwise.
+_v2_route_covered_by_patterns() {
+    local route="$1" patterns="$2" pattern clean_pattern
+    while IFS= read -r pattern; do
+        [ -z "$pattern" ] && continue
+        clean_pattern="${pattern#^}"
+        clean_pattern="${clean_pattern%\$}"
+        if echo "$route" | grep -qE "$clean_pattern" 2>/dev/null; then
+            return 0
+        fi
+    done <<< "$patterns"
+    return 1
+}
+
+# _v2_check_scope_routes <json_data>
+# Rule f: in scoped_production mode, every apply_on_routes entry must match a
+# route_filter allowed_path_pattern. Exits 2 on violation.
+_v2_check_scope_routes() {
+    local json_data="$1"
+    local allowed_patterns all_routes route
+    allowed_patterns=$(printf '%s' "$json_data" | jq -r '
+        [ .e2e.production_scoped_access.scope_tokens[]?
+          | select(.kind == "route_filter")
+          | .allowed_path_patterns[]? ] | .[]
+    ' 2>/dev/null || true)
+    [ -z "$allowed_patterns" ] && return 0
+    all_routes=$(printf '%s' "$json_data" | jq -r '
+        [ .e2e.invariants_v2.invariants[]?.apply_on_routes[]? ] | .[]
+    ' 2>/dev/null || true)
+    while IFS= read -r route; do
+        [ -z "$route" ] && continue
+        if ! _v2_route_covered_by_patterns "$route" "$allowed_patterns"; then
+            printf 'validate-contract: refuse-to-run: mode=scoped_production: apply_on_routes "%s" not covered by any route_filter allowed_path_patterns\n' "$route" >&2
+            exit 2
+        fi
+    done <<< "$all_routes"
+}
+
 validate_contract() {
     local input_file="${1:--}"
     local schema_file="${2:-$DEFAULT_SCHEMA}"
@@ -181,40 +220,9 @@ try {
 
         # ── Rule f: scope-allowed-routes (Mode II only) ───────────────────────
         # When mode=scoped_production + invariants_v2.enabled=true,
-        # all apply_on_routes must be a prefix-match subset of allowed_path_patterns
+        # all apply_on_routes must be covered by route_filter allowed_path_patterns
         if [ "$mode" = "scoped_production" ]; then
-            local allowed_patterns
-            allowed_patterns=$(printf '%s' "$json_data" | jq -r '
-                [ .e2e.production_scoped_access.scope_tokens[]?
-                  | select(.kind == "route_filter")
-                  | .allowed_path_patterns[]? ] | .[]
-            ' 2>/dev/null || true)
-
-            if [ -n "$allowed_patterns" ]; then
-                local all_routes
-                all_routes=$(printf '%s' "$json_data" | jq -r '
-                    [ .e2e.invariants_v2.invariants[]?.apply_on_routes[]? ] | .[]
-                ' 2>/dev/null || true)
-
-                while IFS= read -r route; do
-                    [ -z "$route" ] && continue
-                    local matched=0
-                    while IFS= read -r pattern; do
-                        [ -z "$pattern" ] && continue
-                        # Strip anchors for prefix matching
-                        local clean_pattern="${pattern#^}"
-                        clean_pattern="${clean_pattern%$}"
-                        if echo "$route" | grep -qE "$clean_pattern" 2>/dev/null; then
-                            matched=1
-                            break
-                        fi
-                    done <<< "$allowed_patterns"
-                    if [ "$matched" = "0" ]; then
-                        printf 'validate-contract: refuse-to-run: mode=scoped_production: apply_on_routes entry "%s" is not covered by any route_filter allowed_path_patterns\n' "$route" >&2
-                        exit 2
-                    fi
-                done <<< "$all_routes"
-            fi
+            _v2_check_scope_routes "$json_data"
         fi
 
     fi

--- a/skills/autospec-test/scripts/validate-contract.sh
+++ b/skills/autospec-test/scripts/validate-contract.sh
@@ -8,6 +8,7 @@
 #   0 = valid contract
 #   1 = fatal error (missing tool, unreadable file, internal error)
 #   2 = refuse-to-run: contract is invalid or missing required fields (operator-actionable)
+#   3 = shape-missing: edge_case_seeds enforcement=refuse_to_run_if_missing but no require_shapes provided
 #
 # Validation steps:
 #   1. JSON Schema validation via `ajv validate`
@@ -16,6 +17,13 @@
 #         AND e2e.backup.driver AND e2e.backup.restore_cmd
 #      b. Fail-closed rule: e2e.forbidden_url_patterns=[] without
 #         e2e.forbidden_url_patterns_intentionally_empty=true → exit 2
+#   3. v2 invariants_v2 cross-field rules:
+#      c. enabled-requires-metrics: invariants_v2.enabled=true requires at least one non-empty metric block
+#      d. refuse-requires-shapes: edge_case_seeds.enforcement=refuse_to_run_if_missing requires
+#         at least one entity with non-empty require_shapes → exit 3
+#      e. leading-slash-routes: all apply_on_routes entries must start with /
+#      f. scope-allowed-routes: when mode=scoped_production + invariants_v2.enabled=true,
+#         apply_on_routes must be a subset of scope_tokens route_filter allowed_path_patterns
 
 set -eu
 
@@ -55,17 +63,45 @@ validate_contract() {
     fi
 
     # Write to temp file for ajv (which needs a file argument)
+    # Use mktemp -t for macOS/BSD compatibility (no .json extension in template)
     local tmpfile
-    tmpfile=$(mktemp /tmp/autospec-test-contract-XXXXXX.json)
+    tmpfile=$(mktemp -t autospec-test-contract)
     # shellcheck disable=SC2064
     trap "rm -f '$tmpfile'" EXIT
     printf '%s' "$json_data" > "$tmpfile"
 
     # ── Step 1: JSON Schema validation ────────────────────────────────────────
-    local ajv_out
-    if ! ajv_out=$(ajv validate -s "$schema_file" -d "$tmpfile" --spec=draft2020 2>&1); then
-        printf 'validate-contract: schema validation failed:\n%s\n' "$ajv_out" >&2
-        exit 2
+    # ajv-cli 5.x --spec=draft2020 flag has a known CLI parsing bug; use Node/Ajv2020
+    # directly (the same module ajv-cli ships) for reliable draft-2020-12 validation.
+    local ajv_node
+    ajv_node=$(node -e "
+try {
+  var fs = require('fs');
+  // Prefer ajv-cli's bundled Ajv2020; fall back to system ajv
+  var Ajv2020;
+  try { Ajv2020 = require('ajv/dist/2020'); }
+  catch(e) {
+    var paths = [
+      '/opt/homebrew/lib/node_modules/ajv-cli/node_modules/ajv/dist/2020',
+      '/usr/local/lib/node_modules/ajv-cli/node_modules/ajv/dist/2020'
+    ];
+    for (var i = 0; i < paths.length; i++) {
+      try { Ajv2020 = require(paths[i]); break; } catch(e2) {}
+    }
+  }
+  if (!Ajv2020) { console.error('ajv/dist/2020 not found'); process.exit(1); }
+  var schema = JSON.parse(fs.readFileSync('$schema_file', 'utf8'));
+  var data   = JSON.parse(fs.readFileSync('$tmpfile',     'utf8'));
+  var ajv    = new Ajv2020({strict: false, allErrors: true});
+  var valid  = ajv.validate(schema, data);
+  if (valid) { console.log('valid'); process.exit(0); }
+  else { console.error(ajv.errorsText()); process.exit(2); }
+} catch(e) { console.error(e.message); process.exit(1); }
+" 2>&1)
+    local ajv_rc=$?
+    if [ "$ajv_rc" -ne 0 ]; then
+        printf 'validate-contract: schema validation failed:\n%s\n' "$ajv_node" >&2
+        exit "$ajv_rc"
     fi
 
     # ── Step 2a: Mode II conjunction check ────────────────────────────────────
@@ -107,6 +143,102 @@ validate_contract() {
         if [ "$ack_empty" != "true" ]; then
             printf 'validate-contract: refuse-to-run: e2e.forbidden_url_patterns is empty or missing without explicit ack. Set forbidden_url_patterns to at least one pattern, or set forbidden_url_patterns_intentionally_empty=true to acknowledge no URL restrictions apply.\n' >&2
             exit 2
+        fi
+    fi
+
+    # ── Step 3: v2 invariants_v2 cross-field rules ────────────────────────────
+    local v2_enabled
+    v2_enabled=$(printf '%s' "$json_data" | jq -r '.e2e.invariants_v2.enabled // false')
+
+    if [ "$v2_enabled" = "true" ]; then
+
+        # ── Rule c: enabled-requires-metrics ──────────────────────────────────
+        # At least one of: invariants (non-empty array), window_contracts (non-empty array),
+        # crawler.enabled=true, contract_symmetry (non-empty array)
+        local inv_count wc_count crawler_on cs_count
+        inv_count=$(printf '%s' "$json_data" | jq '.e2e.invariants_v2.invariants | length // 0')
+        wc_count=$(printf '%s' "$json_data" | jq '.e2e.invariants_v2.window_contracts | length // 0')
+        crawler_on=$(printf '%s' "$json_data" | jq -r '.e2e.invariants_v2.crawler.enabled // false')
+        cs_count=$(printf '%s' "$json_data" | jq '.e2e.invariants_v2.contract_symmetry | length // 0')
+
+        if [ "$inv_count" = "0" ] && [ "$wc_count" = "0" ] && [ "$crawler_on" != "true" ] && [ "$cs_count" = "0" ]; then
+            printf 'validate-contract: refuse-to-run: e2e.invariants_v2.enabled=true but no metric block is populated (invariants, window_contracts, crawler, or contract_symmetry must have at least one entry)\n' >&2
+            exit 2
+        fi
+
+        # ── Rule e: leading-slash-routes ──────────────────────────────────────
+        # All apply_on_routes entries must start with /
+        local bad_routes
+        bad_routes=$(printf '%s' "$json_data" | jq -r '
+            [ .e2e.invariants_v2.invariants[]?.apply_on_routes[]? ] |
+            map(select(startswith("/") | not)) |
+            .[]
+        ' 2>/dev/null || true)
+        if [ -n "$bad_routes" ]; then
+            printf 'validate-contract: refuse-to-run: all apply_on_routes entries must start with /. Found invalid routes:\n%s\n' "$bad_routes" >&2
+            exit 2
+        fi
+
+        # ── Rule f: scope-allowed-routes (Mode II only) ───────────────────────
+        # When mode=scoped_production + invariants_v2.enabled=true,
+        # all apply_on_routes must be a prefix-match subset of allowed_path_patterns
+        if [ "$mode" = "scoped_production" ]; then
+            local allowed_patterns
+            allowed_patterns=$(printf '%s' "$json_data" | jq -r '
+                [ .e2e.production_scoped_access.scope_tokens[]?
+                  | select(.kind == "route_filter")
+                  | .allowed_path_patterns[]? ] | .[]
+            ' 2>/dev/null || true)
+
+            if [ -n "$allowed_patterns" ]; then
+                local all_routes
+                all_routes=$(printf '%s' "$json_data" | jq -r '
+                    [ .e2e.invariants_v2.invariants[]?.apply_on_routes[]? ] | .[]
+                ' 2>/dev/null || true)
+
+                while IFS= read -r route; do
+                    [ -z "$route" ] && continue
+                    local matched=0
+                    while IFS= read -r pattern; do
+                        [ -z "$pattern" ] && continue
+                        # Strip anchors for prefix matching
+                        local clean_pattern="${pattern#^}"
+                        clean_pattern="${clean_pattern%$}"
+                        if echo "$route" | grep -qE "$clean_pattern" 2>/dev/null; then
+                            matched=1
+                            break
+                        fi
+                    done <<< "$allowed_patterns"
+                    if [ "$matched" = "0" ]; then
+                        printf 'validate-contract: refuse-to-run: mode=scoped_production: apply_on_routes entry "%s" is not covered by any route_filter allowed_path_patterns\n' "$route" >&2
+                        exit 2
+                    fi
+                done <<< "$all_routes"
+            fi
+        fi
+
+    fi
+
+    # ── Rule d: refuse-requires-shapes ────────────────────────────────────────
+    # Runs regardless of enabled flag — enforcement is a declaration-level contract
+    local enforcement
+    enforcement=$(printf '%s' "$json_data" | jq -r '.e2e.invariants_v2.edge_case_seeds.enforcement // empty')
+
+    if [ "$enforcement" = "refuse_to_run_if_missing" ]; then
+        # Count total require_shapes entries across all entity keys (excluding "enforcement")
+        local total_shapes
+        total_shapes=$(printf '%s' "$json_data" | jq '
+            [ .e2e.invariants_v2.edge_case_seeds
+              | to_entries[]
+              | select(.key != "enforcement")
+              | .value.require_shapes?
+              | length? // 0
+            ] | add // 0
+        ' 2>/dev/null || echo "0")
+
+        if [ "$total_shapes" = "0" ]; then
+            printf 'validate-contract: shape-missing: edge_case_seeds.enforcement=refuse_to_run_if_missing but no entity with non-empty require_shapes found. Provision seed shapes or change enforcement to warn_if_missing/skip_if_missing.\n' >&2
+            exit 3
         fi
     fi
 

--- a/skills/autospec-test/tests/fixtures/contracts/v2/all-metrics.yml
+++ b/skills/autospec-test/tests/fixtures/contracts/v2/all-metrics.yml
@@ -1,0 +1,118 @@
+# all-metrics.yml — all four metric blocks (F/G/H/I) plus edge_case_seeds
+# Expected: validate-contract.sh exits 0, ajv accepts
+
+mode: strict_isolation
+
+e2e:
+  forbidden_url_patterns:
+    - "^https?://app\\.acme\\.com"
+  clone_url_env: E2E_BASE_URL
+
+  invariants_v2:
+    enabled: true
+
+    # Metric F — Structural invariants
+    invariants:
+      - id: dashboard-done-items-editable
+        kind: every_visible_X_is_Y
+        visible: '[data-testid^="done-item-row-"]'
+        action: 'role=button[name=/edit/i]'
+        verifies_open: '[data-testid="done-item-edit-dialog"]'
+        verifies_close: 'role=button[name=/close/i]'
+        apply_on_routes:
+          - /dashboard
+          - /family
+        require_count_at_least: 1
+      - id: foldouts-all-open
+        kind: every_foldout_opens_all_nested
+        foldout: '[data-testid^="day-foldout-"]'
+        nested_must_be_visible_after_open: '[data-testid^="day-foldout-row-"]'
+        apply_on_routes:
+          - /dashboard
+      - id: list-items-have-actions
+        kind: every_row_has_required_actions
+        row: '[data-testid^="task-row-"]'
+        required_actions:
+          - 'role=button[name=/edit/i]'
+          - 'role=button[name=/delete/i]'
+        apply_on_routes:
+          - /tasks
+
+    # Metric G — Window-contract symmetry
+    window_contracts:
+      - id: dashboard-streak-window
+        ui_display:
+          route: /dashboard
+          widget: '[data-testid=streak-widget]'
+          window_days_attr: data-window-days
+        api_query:
+          method: GET
+          path_pattern: '^/api/household/timeline$'
+          window_params:
+            from:
+              type: iso_date
+              must_be: 'today - $N days'
+              tolerance_days: 1
+            to:
+              type: iso_date
+              must_be: today
+              tolerance_days: 1
+          recorded_via: network_intercept
+        mismatch_action: hard_fail
+
+    # Metric H — Extended crawler
+    crawler:
+      enabled: true
+      bfs_max_routes: 200
+      open_all_foldouts: true
+      affordance_patterns:
+        - element: '[data-testid^="done-item-row-"] role=button[name=/edit/i]'
+          opens: '[data-testid="done-item-edit-dialog"]'
+          closes_via: 'role=button[name=/close/i]'
+        - element: '[data-testid^="task-row-"] role=button[name=/delete/i]'
+          opens: '[data-testid="confirm-delete-dialog"]'
+          closes_via: 'role=button[name=/cancel/i]'
+      failure_threshold:
+        max_unaffordable_elements: 0
+
+    # Metric I — Data-source contract symmetry
+    contract_symmetry:
+      - id: streak-task-must-be-editable
+        ui_source:
+          route: /dashboard
+          extract: '[data-testid^="streak-task-"]'
+          per_match:
+            task_id: data-task-id
+            date: data-date
+        api_target:
+          method: GET
+          path_template: '/api/household/timeline?from=${date}&to=${date}&member_id=current'
+          must_contain: '$.events[?(@.task_id=="${task_id}")]'
+          must_be_editable: '$.events[?(@.task_id=="${task_id}")].editable == true'
+        mismatch_action: hard_fail
+
+    # Edge-case seeds
+    edge_case_seeds:
+      household_test_family:
+        require_shapes:
+          - name: task_done_today
+            count_min: 1
+          - name: task_done_yesterday
+            count_min: 1
+          - name: task_done_2_to_6_days_ago
+            count_min: 5
+          - name: task_done_around_midnight
+            count_min: 1
+          - name: multiple_tasks_same_day
+            count_min: 1
+          - name: task_in_collapsed_foldout
+            count_min: 1
+          - name: last_item_in_long_list
+            count_min: 1
+      enforcement: refuse_to_run_if_missing
+
+    thresholds:
+      invariants_required_pass_rate: 100
+      window_contracts_required_pass_rate: 100
+      crawler_required_pass_rate: 100
+      contract_symmetry_required_pass_rate: 100

--- a/skills/autospec-test/tests/fixtures/contracts/v2/invalid-shapes.yml
+++ b/skills/autospec-test/tests/fixtures/contracts/v2/invalid-shapes.yml
@@ -1,0 +1,25 @@
+# invalid-shapes.yml — enforcement=refuse_to_run_if_missing with no entity key at all
+# (edge_case_seeds has only enforcement, no entity with require_shapes)
+# Expected: validate-contract.sh exits 3 (shape-missing), stderr mentions "shape"
+
+mode: strict_isolation
+
+e2e:
+  forbidden_url_patterns:
+    - "^https?://app\\.acme\\.com"
+  clone_url_env: E2E_BASE_URL
+
+  invariants_v2:
+    enabled: true
+    invariants:
+      - id: items-editable
+        kind: every_visible_X_is_Y
+        visible: '[data-testid^="item-row-"]'
+        action: 'role=button[name=/edit/i]'
+        apply_on_routes:
+          - /tasks
+        require_count_at_least: 1
+    edge_case_seeds:
+      enforcement: refuse_to_run_if_missing
+    thresholds:
+      invariants_required_pass_rate: 100

--- a/skills/autospec-test/tests/fixtures/contracts/v2/minimal-v2.yml
+++ b/skills/autospec-test/tests/fixtures/contracts/v2/minimal-v2.yml
@@ -1,0 +1,21 @@
+# minimal-v2.yml — minimal valid v2 contract with one Metric F invariant
+# Expected: validate-contract.sh exits 0, ajv accepts
+
+mode: strict_isolation
+
+e2e:
+  forbidden_url_patterns:
+    - "^https?://app\\.acme\\.com"
+  clone_url_env: E2E_BASE_URL
+  invariants_v2:
+    enabled: true
+    invariants:
+      - id: items-editable
+        kind: every_visible_X_is_Y
+        visible: '[data-testid^="item-row-"]'
+        action: 'role=button[name=/edit/i]'
+        apply_on_routes:
+          - /dashboard
+        require_count_at_least: 1
+    thresholds:
+      invariants_required_pass_rate: 100

--- a/skills/autospec-test/tests/fixtures/contracts/v2/missing-edge-seeds.yml
+++ b/skills/autospec-test/tests/fixtures/contracts/v2/missing-edge-seeds.yml
@@ -1,0 +1,26 @@
+# missing-edge-seeds.yml — enforcement=refuse_to_run_if_missing but require_shapes is empty
+# Expected: validate-contract.sh exits 3 (shape-missing), stderr mentions "shape"
+
+mode: strict_isolation
+
+e2e:
+  forbidden_url_patterns:
+    - "^https?://app\\.acme\\.com"
+  clone_url_env: E2E_BASE_URL
+
+  invariants_v2:
+    enabled: true
+    invariants:
+      - id: items-editable
+        kind: every_visible_X_is_Y
+        visible: '[data-testid^="item-row-"]'
+        action: 'role=button[name=/edit/i]'
+        apply_on_routes:
+          - /dashboard
+        require_count_at_least: 1
+    edge_case_seeds:
+      household_test_family:
+        require_shapes: []
+      enforcement: refuse_to_run_if_missing
+    thresholds:
+      invariants_required_pass_rate: 100

--- a/skills/autospec-test/tests/fixtures/contracts/v2/scoped-prod-with-v2.yml
+++ b/skills/autospec-test/tests/fixtures/contracts/v2/scoped-prod-with-v2.yml
@@ -1,0 +1,41 @@
+# scoped-prod-with-v2.yml — Mode II (scoped_production) + invariants_v2 with scope-allowed routes
+# Expected: validate-contract.sh exits 0, ajv accepts
+
+mode: scoped_production
+i_understand_this_writes_to_production: true
+
+e2e:
+  forbidden_url_patterns:
+    - "^https?://external\\.example\\.com"
+  clone_url_env: E2E_BASE_URL
+
+  backup:
+    driver: pgdump
+    pre_test_snapshot: true
+    restore_cmd: "pg_restore --clean -d $DB_NAME /tmp/autospec-backup.dump"
+    on_test_catastrophe: restore_and_halt
+    refuse_to_run_without_backup: true
+
+  production_scoped_access:
+    scope_tokens:
+      - kind: route_filter
+        methods:
+          - GET
+        allowed_path_patterns:
+          - '^/api/household/timeline'
+          - '^/dashboard'
+          - '^/tasks'
+        action_on_violation: hard_fail
+
+  invariants_v2:
+    enabled: true
+    invariants:
+      - id: dashboard-done-items-editable
+        kind: every_visible_X_is_Y
+        visible: '[data-testid^="done-item-row-"]'
+        action: 'role=button[name=/edit/i]'
+        apply_on_routes:
+          - /dashboard
+        require_count_at_least: 1
+    thresholds:
+      invariants_required_pass_rate: 100

--- a/skills/autospec-test/tests/unit/v2/contract-loader-v2.bats
+++ b/skills/autospec-test/tests/unit/v2/contract-loader-v2.bats
@@ -1,0 +1,224 @@
+#!/usr/bin/env bats
+# contract-loader-v2.bats — TDD tests for v2 contract extension (phase 1)
+#
+# Tests validate that:
+#   1. v2 fixture files are accepted/rejected by validate-contract.sh with correct exit codes
+#   2. ajv schema validation matches expected accept/reject for each fixture
+#   3. v1 fixtures still pass (backward compatibility)
+#
+# Exit codes from validate-contract.sh:
+#   0 = valid
+#   1 = fatal (missing tool)
+#   2 = refuse-to-run (invalid/missing fields)
+#   3 = shape-missing (edge_case_seeds enforcement failure)
+
+# Path computation:
+#   This file lives at: skills/autospec-test/tests/unit/v2/contract-loader-v2.bats
+#   v2/ → unit/ → tests/ → autospec-test/ = 3 levels up for SKILL_DIR
+#   autospec-test/ → skills/ → repo_root/  = 2 levels up for REPO_ROOT
+SKILL_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd)"
+SCHEMA="$REPO_ROOT/schemas/autospec-test-contract.schema.json"
+VALIDATE="$SKILL_DIR/scripts/validate-contract.sh"
+FIXTURES_V1="$SKILL_DIR/tests/fixtures/contracts"
+FIXTURES_V2="$SKILL_DIR/tests/fixtures/contracts/v2"
+
+# Helper: convert YAML fixture to JSON temp file for ajv (macOS-compatible mktemp)
+yaml_to_json_tmp() {
+  local yaml_file="$1"
+  local tmp
+  tmp=$(mktemp -t autospec-v2-fixture)
+  yq -o=json '.' "$yaml_file" > "$tmp"
+  echo "$tmp"
+}
+
+# ── Preconditions ──────────────────────────────────────────────────────────────
+
+@test "ajv CLI is available" {
+  command -v ajv
+}
+
+@test "yq CLI is available" {
+  command -v yq
+}
+
+@test "jq CLI is available" {
+  command -v jq
+}
+
+@test "schema file exists" {
+  [ -f "$SCHEMA" ]
+}
+
+@test "validate-contract.sh exists and is executable" {
+  [ -x "$VALIDATE" ]
+}
+
+# ── v2 fixtures exist ──────────────────────────────────────────────────────────
+
+@test "v2 fixture: minimal-v2.yml exists" {
+  [ -f "$FIXTURES_V2/minimal-v2.yml" ]
+}
+
+@test "v2 fixture: all-metrics.yml exists" {
+  [ -f "$FIXTURES_V2/all-metrics.yml" ]
+}
+
+@test "v2 fixture: missing-edge-seeds.yml exists" {
+  [ -f "$FIXTURES_V2/missing-edge-seeds.yml" ]
+}
+
+@test "v2 fixture: scoped-prod-with-v2.yml exists" {
+  [ -f "$FIXTURES_V2/scoped-prod-with-v2.yml" ]
+}
+
+@test "v2 fixture: invalid-shapes.yml exists" {
+  [ -f "$FIXTURES_V2/invalid-shapes.yml" ]
+}
+
+# ── Schema compiles (draft2020) ────────────────────────────────────────────────
+
+@test "schema compiles with ajv draft2020" {
+  run ajv compile -s "$SCHEMA" --spec=draft2020
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"is valid"* ]]
+}
+
+# ── Schema accepts valid v2 fixtures (via validate-contract.sh) ───────────────
+# Note: ajv validate --spec=draft2020 has a CLI flag-parsing quirk on this
+# version of ajv-cli; validate-contract.sh handles it correctly via its own
+# tempfile approach. These tests use validate-contract.sh as the authoritative
+# accept/reject gate.
+
+@test "schema accepts minimal-v2.yml" {
+  local tmp
+  tmp=$(yaml_to_json_tmp "$FIXTURES_V2/minimal-v2.yml")
+  run bash "$VALIDATE" "$tmp"
+  rm -f "$tmp"
+  [ "$status" -eq 0 ]
+}
+
+@test "schema accepts all-metrics.yml" {
+  local tmp
+  tmp=$(yaml_to_json_tmp "$FIXTURES_V2/all-metrics.yml")
+  run bash "$VALIDATE" "$tmp"
+  rm -f "$tmp"
+  [ "$status" -eq 0 ]
+}
+
+@test "schema accepts scoped-prod-with-v2.yml" {
+  local tmp
+  tmp=$(yaml_to_json_tmp "$FIXTURES_V2/scoped-prod-with-v2.yml")
+  run bash "$VALIDATE" "$tmp"
+  rm -f "$tmp"
+  [ "$status" -eq 0 ]
+}
+
+# ── Schema parses invalid-shapes.yml (rejection is at validate-contract.sh level) ─
+
+@test "invalid-shapes.yml is parseable YAML" {
+  run yq -o=json '.' "$FIXTURES_V2/invalid-shapes.yml"
+  [ "$status" -eq 0 ]
+}
+
+# ── validate-contract.sh cross-field rules ────────────────────────────────────
+
+@test "missing-edge-seeds.yml rejects with exit 3 (shape-missing)" {
+  local tmp
+  tmp=$(yaml_to_json_tmp "$FIXTURES_V2/missing-edge-seeds.yml")
+  run bash "$VALIDATE" "$tmp"
+  rm -f "$tmp"
+  [ "$status" -eq 3 ]
+}
+
+@test "missing-edge-seeds.yml stderr mentions shape" {
+  local tmp
+  tmp=$(yaml_to_json_tmp "$FIXTURES_V2/missing-edge-seeds.yml")
+  run bash "$VALIDATE" "$tmp"
+  rm -f "$tmp"
+  [[ "$output" == *"shape"* ]]
+}
+
+@test "invalid-shapes.yml rejects with exit 3 (no shapes under enforcement)" {
+  local tmp
+  tmp=$(yaml_to_json_tmp "$FIXTURES_V2/invalid-shapes.yml")
+  run bash "$VALIDATE" "$tmp"
+  rm -f "$tmp"
+  [ "$status" -eq 3 ]
+}
+
+@test "v2 enabled=true with no metrics rejects with exit 2 (enabled-requires-metrics)" {
+  local tmp
+  tmp=$(mktemp -t autospec-v2-no-metrics)
+  cat > "$tmp" <<'EOF'
+{
+  "mode": "strict_isolation",
+  "e2e": {
+    "forbidden_url_patterns_intentionally_empty": true,
+    "invariants_v2": {
+      "enabled": true,
+      "invariants": [],
+      "thresholds": {
+        "invariants_required_pass_rate": 100
+      }
+    }
+  }
+}
+EOF
+  run bash "$VALIDATE" "$tmp"
+  rm -f "$tmp"
+  [ "$status" -eq 2 ]
+}
+
+@test "apply_on_routes without leading slash rejects with exit 2" {
+  local tmp
+  tmp=$(mktemp -t autospec-v2-no-slash)
+  cat > "$tmp" <<'EOF'
+{
+  "mode": "strict_isolation",
+  "e2e": {
+    "forbidden_url_patterns_intentionally_empty": true,
+    "invariants_v2": {
+      "enabled": true,
+      "invariants": [
+        {
+          "id": "test-invariant",
+          "kind": "every_visible_X_is_Y",
+          "visible": "[data-testid=item]",
+          "action": "role=button[name=/edit/i]",
+          "apply_on_routes": ["dashboard"]
+        }
+      ],
+      "thresholds": {
+        "invariants_required_pass_rate": 100
+      }
+    }
+  }
+}
+EOF
+  run bash "$VALIDATE" "$tmp"
+  rm -f "$tmp"
+  [ "$status" -eq 2 ]
+}
+
+# ── v1 backward compatibility ─────────────────────────────────────────────────
+
+@test "v1 minimal-valid.yml still passes validate-contract.sh" {
+  local tmp
+  tmp=$(yaml_to_json_tmp "$FIXTURES_V1/minimal-valid.yml")
+  run bash "$VALIDATE" "$tmp"
+  rm -f "$tmp"
+  [ "$status" -eq 0 ]
+}
+
+@test "v1 mode-ii-valid.yml still passes validate-contract.sh" {
+  local tmp
+  tmp=$(yaml_to_json_tmp "$FIXTURES_V1/mode-ii-valid.yml")
+  run bash "$VALIDATE" "$tmp"
+  rm -f "$tmp"
+  [ "$status" -eq 0 ]
+}
+
+@test "invariants_v2 field appears in schema" {
+  grep -q 'invariants_v2' "$SCHEMA"
+}


### PR DESCRIPTION
Closes #342

## Summary

- Extend `schemas/autospec-test-contract.schema.json` with `e2e.invariants_v2` sub-schema covering all 4 metric blocks (Metric F structural invariants, G window-contract symmetry, H extended crawler, I contract symmetry), `edge_case_seeds`, and `thresholds`. All v2 fields nest under `invariants_v2:` to avoid clobbering v1 `e2e.*` fields.
- Fix `validate-contract.sh` schema validation to use Node/Ajv2020 directly (ajv-cli 5.x `--spec=draft2020` CLI flag has a known parsing bug that silently passed against a stale temp file); also fix macOS-compatible `mktemp` usage.
- Add 4 v2 cross-field rules: `enabled-requires-metrics` (exit 2), `refuse-requires-shapes` (exit 3), `leading-slash-routes` (exit 2), `scope-allowed-routes` for Mode II (exit 2).
- Add 5 fixture contracts under `tests/fixtures/contracts/v2/`: `minimal-v2`, `all-metrics`, `missing-edge-seeds`, `scoped-prod-with-v2`, `invalid-shapes`.
- Add TDD bats tests in `tests/unit/v2/contract-loader-v2.bats` (23 tests, all passing); v1 fixtures remain backward-compatible.

## Test plan

- [x] `bats skills/autospec-test/tests/unit/v2/contract-loader-v2.bats` — 23/23 pass
- [x] v1 fixtures `minimal-valid.yml`, `mode-ii-valid.yml` still pass `validate-contract.sh` (backward compat)
- [x] `missing-edge-seeds.yml` exits 3 with shape-missing message
- [x] `invalid-shapes.yml` exits 3 (no entity with require_shapes under enforcement)
- [x] `invariants_v2` appears in schema (`git grep -nE 'invariants_v2' schemas/`)
- [x] `ajv compile -s schemas/autospec-test-contract.schema.json --spec=draft2020` passes