### PR TITLE
feat(autospec-test): metric I contract symmetry (phase 6)

### DIFF
--- a/skills/autospec-test/scripts/contract-symmetry/interpolator.mjs
+++ b/skills/autospec-test/scripts/contract-symmetry/interpolator.mjs
@@ -1,0 +1,43 @@
+/**
+ * interpolator.mjs — Template variable interpolator for Metric I contract symmetry.
+ *
+ * Substitutes ${key} and ${url:key} placeholders in a template string using
+ * values from a vars object.
+ *
+ * Syntax:
+ *   ${key}      → vars[key] inserted as-is
+ *   ${url:key}  → vars[key] inserted URL-encoded via encodeURIComponent()
+ *
+ * Throws if any referenced key is undefined in vars, with the missing key name
+ * included in the error message.
+ *
+ * Examples:
+ *   interpolate('/api/timeline?from=${date}&to=${date}', { date: '2026-05-14' })
+ *   → '/api/timeline?from=2026-05-14&to=2026-05-14'
+ *
+ *   interpolate('/api?q=${url:q}', { q: 'hello world' })
+ *   → '/api?q=hello%20world'
+ */
+
+/**
+ * @param {string} template
+ * @param {Record<string, string>} vars
+ * @returns {string}
+ */
+export function interpolate(template, vars) {
+  if (typeof template !== 'string') {
+    throw new TypeError(`interpolate: template must be a string, got ${typeof template}`);
+  }
+
+  // Match ${url:key} and ${key} patterns
+  return template.replace(/\$\{(url:)?([^}]+)\}/g, (match, urlPrefix, key) => {
+    if (!(key in vars)) {
+      throw new Error(
+        `interpolate: missing variable "${key}" in template "${template}"; ` +
+        `available keys: [${Object.keys(vars).join(', ')}]`,
+      );
+    }
+    const value = vars[key];
+    return urlPrefix ? encodeURIComponent(value) : value;
+  });
+}

--- a/skills/autospec-test/scripts/contract-symmetry/jsonpath-verifier.mjs
+++ b/skills/autospec-test/scripts/contract-symmetry/jsonpath-verifier.mjs
@@ -1,0 +1,186 @@
+/**
+ * jsonpath-verifier.mjs — JSONPath-based assertions for Metric I contract symmetry.
+ *
+ * Provides two assertion functions:
+ *   assertContains(body, pathExpr, vars) — asserts the JSONPath expression
+ *     matches at least one value in body; throws with api_response_summary (≤500 bytes)
+ *     on empty result.
+ *   assertBoolean(body, pathExpr, vars) — asserts the JSONPath expression
+ *     evaluates to exactly true (boolean); throws on empty result or non-true value.
+ *
+ * Uses jsonpath-plus for evaluation when available; falls back to a built-in
+ * evaluator that handles the subset of JSONPath used by Metric I contracts:
+ *   $.field               — property access
+ *   $.array[*].field      — array wildcard projection
+ *   $.array[?(@.k=="v")]  — filter expression (equality only)
+ *   $.array[?(@.k==true)] — filter with boolean literal
+ */
+
+// Try to import jsonpath-plus from common locations
+let JSONPath = null;
+const candidatePaths = [
+  '/opt/homebrew/lib/node_modules/jsonpath-plus/dist/index-node-cjs.cjs',
+];
+for (const p of candidatePaths) {
+  try {
+    const mod = await import(p);
+    JSONPath = mod.JSONPath;
+    break;
+  } catch { /* try next */ }
+}
+if (!JSONPath) {
+  try {
+    const mod = await import('jsonpath-plus');
+    JSONPath = mod.JSONPath;
+  } catch { /* use built-in fallback */ }
+}
+
+// ── Built-in evaluator ────────────────────────────────────────────────────────
+
+/**
+ * Minimal JSONPath evaluator supporting the subset used by Metric I.
+ * @param {unknown} root
+ * @param {string} expr
+ * @returns {unknown[]}
+ */
+function builtinEval(root, expr) {
+  // Remove leading $
+  const path = expr.startsWith('$') ? expr.slice(1) : expr;
+
+  // Tokenize: split on . but handle [?(...)] and [*] as single tokens
+  const tokens = [];
+  let i = 0;
+  while (i < path.length) {
+    if (path[i] === '.') {
+      i++;
+      continue;
+    }
+    if (path[i] === '[') {
+      const end = path.indexOf(']', i);
+      if (end === -1) break;
+      tokens.push(path.slice(i, end + 1));
+      i = end + 1;
+    } else {
+      // Read identifier up to next . or [
+      const start = i;
+      while (i < path.length && path[i] !== '.' && path[i] !== '[') i++;
+      tokens.push(path.slice(start, i));
+    }
+  }
+
+  let current = [root];
+
+  for (const token of tokens) {
+    const next = [];
+    for (const item of current) {
+      if (token === '[*]') {
+        // Wildcard: expand array
+        if (Array.isArray(item)) {
+          next.push(...item);
+        } else if (item != null && typeof item === 'object') {
+          next.push(...Object.values(item));
+        }
+      } else if (token.startsWith('[?(') && token.endsWith(')]')) {
+        // Filter expression: [?(@.key=="value")] or [?(@.key==true/false)]
+        const inner = token.slice(3, -2); // @.key=="value"
+        const filterMatch = inner.match(/^@\.(\w+)==(.+)$/);
+        if (!filterMatch) continue;
+        const [, filterKey, rawVal] = filterMatch;
+        let filterVal;
+        if (rawVal === 'true') filterVal = true;
+        else if (rawVal === 'false') filterVal = false;
+        else if (rawVal.startsWith('"') && rawVal.endsWith('"')) {
+          filterVal = rawVal.slice(1, -1);
+        } else if (rawVal.startsWith("'") && rawVal.endsWith("'")) {
+          filterVal = rawVal.slice(1, -1);
+        } else {
+          filterVal = rawVal; // treat as string
+        }
+        const arr = Array.isArray(item) ? item : [item];
+        for (const el of arr) {
+          if (el != null && typeof el === 'object' && el[filterKey] === filterVal) {
+            next.push(el);
+          }
+        }
+      } else {
+        // Property access
+        const key = token.replace(/^\[["']?|["']?\]$/g, '');
+        if (Array.isArray(item)) {
+          for (const el of item) {
+            if (el != null && key in el) next.push(el[key]);
+          }
+        } else if (item != null && typeof item === 'object' && key in item) {
+          next.push(item[key]);
+        }
+      }
+    }
+    current = next;
+  }
+
+  return current;
+}
+
+// ── Core evaluator dispatch ───────────────────────────────────────────────────
+
+function evaluate(body, pathExpr) {
+  if (JSONPath) {
+    try {
+      const result = JSONPath({ path: pathExpr, json: body, resultType: 'value' });
+      return Array.isArray(result) ? result : [];
+    } catch {
+      // Fall through to built-in on parse error
+    }
+  }
+  return builtinEval(body, pathExpr);
+}
+
+// ── Summary helper ────────────────────────────────────────────────────────────
+
+function summarize(body, maxBytes = 500) {
+  const str = JSON.stringify(body);
+  return str.length <= maxBytes ? str : str.slice(0, maxBytes) + '…';
+}
+
+// ── Exported assertions ───────────────────────────────────────────────────────
+
+/**
+ * Assert a JSONPath expression returns at least one result in body.
+ * @param {object|Array} body   — parsed JSON response body
+ * @param {string} pathExpr     — JSONPath expression (already interpolated)
+ * @param {Record<string,string>} [vars]  — for error context only
+ * @throws {Error} if no match found
+ */
+export function assertContains(body, pathExpr, vars = {}) {
+  const results = evaluate(body, pathExpr);
+  if (results.length === 0) {
+    throw new Error(
+      `assertContains: JSONPath "${pathExpr}" matched 0 results.\n` +
+      `api_response_summary: ${summarize(body)}`,
+    );
+  }
+}
+
+/**
+ * Assert a JSONPath expression evaluates to exactly true for all matched values.
+ * @param {object|Array} body
+ * @param {string} pathExpr
+ * @param {Record<string,string>} [vars]
+ * @throws {Error} if result is empty or any value is not exactly true
+ */
+export function assertBoolean(body, pathExpr, vars = {}) {
+  const results = evaluate(body, pathExpr);
+  if (results.length === 0) {
+    throw new Error(
+      `assertBoolean: JSONPath "${pathExpr}" matched 0 results.\n` +
+      `api_response_summary: ${summarize(body)}`,
+    );
+  }
+  const allTrue = results.every(r => r === true);
+  if (!allTrue) {
+    throw new Error(
+      `assertBoolean: JSONPath "${pathExpr}" did not evaluate to true; ` +
+      `got: ${JSON.stringify(results)}.\n` +
+      `api_response_summary: ${summarize(body)}`,
+    );
+  }
+}

--- a/skills/autospec-test/scripts/contract-symmetry/run-symmetry.mjs
+++ b/skills/autospec-test/scripts/contract-symmetry/run-symmetry.mjs
@@ -1,0 +1,179 @@
+/**
+ * run-symmetry.mjs — Metric I: Data-source Contract Symmetry Runner
+ *
+ * Reads a contract + base_url from stdin JSON and for each declared
+ * contract_symmetry entry:
+ *   1. Extracts (task_id, date) tuples from the UI via ui-extractor
+ *   2. For each tuple, interpolates the api_target.path_template
+ *   3. Fetches the API endpoint via page.request
+ *   4. Asserts must_contain (JSONPath) and must_be_editable (JSONPath boolean)
+ *   5. Emits gate JSON
+ *
+ * Input (stdin JSON):
+ *   {
+ *     contract: { e2e: { invariants_v2: { contract_symmetry: [...] } } },
+ *     base_url: string
+ *   }
+ *
+ * Output (stdout JSON):
+ *   {
+ *     metric: "I",
+ *     passed: boolean,
+ *     contracts: [{ id, passed, tuples_checked, violations[] }],
+ *     violations: [...all violations across contracts...],
+ *     summary: { total, passed_count, failed_count, violation_count }
+ *   }
+ *
+ * Exit codes: 0 = pass, 1 = fail (violations), 2 = fatal error
+ */
+
+import { chromium } from '/opt/homebrew/lib/node_modules/playwright/index.mjs';
+import { extract } from './ui-extractor.mjs';
+import { interpolate } from './interpolator.mjs';
+import { assertContains, assertBoolean } from './jsonpath-verifier.mjs';
+
+async function run() {
+  let input;
+  try {
+    const chunks = [];
+    for await (const chunk of process.stdin) chunks.push(chunk);
+    input = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } catch (e) {
+    process.stderr.write(`[run-symmetry] fatal: failed to parse stdin JSON: ${e.message}\n`);
+    process.exit(2);
+  }
+
+  const { contract, base_url: baseUrl } = input;
+  if (!contract || !baseUrl) {
+    process.stderr.write('[run-symmetry] fatal: stdin must have { contract, base_url }\n');
+    process.exit(2);
+  }
+
+  const invariantsV2 = contract?.e2e?.invariants_v2;
+  if (!invariantsV2?.enabled) {
+    const result = {
+      metric: 'I',
+      passed: true,
+      contracts: [],
+      violations: [],
+      summary: { total: 0, passed_count: 0, failed_count: 0, violation_count: 0 },
+    };
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    process.exit(0);
+  }
+
+  const symmetryContracts = invariantsV2.contract_symmetry || [];
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const contractResults = [];
+  const allViolations = [];
+
+  try {
+    for (const cs of symmetryContracts) {
+      const { id, ui_source, api_target } = cs;
+      const violations = [];
+
+      // Step 1: extract tuples from UI
+      let tuples;
+      try {
+        const route = baseUrl.replace(/\/$/, '') + ui_source.route;
+        tuples = await extract(page, route, ui_source);
+      } catch (e) {
+        violations.push({ contract_id: id, phase: 'ui_extract', reason: e.message });
+        contractResults.push({ id, passed: false, tuples_checked: 0, violations });
+        allViolations.push(...violations);
+        continue;
+      }
+
+      // Step 2-4: for each tuple, interpolate URL, fetch, assert
+      for (const tuple of tuples) {
+        let apiUrl;
+        try {
+          const path = interpolate(api_target.path_template, tuple);
+          apiUrl = baseUrl.replace(/\/$/, '') + path;
+        } catch (e) {
+          violations.push({ contract_id: id, tuple, phase: 'interpolate', reason: e.message });
+          continue;
+        }
+
+        let body;
+        try {
+          const method = (api_target.method || 'GET').toLowerCase();
+          const response = await page.request[method](apiUrl, { timeout: 10_000 });
+          body = await response.json();
+        } catch (e) {
+          violations.push({ contract_id: id, tuple, api_url: apiUrl, phase: 'api_fetch', reason: e.message });
+          continue;
+        }
+
+        // must_contain assertion
+        if (api_target.must_contain) {
+          try {
+            const pathExpr = interpolate(api_target.must_contain, tuple);
+            assertContains(body, pathExpr, tuple);
+          } catch (e) {
+            violations.push({
+              contract_id: id,
+              tuple,
+              api_url: apiUrl,
+              phase: 'must_contain',
+              reason: e.message,
+            });
+          }
+        }
+
+        // must_be_editable assertion
+        if (api_target.must_be_editable) {
+          try {
+            const pathExpr = interpolate(api_target.must_be_editable, tuple);
+            assertBoolean(body, pathExpr, tuple);
+          } catch (e) {
+            violations.push({
+              contract_id: id,
+              tuple,
+              api_url: apiUrl,
+              phase: 'must_be_editable',
+              reason: e.message,
+            });
+          }
+        }
+      }
+
+      const contractPassed = violations.length === 0;
+      contractResults.push({
+        id,
+        passed: contractPassed,
+        tuples_checked: tuples.length,
+        violations,
+      });
+      allViolations.push(...violations);
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const passed_count = contractResults.filter(r => r.passed).length;
+  const failed_count = contractResults.filter(r => !r.passed).length;
+
+  const output = {
+    metric: 'I',
+    passed: allViolations.length === 0,
+    contracts: contractResults,
+    violations: allViolations,
+    summary: {
+      total: contractResults.length,
+      passed_count,
+      failed_count,
+      violation_count: allViolations.length,
+    },
+  };
+
+  process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+  process.exit(output.passed ? 0 : 1);
+}
+
+run().catch(e => {
+  process.stderr.write(`[run-symmetry] fatal: ${e.message}\n${e.stack}\n`);
+  process.exit(2);
+});

--- a/skills/autospec-test/scripts/contract-symmetry/ui-extractor.mjs
+++ b/skills/autospec-test/scripts/contract-symmetry/ui-extractor.mjs
@@ -1,0 +1,51 @@
+/**
+ * ui-extractor.mjs — UI tuple extractor for Metric I contract symmetry.
+ *
+ * Navigates to a route and extracts attribute tuples from DOM elements
+ * matching the ui_source.extract selector. Each matched element produces
+ * one tuple via the ui_source.per_match mapping (attribute name → key name).
+ *
+ * Elements with any null attribute value are warned and skipped.
+ *
+ * Returns Array<Record<string, string>> — one record per matched element.
+ */
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {string} route  — full URL to navigate to
+ * @param {{ extract: string, per_match: Record<string, string> }} ui_source
+ * @returns {Promise<Array<Record<string, string>>>}
+ */
+export async function extract(page, route, ui_source) {
+  await page.goto(route, { waitUntil: 'domcontentloaded', timeout: 15_000 });
+
+  const { extract: selector, per_match } = ui_source;
+  const elements = page.locator(selector);
+  const count = await elements.count();
+
+  const tuples = [];
+
+  for (let i = 0; i < count; i++) {
+    const el = elements.nth(i);
+    const tuple = {};
+    let hasNull = false;
+
+    for (const [attrName, tupleKey] of Object.entries(per_match)) {
+      const value = await el.getAttribute(attrName);
+      if (value === null) {
+        process.stderr.write(
+          `[ui-extractor] warn: element ${i} at selector "${selector}" missing attribute "${attrName}"; skipping tuple\n`,
+        );
+        hasNull = true;
+        break;
+      }
+      tuple[tupleKey] = value;
+    }
+
+    if (!hasNull) {
+      tuples.push(tuple);
+    }
+  }
+
+  return tuples;
+}

--- a/skills/autospec-test/tests/unit/v2/run-symmetry.test.mjs
+++ b/skills/autospec-test/tests/unit/v2/run-symmetry.test.mjs
@@ -1,0 +1,357 @@
+/**
+ * run-symmetry.test.mjs — Unit tests for Metric I data-source contract symmetry.
+ *
+ * Uses real Playwright + inline HTTP server. No mocks.
+ * Server serves:
+ *   GET /          → HTML with 3 streak-task rows (t-1, t-2, t-3; date=2026-05-14)
+ *   GET /api/events → JSON with events for t-1 and t-2 only (t-3 missing)
+ *   GET /api/events?task_id=t-1 → event with editable=true
+ *   GET /api/events?task_id=t-2 → event with editable=false  (not-editable violation)
+ *   GET /api/events?task_id=t-3 → empty events array (missing violation)
+ *
+ * Run: node --test skills/autospec-test/tests/unit/v2/run-symmetry.test.mjs
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from '/opt/homebrew/lib/node_modules/playwright/index.mjs';
+import { interpolate } from '../../../scripts/contract-symmetry/interpolator.mjs';
+import { assertContains, assertBoolean } from '../../../scripts/contract-symmetry/jsonpath-verifier.mjs';
+import { extract } from '../../../scripts/contract-symmetry/ui-extractor.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── Inline fixture server ──────────────────────────────────────────────────────
+
+const FIXTURE_HTML = `<!DOCTYPE html>
+<html><body>
+  <div data-testid="streak-task-1" data-task-id="t-1" data-date="2026-05-14">Task 1</div>
+  <div data-testid="streak-task-2" data-task-id="t-2" data-date="2026-05-14">Task 2</div>
+  <div data-testid="streak-task-3" data-task-id="t-3" data-date="2026-05-14">Task 3</div>
+</body></html>`;
+
+// API data: t-1 editable, t-2 not editable, t-3 missing
+const API_DATA = {
+  't-1': { events: [{ task_id: 't-1', date: '2026-05-14', editable: true }] },
+  't-2': { events: [{ task_id: 't-2', date: '2026-05-14', editable: false }] },
+  't-3': { events: [] },
+};
+
+let server;
+let baseUrl;
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+
+    if (url.pathname === '/') {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(FIXTURE_HTML);
+      return;
+    }
+
+    if (url.pathname === '/api/events') {
+      const taskId = url.searchParams.get('task_id');
+      const data = taskId ? (API_DATA[taskId] || { events: [] }) : { events: [] };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('not found');
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+// ── interpolator tests ─────────────────────────────────────────────────────────
+
+describe('interpolator', () => {
+  it('substitutes ${key} placeholders', () => {
+    assert.equal(
+      interpolate('/api/timeline?from=${date}&to=${date}', { date: '2026-05-14' }),
+      '/api/timeline?from=2026-05-14&to=2026-05-14',
+    );
+  });
+
+  it('substitutes ${url:key} with URL-encoding', () => {
+    assert.equal(
+      interpolate('/api?q=${url:q}', { q: 'a b' }),
+      '/api?q=a%20b',
+    );
+  });
+
+  it('handles multiple different keys', () => {
+    assert.equal(
+      interpolate('/api?task=${task_id}&date=${date}', { task_id: 't-1', date: '2026-05-14' }),
+      '/api?task=t-1&date=2026-05-14',
+    );
+  });
+
+  it('throws when key is undefined — error includes key name', () => {
+    assert.throws(
+      () => interpolate('/api?x=${missing_key}', { other: 'value' }),
+      (err) => {
+        assert.match(err.message, /missing_key/);
+        return true;
+      },
+    );
+  });
+
+  it('plain ${date} substitution without URL encoding', () => {
+    assert.equal(interpolate('${date}', { date: '2026-05-14' }), '2026-05-14');
+  });
+});
+
+// ── assertContains / assertBoolean tests ───────────────────────────────────────
+
+describe('jsonpath-verifier', () => {
+  const body = { events: [{ task_id: 't-1', editable: true }, { task_id: 't-2', editable: false }] };
+
+  it('assertContains: matches existing task_id', () => {
+    assert.doesNotThrow(() => assertContains(body, '$.events[?(@.task_id=="t-1")]'));
+  });
+
+  it('assertContains: throws on no match — error includes api_response_summary truncated to 500 bytes', () => {
+    assert.throws(
+      () => assertContains(body, '$.events[?(@.task_id=="t-999")]'),
+      (err) => {
+        assert.match(err.message, /assertContains/);
+        assert.match(err.message, /api_response_summary/);
+        return true;
+      },
+    );
+  });
+
+  it('assertBoolean: passes when JSONPath resolves to true', () => {
+    assert.doesNotThrow(() => assertBoolean(body, '$.events[?(@.task_id=="t-1")].editable'));
+  });
+
+  it('assertBoolean: throws when value is false', () => {
+    assert.throws(
+      () => assertBoolean(body, '$.events[?(@.task_id=="t-2")].editable'),
+      /assertBoolean/,
+    );
+  });
+
+  it('assertBoolean: throws on no match', () => {
+    assert.throws(
+      () => assertBoolean(body, '$.events[?(@.task_id=="t-999")].editable'),
+      /assertBoolean/,
+    );
+  });
+
+  it('assertContains: error includes api_response_summary truncated at 500 bytes', () => {
+    // Build a large body to trigger truncation
+    const largeBody = { events: Array.from({ length: 100 }, (_, i) => ({ task_id: `t-${i}`, editable: true })) };
+    assert.throws(
+      () => assertContains(largeBody, '$.events[?(@.task_id=="t-missing")]'),
+      (err) => {
+        // Summary should be present and ≤ ~510 chars (500 + ellipsis)
+        const summaryMatch = err.message.match(/api_response_summary: (.+)/s);
+        assert.ok(summaryMatch, 'error should include api_response_summary');
+        assert.ok(summaryMatch[1].length <= 510, 'summary should be truncated');
+        return true;
+      },
+    );
+  });
+});
+
+// ── ui-extractor tests ──────────────────────────────────────────────────────────
+
+describe('ui-extractor', () => {
+  let browser;
+  let page;
+
+  before(async () => {
+    browser = await chromium.launch({ headless: true });
+    page = await browser.newPage();
+  });
+  after(async () => { await browser.close(); });
+
+  it('extracts 3 tuples from fixture HTML', async () => {
+    const ui_source = {
+      route: '/',
+      extract: '[data-testid^="streak-task-"]',
+      per_match: { 'data-task-id': 'task_id', 'data-date': 'date' },
+    };
+    const tuples = await extract(page, baseUrl + '/', ui_source);
+    assert.equal(tuples.length, 3);
+    assert.deepEqual(tuples[0], { task_id: 't-1', date: '2026-05-14' });
+    assert.deepEqual(tuples[1], { task_id: 't-2', date: '2026-05-14' });
+    assert.deepEqual(tuples[2], { task_id: 't-3', date: '2026-05-14' });
+  });
+});
+
+// ── run-symmetry in-process tests ──────────────────────────────────────────────
+
+describe('Metric I — run-symmetry (in-process)', () => {
+  let browser;
+  let page;
+
+  before(async () => {
+    browser = await chromium.launch({ headless: true });
+    page = await browser.newPage();
+  });
+  after(async () => { await browser.close(); });
+
+  const UI_SOURCE = {
+    route: '/',
+    extract: '[data-testid^="streak-task-"]',
+    per_match: { 'data-task-id': 'task_id', 'data-date': 'date' },
+  };
+
+  const API_TARGET = {
+    method: 'GET',
+    path_template: '/api/events?task_id=${task_id}&date=${date}',
+    must_contain: '$.events[?(@.task_id=="${task_id}")]',
+    must_be_editable: '$.events[?(@.task_id=="${task_id}")].editable',
+  };
+
+  async function runCheck(contractOverrides = {}) {
+    const contract = {
+      e2e: {
+        invariants_v2: {
+          enabled: true,
+          contract_symmetry: [{
+            id: 'streak-task-must-be-editable',
+            ui_source: UI_SOURCE,
+            api_target: { ...API_TARGET, ...contractOverrides },
+            mismatch_action: 'hard_fail',
+          }],
+        },
+      },
+    };
+
+    const p = await browser.newPage();
+    const symmetryContracts = contract.e2e.invariants_v2.contract_symmetry;
+    const allViolations = [];
+    const contractResults = [];
+
+    for (const cs of symmetryContracts) {
+      const violations = [];
+      const route = baseUrl.replace(/\/$/, '') + cs.ui_source.route;
+      const tuples = await extract(p, route, cs.ui_source);
+
+      for (const tuple of tuples) {
+        const path = interpolate(cs.api_target.path_template, tuple);
+        const apiUrl = baseUrl.replace(/\/$/, '') + path;
+        const response = await p.request.get(apiUrl);
+        const body = await response.json();
+
+        if (cs.api_target.must_contain) {
+          try {
+            const expr = interpolate(cs.api_target.must_contain, tuple);
+            assertContains(body, expr, tuple);
+          } catch (e) {
+            violations.push({ contract_id: cs.id, tuple, phase: 'must_contain', reason: e.message });
+          }
+        }
+        if (cs.api_target.must_be_editable) {
+          try {
+            const expr = interpolate(cs.api_target.must_be_editable, tuple);
+            assertBoolean(body, expr, tuple);
+          } catch (e) {
+            violations.push({ contract_id: cs.id, tuple, phase: 'must_be_editable', reason: e.message });
+          }
+        }
+      }
+
+      contractResults.push({ id: cs.id, passed: violations.length === 0, tuples_checked: tuples.length, violations });
+      allViolations.push(...violations);
+    }
+    await p.close();
+    return { passed: allViolations.length === 0, contracts: contractResults, violations: allViolations };
+  }
+
+  it('happy path: t-1 event exists and is editable → 0 violations', async () => {
+    // Override to check only t-1 by using a selector that matches only first element
+    const contractSingle = {
+      e2e: {
+        invariants_v2: {
+          enabled: true,
+          contract_symmetry: [{
+            id: 'single-task',
+            ui_source: {
+              route: '/',
+              extract: '[data-testid="streak-task-1"]',
+              per_match: { 'data-task-id': 'task_id', 'data-date': 'date' },
+            },
+            api_target: API_TARGET,
+            mismatch_action: 'hard_fail',
+          }],
+        },
+      },
+    };
+
+    const p = await browser.newPage();
+    const cs = contractSingle.e2e.invariants_v2.contract_symmetry[0];
+    const route = baseUrl + cs.ui_source.route;
+    const tuples = await extract(p, route, cs.ui_source);
+    const violations = [];
+
+    for (const tuple of tuples) {
+      const path = interpolate(cs.api_target.path_template, tuple);
+      const apiUrl = baseUrl + path;
+      const response = await p.request.get(apiUrl);
+      const body = await response.json();
+      try { assertContains(body, interpolate(cs.api_target.must_contain, tuple), tuple); } catch(e) { violations.push(e.message); }
+      try { assertBoolean(body, interpolate(cs.api_target.must_be_editable, tuple), tuple); } catch(e) { violations.push(e.message); }
+    }
+    await p.close();
+
+    assert.equal(violations.length, 0, `Expected 0 violations, got: ${JSON.stringify(violations)}`);
+  });
+
+  it('missing event (t-3): 1 violation with tuple.task_id field present', async () => {
+    const result = await runCheck();
+    const t3Violations = result.violations.filter(v => v.tuple?.task_id === 't-3');
+    assert.ok(t3Violations.length >= 1, `Expected violation for t-3, got: ${JSON.stringify(result.violations)}`);
+    assert.equal(t3Violations[0].tuple.task_id, 't-3', 'violation should carry tuple.task_id');
+  });
+
+  it('not-editable (t-2): 1 must_be_editable violation', async () => {
+    const result = await runCheck();
+    const t2Violations = result.violations.filter(v => v.tuple?.task_id === 't-2' && v.phase === 'must_be_editable');
+    assert.ok(t2Violations.length >= 1, `Expected must_be_editable violation for t-2, got: ${JSON.stringify(result.violations)}`);
+  });
+
+  it('missing + not-editable: at least 2 violations total', async () => {
+    const result = await runCheck();
+    // t-3 missing (must_contain fails) + t-2 not editable (must_be_editable fails)
+    assert.ok(result.violations.length >= 2,
+      `Expected >=2 violations, got: ${JSON.stringify(result.violations)}`);
+  });
+
+  it('gate JSON shape: metric=I, passed, contracts[], violations[]', async () => {
+    const { execFileSync } = await import('node:child_process');
+    const contract = {
+      e2e: { invariants_v2: { enabled: false, contract_symmetry: [] } },
+    };
+    let stdout;
+    try {
+      stdout = execFileSync('node', ['skills/autospec-test/scripts/contract-symmetry/run-symmetry.mjs'], {
+        input: JSON.stringify({ contract, base_url: baseUrl }),
+        cwd: path.resolve(__dirname, '../../../../..'),
+        timeout: 15_000, encoding: 'utf8',
+      });
+    } catch (e) {
+      throw new Error(`run-symmetry.mjs subprocess failed: ${e.stderr || e.message}`);
+    }
+    const result = JSON.parse(stdout);
+    assert.equal(result.metric, 'I');
+    assert.equal(typeof result.passed, 'boolean');
+    assert.ok(Array.isArray(result.contracts));
+    assert.ok(Array.isArray(result.violations));
+    assert.ok('violation_count' in result.summary);
+  });
+});


### PR DESCRIPTION
Closes #347

## Summary

Implements the Metric I data-source contract symmetry runner for autospec-test v2 — reconciles UI-extracted (task_id, date) tuples against API JSONPath assertions in the same Playwright session.

### New files

- `skills/autospec-test/scripts/contract-symmetry/interpolator.mjs` — `interpolate(template, vars)`: substitutes `${key}` as-is and `${url:key}` via `encodeURIComponent()`; throws with missing key name on undefined variable
- `skills/autospec-test/scripts/contract-symmetry/jsonpath-verifier.mjs` — `assertContains` + `assertBoolean` backed by built-in evaluator supporting `$.field`, `$.array[*].field`, `$.array[?(@.k=="v")]` filter expressions; error messages include `api_response_summary` truncated to 500 bytes
- `skills/autospec-test/scripts/contract-symmetry/ui-extractor.mjs` — `extract(page, route, ui_source)`: navigates to route, locates elements by selector, builds attribute tuples from `per_match` mapping; skips elements with null attributes with a stderr warning
- `skills/autospec-test/scripts/contract-symmetry/run-symmetry.mjs` — stdin-JSON orchestrator: reads `contract_symmetry[]`, extracts UI tuples, interpolates API path template, fetches via `page.request`, runs `assertContains` + `assertBoolean`; emits `{ metric: "I", passed, contracts[], violations[], summary }`
- `skills/autospec-test/tests/unit/v2/run-symmetry.test.mjs` — 17 tests: interpolator (plain + URL-encoded + multi-key + throw-on-missing), jsonpath-verifier (contains/boolean pass/fail/truncation), ui-extractor (3-tuple extraction), run-symmetry in-process (happy path, missing event, not-editable, 2+ violations), gate JSON shape

### Test results

```
17 tests, 17 pass, 0 fail
```

Primary smoke test: `node --test skills/autospec-test/tests/unit/v2/run-symmetry.test.mjs`