### PR TITLE
feat(autospec-docs): tree-sitter foundation + per-language queries (phase 1)

### DIFF
--- a/skills/autospec-shared/bin/tree-sitter-walk
+++ b/skills/autospec-shared/bin/tree-sitter-walk
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// bin/tree-sitter-walk — CLI wrapper for the autospec-shared tree-sitter walker.
+//
+// Usage:
+//   tree-sitter-walk <file>               Walk a single file; emit JSON to stdout.
+//   tree-sitter-walk --root <dir>         Walk all supported files under <dir>; emit JSON array.
+//   tree-sitter-walk --help               Print usage.
+//
+// Exit codes:
+//   0 = success (JSON emitted)
+//   1 = error (message on stderr)
+
+import { walk } from '../scripts/tree-sitter-walk/walker.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SUPPORTED_EXTS = new Set(['.ts', '.tsx', '.mts', '.js', '.mjs', '.cjs', '.jsx', '.py', '.go', '.rs', '.java']);
+
+function walkDirRecursive(dir) {
+    const results = [];
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            // Skip common non-source directories
+            if (['.git', 'node_modules', 'vendor', '.turbo', 'dist', 'build', '__pycache__'].includes(entry.name)) continue;
+            results.push(...walkDirRecursive(fullPath));
+        } else if (entry.isFile() && SUPPORTED_EXTS.has(path.extname(entry.name).toLowerCase())) {
+            results.push(fullPath);
+        }
+    }
+    return results;
+}
+
+async function main() {
+    const args = process.argv.slice(2);
+
+    if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+        process.stdout.write([
+            'Usage:',
+            '  tree-sitter-walk <file>         Walk a single file; emit JSON to stdout.',
+            '  tree-sitter-walk --root <dir>   Walk all supported files under <dir>.',
+            '  tree-sitter-walk --help         Print this help.',
+            '',
+            'Supported languages: TypeScript, JavaScript, Python, Go, Rust, Java',
+            '',
+        ].join('\n'));
+        process.exit(args.length === 0 ? 1 : 0);
+    }
+
+    try {
+        if (args[0] === '--root') {
+            const dir = args[1];
+            if (!dir) {
+                process.stderr.write('tree-sitter-walk: --root requires a directory argument\n');
+                process.exit(1);
+            }
+            if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+                process.stderr.write(`tree-sitter-walk: not a directory: ${dir}\n`);
+                process.exit(1);
+            }
+            const files = walkDirRecursive(dir);
+            const outputs = await Promise.all(files.map(f => walk(f)));
+            process.stdout.write(JSON.stringify(outputs, null, 2) + '\n');
+        } else {
+            const filePath = args[0];
+            if (!fs.existsSync(filePath)) {
+                process.stderr.write(`tree-sitter-walk: file not found: ${filePath}\n`);
+                process.exit(1);
+            }
+            const output = await walk(filePath);
+            process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+        }
+    } catch (err) {
+        process.stderr.write(`tree-sitter-walk: error: ${err.message}\n`);
+        process.exit(1);
+    }
+}
+
+main();

--- a/skills/autospec-shared/package-lock.json
+++ b/skills/autospec-shared/package-lock.json
@@ -1,0 +1,195 @@
+{
+  "name": "@autospec/shared",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@autospec/shared",
+      "version": "1.0.0",
+      "dependencies": {
+        "tree-sitter-go": "^0.23.4",
+        "tree-sitter-java": "^0.23.5",
+        "tree-sitter-javascript": "^0.23.1",
+        "tree-sitter-python": "^0.23.6",
+        "tree-sitter-rust": "^0.23.2",
+        "tree-sitter-typescript": "^0.23.2",
+        "web-tree-sitter": "^0.24.7"
+      },
+      "bin": {
+        "tree-sitter-walk": "bin/tree-sitter-walk"
+      },
+      "devDependencies": {
+        "node": ">=20.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/node": {
+      "version": "24.16.0",
+      "resolved": "https://registry.npmjs.org/node/-/node-24.16.0.tgz",
+      "integrity": "sha512-/I/OXFqToKBumieZArsCwPrHdbsgwa6Ho3acCaDZwKlcVkgUyQ6+AERsEicdAoZNkKR3TXkh462gEW301y+/1g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-bin-setup": "^1.0.0"
+      },
+      "bin": {
+        "node": "bin/node"
+      },
+      "engines": {
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-bin-setup": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.4.tgz",
+      "integrity": "sha512-vWNHOne0ZUavArqPP5LJta50+S8R261Fr5SvGul37HbEDcowvLjwdvd0ZeSr0r2lTSrPxl6okq9QUw8BFGiAxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/tree-sitter-go": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-go/-/tree-sitter-go-0.23.4.tgz",
+      "integrity": "sha512-iQaHEs4yMa/hMo/ZCGqLfG61F0miinULU1fFh+GZreCRtKylFLtvn798ocCZjO2r/ungNZgAY1s1hPFyAwkc7w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-java": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-java/-/tree-sitter-java-0.23.5.tgz",
+      "integrity": "sha512-Yju7oQ0Xx7GcUT01mUglPP+bYfvqjNCGdxqigTnew9nLGoII42PNVP3bHrYeMxswiCRM0yubWmN5qk+zsg0zMA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-javascript": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+      "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-python": {
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.23.6.tgz",
+      "integrity": "sha512-yIM9z0oxKIxT7bAtPOhgoVl6gTXlmlIhue7liFT4oBPF/lha7Ha4dQBS82Av6hMMRZoVnFJI8M6mL+SwWoLD3A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-rust": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.23.3.tgz",
+      "integrity": "sha512-uLdZJ1K26EuJTBMJlz1ltTlg7nJyAYThfouXgigf5ixKOasOL5wNrRCpuWTsl6rDcKlZK9UX+annFLqP/kchwQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-typescript": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
+      "integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-javascript": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.24.7",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.7.tgz",
+      "integrity": "sha512-CdC/TqVFbXqR+C51v38hv6wOPatKEUGxa39scAeFSm98wIhZxAYonhRQPSMmfZ2w7JDI0zQDdzdmgtNk06/krQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/skills/autospec-shared/package.json
+++ b/skills/autospec-shared/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@autospec/shared",
+  "version": "1.0.0",
+  "description": "Cross-skill shared tooling for autospec — tree-sitter walker, doc generators, and utilities.",
+  "type": "module",
+  "scripts": {
+    "test": "node --test tests/unit/"
+  },
+  "bin": {
+    "tree-sitter-walk": "./bin/tree-sitter-walk"
+  },
+  "dependencies": {
+    "web-tree-sitter": "^0.24.7",
+    "tree-sitter-typescript": "^0.23.2",
+    "tree-sitter-javascript": "^0.23.1",
+    "tree-sitter-python": "^0.23.6",
+    "tree-sitter-go": "^0.23.4",
+    "tree-sitter-rust": "^0.23.2",
+    "tree-sitter-java": "^0.23.5"
+  },
+  "devDependencies": {
+    "node": ">=20.0.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/skills/autospec-shared/package.json
+++ b/skills/autospec-shared/package.json
@@ -4,7 +4,7 @@
   "description": "Cross-skill shared tooling for autospec — tree-sitter walker, doc generators, and utilities.",
   "type": "module",
   "scripts": {
-    "test": "node --test tests/unit/"
+    "test": "node --test tests/unit/tree-sitter-walk.test.mjs"
   },
   "bin": {
     "tree-sitter-walk": "./bin/tree-sitter-walk"

--- a/skills/autospec-shared/scripts/tree-sitter-walk/queries/go.scm
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/queries/go.scm
@@ -1,0 +1,59 @@
+; Go tree-sitter queries for autospec-docs walker
+; Captures: exports (exported identifiers start with uppercase), entry_points, imports
+
+; ── Exported functions ────────────────────────────────────────────────────────
+
+(function_declaration
+  name: (identifier) @export.name
+  parameters: (parameter_list) @export.params
+  (#match? @export.name "^[A-Z]")
+  (#set! export.kind "function"))
+
+; ── Exported types (struct, interface, type alias) ───────────────────────────
+
+(type_declaration
+  (type_spec
+    name: (type_identifier) @export.name
+    (#match? @export.name "^[A-Z]"))
+  (#set! export.kind "type"))
+
+; ── Exported constants and variables ─────────────────────────────────────────
+
+(const_declaration
+  (const_spec
+    name: (identifier) @export.name
+    (#match? @export.name "^[A-Z]"))
+  (#set! export.kind "const"))
+
+(var_declaration
+  (var_spec
+    name: (identifier) @export.name
+    (#match? @export.name "^[A-Z]"))
+  (#set! export.kind "const"))
+
+; ── CLI entry points (func main()) ───────────────────────────────────────────
+
+(function_declaration
+  name: (identifier) @entry.main
+  (#eq? @entry.main "main")
+  (#set! entry.kind "cli_command"))
+
+; ── HTTP routes (net/http and gorilla/mux / gin / echo patterns) ─────────────
+
+; http.HandleFunc("/path", handler)
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @_hf
+    (#match? @_hf "^(HandleFunc|Handle|GET|POST|PUT|PATCH|DELETE|Any|Group)$"))
+  arguments: (argument_list
+    (interpreted_string_literal) @entry.route)
+  (#set! entry.kind "http_route"))
+
+; ── Import statements ─────────────────────────────────────────────────────────
+
+(import_spec
+  path: (interpreted_string_literal) @import.source)
+
+(import_spec
+  name: (identifier) @import.name
+  path: (interpreted_string_literal) @import.source)

--- a/skills/autospec-shared/scripts/tree-sitter-walk/queries/go.scm
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/queries/go.scm
@@ -50,10 +50,10 @@
   (#set! entry.kind "http_route"))
 
 ; ── Import statements ─────────────────────────────────────────────────────────
+; Capture the string content of each import spec.
+; web-tree-sitter: import_spec has no named fields; use child node traversal.
+; The interpreted_string_literal_content holds the path without quotes.
 
 (import_spec
-  path: (interpreted_string_literal) @import.source)
-
-(import_spec
-  name: (identifier) @import.name
-  path: (interpreted_string_literal) @import.source)
+  (interpreted_string_literal
+    (interpreted_string_literal_content) @import.source))

--- a/skills/autospec-shared/scripts/tree-sitter-walk/queries/java.scm
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/queries/java.scm
@@ -4,45 +4,43 @@
 ; ── Public classes ────────────────────────────────────────────────────────────
 
 (class_declaration
-  (modifiers
-    (modifier) @_pub (#eq? @_pub "public"))
+  (modifiers) @_mods
   name: (identifier) @export.name
+  (#match? @_mods "public")
   (#set! export.kind "class"))
 
 (interface_declaration
-  (modifiers
-    (modifier) @_pub (#eq? @_pub "public"))
+  (modifiers) @_mods
   name: (identifier) @export.name
+  (#match? @_mods "public")
   (#set! export.kind "type"))
 
 ; ── Public methods ────────────────────────────────────────────────────────────
 
 (method_declaration
-  (modifiers
-    (modifier) @_pub (#eq? @_pub "public"))
+  (modifiers) @_mods
   name: (identifier) @export.name
   parameters: (formal_parameters) @export.params
+  (#match? @_mods "public")
   (#set! export.kind "function"))
 
 ; ── Public constants (public static final) ───────────────────────────────────
 
 (field_declaration
-  (modifiers
-    (modifier) @_pub (#eq? @_pub "public")
-    (modifier) @_sta (#eq? @_sta "static")
-    (modifier) @_fin (#eq? @_fin "final"))
+  (modifiers) @_mods
   declarator: (variable_declarator
     name: (identifier) @export.name)
+  (#match? @_mods "public")
   (#set! export.kind "const"))
 
 ; ── CLI entry points (public static void main(String[] args)) ────────────────
 
 (method_declaration
-  (modifiers
-    (modifier) @_pub (#eq? @_pub "public")
-    (modifier) @_sta (#eq? @_sta "static"))
+  (modifiers) @_mods
   type: (void_type)
   name: (identifier) @entry.main
+  (#match? @_mods "public")
+  (#match? @_mods "static")
   (#eq? @entry.main "main")
   (#set! entry.kind "cli_command"))
 

--- a/skills/autospec-shared/scripts/tree-sitter-walk/queries/java.scm
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/queries/java.scm
@@ -1,0 +1,61 @@
+; Java tree-sitter queries for autospec-docs walker
+; Captures: exports (public methods/classes), entry_points, imports
+
+; ── Public classes ────────────────────────────────────────────────────────────
+
+(class_declaration
+  (modifiers
+    (modifier) @_pub (#eq? @_pub "public"))
+  name: (identifier) @export.name
+  (#set! export.kind "class"))
+
+(interface_declaration
+  (modifiers
+    (modifier) @_pub (#eq? @_pub "public"))
+  name: (identifier) @export.name
+  (#set! export.kind "type"))
+
+; ── Public methods ────────────────────────────────────────────────────────────
+
+(method_declaration
+  (modifiers
+    (modifier) @_pub (#eq? @_pub "public"))
+  name: (identifier) @export.name
+  parameters: (formal_parameters) @export.params
+  (#set! export.kind "function"))
+
+; ── Public constants (public static final) ───────────────────────────────────
+
+(field_declaration
+  (modifiers
+    (modifier) @_pub (#eq? @_pub "public")
+    (modifier) @_sta (#eq? @_sta "static")
+    (modifier) @_fin (#eq? @_fin "final"))
+  declarator: (variable_declarator
+    name: (identifier) @export.name)
+  (#set! export.kind "const"))
+
+; ── CLI entry points (public static void main(String[] args)) ────────────────
+
+(method_declaration
+  (modifiers
+    (modifier) @_pub (#eq? @_pub "public")
+    (modifier) @_sta (#eq? @_sta "static"))
+  type: (void_type)
+  name: (identifier) @entry.main
+  (#eq? @entry.main "main")
+  (#set! entry.kind "cli_command"))
+
+; ── HTTP routes (Spring @GetMapping / @PostMapping etc.) ─────────────────────
+
+(annotation
+  name: (identifier) @_ann
+  (#match? @_ann "^(GetMapping|PostMapping|PutMapping|PatchMapping|DeleteMapping|RequestMapping)$")
+  arguments: (annotation_argument_list
+    (string_literal) @entry.route)
+  (#set! entry.kind "http_route"))
+
+; ── Import statements ─────────────────────────────────────────────────────────
+
+(import_declaration
+  (scoped_identifier) @import.source)

--- a/skills/autospec-shared/scripts/tree-sitter-walk/queries/javascript.scm
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/queries/javascript.scm
@@ -1,0 +1,87 @@
+; JavaScript tree-sitter queries for autospec-docs walker
+; Captures: exports, entry_points, imports
+
+; ── Exported functions ────────────────────────────────────────────────────────
+
+(export_statement
+  declaration: (function_declaration
+    name: (identifier) @export.name
+    parameters: (formal_parameters) @export.params)
+  (#set! export.kind "function"))
+
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @export.name
+      value: [(arrow_function) (function_expression)])) @export.decl
+  (#set! export.kind "function"))
+
+; ── Exported classes ──────────────────────────────────────────────────────────
+
+(export_statement
+  declaration: (class_declaration
+    name: (identifier) @export.name)
+  (#set! export.kind "class"))
+
+; ── Exported constants ────────────────────────────────────────────────────────
+
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @export.name))
+  (#set! export.kind "const"))
+
+; Named re-exports
+(export_statement
+  (export_clause
+    (export_specifier
+      name: (identifier) @export.name))
+  (#set! export.kind "const"))
+
+; module.exports = { ... }
+(expression_statement
+  (assignment_expression
+    left: (member_expression
+      object: (identifier) @_mod (#eq? @_mod "module")
+      property: (property_identifier) @_exp (#eq? @_exp "exports"))
+    right: (object
+      (pair
+        key: (property_identifier) @export.name)))
+  (#set! export.kind "const"))
+
+; ── CLI entry points ─────────────────────────────────────────────────────────
+
+(program
+  (hash_bang_line) @entry.shebang
+  (#set! entry.kind "cli_command"))
+
+; ── HTTP routes ───────────────────────────────────────────────────────────────
+
+(call_expression
+  function: (member_expression
+    object: (identifier)
+    property: (property_identifier) @http.method
+    (#match? @http.method "^(get|post|put|patch|delete|head|options|all|route)$"))
+  arguments: (arguments
+    (string) @entry.route)
+  (#set! entry.kind "http_route"))
+
+; ── Import / require statements ───────────────────────────────────────────────
+
+(import_statement
+  source: (string (string_fragment) @import.source)
+  (import_clause
+    (named_imports
+      (import_specifier
+        name: (identifier) @import.name))))
+
+(import_statement
+  source: (string (string_fragment) @import.source)
+  (import_clause
+    (identifier) @import.name))
+
+; require()
+(call_expression
+  function: (identifier) @_req (#eq? @_req "require")
+  arguments: (arguments
+    (string (string_fragment) @import.source)))

--- a/skills/autospec-shared/scripts/tree-sitter-walk/queries/javascript.scm
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/queries/javascript.scm
@@ -66,19 +66,13 @@
     (string) @entry.route)
   (#set! entry.kind "http_route"))
 
-; ── Import / require statements ───────────────────────────────────────────────
+; ── Import statements ─────────────────────────────────────────────────────────
+; Note: web-tree-sitter does not support non-field anonymous children in patterns,
+; so import names are extracted via node traversal in walker.mjs buildOutput().
+; We only capture the source here; names are resolved programmatically.
 
 (import_statement
-  source: (string (string_fragment) @import.source)
-  (import_clause
-    (named_imports
-      (import_specifier
-        name: (identifier) @import.name))))
-
-(import_statement
-  source: (string (string_fragment) @import.source)
-  (import_clause
-    (identifier) @import.name))
+  source: (string (string_fragment) @import.source))
 
 ; require()
 (call_expression

--- a/skills/autospec-shared/scripts/tree-sitter-walk/queries/python.scm
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/queries/python.scm
@@ -1,0 +1,65 @@
+; Python tree-sitter queries for autospec-docs walker
+; Captures: exports (public top-level functions/classes), entry_points, imports
+
+; ── Public functions (not prefixed with _) ────────────────────────────────────
+
+(function_definition
+  name: (identifier) @export.name
+  parameters: (parameters) @export.params
+  (#not-match? @export.name "^_")
+  (#set! export.kind "function"))
+
+; ── Public classes ────────────────────────────────────────────────────────────
+
+(class_definition
+  name: (identifier) @export.name
+  (#not-match? @export.name "^_")
+  (#set! export.kind "class"))
+
+; ── Top-level constants (ALL_CAPS or explicitly __all__) ─────────────────────
+
+(expression_statement
+  (assignment
+    left: (identifier) @export.name
+    (#match? @export.name "^[A-Z][A-Z0-9_]+$"))
+  (#set! export.kind "const"))
+
+(expression_statement
+  (assignment
+    left: (identifier) @_all (#eq? @_all "__all__"))
+  (#set! export.kind "const"))
+
+; ── CLI entry points ─────────────────────────────────────────────────────────
+; if __name__ == "__main__":
+
+(if_statement
+  condition: (comparison_operator
+    (identifier) @_name (#eq? @_name "__name__")
+    (string) @_main (#match? @_main "__main__"))
+  (#set! entry.kind "cli_command"))
+
+; ── HTTP routes (Flask / FastAPI / Django patterns) ──────────────────────────
+
+; @app.route("/path")
+(decorated_definition
+  (decorator
+    (call
+      function: (attribute
+        attribute: (identifier) @_route (#match? @_route "^(route|get|post|put|patch|delete)$"))
+      arguments: (argument_list
+        (string) @entry.route)))
+  (#set! entry.kind "http_route"))
+
+; ── Import statements ─────────────────────────────────────────────────────────
+
+(import_statement
+  name: (dotted_name) @import.source)
+
+(import_from_statement
+  module_name: (dotted_name) @import.source
+  name: (dotted_name) @import.name)
+
+(import_from_statement
+  module_name: (dotted_name) @import.source
+  name: (aliased_import
+    name: (dotted_name) @import.name))

--- a/skills/autospec-shared/scripts/tree-sitter-walk/queries/python.scm
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/queries/python.scm
@@ -35,8 +35,7 @@
 (if_statement
   condition: (comparison_operator
     (identifier) @_name (#eq? @_name "__name__")
-    (string) @_main (#match? @_main "__main__"))
-  (#set! entry.kind "cli_command"))
+    (string) @entry.main (#match? @entry.main "__main__")))
 
 ; ── HTTP routes (Flask / FastAPI / Django patterns) ──────────────────────────
 

--- a/skills/autospec-shared/scripts/tree-sitter-walk/queries/rust.scm
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/queries/rust.scm
@@ -1,0 +1,73 @@
+; Rust tree-sitter queries for autospec-docs walker
+; Captures: exports (pub items), entry_points, imports (use declarations)
+
+; ── Public functions ─────────────────────────────────────────────────────────
+
+(function_item
+  (visibility_modifier) @_pub (#eq? @_pub "pub")
+  name: (identifier) @export.name
+  parameters: (parameters) @export.params
+  (#set! export.kind "function"))
+
+; ── Public structs / enums / traits / type aliases ───────────────────────────
+
+(struct_item
+  (visibility_modifier) @_pub (#eq? @_pub "pub")
+  name: (type_identifier) @export.name
+  (#set! export.kind "type"))
+
+(enum_item
+  (visibility_modifier) @_pub (#eq? @_pub "pub")
+  name: (type_identifier) @export.name
+  (#set! export.kind "type"))
+
+(trait_item
+  (visibility_modifier) @_pub (#eq? @_pub "pub")
+  name: (type_identifier) @export.name
+  (#set! export.kind "type"))
+
+(type_item
+  (visibility_modifier) @_pub (#eq? @_pub "pub")
+  name: (type_identifier) @export.name
+  (#set! export.kind "type"))
+
+; ── Public constants ─────────────────────────────────────────────────────────
+
+(const_item
+  (visibility_modifier) @_pub (#eq? @_pub "pub")
+  name: (identifier) @export.name
+  (#set! export.kind "const"))
+
+; ── CLI entry points (fn main()) ─────────────────────────────────────────────
+
+(function_item
+  name: (identifier) @entry.main
+  (#eq? @entry.main "main")
+  (#set! entry.kind "cli_command"))
+
+; ── HTTP routes (actix-web / axum / rocket attribute patterns) ───────────────
+
+; #[get("/path")]  #[post("/path")]  etc.
+(attribute_item
+  (attribute
+    (identifier) @_method
+    (#match? @_method "^(get|post|put|patch|delete|head|options|route)$")
+    arguments: (token_tree
+      (string_literal) @entry.route))
+  (#set! entry.kind "http_route"))
+
+; ── Use declarations ──────────────────────────────────────────────────────────
+
+(use_declaration
+  argument: (scoped_identifier
+    path: (identifier) @import.source
+    name: (identifier) @import.name))
+
+(use_declaration
+  argument: (identifier) @import.source)
+
+(use_declaration
+  argument: (scoped_use_list
+    path: (identifier) @import.source
+    list: (use_list
+      (identifier) @import.name)))

--- a/skills/autospec-shared/scripts/tree-sitter-walk/queries/rust.scm
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/queries/rust.scm
@@ -57,17 +57,15 @@
   (#set! entry.kind "http_route"))
 
 ; ── Use declarations ──────────────────────────────────────────────────────────
+; Capture the full path of each use declaration as import.source.
+; e.g. `use std::fs;` → import.source = "std::fs"
+;      `use std::collections::HashMap;` → import.source = "std::collections::HashMap"
 
 (use_declaration
-  argument: (scoped_identifier
-    path: (identifier) @import.source
-    name: (identifier) @import.name))
+  argument: (scoped_identifier) @import.source)
 
 (use_declaration
   argument: (identifier) @import.source)
 
 (use_declaration
-  argument: (scoped_use_list
-    path: (identifier) @import.source
-    list: (use_list
-      (identifier) @import.name)))
+  argument: (scoped_use_list) @import.source)

--- a/skills/autospec-shared/scripts/tree-sitter-walk/queries/typescript.scm
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/queries/typescript.scm
@@ -1,0 +1,83 @@
+; TypeScript tree-sitter queries for autospec-docs walker
+; Captures: exports, entry_points, imports
+
+; ── Exported functions ────────────────────────────────────────────────────────
+
+(export_statement
+  declaration: (function_declaration
+    name: (identifier) @export.name
+    parameters: (formal_parameters) @export.params)
+  (#set! export.kind "function"))
+
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @export.name
+      value: [(arrow_function) (function_expression)])) @export.decl
+  (#set! export.kind "function"))
+
+; ── Exported classes ──────────────────────────────────────────────────────────
+
+(export_statement
+  declaration: (class_declaration
+    name: (type_identifier) @export.name)
+  (#set! export.kind "class"))
+
+; ── Exported type aliases / interfaces ───────────────────────────────────────
+
+(export_statement
+  declaration: (type_alias_declaration
+    name: (type_identifier) @export.name)
+  (#set! export.kind "type"))
+
+(export_statement
+  declaration: (interface_declaration
+    name: (type_identifier) @export.name)
+  (#set! export.kind "type"))
+
+; ── Exported constants ────────────────────────────────────────────────────────
+
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @export.name))
+  (#set! export.kind "const"))
+
+; Named re-exports: export { foo, bar }
+(export_statement
+  (export_clause
+    (export_specifier
+      name: (identifier) @export.name))
+  (#set! export.kind "const"))
+
+; ── CLI entry points ─────────────────────────────────────────────────────────
+; Detect `#!/usr/bin/env node` shebang at top of file
+
+(program
+  (hash_bang_line) @entry.shebang
+  (#set! entry.kind "cli_command"))
+
+; ── HTTP routes (Express / Fastify / Hono patterns) ─────────────────────────
+
+(call_expression
+  function: (member_expression
+    object: (identifier)
+    property: (property_identifier) @http.method
+    (#match? @http.method "^(get|post|put|patch|delete|head|options|all|route)$"))
+  arguments: (arguments
+    (string) @entry.route)
+  (#set! entry.kind "http_route"))
+
+; ── Import statements ─────────────────────────────────────────────────────────
+
+(import_statement
+  source: (string (string_fragment) @import.source)
+  (import_clause
+    (named_imports
+      (import_specifier
+        name: (identifier) @import.name))))
+
+(import_statement
+  source: (string (string_fragment) @import.source)
+  (import_clause
+    (identifier) @import.name))

--- a/skills/autospec-shared/scripts/tree-sitter-walk/queries/typescript.scm
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/queries/typescript.scm
@@ -69,15 +69,9 @@
   (#set! entry.kind "http_route"))
 
 ; ── Import statements ─────────────────────────────────────────────────────────
+; Note: web-tree-sitter does not support non-field anonymous children in patterns,
+; so import names are extracted via node traversal in walker.mjs buildOutput().
+; We only capture the source here; names are resolved programmatically.
 
 (import_statement
-  source: (string (string_fragment) @import.source)
-  (import_clause
-    (named_imports
-      (import_specifier
-        name: (identifier) @import.name))))
-
-(import_statement
-  source: (string (string_fragment) @import.source)
-  (import_clause
-    (identifier) @import.name))
+  source: (string (string_fragment) @import.source))

--- a/skills/autospec-shared/scripts/tree-sitter-walk/walker.mjs
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/walker.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+// walker.mjs — tree-sitter walker for autospec-docs amendment pipeline.
+//
+// Exports:
+//   walk(filePath: string): Promise<WalkOutput>
+//
+// WalkOutput schema (per plan §1.2):
+//   {
+//     language: string,           // 'typescript' | 'javascript' | 'python' | 'go' | 'rust' | 'java' | 'unknown'
+//     exports: Array<{
+//       name: string,
+//       kind: 'function' | 'class' | 'type' | 'const',
+//       signature: string,
+//       line: number,
+//     }>,
+//     entry_points: Array<{
+//       kind: 'cli_command' | 'http_route',
+//       identifier: string,
+//       line: number,
+//     }>,
+//     imports: Array<{
+//       source: string,
+//       names: string[],
+//     }>,
+//     file_path: string,          // absolute path
+//   }
+//
+// Malformed / unsupported input returns { language: 'unknown', exports: [], entry_points: [], imports: [], file_path }
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const QUERIES_DIR = path.join(__dirname, 'queries');
+
+// ── Language detection ────────────────────────────────────────────────────────
+
+const EXT_TO_LANG = {
+    '.ts':   'typescript',
+    '.tsx':  'typescript',
+    '.mts':  'typescript',
+    '.js':   'javascript',
+    '.mjs':  'javascript',
+    '.cjs':  'javascript',
+    '.jsx':  'javascript',
+    '.py':   'python',
+    '.go':   'go',
+    '.rs':   'rust',
+    '.java': 'java',
+};
+
+const LANG_TO_GRAMMAR_PKG = {
+    typescript:  'tree-sitter-typescript',
+    javascript:  'tree-sitter-javascript',
+    python:      'tree-sitter-python',
+    go:          'tree-sitter-go',
+    rust:        'tree-sitter-rust',
+    java:        'tree-sitter-java',
+};
+
+function detectLanguage(filePath) {
+    const ext = path.extname(filePath).toLowerCase();
+    return EXT_TO_LANG[ext] || 'unknown';
+}
+
+// ── Parser cache ──────────────────────────────────────────────────────────────
+
+let Parser = null;
+const grammarCache = new Map();
+const queryCache   = new Map();
+
+async function loadParser() {
+    if (Parser) return Parser;
+    const { default: TreeSitter } = await import('web-tree-sitter');
+    await TreeSitter.init();
+    Parser = TreeSitter;
+    return Parser;
+}
+
+async function loadGrammar(lang) {
+    if (grammarCache.has(lang)) return grammarCache.get(lang);
+    const TS = await loadParser();
+    const pkg = LANG_TO_GRAMMAR_PKG[lang];
+    if (!pkg) return null;
+
+    // web-tree-sitter grammars ship as .wasm files in their npm packages.
+    // Resolve the .wasm path via node module resolution.
+    const require = createRequire(import.meta.url);
+    let wasmPath;
+    try {
+        // Try common locations: pkg root or /grammar.wasm, /tree-sitter-<lang>.wasm
+        const pkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
+        const candidates = [
+            path.join(pkgDir, `tree-sitter-${lang}.wasm`),
+            path.join(pkgDir, 'grammar.wasm'),
+            path.join(pkgDir, `tree-sitter-${lang === 'typescript' ? 'typescript' : lang}.wasm`),
+        ];
+        // For typescript: also try tree-sitter-tsx.wasm
+        if (lang === 'typescript') {
+            candidates.unshift(path.join(pkgDir, 'tree-sitter-typescript.wasm'));
+        }
+        wasmPath = candidates.find(p => fs.existsSync(p));
+        if (!wasmPath) {
+            // Fall back: search the package dir for any .wasm
+            const wasmFiles = fs.readdirSync(pkgDir).filter(f => f.endsWith('.wasm'));
+            if (wasmFiles.length > 0) wasmPath = path.join(pkgDir, wasmFiles[0]);
+        }
+    } catch {
+        return null;
+    }
+    if (!wasmPath) return null;
+
+    try {
+        const grammar = await TS.Language.load(wasmPath);
+        grammarCache.set(lang, grammar);
+        return grammar;
+    } catch {
+        return null;
+    }
+}
+
+function loadQuery(lang, grammar) {
+    if (queryCache.has(lang)) return queryCache.get(lang);
+    const qFile = path.join(QUERIES_DIR, `${lang}.scm`);
+    if (!fs.existsSync(qFile)) return null;
+    const qSrc = fs.readFileSync(qFile, 'utf8');
+    try {
+        const q = grammar.query(qSrc);
+        queryCache.set(lang, q);
+        return q;
+    } catch {
+        // Query compilation failure — degrade gracefully
+        return null;
+    }
+}
+
+// ── Result builders ───────────────────────────────────────────────────────────
+
+/**
+ * Build WalkOutput from tree-sitter query matches.
+ * The .scm queries use capture names like @export.name, @export.kind (metadata),
+ * @entry.kind, @import.source, @import.name.
+ */
+function buildOutput(filePath, lang, matches, source) {
+    const exportMap  = new Map(); // name → WalkExport
+    const entryMap   = new Map(); // identifier → WalkEntry
+    const importMap  = new Map(); // source → Set<name>
+
+    for (const { pattern, captures } of matches) {
+        const get = (name) => captures.find(c => c.name === name);
+        const getAll = (name) => captures.filter(c => c.name === name);
+        const nodeText = (c) => c ? source.slice(c.node.startIndex, c.node.endIndex).replace(/['"]/g, '') : '';
+        const nodeLine = (c) => c ? c.node.startPosition.row + 1 : 0;
+
+        // ── Exports ────────────────────────────────────────────────────────
+        const expName = get('export.name');
+        if (expName) {
+            const name = nodeText(expName);
+            if (name && !exportMap.has(name)) {
+                // Determine kind from set! metadata or defaults
+                const kindMeta = captures.find(c => c.name === 'export.kind');
+                let kind = kindMeta ? kindMeta.name.replace('export.', '') : 'const';
+                // Heuristic from pattern text metadata stored as set! values
+                // Since web-tree-sitter doesn't expose set! values directly, detect from pattern
+                const paramsCapture = get('export.params');
+                const declCapture = get('export.decl');
+                if (!kind || kind === 'export.kind') {
+                    if (paramsCapture) kind = 'function';
+                    else if (name.match(/^[A-Z]/) && lang !== 'go') kind = 'class';
+                    else kind = 'const';
+                }
+                // Build signature from source line
+                const line = nodeLine(expName);
+                const lines = source.split('\n');
+                const sigLine = lines[line - 1] || '';
+                const signature = sigLine.trim().replace(/\s+/g, ' ').slice(0, 120);
+                exportMap.set(name, { name, kind, signature, line });
+            }
+        }
+
+        // ── Entry points ───────────────────────────────────────────────────
+        const entryShebang = get('entry.shebang');
+        if (entryShebang) {
+            const identifier = path.basename(filePath);
+            if (!entryMap.has(identifier)) {
+                entryMap.set(identifier, { kind: 'cli_command', identifier, line: 1 });
+            }
+        }
+        const entryMain = get('entry.main');
+        if (entryMain) {
+            const identifier = nodeText(entryMain);
+            if (!entryMap.has(identifier)) {
+                entryMap.set(identifier, { kind: 'cli_command', identifier, line: nodeLine(entryMain) });
+            }
+        }
+        const entryRoute = get('entry.route');
+        if (entryRoute) {
+            const route = nodeText(entryRoute);
+            const key = `route:${route}`;
+            if (!entryMap.has(key)) {
+                entryMap.set(key, { kind: 'http_route', identifier: route, line: nodeLine(entryRoute) });
+            }
+        }
+
+        // ── Imports ────────────────────────────────────────────────────────
+        const importSource = get('import.source');
+        if (importSource) {
+            const src = nodeText(importSource);
+            if (src) {
+                if (!importMap.has(src)) importMap.set(src, new Set());
+                const importNames = getAll('import.name');
+                for (const imp of importNames) {
+                    const n = nodeText(imp);
+                    if (n) importMap.get(src).add(n);
+                }
+            }
+        }
+    }
+
+    return {
+        language: lang,
+        exports: [...exportMap.values()],
+        entry_points: [...entryMap.values()],
+        imports: [...importMap.entries()].map(([source, names]) => ({
+            source,
+            names: [...names],
+        })),
+        file_path: path.resolve(filePath),
+    };
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+const EMPTY_OUTPUT = (filePath) => ({
+    language: 'unknown',
+    exports: [],
+    entry_points: [],
+    imports: [],
+    file_path: path.resolve(filePath),
+});
+
+/**
+ * Walk a source file and extract exports, entry points, and imports.
+ *
+ * @param {string} filePath - absolute or relative path to the source file
+ * @returns {Promise<WalkOutput>}
+ */
+export async function walk(filePath) {
+    // Malformed input guard
+    if (!filePath || typeof filePath !== 'string') return EMPTY_OUTPUT(filePath || '');
+
+    let source;
+    try {
+        source = fs.readFileSync(filePath, 'utf8');
+    } catch {
+        return EMPTY_OUTPUT(filePath);
+    }
+
+    const lang = detectLanguage(filePath);
+    if (lang === 'unknown') return EMPTY_OUTPUT(filePath);
+
+    let TS;
+    try {
+        TS = await loadParser();
+    } catch {
+        return EMPTY_OUTPUT(filePath);
+    }
+
+    const grammar = await loadGrammar(lang);
+    if (!grammar) return EMPTY_OUTPUT(filePath);
+
+    const parser = new TS.Parser();
+    parser.setLanguage(grammar);
+
+    let tree;
+    try {
+        tree = parser.parse(source);
+    } catch {
+        return EMPTY_OUTPUT(filePath);
+    }
+
+    const query = loadQuery(lang, grammar);
+    if (!query) return EMPTY_OUTPUT(filePath);
+
+    let matches;
+    try {
+        matches = query.matches(tree.rootNode);
+    } catch {
+        return EMPTY_OUTPUT(filePath);
+    }
+
+    return buildOutput(filePath, lang, matches, source);
+}

--- a/skills/autospec-shared/scripts/tree-sitter-walk/walker.mjs
+++ b/skills/autospec-shared/scripts/tree-sitter-walk/walker.mjs
@@ -76,9 +76,12 @@ async function loadParser() {
     if (Parser) return Parser;
     const { default: TreeSitter } = await import('web-tree-sitter');
     await TreeSitter.init();
+    // In web-tree-sitter, the default export IS the Parser constructor.
+    // TreeSitter.Language is available for loading grammars.
     Parser = TreeSitter;
     return Parser;
 }
+
 
 async function loadGrammar(lang) {
     if (grammarCache.has(lang)) return grammarCache.get(lang);
@@ -160,18 +163,38 @@ function buildOutput(filePath, lang, matches, source) {
         if (expName) {
             const name = nodeText(expName);
             if (name && !exportMap.has(name)) {
-                // Determine kind from set! metadata or defaults
-                const kindMeta = captures.find(c => c.name === 'export.kind');
-                let kind = kindMeta ? kindMeta.name.replace('export.', '') : 'const';
-                // Heuristic from pattern text metadata stored as set! values
-                // Since web-tree-sitter doesn't expose set! values directly, detect from pattern
+                // web-tree-sitter does not expose #set! directive values as captures,
+                // so we infer kind from sibling captures and node ancestry instead.
                 const paramsCapture = get('export.params');
                 const declCapture = get('export.decl');
-                if (!kind || kind === 'export.kind') {
-                    if (paramsCapture) kind = 'function';
-                    else if (name.match(/^[A-Z]/) && lang !== 'go') kind = 'class';
+
+                let kind;
+                if (paramsCapture) {
+                    kind = 'function';
+                } else if (declCapture) {
+                    kind = 'function';
+                } else {
+                    // Walk up from the export.name node to find the declaration node type
+                    const nameNode = expName.node;
+                    const parent = nameNode.parent;
+                    const grandParent = parent?.parent;
+                    const declType = parent?.type || grandParent?.type || '';
+
+                    if (declType === 'class_declaration') kind = 'class';
+                    else if (declType === 'function_declaration') kind = 'function';
+                    else if (declType === 'interface_declaration') kind = 'type';
+                    else if (declType === 'type_alias_declaration') kind = 'type';
+                    else if (declType === 'trait_item') kind = 'type';
+                    else if (declType === 'struct_item') kind = 'type';
+                    else if (declType === 'enum_item') kind = 'type';
+                    else if (declType === 'type_item') kind = 'type';
+                    else if (grandParent?.type === 'class_declaration') kind = 'class';
+                    else if (grandParent?.type === 'function_declaration') kind = 'function';
+                    else if (grandParent?.type === 'interface_declaration') kind = 'type';
+                    else if (grandParent?.type === 'type_alias_declaration') kind = 'type';
                     else kind = 'const';
                 }
+
                 // Build signature from source line
                 const line = nodeLine(expName);
                 const lines = source.split('\n');
@@ -191,7 +214,9 @@ function buildOutput(filePath, lang, matches, source) {
         }
         const entryMain = get('entry.main');
         if (entryMain) {
-            const identifier = nodeText(entryMain);
+            const rawText = nodeText(entryMain);
+            // Python: @entry.main captures `"__main__"` string node — strip quotes for identifier
+            const identifier = rawText.replace(/^["']|["']$/g, '') || rawText;
             if (!entryMap.has(identifier)) {
                 entryMap.set(identifier, { kind: 'cli_command', identifier, line: nodeLine(entryMain) });
             }
@@ -211,10 +236,44 @@ function buildOutput(filePath, lang, matches, source) {
             const src = nodeText(importSource);
             if (src) {
                 if (!importMap.has(src)) importMap.set(src, new Set());
+
+                // First try explicit @import.name captures (Go, etc.)
                 const importNames = getAll('import.name');
                 for (const imp of importNames) {
                     const n = nodeText(imp);
                     if (n) importMap.get(src).add(n);
+                }
+
+                // For JS/TS: import names are not captured via query (web-tree-sitter
+                // limitation with non-field anonymous children). Walk the parent
+                // import_statement node to extract them programmatically.
+                if (importNames.length === 0 && importSource.node.type === 'string_fragment') {
+                    // string_fragment → string → import_statement
+                    const stmtNode = importSource.node.parent?.parent;
+                    if (stmtNode?.type === 'import_statement') {
+                        for (let i = 0; i < stmtNode.childCount; i++) {
+                            const child = stmtNode.child(i);
+                            if (child.type === 'import_clause') {
+                                for (let j = 0; j < child.childCount; j++) {
+                                    const clauseChild = child.child(j);
+                                    if (clauseChild.type === 'identifier') {
+                                        // default import: import path from 'path'
+                                        importMap.get(src).add(source.slice(clauseChild.startIndex, clauseChild.endIndex));
+                                    } else if (clauseChild.type === 'named_imports') {
+                                        // named: import { walk, run } from 'fs'
+                                        for (let k = 0; k < clauseChild.childCount; k++) {
+                                            const spec = clauseChild.child(k);
+                                            if (spec.type === 'import_specifier') {
+                                                const nameNode = spec.childForFieldName('name');
+                                                if (nameNode) importMap.get(src).add(source.slice(nameNode.startIndex, nameNode.endIndex));
+                                            }
+                                        }
+                                    }
+                                }
+                                break;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -272,7 +331,7 @@ export async function walk(filePath) {
     const grammar = await loadGrammar(lang);
     if (!grammar) return EMPTY_OUTPUT(filePath);
 
-    const parser = new TS.Parser();
+    const parser = new TS();
     parser.setLanguage(grammar);
 
     let tree;

--- a/skills/autospec-shared/tests/fixtures/tree-sitter/go/sample.go
+++ b/skills/autospec-shared/tests/fixtures/tree-sitter/go/sample.go
@@ -1,0 +1,36 @@
+// sample.go — Go fixture for autospec-docs walker unit tests.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const DefaultPort = 8080
+
+type Config struct {
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
+func ParseConfig(data []byte) (Config, error) {
+	var cfg Config
+	err := json.Unmarshal(data, &cfg)
+	return cfg, err
+}
+
+func FormatAddress(cfg Config) string {
+	return fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "ok")
+	})
+	addr := fmt.Sprintf(":%d", DefaultPort)
+	http.ListenAndServe(addr, mux)
+}

--- a/skills/autospec-shared/tests/fixtures/tree-sitter/java/sample.java
+++ b/skills/autospec-shared/tests/fixtures/tree-sitter/java/sample.java
@@ -1,0 +1,24 @@
+// sample.java — Java fixture for autospec-docs walker unit tests.
+
+package com.example;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class ConfigLoader {
+
+    public static final int DEFAULT_PORT = 8080;
+
+    public static String loadConfig(String path) throws IOException {
+        return Files.readString(Paths.get(path));
+    }
+
+    public static String formatAddress(String host, int port) {
+        return host + ":" + port;
+    }
+
+    public static void main(String[] args) {
+        System.out.println(formatAddress("localhost", DEFAULT_PORT));
+    }
+}

--- a/skills/autospec-shared/tests/fixtures/tree-sitter/javascript/sample.js
+++ b/skills/autospec-shared/tests/fixtures/tree-sitter/javascript/sample.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// sample.js — JavaScript fixture for autospec-docs walker unit tests.
+
+const express = require('express');
+import { readFile } from 'fs/promises';
+
+const app = express();
+
+export const VERSION = '1.0.0';
+
+export function greet(name) {
+    return `Hello, ${name}!`;
+}
+
+export class EventEmitter {
+    constructor() {
+        this.listeners = {};
+    }
+    on(event, handler) {
+        this.listeners[event] = handler;
+    }
+}
+
+app.get('/health', (req, res) => {
+    res.json({ status: 'ok' });
+});
+
+app.post('/greet', (req, res) => {
+    res.json({ message: greet(req.body.name) });
+});

--- a/skills/autospec-shared/tests/fixtures/tree-sitter/python/sample.py
+++ b/skills/autospec-shared/tests/fixtures/tree-sitter/python/sample.py
@@ -1,0 +1,37 @@
+"""sample.py — Python fixture for autospec-docs walker unit tests."""
+
+import os
+import json
+from pathlib import Path
+
+MAX_RETRIES = 3
+DEFAULT_TIMEOUT = 30
+
+
+def parse_config(file_path: str) -> dict:
+    """Parse a JSON config file and return the result."""
+    with open(file_path) as f:
+        return json.load(f)
+
+
+def format_message(template: str, **kwargs) -> str:
+    """Format a message template with keyword arguments."""
+    return template.format(**kwargs)
+
+
+class ConfigLoader:
+    """Loads and caches configuration from disk."""
+
+    def __init__(self, base_dir: str):
+        self.base_dir = Path(base_dir)
+        self._cache: dict = {}
+
+    def load(self, name: str) -> dict:
+        if name not in self._cache:
+            self._cache[name] = parse_config(str(self.base_dir / f"{name}.json"))
+        return self._cache[name]
+
+
+if __name__ == "__main__":
+    loader = ConfigLoader(os.getcwd())
+    print(loader.load("default"))

--- a/skills/autospec-shared/tests/fixtures/tree-sitter/rust/sample.rs
+++ b/skills/autospec-shared/tests/fixtures/tree-sitter/rust/sample.rs
@@ -1,0 +1,37 @@
+// sample.rs — Rust fixture for autospec-docs walker unit tests.
+
+use std::collections::HashMap;
+use std::fs;
+
+pub const MAX_CONNECTIONS: u32 = 100;
+
+pub struct Config {
+    pub host: String,
+    pub port: u16,
+}
+
+pub fn parse_config(path: &str) -> Result<Config, String> {
+    let content = fs::read_to_string(path).map_err(|e| e.to_string())?;
+    // Simplified: real impl would use serde_json
+    let _ = content;
+    Ok(Config {
+        host: "localhost".to_string(),
+        port: 8080,
+    })
+}
+
+pub fn format_address(config: &Config) -> String {
+    format!("{}:{}", config.host, config.port)
+}
+
+pub trait Handler {
+    fn handle(&self, request: &str) -> String;
+}
+
+fn main() {
+    let cfg = parse_config("config.json").unwrap_or(Config {
+        host: "localhost".to_string(),
+        port: 8080,
+    });
+    println!("{}", format_address(&cfg));
+}

--- a/skills/autospec-shared/tests/fixtures/tree-sitter/typescript/sample.ts
+++ b/skills/autospec-shared/tests/fixtures/tree-sitter/typescript/sample.ts
@@ -1,0 +1,28 @@
+// sample.ts — TypeScript fixture for autospec-docs walker unit tests.
+
+import { readFileSync } from 'fs';
+import path from 'path';
+
+export interface Config {
+    host: string;
+    port: number;
+}
+
+export type StatusCode = 200 | 400 | 404 | 500;
+
+export const DEFAULT_PORT = 3000;
+
+export function parseConfig(filePath: string): Config {
+    const raw = readFileSync(filePath, 'utf8');
+    return JSON.parse(raw) as Config;
+}
+
+export class Server {
+    private config: Config;
+    constructor(config: Config) {
+        this.config = config;
+    }
+    start(): void {
+        console.log(`Listening on ${this.config.host}:${this.config.port}`);
+    }
+}

--- a/skills/autospec-shared/tests/unit/tree-sitter-walk.test.mjs
+++ b/skills/autospec-shared/tests/unit/tree-sitter-walk.test.mjs
@@ -1,0 +1,295 @@
+// tests/unit/tree-sitter-walk.test.mjs
+// Unit tests for skills/autospec-shared/scripts/tree-sitter-walk/walker.mjs
+//
+// Run: node --test tests/unit/ (from skills/autospec-shared/)
+// or:  cd skills/autospec-shared && npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SKILL_DIR = path.resolve(__dirname, '../../');
+const FIXTURES_DIR = path.join(SKILL_DIR, 'tests/fixtures/tree-sitter');
+const WALKER = path.join(SKILL_DIR, 'scripts/tree-sitter-walk/walker.mjs');
+
+// Import walker
+const { walk } = await import(`file://${WALKER}`);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fixture(lang, ext) {
+    return path.join(FIXTURES_DIR, lang, `sample.${ext}`);
+}
+
+function assertExportExists(output, name) {
+    const found = output.exports.find(e => e.name === name);
+    assert.ok(found, `Expected export named '${name}' in ${output.file_path}. Got: ${output.exports.map(e => e.name).join(', ')}`);
+    return found;
+}
+
+function assertImportExists(output, source) {
+    const found = output.imports.find(i => i.source === source || i.source.includes(source));
+    assert.ok(found, `Expected import from '${source}' in ${output.file_path}. Got: ${output.imports.map(i => i.source).join(', ')}`);
+    return found;
+}
+
+function assertEntryPointExists(output, kind) {
+    const found = output.entry_points.find(e => e.kind === kind);
+    assert.ok(found, `Expected entry_point kind='${kind}' in ${output.file_path}. Got: ${JSON.stringify(output.entry_points)}`);
+    return found;
+}
+
+// ── Malformed input ───────────────────────────────────────────────────────────
+
+test('malformed input: null returns unknown language', async () => {
+    const result = await walk(null);
+    assert.equal(result.language, 'unknown');
+    assert.deepEqual(result.exports, []);
+    assert.deepEqual(result.entry_points, []);
+    assert.deepEqual(result.imports, []);
+});
+
+test('malformed input: nonexistent file returns unknown language', async () => {
+    const result = await walk('/tmp/autospec-nonexistent-fixture-xyz.ts');
+    assert.equal(result.language, 'unknown');
+    assert.deepEqual(result.exports, []);
+});
+
+test('malformed input: unsupported extension returns unknown language', async () => {
+    // Create a temp .md file
+    const tmpFile = path.join('/tmp', 'autospec-test-fixture.md');
+    fs.writeFileSync(tmpFile, '# hello\n');
+    try {
+        const result = await walk(tmpFile);
+        assert.equal(result.language, 'unknown');
+    } finally {
+        fs.unlinkSync(tmpFile);
+    }
+});
+
+// ── Output schema ─────────────────────────────────────────────────────────────
+
+test('output schema: all required fields present', async () => {
+    const result = await walk(fixture('typescript', 'ts'));
+    assert.ok(typeof result.language === 'string', 'language must be string');
+    assert.ok(Array.isArray(result.exports), 'exports must be array');
+    assert.ok(Array.isArray(result.entry_points), 'entry_points must be array');
+    assert.ok(Array.isArray(result.imports), 'imports must be array');
+    assert.ok(typeof result.file_path === 'string', 'file_path must be string');
+});
+
+test('output schema: export entries have required fields', async () => {
+    const result = await walk(fixture('typescript', 'ts'));
+    for (const exp of result.exports) {
+        assert.ok(typeof exp.name === 'string', `export.name must be string, got ${typeof exp.name}`);
+        assert.ok(['function', 'class', 'type', 'const'].includes(exp.kind),
+            `export.kind must be one of function|class|type|const, got ${exp.kind}`);
+        assert.ok(typeof exp.signature === 'string', 'export.signature must be string');
+        assert.ok(typeof exp.line === 'number', 'export.line must be number');
+    }
+});
+
+test('output schema: entry_point entries have required fields', async () => {
+    const result = await walk(fixture('go', 'go'));
+    for (const ep of result.entry_points) {
+        assert.ok(['cli_command', 'http_route'].includes(ep.kind),
+            `entry_point.kind must be cli_command|http_route, got ${ep.kind}`);
+        assert.ok(typeof ep.identifier === 'string', 'entry_point.identifier must be string');
+        assert.ok(typeof ep.line === 'number', 'entry_point.line must be number');
+    }
+});
+
+test('output schema: import entries have required fields', async () => {
+    const result = await walk(fixture('typescript', 'ts'));
+    for (const imp of result.imports) {
+        assert.ok(typeof imp.source === 'string', 'import.source must be string');
+        assert.ok(Array.isArray(imp.names), 'import.names must be array');
+    }
+});
+
+// ── TypeScript ────────────────────────────────────────────────────────────────
+
+test('typescript: detected language', async () => {
+    const result = await walk(fixture('typescript', 'ts'));
+    assert.equal(result.language, 'typescript');
+});
+
+test('typescript: exports Config interface', async () => {
+    const result = await walk(fixture('typescript', 'ts'));
+    assertExportExists(result, 'Config');
+});
+
+test('typescript: exports parseConfig function', async () => {
+    const result = await walk(fixture('typescript', 'ts'));
+    const exp = assertExportExists(result, 'parseConfig');
+    assert.equal(exp.kind, 'function');
+});
+
+test('typescript: exports Server class', async () => {
+    const result = await walk(fixture('typescript', 'ts'));
+    const exp = assertExportExists(result, 'Server');
+    assert.equal(exp.kind, 'class');
+});
+
+test('typescript: exports DEFAULT_PORT constant', async () => {
+    const result = await walk(fixture('typescript', 'ts'));
+    assertExportExists(result, 'DEFAULT_PORT');
+});
+
+test('typescript: imports from fs', async () => {
+    const result = await walk(fixture('typescript', 'ts'));
+    assertImportExists(result, 'fs');
+});
+
+test('typescript: file_path is absolute', async () => {
+    const result = await walk(fixture('typescript', 'ts'));
+    assert.ok(path.isAbsolute(result.file_path), `file_path should be absolute, got: ${result.file_path}`);
+});
+
+// ── JavaScript ────────────────────────────────────────────────────────────────
+
+test('javascript: detected language', async () => {
+    const result = await walk(fixture('javascript', 'js'));
+    assert.equal(result.language, 'javascript');
+});
+
+test('javascript: exports greet function', async () => {
+    const result = await walk(fixture('javascript', 'js'));
+    assertExportExists(result, 'greet');
+});
+
+test('javascript: exports VERSION constant', async () => {
+    const result = await walk(fixture('javascript', 'js'));
+    assertExportExists(result, 'VERSION');
+});
+
+test('javascript: detects cli_command entry (shebang)', async () => {
+    const result = await walk(fixture('javascript', 'js'));
+    assertEntryPointExists(result, 'cli_command');
+});
+
+test('javascript: detects http_route entry points', async () => {
+    const result = await walk(fixture('javascript', 'js'));
+    assertEntryPointExists(result, 'http_route');
+});
+
+// ── Python ────────────────────────────────────────────────────────────────────
+
+test('python: detected language', async () => {
+    const result = await walk(fixture('python', 'py'));
+    assert.equal(result.language, 'python');
+});
+
+test('python: exports parse_config function', async () => {
+    const result = await walk(fixture('python', 'py'));
+    assertExportExists(result, 'parse_config');
+});
+
+test('python: exports ConfigLoader class', async () => {
+    const result = await walk(fixture('python', 'py'));
+    assertExportExists(result, 'ConfigLoader');
+});
+
+test('python: detects cli_command entry (__main__)', async () => {
+    const result = await walk(fixture('python', 'py'));
+    assertEntryPointExists(result, 'cli_command');
+});
+
+test('python: imports from os', async () => {
+    const result = await walk(fixture('python', 'py'));
+    assertImportExists(result, 'os');
+});
+
+// ── Go ────────────────────────────────────────────────────────────────────────
+
+test('go: detected language', async () => {
+    const result = await walk(fixture('go', 'go'));
+    assert.equal(result.language, 'go');
+});
+
+test('go: exports ParseConfig function', async () => {
+    const result = await walk(fixture('go', 'go'));
+    assertExportExists(result, 'ParseConfig');
+});
+
+test('go: exports FormatAddress function', async () => {
+    const result = await walk(fixture('go', 'go'));
+    assertExportExists(result, 'FormatAddress');
+});
+
+test('go: detects cli_command (main function)', async () => {
+    const result = await walk(fixture('go', 'go'));
+    assertEntryPointExists(result, 'cli_command');
+});
+
+test('go: detects http_route entry point', async () => {
+    const result = await walk(fixture('go', 'go'));
+    assertEntryPointExists(result, 'http_route');
+});
+
+test('go: imports from net/http', async () => {
+    const result = await walk(fixture('go', 'go'));
+    assertImportExists(result, 'net/http');
+});
+
+// ── Rust ──────────────────────────────────────────────────────────────────────
+
+test('rust: detected language', async () => {
+    const result = await walk(fixture('rust', 'rs'));
+    assert.equal(result.language, 'rust');
+});
+
+test('rust: exports parse_config function', async () => {
+    const result = await walk(fixture('rust', 'rs'));
+    assertExportExists(result, 'parse_config');
+});
+
+test('rust: exports Config struct (type)', async () => {
+    const result = await walk(fixture('rust', 'rs'));
+    assertExportExists(result, 'Config');
+});
+
+test('rust: exports Handler trait', async () => {
+    const result = await walk(fixture('rust', 'rs'));
+    assertExportExists(result, 'Handler');
+});
+
+test('rust: detects cli_command (main function)', async () => {
+    const result = await walk(fixture('rust', 'rs'));
+    assertEntryPointExists(result, 'cli_command');
+});
+
+test('rust: imports from std::fs', async () => {
+    const result = await walk(fixture('rust', 'rs'));
+    assertImportExists(result, 'fs');
+});
+
+// ── Java ──────────────────────────────────────────────────────────────────────
+
+test('java: detected language', async () => {
+    const result = await walk(fixture('java', 'java'));
+    assert.equal(result.language, 'java');
+});
+
+test('java: exports ConfigLoader class', async () => {
+    const result = await walk(fixture('java', 'java'));
+    assertExportExists(result, 'ConfigLoader');
+});
+
+test('java: exports loadConfig method (function)', async () => {
+    const result = await walk(fixture('java', 'java'));
+    assertExportExists(result, 'loadConfig');
+});
+
+test('java: detects cli_command (main method)', async () => {
+    const result = await walk(fixture('java', 'java'));
+    assertEntryPointExists(result, 'cli_command');
+});
+
+test('java: imports java.io.IOException', async () => {
+    const result = await walk(fixture('java', 'java'));
+    assert.ok(result.imports.length > 0, 'Expected at least one import');
+});


### PR DESCRIPTION
Closes #361

## Summary

Completes the tree-sitter foundation for the autospec-docs amendment pipeline. The WIP branch had the structural files (walker, queries, CLI, package.json) but was missing tests and fixtures, and had several web-tree-sitter API incompatibilities.

### Changes in this PR

**Tests + Fixtures (new)**
- `tests/unit/tree-sitter-walk.test.mjs` — 41 tests covering all 6 languages: malformed input, schema validation, per-language exports/imports/entry-points
- `tests/fixtures/tree-sitter/{typescript,javascript,python,go,rust,java}/sample.*` — 6 language fixtures

**Bug fixes**
- `walker.mjs`: Use `new TreeSitter()` not `new TS.Parser()` (web-tree-sitter default export IS the Parser)
- `walker.mjs`: Infer export kind from parent node ancestry (web-tree-sitter doesn't expose `#set!` values)
- `walker.mjs`: Extract JS/TS import names via node traversal (web-tree-sitter can't match non-field anonymous children)
- `walker.mjs`: Fix Python `__main__` entry point via `@entry.main` capture + quote-stripping
- `queries/go.scm`: Use `interpreted_string_literal_content` for import path
- `queries/java.scm`: Use `(modifiers) @_mods` + `#match?` instead of non-existent `(modifier)` node
- `queries/rust.scm`: Capture full scoped path (`std::fs`) instead of just `std`
- `package.json`: Fix `npm test` script for Node v25 (explicit file path required)

## Test plan

- [x] `cd skills/autospec-shared && npm test` → 41/41 pass
- [x] `node skills/autospec-shared/bin/tree-sitter-walk sample.ts` → well-formed JSON
- [x] `node skills/autospec-shared/bin/tree-sitter-walk sample.py` → well-formed JSON
- [x] Malformed input returns `{ language: 'unknown', exports: [], entry_points: [], imports: [] }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)