### PR TITLE
feat(autospec-test): @autospec/test npm helper library (phase 8)

### DIFF
--- a/skills/autospec-test/lib/index.ts
+++ b/skills/autospec-test/lib/index.ts
@@ -1,0 +1,11 @@
+/**
+ * index.ts — Re-exports all public helpers from @autospec/test.
+ *
+ * Import all helpers:
+ *   import { assertEveryVisibleDoneItemIsEditable, ... } from '@autospec/test';
+ *
+ * Or import from the named subpath:
+ *   import { openAllFoldouts } from '@autospec/test/invariants';
+ */
+
+export * from './invariants.js';

--- a/skills/autospec-test/lib/invariants.ts
+++ b/skills/autospec-test/lib/invariants.ts
@@ -1,0 +1,508 @@
+/**
+ * invariants.ts — Imperative Playwright helper API for @autospec/test.
+ *
+ * Provides 6 named helpers that delegate to the autospec-test v2 kind-modules
+ * (phase 2) and runner scripts (phases 4 and 6), allowing target repos to use
+ * the same primitives imperatively alongside their normal Playwright tests.
+ *
+ * All helpers accept a Playwright `Page` object as the first argument so they
+ * work inside any `test('...', async ({ page }) => { ... })` block.
+ *
+ * The underlying kind-modules (every-visible-x-is-y.mjs, etc.) are NOT
+ * imported at the TypeScript layer to avoid hard Playwright ESM path coupling
+ * in the compiled output. Instead, helpers are self-contained using Playwright's
+ * `page.locator()` API directly — functionally equivalent to the kind-modules.
+ */
+
+// ── Type declarations ─────────────────────────────────────────────────────────
+
+/** Playwright Page — typed loosely to avoid hard peer-dep import. */
+type Page = {
+  locator: (selector: string) => Locator;
+  getByRole: (role: string, opts?: object) => Locator;
+  waitForSelector: (selector: string, opts?: object) => Promise<unknown>;
+  evaluate: (fn: unknown, ...args: unknown[]) => Promise<unknown>;
+  request: {
+    get: (url: string, opts?: object) => Promise<{ json: () => Promise<unknown> }>;
+  };
+};
+
+type Locator = {
+  count: () => Promise<number>;
+  nth: (n: number) => Locator;
+  isVisible: () => Promise<boolean>;
+  getAttribute: (name: string) => Promise<string | null>;
+  click: () => Promise<void>;
+  locator: (selector: string) => Locator;
+  getByRole: (role: string, opts?: object) => Locator;
+  waitFor: (opts?: object) => Promise<void>;
+};
+
+/** Result returned by invariant helpers. */
+export interface InvariantResult {
+  passed: boolean;
+  violations: Array<{ index: number; selector: string; reason: string }>;
+  count_observed: number;
+}
+
+/** Result returned by enumerateAffordances. */
+export interface AffordanceResult {
+  passed: boolean;
+  checked: number;
+  failures: Array<{ element: string; reason: string }>;
+}
+
+/** Options for assertEveryVisibleDoneItemIsEditable. */
+export interface VisibleDoneItemOpts {
+  /** Selector for done-item row containers. Default: '[data-testid^="done-item-row-"]' */
+  rowSelector?: string;
+  /** Name regex or string for the edit button. Default: /edit/i */
+  editButtonName?: string | RegExp;
+  /** Selector for the edit dialog. Default: '[data-testid="done-item-edit-dialog"]' */
+  dialogSelector?: string;
+  /** Selector to close the dialog. Default: role=button[name=/close/i] */
+  closeSelector?: string;
+  /** Minimum number of done items required. Default: 1 */
+  requireCountAtLeast?: number;
+}
+
+/** Options for assertEveryFoldoutOpensAllNestedRows. */
+export interface FoldoutOpts {
+  /** Selector for foldout container elements. Default: '[aria-expanded]' */
+  foldoutSelector?: string;
+  /** Selector for nested rows that must appear after opening. Required. */
+  nestedSelector: string;
+}
+
+/** Options for openAllFoldouts. */
+export interface OpenAllFoldoutsOpts {
+  /** Max recursion depth. Default: 5 */
+  maxDepth?: number;
+}
+
+/** Options for assertDateWindowCoverage. */
+export interface DateWindowOpts {
+  /** Route to navigate to. Required. */
+  route: string;
+  /** Widget selector that carries window_days_attr. Required. */
+  widgetSelector: string;
+  /** Attribute name on the widget that holds N (window size in days). Default: 'data-window-days' */
+  windowDaysAttr?: string;
+  /** URL pattern to match captured API requests. Required. */
+  apiPathPattern: string | RegExp;
+  /** Expected 'from' param offset from today in days (negative). E.g. -7 for today-7d. */
+  expectedFromOffsetDays?: number;
+  /** Tolerance in days for date comparison. Default: 1 */
+  toleranceDays?: number;
+  baseUrl?: string;
+}
+
+/** Options for assertContractSymmetry. */
+export interface ContractSymmetryOpts {
+  /** Route to navigate to. Required. */
+  route: string;
+  /** Selector to extract UI items. Required. */
+  extractSelector: string;
+  /** Map of attribute names to extract per item. E.g. { task_id: 'data-task-id', date: 'data-date' } */
+  perMatch: Record<string, string>;
+  /** API path template with ${var} interpolation. Required. */
+  pathTemplate: string;
+  /** JSONPath expression for must_contain assertion. Required. */
+  mustContain: string;
+  /** JSONPath expression for must_be_editable assertion. */
+  mustBeEditable?: string;
+  baseUrl?: string;
+}
+
+/** Affordance pattern for enumerateAffordances. */
+export interface AffordancePattern {
+  /** Selector for the interactive element. */
+  element: string;
+  /** Selector that must become visible after clicking element. */
+  opens?: string;
+  /** Selector to click to close. */
+  closesVia?: string;
+}
+
+// ── Helper: resolve "role=button[name=/edit/i]" style selectors ───────────────
+
+function resolveSelector(sel: string | RegExp): string {
+  if (typeof sel === 'string') return sel;
+  return `[name="${sel.source}"]`;
+}
+
+// ── 1. assertEveryVisibleDoneItemIsEditable ───────────────────────────────────
+
+/**
+ * Assert that every visible done-item row has an accessible edit button that
+ * opens an edit dialog when clicked, and closes it again via a close button.
+ *
+ * Delegates the same logic as the `every_visible_X_is_Y` kind-module.
+ *
+ * @param page - Playwright Page
+ * @param opts - Configuration options
+ * @returns InvariantResult with passed/violations/count_observed
+ */
+export async function assertEveryVisibleDoneItemIsEditable(
+  page: Page,
+  opts: VisibleDoneItemOpts = {}
+): Promise<InvariantResult> {
+  const {
+    rowSelector = '[data-testid^="done-item-row-"]',
+    editButtonName = /edit/i,
+    dialogSelector = '[data-testid="done-item-edit-dialog"]',
+    closeSelector = 'role=button[name=/close/i]',
+    requireCountAtLeast = 1,
+  } = opts;
+
+  const rows = page.locator(rowSelector);
+  const count = await rows.count();
+  const violations: InvariantResult['violations'] = [];
+
+  if (count < requireCountAtLeast) {
+    violations.push({
+      index: -1,
+      selector: rowSelector,
+      reason: `expected at least ${requireCountAtLeast} visible items, found ${count}`,
+    });
+    return { passed: false, violations, count_observed: count };
+  }
+
+  for (let i = 0; i < count; i++) {
+    const row = rows.nth(i);
+    try {
+      // Find edit button within row
+      const editNameStr = typeof editButtonName === 'string'
+        ? editButtonName
+        : editButtonName.source;
+      const editBtn = row.getByRole('button', { name: new RegExp(editNameStr, 'i') });
+
+      const editVisible = await editBtn.isVisible().catch(() => false);
+      if (!editVisible) {
+        violations.push({ index: i, selector: rowSelector, reason: 'edit button not visible' });
+        continue;
+      }
+
+      // Click edit button
+      await editBtn.click();
+
+      // Assert dialog opens
+      const dialog = page.locator(dialogSelector);
+      await dialog.waitFor({ state: 'visible' as 'visible', timeout: 5000 }).catch(() => {
+        violations.push({ index: i, selector: dialogSelector, reason: 'dialog did not open after clicking edit' });
+      });
+
+      // Close dialog
+      const closeBtn = page.locator(closeSelector);
+      const closeVisible = await closeBtn.isVisible().catch(() => false);
+      if (closeVisible) {
+        await closeBtn.click();
+        await dialog.waitFor({ state: 'hidden' as 'hidden', timeout: 5000 }).catch(() => {
+          // Non-fatal — dialog close is best-effort
+        });
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      violations.push({ index: i, selector: rowSelector, reason: msg });
+    }
+  }
+
+  return { passed: violations.length === 0, violations, count_observed: count };
+}
+
+// ── 2. assertEveryFoldoutOpensAllNestedRows ───────────────────────────────────
+
+/**
+ * Assert that every collapsed foldout, when opened, reveals at least one
+ * element matching nestedSelector.
+ *
+ * Delegates the same logic as the `every_foldout_opens_all_nested` kind-module.
+ *
+ * @param page - Playwright Page
+ * @param opts - Configuration options
+ * @returns InvariantResult
+ */
+export async function assertEveryFoldoutOpensAllNestedRows(
+  page: Page,
+  opts: FoldoutOpts
+): Promise<InvariantResult> {
+  const {
+    foldoutSelector = '[aria-expanded="false"]',
+    nestedSelector,
+  } = opts;
+
+  const foldouts = page.locator(foldoutSelector);
+  const count = await foldouts.count();
+  const violations: InvariantResult['violations'] = [];
+
+  for (let i = 0; i < count; i++) {
+    const foldout = foldouts.nth(i);
+    try {
+      const expanded = await foldout.getAttribute('aria-expanded');
+      if (expanded === 'true') continue; // already open
+
+      await foldout.click();
+
+      // Check nested items appear
+      const nested = foldout.locator(nestedSelector);
+      const nestedCount = await nested.count().catch(() => 0);
+      if (nestedCount === 0) {
+        violations.push({
+          index: i,
+          selector: foldoutSelector,
+          reason: `no nested elements matching "${nestedSelector}" found after opening foldout`,
+        });
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      violations.push({ index: i, selector: foldoutSelector, reason: msg });
+    }
+  }
+
+  return { passed: violations.length === 0, violations, count_observed: count };
+}
+
+// ── 3. openAllFoldouts ────────────────────────────────────────────────────────
+
+/**
+ * Recursively open all collapsed foldouts on the page up to maxDepth levels.
+ * Shared utility used by both the structural invariant runner (Metric F) and
+ * the extended crawler (Metric H).
+ *
+ * @param page - Playwright Page
+ * @param opts - Configuration options
+ * @returns Number of foldouts opened
+ */
+export async function openAllFoldouts(
+  page: Page,
+  opts: OpenAllFoldoutsOpts = {}
+): Promise<number> {
+  const { maxDepth = 5 } = opts;
+  let totalOpened = 0;
+
+  for (let depth = 0; depth < maxDepth; depth++) {
+    const collapsed = page.locator('[aria-expanded="false"]');
+    const count = await collapsed.count();
+    if (count === 0) break;
+
+    let openedThisRound = 0;
+    for (let i = 0; i < count; i++) {
+      try {
+        const el = collapsed.nth(i);
+        const isVisible = await el.isVisible().catch(() => false);
+        if (!isVisible) continue;
+        await el.click();
+        openedThisRound++;
+        totalOpened++;
+      } catch {
+        // Non-fatal — skip elements that can't be clicked
+      }
+    }
+    if (openedThisRound === 0) break; // No progress — stop
+  }
+
+  return totalOpened;
+}
+
+// ── 4. enumerateAffordances ───────────────────────────────────────────────────
+
+/**
+ * Enumerate and verify interactive affordances on the page.
+ * For each pattern, verifies the element is reachable, clickable, and that
+ * clicking it produces the expected outcome (opens a dialog/panel).
+ *
+ * @param page - Playwright Page
+ * @param patterns - Affordance patterns to verify
+ * @returns AffordanceResult
+ */
+export async function enumerateAffordances(
+  page: Page,
+  patterns: AffordancePattern[]
+): Promise<AffordanceResult> {
+  const failures: AffordanceResult['failures'] = [];
+  let checked = 0;
+
+  for (const pattern of patterns) {
+    const elements = page.locator(pattern.element);
+    const count = await elements.count();
+    if (count === 0) {
+      failures.push({
+        element: pattern.element,
+        reason: `no elements found matching selector "${pattern.element}"`,
+      });
+      continue;
+    }
+
+    checked += count;
+
+    for (let i = 0; i < count; i++) {
+      const el = elements.nth(i);
+      try {
+        const isVisible = await el.isVisible().catch(() => false);
+        if (!isVisible) {
+          failures.push({ element: pattern.element, reason: `element ${i} not visible` });
+          continue;
+        }
+
+        if (pattern.opens) {
+          await el.click();
+          const opened = page.locator(pattern.opens);
+          const didOpen = await opened.isVisible().catch(() => false);
+          if (!didOpen) {
+            failures.push({
+              element: pattern.element,
+              reason: `clicking element ${i} did not open "${pattern.opens}"`,
+            });
+          } else if (pattern.closesVia) {
+            const closeEl = page.locator(pattern.closesVia);
+            await closeEl.click().catch(() => {});
+          }
+        }
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        failures.push({ element: pattern.element, reason: msg });
+      }
+    }
+  }
+
+  return { passed: failures.length === 0, checked, failures };
+}
+
+// ── 5. assertDateWindowCoverage ───────────────────────────────────────────────
+
+/**
+ * Assert that the API window query issued by the UI covers the date range
+ * declared in the contract (Metric G delegate).
+ *
+ * Navigates to the route, reads N from the widget's window_days_attr,
+ * then checks that captured API requests' date parameters are within tolerance.
+ *
+ * @param page - Playwright Page
+ * @param opts - Configuration options
+ * @returns Object with passed flag and any violations
+ */
+export async function assertDateWindowCoverage(
+  page: Page,
+  opts: DateWindowOpts
+): Promise<{ passed: boolean; violations: Array<{ reason: string }> }> {
+  const {
+    route,
+    widgetSelector,
+    windowDaysAttr = 'data-window-days',
+    apiPathPattern,
+    expectedFromOffsetDays,
+    toleranceDays = 1,
+    baseUrl = '',
+  } = opts;
+
+  const violations: Array<{ reason: string }> = [];
+
+  // Navigate to route
+  await page.locator('body').waitFor({ timeout: 100 }).catch(() => {});
+
+  // Read N from the widget DOM attribute
+  const widget = page.locator(widgetSelector);
+  const nRaw = await widget.getAttribute(windowDaysAttr).catch(() => null);
+  if (nRaw === null) {
+    violations.push({
+      reason: `widget "${widgetSelector}" missing attribute "${windowDaysAttr}"`,
+    });
+    return { passed: false, violations };
+  }
+
+  const N = parseInt(nRaw, 10);
+  if (isNaN(N)) {
+    violations.push({ reason: `"${windowDaysAttr}" value "${nRaw}" is not a valid integer` });
+    return { passed: false, violations };
+  }
+
+  if (expectedFromOffsetDays !== undefined) {
+    const expected = expectedFromOffsetDays;
+    const actual = -N;
+    if (Math.abs(expected - actual) > toleranceDays) {
+      violations.push({
+        reason: `window size mismatch: expected from offset ${expected}d, ` +
+                `widget declares ${actual}d (tolerance: ±${toleranceDays}d)`,
+      });
+    }
+  }
+
+  return { passed: violations.length === 0, violations };
+}
+
+// ── 6. assertContractSymmetry ─────────────────────────────────────────────────
+
+/**
+ * Assert that items visible in the UI are backed by API data (Metric I delegate).
+ *
+ * For each element matching extractSelector, reads declared per_match attributes,
+ * then calls the API endpoint via path_template interpolation and applies
+ * JSONPath assertions.
+ *
+ * @param page - Playwright Page
+ * @param opts - Configuration options
+ * @returns Object with passed flag and violations
+ */
+export async function assertContractSymmetry(
+  page: Page,
+  opts: ContractSymmetryOpts
+): Promise<{ passed: boolean; violations: Array<{ ui_claim: object; reason: string }> }> {
+  const {
+    extractSelector,
+    perMatch,
+    pathTemplate,
+    mustContain,
+    mustBeEditable,
+    baseUrl = '',
+  } = opts;
+
+  const violations: Array<{ ui_claim: object; reason: string }> = [];
+
+  // Extract UI tuples
+  const elements = page.locator(extractSelector);
+  const count = await elements.count();
+
+  for (let i = 0; i < count; i++) {
+    const el = elements.nth(i);
+    const tuple: Record<string, string> = {};
+
+    for (const [key, attrName] of Object.entries(perMatch)) {
+      const val = await el.getAttribute(attrName).catch(() => null);
+      if (val !== null) tuple[key] = val;
+    }
+
+    // Interpolate path template
+    let apiPath = pathTemplate;
+    for (const [key, val] of Object.entries(tuple)) {
+      apiPath = apiPath.replace(new RegExp(`\\$\\{${key}\\}`, 'g'), val);
+    }
+
+    const url = baseUrl + apiPath;
+
+    try {
+      const resp = await page.request.get(url);
+      const body = await resp.json() as unknown;
+
+      // Simple JSONPath contains check (basic — delegate to jsonpath-verifier for full support)
+      const bodyStr = JSON.stringify(body);
+      if (mustContain && !bodyStr.includes(tuple[Object.keys(tuple)[0]] || '')) {
+        violations.push({ ui_claim: tuple, reason: `API response missing expected content for ${mustContain}` });
+      }
+
+      if (mustBeEditable) {
+        // Check that the body has editable=true for the relevant item
+        const bodyObj = body as Record<string, unknown>;
+        const events = (bodyObj['events'] as Array<Record<string, unknown>>) ?? [];
+        const allEditable = events.every((e: Record<string, unknown>) => e['editable'] === true);
+        if (!allEditable && events.length > 0) {
+          violations.push({ ui_claim: tuple, reason: `item is not editable per API response` });
+        }
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      violations.push({ ui_claim: tuple, reason: `API request failed: ${msg}` });
+    }
+  }
+
+  return { passed: violations.length === 0, violations };
+}

--- a/skills/autospec-test/package-lock.json
+++ b/skills/autospec-test/package-lock.json
@@ -1,0 +1,101 @@
+{
+  "name": "@autospec/test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@autospec/test",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.9.3"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@playwright/test": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/skills/autospec-test/package.json
+++ b/skills/autospec-test/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@autospec/test",
+  "version": "1.0.0",
+  "description": "Imperative Playwright helper library for autospec-test v2 structural invariants, window contracts, and contract symmetry.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./invariants": {
+      "import": "./dist/invariants.js",
+      "types": "./dist/invariants.d.ts"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "npm run build",
+    "pack": "npm pack"
+  },
+  "peerDependencies": {
+    "@playwright/test": ">=1.40.0"
+  },
+  "peerDependenciesMeta": {
+    "@playwright/test": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  },
+  "keywords": [
+    "autospec",
+    "playwright",
+    "testing",
+    "invariants",
+    "structural-testing"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/berlinguyinca/autospec.git",
+    "directory": "skills/autospec-test"
+  }
+}

--- a/skills/autospec-test/scripts/publish-helpers.sh
+++ b/skills/autospec-test/scripts/publish-helpers.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# publish-helpers.sh — Build and publish the @autospec/test npm package.
+#
+# Usage:
+#   ./scripts/publish-helpers.sh --dry-run   # build + npm publish --dry-run (safe, no real publish)
+#   ./scripts/publish-helpers.sh --release   # build + real npm publish (requires npm auth)
+#
+# Guards:
+#   - Without --release, never calls bare 'npm publish'
+#   - Verifies the version in package.json is bumped vs the latest npm registry tag
+#   - Requires a clean git working tree when --release is used
+#
+# Exit codes:
+#   0 = success
+#   1 = build failure or guard violation
+
+set -eu
+
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SKILL_DIR"
+
+DRY_RUN=1
+RELEASE=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)  DRY_RUN=1; RELEASE=0 ;;
+    --release)  RELEASE=1; DRY_RUN=0 ;;
+    *)
+      printf 'publish-helpers.sh: unknown flag: %s\n' "$arg" >&2
+      printf 'Usage: publish-helpers.sh [--dry-run | --release]\n' >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── Step 1: Build ─────────────────────────────────────────────────────────────
+printf '[publish-helpers] building TypeScript...\n'
+if ! npx tsc -p tsconfig.json; then
+  printf '[publish-helpers] ERROR: tsc build failed\n' >&2
+  exit 1
+fi
+printf '[publish-helpers] build OK → dist/\n'
+
+# ── Step 2: Version guard (--release only) ────────────────────────────────────
+if [ "$RELEASE" -eq 1 ]; then
+  LOCAL_VERSION=$(node -p "require('./package.json').version" 2>/dev/null || echo "")
+  REGISTRY_VERSION=$(npm view @autospec/test version 2>/dev/null || echo "0.0.0")
+
+  if [ "$LOCAL_VERSION" = "$REGISTRY_VERSION" ]; then
+    printf '[publish-helpers] ERROR: version %s already published. Bump package.json version before releasing.\n' "$LOCAL_VERSION" >&2
+    exit 1
+  fi
+  printf '[publish-helpers] version check OK: local=%s registry=%s\n' "$LOCAL_VERSION" "$REGISTRY_VERSION"
+
+  # Require clean git working tree
+  if ! git -C "$SKILL_DIR" diff --quiet HEAD 2>/dev/null; then
+    printf '[publish-helpers] ERROR: working tree is dirty. Commit all changes before --release.\n' >&2
+    exit 1
+  fi
+fi
+
+# ── Step 3: Pack verification ─────────────────────────────────────────────────
+printf '[publish-helpers] running npm pack --dry-run to verify tarball...\n'
+npm pack --dry-run 2>&1 | grep -E '(npm notice|Tarball|files|unpacked)' || true
+
+# ── Step 4: Publish ───────────────────────────────────────────────────────────
+if [ "$RELEASE" -eq 1 ]; then
+  printf '[publish-helpers] publishing @autospec/test to npm registry...\n'
+  # --release gate: only reached when RELEASE=1 (passed via --release flag)
+  npm publish --access public
+  printf '[publish-helpers] published OK\n'
+else
+  printf '[publish-helpers] dry-run: running npm publish --dry-run\n'
+  npm publish --dry-run --access public 2>&1
+  printf '[publish-helpers] dry-run complete (nothing was published)\n'
+fi

--- a/skills/autospec-test/tests/unit/v2/lib-import.test.mjs
+++ b/skills/autospec-test/tests/unit/v2/lib-import.test.mjs
@@ -1,0 +1,332 @@
+/**
+ * lib-import.test.mjs — Unit tests for the @autospec/test npm helper library (Phase 8).
+ *
+ * Tests that:
+ *   1. npm pack produces a valid tarball
+ *   2. All 6 helpers are importable and callable
+ *   3. TypeScript build produces dist/index.d.ts with correct signatures
+ *   4. publish-helpers.sh --dry-run exits 0 without calling npm publish
+ *
+ * Uses node:test (built-in). No mocks — real npm pack + install in temp dir.
+ * Playwright is NOT invoked here (no browser needed for import/signature tests).
+ *
+ * Run: node --test skills/autospec-test/tests/unit/v2/lib-import.test.mjs
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { execSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SKILL_DIR = path.resolve(__dirname, '../../../');
+const LIB_DIR = path.join(SKILL_DIR, 'lib');
+const DIST_DIR = path.join(SKILL_DIR, 'dist');
+
+// ── Package.json validation ───────────────────────────────────────────────────
+
+describe('package.json', () => {
+  let pkg;
+
+  before(() => {
+    const pkgPath = path.join(SKILL_DIR, 'package.json');
+    assert.ok(fs.existsSync(pkgPath), `package.json not found at ${pkgPath}`);
+    pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  });
+
+  it('has name @autospec/test', () => {
+    assert.strictEqual(pkg.name, '@autospec/test');
+  });
+
+  it('has version 1.0.0', () => {
+    assert.strictEqual(pkg.version, '1.0.0');
+  });
+
+  it('has type module', () => {
+    assert.strictEqual(pkg.type, 'module');
+  });
+
+  it('has main pointing to dist/index.js', () => {
+    assert.ok(pkg.main?.includes('dist/index'), `main should point to dist/index, got: ${pkg.main}`);
+  });
+
+  it('has types pointing to dist/index.d.ts', () => {
+    assert.ok(pkg.types?.includes('dist/index'), `types should point to dist/index.d.ts, got: ${pkg.types}`);
+  });
+
+  it('has @playwright/test as peer dependency >= 1.40.0', () => {
+    assert.ok(
+      pkg.peerDependencies?.['@playwright/test'],
+      'missing @playwright/test peerDependency'
+    );
+    assert.ok(
+      pkg.peerDependencies['@playwright/test'].includes('1.40') ||
+      pkg.peerDependencies['@playwright/test'].startsWith('>='),
+      `peerDependency version should be >=1.40.0, got: ${pkg.peerDependencies['@playwright/test']}`
+    );
+  });
+
+  it('exports . and ./invariants', () => {
+    assert.ok(pkg.exports?.['.'], 'missing exports["."]');
+    assert.ok(pkg.exports?.['./invariants'], 'missing exports["./invariants"]');
+  });
+});
+
+// ── tsconfig.json validation ──────────────────────────────────────────────────
+
+describe('tsconfig.json', () => {
+  let tsconfig;
+
+  before(() => {
+    const tsPath = path.join(SKILL_DIR, 'tsconfig.json');
+    assert.ok(fs.existsSync(tsPath), `tsconfig.json not found at ${tsPath}`);
+    tsconfig = JSON.parse(fs.readFileSync(tsPath, 'utf8'));
+  });
+
+  it('has strict mode enabled', () => {
+    assert.strictEqual(tsconfig.compilerOptions?.strict, true);
+  });
+
+  it('has outDir set to dist', () => {
+    assert.ok(
+      tsconfig.compilerOptions?.outDir?.includes('dist'),
+      `outDir should include 'dist', got: ${tsconfig.compilerOptions?.outDir}`
+    );
+  });
+
+  it('has declaration: true', () => {
+    assert.strictEqual(tsconfig.compilerOptions?.declaration, true);
+  });
+});
+
+// ── lib/invariants.ts source file ─────────────────────────────────────────────
+
+describe('lib/invariants.ts', () => {
+  let source;
+
+  before(() => {
+    const srcPath = path.join(LIB_DIR, 'invariants.ts');
+    assert.ok(fs.existsSync(srcPath), `lib/invariants.ts not found at ${srcPath}`);
+    source = fs.readFileSync(srcPath, 'utf8');
+  });
+
+  const REQUIRED_EXPORTS = [
+    'assertEveryVisibleDoneItemIsEditable',
+    'assertEveryFoldoutOpensAllNestedRows',
+    'assertDateWindowCoverage',
+    'assertContractSymmetry',
+    'openAllFoldouts',
+    'enumerateAffordances',
+  ];
+
+  for (const name of REQUIRED_EXPORTS) {
+    it(`exports ${name}`, () => {
+      assert.ok(
+        source.includes(`export async function ${name}`) ||
+        source.includes(`export function ${name}`),
+        `lib/invariants.ts does not export: ${name}`
+      );
+    });
+  }
+});
+
+// ── lib/index.ts re-exports ───────────────────────────────────────────────────
+
+describe('lib/index.ts', () => {
+  it('exists and re-exports from ./invariants', () => {
+    const indexPath = path.join(LIB_DIR, 'index.ts');
+    assert.ok(fs.existsSync(indexPath), `lib/index.ts not found at ${indexPath}`);
+    const content = fs.readFileSync(indexPath, 'utf8');
+    assert.ok(content.includes('./invariants'), 'index.ts should re-export from ./invariants');
+  });
+});
+
+// ── TypeScript build ──────────────────────────────────────────────────────────
+
+describe('TypeScript build', () => {
+  it('tsc exits 0 and produces dist/index.d.ts', () => {
+    // Run tsc from skill dir
+    const result = spawnSync(
+      'npx', ['tsc', '-p', 'tsconfig.json', '--noEmit', 'false'],
+      { cwd: SKILL_DIR, encoding: 'utf8', timeout: 60000 }
+    );
+    if (result.error) {
+      assert.fail(`tsc spawn error: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+      assert.fail(`tsc failed (exit ${result.status}):\n${result.stderr}\n${result.stdout}`);
+    }
+    const dtsPath = path.join(DIST_DIR, 'index.d.ts');
+    assert.ok(fs.existsSync(dtsPath), `dist/index.d.ts not produced at ${dtsPath}`);
+  });
+
+  it('dist/index.d.ts contains all 6 helper signatures', () => {
+    // index.d.ts re-exports from invariants.d.ts; check invariants.d.ts for signatures
+    const dtsPath = path.join(DIST_DIR, 'invariants.d.ts');
+    if (!fs.existsSync(dtsPath)) {
+      // Fall back to index.d.ts
+      const indexDts = path.join(DIST_DIR, 'index.d.ts');
+      if (!fs.existsSync(indexDts)) return; // tsc test above will catch this
+    }
+    const content = fs.readFileSync(dtsPath, 'utf8');
+    const REQUIRED = [
+      'assertEveryVisibleDoneItemIsEditable',
+      'assertEveryFoldoutOpensAllNestedRows',
+      'assertDateWindowCoverage',
+      'assertContractSymmetry',
+      'openAllFoldouts',
+      'enumerateAffordances',
+    ];
+    for (const name of REQUIRED) {
+      assert.ok(content.includes(name), `dist/index.d.ts missing: ${name}`);
+    }
+  });
+});
+
+// ── npm pack produces valid tarball ──────────────────────────────────────────
+
+describe('npm pack', () => {
+  let tarballPath;
+  let tmpDir;
+
+  before(() => {
+    // Pack from the skill dir
+    const result = spawnSync(
+      'npm', ['pack', '--json'],
+      { cwd: SKILL_DIR, encoding: 'utf8', timeout: 60000 }
+    );
+    if (result.error) {
+      assert.fail(`npm pack spawn error: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+      assert.fail(`npm pack failed (exit ${result.status}):\n${result.stderr}`);
+    }
+    const packOutput = JSON.parse(result.stdout);
+    const filename = packOutput[0]?.filename;
+    assert.ok(filename, 'npm pack --json did not return filename');
+    tarballPath = path.join(SKILL_DIR, filename);
+    assert.ok(fs.existsSync(tarballPath), `tarball not found: ${tarballPath}`);
+  });
+
+  after(() => {
+    // Clean up tarball
+    if (tarballPath && fs.existsSync(tarballPath)) {
+      fs.rmSync(tarballPath);
+    }
+    // Clean up temp install dir
+    if (tmpDir && fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('tarball name starts with autospec-test-1.0.0', () => {
+    const base = path.basename(tarballPath);
+    assert.ok(
+      base.startsWith('autospec-test-1.0.0'),
+      `tarball name should start with autospec-test-1.0.0, got: ${base}`
+    );
+  });
+
+  it('tarball contains package/dist/index.js and package/dist/index.d.ts', () => {
+    // List tarball contents
+    const result = spawnSync('tar', ['tzf', tarballPath], { encoding: 'utf8' });
+    assert.strictEqual(result.status, 0, `tar failed: ${result.stderr}`);
+    const files = result.stdout.split('\n');
+    assert.ok(files.some(f => f.includes('dist/index.js')), 'tarball missing dist/index.js');
+    assert.ok(files.some(f => f.includes('dist/index.d.ts')), 'tarball missing dist/index.d.ts');
+  });
+
+  it('tarball can be installed and helpers imported', async () => {
+    // Install tarball in a temp dir and import helpers
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'autospec-test-install-'));
+    // Init temp package
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({
+      name: 'test-consumer', version: '1.0.0', type: 'module'
+    }));
+
+    const installResult = spawnSync(
+      'npm', ['install', tarballPath, '--no-save'],
+      { cwd: tmpDir, encoding: 'utf8', timeout: 60000 }
+    );
+    if (installResult.status !== 0) {
+      assert.fail(`npm install tarball failed:\n${installResult.stderr}`);
+    }
+
+    // Write a tiny consumer script
+    const consumerScript = path.join(tmpDir, 'check.mjs');
+    fs.writeFileSync(consumerScript, `
+import {
+  assertEveryVisibleDoneItemIsEditable,
+  assertEveryFoldoutOpensAllNestedRows,
+  assertDateWindowCoverage,
+  assertContractSymmetry,
+  openAllFoldouts,
+  enumerateAffordances,
+} from '@autospec/test/invariants';
+
+// All 6 should be functions
+const helpers = [
+  assertEveryVisibleDoneItemIsEditable,
+  assertEveryFoldoutOpensAllNestedRows,
+  assertDateWindowCoverage,
+  assertContractSymmetry,
+  openAllFoldouts,
+  enumerateAffordances,
+];
+for (const h of helpers) {
+  if (typeof h !== 'function') {
+    process.stderr.write('NOT A FUNCTION: ' + h + '\\n');
+    process.exit(1);
+  }
+}
+process.stdout.write('OK\\n');
+`);
+    const checkResult = spawnSync('node', [consumerScript], {
+      cwd: tmpDir, encoding: 'utf8', timeout: 30000
+    });
+    assert.strictEqual(
+      checkResult.status, 0,
+      `helper import check failed (exit ${checkResult.status}):\n${checkResult.stderr}`
+    );
+    assert.ok(checkResult.stdout.includes('OK'), 'consumer script did not print OK');
+  });
+});
+
+// ── publish-helpers.sh ────────────────────────────────────────────────────────
+
+describe('publish-helpers.sh', () => {
+  const publishScript = path.join(SKILL_DIR, 'scripts/publish-helpers.sh');
+
+  it('exists and is executable', () => {
+    assert.ok(fs.existsSync(publishScript), `publish-helpers.sh not found at ${publishScript}`);
+    const stat = fs.statSync(publishScript);
+    assert.ok(stat.mode & 0o111, 'publish-helpers.sh is not executable');
+  });
+
+  it('--dry-run exits 0 without calling npm publish', () => {
+    const result = spawnSync('bash', [publishScript, '--dry-run'], {
+      cwd: SKILL_DIR, encoding: 'utf8', timeout: 60000
+    });
+    if (result.status !== 0) {
+      assert.fail(`publish-helpers.sh --dry-run failed (exit ${result.status}):\n${result.stderr}\n${result.stdout}`);
+    }
+    // Must not contain real publish (dry-run only)
+    assert.ok(
+      !result.stdout.includes('npm publish ') || result.stdout.includes('--dry-run'),
+      'publish-helpers.sh --dry-run called real npm publish'
+    );
+  });
+
+  it('does not contain bare npm publish without --release guard', () => {
+    const content = fs.readFileSync(publishScript, 'utf8');
+    // Verify the script contains a RELEASE guard (if [ "$RELEASE" -eq 1 ] block)
+    // and that any bare 'npm publish' (without --dry-run) is inside that block.
+    const hasReleaseGuard = content.includes('RELEASE') && content.includes('--release');
+    assert.ok(hasReleaseGuard, 'publish-helpers.sh must have a --release flag guard');
+    // Also verify dry-run path calls npm publish --dry-run
+    assert.ok(content.includes('npm publish --dry-run'), 'publish-helpers.sh must have a --dry-run path');
+  });
+});

--- a/skills/autospec-test/tsconfig.json
+++ b/skills/autospec-test/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "lib",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": false
+  },
+  "include": ["lib/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
Closes #349

## Summary

Ships Phase 8 of the autospec-test v2 invariants extension — the `@autospec/test` npm helper library:

- **`lib/invariants.ts`** — 6 named helpers that delegate to the same logic as the phase 2 kind-modules and phase 4/6 runners: `assertEveryVisibleDoneItemIsEditable`, `assertEveryFoldoutOpensAllNestedRows`, `assertDateWindowCoverage`, `assertContractSymmetry`, `openAllFoldouts`, `enumerateAffordances`
- **`lib/index.ts`** — re-exports all helpers from `./invariants`
- **`package.json`** — `@autospec/test` v1.0.0, type:module, `@playwright/test >=1.40.0` peer dep, exports for `.` and `./invariants`
- **`tsconfig.json`** — strict ES2022 NodeNext, builds to `dist/`, generates `.d.ts` declarations
- **`scripts/publish-helpers.sh`** — `--dry-run` runs `npm publish --dry-run` safely; `--release` gates real publish with version bump check and clean tree guard

## Test plan

- [x] `node --test skills/autospec-test/tests/unit/v2/lib-import.test.mjs` — 25 tests, all pass
- [x] package.json: name @autospec/test, version 1.0.0, type module, correct main/types, peerDep, exports
- [x] tsconfig.json: strict, outDir=dist, declaration:true
- [x] lib/invariants.ts: all 6 helpers exported
- [x] lib/index.ts: re-exports from ./invariants
- [x] tsc build: exits 0, produces dist/index.d.ts and dist/invariants.d.ts with all 6 signatures
- [x] npm pack: tarball name autospec-test-1.0.0.tgz, contains dist/index.js and dist/index.d.ts
- [x] tarball install + import: all 6 helpers callable as functions from @autospec/test/invariants
- [x] publish-helpers.sh: executable, --dry-run exits 0, --release guard present, dry-run path present