### PR TITLE
feat(autospec-run): adaptive-retry loop in implementer (Fix #4, #386)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -438,6 +438,28 @@ check_phase4_immediate_next_issue_pickup() {
     done
 }
 
+# Phase 4 adaptive-retry loop: the implementer prompt block must contain the
+# MAX_IMPL_RETRIES while-loop with directive_context accumulation and an
+# exhaustion branch that posts a manual-intervention comment. All three trio
+# files (SKILL.md, codex/prompt.md, opencode/agent.md) must be in sync.
+check_phase4_adaptive_retry() {
+    info "phase4 adaptive-retry loop: autospec-run trio"
+    for f in "skills/autospec-run/SKILL.md" "skills/autospec-run/codex/prompt.md" "skills/autospec-run/opencode/agent.md"; do
+        grep -q 'RETRY-LOOP:begin' "$f" \
+            || fail "$f missing RETRY-LOOP:begin marker"
+        grep -q 'MAX_IMPL_RETRIES' "$f" \
+            || fail "$f missing MAX_IMPL_RETRIES variable"
+        grep -q 'directive_context' "$f" \
+            || fail "$f missing directive_context variable"
+        grep -q 'Retry attempt' "$f" \
+            || fail "$f missing 'Retry attempt' findings block"
+        grep -q 'Implementer hit max retries; manual intervention needed' "$f" \
+            || fail "$f missing manual-intervention exhaustion comment"
+        grep -q 'auto-implement-active' "$f" \
+            || fail "$f missing lock-label release on exhaustion"
+    done
+}
+
 # Governance copy: the listener lifecycle and anti-loop guardrails must be
 # documented in AGENTS.md, and the listener skill must appear in both the
 # top-level README.md and SKILLS.md skill index. Spec §6.1, §7.1.
@@ -573,6 +595,7 @@ main() {
     check_phase4_guardian_block_lockstep
     check_phase4_issue_start_summary
     check_phase4_immediate_next_issue_pickup
+    check_phase4_adaptive_retry
     check_autospec_run_priority_sort_lockstep
     check_autospec_run_regression_review_lockstep
     check_autospec_review_skill_present

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -498,7 +498,40 @@ issues unblock the queue before continuing with normal feature work.
 >    fi
 >    ```
 >    Exit 0: proceed to merge. Exit 1: block PR (post comment + labels; do NOT merge; treat as review finding). Exit 2: halt entire batch (comment on issue, label `in-progress-by-bot` → `auto-implement`, exit monitor).
-> 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
+> 4. <!-- RETRY-LOOP:begin --> Adaptive commit loop (MAX_IMPL_RETRIES):
+>    ```bash
+>    attempt=1
+>    MAX_IMPL_RETRIES="${MAX_IMPL_RETRIES:-5}"
+>    directive_context=""
+>    while [ "$attempt" -le "$MAX_IMPL_RETRIES" ]; do
+>      # Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
+>      if git commit -m "<conventional-commit-message>"; then
+>        # pre-commit hook passed — verify AC bats tests are green
+>        if bats tests/ac/issue-<ISSUE>.bats 2>/dev/null; then
+>          break  # success
+>        fi
+>        # AC tests still failing — treat as lint failure, roll back commit
+>        git reset HEAD~1
+>      fi
+>      # Capture lint directives for next attempt
+>      findings=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" --pre-commit --staged --directives 2>/dev/null || true)
+>      if [ -n "$findings" ]; then
+>        directive_context="${directive_context}
+>
+> ## Retry attempt ${attempt} findings
+> ${findings}
+>
+> Fix these BEFORE the next code generation."
+>      fi
+>      attempt=$((attempt + 1))
+>    done
+>    if [ "$attempt" -gt "$MAX_IMPL_RETRIES" ]; then
+>      gh issue comment <ISSUE> --body "Implementer hit max retries; manual intervention needed"
+>      gh issue edit <ISSUE> --remove-label "auto-implement-active" 2>/dev/null || true
+>      exit 1
+>    fi
+>    ```
+>    <!-- RETRY-LOOP:end -->
 > 5. Push: git push -u origin <BRANCH>
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -493,7 +493,40 @@ issues unblock the queue before continuing with normal feature work.
 >    fi
 >    ```
 >    Exit 0: proceed to merge. Exit 1: block PR (post comment + labels; do NOT merge; treat as review finding). Exit 2: halt entire batch (comment on issue, label `in-progress-by-bot` → `auto-implement`, exit monitor).
-> 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
+> 4. <!-- RETRY-LOOP:begin --> Adaptive commit loop (MAX_IMPL_RETRIES):
+>    ```bash
+>    attempt=1
+>    MAX_IMPL_RETRIES="${MAX_IMPL_RETRIES:-5}"
+>    directive_context=""
+>    while [ "$attempt" -le "$MAX_IMPL_RETRIES" ]; do
+>      # Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
+>      if git commit -m "<conventional-commit-message>"; then
+>        # pre-commit hook passed — verify AC bats tests are green
+>        if bats tests/ac/issue-<ISSUE>.bats 2>/dev/null; then
+>          break  # success
+>        fi
+>        # AC tests still failing — treat as lint failure, roll back commit
+>        git reset HEAD~1
+>      fi
+>      # Capture lint directives for next attempt
+>      findings=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" --pre-commit --staged --directives 2>/dev/null || true)
+>      if [ -n "$findings" ]; then
+>        directive_context="${directive_context}
+>
+> ## Retry attempt ${attempt} findings
+> ${findings}
+>
+> Fix these BEFORE the next code generation."
+>      fi
+>      attempt=$((attempt + 1))
+>    done
+>    if [ "$attempt" -gt "$MAX_IMPL_RETRIES" ]; then
+>      gh issue comment <ISSUE> --body "Implementer hit max retries; manual intervention needed"
+>      gh issue edit <ISSUE> --remove-label "auto-implement-active" 2>/dev/null || true
+>      exit 1
+>    fi
+>    ```
+>    <!-- RETRY-LOOP:end -->
 > 5. Push: git push -u origin <BRANCH>
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -497,7 +497,40 @@ issues unblock the queue before continuing with normal feature work.
 >    fi
 >    ```
 >    Exit 0: proceed to merge. Exit 1: block PR (post comment + labels; do NOT merge; treat as review finding). Exit 2: halt entire batch (comment on issue, label `in-progress-by-bot` → `auto-implement`, exit monitor).
-> 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
+> 4. <!-- RETRY-LOOP:begin --> Adaptive commit loop (MAX_IMPL_RETRIES):
+>    ```bash
+>    attempt=1
+>    MAX_IMPL_RETRIES="${MAX_IMPL_RETRIES:-5}"
+>    directive_context=""
+>    while [ "$attempt" -le "$MAX_IMPL_RETRIES" ]; do
+>      # Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
+>      if git commit -m "<conventional-commit-message>"; then
+>        # pre-commit hook passed — verify AC bats tests are green
+>        if bats tests/ac/issue-<ISSUE>.bats 2>/dev/null; then
+>          break  # success
+>        fi
+>        # AC tests still failing — treat as lint failure, roll back commit
+>        git reset HEAD~1
+>      fi
+>      # Capture lint directives for next attempt
+>      findings=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-implementation.sh" --pre-commit --staged --directives 2>/dev/null || true)
+>      if [ -n "$findings" ]; then
+>        directive_context="${directive_context}
+>
+> ## Retry attempt ${attempt} findings
+> ${findings}
+>
+> Fix these BEFORE the next code generation."
+>      fi
+>      attempt=$((attempt + 1))
+>    done
+>    if [ "$attempt" -gt "$MAX_IMPL_RETRIES" ]; then
+>      gh issue comment <ISSUE> --body "Implementer hit max retries; manual intervention needed"
+>      gh issue edit <ISSUE> --remove-label "auto-implement-active" 2>/dev/null || true
+>      exit 1
+>    fi
+>    ```
+>    <!-- RETRY-LOOP:end -->
 > 5. Push: git push -u origin <BRANCH>
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step

--- a/tests/autospec-run-impl-retry.bats
+++ b/tests/autospec-run-impl-retry.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+# tests/autospec-run-impl-retry.bats — TDD for Phase 4 adaptive-retry loop (issue #392)
+#
+# These tests exercise the RETRY-LOOP block in SKILL.md by driving a stub
+# implementer script that simulates bad/good commit outcomes.
+
+SKILL_MD="${BATS_TEST_DIRNAME}/../skills/autospec-run/SKILL.md"
+CODEX_MD="${BATS_TEST_DIRNAME}/../skills/autospec-run/codex/prompt.md"
+OPENCODE_MD="${BATS_TEST_DIRNAME}/../skills/autospec-run/opencode/agent.md"
+LINT_SCRIPT="${BATS_TEST_DIRNAME}/../scripts/lint-implementation.sh"
+
+# ── structural presence tests ─────────────────────────────────────────────────
+
+@test "SKILL.md Phase 4 contains RETRY-LOOP:begin marker" {
+  grep -q 'RETRY-LOOP:begin' "$SKILL_MD"
+}
+
+@test "SKILL.md Phase 4 contains MAX_IMPL_RETRIES variable" {
+  grep -q 'MAX_IMPL_RETRIES' "$SKILL_MD"
+}
+
+@test "SKILL.md Phase 4 contains directive_context variable" {
+  grep -q 'directive_context' "$SKILL_MD"
+}
+
+@test "SKILL.md Phase 4 contains Retry attempt findings block" {
+  grep -q 'Retry attempt' "$SKILL_MD"
+}
+
+@test "SKILL.md Phase 4 contains manual-intervention comment on exhaustion" {
+  grep -q 'Implementer hit max retries; manual intervention needed' "$SKILL_MD"
+}
+
+@test "SKILL.md Phase 4 contains label release on exhaustion" {
+  grep -q 'auto-implement-active' "$SKILL_MD"
+}
+
+@test "codex/prompt.md contains RETRY-LOOP:begin marker" {
+  grep -q 'RETRY-LOOP:begin' "$CODEX_MD"
+}
+
+@test "codex/prompt.md contains MAX_IMPL_RETRIES variable" {
+  grep -q 'MAX_IMPL_RETRIES' "$CODEX_MD"
+}
+
+@test "opencode/agent.md contains RETRY-LOOP:begin marker" {
+  grep -q 'RETRY-LOOP:begin' "$OPENCODE_MD"
+}
+
+@test "opencode/agent.md contains MAX_IMPL_RETRIES variable" {
+  grep -q 'MAX_IMPL_RETRIES' "$OPENCODE_MD"
+}
+
+# ── behavioral tests via stub scripts ────────────────────────────────────────
+
+setup() {
+  WORK_DIR=$(mktemp -d /tmp/impl-retry-test-XXXXXX)
+  export WORK_DIR
+  export AUTOSPEC_SCRIPTS_DIR="$WORK_DIR/scripts"
+  mkdir -p "$AUTOSPEC_SCRIPTS_DIR"
+  # Stub lint-implementation.sh --directives
+  cat > "$AUTOSPEC_SCRIPTS_DIR/lint-implementation.sh" <<'STUB'
+#!/usr/bin/env bash
+# Stub: emit a deterministic directive line
+echo "Fix COMPLEXITY: function too long"
+exit 0
+STUB
+  chmod +x "$AUTOSPEC_SCRIPTS_DIR/lint-implementation.sh"
+}
+
+teardown() {
+  rm -rf "$WORK_DIR"
+}
+
+# Helper: build and run a retry-loop harness script
+_run_retry_harness() {
+  local max_retries="$1"
+  local good_on_attempt="$2"   # commit succeeds on this attempt number
+  local harness="$WORK_DIR/harness.sh"
+  cat > "$harness" <<HARNESS
+#!/usr/bin/env bash
+set -eu
+attempt=1
+MAX_IMPL_RETRIES="\${MAX_IMPL_RETRIES:-${max_retries}}"
+directive_context=""
+ATTEMPTS_LOG="$WORK_DIR/attempts.log"
+echo "" > "\$ATTEMPTS_LOG"
+
+while [ "\$attempt" -le "\$MAX_IMPL_RETRIES" ]; do
+  echo "\$attempt" >> "\$ATTEMPTS_LOG"
+  if [ "\$attempt" -ge "${good_on_attempt}" ]; then
+    # Simulate successful commit + green bats on this attempt
+    break
+  fi
+  # Simulate failed commit — capture directives
+  findings=\$(bash "\${AUTOSPEC_SCRIPTS_DIR}/lint-implementation.sh" --pre-commit --staged --directives 2>/dev/null || true)
+  if [ -n "\$findings" ]; then
+    directive_context="\${directive_context}
+
+## Retry attempt \${attempt} findings
+\${findings}
+
+Fix these BEFORE the next code generation."
+  fi
+  attempt=\$((attempt + 1))
+done
+
+if [ "\$attempt" -gt "\$MAX_IMPL_RETRIES" ]; then
+  echo "EXHAUSTED" > "$WORK_DIR/outcome.txt"
+  echo "Implementer hit max retries; manual intervention needed" >> "$WORK_DIR/outcome.txt"
+  exit 1
+fi
+
+echo "SUCCESS:attempt=\$attempt" > "$WORK_DIR/outcome.txt"
+printf '%s' "\$directive_context" > "$WORK_DIR/directive_context.txt"
+exit 0
+HARNESS
+  chmod +x "$harness"
+  bash "$harness"
+}
+
+@test "retry loop succeeds on attempt 3 when good_on=3" {
+  run _run_retry_harness 5 3
+  [ "$status" -eq 0 ]
+  grep -q "SUCCESS:attempt=3" "$WORK_DIR/outcome.txt"
+  # Verify exactly 3 attempt entries were logged
+  count=$(grep -c '[0-9]' "$WORK_DIR/attempts.log")
+  [ "$count" -eq 3 ]
+}
+
+@test "directive_context accumulates findings across attempts" {
+  _run_retry_harness 5 3
+  # directive_context should contain findings from attempts 1 and 2
+  grep -q "Retry attempt 1 findings" "$WORK_DIR/directive_context.txt"
+  grep -q "Retry attempt 2 findings" "$WORK_DIR/directive_context.txt"
+  grep -q "Fix COMPLEXITY" "$WORK_DIR/directive_context.txt"
+}
+
+@test "retry loop fires exhaustion branch after MAX_IMPL_RETRIES=5 bad attempts" {
+  run _run_retry_harness 5 99
+  [ "$status" -eq 1 ]
+  grep -q "EXHAUSTED" "$WORK_DIR/outcome.txt"
+  grep -q "Implementer hit max retries; manual intervention needed" "$WORK_DIR/outcome.txt"
+}
+
+@test "MAX_IMPL_RETRIES env override is respected" {
+  MAX_IMPL_RETRIES=2 run _run_retry_harness 2 99
+  [ "$status" -eq 1 ]
+  grep -q "EXHAUSTED" "$WORK_DIR/outcome.txt"
+}


### PR DESCRIPTION
## Summary

- Wraps Phase 4 implementer commit step in a `MAX_IMPL_RETRIES=5` while-loop that captures `lint-implementation.sh --pre-commit --staged --directives` findings into a cumulative `directive_context` and re-prompts on each failure
- Exhaustion branch posts `Implementer hit max retries; manual intervention needed` comment and releases the `auto-implement-active` lock label
- All three trio files (SKILL.md, codex/prompt.md, opencode/agent.md) updated in lockstep with `RETRY-LOOP:begin/end` markers
- Adds `tests/autospec-run-impl-retry.bats` (14 tests: structural presence + behavioral via stub harness)
- Adds `check_phase4_adaptive_retry` gate to `scripts/validate.sh`

Closes #392

## Test plan

- [ ] `bats tests/autospec-run-impl-retry.bats` — all 14 tests pass
- [ ] `bash scripts/validate.sh` — all checks pass including new `phase4 adaptive-retry loop` gate
- [ ] Verify RETRY-LOOP block present in all 3 trio files
- [ ] Verify exhaustion path emits manual-intervention comment + label release