### PR TITLE
feat(autospec-docs): self-heal classifier extension (phase 3)

### DIFF
--- a/skills/autospec-shared/scripts/loop-classifier-docs-extension.mjs
+++ b/skills/autospec-shared/scripts/loop-classifier-docs-extension.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+// loop-classifier-docs-extension.mjs
+// Docs-amendment extension for the v1 self-heal loop classifier.
+//
+// Exports:
+//   classify(gateJson, lastIterations) → ClassifyResult | null
+//   DOCS_CATEGORY_PRIORITY: string[]   — ordered list (highest priority first)
+//   LOOSENING_PATTERNS: RegExp[]       — anti-rubber-stamp detector patterns
+//   detectBucket(diffText) → 'LOOSENING' | 'STRENGTHENING' | 'SHIFTING' | null
+//
+// ClassifyResult schema (superset of v1 schema):
+//   {
+//     classification: string,
+//     target_files: string[],       // doc files or source files to fix
+//     suggested_action: string,     // short imperative instruction
+//     estimated_minutes: number,
+//     priority: number,
+//     bucket?: 'LOOSENING' | 'STRENGTHENING' | 'SHIFTING',
+//   }
+//
+// Returns null if the gate JSON does not represent a docs-gate failure.
+// The v1 classifier should call this before its own fallback logic.
+
+// ── Priority ordering per spec §3c ────────────────────────────────────────────
+
+export const DOCS_CATEGORY_PRIORITY = [
+    'missing_doc_scope',       // 12 — highest: no scope declared at all
+    'failing_doc_drift',       // 11 — doc not updated when source changed
+    'failing_visual_stale',    // 10 — screenshot older than source
+    'failing_ai_review_stale', //  9 — AI review stale
+    'failing_manifest_stale',  //  8 — LLM manifest stale
+];
+
+const PRIORITY_BASE = 8; // lowest docs priority; missing_doc_scope = PRIORITY_BASE + 4
+
+function categoryPriority(category) {
+    const idx = DOCS_CATEGORY_PRIORITY.indexOf(category);
+    if (idx === -1) return 0;
+    return PRIORITY_BASE + (DOCS_CATEGORY_PRIORITY.length - 1 - idx);
+}
+
+// ── Anti-rubber-stamp guardrail per spec §3d ─────────────────────────────────
+
+/**
+ * Detect the edit bucket from a unified diff of doc changes.
+ * Returns 'LOOSENING', 'STRENGTHENING', 'SHIFTING', or null (no doc changes).
+ *
+ * LOOSENING (❌ blocks auto-merge):
+ *   - Remove autospec-doc-scope comment
+ *   - Narrow src: globs (remove a glob from the array)
+ *   - Remove a section that had non-empty scope
+ *
+ * STRENGTHENING (✅ auto-merge allowed):
+ *   - Add new autospec-doc-scope block
+ *   - Widen src: globs (add a glob)
+ *
+ * SHIFTING (conditional):
+ *   - Edit doc section body (content change)
+ */
+export function detectBucket(diffText) {
+    if (!diffText || typeof diffText !== 'string') return null;
+
+    const lines = diffText.split('\n');
+    const removedLines = lines.filter(l => l.startsWith('-') && !l.startsWith('---'));
+    const addedLines   = lines.filter(l => l.startsWith('+') && !l.startsWith('+++'));
+
+    const removedText = removedLines.map(l => l.slice(1)).join('\n');
+    const addedText   = addedLines.map(l => l.slice(1)).join('\n');
+
+    // LOOSENING: scope comment removed
+    const scopeCommentRe = /autospec-doc-scope/;
+    if (scopeCommentRe.test(removedText) && !scopeCommentRe.test(addedText)) {
+        return 'LOOSENING';
+    }
+
+    // LOOSENING: src globs narrowed (fewer quoted glob strings in removed vs added)
+    // Count individual quoted strings in src: context lines across removed/added
+    function countGlobs(lines) {
+        let count = 0;
+        for (const l of lines) {
+            const content = l.slice(1); // strip +/-
+            // Count quoted strings that look like globs (contain / or * or end in extension)
+            const matches = content.match(/"[^"]+"/g) || [];
+            count += matches.filter(m => /[/*.]/.test(m)).length;
+        }
+        return count;
+    }
+    const removedGlobCount = countGlobs(removedLines);
+    const addedGlobCount   = countGlobs(addedLines);
+    if (removedGlobCount > addedGlobCount && removedGlobCount > 0) {
+        return 'LOOSENING';
+    }
+
+    // STRENGTHENING: new scope comment added
+    if (scopeCommentRe.test(addedText) && !scopeCommentRe.test(removedText)) {
+        return 'STRENGTHENING';
+    }
+
+    // STRENGTHENING: globs widened (more globs added than removed)
+    if (addedGlobCount > removedGlobCount && addedGlobCount > 0) {
+        return 'STRENGTHENING';
+    }
+
+    // SHIFTING: doc content changed (any +/- lines in doc files)
+    if (removedLines.length > 0 || addedLines.length > 0) {
+        return 'SHIFTING';
+    }
+
+    return null;
+}
+
+// ── Main classify function ────────────────────────────────────────────────────
+
+/**
+ * Classify a docs-gate failure.
+ *
+ * @param {object} gateJson - parsed gate JSON from check-doc-drift.sh
+ * @param {object[]} [lastIterations] - last N loop iterations (unused for docs)
+ * @returns {object|null} ClassifyResult or null if not a docs gate failure
+ */
+export function classify(gateJson, lastIterations = []) {
+    // Only handle doc-gate JSON (has drift/missing_scope/visual_stale fields)
+    if (!gateJson || typeof gateJson !== 'object') return null;
+    const hasDocFields = 'drift' in gateJson || 'missing_scope' in gateJson ||
+                         'visual_stale' in gateJson || 'ai_review_stale' in gateJson;
+    if (!hasDocFields) return null;
+
+    // If gate passed, no action needed
+    if (gateJson.passed === true) return null;
+
+    const candidates = [];
+
+    // missing_doc_scope — changed source not covered by any scope
+    const missingScope = gateJson.missing_scope || [];
+    if (missingScope.length > 0) {
+        const targetFiles = missingScope.map(e => e.source_file || e).filter(Boolean);
+        candidates.push({
+            classification: 'missing_doc_scope',
+            target_files: targetFiles,
+            suggested_action: [
+                'Add an <!-- autospec-doc-scope: src: ["<glob>"] --> block to the',
+                'appropriate doc section (default: docs/ARCHITECTURE.md) covering:',
+                targetFiles.slice(0, 3).join(', '),
+            ].join(' '),
+            estimated_minutes: 5,
+            priority: categoryPriority('missing_doc_scope'),
+        });
+    }
+
+    // failing_doc_drift — doc section not updated when matching source changed
+    const drift = gateJson.drift || [];
+    if (drift.length > 0) {
+        const targetFiles = drift.map(e => e.doc_file).filter(Boolean);
+        const reasons = drift.map(e => {
+            const src = (e.matching_source_files || []).join(', ');
+            return `${e.doc_file} §${e.heading}: source changed (${src})`;
+        });
+        candidates.push({
+            classification: 'failing_doc_drift',
+            target_files: targetFiles,
+            suggested_action: [
+                'Update the following doc sections to reflect source changes:',
+                reasons.slice(0, 2).join('; '),
+            ].join(' '),
+            estimated_minutes: 10,
+            priority: categoryPriority('failing_doc_drift'),
+        });
+    }
+
+    // failing_visual_stale — screenshot older than source
+    const visualStale = gateJson.visual_stale || [];
+    if (visualStale.length > 0) {
+        const targetFiles = visualStale.map(e => e.screenshot || e.doc_file).filter(Boolean);
+        candidates.push({
+            classification: 'failing_visual_stale',
+            target_files: targetFiles,
+            suggested_action: 'Regenerate screenshots via gen-screenshots.mjs for stale visual sections.',
+            estimated_minutes: 15,
+            priority: categoryPriority('failing_visual_stale'),
+        });
+    }
+
+    // failing_ai_review_stale — AI review stale
+    const aiStale = gateJson.ai_review_stale || [];
+    if (aiStale.length > 0) {
+        const targetFiles = aiStale.map(e => e.doc_file).filter(Boolean);
+        candidates.push({
+            classification: 'failing_ai_review_stale',
+            target_files: targetFiles,
+            suggested_action: 'Rerun ai-review-doc.mjs for the stale sections.',
+            estimated_minutes: 10,
+            priority: categoryPriority('failing_ai_review_stale'),
+        });
+    }
+
+    // failing_manifest_stale — manifest stale (inferred when gate fails but no drift/scope)
+    if (gateJson.manifest_stale === true) {
+        candidates.push({
+            classification: 'failing_manifest_stale',
+            target_files: ['docs/.llm-manifest.json'],
+            suggested_action: 'Rerun gen-llm-manifest.mjs to update the LLM manifest.',
+            estimated_minutes: 5,
+            priority: categoryPriority('failing_manifest_stale'),
+        });
+    }
+
+    if (candidates.length === 0) return null;
+
+    // Return highest-priority candidate
+    candidates.sort((a, b) => b.priority - a.priority);
+    return candidates[0];
+}

--- a/skills/autospec-shared/tests/unit/loop-classifier-docs.test.mjs
+++ b/skills/autospec-shared/tests/unit/loop-classifier-docs.test.mjs
@@ -1,0 +1,279 @@
+// tests/unit/loop-classifier-docs.test.mjs
+// Unit tests for skills/autospec-shared/scripts/loop-classifier-docs-extension.mjs
+//
+// Run: node --test skills/autospec-shared/tests/unit/loop-classifier-docs.test.mjs
+// (from repo root, or: node --test tests/unit/loop-classifier-docs.test.mjs
+//  from skills/autospec-shared/)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = path.resolve(__dirname, '../../scripts');
+const EXT_PATH = path.join(SCRIPTS_DIR, 'loop-classifier-docs-extension.mjs');
+
+const { classify, detectBucket, DOCS_CATEGORY_PRIORITY } = await import(`file://${EXT_PATH}`);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeDriftGate(opts = {}) {
+    return {
+        passed: opts.passed ?? false,
+        drift: opts.drift || [],
+        missing_scope: opts.missingScope || [],
+        visual_stale: opts.visualStale || [],
+        ai_review_stale: opts.aiStale || [],
+        skipped: opts.skipped || false,
+        manifest_stale: opts.manifestStale || false,
+    };
+}
+
+// ── Null cases ────────────────────────────────────────────────────────────────
+
+test('returns null for non-doc gate JSON (no doc fields)', () => {
+    const result = classify({ stage: 'unit', passed: false, reason: 'tests_red' });
+    assert.equal(result, null);
+});
+
+test('returns null for null input', () => {
+    assert.equal(classify(null), null);
+});
+
+test('returns null when gate passed', () => {
+    const gate = makeDriftGate({ passed: true, drift: [], missingScope: [] });
+    assert.equal(classify(gate), null);
+});
+
+test('returns null when no findings', () => {
+    const gate = makeDriftGate({ passed: false, drift: [], missingScope: [] });
+    assert.equal(classify(gate), null);
+});
+
+// ── missing_doc_scope ─────────────────────────────────────────────────────────
+
+test('missing_doc_scope: routes correctly from missing_scope array', () => {
+    const gate = makeDriftGate({
+        passed: false,
+        missingScope: [
+            { source_file: 'skills/autospec-test/scripts/new-thing.sh',
+              suggestion: 'no docs section declares scope for this path' }
+        ],
+    });
+    const result = classify(gate);
+    assert.ok(result, 'Expected non-null result');
+    assert.equal(result.classification, 'missing_doc_scope');
+    assert.ok(result.target_files.includes('skills/autospec-test/scripts/new-thing.sh'));
+});
+
+test('missing_doc_scope: suggested_action mentions the source file', () => {
+    const gate = makeDriftGate({
+        passed: false,
+        missingScope: [{ source_file: 'src/foo.ts', suggestion: '' }],
+    });
+    const result = classify(gate);
+    assert.ok(result.suggested_action.includes('src/foo.ts') ||
+              result.suggested_action.length > 0);
+});
+
+// ── failing_doc_drift ─────────────────────────────────────────────────────────
+
+test('failing_doc_drift: routes correctly from drift array', () => {
+    const gate = makeDriftGate({
+        passed: false,
+        drift: [
+            { doc_file: 'docs/USER_MANUAL.md',
+              heading: '## Installing autospec-test',
+              matching_source_files: ['install.sh'],
+              reason: 'install instructions outdated' }
+        ],
+    });
+    const result = classify(gate);
+    assert.ok(result, 'Expected non-null result');
+    assert.equal(result.classification, 'failing_doc_drift');
+    assert.ok(result.target_files.includes('docs/USER_MANUAL.md'));
+});
+
+test('failing_doc_drift: estimated_minutes is reasonable', () => {
+    const gate = makeDriftGate({
+        passed: false,
+        drift: [{ doc_file: 'docs/ARCHITECTURE.md', heading: '## Overview',
+                  matching_source_files: ['src/main.ts'], reason: '' }],
+    });
+    const result = classify(gate);
+    assert.ok(result.estimated_minutes > 0);
+    assert.ok(result.estimated_minutes <= 30);
+});
+
+// ── failing_visual_stale ──────────────────────────────────────────────────────
+
+test('failing_visual_stale: routes correctly from visual_stale array', () => {
+    const gate = makeDriftGate({
+        passed: false,
+        visualStale: [
+            { doc_file: 'docs/USER_MANUAL.md',
+              heading: '## Dashboard',
+              screenshot: 'docs/assets/screenshots/dashboard__desktop.png',
+              source_changed: ['components/dashboard/index.tsx'] }
+        ],
+    });
+    const result = classify(gate);
+    assert.ok(result, 'Expected non-null result');
+    assert.equal(result.classification, 'failing_visual_stale');
+    assert.ok(result.target_files.includes('docs/assets/screenshots/dashboard__desktop.png'));
+});
+
+// ── failing_ai_review_stale ───────────────────────────────────────────────────
+
+test('failing_ai_review_stale: routes correctly from ai_review_stale array', () => {
+    const gate = makeDriftGate({
+        passed: false,
+        aiStale: [
+            { doc_file: 'docs/ARCHITECTURE.md',
+              heading: '## Module graph',
+              last_reviewed_at: '2026-05-01T00:00:00Z',
+              source_changed_after: '2026-05-10T00:00:00Z' }
+        ],
+    });
+    const result = classify(gate);
+    assert.ok(result, 'Expected non-null result');
+    assert.equal(result.classification, 'failing_ai_review_stale');
+    assert.ok(result.target_files.includes('docs/ARCHITECTURE.md'));
+});
+
+// ── failing_manifest_stale ────────────────────────────────────────────────────
+
+test('failing_manifest_stale: routes correctly when manifest_stale=true', () => {
+    const gate = makeDriftGate({ passed: false, manifestStale: true });
+    const result = classify(gate);
+    assert.ok(result, 'Expected non-null result');
+    assert.equal(result.classification, 'failing_manifest_stale');
+    assert.ok(result.target_files.includes('docs/.llm-manifest.json'));
+});
+
+// ── Priority ordering ─────────────────────────────────────────────────────────
+
+test('DOCS_CATEGORY_PRIORITY is an array of 5 items in correct order', () => {
+    assert.ok(Array.isArray(DOCS_CATEGORY_PRIORITY));
+    assert.equal(DOCS_CATEGORY_PRIORITY.length, 5);
+    assert.equal(DOCS_CATEGORY_PRIORITY[0], 'missing_doc_scope');
+    assert.equal(DOCS_CATEGORY_PRIORITY[1], 'failing_doc_drift');
+});
+
+test('missing_doc_scope outranks failing_doc_drift when both present', () => {
+    const gate = makeDriftGate({
+        passed: false,
+        missingScope: [{ source_file: 'src/foo.ts', suggestion: '' }],
+        drift: [{ doc_file: 'docs/USER_MANUAL.md', heading: '## Foo',
+                  matching_source_files: ['src/foo.ts'], reason: '' }],
+    });
+    const result = classify(gate);
+    assert.equal(result.classification, 'missing_doc_scope',
+        `Expected missing_doc_scope to win, got ${result.classification}`);
+});
+
+test('failing_doc_drift outranks failing_visual_stale when both present', () => {
+    const gate = makeDriftGate({
+        passed: false,
+        drift: [{ doc_file: 'docs/USER_MANUAL.md', heading: '## Foo',
+                  matching_source_files: ['src/foo.ts'], reason: '' }],
+        visualStale: [{ doc_file: 'docs/USER_MANUAL.md', heading: '## Bar',
+                        screenshot: 'docs/assets/screenshots/foo.png',
+                        source_changed: ['src/foo.ts'] }],
+    });
+    const result = classify(gate);
+    assert.equal(result.classification, 'failing_doc_drift',
+        `Expected failing_doc_drift to win, got ${result.classification}`);
+});
+
+// ── Output schema ─────────────────────────────────────────────────────────────
+
+test('result has all required fields', () => {
+    const gate = makeDriftGate({
+        passed: false,
+        missingScope: [{ source_file: 'src/foo.ts', suggestion: '' }],
+    });
+    const result = classify(gate);
+    assert.ok('classification' in result, 'missing classification');
+    assert.ok('target_files' in result, 'missing target_files');
+    assert.ok('suggested_action' in result, 'missing suggested_action');
+    assert.ok('estimated_minutes' in result, 'missing estimated_minutes');
+    assert.ok('priority' in result, 'missing priority');
+    assert.ok(Array.isArray(result.target_files), 'target_files must be array');
+    assert.ok(typeof result.priority === 'number', 'priority must be number');
+    assert.ok(typeof result.suggested_action === 'string', 'suggested_action must be string');
+});
+
+test('priority is always a positive number for docs findings', () => {
+    const gate = makeDriftGate({
+        passed: false,
+        drift: [{ doc_file: 'docs/USER_MANUAL.md', heading: '## Foo',
+                  matching_source_files: ['src/foo.ts'], reason: '' }],
+    });
+    const result = classify(gate);
+    assert.ok(result.priority > 0, `Expected priority > 0, got ${result.priority}`);
+});
+
+// ── detectBucket ──────────────────────────────────────────────────────────────
+
+test('detectBucket: scope comment removed → LOOSENING', () => {
+    const diff = [
+        '--- a/docs/USER_MANUAL.md',
+        '+++ b/docs/USER_MANUAL.md',
+        '-<!-- autospec-doc-scope:',
+        '-  src: ["install.sh"]',
+        '--->',
+    ].join('\n');
+    assert.equal(detectBucket(diff), 'LOOSENING');
+});
+
+test('detectBucket: scope comment added → STRENGTHENING', () => {
+    const diff = [
+        '--- a/docs/USER_MANUAL.md',
+        '+++ b/docs/USER_MANUAL.md',
+        '+<!-- autospec-doc-scope:',
+        '+  src: ["install.sh"]',
+        '+-->',
+    ].join('\n');
+    assert.equal(detectBucket(diff), 'STRENGTHENING');
+});
+
+test('detectBucket: glob removed → LOOSENING', () => {
+    const diff = [
+        '--- a/docs/USER_MANUAL.md',
+        '+++ b/docs/USER_MANUAL.md',
+        ' <!-- autospec-doc-scope:',
+        '-  src: ["install.sh", "skills/autospec-test/install.sh"]',
+        '+  src: ["install.sh"]',
+        ' -->',
+    ].join('\n');
+    assert.equal(detectBucket(diff), 'LOOSENING');
+});
+
+test('detectBucket: glob added → STRENGTHENING', () => {
+    const diff = [
+        '--- a/docs/USER_MANUAL.md',
+        '+++ b/docs/USER_MANUAL.md',
+        ' <!-- autospec-doc-scope:',
+        '-  src: ["install.sh"]',
+        '+  src: ["install.sh", "skills/autospec-test/install.sh"]',
+        ' -->',
+    ].join('\n');
+    assert.equal(detectBucket(diff), 'STRENGTHENING');
+});
+
+test('detectBucket: doc content changed (no scope lines) → SHIFTING', () => {
+    const diff = [
+        '--- a/docs/USER_MANUAL.md',
+        '+++ b/docs/USER_MANUAL.md',
+        '-Old paragraph text.',
+        '+New paragraph text.',
+    ].join('\n');
+    assert.equal(detectBucket(diff), 'SHIFTING');
+});
+
+test('detectBucket: null input → null', () => {
+    assert.equal(detectBucket(null), null);
+    assert.equal(detectBucket(''), null);
+});

--- a/skills/autospec-test/scripts/loop-classifier.mjs
+++ b/skills/autospec-test/scripts/loop-classifier.mjs
@@ -17,6 +17,24 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ── Docs-amendment extension (Phase 3) ───────────────────────────────────────
+// Route docs-gate JSON through the docs classifier before v1 fallback.
+// Path: skills/autospec-shared/scripts/loop-classifier-docs-extension.mjs
+let _docsClassify = null;
+try {
+    const docsExtPath = path.resolve(
+        __dirname,
+        '../../../autospec-shared/scripts/loop-classifier-docs-extension.mjs'
+    );
+    if (fs.existsSync(docsExtPath)) {
+        const { classify: dc } = await import(`file://${docsExtPath}`);
+        _docsClassify = dc;
+    }
+} catch {
+    // Extension not installed — degrade gracefully; v1 logic runs unmodified.
+}
 
 /** Priority rank per spec §6 (higher = more urgent) */
 const PRIORITY_RANK = {
@@ -170,6 +188,23 @@ export function classify(options) {
                 suggested_files: ['playwright.config.ts', 'playwright.config.js', 'tests/'],
                 estimated_minutes: 10,
                 priority: PRIORITY_RANK.flaky_test,
+            });
+        }
+    }
+
+    // ── docs-amendment extension (Phase 3) ───────────────────────────────────
+    // If the gate JSON looks like a doc-drift result, route to docs classifier.
+    // Doc findings are inserted ahead of the v1 fallback but after all v1
+    // signal-based candidates so existing priority ordering is preserved.
+    if (_docsClassify) {
+        const docsResult = _docsClassify(gate_json, last_3_iterations);
+        if (docsResult) {
+            candidates.push({
+                classification: docsResult.classification,
+                target_failures: docsResult.target_files || [],
+                suggested_files: docsResult.target_files || [],
+                estimated_minutes: docsResult.estimated_minutes,
+                priority: docsResult.priority,
             });
         }
     }


### PR DESCRIPTION
Closes #363

## Summary

Extends v1 `loop-classifier.mjs` with 5 docs-amendment failure categories per spec §3c, plus the anti-rubber-stamp bucket detector from §3d.

- **`loop-classifier-docs-extension.mjs`** (new) — exports `classify(gateJson, lastIterations)` routing doc-gate failures to the correct category with priority ordering; exports `detectBucket(diffText)` returning `LOOSENING`/`STRENGTHENING`/`SHIFTING` for anti-rubber-stamp enforcement
- **`loop-classifier.mjs`** (modified) — dynamically imports the docs extension before the v1 fallback; degrades gracefully if extension not installed; all 11 existing tests unchanged
- **`loop-classifier-docs.test.mjs`** (new) — 22 unit tests: one fixture per category, priority ordering, detectBucket edge cases

## Priority order (spec §3c)
`missing_doc_scope` → `failing_doc_drift` → `failing_visual_stale` → `failing_ai_review_stale` → `failing_manifest_stale`

## Test plan

- [x] `node --test skills/autospec-shared/tests/unit/loop-classifier-docs.test.mjs` → 22/22 pass
- [x] `node --test skills/autospec-test/tests/unit/loop-classifier.test.mjs` → 11/11 pass (no regression)
- [x] LOOSENING/STRENGTHENING/SHIFTING detection verified for scope removal, scope addition, glob narrowing, glob widening, content change

🤖 Generated with [Claude Code](https://claude.com/claude-code)