### PR TITLE
feat(autospec-docs): scope parser + drift checker (phase 2)

### DIFF
--- a/skills/autospec-shared/package.json
+++ b/skills/autospec-shared/package.json
@@ -4,7 +4,7 @@
   "description": "Cross-skill shared tooling for autospec — tree-sitter walker, doc generators, and utilities.",
   "type": "module",
   "scripts": {
-    "test": "node --test tests/unit/tree-sitter-walk.test.mjs"
+    "test": "node --test tests/unit/tree-sitter-walk.test.mjs tests/unit/scan-doc-scope.test.mjs"
   },
   "bin": {
     "tree-sitter-walk": "./bin/tree-sitter-walk"

--- a/skills/autospec-shared/scripts/check-doc-drift.sh
+++ b/skills/autospec-shared/scripts/check-doc-drift.sh
@@ -1,0 +1,457 @@
+#!/usr/bin/env bash
+# check-doc-drift.sh — Deterministic doc-drift gate.
+#
+# Usage:
+#   check-doc-drift.sh --diff <git_diff_file>    # diff from file (or - for stdin)
+#   check-doc-drift.sh --pr <N>                  # fetch PR diff via gh CLI
+#   check-doc-drift.sh --working-tree            # diff against HEAD
+#
+# Exit codes:
+#   0 = clean (no drift found)
+#   1 = drift detected
+#   2 = missing-scope (changed source files not covered by any doc scope)
+#
+# Stdout: gate JSON per spec §3b
+# Stderr: diagnostic messages
+#
+# Requires: bash 3.2+, node (for scan-doc-scope.mjs), git
+# Optional: gh CLI (for --pr mode)
+#
+# Environment:
+#   AUTOSPEC_DOCS_DIR     — docs directory to scan (default: docs/ under repo root)
+#   AUTOSPEC_REPO_ROOT    — repo root (default: git rev-parse --show-toplevel)
+#   SCAN_DOC_SCOPE_MJS    — path to scan-doc-scope.mjs (auto-discovered)
+
+set -euo pipefail
+
+# ── Resolve paths ─────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "${AUTOSPEC_REPO_ROOT:-}" ]; then
+    AUTOSPEC_REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || git rev-parse --show-toplevel)"
+fi
+
+DOCS_DIR="${AUTOSPEC_DOCS_DIR:-${AUTOSPEC_REPO_ROOT}/docs}"
+SCAN_MJS="${SCAN_DOC_SCOPE_MJS:-${SCRIPT_DIR}/scan-doc-scope.mjs}"
+
+if [ ! -f "$SCAN_MJS" ]; then
+    echo "check-doc-drift: cannot find scan-doc-scope.mjs; set SCAN_DOC_SCOPE_MJS" >&2
+    exit 2
+fi
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+MODE=""
+DIFF_ARG=""
+PR_NUM=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --diff)
+            MODE="diff"
+            DIFF_ARG="${2:-}"
+            if [ -z "$DIFF_ARG" ]; then
+                echo "check-doc-drift: --diff requires an argument" >&2; exit 2
+            fi
+            shift 2
+            ;;
+        --pr)
+            MODE="pr"
+            PR_NUM="${2:-}"
+            if [ -z "$PR_NUM" ]; then
+                echo "check-doc-drift: --pr requires a PR number" >&2; exit 2
+            fi
+            shift 2
+            ;;
+        --working-tree)
+            MODE="working-tree"
+            shift
+            ;;
+        --help|-h)
+            cat <<'USAGE'
+check-doc-drift.sh — Deterministic doc-drift gate (autospec-docs phase 2)
+
+Usage:
+  check-doc-drift.sh --diff <file>    Analyse a saved git diff file (- for stdin)
+  check-doc-drift.sh --pr <N>         Fetch PR #N diff via gh CLI
+  check-doc-drift.sh --working-tree   Check working-tree changes vs HEAD
+
+Exit codes: 0=clean  1=drift  2=missing-scope-or-error
+Stdout: JSON gate result per spec §3b
+USAGE
+            exit 0
+            ;;
+        *)
+            echo "check-doc-drift: unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$MODE" ]; then
+    echo "check-doc-drift: one of --diff, --pr, --working-tree required" >&2
+    exit 2
+fi
+
+# ── Temp directory for working files ─────────────────────────────────────────
+
+WORK_DIR="$(mktemp -d /tmp/autospec-drift-work-XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# ── Collect diff text ─────────────────────────────────────────────────────────
+
+PR_BODY=""
+
+case "$MODE" in
+    diff)
+        if [ "$DIFF_ARG" = "-" ]; then
+            cat > "$WORK_DIR/diff.txt"
+        elif [ -f "$DIFF_ARG" ]; then
+            cp "$DIFF_ARG" "$WORK_DIR/diff.txt"
+        else
+            echo "check-doc-drift: diff file not found: $DIFF_ARG" >&2
+            exit 2
+        fi
+        ;;
+    pr)
+        if ! command -v gh >/dev/null 2>&1; then
+            echo "check-doc-drift: gh CLI not found; install it or use --diff mode" >&2
+            exit 2
+        fi
+        if ! gh pr diff "$PR_NUM" > "$WORK_DIR/diff.txt" 2>/dev/null; then
+            echo "check-doc-drift: failed to fetch diff for PR #${PR_NUM}" >&2
+            exit 2
+        fi
+        PR_BODY="$(gh pr view "$PR_NUM" --json body --jq .body 2>/dev/null || true)"
+        ;;
+    working-tree)
+        git -C "$AUTOSPEC_REPO_ROOT" diff HEAD > "$WORK_DIR/diff.txt" 2>/dev/null || true
+        if [ ! -s "$WORK_DIR/diff.txt" ]; then
+            git -C "$AUTOSPEC_REPO_ROOT" diff HEAD --cached > "$WORK_DIR/diff.txt" 2>/dev/null || true
+        fi
+        ;;
+esac
+
+# Ensure diff file exists
+touch "$WORK_DIR/diff.txt"
+
+# ── docs: skip check ──────────────────────────────────────────────────────────
+
+DOCS_SKIP=false
+if [ -n "$PR_BODY" ]; then
+    if echo "$PR_BODY" | grep -qiE '^docs:[[:space:]]*skip[[:space:]]*$'; then
+        DOCS_SKIP=true
+    fi
+fi
+
+# ── Extract changed files from diff ──────────────────────────────────────────
+
+# Changed source files (not docs/) — one per line in a temp file
+grep -E '^\+\+\+ ' "$WORK_DIR/diff.txt" 2>/dev/null \
+    | sed 's|^+++ b/||; s|^+++ /dev/null||' \
+    | grep -v '^$' \
+    | grep -v '^docs/' \
+    | sort -u > "$WORK_DIR/changed_source.txt" || true
+
+# Changed doc files — one per line in a temp file
+grep -E '^\+\+\+ ' "$WORK_DIR/diff.txt" 2>/dev/null \
+    | sed 's|^+++ b/||; s|^+++ /dev/null||' \
+    | grep -v '^$' \
+    | grep '^docs/' \
+    | sort -u > "$WORK_DIR/changed_docs.txt" || true
+
+# For each changed doc file, extract the changed line numbers
+# Format: one file per temp file named by index
+while IFS= read -r df; do
+    [ -z "$df" ] && continue
+    safe_name="$(echo "$df" | tr '/' '_')"
+    awk -v target="$df" '
+        /^\+\+\+ b\// { in_file = ($0 == "+++ b/" target); lineno = 0 }
+        in_file && /^@@ / {
+            s = $0; sub(/.*\+/, "", s); split(s, a, ","); lineno = a[1] - 1
+        }
+        in_file && /^\+/ && !/^\+\+\+/ { lineno++; print lineno }
+        in_file && /^[ ]/ { lineno++ }
+    ' "$WORK_DIR/diff.txt" > "$WORK_DIR/changedlines_${safe_name}.txt" 2>/dev/null || true
+done < "$WORK_DIR/changed_docs.txt"
+
+# ── Glob matching helper ──────────────────────────────────────────────────────
+
+# Write glob matcher script to a temp file once (avoids bash 3.2 escaping issues)
+GLOB_MATCH_JS="$WORK_DIR/glob-match.mjs"
+cat > "$GLOB_MATCH_JS" << 'GLOBEOF'
+#!/usr/bin/env node
+// glob-match.mjs <file> <pattern>
+// Exit 0 if file matches glob pattern, 1 otherwise.
+// Supports: * (not /), ** (any path), ? (single char)
+const f = process.argv[2];
+const p = process.argv[3];
+if (!f || !p) process.exit(1);
+function globToRe(pat) {
+    let re = '^';
+    let i = 0;
+    while (i < pat.length) {
+        if (pat[i] === '*' && pat[i+1] === '*') {
+            re += '.*';
+            i += 2;
+            if (pat[i] === '/') i++; // consume trailing slash
+        } else if (pat[i] === '*') {
+            re += '[^/]*';
+            i++;
+        } else if (pat[i] === '?') {
+            re += '[^/]';
+            i++;
+        } else {
+            re += pat[i].replace(/[.+^${}()|[\]\\]/g, '\\$&');
+            i++;
+        }
+    }
+    re += '$';
+    return new RegExp(re);
+}
+process.exit(globToRe(p).test(f) ? 0 : 1);
+GLOBEOF
+
+glob_match_js() {
+    local file="$1"
+    local pattern="$2"
+    node "$GLOB_MATCH_JS" "$file" "$pattern" 2>/dev/null
+}
+
+# ── Process all docs/*.md for scope ──────────────────────────────────────────
+
+# Track which source files are covered by any scope (write to temp file)
+touch "$WORK_DIR/covered_sources.txt"
+
+# Drift entries (newline-delimited JSON objects)
+touch "$WORK_DIR/drift_entries.txt"
+touch "$WORK_DIR/visual_stale_entries.txt"
+
+if [ -d "$DOCS_DIR" ]; then
+    # Find all .md files in docs dir
+    find "$DOCS_DIR" -name '*.md' > "$WORK_DIR/doc_files.txt" 2>/dev/null || true
+
+    while IFS= read -r docfile; do
+        [ -z "$docfile" ] && continue
+        rel_docfile="${docfile#${AUTOSPEC_REPO_ROOT}/}"
+
+        # Parse scope entries
+        scope_json="$(node "$SCAN_MJS" "$docfile" 2>/dev/null)" || {
+            echo "check-doc-drift: scan-doc-scope failed for ${docfile}" >&2
+            continue
+        }
+
+        entry_count="$(echo "$scope_json" | node -e "
+const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+process.stdout.write(String(d.length));
+" 2>/dev/null)" || entry_count=0
+
+        [ "$entry_count" -eq 0 ] 2>/dev/null && continue
+
+        idx=0
+        while [ "$idx" -lt "$entry_count" ]; do
+            # Extract fields for this entry
+            entry_json="$(echo "$scope_json" | node -e "
+const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+const e=d[$idx];
+process.stdout.write(JSON.stringify({
+  heading: e.heading_path||'',
+  reason: e.reason||'',
+  visual_glob: e.visual_glob||'',
+  src_globs: e.src_globs||[],
+  byte_start: e.byte_range[0],
+  byte_end: e.byte_range[1]
+}));
+" 2>/dev/null)"
+
+            heading="$(echo "$entry_json" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).heading)" 2>/dev/null)"
+            reason="$(echo "$entry_json" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).reason)" 2>/dev/null)"
+            visual_glob="$(echo "$entry_json" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).visual_glob)" 2>/dev/null)"
+            byte_start="$(echo "$entry_json" | node -e "process.stdout.write(String(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).byte_start))" 2>/dev/null)"
+            byte_end="$(echo "$entry_json" | node -e "process.stdout.write(String(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).byte_end))" 2>/dev/null)"
+            src_globs_str="$(echo "$entry_json" | node -e "
+const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+process.stdout.write(d.src_globs.join('\n'));
+" 2>/dev/null)"
+
+            # Find matching changed source files
+            touch "$WORK_DIR/matching_sources_${idx}.txt"
+            if [ -s "$WORK_DIR/changed_source.txt" ] && [ -n "$src_globs_str" ]; then
+                while IFS= read -r sf; do
+                    [ -z "$sf" ] && continue
+                    while IFS= read -r glob; do
+                        [ -z "$glob" ] && continue
+                        if glob_match_js "$sf" "$glob"; then
+                            echo "$sf" >> "$WORK_DIR/matching_sources_${idx}.txt"
+                            echo "$sf" >> "$WORK_DIR/covered_sources.txt"
+                            break
+                        fi
+                    done <<< "$src_globs_str"
+                done < "$WORK_DIR/changed_source.txt"
+                sort -u "$WORK_DIR/matching_sources_${idx}.txt" -o "$WORK_DIR/matching_sources_${idx}.txt"
+            fi
+
+            # Skip if no source matches
+            if [ ! -s "$WORK_DIR/matching_sources_${idx}.txt" ]; then
+                idx=$((idx + 1))
+                continue
+            fi
+
+            # Check if doc section was updated in this diff.
+            # Strategy: if the doc file was changed in this diff AND the section's
+            # byte range overlaps with any changed line, mark as updated.
+            # For robustness we use a generous check: if the doc file is in the
+            # changed list, compute section line range and check against changed lines.
+            # If byte_start/byte_end are unavailable, fall back to doc-file-level check.
+            section_updated=false
+            if grep -qF "$rel_docfile" "$WORK_DIR/changed_docs.txt" 2>/dev/null; then
+                safe_name="$(echo "$rel_docfile" | tr '/' '_')"
+                changed_lines_file="$WORK_DIR/changedlines_${safe_name}.txt"
+                if [ -f "$changed_lines_file" ] && [ -s "$changed_lines_file" ] && [ -f "$docfile" ]; then
+                    # Compute section line range from byte offsets
+                    # byte_start = offset of first byte AFTER the scope comment
+                    # We add 1 to be inclusive of the line following the comment
+                    sec_start_line="$(head -c "$byte_start" "$docfile" 2>/dev/null | wc -l | tr -d ' \t')" || sec_start_line=0
+                    sec_end_line="$(head -c "$byte_end" "$docfile" 2>/dev/null | wc -l | tr -d ' \t')" || sec_end_line=9999
+                    # Check if any changed line is in the section (±2 lines tolerance)
+                    tol_start=$(( ${sec_start_line:-0} - 2 ))
+                    tol_end=$(( ${sec_end_line:-9999} + 2 ))
+                    [ "$tol_start" -lt 0 ] && tol_start=0
+                    while IFS= read -r lnum; do
+                        [ -z "$lnum" ] && continue
+                        if [ "$lnum" -ge "$tol_start" ] 2>/dev/null && \
+                           [ "$lnum" -le "$tol_end" ] 2>/dev/null; then
+                            section_updated=true
+                            break
+                        fi
+                    done < "$changed_lines_file"
+                elif grep -qF "$rel_docfile" "$WORK_DIR/changed_docs.txt" 2>/dev/null; then
+                    # Fallback: doc file was touched but we can't compute line ranges
+                    # Treat as updated (avoids false positives)
+                    section_updated=true
+                fi
+            fi
+
+            if ! $section_updated; then
+                # Build matching_sources JSON array
+                src_arr="$(while IFS= read -r sf; do
+                    printf '"%s",' "$sf"
+                done < "$WORK_DIR/matching_sources_${idx}.txt" | sed 's/,$//')"
+                # Escape heading and reason for JSON
+                h_esc="$(echo "$heading" | sed 's/"/\\"/g')"
+                r_esc="$(echo "$reason" | sed 's/"/\\"/g')"
+                printf '{"doc_file":"%s","heading":"%s","matching_source_files":[%s],"reason":"%s"}\n' \
+                    "$rel_docfile" "$h_esc" "$src_arr" "$r_esc" >> "$WORK_DIR/drift_entries.txt"
+            fi
+
+            # Visual staleness check
+            if [ -n "$visual_glob" ] && [ -s "$WORK_DIR/matching_sources_${idx}.txt" ]; then
+                find "$AUTOSPEC_REPO_ROOT" -name "$(basename "$visual_glob")" 2>/dev/null | while IFS= read -r screenshot; do
+                    rel_screenshot="${screenshot#${AUTOSPEC_REPO_ROOT}/}"
+                    screenshot_mtime=0
+                    if [ -f "$screenshot" ]; then
+                        screenshot_mtime="$(stat -f '%m' "$screenshot" 2>/dev/null || stat -c '%Y' "$screenshot" 2>/dev/null || echo 0)"
+                    fi
+                    stale_sources=""
+                    while IFS= read -r sf; do
+                        [ -z "$sf" ] && continue
+                        full_sf="${AUTOSPEC_REPO_ROOT}/${sf}"
+                        if [ -f "$full_sf" ]; then
+                            src_mtime="$(stat -f '%m' "$full_sf" 2>/dev/null || stat -c '%Y' "$full_sf" 2>/dev/null || echo 0)"
+                            if [ "$src_mtime" -gt "$screenshot_mtime" ] 2>/dev/null; then
+                                stale_sources="${stale_sources:+$stale_sources,}\"$sf\""
+                            fi
+                        fi
+                    done < "$WORK_DIR/matching_sources_${idx}.txt"
+                    if [ -n "$stale_sources" ]; then
+                        h_esc="$(echo "$heading" | sed 's/"/\\"/g')"
+                        printf '{"doc_file":"%s","heading":"%s","screenshot":"%s","source_changed":[%s]}\n' \
+                            "$rel_docfile" "$h_esc" "$rel_screenshot" "$stale_sources" >> "$WORK_DIR/visual_stale_entries.txt"
+                    fi
+                done || true
+            fi
+
+            idx=$((idx + 1))
+        done
+    done < "$WORK_DIR/doc_files.txt"
+fi
+
+# ── Missing scope: source files not covered by any scope ─────────────────────
+
+touch "$WORK_DIR/missing_scope_entries.txt"
+sort -u "$WORK_DIR/covered_sources.txt" -o "$WORK_DIR/covered_sources.txt" 2>/dev/null || true
+
+if [ -s "$WORK_DIR/changed_source.txt" ]; then
+    while IFS= read -r sf; do
+        [ -z "$sf" ] && continue
+        if ! grep -qF "$sf" "$WORK_DIR/covered_sources.txt" 2>/dev/null; then
+            printf '{"source_file":"%s","suggestion":"no docs section declares scope for this path"}\n' \
+                "$sf" >> "$WORK_DIR/missing_scope_entries.txt"
+        fi
+    done < "$WORK_DIR/changed_source.txt"
+fi
+
+# ── Build JSON arrays ─────────────────────────────────────────────────────────
+
+build_json_array() {
+    local file="$1"
+    if [ -s "$file" ]; then
+        echo -n "["
+        first=true
+        while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            $first || echo -n ","
+            echo -n "$line"
+            first=false
+        done < "$file"
+        echo -n "]"
+    else
+        echo -n "[]"
+    fi
+}
+
+drift_arr="$(build_json_array "$WORK_DIR/drift_entries.txt")"
+missing_arr="$(build_json_array "$WORK_DIR/missing_scope_entries.txt")"
+vstale_arr="$(build_json_array "$WORK_DIR/visual_stale_entries.txt")"
+
+# ── Apply docs: skip ──────────────────────────────────────────────────────────
+
+if $DOCS_SKIP; then
+    passed=true
+    exit_code=0
+    skipped_val=true
+    drift_arr="[]"
+else
+    drift_count=0
+    missing_count=0
+    [ -s "$WORK_DIR/drift_entries.txt" ] && drift_count="$(wc -l < "$WORK_DIR/drift_entries.txt" | tr -d ' \n')" || drift_count=0
+    [ -s "$WORK_DIR/missing_scope_entries.txt" ] && missing_count="$(wc -l < "$WORK_DIR/missing_scope_entries.txt" | tr -d ' \n')" || missing_count=0
+
+    if [ "${drift_count:-0}" -gt 0 ]; then
+        passed=false
+        exit_code=1
+    elif [ "${missing_count:-0}" -gt 0 ]; then
+        passed=false
+        exit_code=2
+    else
+        passed=true
+        exit_code=0
+    fi
+    skipped_val=false
+fi
+
+# ── Emit JSON ─────────────────────────────────────────────────────────────────
+
+cat <<JSON
+{
+  "passed": ${passed},
+  "drift": ${drift_arr},
+  "missing_scope": ${missing_arr},
+  "visual_stale": ${vstale_arr},
+  "ai_review_stale": [],
+  "skipped": ${skipped_val}
+}
+JSON
+
+exit "$exit_code"

--- a/skills/autospec-shared/scripts/scan-doc-scope.mjs
+++ b/skills/autospec-shared/scripts/scan-doc-scope.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+// scan-doc-scope.mjs — Parse autospec-doc-scope declarations from markdown files.
+//
+// Exports:
+//   parse(markdownPath: string): Array<ScopeEntry>
+//
+// ScopeEntry schema (per plan §2.1):
+//   {
+//     heading_path: string,          // e.g. "## Installing autospec-test"
+//     src_globs: string[],           // from src: field
+//     visual_glob?: string,          // from visual: field
+//     generated?: boolean,           // from generated: true
+//     reason?: string,               // from reason: field
+//     byte_range: [number, number],  // byte offsets of section body in the file
+//   }
+//
+// Syntax:
+//   <!-- autospec-doc-scope:
+//     src: ["glob1", "glob2"]
+//     reason: "optional note"
+//     visual: "docs/assets/screenshots/*.png"
+//     generated: true
+//   -->
+//
+// One block per section; section delimited by markdown headings at same-or-higher level.
+// Malformed YAML inside the comment block → throws with a diagnostic message.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ── YAML mini-parser ──────────────────────────────────────────────────────────
+// Parses the simple subset used in autospec-doc-scope blocks.
+// Supports: string scalars, boolean, string arrays (block or flow).
+
+function parseYaml(text, sourcePath) {
+    const result = {};
+    const lines = text.split('\n');
+    let i = 0;
+
+    function trim(s) { return s.trim(); }
+    function stripQuotes(s) {
+        s = trim(s);
+        if ((s.startsWith('"') && s.endsWith('"')) ||
+            (s.startsWith("'") && s.endsWith("'"))) {
+            return s.slice(1, -1);
+        }
+        return s;
+    }
+
+    while (i < lines.length) {
+        const line = lines[i].replace(/^\s+/, ''); // strip leading indent
+        const keyMatch = line.match(/^(\w[\w-]*)\s*:\s*(.*)/);
+        if (!keyMatch) { i++; continue; }
+
+        const key = keyMatch[1];
+        const rest = trim(keyMatch[2]);
+
+        if (rest === '' || rest === '|' || rest === '>') {
+            // Could be block sequence start or empty value — look ahead
+            i++;
+            const items = [];
+            while (i < lines.length && lines[i].match(/^\s+-\s+/)) {
+                items.push(stripQuotes(lines[i].replace(/^\s+-\s+/, '')));
+                i++;
+            }
+            result[key] = items.length > 0 ? items : '';
+        } else if (rest.startsWith('[')) {
+            // Flow sequence: ["a", "b"] or ['a', 'b']
+            const seqMatch = rest.match(/^\[(.*)\]$/);
+            if (!seqMatch) {
+                throw new Error(
+                    `scan-doc-scope: malformed flow sequence for key '${key}' in ${sourcePath}: ${rest}`
+                );
+            }
+            const items = seqMatch[1].split(',').map(s => stripQuotes(s)).filter(Boolean);
+            result[key] = items;
+            i++;
+        } else if (rest === 'true' || rest === 'yes') {
+            result[key] = true;
+            i++;
+        } else if (rest === 'false' || rest === 'no') {
+            result[key] = false;
+            i++;
+        } else {
+            result[key] = stripQuotes(rest);
+            i++;
+        }
+    }
+
+    return result;
+}
+
+// ── Heading helpers ───────────────────────────────────────────────────────────
+
+function headingLevel(line) {
+    const m = line.match(/^(#{1,6})\s/);
+    return m ? m[1].length : 0;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+const SCOPE_OPEN_RE  = /<!--\s*autospec-doc-scope\s*:/;
+const SCOPE_CLOSE_RE = /-->/;
+
+/**
+ * Parse all autospec-doc-scope blocks from a markdown file.
+ *
+ * @param {string} markdownPath - path to the markdown file
+ * @returns {Array<ScopeEntry>}
+ * @throws if a scope block contains malformed YAML
+ */
+export function parse(markdownPath) {
+    if (!markdownPath || typeof markdownPath !== 'string') {
+        throw new Error('scan-doc-scope: markdownPath must be a non-empty string');
+    }
+
+    let content;
+    try {
+        content = fs.readFileSync(markdownPath, 'utf8');
+    } catch (err) {
+        throw new Error(`scan-doc-scope: cannot read file: ${markdownPath}: ${err.message}`);
+    }
+
+    const lines = content.split('\n');
+    const results = [];
+
+    // Track headings and sections
+    let currentHeading = null;
+    let currentHeadingLevel = 0;
+    let i = 0;
+
+    while (i < lines.length) {
+        const line = lines[i];
+        const lvl = headingLevel(line);
+
+        if (lvl > 0) {
+            currentHeading = line.trim();
+            currentHeadingLevel = lvl;
+            i++;
+            continue;
+        }
+
+        // Detect scope comment start
+        if (SCOPE_OPEN_RE.test(line)) {
+            // Collect the YAML content between the comment markers
+            const commentLines = [];
+            // The opening line may have content after the "autospec-doc-scope:"
+            const openMatch = line.match(/<!--\s*autospec-doc-scope\s*:(.*)/s);
+            let rest = openMatch ? openMatch[1] : '';
+
+            // Check if close is on the same line
+            let closed = false;
+            const closeIdx = rest.indexOf('-->');
+            if (closeIdx !== -1) {
+                commentLines.push(rest.slice(0, closeIdx));
+                closed = true;
+                i++;
+            } else {
+                commentLines.push(rest);
+                i++;
+                while (i < lines.length && !closed) {
+                    const inner = lines[i];
+                    const endIdx = inner.indexOf('-->');
+                    if (endIdx !== -1) {
+                        commentLines.push(inner.slice(0, endIdx));
+                        closed = true;
+                    } else {
+                        commentLines.push(inner);
+                    }
+                    i++;
+                }
+            }
+
+            if (!closed) {
+                throw new Error(
+                    `scan-doc-scope: unclosed autospec-doc-scope block in ${markdownPath} near line ${i}`
+                );
+            }
+
+            // Parse YAML
+            const yamlText = commentLines.join('\n').trim();
+            let parsed;
+            try {
+                parsed = parseYaml(yamlText, markdownPath);
+            } catch (err) {
+                throw new Error(`scan-doc-scope: ${err.message}`);
+            }
+
+            // Validate src field
+            const srcRaw = parsed.src;
+            let src_globs;
+            if (!srcRaw) {
+                src_globs = [];
+            } else if (Array.isArray(srcRaw)) {
+                src_globs = srcRaw.map(String);
+            } else if (typeof srcRaw === 'string') {
+                src_globs = [srcRaw];
+            } else {
+                throw new Error(
+                    `scan-doc-scope: 'src' field must be an array or string in ${markdownPath}`
+                );
+            }
+
+            // Find the byte range of the section body: from after this comment to next same-or-higher heading
+            const bodyStartLine = i; // first line after the comment close
+            let bodyEndLine = lines.length;
+            if (currentHeadingLevel > 0) {
+                for (let j = bodyStartLine; j < lines.length; j++) {
+                    const nextLvl = headingLevel(lines[j]);
+                    if (nextLvl > 0 && nextLvl <= currentHeadingLevel) {
+                        bodyEndLine = j;
+                        break;
+                    }
+                }
+            }
+
+            // Compute byte offsets
+            const lineOffsets = computeLineOffsets(content);
+            const byteStart = bodyStartLine < lineOffsets.length ? lineOffsets[bodyStartLine] : content.length;
+            const byteEnd = bodyEndLine < lineOffsets.length ? lineOffsets[bodyEndLine] : content.length;
+
+            const entry = {
+                heading_path: currentHeading || '(root)',
+                src_globs,
+                byte_range: [byteStart, byteEnd],
+            };
+            if (parsed.visual) entry.visual_glob = String(parsed.visual);
+            if (parsed.generated === true) entry.generated = true;
+            if (parsed.reason) entry.reason = String(parsed.reason);
+
+            results.push(entry);
+            continue;
+        }
+
+        i++;
+    }
+
+    return results;
+}
+
+/** Compute byte offset of the start of each line. */
+function computeLineOffsets(content) {
+    const offsets = [0];
+    for (let i = 0; i < content.length; i++) {
+        if (content[i] === '\n') {
+            offsets.push(i + 1);
+        }
+    }
+    return offsets;
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+if (process.argv[1] && (
+    process.argv[1].endsWith('scan-doc-scope.mjs') ||
+    process.argv[1].endsWith('scan-doc-scope')
+)) {
+    const filePath = process.argv[2];
+    if (!filePath) {
+        process.stderr.write('Usage: scan-doc-scope.mjs <markdown-file>\n');
+        process.exit(1);
+    }
+    try {
+        const entries = parse(filePath);
+        process.stdout.write(JSON.stringify(entries, null, 2) + '\n');
+    } catch (err) {
+        process.stderr.write(`${err.message}\n`);
+        process.exit(2);
+    }
+}

--- a/skills/autospec-shared/tests/fixtures/doc-scope/generated-section.md
+++ b/skills/autospec-shared/tests/fixtures/doc-scope/generated-section.md
@@ -1,0 +1,14 @@
+# Generated Section Test
+
+## Module Graph
+
+<!-- autospec-doc-scope:
+  src: ["skills/**/*.mjs", "skills/**/*.sh"]
+  generated: true
+  reason: "Auto-generated from tree-sitter module graph"
+-->
+
+```mermaid
+graph TD
+  A --> B
+```

--- a/skills/autospec-shared/tests/fixtures/doc-scope/malformed-yaml.md
+++ b/skills/autospec-shared/tests/fixtures/doc-scope/malformed-yaml.md
@@ -1,0 +1,10 @@
+# Malformed YAML Test
+
+## Section With Bad YAML
+
+<!-- autospec-doc-scope:
+  src: [unclosed bracket
+  reason: "this will fail"
+-->
+
+Some content here.

--- a/skills/autospec-shared/tests/fixtures/doc-scope/no-scope.md
+++ b/skills/autospec-shared/tests/fixtures/doc-scope/no-scope.md
@@ -1,0 +1,9 @@
+# File Without Any Scope Declarations
+
+## Section One
+
+Some content without scope.
+
+## Section Two
+
+More content without scope.

--- a/skills/autospec-shared/tests/fixtures/doc-scope/valid-scope.md
+++ b/skills/autospec-shared/tests/fixtures/doc-scope/valid-scope.md
@@ -1,0 +1,30 @@
+# Sample Docs File
+
+## Installing autospec-test
+
+<!-- autospec-doc-scope:
+  src: ["install.sh", "skills/autospec-test/install.sh"]
+  reason: "User-facing install instructions must reflect actual install.sh behavior"
+-->
+
+To install, run the installer script.
+
+## Configuration
+
+<!-- autospec-doc-scope:
+  src: ["skills/autospec-test/scripts/config.sh"]
+  reason: "Config section must match script options"
+  visual: "docs/assets/screenshots/config*.png"
+-->
+
+Configure autospec-test by editing the settings file.
+
+## Architecture
+
+<!-- autospec-doc-scope:
+  src: ["skills/autospec-test/scripts/*.sh"]
+  generated: true
+  reason: "Auto-generated from tree-sitter scan"
+-->
+
+This section is auto-generated.

--- a/skills/autospec-shared/tests/unit/check-doc-drift.bats
+++ b/skills/autospec-shared/tests/unit/check-doc-drift.bats
@@ -1,0 +1,263 @@
+#!/usr/bin/env bats
+# check-doc-drift.bats — Bats tests for check-doc-drift.sh
+#
+# Run: bats skills/autospec-shared/tests/unit/check-doc-drift.bats
+# (from repo root, or adjust paths accordingly)
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
+    CHECK_DRIFT="${SCRIPT_DIR}/scripts/check-doc-drift.sh"
+    SCAN_MJS="${SCRIPT_DIR}/scripts/scan-doc-scope.mjs"
+    FIXTURES_DIR="${SCRIPT_DIR}/tests/fixtures/doc-scope"
+
+    TMP_DIR="$(mktemp -d /tmp/autospec-drifttest-XXXXXX)"
+    export AUTOSPEC_REPO_ROOT="$TMP_DIR"
+    export AUTOSPEC_DOCS_DIR="$TMP_DIR/docs"
+    export SCAN_DOC_SCOPE_MJS="$SCAN_MJS"
+
+    mkdir -p "$TMP_DIR/docs"
+    mkdir -p "$TMP_DIR/skills/autospec-test/scripts"
+    printf '#!/bin/bash\n# install\n' > "$TMP_DIR/install.sh"
+    printf '#!/bin/bash\n# config\n' > "$TMP_DIR/skills/autospec-test/scripts/config.sh"
+    printf '#!/bin/bash\n# test install\n' > "$TMP_DIR/skills/autospec-test/install.sh"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+# Helper: run script suppressing stderr (bats captures both stdout+stderr into $output)
+run_drift() {
+    run bash -c "\"$CHECK_DRIFT\" $* 2>/dev/null"
+}
+
+# Helper: parse JSON field from output
+json_field() {
+    local json="$1"
+    local expr="$2"
+    echo "$json" | node -e "
+const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+process.stdout.write(String($expr));
+" 2>/dev/null || echo "PARSE_ERROR"
+}
+
+# ── Argument validation ───────────────────────────────────────────────────────
+
+@test "no arguments prints error and exits 2" {
+    run bash "$CHECK_DRIFT" 2>/dev/null
+    [ "$status" -eq 2 ]
+}
+
+@test "--help exits 0" {
+    run bash "$CHECK_DRIFT" --help 2>/dev/null
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage" ]]
+}
+
+@test "--diff with missing file exits 2" {
+    run bash "$CHECK_DRIFT" --diff /tmp/nonexistent-autospec-drift-xyz.patch 2>/dev/null
+    [ "$status" -eq 2 ]
+}
+
+@test "unknown option exits 2" {
+    run bash "$CHECK_DRIFT" --bogus-option 2>/dev/null
+    [ "$status" -eq 2 ]
+}
+
+# ── Empty diff ────────────────────────────────────────────────────────────────
+
+@test "empty diff passes with exit 0 and valid JSON" {
+    DFILE="$(mktemp /tmp/autospec-driftempty-XXXXXX)"
+    printf "" > "$DFILE"
+    run bash -c "\"$CHECK_DRIFT\" --diff \"$DFILE\" 2>/dev/null"
+    rm -f "$DFILE"
+    [ "$status" -eq 0 ]
+    passed="$(json_field "$output" "d.passed")"
+    [ "$passed" = "true" ]
+}
+
+# ── Working tree mode ─────────────────────────────────────────────────────────
+
+@test "--working-tree on clean git repo exits 0" {
+    git -C "$TMP_DIR" init -q
+    git -C "$TMP_DIR" config user.email "test@test.com"
+    git -C "$TMP_DIR" config user.name "Test"
+    git -C "$TMP_DIR" add -A
+    git -C "$TMP_DIR" commit -q -m "init"
+    run bash -c "\"$CHECK_DRIFT\" --working-tree 2>/dev/null"
+    [ "$status" -eq 0 ]
+}
+
+# ── JSON output schema ────────────────────────────────────────────────────────
+
+@test "output JSON has all required fields" {
+    DFILE="$(mktemp /tmp/autospec-driftempty-XXXXXX)"
+    printf "" > "$DFILE"
+    run bash -c "\"$CHECK_DRIFT\" --diff \"$DFILE\" 2>/dev/null"
+    rm -f "$DFILE"
+    [ "$status" -eq 0 ]
+    result="$(json_field "$output" "
+typeof d.passed==='boolean' &&
+Array.isArray(d.drift) &&
+Array.isArray(d.missing_scope) &&
+Array.isArray(d.visual_stale) &&
+Array.isArray(d.ai_review_stale) &&
+typeof d.skipped==='boolean' ? 'ok' : 'fail'
+")"
+    [ "$result" = "ok" ]
+}
+
+# ── Missing scope detection ───────────────────────────────────────────────────
+
+@test "changed source with no doc scope → missing_scope + exit 2" {
+    cp "$FIXTURES_DIR/no-scope.md" "$TMP_DIR/docs/USER_MANUAL.md"
+
+    DFILE="$(mktemp /tmp/autospec-driftpatch-XXXXXX)"
+    cat > "$DFILE" <<'DIFF'
+diff --git a/install.sh b/install.sh
+index abc..def 100755
+--- a/install.sh
++++ b/install.sh
+@@ -1,2 +1,3 @@
+ #!/bin/bash
+ # install script
++echo "new line"
+DIFF
+
+    run bash -c "\"$CHECK_DRIFT\" --diff \"$DFILE\" 2>/dev/null"
+    rm -f "$DFILE"
+    [ "$status" -eq 2 ]
+    mc="$(json_field "$output" "d.missing_scope.length")"
+    [ "$mc" -gt 0 ]
+}
+
+# ── Drift detection ───────────────────────────────────────────────────────────
+
+@test "source matches scope but doc not updated → drift + exit 1" {
+    cp "$FIXTURES_DIR/valid-scope.md" "$TMP_DIR/docs/USER_MANUAL.md"
+
+    DFILE="$(mktemp /tmp/autospec-driftpatch-XXXXXX)"
+    cat > "$DFILE" <<'DIFF'
+diff --git a/install.sh b/install.sh
+index abc..def 100755
+--- a/install.sh
++++ b/install.sh
+@@ -1,2 +1,3 @@
+ #!/bin/bash
+ # install script
++echo "new line"
+DIFF
+
+    run bash -c "\"$CHECK_DRIFT\" --diff \"$DFILE\" 2>/dev/null"
+    rm -f "$DFILE"
+    [ "$status" -eq 1 ]
+    dc="$(json_field "$output" "d.drift.length")"
+    [ "$dc" -gt 0 ]
+}
+
+@test "drift entry has required doc_file, heading, matching_source_files fields" {
+    cp "$FIXTURES_DIR/valid-scope.md" "$TMP_DIR/docs/USER_MANUAL.md"
+
+    DFILE="$(mktemp /tmp/autospec-driftpatch-XXXXXX)"
+    cat > "$DFILE" <<'DIFF'
+diff --git a/install.sh b/install.sh
+index abc..def 100755
+--- a/install.sh
++++ b/install.sh
+@@ -1 +1,2 @@
+ #!/bin/bash
++echo hi
+DIFF
+
+    run bash -c "\"$CHECK_DRIFT\" --diff \"$DFILE\" 2>/dev/null"
+    rm -f "$DFILE"
+    result="$(json_field "$output" "
+d.drift.length===0 ? 'no-drift' :
+(typeof d.drift[0].doc_file==='string' &&
+ typeof d.drift[0].heading==='string' &&
+ Array.isArray(d.drift[0].matching_source_files)) ? 'ok' : 'fail'
+")"
+    [ "$result" = "ok" ]
+}
+
+# ── Clean path ────────────────────────────────────────────────────────────────
+
+@test "source matches scope AND doc updated → passed:true exit 0" {
+    cp "$FIXTURES_DIR/valid-scope.md" "$TMP_DIR/docs/USER_MANUAL.md"
+
+    DFILE="$(mktemp /tmp/autospec-driftpatch-XXXXXX)"
+    cat > "$DFILE" <<'DIFF'
+diff --git a/install.sh b/install.sh
+index abc..def 100755
+--- a/install.sh
++++ b/install.sh
+@@ -1 +1,2 @@
+ #!/bin/bash
++echo hi
+diff --git a/docs/USER_MANUAL.md b/docs/USER_MANUAL.md
+index 111..222 100644
+--- a/docs/USER_MANUAL.md
++++ b/docs/USER_MANUAL.md
+@@ -9,3 +9,4 @@ To install, run the installer script.
+
+ To install, run the installer script.
++Updated install instructions here.
+DIFF
+
+    run bash -c "\"$CHECK_DRIFT\" --diff \"$DFILE\" 2>/dev/null"
+    rm -f "$DFILE"
+    [ "$status" -eq 0 ]
+    passed="$(json_field "$output" "d.passed")"
+    [ "$passed" = "true" ]
+}
+
+# ── docs: skip pattern matching ───────────────────────────────────────────────
+
+@test "exact 'docs: skip' matches skip pattern" {
+    run bash -c 'echo "docs: skip" | grep -qiE "^docs:[[:space:]]*skip[[:space:]]*$"'
+    [ "$status" -eq 0 ]
+}
+
+@test "docs:SKIP (uppercase) matches skip pattern" {
+    run bash -c 'echo "docs: SKIP" | grep -qiE "^docs:[[:space:]]*skip[[:space:]]*$"'
+    [ "$status" -eq 0 ]
+}
+
+@test "docs: skip with trailing spaces matches" {
+    run bash -c 'echo "docs: skip   " | grep -qiE "^docs:[[:space:]]*skip[[:space:]]*$"'
+    [ "$status" -eq 0 ]
+}
+
+@test "partial match 'docs: skip me' does NOT trigger skip" {
+    run bash -c 'echo "docs: skip me" | grep -qiE "^docs:[[:space:]]*skip[[:space:]]*$"'
+    [ "$status" -ne 0 ]
+}
+
+# ── No docs directory ─────────────────────────────────────────────────────────
+
+@test "no docs directory + changed source → missing_scope + exit 2" {
+    rm -rf "$TMP_DIR/docs"
+
+    DFILE="$(mktemp /tmp/autospec-driftpatch-XXXXXX)"
+    cat > "$DFILE" <<'DIFF'
+diff --git a/install.sh b/install.sh
+index abc..def 100755
+--- a/install.sh
++++ b/install.sh
+@@ -1 +1,2 @@
+ #!/bin/bash
++echo hi
+DIFF
+
+    run bash -c "\"$CHECK_DRIFT\" --diff \"$DFILE\" 2>/dev/null"
+    rm -f "$DFILE"
+    [ "$status" -eq 2 ]
+}
+
+@test "empty docs dir + no source changes → exit 0" {
+    DFILE="$(mktemp /tmp/autospec-driftempty-XXXXXX)"
+    printf "" > "$DFILE"
+    run bash -c "\"$CHECK_DRIFT\" --diff \"$DFILE\" 2>/dev/null"
+    rm -f "$DFILE"
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-shared/tests/unit/scan-doc-scope.test.mjs
+++ b/skills/autospec-shared/tests/unit/scan-doc-scope.test.mjs
@@ -1,0 +1,174 @@
+// tests/unit/scan-doc-scope.test.mjs
+// Unit tests for skills/autospec-shared/scripts/scan-doc-scope.mjs
+//
+// Run: node tests/unit/scan-doc-scope.test.mjs (from skills/autospec-shared/)
+// or:  npm test  (if test script is updated)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SKILL_DIR = path.resolve(__dirname, '../../');
+const FIXTURES_DIR = path.join(SKILL_DIR, 'tests/fixtures/doc-scope');
+const SCAN_MJS = path.join(SKILL_DIR, 'scripts/scan-doc-scope.mjs');
+
+const { parse } = await import(`file://${SCAN_MJS}`);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fixture(name) {
+    return path.join(FIXTURES_DIR, name);
+}
+
+// ── Error cases ───────────────────────────────────────────────────────────────
+
+test('throws on null input', async () => {
+    assert.throws(() => parse(null), /markdownPath must be a non-empty string/);
+});
+
+test('throws on missing file', async () => {
+    assert.throws(
+        () => parse('/tmp/autospec-nonexistent-fixture-xyz.md'),
+        /cannot read file/
+    );
+});
+
+test('throws on malformed YAML in scope block', async () => {
+    assert.throws(
+        () => parse(fixture('malformed-yaml.md')),
+        /scan-doc-scope/
+    );
+});
+
+// ── No scope ──────────────────────────────────────────────────────────────────
+
+test('returns empty array for file with no scope declarations', async () => {
+    const result = parse(fixture('no-scope.md'));
+    assert.ok(Array.isArray(result));
+    assert.equal(result.length, 0);
+});
+
+// ── Valid scope ───────────────────────────────────────────────────────────────
+
+test('parses multiple scope blocks from valid-scope.md', async () => {
+    const result = parse(fixture('valid-scope.md'));
+    assert.ok(Array.isArray(result));
+    assert.equal(result.length, 3, `Expected 3 scope entries, got ${result.length}`);
+});
+
+test('first entry: heading_path is the Installing heading', async () => {
+    const result = parse(fixture('valid-scope.md'));
+    assert.ok(result[0].heading_path.includes('Installing'), `heading_path: ${result[0].heading_path}`);
+});
+
+test('first entry: src_globs contains both install.sh globs', async () => {
+    const result = parse(fixture('valid-scope.md'));
+    assert.ok(Array.isArray(result[0].src_globs));
+    assert.equal(result[0].src_globs.length, 2);
+    assert.ok(result[0].src_globs.includes('install.sh'));
+    assert.ok(result[0].src_globs.includes('skills/autospec-test/install.sh'));
+});
+
+test('first entry: reason is present', async () => {
+    const result = parse(fixture('valid-scope.md'));
+    assert.ok(typeof result[0].reason === 'string');
+    assert.ok(result[0].reason.length > 0);
+});
+
+test('second entry: has visual_glob', async () => {
+    const result = parse(fixture('valid-scope.md'));
+    assert.ok(result[1].visual_glob, `Expected visual_glob in entry 1: ${JSON.stringify(result[1])}`);
+    assert.ok(result[1].visual_glob.includes('screenshots'));
+});
+
+test('third entry: generated is true', async () => {
+    const result = parse(fixture('valid-scope.md'));
+    assert.equal(result[2].generated, true);
+});
+
+test('all entries: byte_range is a two-element number array', async () => {
+    const result = parse(fixture('valid-scope.md'));
+    for (const entry of result) {
+        assert.ok(Array.isArray(entry.byte_range), 'byte_range must be array');
+        assert.equal(entry.byte_range.length, 2, 'byte_range must have 2 elements');
+        assert.ok(typeof entry.byte_range[0] === 'number', 'byte_range[0] must be number');
+        assert.ok(typeof entry.byte_range[1] === 'number', 'byte_range[1] must be number');
+        assert.ok(entry.byte_range[0] <= entry.byte_range[1], 'byte_range start must be <= end');
+    }
+});
+
+test('all entries: src_globs is always an array', async () => {
+    const result = parse(fixture('valid-scope.md'));
+    for (const entry of result) {
+        assert.ok(Array.isArray(entry.src_globs), `src_globs must be array in ${entry.heading_path}`);
+    }
+});
+
+// ── Generated section ─────────────────────────────────────────────────────────
+
+test('generated-section.md: parses generated:true entry', async () => {
+    const result = parse(fixture('generated-section.md'));
+    assert.equal(result.length, 1);
+    assert.equal(result[0].generated, true);
+    assert.ok(result[0].src_globs.some(g => g.includes('**')), 'should have glob pattern');
+});
+
+// ── Inline fixture via temp file ──────────────────────────────────────────────
+
+test('single-glob src in flow syntax', async () => {
+    const tmp = path.join(os.tmpdir(), `autospec-test-scope-${Date.now()}.md`);
+    fs.writeFileSync(tmp, `## My Section\n\n<!-- autospec-doc-scope:\n  src: ["path/to/file.sh"]\n-->\n\nBody.\n`);
+    try {
+        const result = parse(tmp);
+        assert.equal(result.length, 1);
+        assert.deepEqual(result[0].src_globs, ['path/to/file.sh']);
+    } finally {
+        fs.unlinkSync(tmp);
+    }
+});
+
+test('scope block with no src field yields empty src_globs', async () => {
+    const tmp = path.join(os.tmpdir(), `autospec-test-scope-${Date.now()}.md`);
+    fs.writeFileSync(tmp, `## Section\n\n<!-- autospec-doc-scope:\n  reason: "no src"\n-->\n\nBody.\n`);
+    try {
+        const result = parse(tmp);
+        assert.equal(result.length, 1);
+        assert.deepEqual(result[0].src_globs, []);
+    } finally {
+        fs.unlinkSync(tmp);
+    }
+});
+
+test('scope block on same line as closing -->', async () => {
+    const tmp = path.join(os.tmpdir(), `autospec-test-scope-${Date.now()}.md`);
+    fs.writeFileSync(tmp, `## Section\n\n<!-- autospec-doc-scope:\n  src: ["a.sh"]\n  reason: "test"\n-->\n\nBody.\n`);
+    try {
+        const result = parse(tmp);
+        assert.equal(result.length, 1);
+        assert.deepEqual(result[0].src_globs, ['a.sh']);
+    } finally {
+        fs.unlinkSync(tmp);
+    }
+});
+
+test('byte_range start is after the scope comment', async () => {
+    const tmp = path.join(os.tmpdir(), `autospec-test-scope-${Date.now()}.md`);
+    const content = `## Section\n\n<!-- autospec-doc-scope:\n  src: ["a.sh"]\n-->\n\nBody text here.\n`;
+    fs.writeFileSync(tmp, content);
+    try {
+        const result = parse(tmp);
+        assert.equal(result.length, 1);
+        const [start, end] = result[0].byte_range;
+        assert.ok(start > 0, 'byte_range start should be > 0');
+        assert.ok(end > start, 'byte_range end should be > start');
+        // The body "Body text here." should fall within the range
+        const body = content.slice(start, end);
+        assert.ok(body.includes('Body'), `body should contain 'Body', got: ${JSON.stringify(body)}`);
+    } finally {
+        fs.unlinkSync(tmp);
+    }
+});


### PR DESCRIPTION
Closes #362

## Summary

Implements the doc-scope parser and drift-checker gate from spec §3b.

- **`scan-doc-scope.mjs`** — parses `<!-- autospec-doc-scope: ... -->` YAML blocks from markdown files; exports `parse(markdownPath)` returning `{heading_path, src_globs, visual_glob?, generated?, reason?, byte_range}`
- **`check-doc-drift.sh`** — bash 3.2-compatible drift checker with `--diff`, `--pr`, `--working-tree` modes; exits 0=clean/1=drift/2=missing-scope; emits gate JSON per spec §3b; honors `docs: skip` in PR body; detects visual staleness via mtime
- **4 fixture markdown files** — valid scope, malformed YAML, generated:true, no-scope
- **17 scan-doc-scope tests** (node --test) — all pass
- **17 bats tests** for check-doc-drift.sh — all pass

## Test plan

- [x] `node --test tests/unit/scan-doc-scope.test.mjs` → 17/17 pass
- [x] `bats skills/autospec-shared/tests/unit/check-doc-drift.bats` → 17/17 pass
- [x] `node scripts/scan-doc-scope.mjs tests/fixtures/doc-scope/valid-scope.md` → valid JSON output
- [x] `bash scripts/check-doc-drift.sh --working-tree` → `{"passed":true,...}`
- [x] `docs: skip` pattern correctly demotes drift to skipped
- [x] Malformed YAML throws with diagnostic message

🤖 Generated with [Claude Code](https://claude.com/claude-code)