### PR TITLE
feat(autospec-run): bundle-static-context.sh + implementer prompt cache structure

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -449,6 +449,25 @@ issues unblock the queue before continuing with normal feature work.
 >
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
 >
+> **Prompt construction (cache-prefix + dynamic suffix):**
+> Before dispatch, the orchestrator builds the subagent prompt in two parts:
+>
+> 1. **Static cached prefix** — call `bundle-static-context.sh` to emit the static blob:
+>    ```bash
+>    static_prefix=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-static-context.sh" \
+>      --role implementer \
+>      --issue-labels "<ISSUE_LABELS>")
+>    ```
+>    The blob is framed by `<!-- CACHE BOUNDARY -->` markers and contains:
+>    SKILL.md + AGENTS.md + RULE_ID table + tag-filtered saved-memory + lockstep rules + implementer scaffolding.
+>    Pass this blob as the first content block of the subagent prompt with `cache_control: { type: "ephemeral" }`
+>    so Anthropic's prompt cache can reuse it across dispatches in the same monitor session (5-min TTL).
+>
+> 2. **Dynamic uncached suffix** — append after the cached prefix:
+>    the issue body, per-iteration findings (if retry > 1), branch name, and "begin coding now".
+>
+> The combined prompt sent to the subagent is:
+>
 > ```
 > **Model tier:** `TIER_B` (implementation work) — cheaper model with medium thinking; resolved at startup. Silently fall back to `TIER_A` if unavailable.
 >
@@ -468,11 +487,11 @@ issues unblock the queue before continuing with normal feature work.
 >
 > ## Project rules you MUST honor
 >
-> <verbatim concatenation of relevant feedback_*.md bodies — injected by assemble-impl-prompt.sh before dispatch>
+> <verbatim concatenation of relevant feedback_*.md bodies — injected by bundle-static-context.sh --role implementer before dispatch>
 >
 > ## RULE_IDs (from AGENTS.md ## Implementation-quality contract)
 >
-> <verbatim RULE_ID table from AGENTS.md — injected by assemble-impl-prompt.sh>
+> <verbatim RULE_ID table from AGENTS.md — injected by bundle-static-context.sh --role implementer>
 >
 > ## Acceptance criteria as constraints
 >

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -444,6 +444,25 @@ issues unblock the queue before continuing with normal feature work.
 >
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
 >
+> **Prompt construction (cache-prefix + dynamic suffix):**
+> Before dispatch, the orchestrator builds the subagent prompt in two parts:
+>
+> 1. **Static cached prefix** — call `bundle-static-context.sh` to emit the static blob:
+>    ```bash
+>    static_prefix=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-static-context.sh" \
+>      --role implementer \
+>      --issue-labels "<ISSUE_LABELS>")
+>    ```
+>    The blob is framed by `<!-- CACHE BOUNDARY -->` markers and contains:
+>    SKILL.md + AGENTS.md + RULE_ID table + tag-filtered saved-memory + lockstep rules + implementer scaffolding.
+>    Pass this blob as the first content block of the subagent prompt with `cache_control: { type: "ephemeral" }`
+>    so Anthropic's prompt cache can reuse it across dispatches in the same monitor session (5-min TTL).
+>
+> 2. **Dynamic uncached suffix** — append after the cached prefix:
+>    the issue body, per-iteration findings (if retry > 1), branch name, and "begin coding now".
+>
+> The combined prompt sent to the subagent is:
+>
 > ```
 > **Model tier:** `TIER_B` (implementation work) — cheaper model with medium thinking; resolved at startup. Silently fall back to `TIER_A` if unavailable.
 >
@@ -463,11 +482,11 @@ issues unblock the queue before continuing with normal feature work.
 >
 > ## Project rules you MUST honor
 >
-> <verbatim concatenation of relevant feedback_*.md bodies — injected by assemble-impl-prompt.sh before dispatch>
+> <verbatim concatenation of relevant feedback_*.md bodies — injected by bundle-static-context.sh --role implementer before dispatch>
 >
 > ## RULE_IDs (from AGENTS.md ## Implementation-quality contract)
 >
-> <verbatim RULE_ID table from AGENTS.md — injected by assemble-impl-prompt.sh>
+> <verbatim RULE_ID table from AGENTS.md — injected by bundle-static-context.sh --role implementer>
 >
 > ## Acceptance criteria as constraints
 >

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -448,6 +448,25 @@ issues unblock the queue before continuing with normal feature work.
 >
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
 >
+> **Prompt construction (cache-prefix + dynamic suffix):**
+> Before dispatch, the orchestrator builds the subagent prompt in two parts:
+>
+> 1. **Static cached prefix** — call `bundle-static-context.sh` to emit the static blob:
+>    ```bash
+>    static_prefix=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-static-context.sh" \
+>      --role implementer \
+>      --issue-labels "<ISSUE_LABELS>")
+>    ```
+>    The blob is framed by `<!-- CACHE BOUNDARY -->` markers and contains:
+>    SKILL.md + AGENTS.md + RULE_ID table + tag-filtered saved-memory + lockstep rules + implementer scaffolding.
+>    Pass this blob as the first content block of the subagent prompt with `cache_control: { type: "ephemeral" }`
+>    so Anthropic's prompt cache can reuse it across dispatches in the same monitor session (5-min TTL).
+>
+> 2. **Dynamic uncached suffix** — append after the cached prefix:
+>    the issue body, per-iteration findings (if retry > 1), branch name, and "begin coding now".
+>
+> The combined prompt sent to the subagent is:
+>
 > ```
 > **Model tier:** `TIER_B` (implementation work) — cheaper model with medium thinking; resolved at startup. Silently fall back to `TIER_A` if unavailable.
 >
@@ -467,11 +486,11 @@ issues unblock the queue before continuing with normal feature work.
 >
 > ## Project rules you MUST honor
 >
-> <verbatim concatenation of relevant feedback_*.md bodies — injected by assemble-impl-prompt.sh before dispatch>
+> <verbatim concatenation of relevant feedback_*.md bodies — injected by bundle-static-context.sh --role implementer before dispatch>
 >
 > ## RULE_IDs (from AGENTS.md ## Implementation-quality contract)
 >
-> <verbatim RULE_ID table from AGENTS.md — injected by assemble-impl-prompt.sh>
+> <verbatim RULE_ID table from AGENTS.md — injected by bundle-static-context.sh --role implementer>
 >
 > ## Acceptance criteria as constraints
 >

--- a/skills/autospec-shared/scripts/bundle-static-context.sh
+++ b/skills/autospec-shared/scripts/bundle-static-context.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# skills/autospec-shared/scripts/bundle-static-context.sh — Emit static prompt prefix for LLM dispatch.
+#
+# Usage:
+#   bundle-static-context.sh --role implementer|reviewer|decomposer|classifier
+#                            [--issue-labels "label1,label2,..."]
+#
+# Output (stdout): static blob framed by <!-- CACHE BOUNDARY --> markers.
+# Composition order (implementer role):
+#   1. SKILL.md (autospec-run, verbatim)
+#   2. AGENTS.md (verbatim)
+#   3. RULE_ID table (extracted from AGENTS.md)
+#   4. Tag-filtered saved-memory files
+#   5. Lockstep paragraph
+#   6. Role-specific implementer scaffolding
+#
+# Environment overrides (for testing):
+#   AUTOSPEC_REPO_ROOT    — repo root (default: dirname of this script / 3 levels up)
+#   AUTOSPEC_MEMORY_DIR   — path to memory files
+#   AUTOSPEC_SCRIPTS_DIR  — path to scripts dir (for memory-tags.yml)
+#
+# Idempotent + deterministic: same inputs → byte-identical output.
+#
+# Exit codes:
+#   0  Success
+#   1  Argument/file error or unknown role
+#
+# Compatible with bash 3.2+
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Resolve repo root: scripts live at skills/autospec-shared/scripts/ — 3 levels up
+REPO_ROOT="${AUTOSPEC_REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+
+HELP_TEXT='Usage:
+  bundle-static-context.sh --role implementer|reviewer|decomposer|classifier
+                            [--issue-labels "label1,label2,..."]
+  bundle-static-context.sh --help
+
+Emit static LLM prompt prefix framed by <!-- CACHE BOUNDARY --> markers.
+Composition: SKILL.md + AGENTS.md + RULE_ID table + tag-filtered memory + lockstep + role scaffolding.'
+
+ROLE=""
+ISSUE_LABELS=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --help|-h)
+      printf '%s\n' "$HELP_TEXT"
+      exit 0
+      ;;
+    --role)
+      if [ $# -lt 2 ]; then printf 'bundle-static-context.sh: --role requires an argument\n' >&2; exit 1; fi
+      ROLE="$2"
+      shift 2
+      ;;
+    --issue-labels)
+      if [ $# -lt 2 ]; then printf 'bundle-static-context.sh: --issue-labels requires an argument\n' >&2; exit 1; fi
+      ISSUE_LABELS="$2"
+      shift 2
+      ;;
+    -*)
+      printf 'bundle-static-context.sh: unknown option: %s\n' "$1" >&2
+      exit 1
+      ;;
+    *)
+      printf 'bundle-static-context.sh: unexpected argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$ROLE" ]; then
+  printf '%s\n' "$HELP_TEXT" >&2
+  exit 1
+fi
+
+# Validate role
+case "$ROLE" in
+  implementer|reviewer|decomposer|classifier) ;;
+  *)
+    printf 'bundle-static-context.sh: unknown role: %s (must be implementer|reviewer|decomposer|classifier)\n' "$ROLE" >&2
+    exit 1
+    ;;
+esac
+
+# ── resolve paths ─────────────────────────────────────────────────────────────
+
+WHOAMI=$(whoami 2>/dev/null || echo "$(id -un)")
+MEMORY_DIR="${AUTOSPEC_MEMORY_DIR:-$HOME/.claude/projects/-Users-${WHOAMI}-IdeaProjects-autospec/memory}"
+SCRIPTS_DIR="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}"
+# Allow explicit override for testing; fall back to scripts dir
+MANIFEST="${AUTOSPEC_MANIFEST:-$SCRIPTS_DIR/memory-tags.yml}"
+AGENTS_MD="$REPO_ROOT/AGENTS.md"
+
+# Role-to-skill mapping
+case "$ROLE" in
+  implementer) SKILL_MD="$REPO_ROOT/skills/autospec-run/SKILL.md" ;;
+  reviewer)    SKILL_MD="$REPO_ROOT/skills/autospec-run/SKILL.md" ;;
+  decomposer)  SKILL_MD="$REPO_ROOT/skills/autospec-define/SKILL.md" ;;
+  classifier)  SKILL_MD="$REPO_ROOT/skills/autospec-classify/SKILL.md" ;;
+esac
+
+# Validate required files
+if [ ! -f "$AGENTS_MD" ]; then
+  printf 'bundle-static-context.sh: AGENTS.md not found: %s\n' "$AGENTS_MD" >&2
+  exit 1
+fi
+if [ ! -f "$SKILL_MD" ]; then
+  printf 'bundle-static-context.sh: SKILL.md not found for role %s: %s\n' "$ROLE" "$SKILL_MD" >&2
+  exit 1
+fi
+
+# ── tag-filtered memory selection ────────────────────────────────────────────
+
+# Normalize issue labels to space-separated lowercase tokens.
+# Also split each label on ':' to generate sub-tokens, so that
+# "skill:autospec-run" matches both "skill" and "autospec-run" tags.
+_raw_tokens=$(printf '%s' "$ISSUE_LABELS" | tr ',' ' ' | tr '[:upper:]' '[:lower:]')
+_colon_tokens=$(printf '%s' "$_raw_tokens" | tr ':' ' ')
+issue_tokens=" ${_raw_tokens} ${_colon_tokens} "
+
+# Build list of matched memory file paths from manifest
+matched_memory=""
+if [ -f "$MANIFEST" ] && [ -d "$MEMORY_DIR" ]; then
+  current_file=""
+  while IFS= read -r line; do
+    # Detect filename line: feedback_foo.md:
+    if printf '%s' "$line" | grep -qE '^feedback_[^:]+\.md:'; then
+      current_file=$(printf '%s' "$line" | sed 's/:.*//')
+      continue
+    fi
+    # Detect tags line:   tags: [a, b, c]
+    if printf '%s' "$line" | grep -qE '^[[:space:]]+tags:' && [ -n "$current_file" ]; then
+      tags_raw=$(printf '%s' "$line" | sed 's/.*\[//; s/\].*//')
+      current_path="$MEMORY_DIR/$current_file"
+      match=0
+      for tag in $(printf '%s' "$tags_raw" | tr ',' '\n' | tr -d ' []"'"'" | tr '[:upper:]' '[:lower:]'); do
+        if printf '%s' "$issue_tokens" | grep -qw "$tag"; then
+          match=1
+          break
+        fi
+      done
+      if [ "$match" -eq 1 ] && [ -f "$current_path" ]; then
+        matched_memory="${matched_memory}${current_path}
+"
+      fi
+      current_file=""
+    fi
+  done < "$MANIFEST"
+fi
+
+# ── emit output ───────────────────────────────────────────────────────────────
+
+printf '<!-- CACHE BOUNDARY -->\n'
+
+# 1. SKILL.md verbatim
+printf '## SKILL.md (%s role)\n\n' "$ROLE"
+cat "$SKILL_MD"
+printf '\n'
+
+# 2. AGENTS.md verbatim
+printf '## AGENTS.md\n\n'
+cat "$AGENTS_MD"
+printf '\n'
+
+# 3. RULE_ID table extracted from AGENTS.md
+printf '## RULE_ID table\n\n'
+awk '
+  /^### RULE_ID table/ { in_table=1; next }
+  /^### / && in_table { exit }
+  /^## / && in_table { exit }
+  in_table { print }
+' "$AGENTS_MD"
+printf '\n'
+
+# 4. Tag-filtered saved-memory files
+printf '## Project rules (saved memory)\n\n'
+if [ -z "$matched_memory" ]; then
+  printf '(No memory files matched the issue labels.)\n\n'
+else
+  printf '%s' "$matched_memory" | while IFS= read -r mem_file; do
+    [ -n "$mem_file" ] || continue
+    [ -f "$mem_file" ] || continue
+    # Strip YAML frontmatter (---...---) if present
+    awk '
+      BEGIN { in_front=0; done_front=0 }
+      /^---$/ && !done_front && NR==1 { in_front=1; next }
+      /^---$/ && in_front { in_front=0; done_front=1; next }
+      !in_front { print }
+    ' "$mem_file"
+    printf '\n'
+  done
+fi
+
+# 5. Lockstep paragraph
+printf '## Lockstep rules\n\n'
+printf 'All SKILL.md edits must be byte-identically mirrored to codex/prompt.md and opencode/agent.md.\n'
+printf 'Run scripts/validate.sh to confirm lockstep compliance before every push.\n'
+printf 'Renaming any prose section heading in SKILL.md requires updating scripts/validate.sh named-content checks.\n'
+printf '\n'
+
+# 6. Role-specific scaffolding
+case "$ROLE" in
+  implementer)
+    printf '## Implementer scaffolding\n\n'
+    printf 'You are implementing a GitHub issue in a git worktree off origin/main.\n'
+    printf 'TDD discipline: write failing tests first, then implement, then make tests pass.\n'
+    printf 'Use conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.\n'
+    printf 'Keep heartbeat updated at each major step: claimed → worktree_ready → tests_started → tests_passed → pr_created → reviewed → merged.\n'
+    printf '\n'
+    ;;
+  reviewer)
+    printf '## Reviewer scaffolding\n\n'
+    printf 'You are performing fused guardian + LGTM review of a GitHub PR.\n'
+    printf 'Part 1 — Guardian: apply RULE_ID table to the diff. Collect findings as RULE_ID:<path>:<line>: <desc>.\n'
+    printf 'Part 2 — LGTM: check correctness, edge cases, missing tests, AGENTS.md compliance.\n'
+    printf 'Verdict: if zero blocking findings → return only the token LGTM. Otherwise return numbered findings list.\n'
+    printf '\n'
+    ;;
+  decomposer)
+    printf '## Decomposer scaffolding\n\n'
+    printf 'You are decomposing a feature spec into GitHub issues for autonomous implementation.\n'
+    printf 'Each issue must be self-contained, sized for 32B-class local LLMs (48 GB Macs), with one primary smoke test.\n'
+    printf '\n'
+    ;;
+  classifier)
+    printf '## Classifier scaffolding\n\n'
+    printf 'You are classifying GitHub issues with model-fit labels (ctx:* and reasoning:*).\n'
+    printf 'Ordinals: ctx: 32k < 64k < 120k; reasoning: shallow < medium < deep.\n'
+    printf '\n'
+    ;;
+esac
+
+printf '<!-- CACHE BOUNDARY -->\n'

--- a/tests/bundle-static-context.bats
+++ b/tests/bundle-static-context.bats
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+# tests/bundle-static-context.bats — TDD for skills/autospec-shared/scripts/bundle-static-context.sh (issue #402)
+
+SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/bundle-static-context.sh"
+FIXTURES_DIR="${BATS_TEST_DIRNAME}/fixtures/bundle-static-context"
+
+setup() {
+  mkdir -p "$FIXTURES_DIR/memory"
+  mkdir -p "$FIXTURES_DIR/skills/autospec-run"
+  mkdir -p "$FIXTURES_DIR/skills/autospec-shared/scripts"
+
+  # Fixture SKILL.md for implementer role
+  cat > "$FIXTURES_DIR/skills/autospec-run/SKILL.md" <<'EOF'
+---
+name: autospec-run
+description: test fixture
+---
+
+# autospec-run workflow
+
+This is the SKILL.md content for testing.
+EOF
+
+  # Fixture AGENTS.md with RULE_ID table
+  cat > "$FIXTURES_DIR/AGENTS.md" <<'EOF'
+# AGENTS.md
+
+## Implementation-quality contract
+
+### RULE_ID table
+
+| RULE_ID | Detector | Tier | Threshold / regex |
+|---------|----------|------|-------------------|
+| `OUT_OF_SCOPE` | det | path-list compare | files touched not listed |
+| `MISSING_TEST` | det | path-prefix scan | required test absent |
+
+### Other section
+EOF
+
+  # Fixture memory files
+  cat > "$FIXTURES_DIR/memory/feedback_autospec_run_prefs.md" <<'EOF'
+---
+tags: [autospec-run, monitor, orchestrator]
+---
+Always use ascending issue order in the monitor queue.
+EOF
+
+  cat > "$FIXTURES_DIR/memory/feedback_bash_style.md" <<'EOF'
+---
+tags: [bash, scripting]
+---
+Use set -eu at the top of every bash script.
+EOF
+
+  # Fixture memory-tags.yml
+  cat > "$FIXTURES_DIR/memory-tags.yml" <<'EOF'
+feedback_autospec_run_prefs.md:
+  tags: [autospec-run, monitor, orchestrator]
+feedback_bash_style.md:
+  tags: [bash, scripting]
+EOF
+}
+
+teardown() {
+  rm -rf "$FIXTURES_DIR"
+}
+
+@test "bundle-static-context.sh is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "bundle-static-context.sh --help exits 0" {
+  run "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+}
+
+@test "bundle-static-context.sh --role implementer emits opening CACHE BOUNDARY marker" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | head -1 | grep -q "CACHE BOUNDARY"
+}
+
+@test "bundle-static-context.sh --role implementer emits closing CACHE BOUNDARY marker" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | tail -1 | grep -q "CACHE BOUNDARY"
+}
+
+@test "bundle-static-context.sh --role implementer output is idempotent" {
+  local out1 out2
+  out1=$(env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run")
+  out2=$(env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run")
+  [ "$out1" = "$out2" ]
+}
+
+@test "bundle-static-context.sh --role implementer includes AGENTS.md content" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q "Implementation-quality contract"
+}
+
+@test "bundle-static-context.sh --role implementer includes RULE_ID table" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q "OUT_OF_SCOPE"
+}
+
+@test "bundle-static-context.sh --role implementer includes matching memory file" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q "ascending issue order"
+}
+
+@test "bundle-static-context.sh --role implementer excludes non-matching memory file" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run"
+  [ "$status" -eq 0 ]
+  # bash_style only matches "bash" or "scripting" — not "skill:autospec-run"
+  ! printf '%s\n' "$output" | grep -q "set -eu at the top"
+}
+
+@test "bundle-static-context.sh exits 1 with unknown --role" {
+  run "$SCRIPT" --role unknown-role
+  [ "$status" -ne 0 ]
+}
+
+@test "SKILL.md Phase 4 implementer section references bundle-static-context.sh" {
+  skill_md="${BATS_TEST_DIRNAME}/../skills/autospec-run/SKILL.md"
+  [ -f "$skill_md" ]
+  grep -q "bundle-static-context.sh" "$skill_md"
+}


### PR DESCRIPTION
Closes #402

## Summary

Add `skills/autospec-shared/scripts/bundle-static-context.sh` — a deterministic static-context bundler that emits a prompt prefix framed by `<!-- CACHE BOUNDARY -->` markers. The bundler composes SKILL.md + AGENTS.md + RULE_ID table + tag-filtered saved-memory + lockstep rules + role scaffolding into a single blob suitable for `cache_control: { type: "ephemeral" }` annotation.

Amend the Phase 4 implementer dispatch section of `skills/autospec-run/SKILL.md` (+ lockstep mirrors `codex/prompt.md` and `opencode/agent.md`) to document the two-part prompt construction: static cached prefix via `bundle-static-context.sh --role implementer` + dynamic uncached suffix (issue body + per-iteration findings).

Add `tests/bundle-static-context.bats` with 11 tests covering: `<!-- CACHE BOUNDARY -->` markers, AGENTS.md inclusion, RULE_ID table, tag-filtered memory matching/exclusion, idempotency, unknown-role exit, and SKILL.md reference check. All 11 pass; `scripts/validate.sh` exits 0.

## Test plan

- [x] `bats tests/bundle-static-context.bats` — 11/11 pass
- [x] `bash scripts/validate.sh` — all checks pass (lockstep byte-identical)
- [x] `bats tests/` — all existing tests pass (pre-existing test 61 failure unrelated to this PR)
- [x] Smoke: `bash skills/autospec-shared/scripts/bundle-static-context.sh --role implementer --issue-labels "skill:autospec-run" | head -1 | grep -q "CACHE BOUNDARY"`