### PR TITLE
feat(autospec-test): metric H extended crawler (phase 5)

### DIFF
--- a/skills/autospec-test/scripts/crawler-v2/affordance-verifier.mjs
+++ b/skills/autospec-test/scripts/crawler-v2/affordance-verifier.mjs
@@ -1,0 +1,144 @@
+/**
+ * affordance-verifier.mjs — Verifies interactive affordances on a Playwright page.
+ *
+ * For each element matching pattern.element:
+ *   1. Capture pre-click DOM snapshot (focused element tag, body class list)
+ *   2. Assert element has an interactive role (button, link, menuitem)
+ *   3. Click the element
+ *   4. Assert pattern.opens becomes visible within timeout (default 5s)
+ *   5. Click pattern.closes_via
+ *   6. Assert pattern.opens is hidden
+ *   7. Best-effort: assert body classes restored (not hard-fail)
+ *
+ * Returns Array<{ route, element_index, passed, failure_reason? }>
+ */
+
+const INTERACTIVE_ROLES = new Set(['button', 'link', 'menuitem']);
+const OPEN_TIMEOUT_MS = parseInt(process.env.AUTOSPEC_AFFORDANCE_OPEN_TIMEOUT_MS ?? '5000', 10);
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {{ element: string, opens: string, closes_via: string }} pattern
+ * @param {string} route
+ * @returns {Promise<Array<{ route: string, element_index: number, passed: boolean, failure_reason?: string }>>}
+ */
+export async function verifyAffordance(page, pattern, route) {
+  const results = [];
+
+  const elements = page.locator(pattern.element);
+  const count = await elements.count();
+
+  for (let i = 0; i < count; i++) {
+    const el = elements.nth(i);
+
+    // Skip invisible elements
+    const isVisible = await el.isVisible().catch(() => false);
+    if (!isVisible) {
+      results.push({
+        route,
+        element_index: i,
+        passed: true, // invisible elements are not affordances to verify
+        skipped: true,
+        failure_reason: undefined,
+      });
+      continue;
+    }
+
+    // Capture pre-click snapshot
+    const preSnapshot = await page.evaluate(() => ({
+      focusedTag: document.activeElement?.tagName ?? '',
+      bodyClasses: document.body.className,
+    })).catch(() => ({ focusedTag: '', bodyClasses: '' }));
+
+    // Check role
+    const role = await el.evaluate(node => {
+      const explicit = node.getAttribute('role');
+      if (explicit) return explicit.toLowerCase();
+      const tag = node.tagName.toLowerCase();
+      if (tag === 'button') return 'button';
+      if (tag === 'a') return 'link';
+      return '';
+    }).catch(() => '');
+
+    if (!INTERACTIVE_ROLES.has(role)) {
+      results.push({
+        route,
+        element_index: i,
+        passed: false,
+        failure_reason: `element at index ${i} has non-interactive role "${role}" (expected one of: ${[...INTERACTIVE_ROLES].join(', ')})`,
+      });
+      continue;
+    }
+
+    // Click the element
+    try {
+      await el.click({ timeout: 3000 });
+    } catch (e) {
+      results.push({
+        route,
+        element_index: i,
+        passed: false,
+        failure_reason: `click failed: ${e.message}`,
+      });
+      continue;
+    }
+
+    // Assert opens becomes visible
+    try {
+      await page.locator(pattern.opens).waitFor({ state: 'visible', timeout: OPEN_TIMEOUT_MS });
+    } catch {
+      results.push({
+        route,
+        element_index: i,
+        passed: false,
+        failure_reason: `"${pattern.opens}" did not become visible within ${OPEN_TIMEOUT_MS}ms after clicking element at index ${i}`,
+      });
+      continue;
+    }
+
+    // Click closes_via
+    try {
+      await page.locator(pattern.closes_via).click({ timeout: 3000 });
+    } catch (e) {
+      results.push({
+        route,
+        element_index: i,
+        passed: false,
+        failure_reason: `closes_via click failed: ${e.message}`,
+      });
+      continue;
+    }
+
+    // Assert opens is hidden
+    try {
+      await page.locator(pattern.opens).waitFor({ state: 'hidden', timeout: OPEN_TIMEOUT_MS });
+    } catch {
+      results.push({
+        route,
+        element_index: i,
+        passed: false,
+        failure_reason: `"${pattern.opens}" did not hide within ${OPEN_TIMEOUT_MS}ms after clicking closes_via`,
+      });
+      continue;
+    }
+
+    // Best-effort post-close snapshot check (body classes)
+    const postSnapshot = await page.evaluate(() => ({
+      bodyClasses: document.body.className,
+    })).catch(() => ({ bodyClasses: '' }));
+
+    const bodyRestored = preSnapshot.bodyClasses === postSnapshot.bodyClasses;
+    // Body class mismatch is a warning, not a hard failure — modal libraries vary
+    const snapshotNote = bodyRestored ? undefined : `body classes changed: "${preSnapshot.bodyClasses}" → "${postSnapshot.bodyClasses}"`;
+
+    results.push({
+      route,
+      element_index: i,
+      passed: true,
+      failure_reason: undefined,
+      ...(snapshotNote ? { snapshot_note: snapshotNote } : {}),
+    });
+  }
+
+  return results;
+}

--- a/skills/autospec-test/scripts/crawler-v2/extended-crawler.mjs
+++ b/skills/autospec-test/scripts/crawler-v2/extended-crawler.mjs
@@ -1,0 +1,196 @@
+/**
+ * extended-crawler.mjs — Metric H: Extended BFS Crawler
+ *
+ * Reads a contract + base_url from stdin JSON and performs:
+ *   1. BFS over in-domain a[href] links, capped at bfs_max_routes (default 200)
+ *   2. Opens all foldouts on each page when crawler.open_all_foldouts=true
+ *   3. Verifies every declared affordance_pattern on each visited page
+ *   4. Emits gate JSON on stdout
+ *
+ * Input (stdin JSON):
+ *   {
+ *     contract: { e2e: { invariants_v2: { crawler: { ... } } } },
+ *     base_url: string
+ *   }
+ *
+ * Output (stdout JSON):
+ *   {
+ *     metric: "H",
+ *     passed: boolean,
+ *     unaffordable_elements: [{ route, element_index, failure_reason }],
+ *     routes_visited: number,
+ *     routes_capped: boolean,
+ *     summary: { total_checks, passed_checks, failed_checks }
+ *   }
+ *
+ * Exit codes: 0 = pass, 1 = fail, 2 = fatal error
+ */
+
+import { chromium } from '/opt/homebrew/lib/node_modules/playwright/index.mjs';
+import { openAllFoldouts } from './foldout-opener.mjs';
+import { verifyAffordance } from './affordance-verifier.mjs';
+
+async function run() {
+  let input;
+  try {
+    const chunks = [];
+    for await (const chunk of process.stdin) chunks.push(chunk);
+    input = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } catch (e) {
+    process.stderr.write(`[extended-crawler] fatal: failed to parse stdin JSON: ${e.message}\n`);
+    process.exit(2);
+  }
+
+  const { contract, base_url: baseUrl } = input;
+  if (!contract || !baseUrl) {
+    process.stderr.write('[extended-crawler] fatal: stdin must have { contract, base_url }\n');
+    process.exit(2);
+  }
+
+  const invariantsV2 = contract?.e2e?.invariants_v2;
+  if (!invariantsV2?.enabled || !invariantsV2?.crawler?.enabled) {
+    const result = {
+      metric: 'H',
+      passed: true,
+      unaffordable_elements: [],
+      routes_visited: 0,
+      routes_capped: false,
+      summary: { total_checks: 0, passed_checks: 0, failed_checks: 0 },
+    };
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    process.exit(0);
+  }
+
+  const crawlerConfig = invariantsV2.crawler;
+  const bfsMaxRoutes = crawlerConfig.bfs_max_routes ?? 200;
+  const openFoldouts = crawlerConfig.open_all_foldouts ?? false;
+  const affordancePatterns = crawlerConfig.affordance_patterns ?? [];
+  const maxUnaffordable = crawlerConfig.failure_threshold?.max_unaffordable_elements ?? 0;
+
+  // Normalise base URL (strip trailing slash)
+  const base = baseUrl.replace(/\/$/, '');
+  let baseOrigin;
+  try {
+    baseOrigin = new URL(base).origin;
+  } catch {
+    process.stderr.write(`[extended-crawler] fatal: invalid base_url: ${base}\n`);
+    process.exit(2);
+  }
+
+  /** Normalise URL: strip trailing slash (except bare origin), strip hash */
+  function normalizeUrl(u) {
+    try {
+      const parsed = new URL(u);
+      parsed.hash = '';
+      // Keep pathname as-is but strip trailing slash if it has a path
+      if (parsed.pathname.length > 1 && parsed.pathname.endsWith('/')) {
+        parsed.pathname = parsed.pathname.slice(0, -1);
+      }
+      return parsed.toString();
+    } catch {
+      return u;
+    }
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  const startUrl = normalizeUrl(base + '/');
+  const queue = [startUrl];
+  const visited = new Set();
+  const allResults = [];
+
+  try {
+    while (queue.length > 0 && visited.size < bfsMaxRoutes) {
+      const url = normalizeUrl(queue.shift());
+      if (visited.has(url)) continue;
+      visited.add(url);
+
+      // Navigate to the URL
+      try {
+        await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15_000 });
+      } catch (e) {
+        process.stderr.write(`[extended-crawler] warn: goto ${url} failed: ${e.message}\n`);
+        continue;
+      }
+
+      // Open foldouts if configured
+      if (openFoldouts) {
+        await openAllFoldouts(page).catch(e => {
+          process.stderr.write(`[extended-crawler] warn: openAllFoldouts failed on ${url}: ${e.message}\n`);
+        });
+      }
+
+      // Discover in-domain hrefs
+      const hrefs = await page.evaluate((origin) => {
+        const links = Array.from(document.querySelectorAll('a[href]'));
+        return links
+          .map(a => a.href)
+          .filter(href => {
+            try {
+              const u = new URL(href);
+              return u.origin === origin && !href.includes('#');
+            } catch {
+              return false;
+            }
+          });
+      }, baseOrigin).catch(() => []);
+
+      for (const rawHref of hrefs) {
+        const href = normalizeUrl(rawHref);
+        if (!visited.has(href) && !queue.includes(href)) {
+          queue.push(href);
+        }
+      }
+
+      // Verify affordance patterns on this page
+      const route = url;
+      for (const pattern of affordancePatterns) {
+        // Quick check: does the element exist on this page?
+        const matchCount = await page.locator(pattern.element).count().catch(() => 0);
+        if (matchCount === 0) continue;
+
+        const results = await verifyAffordance(page, pattern, route).catch(e => {
+          process.stderr.write(`[extended-crawler] warn: verifyAffordance failed on ${url}: ${e.message}\n`);
+          return [];
+        });
+        allResults.push(...results);
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const routesCapped = visited.size >= bfsMaxRoutes && queue.length > 0;
+  const unaffordableElements = allResults.filter(r => !r.passed && !r.skipped);
+  const passedChecks = allResults.filter(r => r.passed && !r.skipped).length;
+  const failedChecks = unaffordableElements.length;
+  const totalChecks = allResults.filter(r => !r.skipped).length;
+
+  const passed = unaffordableElements.length <= maxUnaffordable;
+
+  const output = {
+    metric: 'H',
+    passed,
+    unaffordable_elements: unaffordableElements.map(r => ({
+      route: r.route,
+      element_index: r.element_index,
+      failure_reason: r.failure_reason,
+    })),
+    routes_visited: visited.size,
+    routes_capped: routesCapped,
+    summary: {
+      total_checks: totalChecks,
+      passed_checks: passedChecks,
+      failed_checks: failedChecks,
+    },
+  };
+
+  process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+  process.exit(output.passed ? 0 : 1);
+}
+
+run().catch(e => {
+  process.stderr.write(`[extended-crawler] fatal: ${e.message}\n${e.stack}\n`);
+  process.exit(2);
+});

--- a/skills/autospec-test/tests/fixtures/v2/crawler-v2/site/page-a.html
+++ b/skills/autospec-test/tests/fixtures/v2/crawler-v2/site/page-a.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page A — working affordance</title>
+</head>
+<body>
+  <nav>
+    <a href="/page-b.html">Go to B</a>
+    <a href="/page-c.html">Go to C</a>
+  </nav>
+
+  <!-- Working done-item with a functioning edit button -->
+  <div data-testid="done-item-row-1" role="listitem">
+    <span>Task completed today</span>
+    <button
+      role="button"
+      aria-label="Edit task"
+      id="edit-btn-a"
+      onclick="document.getElementById('done-item-edit-dialog').style.display='block'"
+    >Edit</button>
+  </div>
+
+  <!-- Edit dialog (opens + closes correctly) -->
+  <div
+    id="done-item-edit-dialog"
+    data-testid="done-item-edit-dialog"
+    role="dialog"
+    aria-modal="true"
+    style="display:none;padding:16px;border:1px solid #000;background:#fff"
+  >
+    <p>Edit task dialog</p>
+    <button
+      role="button"
+      aria-label="Close dialog"
+      onclick="document.getElementById('done-item-edit-dialog').style.display='none'"
+    >Close</button>
+  </div>
+</body>
+</html>

--- a/skills/autospec-test/tests/fixtures/v2/crawler-v2/site/page-b.html
+++ b/skills/autospec-test/tests/fixtures/v2/crawler-v2/site/page-b.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page B — broken affordance (button opens nothing)</title>
+</head>
+<body>
+  <nav>
+    <a href="/page-a.html">Go to A</a>
+    <a href="/page-c.html">Go to C</a>
+  </nav>
+
+  <!-- Broken done-item: edit button exists but opens no dialog -->
+  <div data-testid="done-item-row-2" role="listitem">
+    <span>Task with broken edit button</span>
+    <button
+      role="button"
+      aria-label="Edit task"
+      id="edit-btn-b"
+      onclick="/* intentionally does nothing */"
+    >Edit</button>
+  </div>
+
+  <!-- The dialog is never shown — this is the bug -->
+  <!-- No done-item-edit-dialog present on this page -->
+</body>
+</html>

--- a/skills/autospec-test/tests/fixtures/v2/crawler-v2/site/page-c.html
+++ b/skills/autospec-test/tests/fixtures/v2/crawler-v2/site/page-c.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page C — foldout with hidden broken affordance</title>
+</head>
+<body>
+  <nav>
+    <a href="/page-a.html">Go to A</a>
+    <a href="/page-b.html">Go to B</a>
+  </nav>
+
+  <!-- Foldout that hides a broken done-item row -->
+  <details aria-expanded="false" id="foldout-c">
+    <summary>Show completed tasks (click to expand)</summary>
+
+    <!-- Hidden behind foldout: broken affordance only visible after open -->
+    <div data-testid="done-item-row-3" role="listitem">
+      <span>Hidden task behind foldout</span>
+      <button
+        role="button"
+        aria-label="Edit task"
+        id="edit-btn-c"
+        onclick="/* intentionally does nothing */"
+      >Edit</button>
+    </div>
+    <!-- No dialog — broken affordance, only discoverable with open_all_foldouts -->
+  </details>
+</body>
+</html>

--- a/skills/autospec-test/tests/unit/v2/extended-crawler.test.mjs
+++ b/skills/autospec-test/tests/unit/v2/extended-crawler.test.mjs
@@ -1,0 +1,377 @@
+/**
+ * extended-crawler.test.mjs — Unit tests for Metric H extended crawler.
+ *
+ * Uses real Playwright against a static inline HTTP server serving the 3-page fixture.
+ * No mocks. Tests: working case, broken case, tolerance, BFS cap, foldout integration.
+ *
+ * Run: node --test skills/autospec-test/tests/unit/v2/extended-crawler.test.mjs
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from '/opt/homebrew/lib/node_modules/playwright/index.mjs';
+import { verifyAffordance } from '../../../scripts/crawler-v2/affordance-verifier.mjs';
+import { openAllFoldouts } from '../../../scripts/crawler-v2/foldout-opener.mjs';
+
+// ── In-process BFS crawler (mirrors extended-crawler.mjs logic for direct testing) ──
+
+async function runCrawlerInProcess({ page, baseUrl, crawlerConfig }) {
+  const bfsMaxRoutes = crawlerConfig.bfs_max_routes ?? 200;
+  const openFoldouts = crawlerConfig.open_all_foldouts ?? false;
+  const affordancePatterns = crawlerConfig.affordance_patterns ?? [];
+  const maxUnaffordable = crawlerConfig.failure_threshold?.max_unaffordable_elements ?? 0;
+
+  const base = baseUrl.replace(/\/$/, '');
+  const baseOrigin = new URL(base).origin;
+
+  function normalizeUrl(u) {
+    try {
+      const parsed = new URL(u);
+      parsed.hash = '';
+      if (parsed.pathname.length > 1 && parsed.pathname.endsWith('/')) {
+        parsed.pathname = parsed.pathname.slice(0, -1);
+      }
+      return parsed.toString();
+    } catch { return u; }
+  }
+
+  const startUrl = normalizeUrl(base + '/');
+  const queue = [startUrl];
+  const visited = new Set();
+  const allResults = [];
+
+  while (queue.length > 0 && visited.size < bfsMaxRoutes) {
+    const url = normalizeUrl(queue.shift());
+    if (visited.has(url)) continue;
+    visited.add(url);
+
+    try {
+      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 10_000 });
+    } catch {
+      continue;
+    }
+
+    if (openFoldouts) {
+      await openAllFoldouts(page).catch(() => {});
+    }
+
+    const hrefs = await page.evaluate((origin) => {
+      return Array.from(document.querySelectorAll('a[href]'))
+        .map(a => a.href)
+        .filter(href => {
+          try { const u = new URL(href); return u.origin === origin && !href.includes('#'); }
+          catch { return false; }
+        });
+    }, baseOrigin).catch(() => []);
+
+    for (const rawHref of hrefs) {
+      const href = normalizeUrl(rawHref);
+      if (!visited.has(href) && !queue.includes(href)) queue.push(href);
+    }
+
+    for (const pattern of affordancePatterns) {
+      const matchCount = await page.locator(pattern.element).count().catch(() => 0);
+      if (matchCount === 0) continue;
+      const results = await verifyAffordance(page, pattern, url).catch(() => []);
+      allResults.push(...results);
+    }
+  }
+
+  const routesCapped = visited.size >= bfsMaxRoutes && queue.length > 0;
+  const unaffordableElements = allResults.filter(r => !r.passed && !r.skipped);
+  const passedChecks = allResults.filter(r => r.passed && !r.skipped).length;
+  const failedChecks = unaffordableElements.length;
+  const totalChecks = allResults.filter(r => !r.skipped).length;
+  const passed = unaffordableElements.length <= maxUnaffordable;
+
+  return {
+    metric: 'H',
+    passed,
+    unaffordable_elements: unaffordableElements,
+    routes_visited: visited.size,
+    routes_capped: routesCapped,
+    summary: { total_checks: totalChecks, passed_checks: passedChecks, failed_checks: failedChecks },
+  };
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = path.join(__dirname, '../../fixtures/v2/crawler-v2/site');
+
+// ── Inline test server ─────────────────────────────────────────────────────────
+
+let server;
+let baseUrl;
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+    let filePath;
+
+    if (url.pathname === '/' || url.pathname === '/index.html' || url.pathname === '/page-a.html') {
+      filePath = path.join(FIXTURE_DIR, 'page-a.html');
+    } else if (url.pathname === '/page-b.html') {
+      filePath = path.join(FIXTURE_DIR, 'page-b.html');
+    } else if (url.pathname === '/page-c.html') {
+      filePath = path.join(FIXTURE_DIR, 'page-c.html');
+    } else {
+      res.writeHead(404);
+      res.end('not found');
+      return;
+    }
+
+    const html = fs.readFileSync(filePath, 'utf8');
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(html);
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+// ── Shared affordance pattern ──────────────────────────────────────────────────
+
+const WORKING_PATTERN = {
+  element: '[data-testid^="done-item-row-"] [role="button"]',
+  opens: '[data-testid="done-item-edit-dialog"]',
+  closes_via: '[data-testid="done-item-edit-dialog"] [role="button"][aria-label="Close dialog"]',
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('Metric H — affordance verifier', () => {
+  let browser;
+  let page;
+
+  before(async () => {
+    browser = await chromium.launch({ headless: true });
+    page = await browser.newPage();
+  });
+
+  after(async () => {
+    await browser.close();
+  });
+
+  it('working affordance on page-a: all checks pass', async () => {
+    await page.goto(`${baseUrl}/page-a.html`, { waitUntil: 'domcontentloaded' });
+    const results = await verifyAffordance(page, WORKING_PATTERN, '/page-a.html');
+    const failures = results.filter(r => !r.passed && !r.skipped);
+    assert.equal(failures.length, 0, `Expected no failures, got: ${JSON.stringify(failures)}`);
+    assert.ok(results.length > 0, 'Expected at least one affordance checked');
+  });
+
+  it('broken affordance on page-b: dialog does not open → violation', async () => {
+    await page.goto(`${baseUrl}/page-b.html`, { waitUntil: 'domcontentloaded' });
+    const results = await verifyAffordance(page, WORKING_PATTERN, '/page-b.html');
+    const failures = results.filter(r => !r.passed && !r.skipped);
+    assert.ok(failures.length > 0, `Expected at least one failure on page-b, got: ${JSON.stringify(results)}`);
+    assert.ok(failures[0].failure_reason, 'failure_reason should be set');
+  });
+
+  it('foldout hidden affordance: not found without openAllFoldouts', async () => {
+    await page.goto(`${baseUrl}/page-c.html`, { waitUntil: 'domcontentloaded' });
+    // Without opening foldouts, the done-item-row-3 inside <details> is hidden
+    const results = await verifyAffordance(page, WORKING_PATTERN, '/page-c.html');
+    // All elements should be skipped (not visible) or count=0
+    const nonSkipped = results.filter(r => !r.skipped);
+    assert.equal(nonSkipped.length, 0, 'Without foldout open, no visible affordances should be checked');
+  });
+
+  it('foldout hidden affordance: found and fails with openAllFoldouts', async () => {
+    await page.goto(`${baseUrl}/page-c.html`, { waitUntil: 'domcontentloaded' });
+    await openAllFoldouts(page);
+    const results = await verifyAffordance(page, WORKING_PATTERN, '/page-c.html');
+    const failures = results.filter(r => !r.passed && !r.skipped);
+    assert.ok(failures.length > 0,
+      `Expected failure after foldout opened (broken affordance inside), got: ${JSON.stringify(results)}`);
+  });
+});
+
+describe('Metric H — extended-crawler (in-process BFS)', () => {
+  let browser;
+  let crawlPage;
+
+  before(async () => {
+    browser = await chromium.launch({ headless: true });
+    crawlPage = await browser.newPage();
+  });
+
+  after(async () => {
+    await browser.close();
+  });
+
+  it('working 3-page site with high tolerance: passed=true', async () => {
+    const result = await runCrawlerInProcess({
+      page: crawlPage,
+      baseUrl,
+      crawlerConfig: {
+        bfs_max_routes: 200,
+        open_all_foldouts: false,
+        affordance_patterns: [WORKING_PATTERN],
+        failure_threshold: { max_unaffordable_elements: 10 },
+      },
+    });
+    assert.equal(result.metric, 'H');
+    assert.equal(result.passed, true, `Expected passed=true with tolerance=10, got: ${JSON.stringify(result)}`);
+    assert.ok(result.routes_visited >= 2, 'Should visit at least 2 routes (root + pages)');
+  });
+
+  it('broken fixture (page-b) emits passed:false with max_unaffordable_elements:0', async () => {
+    // Fresh page to avoid route recorder interference from previous test
+    const p = await browser.newPage();
+    const result = await runCrawlerInProcess({
+      page: p,
+      baseUrl,
+      crawlerConfig: {
+        bfs_max_routes: 200,
+        open_all_foldouts: false,
+        affordance_patterns: [WORKING_PATTERN],
+        failure_threshold: { max_unaffordable_elements: 0 },
+      },
+    });
+    await p.close();
+
+    assert.equal(result.passed, false, `Expected passed=false, got: ${JSON.stringify(result)}`);
+    assert.ok(result.unaffordable_elements.length >= 1, 'Expected at least 1 unaffordable element');
+    assert.ok(result.unaffordable_elements[0].failure_reason, 'violation should have failure_reason');
+  });
+
+  it('tolerance: max_unaffordable_elements=10 flips broken fixture to passed:true', async () => {
+    const p = await browser.newPage();
+    const result = await runCrawlerInProcess({
+      page: p,
+      baseUrl,
+      crawlerConfig: {
+        bfs_max_routes: 200,
+        open_all_foldouts: false,
+        affordance_patterns: [WORKING_PATTERN],
+        failure_threshold: { max_unaffordable_elements: 10 },
+      },
+    });
+    await p.close();
+    assert.equal(result.passed, true, `Expected passed=true with tolerance=10, got: ${JSON.stringify(result)}`);
+  });
+
+  it('BFS cap: stops at bfs_max_routes and sets routes_capped=true when site has more routes', async () => {
+    // Serve many pages via a dynamic server that generates N pages
+    const manyServer = http.createServer((req, res) => {
+      const url = new URL(req.url, 'http://localhost');
+      const match = url.pathname.match(/^\/page-(\d+)\.html$/);
+      if (url.pathname === '/') {
+        // Root links to 250 pages
+        let links = '';
+        for (let i = 1; i <= 250; i++) links += `<a href="/page-${i}.html">P${i}</a>`;
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(`<html><body>${links}</body></html>`);
+      } else if (match) {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(`<html><body><p>Page ${match[1]}</p><a href="/">Home</a></body></html>`);
+      } else {
+        res.writeHead(404); res.end();
+      }
+    });
+    await new Promise(r => manyServer.listen(0, '127.0.0.1', r));
+    const manyBase = `http://127.0.0.1:${manyServer.address().port}`;
+
+    const p = await browser.newPage();
+    const result = await runCrawlerInProcess({
+      page: p,
+      baseUrl: manyBase,
+      crawlerConfig: {
+        bfs_max_routes: 10, // cap at 10 of 251 total routes
+        open_all_foldouts: false,
+        affordance_patterns: [],
+        failure_threshold: { max_unaffordable_elements: 0 },
+      },
+    });
+    await p.close();
+    await new Promise(r => manyServer.close(r));
+
+    assert.equal(result.routes_visited, 10, `Expected routes_visited=10, got ${result.routes_visited}`);
+    assert.equal(result.routes_capped, true, 'Expected routes_capped=true');
+    assert.equal(result.passed, true, 'No affordances checked → passed=true');
+  });
+
+  it('foldout integration: hidden broken affordance found only with open_all_foldouts', async () => {
+    // Without foldouts: page-c's broken affordance (inside <details>) stays hidden
+    const pNo = await browser.newPage();
+    const resultNoFoldout = await runCrawlerInProcess({
+      page: pNo,
+      baseUrl,
+      crawlerConfig: {
+        bfs_max_routes: 200,
+        open_all_foldouts: false,
+        affordance_patterns: [WORKING_PATTERN],
+        failure_threshold: { max_unaffordable_elements: 0 },
+      },
+    });
+    await pNo.close();
+
+    // With foldouts: page-c's foldout opens, broken affordance is found
+    const pYes = await browser.newPage();
+    const resultWithFoldout = await runCrawlerInProcess({
+      page: pYes,
+      baseUrl,
+      crawlerConfig: {
+        bfs_max_routes: 200,
+        open_all_foldouts: true,
+        affordance_patterns: [WORKING_PATTERN],
+        failure_threshold: { max_unaffordable_elements: 0 },
+      },
+    });
+    await pYes.close();
+
+    assert.ok(
+      resultWithFoldout.unaffordable_elements.length >= resultNoFoldout.unaffordable_elements.length,
+      `With foldouts should find same or more violations. ` +
+      `Without: ${resultNoFoldout.unaffordable_elements.length}, ` +
+      `With: ${resultWithFoldout.unaffordable_elements.length}`,
+    );
+  });
+});
+
+describe('Metric H — extended-crawler subprocess (gate JSON shape)', () => {
+  it('emits correct gate JSON with metric:H when disabled', async () => {
+    const { execFileSync } = await import('node:child_process');
+
+    const contract = {
+      e2e: {
+        invariants_v2: {
+          enabled: false,
+          crawler: { enabled: false },
+        },
+      },
+    };
+
+    let stdout;
+    try {
+      stdout = execFileSync('node', [
+        'skills/autospec-test/scripts/crawler-v2/extended-crawler.mjs',
+      ], {
+        input: JSON.stringify({ contract, base_url: baseUrl }),
+        cwd: path.resolve(__dirname, '../../../../..'),
+        timeout: 15_000,
+        encoding: 'utf8',
+      });
+    } catch (e) {
+      throw new Error(`extended-crawler.mjs subprocess failed: ${e.stderr || e.message}`);
+    }
+
+    const result = JSON.parse(stdout);
+    assert.equal(result.metric, 'H');
+    assert.equal(typeof result.passed, 'boolean');
+    assert.ok(Array.isArray(result.unaffordable_elements));
+    assert.equal(typeof result.routes_visited, 'number');
+    assert.equal(typeof result.routes_capped, 'boolean');
+    assert.ok('total_checks' in result.summary);
+    assert.ok('passed_checks' in result.summary);
+    assert.ok('failed_checks' in result.summary);
+  });
+});


### PR DESCRIPTION
Closes #346

## Summary

Implements the Metric H extended BFS crawler for autospec-test v2 — performs in-domain BFS up to `bfs_max_routes`, opens all foldouts, and verifies every declared affordance pattern via click-open-close semantics with hard default `max_unaffordable_elements: 0`.

### New files

- `skills/autospec-test/scripts/crawler-v2/affordance-verifier.mjs` — `verifyAffordance(page, pattern, route)`: for each visible element matching `pattern.element`, asserts interactive role (button/link/menuitem), clicks, waits for `pattern.opens` visible within configurable timeout, clicks `closes_via`, asserts hidden; returns `Array<{ route, element_index, passed, failure_reason? }>`
- `skills/autospec-test/scripts/crawler-v2/extended-crawler.mjs` — stdin-JSON BFS orchestrator: URL-normalized queue, in-domain link discovery via `a[href]`, capped at `bfs_max_routes`, `open_all_foldouts` integration, per-page affordance verification; emits `{ metric: "H", passed, unaffordable_elements[], routes_visited, routes_capped, summary }`
- `skills/autospec-test/tests/fixtures/v2/crawler-v2/site/page-a.html` — working edit affordance (dialog opens and closes correctly)
- `skills/autospec-test/tests/fixtures/v2/crawler-v2/site/page-b.html` — broken button (onclick does nothing; no dialog)
- `skills/autospec-test/tests/fixtures/v2/crawler-v2/site/page-c.html` — broken affordance hidden behind `<details>` foldout (only discoverable with `open_all_foldouts: true`)
- `skills/autospec-test/tests/unit/v2/extended-crawler.test.mjs` — 10 real-Playwright tests: working affordance pass, broken button fail, foldout hidden/found, in-process BFS working/broken/tolerance/BFS-cap/foldout-integration, subprocess gate JSON shape

### Test results

```
10 tests, 10 pass, 0 fail
```

Primary smoke test: `node --test skills/autospec-test/tests/unit/v2/extended-crawler.test.mjs`