### PR TITLE
fix(autospec-run): batch size + reasoning:deep gating (Fix #5, #386)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,3 +318,7 @@ Replaces synchronous `gh pr checks --watch` with a fire-and-forget background po
 Signal file: `~/.autospec/ci-state/<PR>.signal` — JSON `{pr, state, checks, settled_at}`.
 State values: `pending | pass | fail | stalled`.
 Exit codes from `ci-wait-poll.sh`: 0=pass, 1=fail/stalled, 2=pending, 3=no sentinel.
+
+## Batch size policy
+
+Default `AUTOSPEC_BATCH_SIZE=3`; force batch=1 when the next ready issue is `reasoning:deep` (high blast-radius work runs one-at-a-time per monitor session).

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -361,6 +361,18 @@ issues unblock the queue before continuing with normal feature work.
 >       fi
 >     fi
 >   fi
+>   # effective_batch_size probe — recomputed each outer-loop tick (not cached).
+>   # Force batch=1 when the next ready issue is reasoning:deep (high blast-radius).
+>   _next_reasoning=$(gh issue view "${ready[0]}" --json labels \
+>     --jq '[.labels[].name | select(startswith("reasoning:"))] | first // "reasoning:medium"' \
+>     2>/dev/null || echo "reasoning:medium")
+>   if [ "$_next_reasoning" = "reasoning:deep" ]; then
+>     effective_batch_size=1
+>   else
+>     effective_batch_size="${AUTOSPEC_BATCH_SIZE:-3}"
+>     [ "$effective_batch_size" -gt 0 ] 2>/dev/null || effective_batch_size=3
+>   fi
+>   echo "[monitor] effective_batch_size=$effective_batch_size (next issue reasoning: $_next_reasoning)"
 >   ISSUE = ready[0]
 >   # Claim check: verify the issue is still labeled auto-implement before processing.
 >   # Multiple monitors can query the same candidate list simultaneously;
@@ -410,11 +422,11 @@ issues unblock the queue before continuing with normal feature work.
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
 >   batch_issue_count=$((batch_issue_count + 1))
->   if [ "$batch_issue_count" -ge "$BATCH_SIZE" ]; then
+>   if [ "$batch_issue_count" -ge "${effective_batch_size:-$BATCH_SIZE}" ]; then
 >     printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"BATCH_COMPLETE"}\n' \
 >       "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
 >       > "$HOME/.autospec/batch-done.json"
->     echo "[monitor] batch ${batch_num:-1}: processed $batch_issue_count/$BATCH_SIZE issues — writing batch-done.json and exiting for fresh context"
+>     echo "[monitor] batch ${batch_num:-1}: processed $batch_issue_count/${effective_batch_size:-$BATCH_SIZE} issues — writing batch-done.json and exiting for fresh context"
 >     exit 0
 >   fi
 >   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -356,6 +356,18 @@ issues unblock the queue before continuing with normal feature work.
 >       fi
 >     fi
 >   fi
+>   # effective_batch_size probe — recomputed each outer-loop tick (not cached).
+>   # Force batch=1 when the next ready issue is reasoning:deep (high blast-radius).
+>   _next_reasoning=$(gh issue view "${ready[0]}" --json labels \
+>     --jq '[.labels[].name | select(startswith("reasoning:"))] | first // "reasoning:medium"' \
+>     2>/dev/null || echo "reasoning:medium")
+>   if [ "$_next_reasoning" = "reasoning:deep" ]; then
+>     effective_batch_size=1
+>   else
+>     effective_batch_size="${AUTOSPEC_BATCH_SIZE:-3}"
+>     [ "$effective_batch_size" -gt 0 ] 2>/dev/null || effective_batch_size=3
+>   fi
+>   echo "[monitor] effective_batch_size=$effective_batch_size (next issue reasoning: $_next_reasoning)"
 >   ISSUE = ready[0]
 >   # Claim check: verify the issue is still labeled auto-implement before processing.
 >   # Multiple monitors can query the same candidate list simultaneously;
@@ -405,11 +417,11 @@ issues unblock the queue before continuing with normal feature work.
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
 >   batch_issue_count=$((batch_issue_count + 1))
->   if [ "$batch_issue_count" -ge "$BATCH_SIZE" ]; then
+>   if [ "$batch_issue_count" -ge "${effective_batch_size:-$BATCH_SIZE}" ]; then
 >     printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"BATCH_COMPLETE"}\n' \
 >       "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
 >       > "$HOME/.autospec/batch-done.json"
->     echo "[monitor] batch ${batch_num:-1}: processed $batch_issue_count/$BATCH_SIZE issues — writing batch-done.json and exiting for fresh context"
+>     echo "[monitor] batch ${batch_num:-1}: processed $batch_issue_count/${effective_batch_size:-$BATCH_SIZE} issues — writing batch-done.json and exiting for fresh context"
 >     exit 0
 >   fi
 >   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -360,6 +360,18 @@ issues unblock the queue before continuing with normal feature work.
 >       fi
 >     fi
 >   fi
+>   # effective_batch_size probe — recomputed each outer-loop tick (not cached).
+>   # Force batch=1 when the next ready issue is reasoning:deep (high blast-radius).
+>   _next_reasoning=$(gh issue view "${ready[0]}" --json labels \
+>     --jq '[.labels[].name | select(startswith("reasoning:"))] | first // "reasoning:medium"' \
+>     2>/dev/null || echo "reasoning:medium")
+>   if [ "$_next_reasoning" = "reasoning:deep" ]; then
+>     effective_batch_size=1
+>   else
+>     effective_batch_size="${AUTOSPEC_BATCH_SIZE:-3}"
+>     [ "$effective_batch_size" -gt 0 ] 2>/dev/null || effective_batch_size=3
+>   fi
+>   echo "[monitor] effective_batch_size=$effective_batch_size (next issue reasoning: $_next_reasoning)"
 >   ISSUE = ready[0]
 >   # Claim check: verify the issue is still labeled auto-implement before processing.
 >   # Multiple monitors can query the same candidate list simultaneously;
@@ -409,11 +421,11 @@ issues unblock the queue before continuing with normal feature work.
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
 >   process(ISSUE)   # foreground subagent — see template below
 >   batch_issue_count=$((batch_issue_count + 1))
->   if [ "$batch_issue_count" -ge "$BATCH_SIZE" ]; then
+>   if [ "$batch_issue_count" -ge "${effective_batch_size:-$BATCH_SIZE}" ]; then
 >     printf '{"batch":%s,"processed":%s,"repo":"%s","ts":%s,"status":"BATCH_COMPLETE"}\n' \
 >       "${batch_num:-1}" "$batch_issue_count" "{repo}" "$(date -u +%s)" \
 >       > "$HOME/.autospec/batch-done.json"
->     echo "[monitor] batch ${batch_num:-1}: processed $batch_issue_count/$BATCH_SIZE issues — writing batch-done.json and exiting for fresh context"
+>     echo "[monitor] batch ${batch_num:-1}: processed $batch_issue_count/${effective_batch_size:-$BATCH_SIZE} issues — writing batch-done.json and exiting for fresh context"
 >     exit 0
 >   fi
 >   # Immediate next-issue pickup: NO SLEEP after process(ISSUE). Re-enter the top

--- a/tests/batch-size-gating.bats
+++ b/tests/batch-size-gating.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+# tests/batch-size-gating.bats — TDD for effective_batch_size probe (issue #390)
+
+setup() {
+  # Source the helper that computes effective_batch_size.
+  # We define the function inline here as it will appear in SKILL.md pseudocode.
+  compute_effective_batch_size() {
+    local reasoning_lbl="${1:-reasoning:medium}"
+    local batch_size="${AUTOSPEC_BATCH_SIZE:-3}"
+    # Guard against 0 or negative
+    [[ "$batch_size" -gt 0 ]] 2>/dev/null || batch_size=3
+    if [ "$reasoning_lbl" = "reasoning:deep" ]; then
+      echo 1
+    else
+      echo "$batch_size"
+    fi
+  }
+}
+
+@test "reasoning:deep issue forces effective_batch_size=1" {
+  result=$(compute_effective_batch_size "reasoning:deep")
+  [ "$result" = "1" ]
+}
+
+@test "reasoning:medium with AUTOSPEC_BATCH_SIZE=3 gives effective_batch_size=3" {
+  AUTOSPEC_BATCH_SIZE=3 result=$(compute_effective_batch_size "reasoning:medium")
+  [ "$result" = "3" ]
+}
+
+@test "AUTOSPEC_BATCH_SIZE env override of 7 with non-deep label gives effective_batch_size=7" {
+  AUTOSPEC_BATCH_SIZE=7 result=$(compute_effective_batch_size "reasoning:shallow")
+  [ "$result" = "7" ]
+}
+
+@test "unlabeled issue defaults to reasoning:medium behavior (batch size 3)" {
+  AUTOSPEC_BATCH_SIZE=3 result=$(compute_effective_batch_size "reasoning:medium")
+  [ "$result" = "3" ]
+}
+
+@test "reasoning:deep overrides even large AUTOSPEC_BATCH_SIZE" {
+  AUTOSPEC_BATCH_SIZE=10 result=$(compute_effective_batch_size "reasoning:deep")
+  [ "$result" = "1" ]
+}
+
+@test "SKILL.md contains effective_batch_size probe before claim step" {
+  skill_md="${BATS_TEST_DIRNAME}/../skills/autospec-run/SKILL.md"
+  [ -f "$skill_md" ]
+  grep -q "effective_batch_size" "$skill_md"
+}
+
+@test "SKILL.md default AUTOSPEC_BATCH_SIZE is 3" {
+  skill_md="${BATS_TEST_DIRNAME}/../skills/autospec-run/SKILL.md"
+  # Should contain AUTOSPEC_BATCH_SIZE:-3 (the default)
+  grep -q 'AUTOSPEC_BATCH_SIZE:-3' "$skill_md"
+}
+
+@test "AGENTS.md documents batch default and reasoning:deep gating" {
+  agents_md="${BATS_TEST_DIRNAME}/../AGENTS.md"
+  [ -f "$agents_md" ]
+  grep -q "AUTOSPEC_BATCH_SIZE" "$agents_md"
+  grep -q "reasoning:deep" "$agents_md"
+}

--- a/tests/batch-size-gating.bats
+++ b/tests/batch-size-gating.bats
@@ -60,3 +60,25 @@ setup() {
   grep -q "AUTOSPEC_BATCH_SIZE" "$agents_md"
   grep -q "reasoning:deep" "$agents_md"
 }
+
+@test "codex/prompt.md contains effective_batch_size probe (lockstep with SKILL.md)" {
+  codex_md="${BATS_TEST_DIRNAME}/../skills/autospec-run/codex/prompt.md"
+  [ -f "$codex_md" ]
+  grep -q "effective_batch_size" "$codex_md"
+}
+
+@test "codex/prompt.md uses effective_batch_size in batch comparison (lockstep)" {
+  codex_md="${BATS_TEST_DIRNAME}/../skills/autospec-run/codex/prompt.md"
+  grep -q 'effective_batch_size:-\$BATCH_SIZE' "$codex_md"
+}
+
+@test "opencode/agent.md contains effective_batch_size probe (lockstep with SKILL.md)" {
+  opencode_md="${BATS_TEST_DIRNAME}/../skills/autospec-run/opencode/agent.md"
+  [ -f "$opencode_md" ]
+  grep -q "effective_batch_size" "$opencode_md"
+}
+
+@test "opencode/agent.md uses effective_batch_size in batch comparison (lockstep)" {
+  opencode_md="${BATS_TEST_DIRNAME}/../skills/autospec-run/opencode/agent.md"
+  grep -q 'effective_batch_size:-\$BATCH_SIZE' "$opencode_md"
+}


### PR DESCRIPTION
## Summary

- Adds `effective_batch_size` probe to the monitor outer loop in all three harness adapter files (`SKILL.md`, `codex/prompt.md`, `opencode/agent.md`) — lockstep across all three
- Forces `effective_batch_size=1` when the next ready issue carries `reasoning:deep` label, preventing high-blast-radius work from running in multi-issue batches
- Expands bats test suite from 8 to 12 cases, now covering lockstep across all three adapter files
- All 12 bats tests pass; `validate.sh` green

## Test plan

- [x] `bats tests/batch-size-gating.bats` — 12/12 pass
- [x] `bash scripts/validate.sh` — OK
- [x] SKILL.md, codex/prompt.md, opencode/agent.md all contain identical `effective_batch_size` probe block

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)