### PR TITLE
feat(autospec-test): built-in invariant kinds (phase 2)

### DIFF
--- a/skills/autospec-test/scripts/invariants/kinds/custom-kind-protocol.md
+++ b/skills/autospec-test/scripts/invariants/kinds/custom-kind-protocol.md
@@ -1,0 +1,132 @@
+# Custom Invariant Kind Protocol
+
+This document defines the export contract for custom invariant kind modules used by the
+`autospec-test` Metric F runner (`run-structural.mjs`) and the `@autospec/test` helper library.
+
+## Overview
+
+Built-in kinds live in `skills/autospec-test/scripts/invariants/kinds/`. Target repos may
+register additional custom kinds by placing modules under `.autospec/invariant-kinds/<name>.mjs`
+in the target repository root. The runner auto-discovers and loads these alongside built-ins.
+
+## Export Contract
+
+Every kind module **must** export three named exports:
+
+### `id` (string)
+
+The canonical kind identifier used in contract YAML under `invariants[].kind`.
+Must be unique across all loaded kinds. Convention: `every_<subject>_<predicate>`.
+
+```js
+export const id = 'every_widget_has_refresh_button';
+```
+
+### `signature` (object)
+
+JSON Schema describing the parameters the kind accepts from the contract declaration.
+Used for contract validation and IDE auto-complete.
+
+```js
+export const signature = {
+  params: {
+    widget: { type: 'string', description: 'Selector for the widget containers.' },
+    refresh_label: { type: 'string', description: 'Text label of the refresh button.' },
+  },
+  required: ['widget'],
+};
+```
+
+### `run(page, params, ctx)` (async function)
+
+The implementation. Receives:
+- `page` — Playwright `Page` object at the target route (already navigated).
+- `params` — the invariant declaration object from the contract (your kind's fields).
+- `ctx` — `{ baseUrl: string, route: string }` — the current base URL and route path.
+
+Returns a `KindResult`:
+
+```ts
+type KindResult = {
+  passed: boolean;                    // true iff zero violations
+  violations: Array<{
+    index: number;                    // 0-based index of the offending element (-1 for global)
+    selector: string;                 // selector that failed
+    reason: string;                   // human-readable explanation
+  }>;
+  count_observed: number;             // how many elements were evaluated
+};
+```
+
+## Worked Example
+
+Suppose your app has a pattern: every dashboard widget must have a "Refresh" button.
+Create `.autospec/invariant-kinds/every-widget-has-refresh-button.mjs`:
+
+```js
+export const id = 'every_widget_has_refresh_button';
+
+export const signature = {
+  params: {
+    widget: { type: 'string', description: 'Selector for widget containers.' },
+    refresh_label: {
+      type: 'string',
+      description: 'Accessible name / text of the refresh button.',
+      default: 'Refresh',
+    },
+  },
+  required: ['widget'],
+};
+
+export async function run(page, params, _ctx) {
+  const { widget: widgetSel, refresh_label: label = 'Refresh' } = params;
+  const violations = [];
+
+  const widgets = page.locator(widgetSel);
+  const count = await widgets.count();
+
+  for (let i = 0; i < count; i++) {
+    const w = widgets.nth(i);
+    const btn = w.getByRole('button', { name: new RegExp(label, 'i') });
+    const visible = await btn.isVisible().catch(() => false);
+    if (!visible) {
+      violations.push({
+        index: i,
+        selector: widgetSel,
+        reason: `widget at index ${i} is missing a "${label}" button`,
+      });
+    }
+  }
+
+  return { passed: violations.length === 0, violations, count_observed: count };
+}
+```
+
+Then declare it in `.autospec/test.yml`:
+
+```yaml
+e2e:
+  invariants_v2:
+    enabled: true
+    invariants:
+      - id: widgets-have-refresh
+        kind: every_widget_has_refresh_button
+        widget: '[data-testid^="dashboard-widget-"]'
+        refresh_label: Refresh
+        apply_on_routes:
+          - /dashboard
+```
+
+## Error Reporting
+
+- Violations are aggregated per-element; the runner emits all violations, not just the first.
+- `index: -1` signals a global failure (e.g., `require_count_at_least` not met, no elements found).
+- `reason` should be actionable: mention selectors, expected vs actual counts, and route context.
+
+## Registration
+
+The Metric F runner (`run-structural.mjs`) loads custom kinds at startup:
+1. Built-in catalog loaded first (this directory).
+2. Glob `<target_repo_root>/.autospec/invariant-kinds/*.mjs` — each file's default export is
+   checked for `id`, `signature`, and `run`. Missing exports cause a startup warning, not a crash.
+3. Duplicate `id` values: last-loaded wins (custom kinds can override built-ins if needed).

--- a/skills/autospec-test/scripts/invariants/kinds/every-foldout-opens-all-nested.mjs
+++ b/skills/autospec-test/scripts/invariants/kinds/every-foldout-opens-all-nested.mjs
@@ -1,0 +1,71 @@
+/**
+ * every-foldout-opens-all-nested.mjs — Built-in invariant kind: every_foldout_opens_all_nested
+ *
+ * For each element matching `foldout` that is collapsed (aria-expanded=false or absent),
+ * clicks to open it and asserts that at least one element matching
+ * `nested_must_be_visible_after_open` becomes visible inside the foldout.
+ *
+ * KindResult shape:
+ *   { passed: boolean, violations: Array<{index,selector,reason}>, count_observed: number }
+ */
+
+export const id = 'every_foldout_opens_all_nested';
+
+export const signature = {
+  params: {
+    foldout: { type: 'string', description: 'Selector for foldout container elements.' },
+    nested_must_be_visible_after_open: {
+      type: 'string',
+      description: 'Selector for nested elements that must be visible after opening each foldout.',
+    },
+  },
+  required: ['foldout', 'nested_must_be_visible_after_open'],
+};
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {object} params
+ * @param {{ baseUrl: string, route: string }} _ctx
+ * @returns {Promise<{passed: boolean, violations: Array<{index: number, selector: string, reason: string}>, count_observed: number}>}
+ */
+export async function run(page, params, _ctx) {
+  const { foldout: foldoutSel, nested_must_be_visible_after_open: nestedSel } = params;
+
+  const violations = [];
+  const foldouts = page.locator(foldoutSel);
+  const count = await foldouts.count();
+
+  for (let i = 0; i < count; i++) {
+    const foldout = foldouts.nth(i);
+
+    // Click to open if collapsed (aria-expanded=false or absent)
+    const expanded = await foldout.getAttribute('aria-expanded').catch(() => null);
+    if (expanded !== 'true') {
+      // Find a clickable trigger inside or the foldout itself
+      const trigger = foldout.locator('button, [role=button], summary').first();
+      const hasTrigger = await trigger.count() > 0;
+      if (hasTrigger) {
+        await trigger.click().catch((e) => {
+          violations.push({ index: i, selector: foldoutSel, reason: `open click failed: ${e.message}` });
+        });
+      } else {
+        await foldout.click().catch((e) => {
+          violations.push({ index: i, selector: foldoutSel, reason: `open click failed (no trigger): ${e.message}` });
+        });
+      }
+    }
+
+    // Assert nested elements are visible inside the foldout
+    const nested = foldout.locator(nestedSel);
+    const nestedCount = await nested.count();
+    if (nestedCount === 0) {
+      violations.push({
+        index: i,
+        selector: nestedSel,
+        reason: `no nested elements matching "${nestedSel}" visible after opening foldout`,
+      });
+    }
+  }
+
+  return { passed: violations.length === 0, violations, count_observed: count };
+}

--- a/skills/autospec-test/scripts/invariants/kinds/every-modal-returns-to-body-scroll.mjs
+++ b/skills/autospec-test/scripts/invariants/kinds/every-modal-returns-to-body-scroll.mjs
@@ -1,0 +1,82 @@
+/**
+ * every-modal-returns-to-body-scroll.mjs — Built-in kind: every_modal_returns_to_body_scroll
+ *
+ * Captures document.body.style.overflow before opening a modal, opens it via
+ * `modal_open` selector, asserts the modal becomes visible, closes it via
+ * `modal_close` selector, and asserts that overflow is restored to the captured value.
+ *
+ * KindResult shape:
+ *   { passed: boolean, violations: Array<{index,selector,reason}>, count_observed: number }
+ */
+
+export const id = 'every_modal_returns_to_body_scroll';
+
+export const signature = {
+  params: {
+    modal_open: { type: 'string', description: 'Selector for the trigger that opens the modal.' },
+    modal_selector: { type: 'string', description: 'Selector for the modal element that should become visible.' },
+    modal_close: { type: 'string', description: 'Selector for the trigger that closes the modal.' },
+  },
+  required: ['modal_open', 'modal_selector', 'modal_close'],
+};
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {object} params
+ * @param {{ baseUrl: string, route: string }} _ctx
+ * @returns {Promise<{passed: boolean, violations: Array<{index: number, selector: string, reason: string}>, count_observed: number}>}
+ */
+export async function run(page, params, _ctx) {
+  const { modal_open: openSel, modal_selector: modalSel, modal_close: closeSel } = params;
+
+  const violations = [];
+
+  // Capture body overflow before opening
+  const overflowBefore = await page.evaluate(() => document.body.style.overflow || '').catch(() => '');
+
+  // Open the modal
+  const openTrigger = page.locator(openSel);
+  const openCount = await openTrigger.count();
+  if (openCount === 0) {
+    return {
+      passed: false,
+      violations: [{ index: 0, selector: openSel, reason: 'modal_open selector matched no elements' }],
+      count_observed: 0,
+    };
+  }
+
+  await openTrigger.first().click().catch((e) => {
+    violations.push({ index: 0, selector: openSel, reason: `modal_open click failed: ${e.message}` });
+  });
+
+  // Assert modal is visible
+  const modal = page.locator(modalSel);
+  const modalVisible = await modal.isVisible().catch(() => false);
+  if (!modalVisible) {
+    violations.push({ index: 0, selector: modalSel, reason: 'modal not visible after modal_open click' });
+  }
+
+  // Close the modal
+  const closeTrigger = page.locator(closeSel);
+  await closeTrigger.first().click().catch((e) => {
+    violations.push({ index: 0, selector: closeSel, reason: `modal_close click failed: ${e.message}` });
+  });
+
+  // Assert modal is no longer visible
+  const stillVisible = await modal.isVisible().catch(() => true);
+  if (stillVisible) {
+    violations.push({ index: 0, selector: modalSel, reason: 'modal still visible after modal_close click' });
+  }
+
+  // Assert body overflow is restored
+  const overflowAfter = await page.evaluate(() => document.body.style.overflow || '').catch(() => '');
+  if (overflowAfter !== overflowBefore) {
+    violations.push({
+      index: 0,
+      selector: 'document.body',
+      reason: `body overflow not restored: was "${overflowBefore}", now "${overflowAfter}"`,
+    });
+  }
+
+  return { passed: violations.length === 0, violations, count_observed: openCount };
+}

--- a/skills/autospec-test/scripts/invariants/kinds/every-row-has-required-actions.mjs
+++ b/skills/autospec-test/scripts/invariants/kinds/every-row-has-required-actions.mjs
@@ -1,0 +1,65 @@
+/**
+ * every-row-has-required-actions.mjs — Built-in invariant kind: every_row_has_required_actions
+ *
+ * For each element matching `row`, asserts that every selector in `required_actions`
+ * is visible and interactive (is a button or link role) within the row.
+ *
+ * KindResult shape:
+ *   { passed: boolean, violations: Array<{index,selector,reason}>, count_observed: number }
+ */
+
+export const id = 'every_row_has_required_actions';
+
+export const signature = {
+  params: {
+    row: { type: 'string', description: 'Selector for row container elements.' },
+    required_actions: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'List of selectors that must each be visible and interactive within every row.',
+    },
+  },
+  required: ['row', 'required_actions'],
+};
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {object} params
+ * @param {{ baseUrl: string, route: string }} _ctx
+ * @returns {Promise<{passed: boolean, violations: Array<{index: number, selector: string, reason: string}>, count_observed: number}>}
+ */
+export async function run(page, params, _ctx) {
+  const { row: rowSel, required_actions: requiredActions = [] } = params;
+
+  const violations = [];
+  const rows = page.locator(rowSel);
+  const count = await rows.count();
+
+  for (let i = 0; i < count; i++) {
+    const row = rows.nth(i);
+    for (const actionSel of requiredActions) {
+      const action = row.locator(actionSel);
+      const isVisible = await action.isVisible().catch(() => false);
+      if (!isVisible) {
+        violations.push({
+          index: i,
+          selector: actionSel,
+          reason: `required action "${actionSel}" not visible in row ${i}`,
+        });
+        continue;
+      }
+
+      // Assert it's interactive: enabled and has button/link role or is a native button/a
+      const isEnabled = await action.isEnabled().catch(() => false);
+      if (!isEnabled) {
+        violations.push({
+          index: i,
+          selector: actionSel,
+          reason: `required action "${actionSel}" is visible but disabled in row ${i}`,
+        });
+      }
+    }
+  }
+
+  return { passed: violations.length === 0, violations, count_observed: count };
+}

--- a/skills/autospec-test/scripts/invariants/kinds/every-visible-x-has-accessible-name.mjs
+++ b/skills/autospec-test/scripts/invariants/kinds/every-visible-x-has-accessible-name.mjs
@@ -1,0 +1,85 @@
+/**
+ * every-visible-x-has-accessible-name.mjs — Built-in kind: every_visible_X_has_accessible_name
+ *
+ * Enumerates all visible interactive elements (buttons, links, inputs) on the page
+ * and asserts that each has a non-empty accessible name (aria-label, text content,
+ * or associated label).
+ *
+ * KindResult shape:
+ *   { passed: boolean, violations: Array<{index,selector,reason}>, count_observed: number }
+ */
+
+export const id = 'every_visible_X_has_accessible_name';
+
+export const signature = {
+  params: {
+    scope: {
+      type: 'string',
+      description: 'Optional CSS selector to limit the scope of the check. Defaults to the full page.',
+    },
+    element_types: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Element selectors to check. Defaults to: button, [role=button], a[href], input, select, textarea.',
+    },
+  },
+  required: [],
+};
+
+const DEFAULT_ELEMENT_TYPES = ['button', '[role=button]', 'a[href]', 'input', 'select', 'textarea'];
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {object} params
+ * @param {{ baseUrl: string, route: string }} _ctx
+ * @returns {Promise<{passed: boolean, violations: Array<{index: number, selector: string, reason: string}>, count_observed: number}>}
+ */
+export async function run(page, params, _ctx) {
+  const { scope, element_types: elementTypes = DEFAULT_ELEMENT_TYPES } = params;
+
+  const violations = [];
+  let count_observed = 0;
+
+  const root = scope ? page.locator(scope) : page;
+  const selector = elementTypes.join(', ');
+  const elements = (scope ? root.locator(selector) : page.locator(selector));
+  const count = await elements.count();
+
+  for (let i = 0; i < count; i++) {
+    const el = elements.nth(i);
+    const isVisible = await el.isVisible().catch(() => false);
+    if (!isVisible) continue;
+
+    count_observed++;
+
+    // Get accessible name via evaluate (textContent + aria-label + aria-labelledby)
+    const accessibleName = await el.evaluate((node) => {
+      const ariaLabel = node.getAttribute('aria-label') || '';
+      if (ariaLabel.trim()) return ariaLabel.trim();
+      const labelledBy = node.getAttribute('aria-labelledby');
+      if (labelledBy) {
+        const labelEl = document.getElementById(labelledBy);
+        if (labelEl && labelEl.textContent.trim()) return labelEl.textContent.trim();
+      }
+      // For inputs, check associated <label>
+      if (node.id) {
+        const label = document.querySelector(`label[for="${node.id}"]`);
+        if (label && label.textContent.trim()) return label.textContent.trim();
+      }
+      // Text content for buttons/links
+      const text = (node.textContent || '').trim();
+      return text;
+    }).catch(() => '');
+
+    if (!accessibleName) {
+      const tagName = await el.evaluate((n) => n.tagName.toLowerCase()).catch(() => 'unknown');
+      violations.push({
+        index: i,
+        selector: tagName,
+        reason: `element <${tagName}> at index ${i} has no accessible name (aria-label, text, or label)`,
+      });
+    }
+  }
+
+  return { passed: violations.length === 0, violations, count_observed };
+}

--- a/skills/autospec-test/scripts/invariants/kinds/every-visible-x-is-y.mjs
+++ b/skills/autospec-test/scripts/invariants/kinds/every-visible-x-is-y.mjs
@@ -1,0 +1,90 @@
+/**
+ * every-visible-x-is-y.mjs — Built-in invariant kind: every_visible_X_is_Y
+ *
+ * For each element matching `visible`, asserts that `action` is present and
+ * clickable, that clicking it makes `verifies_open` visible (if declared),
+ * and that clicking `verifies_close` hides `verifies_open` again.
+ *
+ * KindResult shape:
+ *   { passed: boolean, violations: Array<{index,selector,reason}>, count_observed: number }
+ */
+
+export const id = 'every_visible_X_is_Y';
+
+export const signature = {
+  params: {
+    visible: { type: 'string', description: 'Selector for the visible container elements.' },
+    action: { type: 'string', description: 'Selector for the action element within each container.' },
+    verifies_open: { type: 'string', description: 'Selector that must be visible after clicking action (optional).' },
+    verifies_close: { type: 'string', description: 'Selector to click to close the opened element (optional).' },
+    require_count_at_least: { type: 'integer', minimum: 1, description: 'Minimum number of visible elements required.' },
+  },
+  required: ['visible', 'action'],
+};
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {object} params - Invariant parameters per signature above.
+ * @param {{ baseUrl: string, route: string }} ctx
+ * @returns {Promise<{passed: boolean, violations: Array<{index: number, selector: string, reason: string}>, count_observed: number}>}
+ */
+export async function run(page, params, _ctx) {
+  const {
+    visible: visibleSel,
+    action: actionSel,
+    verifies_open: verifiesOpenSel,
+    verifies_close: verifiesCloseSel,
+    require_count_at_least: minCount = 1,
+  } = params;
+
+  const violations = [];
+  const items = page.locator(visibleSel);
+  const count = await items.count();
+
+  if (count < minCount) {
+    violations.push({
+      index: -1,
+      selector: visibleSel,
+      reason: `require_count_at_least=${minCount} but only ${count} elements matched`,
+    });
+    return { passed: false, violations, count_observed: count };
+  }
+
+  for (let i = 0; i < count; i++) {
+    const row = items.nth(i);
+
+    // Assert action is visible within the row
+    const action = row.locator(actionSel);
+    const actionVisible = await action.isVisible().catch(() => false);
+    if (!actionVisible) {
+      violations.push({ index: i, selector: actionSel, reason: 'action not visible' });
+      continue;
+    }
+
+    // Click the action
+    await action.click().catch((e) => {
+      violations.push({ index: i, selector: actionSel, reason: `click failed: ${e.message}` });
+    });
+
+    // Assert verifies_open becomes visible
+    if (verifiesOpenSel) {
+      const opened = page.locator(verifiesOpenSel);
+      const isOpen = await opened.isVisible().catch(() => false);
+      if (!isOpen) {
+        violations.push({ index: i, selector: verifiesOpenSel, reason: 'verifies_open not visible after action click' });
+      } else if (verifiesCloseSel) {
+        // Click close and assert verifies_open disappears
+        const closeBtn = page.locator(verifiesCloseSel);
+        await closeBtn.click().catch((e) => {
+          violations.push({ index: i, selector: verifiesCloseSel, reason: `close click failed: ${e.message}` });
+        });
+        const stillOpen = await opened.isVisible().catch(() => true);
+        if (stillOpen) {
+          violations.push({ index: i, selector: verifiesOpenSel, reason: 'verifies_open still visible after close click' });
+        }
+      }
+    }
+  }
+
+  return { passed: violations.length === 0, violations, count_observed: count };
+}

--- a/skills/autospec-test/tests/fixtures/v2/kinds/every-foldout-opens-all-nested/fail.html
+++ b/skills/autospec-test/tests/fixtures/v2/kinds/every-foldout-opens-all-nested/fail.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>every-foldout-opens-all-nested fail fixture</title></head>
+<body>
+  <!-- Foldout with no nested rows — should fail -->
+  <div data-testid="foldout-day-1" aria-expanded="false">
+    <button onclick="this.parentElement.setAttribute('aria-expanded','true')">Monday</button>
+    <!-- No nested rows matching the selector -->
+  </div>
+</body>
+</html>

--- a/skills/autospec-test/tests/fixtures/v2/kinds/every-foldout-opens-all-nested/pass.html
+++ b/skills/autospec-test/tests/fixtures/v2/kinds/every-foldout-opens-all-nested/pass.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>every-foldout-opens-all-nested pass fixture</title></head>
+<body>
+  <div data-testid="foldout-day-1" aria-expanded="false">
+    <button onclick="
+      this.parentElement.setAttribute('aria-expanded','true');
+      this.parentElement.querySelector('.nested').style.display='block';
+    ">Monday</button>
+    <div class="nested" style="display:none">
+      <div data-testid="nested-row-1-1">Task A</div>
+      <div data-testid="nested-row-1-2">Task B</div>
+    </div>
+  </div>
+  <div data-testid="foldout-day-2" aria-expanded="false">
+    <button onclick="
+      this.parentElement.setAttribute('aria-expanded','true');
+      this.parentElement.querySelector('.nested').style.display='block';
+    ">Tuesday</button>
+    <div class="nested" style="display:none">
+      <div data-testid="nested-row-2-1">Task C</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/skills/autospec-test/tests/fixtures/v2/kinds/every-modal-returns-to-body-scroll/fail.html
+++ b/skills/autospec-test/tests/fixtures/v2/kinds/every-modal-returns-to-body-scroll/fail.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>every-modal-returns-to-body-scroll fail fixture</title>
+<style>
+  .modal { display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5); }
+  .modal.open { display:block; }
+</style>
+</head>
+<body>
+  <!-- Modal that opens but does NOT restore body scroll on close — bug fixture -->
+  <button id="open-modal" onclick="
+    document.getElementById('modal').classList.add('open');
+    document.body.style.overflow='hidden';
+  ">Open modal</button>
+
+  <div id="modal" class="modal" data-testid="test-modal">
+    <div style="background:white;padding:20px;margin:50px auto;width:300px;">
+      <p>Modal content</p>
+      <button id="close-modal" onclick="
+        document.getElementById('modal').classList.remove('open');
+        /* BUG: does NOT restore body overflow */
+      ">Close</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/skills/autospec-test/tests/fixtures/v2/kinds/every-modal-returns-to-body-scroll/pass.html
+++ b/skills/autospec-test/tests/fixtures/v2/kinds/every-modal-returns-to-body-scroll/pass.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>every-modal-returns-to-body-scroll pass fixture</title>
+<style>
+  .modal { display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5); }
+  .modal.open { display:block; }
+</style>
+</head>
+<body>
+  <button id="open-modal" onclick="
+    document.getElementById('modal').classList.add('open');
+    document.body.style.overflow='hidden';
+  ">Open modal</button>
+
+  <div id="modal" class="modal" data-testid="test-modal">
+    <div style="background:white;padding:20px;margin:50px auto;width:300px;">
+      <p>Modal content</p>
+      <button id="close-modal" onclick="
+        document.getElementById('modal').classList.remove('open');
+        document.body.style.overflow='';
+      ">Close</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/skills/autospec-test/tests/fixtures/v2/kinds/every-row-has-required-actions/fail.html
+++ b/skills/autospec-test/tests/fixtures/v2/kinds/every-row-has-required-actions/fail.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>every-row-has-required-actions fail fixture</title></head>
+<body>
+  <!-- Row missing delete button — should fail -->
+  <div data-testid="task-row-1">
+    <span>Task 1</span>
+    <button>edit</button>
+    <!-- no delete button -->
+  </div>
+</body>
+</html>

--- a/skills/autospec-test/tests/fixtures/v2/kinds/every-row-has-required-actions/pass.html
+++ b/skills/autospec-test/tests/fixtures/v2/kinds/every-row-has-required-actions/pass.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>every-row-has-required-actions pass fixture</title></head>
+<body>
+  <div data-testid="task-row-1">
+    <span>Task 1</span>
+    <button>edit</button>
+    <button>delete</button>
+  </div>
+  <div data-testid="task-row-2">
+    <span>Task 2</span>
+    <button>edit</button>
+    <button>delete</button>
+  </div>
+</body>
+</html>

--- a/skills/autospec-test/tests/fixtures/v2/kinds/every-visible-x-has-accessible-name/fail.html
+++ b/skills/autospec-test/tests/fixtures/v2/kinds/every-visible-x-has-accessible-name/fail.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>every-visible-x-has-accessible-name fail fixture</title></head>
+<body>
+  <!-- Button with no accessible name -->
+  <button></button>
+  <!-- Input with no label -->
+  <input type="text" />
+</body>
+</html>

--- a/skills/autospec-test/tests/fixtures/v2/kinds/every-visible-x-has-accessible-name/pass.html
+++ b/skills/autospec-test/tests/fixtures/v2/kinds/every-visible-x-has-accessible-name/pass.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>every-visible-x-has-accessible-name pass fixture</title></head>
+<body>
+  <button aria-label="Save item">Save</button>
+  <button>Delete item</button>
+  <a href="/home" aria-label="Go home">Home</a>
+  <input type="text" aria-label="Search query" />
+</body>
+</html>

--- a/skills/autospec-test/tests/fixtures/v2/kinds/every-visible-x-is-y/fail.html
+++ b/skills/autospec-test/tests/fixtures/v2/kinds/every-visible-x-is-y/fail.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>every-visible-x-is-y fail fixture</title></head>
+<body>
+  <!-- Items WITHOUT edit buttons — invariant should fail -->
+  <div data-testid="done-item-row-1">
+    <span>Task 1 (no edit button)</span>
+  </div>
+  <div data-testid="done-item-row-2">
+    <span>Task 2 (no edit button)</span>
+  </div>
+</body>
+</html>

--- a/skills/autospec-test/tests/fixtures/v2/kinds/every-visible-x-is-y/pass.html
+++ b/skills/autospec-test/tests/fixtures/v2/kinds/every-visible-x-is-y/pass.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>every-visible-x-is-y pass fixture</title></head>
+<body>
+  <!-- Items that have edit buttons that open dialogs -->
+  <div data-testid="done-item-row-1">
+    <span>Task 1</span>
+    <button aria-label="edit" onclick="document.getElementById('dialog').style.display='block'">edit</button>
+  </div>
+  <div data-testid="done-item-row-2">
+    <span>Task 2</span>
+    <button aria-label="edit" onclick="document.getElementById('dialog').style.display='block'">edit</button>
+  </div>
+
+  <!-- Dialog opened by clicking edit -->
+  <div id="dialog" data-testid="done-item-edit-dialog" style="display:none">
+    <p>Edit dialog</p>
+    <button onclick="document.getElementById('dialog').style.display='none'">close</button>
+  </div>
+</body>
+</html>

--- a/skills/autospec-test/tests/unit/v2/kinds/every-foldout-opens-all-nested.test.mjs
+++ b/skills/autospec-test/tests/unit/v2/kinds/every-foldout-opens-all-nested.test.mjs
@@ -1,0 +1,63 @@
+// every-foldout-opens-all-nested.test.mjs
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { chromium } from '/opt/homebrew/lib/node_modules/playwright/index.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const KINDS_DIR = path.resolve(__dirname, '../../../../scripts/invariants/kinds');
+const FIXTURES_DIR = path.resolve(__dirname, '../../../fixtures/v2/kinds/every-foldout-opens-all-nested');
+
+const { id, signature, run } = await import(`${KINDS_DIR}/every-foldout-opens-all-nested.mjs`);
+
+let browser, page;
+before(async () => { browser = await chromium.launch({ headless: true }); page = await browser.newPage(); });
+after(async () => { await browser.close(); });
+
+test('every-foldout-opens-all-nested: id is correct', () => {
+  assert.equal(id, 'every_foldout_opens_all_nested');
+});
+
+test('every-foldout-opens-all-nested: signature has required params', () => {
+  assert.ok(signature.params.foldout);
+  assert.ok(signature.params.nested_must_be_visible_after_open);
+  assert.ok(signature.required.includes('foldout'));
+  assert.ok(signature.required.includes('nested_must_be_visible_after_open'));
+});
+
+test('every-foldout-opens-all-nested: pass fixture returns passed=true', async () => {
+  await page.goto(`file://${FIXTURES_DIR}/pass.html`);
+  const result = await run(page, {
+    foldout: '[data-testid^="foldout-day-"]',
+    nested_must_be_visible_after_open: '[data-testid^="nested-row-"]',
+  }, { baseUrl: 'file://', route: '/pass' });
+
+  assert.equal(result.passed, true, `violations: ${JSON.stringify(result.violations)}`);
+  assert.equal(result.violations.length, 0);
+  assert.ok(result.count_observed >= 1);
+});
+
+test('every-foldout-opens-all-nested: fail fixture returns passed=false', async () => {
+  await page.goto(`file://${FIXTURES_DIR}/fail.html`);
+  const result = await run(page, {
+    foldout: '[data-testid^="foldout-day-"]',
+    nested_must_be_visible_after_open: '[data-testid^="nested-row-"]',
+  }, { baseUrl: 'file://', route: '/fail' });
+
+  assert.equal(result.passed, false, 'Expected passed=false for foldout with no nested rows');
+  assert.ok(result.violations.length > 0);
+});
+
+test('every-foldout-opens-all-nested: KindResult has correct shape', async () => {
+  await page.goto(`file://${FIXTURES_DIR}/pass.html`);
+  const result = await run(page, {
+    foldout: '[data-testid^="foldout-day-"]',
+    nested_must_be_visible_after_open: '[data-testid^="nested-row-"]',
+  }, { baseUrl: 'file://', route: '/pass' });
+  assert.ok('passed' in result);
+  assert.ok('violations' in result);
+  assert.ok('count_observed' in result);
+  assert.equal(typeof result.passed, 'boolean');
+  assert.ok(Array.isArray(result.violations));
+});

--- a/skills/autospec-test/tests/unit/v2/kinds/every-modal-returns-to-body-scroll.test.mjs
+++ b/skills/autospec-test/tests/unit/v2/kinds/every-modal-returns-to-body-scroll.test.mjs
@@ -1,0 +1,67 @@
+// every-modal-returns-to-body-scroll.test.mjs
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { chromium } from '/opt/homebrew/lib/node_modules/playwright/index.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const KINDS_DIR = path.resolve(__dirname, '../../../../scripts/invariants/kinds');
+const FIXTURES_DIR = path.resolve(__dirname, '../../../fixtures/v2/kinds/every-modal-returns-to-body-scroll');
+
+const { id, signature, run } = await import(`${KINDS_DIR}/every-modal-returns-to-body-scroll.mjs`);
+
+let browser, page;
+before(async () => { browser = await chromium.launch({ headless: true }); page = await browser.newPage(); });
+after(async () => { await browser.close(); });
+
+test('every-modal-returns-to-body-scroll: id is correct', () => {
+  assert.equal(id, 'every_modal_returns_to_body_scroll');
+});
+
+test('every-modal-returns-to-body-scroll: signature has required params', () => {
+  assert.ok(signature.params.modal_open);
+  assert.ok(signature.params.modal_selector);
+  assert.ok(signature.params.modal_close);
+  assert.ok(signature.required.includes('modal_open'));
+  assert.ok(signature.required.includes('modal_selector'));
+  assert.ok(signature.required.includes('modal_close'));
+});
+
+test('every-modal-returns-to-body-scroll: pass fixture returns passed=true', async () => {
+  await page.goto(`file://${FIXTURES_DIR}/pass.html`);
+  const result = await run(page, {
+    modal_open: '#open-modal',
+    modal_selector: '#modal',
+    modal_close: '#close-modal',
+  }, { baseUrl: 'file://', route: '/pass' });
+
+  assert.equal(result.passed, true, `violations: ${JSON.stringify(result.violations)}`);
+  assert.equal(result.violations.length, 0);
+});
+
+test('every-modal-returns-to-body-scroll: fail fixture returns passed=false (overflow not restored)', async () => {
+  await page.goto(`file://${FIXTURES_DIR}/fail.html`);
+  const result = await run(page, {
+    modal_open: '#open-modal',
+    modal_selector: '#modal',
+    modal_close: '#close-modal',
+  }, { baseUrl: 'file://', route: '/fail' });
+
+  assert.equal(result.passed, false, 'Expected passed=false when body overflow is not restored');
+  assert.ok(result.violations.some(v => v.reason.includes('overflow')));
+});
+
+test('every-modal-returns-to-body-scroll: KindResult has correct shape', async () => {
+  await page.goto(`file://${FIXTURES_DIR}/pass.html`);
+  const result = await run(page, {
+    modal_open: '#open-modal',
+    modal_selector: '#modal',
+    modal_close: '#close-modal',
+  }, { baseUrl: 'file://', route: '/pass' });
+  assert.ok('passed' in result);
+  assert.ok('violations' in result);
+  assert.ok('count_observed' in result);
+  assert.equal(typeof result.passed, 'boolean');
+  assert.ok(Array.isArray(result.violations));
+});

--- a/skills/autospec-test/tests/unit/v2/kinds/every-row-has-required-actions.test.mjs
+++ b/skills/autospec-test/tests/unit/v2/kinds/every-row-has-required-actions.test.mjs
@@ -1,0 +1,62 @@
+// every-row-has-required-actions.test.mjs
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { chromium } from '/opt/homebrew/lib/node_modules/playwright/index.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const KINDS_DIR = path.resolve(__dirname, '../../../../scripts/invariants/kinds');
+const FIXTURES_DIR = path.resolve(__dirname, '../../../fixtures/v2/kinds/every-row-has-required-actions');
+
+const { id, signature, run } = await import(`${KINDS_DIR}/every-row-has-required-actions.mjs`);
+
+let browser, page;
+before(async () => { browser = await chromium.launch({ headless: true }); page = await browser.newPage(); });
+after(async () => { await browser.close(); });
+
+test('every-row-has-required-actions: id is correct', () => {
+  assert.equal(id, 'every_row_has_required_actions');
+});
+
+test('every-row-has-required-actions: signature has required params', () => {
+  assert.ok(signature.params.row);
+  assert.ok(signature.params.required_actions);
+  assert.ok(signature.required.includes('row'));
+  assert.ok(signature.required.includes('required_actions'));
+});
+
+test('every-row-has-required-actions: pass fixture returns passed=true', async () => {
+  await page.goto(`file://${FIXTURES_DIR}/pass.html`);
+  const result = await run(page, {
+    row: '[data-testid^="task-row-"]',
+    required_actions: ['button:text("edit")', 'button:text("delete")'],
+  }, { baseUrl: 'file://', route: '/pass' });
+
+  assert.equal(result.passed, true, `violations: ${JSON.stringify(result.violations)}`);
+  assert.equal(result.violations.length, 0);
+  assert.ok(result.count_observed >= 1);
+});
+
+test('every-row-has-required-actions: fail fixture returns passed=false (missing delete)', async () => {
+  await page.goto(`file://${FIXTURES_DIR}/fail.html`);
+  const result = await run(page, {
+    row: '[data-testid^="task-row-"]',
+    required_actions: ['button:text("edit")', 'button:text("delete")'],
+  }, { baseUrl: 'file://', route: '/fail' });
+
+  assert.equal(result.passed, false, 'Expected passed=false when delete button is missing');
+  assert.ok(result.violations.length > 0);
+  assert.ok(result.violations.some(v => v.reason.includes('delete')));
+});
+
+test('every-row-has-required-actions: KindResult has correct shape', async () => {
+  await page.goto(`file://${FIXTURES_DIR}/pass.html`);
+  const result = await run(page, {
+    row: '[data-testid^="task-row-"]',
+    required_actions: ['button:text("edit")'],
+  }, { baseUrl: 'file://', route: '/pass' });
+  assert.ok('passed' in result);
+  assert.ok('violations' in result);
+  assert.ok('count_observed' in result);
+});

--- a/skills/autospec-test/tests/unit/v2/kinds/every-visible-x-has-accessible-name.test.mjs
+++ b/skills/autospec-test/tests/unit/v2/kinds/every-visible-x-has-accessible-name.test.mjs
@@ -1,0 +1,49 @@
+// every-visible-x-has-accessible-name.test.mjs
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { chromium } from '/opt/homebrew/lib/node_modules/playwright/index.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const KINDS_DIR = path.resolve(__dirname, '../../../../scripts/invariants/kinds');
+const FIXTURES_DIR = path.resolve(__dirname, '../../../fixtures/v2/kinds/every-visible-x-has-accessible-name');
+
+const { id, signature, run } = await import(`${KINDS_DIR}/every-visible-x-has-accessible-name.mjs`);
+
+let browser, page;
+before(async () => { browser = await chromium.launch({ headless: true }); page = await browser.newPage(); });
+after(async () => { await browser.close(); });
+
+test('every-visible-x-has-accessible-name: id is correct', () => {
+  assert.equal(id, 'every_visible_X_has_accessible_name');
+});
+
+test('every-visible-x-has-accessible-name: signature has params object', () => {
+  assert.ok(signature.params, 'has params');
+  assert.deepEqual(signature.required, [], 'required is empty (all params optional)');
+});
+
+test('every-visible-x-has-accessible-name: pass fixture returns passed=true', async () => {
+  await page.goto(`file://${FIXTURES_DIR}/pass.html`);
+  const result = await run(page, {}, { baseUrl: 'file://', route: '/pass' });
+  assert.equal(result.passed, true, `violations: ${JSON.stringify(result.violations)}`);
+  assert.equal(result.violations.length, 0);
+  assert.ok(result.count_observed >= 1);
+});
+
+test('every-visible-x-has-accessible-name: fail fixture returns passed=false (empty button)', async () => {
+  await page.goto(`file://${FIXTURES_DIR}/fail.html`);
+  const result = await run(page, {}, { baseUrl: 'file://', route: '/fail' });
+  assert.equal(result.passed, false, 'Expected passed=false for elements with no accessible name');
+  assert.ok(result.violations.length > 0);
+});
+
+test('every-visible-x-has-accessible-name: KindResult has correct shape', async () => {
+  await page.goto(`file://${FIXTURES_DIR}/pass.html`);
+  const result = await run(page, {}, { baseUrl: 'file://', route: '/pass' });
+  assert.ok('passed' in result);
+  assert.ok('violations' in result);
+  assert.ok('count_observed' in result);
+  assert.equal(typeof result.count_observed, 'number');
+});

--- a/skills/autospec-test/tests/unit/v2/kinds/every-visible-x-is-y.test.mjs
+++ b/skills/autospec-test/tests/unit/v2/kinds/every-visible-x-is-y.test.mjs
@@ -1,0 +1,113 @@
+// every-visible-x-is-y.test.mjs — TDD tests for every_visible_X_is_Y kind
+// Uses real Playwright (chromium headless) against file:// fixture URLs.
+// Run with: node --test skills/autospec-test/tests/unit/v2/kinds/
+
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { chromium } from '/opt/homebrew/lib/node_modules/playwright/index.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const KINDS_DIR = path.resolve(__dirname, '../../../../scripts/invariants/kinds');
+const FIXTURES_DIR = path.resolve(__dirname, '../../../fixtures/v2/kinds/every-visible-x-is-y');
+
+const { id, signature, run } = await import(`${KINDS_DIR}/every-visible-x-is-y.mjs`);
+
+let browser, page;
+
+before(async () => {
+  browser = await chromium.launch({ headless: true });
+  page = await browser.newPage();
+});
+
+after(async () => {
+  await browser.close();
+});
+
+// ── Module contract ────────────────────────────────────────────────────────────
+
+test('every-visible-x-is-y: id is correct', () => {
+  assert.equal(id, 'every_visible_X_is_Y');
+});
+
+test('every-visible-x-is-y: signature has required params', () => {
+  assert.ok(signature.params.visible, 'has visible param');
+  assert.ok(signature.params.action, 'has action param');
+  assert.deepEqual(signature.required, ['visible', 'action']);
+});
+
+test('every-visible-x-is-y: run is async function', () => {
+  assert.equal(typeof run, 'function');
+  assert.equal(run.constructor.name, 'AsyncFunction');
+});
+
+// ── Pass fixture ──────────────────────────────────────────────────────────────
+
+test('every-visible-x-is-y: pass fixture returns passed=true', async () => {
+  const passUrl = `file://${FIXTURES_DIR}/pass.html`;
+  await page.goto(passUrl);
+
+  const result = await run(page, {
+    visible: '[data-testid^="done-item-row-"]',
+    action: 'button[aria-label="edit"]',
+    verifies_open: '[data-testid="done-item-edit-dialog"]',
+    verifies_close: '#dialog button',
+    require_count_at_least: 1,
+  }, { baseUrl: 'file://', route: '/pass' });
+
+  assert.equal(result.passed, true, `Expected passed=true, violations: ${JSON.stringify(result.violations)}`);
+  assert.equal(result.violations.length, 0);
+  assert.ok(result.count_observed >= 1);
+});
+
+// ── Fail fixture ──────────────────────────────────────────────────────────────
+
+test('every-visible-x-is-y: fail fixture returns passed=false (no action buttons)', async () => {
+  const failUrl = `file://${FIXTURES_DIR}/fail.html`;
+  await page.goto(failUrl);
+
+  const result = await run(page, {
+    visible: '[data-testid^="done-item-row-"]',
+    action: 'button[aria-label="edit"]',
+    require_count_at_least: 1,
+  }, { baseUrl: 'file://', route: '/fail' });
+
+  assert.equal(result.passed, false, 'Expected passed=false when action buttons are missing');
+  assert.ok(result.violations.length > 0);
+});
+
+// ── require_count_at_least ────────────────────────────────────────────────────
+
+test('every-visible-x-is-y: fails when require_count_at_least not met', async () => {
+  const passUrl = `file://${FIXTURES_DIR}/pass.html`;
+  await page.goto(passUrl);
+
+  const result = await run(page, {
+    visible: '[data-testid^="done-item-row-"]',
+    action: 'button[aria-label="edit"]',
+    require_count_at_least: 100, // impossible
+  }, { baseUrl: 'file://', route: '/pass' });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.violations.some(v => v.reason.includes('require_count_at_least')));
+});
+
+// ── KindResult shape ──────────────────────────────────────────────────────────
+
+test('every-visible-x-is-y: KindResult has correct shape', async () => {
+  const passUrl = `file://${FIXTURES_DIR}/pass.html`;
+  await page.goto(passUrl);
+
+  const result = await run(page, {
+    visible: '[data-testid^="done-item-row-"]',
+    action: 'button[aria-label="edit"]',
+  }, { baseUrl: 'file://', route: '/pass' });
+
+  assert.ok('passed' in result, 'has passed');
+  assert.ok('violations' in result, 'has violations');
+  assert.ok('count_observed' in result, 'has count_observed');
+  assert.equal(typeof result.passed, 'boolean');
+  assert.ok(Array.isArray(result.violations));
+  assert.equal(typeof result.count_observed, 'number');
+});


### PR DESCRIPTION
Closes #343

## Summary

- Implement 5 built-in invariant kind modules under `skills/autospec-test/scripts/invariants/kinds/` each exporting `{ id, signature, run(page, params, ctx): KindResult }`:
  - `every-visible-x-is-y.mjs` — visible selector → action click → verifies_open visible → verifies_close → hidden
  - `every-foldout-opens-all-nested.mjs` — open collapsed foldouts, assert nested rows visible
  - `every-row-has-required-actions.mjs` — each row has all declared action buttons visible+enabled
  - `every-visible-x-has-accessible-name.mjs` — a11y floor for buttons/links/inputs
  - `every-modal-returns-to-body-scroll.mjs` — modal close restores body `overflow`
- Add `custom-kind-protocol.md` documenting the export contract, `KindResult` shape, error format, and registration procedure with a full worked example
- Add `pass.html` + `fail.html` fixtures for each kind (10 fixtures total)
- Add Playwright tests using real chromium headless against `file://` URLs — 27/27 pass, no DOM mocks

## Test plan

- [x] `node --test 'skills/autospec-test/tests/unit/v2/kinds/*.test.mjs'` — 27/27 pass
- [x] All 5 kind modules have both pass and fail fixtures
- [x] `custom-kind-protocol.md` contains worked example with `export const id` block
- [x] `KindResult` shape consistent across all 5 modules (`{ passed, violations, count_observed }`)
- [x] All 5 files exist under `skills/autospec-test/scripts/invariants/kinds/`