### PR TITLE
fix(autospec-run): memory-tag frontmatter bootstrap (Fix #1a, #386)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,3 +280,16 @@ Rules:
 - `AUTOSPEC_NO_GUARDIAN=1` — short-circuit guardian, fall back to LGTM-only path.
   Mirrors `AUTOSPEC_NO_AUTOMERGE_SPEC=1` and `AUTOSPEC_NO_SELF_UPDATE=1`. Logged
   as `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN` on every Phase 4 dispatch.
+
+## Memory management scripts
+
+Scripts for managing project memory files under `AUTOSPEC_MEMORY_DIR`
+(`~/.claude/projects/-Users-<user>-IdeaProjects-autospec/memory/`).
+
+| Script | Purpose | Flags |
+|---|---|---|
+| `scripts/memory-tags.yml` | Manifest mapping each `feedback_*.md` to 4–5 tags | — (data file) |
+| `scripts/apply-memory-tags.sh` | Idempotent tagger: prepends `tags:` YAML frontmatter to each `feedback_*.md` | `--dry-run`, `--memory-dir DIR`, `--manifest FILE` |
+
+`AUTOSPEC_MEMORY_DIR` — override for the memory directory path (default: auto-detected
+from `$HOME/.claude/projects/`).

--- a/scripts/apply-memory-tags.sh
+++ b/scripts/apply-memory-tags.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# apply-memory-tags.sh — Idempotent frontmatter tagger for autospec memory files.
+# Reads scripts/memory-tags.yml and prepends YAML frontmatter (tags:) to each
+# matching feedback_*.md file under AUTOSPEC_MEMORY_DIR.
+#
+# Usage:
+#   bash scripts/apply-memory-tags.sh [--dry-run] [--memory-dir DIR] [--manifest FILE]
+#
+# Options:
+#   --dry-run       Print planned edits without writing any files
+#   --memory-dir    Override AUTOSPEC_MEMORY_DIR (default: auto-detect)
+#   --manifest      Path to memory-tags.yml (default: scripts/memory-tags.yml beside this script)
+#
+# Exit codes:
+#   0  All files processed (or dry-run completed)
+#   1  Manifest file not found
+#   2  Memory directory not found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Defaults
+DRY_RUN=false
+MANIFEST="${SCRIPT_DIR}/memory-tags.yml"
+MEMORY_DIR="${AUTOSPEC_MEMORY_DIR:-}"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --memory-dir)
+      MEMORY_DIR="$2"
+      shift 2
+      ;;
+    --manifest)
+      MANIFEST="$2"
+      shift 2
+      ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Resolve memory dir
+if [[ -z "$MEMORY_DIR" ]]; then
+  # Auto-detect: look for the autospec project memory dir
+  CANDIDATE="$HOME/.claude/projects/-Users-$(whoami)-IdeaProjects-autospec/memory"
+  if [[ -d "$CANDIDATE" ]]; then
+    MEMORY_DIR="$CANDIDATE"
+  else
+    # Fallback: search common patterns
+    CANDIDATE2=$(find "$HOME/.claude/projects" -maxdepth 2 -name "memory" -type d 2>/dev/null | grep -i autospec | head -1)
+    if [[ -n "$CANDIDATE2" ]]; then
+      MEMORY_DIR="$CANDIDATE2"
+    fi
+  fi
+fi
+
+if [[ -z "$MEMORY_DIR" || ! -d "$MEMORY_DIR" ]]; then
+  echo "ERROR: Memory directory not found. Set AUTOSPEC_MEMORY_DIR or use --memory-dir." >&2
+  exit 2
+fi
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "ERROR: Manifest not found: $MANIFEST" >&2
+  exit 1
+fi
+
+echo "Memory dir : $MEMORY_DIR"
+echo "Manifest   : $MANIFEST"
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "Mode       : DRY RUN (no files will be written)"
+fi
+echo ""
+
+# Parse the YAML manifest and apply tags
+# Format: filename.md: / tags: [t1, t2, ...]
+current_file=""
+processed=0
+skipped=0
+warned=0
+
+while IFS= read -r line; do
+  # Skip comments and blank lines
+  [[ "$line" =~ ^[[:space:]]*# ]] && continue
+  [[ -z "${line//[[:space:]]/}" ]] && continue
+
+  # File entry: "feedback_something.md:"
+  if [[ "$line" =~ ^(feedback_[^:]+\.md):$ ]]; then
+    current_file="${BASH_REMATCH[1]}"
+    continue
+  fi
+
+  # Tags line: "  tags: [t1, t2, ...]"
+  if [[ -n "$current_file" && "$line" =~ ^[[:space:]]+tags:[[:space:]]*(\[.+\]) ]]; then
+    tags_value="${BASH_REMATCH[1]}"
+    target="$MEMORY_DIR/$current_file"
+
+    if [[ ! -f "$target" ]]; then
+      echo "WARN  $current_file — file not found, skipping" >&2
+      warned=$((warned + 1))
+      current_file=""
+      continue
+    fi
+
+    # Idempotency check: skip if already has 'tags:' in first 10 lines
+    if head -10 "$target" | grep -q "^tags:"; then
+      echo "SKIP  $current_file — already tagged"
+      skipped=$((skipped + 1))
+      current_file=""
+      continue
+    fi
+
+    # Build frontmatter block to prepend
+    frontmatter="tags: ${tags_value}"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+      echo "PLAN  $current_file — would add: $frontmatter"
+    else
+      # Prepend tags line to existing frontmatter or add at top
+      # If file starts with '---', insert after that line
+      first_line=$(head -1 "$target")
+      if [[ "$first_line" == "---" ]]; then
+        # Insert tags: after the opening ---
+        tmp=$(mktemp)
+        {
+          echo "---"
+          echo "$frontmatter"
+          tail -n +2 "$target"
+        } > "$tmp"
+        mv "$tmp" "$target"
+      else
+        # Prepend as standalone block
+        tmp=$(mktemp)
+        {
+          echo "---"
+          echo "$frontmatter"
+          echo "---"
+          cat "$target"
+        } > "$tmp"
+        mv "$tmp" "$target"
+      fi
+      echo "OK    $current_file — added: $frontmatter"
+    fi
+    processed=$((processed + 1))
+    current_file=""
+  fi
+done < "$MANIFEST"
+
+echo ""
+echo "Summary: ${processed} processed, ${skipped} skipped (already tagged), ${warned} warned (file not found)"

--- a/scripts/memory-tags.yml
+++ b/scripts/memory-tags.yml
@@ -1,0 +1,50 @@
+# Memory-tag manifest for autospec project memory files
+# Maps each feedback_*.md filename to a list of tags.
+# Used by apply-memory-tags.sh to prepend YAML frontmatter.
+# Tags are derived from filename slug words + 1-2 content keywords.
+#
+# Schema:
+#   <filename>:       (relative to AUTOSPEC_MEMORY_DIR, no path prefix)
+#     tags: [t1, t2, ...]
+
+feedback_admin_merge_denial.md:
+  tags: [admin-merge, permissions, harness, gh-cli, autospec-run]
+
+feedback_autospec_autonomy_scope.md:
+  tags: [autonomy, autospec-run, merge, orchestrator, workflow]
+
+feedback_autospec_decomposer_gotchas.md:
+  tags: [decomposer, lockstep, autospec-run, skill-creation, issues]
+
+feedback_autospec_design_prefs.md:
+  tags: [design, preferences, autospec, correctness, guardrails]
+
+feedback_autospec_no_shell_user_text.md:
+  tags: [mode-dispatch, shell, autospec, bash, skill-authoring]
+
+feedback_autospec_skill_per_capability.md:
+  tags: [skills, autospec, capability, slash-command, architecture]
+
+feedback_bash_return_trap_leak.md:
+  tags: [bash, trap, set-u, functions, scripting]
+
+feedback_bash_set_e_short_circuit.md:
+  tags: [bash, set-e, conditionals, scripting, install]
+
+feedback_llm_validator_adaptive_retry.md:
+  tags: [validator, adaptive-retry, llm, lint, quality]
+
+feedback_monitor_silent_exit.md:
+  tags: [monitor, autospec-run, silent-exit, recovery, orchestrator]
+
+feedback_omc_autopilot_misfire.md:
+  tags: [omc, autopilot, system-reminder, false-trigger, recovery]
+
+feedback_pre_pipeline_sync.md:
+  tags: [sync, git, pipeline, autospec, design]
+
+feedback_roi_check_new_components.md:
+  tags: [roi, components, architecture, skills, forking]
+
+feedback_validate_sh_lockstep_checks.md:
+  tags: [validate, lockstep, skill-authoring, prose, autospec-run]

--- a/tests/unit/test_apply_memory_tags.bats
+++ b/tests/unit/test_apply_memory_tags.bats
@@ -1,0 +1,210 @@
+#!/usr/bin/env bats
+# tests/unit/test_apply_memory_tags.bats — Exercises scripts/apply-memory-tags.sh
+# Tests: fresh-apply, re-apply (idempotency), missing-file (skip with warn)
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/apply-memory-tags.sh"
+    MANIFEST="$REPO_ROOT/scripts/memory-tags.yml"
+
+    # Create a temp memory dir for each test
+    TMPDIR_MEM="$(mktemp -d)"
+    # Create a minimal test manifest
+    TMPDIR_MANIFEST="$(mktemp)"
+}
+
+teardown() {
+    rm -rf "$TMPDIR_MEM"
+    rm -f "$TMPDIR_MANIFEST"
+}
+
+# ── syntax check ─────────────────────────────────────────────────────────────
+
+@test "apply-memory-tags: bash -n exits 0" {
+    run bash -n "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "apply-memory-tags: --help exits 0" {
+    run bash "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+}
+
+# ── fresh apply ──────────────────────────────────────────────────────────────
+
+@test "apply-memory-tags: inserts tags into untagged file" {
+    # Create stub memory file with existing frontmatter (no tags:)
+    cat > "$TMPDIR_MEM/feedback_test_stub.md" <<'EOF'
+---
+name: Test stub
+description: A test memory file
+---
+Body content here.
+EOF
+
+    # Create minimal manifest
+    cat > "$TMPDIR_MANIFEST" <<'EOF'
+feedback_test_stub.md:
+  tags: [bash, testing, autospec-run]
+EOF
+
+    run bash "$SCRIPT" --memory-dir "$TMPDIR_MEM" --manifest "$TMPDIR_MANIFEST"
+    [ "$status" -eq 0 ]
+
+    # Verify tags: line was added
+    grep -q "^tags: \[bash, testing, autospec-run\]" "$TMPDIR_MEM/feedback_test_stub.md"
+}
+
+@test "apply-memory-tags: prints OK summary line for processed file" {
+    cat > "$TMPDIR_MEM/feedback_test_stub.md" <<'EOF'
+---
+name: Test stub
+---
+Body content.
+EOF
+
+    cat > "$TMPDIR_MANIFEST" <<'EOF'
+feedback_test_stub.md:
+  tags: [bash, testing]
+EOF
+
+    run bash "$SCRIPT" --memory-dir "$TMPDIR_MEM" --manifest "$TMPDIR_MANIFEST"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "OK.*feedback_test_stub.md"
+}
+
+@test "apply-memory-tags: prints summary counts" {
+    cat > "$TMPDIR_MEM/feedback_test_stub.md" <<'EOF'
+---
+name: Test stub
+---
+Body content.
+EOF
+
+    cat > "$TMPDIR_MANIFEST" <<'EOF'
+feedback_test_stub.md:
+  tags: [bash, testing]
+EOF
+
+    run bash "$SCRIPT" --memory-dir "$TMPDIR_MEM" --manifest "$TMPDIR_MANIFEST"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "Summary:"
+    echo "$output" | grep -q "processed"
+}
+
+# ── idempotency ───────────────────────────────────────────────────────────────
+
+@test "apply-memory-tags: re-run on already-tagged file is no-op (exit 0)" {
+    # Create file with tags: already in frontmatter
+    cat > "$TMPDIR_MEM/feedback_already_tagged.md" <<'EOF'
+---
+name: Already tagged
+tags: [bash, existing]
+---
+Body content here.
+EOF
+
+    cat > "$TMPDIR_MANIFEST" <<'EOF'
+feedback_already_tagged.md:
+  tags: [bash, existing]
+EOF
+
+    run bash "$SCRIPT" --memory-dir "$TMPDIR_MEM" --manifest "$TMPDIR_MANIFEST"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "SKIP.*feedback_already_tagged.md"
+}
+
+@test "apply-memory-tags: re-run does not duplicate frontmatter" {
+    cat > "$TMPDIR_MEM/feedback_test_stub.md" <<'EOF'
+---
+name: Test stub
+description: Test
+---
+Body content.
+EOF
+
+    cat > "$TMPDIR_MANIFEST" <<'EOF'
+feedback_test_stub.md:
+  tags: [bash, testing, autospec-run]
+EOF
+
+    # First run
+    run bash "$SCRIPT" --memory-dir "$TMPDIR_MEM" --manifest "$TMPDIR_MANIFEST"
+    [ "$status" -eq 0 ]
+
+    # Second run
+    run bash "$SCRIPT" --memory-dir "$TMPDIR_MEM" --manifest "$TMPDIR_MANIFEST"
+    [ "$status" -eq 0 ]
+
+    # Count occurrences of 'tags:' — should be exactly 1
+    count=$(grep -c "^tags:" "$TMPDIR_MEM/feedback_test_stub.md")
+    [ "$count" -eq 1 ]
+}
+
+# ── missing file warning ──────────────────────────────────────────────────────
+
+@test "apply-memory-tags: missing file in manifest warns to stderr and exits 0" {
+    # manifest references a file that does NOT exist in memory dir
+    cat > "$TMPDIR_MANIFEST" <<'EOF'
+feedback_does_not_exist.md:
+  tags: [bash, missing]
+EOF
+
+    run bash "$SCRIPT" --memory-dir "$TMPDIR_MEM" --manifest "$TMPDIR_MANIFEST"
+    [ "$status" -eq 0 ]
+    echo "$stderr" | grep -q "not found" || echo "$output" | grep -qi "warn"
+}
+
+@test "apply-memory-tags: missing file does not prevent processing other files" {
+    # Create one valid and one missing file in manifest
+    cat > "$TMPDIR_MEM/feedback_valid.md" <<'EOF'
+---
+name: Valid file
+---
+Body.
+EOF
+
+    cat > "$TMPDIR_MANIFEST" <<'EOF'
+feedback_does_not_exist.md:
+  tags: [bash, missing]
+
+feedback_valid.md:
+  tags: [autospec-run, testing]
+EOF
+
+    run bash "$SCRIPT" --memory-dir "$TMPDIR_MEM" --manifest "$TMPDIR_MANIFEST"
+    [ "$status" -eq 0 ]
+    # Valid file was still processed
+    grep -q "^tags:" "$TMPDIR_MEM/feedback_valid.md"
+}
+
+# ── dry-run mode ─────────────────────────────────────────────────────────────
+
+@test "apply-memory-tags: --dry-run does not write files" {
+    cat > "$TMPDIR_MEM/feedback_dryrun_test.md" <<'EOF'
+---
+name: Dry run test
+---
+Body content.
+EOF
+
+    cat > "$TMPDIR_MANIFEST" <<'EOF'
+feedback_dryrun_test.md:
+  tags: [bash, dry-run]
+EOF
+
+    run bash "$SCRIPT" --dry-run --memory-dir "$TMPDIR_MEM" --manifest "$TMPDIR_MANIFEST"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "DRY RUN\|PLAN"
+
+    # File should NOT have tags: added
+    run grep -c "^tags:" "$TMPDIR_MEM/feedback_dryrun_test.md"
+    [ "$output" -eq 0 ]
+}
+
+# ── real manifest check ───────────────────────────────────────────────────────
+
+@test "apply-memory-tags: real manifest has entries for all 14 feedback files" {
+    count=$(grep -c "^feedback_.*\.md:$" "$MANIFEST")
+    [ "$count" -eq 14 ]
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/memory-tags.yml` manifest mapping all 14 `feedback_*.md` memory files to 4-5 tags derived from filename slug + content keywords
- Adds `scripts/apply-memory-tags.sh` idempotent tagger: reads manifest, prepends `tags:` YAML frontmatter to each matching file, skips already-tagged files, warns on missing files
- Supports `--dry-run` flag (prints planned edits without writing), `--memory-dir` and `--manifest` overrides
- 11/11 bats tests pass in `tests/unit/test_apply_memory_tags.bats`

Closes #387

## Test plan

- [x] `bats tests/unit/test_apply_memory_tags.bats` — 11/11 pass
- [x] `bash scripts/apply-memory-tags.sh --dry-run` — 14 planned edits, 0 warnings
- [x] Idempotency: re-run on already-tagged file is SKIP with no duplicate frontmatter
- [x] Missing file in manifest: WARN to stderr, exit 0, other files still processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)