### PR TITLE
feat(autospec-test): metric G window-contract symmetry (phase 4)

### DIFF
--- a/skills/autospec-test/scripts/window-contract/date-math.mjs
+++ b/skills/autospec-test/scripts/window-contract/date-math.mjs
@@ -1,0 +1,71 @@
+/**
+ * date-math.mjs — Pure date expression resolver for Metric G window contracts.
+ *
+ * Recognises:
+ *   "today"               → ctx.today (or Date.now()) formatted as ISO date
+ *   "today ± N day[s]"   → ctx.today ± N calendar days
+ *   "YYYY-MM-DD"          → returned unchanged (validated format)
+ *
+ * Returns an ISO date string (YYYY-MM-DD) in UTC unless ctx.tz is supplied
+ * (tz support is a future extension; currently UTC only).
+ *
+ * Throws on any unrecognised expression with message matching /unparseable/.
+ */
+
+/**
+ * @param {string} expr
+ * @param {{ today?: Date, tz?: string }} ctx
+ * @returns {string}  ISO date string YYYY-MM-DD
+ */
+export function resolve(expr, ctx = {}) {
+  if (typeof expr !== 'string' || expr.trim() === '') {
+    throw new Error(`unparseable date expression: ${JSON.stringify(expr)}`);
+  }
+
+  const trimmed = expr.trim();
+
+  // ── ISO literal: YYYY-MM-DD ───────────────────────────────────────────────
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  // ── "today" variants ──────────────────────────────────────────────────────
+  const base = ctx.today instanceof Date ? new Date(ctx.today) : new Date();
+
+  // Normalise to midnight UTC
+  const baseDate = new Date(Date.UTC(
+    base.getUTCFullYear(),
+    base.getUTCMonth(),
+    base.getUTCDate(),
+  ));
+
+  if (trimmed === 'today') {
+    return formatISO(baseDate);
+  }
+
+  // "today [+-] N day[s]"
+  const offsetMatch = trimmed.match(
+    /^today\s*([+-])\s*(\d+)\s*days?$/i,
+  );
+  if (offsetMatch) {
+    const sign = offsetMatch[1] === '+' ? 1 : -1;
+    const n = parseInt(offsetMatch[2], 10);
+    const result = new Date(baseDate);
+    result.setUTCDate(result.getUTCDate() + sign * n);
+    return formatISO(result);
+  }
+
+  throw new Error(`unparseable date expression: ${JSON.stringify(trimmed)}`);
+}
+
+/**
+ * Format a Date as YYYY-MM-DD using UTC components.
+ * @param {Date} d
+ * @returns {string}
+ */
+function formatISO(d) {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}`;
+}

--- a/skills/autospec-test/scripts/window-contract/request-recorder.mjs
+++ b/skills/autospec-test/scripts/window-contract/request-recorder.mjs
@@ -1,0 +1,72 @@
+/**
+ * request-recorder.mjs — Playwright route-intercept based request recorder.
+ *
+ * Attaches a route handler to a Playwright page that captures every request
+ * whose URL path matches `pathPattern` (a RegExp or string converted to RegExp).
+ * Query parameters are parsed into a `params` object for easy assertion.
+ *
+ * Usage:
+ *   const recorder = attachRecorder(page, '^/api/household/timeline$');
+ *   await page.goto(url);
+ *   // ... wait for requests ...
+ *   console.log(recorder.requests); // [{ url, method, path, params }]
+ *
+ * Idempotent: calling attachRecorder twice on the same page with the same
+ * pattern string does NOT register a duplicate handler (keyed by pattern).
+ */
+
+const ATTACHED_KEY = Symbol('autospec:recorder:attached');
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {string | RegExp} pathPattern  — matched against request.url() pathname only
+ * @returns {{ requests: Array<{ url: string, method: string, path: string, params: Record<string, string> }> }}
+ */
+export function attachRecorder(page, pathPattern) {
+  // Normalise pattern to RegExp
+  const re = pathPattern instanceof RegExp
+    ? pathPattern
+    : new RegExp(pathPattern);
+
+  // Idempotency: track attached patterns on the page object itself
+  if (!page[ATTACHED_KEY]) {
+    page[ATTACHED_KEY] = new Map();
+  }
+
+  const key = re.source + re.flags;
+  if (page[ATTACHED_KEY].has(key)) {
+    return page[ATTACHED_KEY].get(key);
+  }
+
+  const recorder = { requests: [] };
+
+  page.route('**/*', (route) => {
+    const reqUrl = route.request().url();
+    let pathname;
+    try {
+      pathname = new URL(reqUrl).pathname;
+    } catch {
+      // Blob / data URLs — skip matching
+      return route.continue();
+    }
+
+    if (re.test(pathname)) {
+      const parsedUrl = new URL(reqUrl);
+      const params = {};
+      for (const [k, v] of parsedUrl.searchParams.entries()) {
+        params[k] = v;
+      }
+      recorder.requests.push({
+        url: reqUrl,
+        method: route.request().method(),
+        path: pathname,
+        params,
+      });
+    }
+
+    route.continue().catch(() => {});
+  });
+
+  page[ATTACHED_KEY].set(key, recorder);
+  return recorder;
+}

--- a/skills/autospec-test/scripts/window-contract/run-window.mjs
+++ b/skills/autospec-test/scripts/window-contract/run-window.mjs
@@ -1,0 +1,271 @@
+/**
+ * run-window.mjs — Metric G: Window-Contract Symmetry Runner
+ *
+ * Reads a contract + base_url from stdin JSON, for each declared window_contract:
+ *   1. Attaches a request recorder for the declared api_query.path_pattern
+ *   2. Navigates to ui_display.route
+ *   3. Reads N from ui_display.window_days_attr on the widget element
+ *   4. Waits up to 30s for ≥1 matching recorded request
+ *   5. For each declared window_param, resolves the expected date and compares
+ *      to the observed query-param value; a difference > tolerance_days is a violation
+ *   6. Emits gate JSON on stdout
+ *
+ * Input (stdin JSON):
+ *   {
+ *     contract: { e2e: { invariants_v2: { window_contracts: [...] } } },
+ *     base_url: string,
+ *     today?: string,   // optional ISO override for deterministic tests (YYYY-MM-DD)
+ *   }
+ *
+ * Output (stdout JSON):
+ *   {
+ *     metric: "G",
+ *     passed: boolean,
+ *     contracts: [{ id, passed, N, violations[], requests_seen }],
+ *     summary: { total, passed_count, failed_count, violation_count }
+ *   }
+ *
+ * Exit codes: 0 = pass, 1 = fail (violations found), 2 = fatal/config error
+ */
+
+import { chromium } from '/opt/homebrew/lib/node_modules/playwright/index.mjs';
+import { resolve as resolveDateExpr } from './date-math.mjs';
+import { attachRecorder } from './request-recorder.mjs';
+
+const REQUEST_WAIT_MS = parseInt(process.env.AUTOSPEC_WINDOW_REQUEST_WAIT_MS ?? '30000', 10);
+const POLL_INTERVAL_MS = 100;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Wait until recorder has ≥1 request, or timeout.
+ * @param {{ requests: object[] }} recorder
+ * @param {number} timeoutMs
+ * @returns {Promise<boolean>}
+ */
+async function waitForRequest(recorder, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (recorder.requests.length > 0) return true;
+    await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  return false;
+}
+
+/**
+ * Compute the absolute difference in calendar days between two ISO date strings.
+ * @param {string} a YYYY-MM-DD
+ * @param {string} b YYYY-MM-DD
+ * @returns {number}
+ */
+function diffDays(a, b) {
+  const msA = new Date(a + 'T00:00:00Z').getTime();
+  const msB = new Date(b + 'T00:00:00Z').getTime();
+  return Math.abs(Math.round((msA - msB) / 86_400_000));
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function run() {
+  // Read stdin
+  let input;
+  try {
+    const chunks = [];
+    for await (const chunk of process.stdin) chunks.push(chunk);
+    input = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } catch (e) {
+    process.stderr.write(`[run-window] fatal: failed to parse stdin JSON: ${e.message}\n`);
+    process.exit(2);
+  }
+
+  const { contract, base_url: baseUrl, today: todayOverride } = input;
+
+  if (!contract || !baseUrl) {
+    process.stderr.write('[run-window] fatal: stdin must have { contract, base_url }\n');
+    process.exit(2);
+  }
+
+  const invariantsV2 = contract?.e2e?.invariants_v2;
+  if (!invariantsV2?.enabled) {
+    const result = {
+      metric: 'G',
+      passed: true,
+      contracts: [],
+      summary: { total: 0, passed_count: 0, failed_count: 0, violation_count: 0 },
+    };
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    process.exit(0);
+  }
+
+  const windowContracts = invariantsV2.window_contracts || [];
+
+  // Build today Date for date-math
+  const today = todayOverride
+    ? new Date(todayOverride + 'T00:00:00Z')
+    : new Date();
+  const dateCtx = { today };
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  const contractResults = [];
+
+  try {
+    for (const wc of windowContracts) {
+      const { id, ui_display, api_query } = wc;
+      const toleranceDays = wc.tolerance_days ?? 1; // contract-level default
+      const pathPattern = api_query.path_pattern;
+      const recorder = attachRecorder(page, pathPattern);
+
+      // Navigate
+      const url = baseUrl.replace(/\/$/, '') + ui_display.route;
+      try {
+        await page.goto(url, { waitUntil: 'domcontentloaded' });
+      } catch (e) {
+        contractResults.push({
+          id,
+          passed: false,
+          N: null,
+          violations: [{ param: '_navigation', reason: `goto failed: ${e.message}` }],
+          requests_seen: 0,
+        });
+        continue;
+      }
+
+      // Wait for widget
+      try {
+        await page.locator(ui_display.widget).waitFor({ state: 'visible', timeout: 10_000 });
+      } catch {
+        contractResults.push({
+          id,
+          passed: false,
+          N: null,
+          violations: [{ param: '_widget', reason: `widget "${ui_display.widget}" not visible within 10s` }],
+          requests_seen: 0,
+        });
+        continue;
+      }
+
+      // Read N from DOM attribute
+      let N;
+      try {
+        const raw = await page.locator(ui_display.widget).getAttribute(ui_display.window_days_attr);
+        N = parseInt(raw, 10);
+        if (isNaN(N)) throw new Error(`attribute "${ui_display.window_days_attr}" is not a number: ${raw}`);
+      } catch (e) {
+        contractResults.push({
+          id,
+          passed: false,
+          N: null,
+          violations: [{ param: '_window_days_attr', reason: e.message }],
+          requests_seen: 0,
+        });
+        continue;
+      }
+
+      // Wait for at least one recorded request
+      const got = await waitForRequest(recorder, REQUEST_WAIT_MS);
+      if (!got) {
+        contractResults.push({
+          id,
+          passed: false,
+          N,
+          violations: [{ param: '_requests', reason: `no request matching "${pathPattern}" captured within ${REQUEST_WAIT_MS}ms` }],
+          requests_seen: 0,
+        });
+        continue;
+      }
+
+      // Take the first matching request for param comparison
+      const firstReq = recorder.requests[0];
+      const violations = [];
+
+      const windowParams = api_query.window_params || {};
+      for (const [paramName, paramSpec] of Object.entries(windowParams)) {
+        const perParamTolerance = paramSpec.tolerance_days ?? toleranceDays;
+
+        // Resolve expected value: substitute $N in the must_be expression
+        const exprWithN = paramSpec.must_be.replace('$N', String(N));
+        let expected;
+        try {
+          expected = resolveDateExpr(exprWithN, dateCtx);
+        } catch (e) {
+          violations.push({
+            param: paramName,
+            reason: `could not resolve expected expression "${exprWithN}": ${e.message}`,
+          });
+          continue;
+        }
+
+        // Observed value from the captured request
+        const observed = firstReq.params[paramName];
+        if (!observed) {
+          violations.push({
+            param: paramName,
+            expected,
+            observed: null,
+            reason: `param "${paramName}" missing from captured request`,
+          });
+          continue;
+        }
+
+        // Validate observed is a valid ISO date
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(observed)) {
+          violations.push({
+            param: paramName,
+            expected,
+            observed,
+            reason: `param "${paramName}" is not an ISO date: ${observed}`,
+          });
+          continue;
+        }
+
+        const diff = diffDays(expected, observed);
+        if (diff > perParamTolerance) {
+          violations.push({
+            param: paramName,
+            expected,
+            observed,
+            diff_days: diff,
+            tolerance_days: perParamTolerance,
+            reason: `expected ${paramName}=${expected}, got ${observed} (diff=${diff}d > tolerance=${perParamTolerance}d)`,
+          });
+        }
+      }
+
+      contractResults.push({
+        id,
+        passed: violations.length === 0,
+        N,
+        violations,
+        requests_seen: recorder.requests.length,
+      });
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const passed_count = contractResults.filter(r => r.passed).length;
+  const failed_count = contractResults.filter(r => !r.passed).length;
+  const violation_count = contractResults.reduce((s, r) => s + r.violations.length, 0);
+
+  const output = {
+    metric: 'G',
+    passed: failed_count === 0,
+    contracts: contractResults,
+    summary: {
+      total: contractResults.length,
+      passed_count,
+      failed_count,
+      violation_count,
+    },
+  };
+
+  process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+  process.exit(output.passed ? 0 : 1);
+}
+
+run().catch((e) => {
+  process.stderr.write(`[run-window] fatal: ${e.message}\n${e.stack}\n`);
+  process.exit(2);
+});

--- a/skills/autospec-test/tests/fixtures/v2/window-contract/index.html
+++ b/skills/autospec-test/tests/fixtures/v2/window-contract/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Window-contract mismatch fixture</title>
+</head>
+<body>
+  <!--
+    Mismatch fixture: UI declares data-window-days="7" (7-day window)
+    but the inline script fetches from=today-3d (3-day window).
+    Metric G run-window.mjs must detect this and emit a violation.
+  -->
+  <div
+    data-testid="streak-widget"
+    data-window-days="7"
+    data-loaded="true"
+    style="padding:8px;border:1px solid #ccc"
+  >
+    Streak widget (7-day window declared in UI)
+  </div>
+
+  <script>
+    // Deliberately fetches a 3-day window instead of the declared 7-day window.
+    // The test server or page.route handler in run-window.mjs intercepts this.
+    const today = new Date();
+    const from = new Date(today);
+    from.setDate(from.getDate() - 3);
+
+    const pad = n => String(n).padStart(2, '0');
+    const fmt = d => `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
+
+    fetch(`/api/household/timeline?from=${fmt(from)}&to=${fmt(today)}`).catch(() => {});
+  </script>
+</body>
+</html>

--- a/skills/autospec-test/tests/unit/v2/date-math.test.mjs
+++ b/skills/autospec-test/tests/unit/v2/date-math.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * date-math.test.mjs — Unit tests for the date-math expression resolver.
+ *
+ * Run: node --test skills/autospec-test/tests/unit/v2/date-math.test.mjs
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve } from '../../../scripts/window-contract/date-math.mjs';
+
+describe('resolve()', () => {
+  const TODAY = new Date('2026-05-21T00:00:00Z');
+  const ctx = { today: TODAY };
+
+  // ── Table from plan §4.2 ─────────────────────────────────────────────────
+
+  it('resolves "today" to the ctx.today date', () => {
+    assert.equal(resolve('today', ctx), '2026-05-21');
+  });
+
+  it('resolves "today - 7 days" correctly', () => {
+    assert.equal(resolve('today - 7 days', ctx), '2026-05-14');
+  });
+
+  it('resolves an ISO literal unchanged', () => {
+    assert.equal(resolve('2026-05-01', {}), '2026-05-01');
+  });
+
+  it('resolves "today + 3 days" correctly', () => {
+    assert.equal(resolve('today + 3 days', ctx), '2026-05-24');
+  });
+
+  it('throws on unparseable expression', () => {
+    assert.throws(
+      () => resolve('tomorrow', {}),
+      /unparseable/i,
+    );
+  });
+
+  // ── Additional edge cases ────────────────────────────────────────────────
+
+  it('resolves "today - 1 days" correctly', () => {
+    assert.equal(resolve('today - 1 days', ctx), '2026-05-20');
+  });
+
+  it('resolves "today + 0 days" as today', () => {
+    assert.equal(resolve('today + 0 days', ctx), '2026-05-21');
+  });
+
+  it('resolves "today - 0 days" as today', () => {
+    assert.equal(resolve('today - 0 days', ctx), '2026-05-21');
+  });
+
+  it('resolves singular "today - 1 day" (without s)', () => {
+    assert.equal(resolve('today - 1 day', ctx), '2026-05-20');
+  });
+
+  it('resolves singular "today + 1 day" (without s)', () => {
+    assert.equal(resolve('today + 1 day', ctx), '2026-05-22');
+  });
+
+  it('handles month rollover correctly (today - 21 days)', () => {
+    assert.equal(resolve('today - 21 days', ctx), '2026-04-30');
+  });
+
+  it('uses real Date.now() when ctx.today is omitted', () => {
+    const result = resolve('today', {});
+    assert.match(result, /^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('throws on empty string', () => {
+    assert.throws(() => resolve('', {}), /unparseable/i);
+  });
+
+  it('throws on numeric-only input', () => {
+    assert.throws(() => resolve('7', {}), /unparseable/i);
+  });
+
+  it('resolves ISO literal with ctx.today present (ctx ignored for ISO)', () => {
+    assert.equal(resolve('2025-12-31', ctx), '2025-12-31');
+  });
+});

--- a/skills/autospec-test/tests/unit/v2/run-window.test.mjs
+++ b/skills/autospec-test/tests/unit/v2/run-window.test.mjs
@@ -1,0 +1,300 @@
+/**
+ * run-window.test.mjs — Unit tests for Metric G window-contract runner.
+ *
+ * Uses real Playwright against a tiny inline HTTP server serving static HTML.
+ * No mocks — requests are intercepted via page.route() inside the recorder.
+ *
+ * Run: node --test skills/autospec-test/tests/unit/v2/run-window.test.mjs
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from '/opt/homebrew/lib/node_modules/playwright/index.mjs';
+import { attachRecorder } from '../../../scripts/window-contract/request-recorder.mjs';
+import { resolve as resolveDateExpr } from '../../../scripts/window-contract/date-math.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = path.join(__dirname, '../../fixtures/v2/window-contract');
+
+// ── Inline test HTTP server ────────────────────────────────────────────────────
+
+let server;
+let baseUrl;
+
+/**
+ * Serve the mismatch fixture HTML plus a fake API endpoint.
+ * The fixture HTML fetches /api/household/timeline?from=...&to=...
+ * The server responds with 200 JSON to let the browser complete the fetch.
+ */
+before(async () => {
+  server = http.createServer((req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+
+    if (url.pathname === '/api/household/timeline') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ events: [] }));
+      return;
+    }
+
+    if (url.pathname === '/' || url.pathname === '/index.html') {
+      const html = fs.readFileSync(path.join(FIXTURE_DIR, 'index.html'), 'utf8');
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(html);
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('not found');
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal contract for a single window-contract entry.
+ */
+function makeContract(overrides = {}) {
+  return {
+    e2e: {
+      invariants_v2: {
+        enabled: true,
+        window_contracts: [
+          {
+            id: 'dashboard-streak-window',
+            ui_display: {
+              route: '/',
+              widget: '[data-testid="streak-widget"]',
+              window_days_attr: 'data-window-days',
+            },
+            api_query: {
+              method: 'GET',
+              path_pattern: '^/api/household/timeline$',
+              window_params: {
+                from: {
+                  type: 'iso_date',
+                  must_be: 'today - $N days',
+                  tolerance_days: overrides.from_tolerance ?? 1,
+                },
+                to: {
+                  type: 'iso_date',
+                  must_be: 'today',
+                  tolerance_days: overrides.to_tolerance ?? 1,
+                },
+              },
+            },
+            mismatch_action: 'hard_fail',
+            ...overrides.contract_overrides,
+          },
+        ],
+      },
+    },
+  };
+}
+
+/**
+ * Run the core window-contract check logic against a live Playwright page.
+ * Mirrors what run-window.mjs does but in-process so we can assert results.
+ */
+async function runWindowCheck({ page, contract, todayISO, requestWaitMs = 5000 }) {
+  const wc = contract.e2e.invariants_v2.window_contracts[0];
+  const { ui_display, api_query } = wc;
+  const toleranceDays = wc.tolerance_days ?? 1;
+  const today = new Date(todayISO + 'T00:00:00Z');
+  const dateCtx = { today };
+
+  const recorder = attachRecorder(page, api_query.path_pattern);
+  await page.goto(baseUrl + ui_display.route, { waitUntil: 'domcontentloaded' });
+  await page.locator(ui_display.widget).waitFor({ state: 'visible', timeout: 10_000 });
+
+  const raw = await page.locator(ui_display.widget).getAttribute(ui_display.window_days_attr);
+  const N = parseInt(raw, 10);
+
+  // Wait for requests (short poll loop)
+  const deadline = Date.now() + requestWaitMs;
+  while (Date.now() < deadline && recorder.requests.length === 0) {
+    await new Promise(r => setTimeout(r, 50));
+  }
+
+  assert.ok(recorder.requests.length > 0, 'Expected at least one recorded request');
+
+  const firstReq = recorder.requests[0];
+  const violations = [];
+
+  for (const [paramName, paramSpec] of Object.entries(api_query.window_params)) {
+    const perParamTolerance = paramSpec.tolerance_days ?? toleranceDays;
+    const exprWithN = paramSpec.must_be.replace('$N', String(N));
+    const expected = resolveDateExpr(exprWithN, dateCtx);
+    const observed = firstReq.params[paramName];
+
+    if (!observed) {
+      violations.push({ param: paramName, expected, observed: null, reason: 'missing' });
+      continue;
+    }
+
+    const msA = new Date(expected + 'T00:00:00Z').getTime();
+    const msB = new Date(observed + 'T00:00:00Z').getTime();
+    const diff = Math.abs(Math.round((msA - msB) / 86_400_000));
+    if (diff > perParamTolerance) {
+      violations.push({ param: paramName, expected, observed, diff_days: diff });
+    }
+  }
+
+  return { N, violations, requests: recorder.requests };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('Metric G — window-contract runner', () => {
+  let browser;
+  let page;
+
+  before(async () => {
+    browser = await chromium.launch({ headless: true });
+  });
+  after(async () => {
+    await browser.close();
+  });
+
+  // Fresh page per test to isolate recorders
+  async function freshPage() {
+    if (page) await page.close().catch(() => {});
+    page = await browser.newPage();
+    return page;
+  }
+
+  // ── Mismatch case ────────────────────────────────────────────────────────
+
+  it('detects mismatch: UI=7d widget but API fetches 3d window', async () => {
+    const p = await freshPage();
+    // Today is the date the fixture uses as "today" when computing "today - 3d"
+    // We pin today so the test is deterministic regardless of real clock
+    const realToday = new Date();
+    const pad = n => String(n).padStart(2, '0');
+    const todayISO = `${realToday.getUTCFullYear()}-${pad(realToday.getUTCMonth()+1)}-${pad(realToday.getUTCDate())}`;
+
+    const contract = makeContract({ from_tolerance: 1 });
+    const result = await runWindowCheck({ page: p, contract, todayISO });
+
+    // Widget declares N=7; fixture fetches from=today-3d → diff=4 > tolerance=1 → violation
+    assert.equal(result.N, 7);
+    const fromViolation = result.violations.find(v => v.param === 'from');
+    assert.ok(fromViolation, `Expected a 'from' violation; got: ${JSON.stringify(result.violations)}`);
+    assert.ok(fromViolation.diff_days >= 3,
+      `Expected diff_days >= 3, got ${fromViolation.diff_days}`);
+    assert.ok(fromViolation.expected, 'violation should have expected field');
+    assert.ok(fromViolation.observed, 'violation should have observed field');
+  });
+
+  // ── Tolerance boundary: +1 day passes ────────────────────────────────────
+
+  it('tolerance_days=4: mismatch of 4 days passes (boundary)', async () => {
+    const p = await freshPage();
+    const realToday = new Date();
+    const pad = n => String(n).padStart(2, '0');
+    const todayISO = `${realToday.getUTCFullYear()}-${pad(realToday.getUTCMonth()+1)}-${pad(realToday.getUTCDate())}`;
+
+    // With tolerance_days=4 the 4-day difference (today-3d vs today-7d) just passes
+    const contract = makeContract({ from_tolerance: 4 });
+    const result = await runWindowCheck({ page: p, contract, todayISO });
+
+    assert.equal(result.N, 7);
+    const fromViolation = result.violations.find(v => v.param === 'from');
+    assert.equal(fromViolation, undefined, 'Should be no violation with tolerance=4');
+  });
+
+  // ── Tolerance boundary: tolerance=3 passes, tolerance=2 fails ────────────
+
+  it('tolerance_days=3: mismatch of 4 days fails (just outside boundary)', async () => {
+    const p = await freshPage();
+    const realToday = new Date();
+    const pad = n => String(n).padStart(2, '0');
+    const todayISO = `${realToday.getUTCFullYear()}-${pad(realToday.getUTCMonth()+1)}-${pad(realToday.getUTCDate())}`;
+
+    // tolerance=3 < diff=4 → fail
+    const contract = makeContract({ from_tolerance: 3 });
+    const result = await runWindowCheck({ page: p, contract, todayISO });
+
+    const fromViolation = result.violations.find(v => v.param === 'from');
+    assert.ok(fromViolation, 'Should have violation with tolerance=3 and diff=4');
+  });
+
+  // ── attachRecorder idempotency ────────────────────────────────────────────
+
+  it('attachRecorder is idempotent — double attach returns same recorder', async () => {
+    const p = await freshPage();
+    const r1 = attachRecorder(p, '^/api/test$');
+    const r2 = attachRecorder(p, '^/api/test$');
+    assert.strictEqual(r1, r2, 'Same recorder object expected on double attach');
+  });
+
+  // ── attachRecorder: only matching paths recorded ──────────────────────────
+
+  it('attachRecorder captures only matching path pattern', async () => {
+    const p = await freshPage();
+    const recorder = attachRecorder(p, '^/api/household/timeline$');
+
+    // Navigate to the fixture — it fetches /api/household/timeline
+    await p.goto(baseUrl + '/', { waitUntil: 'domcontentloaded' });
+
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline && recorder.requests.length === 0) {
+      await new Promise(r => setTimeout(r, 50));
+    }
+
+    assert.ok(recorder.requests.length >= 1, 'Expected recorded request for /api/household/timeline');
+    for (const req of recorder.requests) {
+      assert.match(req.path, /^\/api\/household\/timeline$/);
+    }
+  });
+
+  // ── Gate JSON shape emitted by run-window.mjs ─────────────────────────────
+
+  it('run-window.mjs emits correct gate JSON shape on stdout', async () => {
+    // Smoke: call run-window.mjs as a subprocess, pipe in minimal contract
+    const { execFileSync } = await import('node:child_process');
+
+    const contract = {
+      e2e: {
+        invariants_v2: {
+          enabled: false,
+          window_contracts: [],
+        },
+      },
+    };
+
+    let stdout;
+    try {
+      stdout = execFileSync('node', [
+        'skills/autospec-test/scripts/window-contract/run-window.mjs',
+      ], {
+        input: JSON.stringify({ contract, base_url: baseUrl }),
+        cwd: path.resolve(__dirname, '../../../../..'),
+        timeout: 15_000,
+        encoding: 'utf8',
+      });
+    } catch (e) {
+      throw new Error(`run-window.mjs subprocess failed: ${e.stderr || e.message}`);
+    }
+
+    const result = JSON.parse(stdout);
+    assert.equal(result.metric, 'G');
+    assert.equal(typeof result.passed, 'boolean');
+    assert.ok(Array.isArray(result.contracts));
+    assert.equal(typeof result.summary, 'object');
+    assert.ok('total' in result.summary);
+    assert.ok('passed_count' in result.summary);
+    assert.ok('failed_count' in result.summary);
+    assert.ok('violation_count' in result.summary);
+  });
+});


### PR DESCRIPTION
Closes #345

## Summary

Implements the Metric G window-contract runner for autospec-test v2 — detects mismatches between UI-declared data-window-days attributes and the actual query-param window sent to backend APIs.

### New files

- `skills/autospec-test/scripts/window-contract/date-math.mjs` — pure resolver for `today`, `today ± N day[s]`, ISO literals; throws `/unparseable/` on bad input; deterministic via `ctx.today` injection
- `skills/autospec-test/scripts/window-contract/request-recorder.mjs` — `attachRecorder(page, pathPattern)` intercepts matching Playwright routes, parses query params into `{ url, method, path, params }`; idempotent on double-attach per page
- `skills/autospec-test/scripts/window-contract/run-window.mjs` — stdin-JSON orchestrator: reads contract, navigates to route, reads `data-window-days=N`, waits ≤30s for ≥1 matching API request, diffs expected vs observed params with per-param `tolerance_days`, emits `{ metric: "G", passed, contracts[], summary }`
- `skills/autospec-test/tests/fixtures/v2/window-contract/index.html` — mismatch fixture: UI declares `data-window-days="7"` but script fetches `from=today-3d` (4-day gap)
- `skills/autospec-test/tests/unit/v2/date-math.test.mjs` — 15 cases covering plan §4.2 table (today, ±N days, ISO literal, unparseable throw, month rollover, singular "day")
- `skills/autospec-test/tests/unit/v2/run-window.test.mjs` — 6 real-Playwright tests: mismatch detection, tolerance boundary pass (tol=4, diff=4), tolerance boundary fail (tol=3, diff=4), recorder idempotency, path-pattern filtering, gate JSON shape

### Test results

```
21 tests, 21 pass, 0 fail
```

Primary smoke test: `node --test skills/autospec-test/tests/unit/v2/date-math.test.mjs skills/autospec-test/tests/unit/v2/run-window.test.mjs`