### PR TITLE
feat(autospec-run): telemetry capture + cache-hit summary (Fix #3)

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -560,6 +560,14 @@ issues unblock the queue before continuing with normal feature work.
 >    fi
 >    ```
 > 6. PR: gh pr create --base main --head <BRANCH> --title "<TITLE>" --body "Closes #<ISSUE>\n\n<summary>". Capture PR.
+>    After the LLM subagent returns, record telemetry (tokens JSON written by the harness to `.autospec/tokens-<ISSUE>.json` if present):
+>    ```bash
+>    if [ -f ".autospec/tokens-<ISSUE>.json" ]; then
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
+>        --dispatch-id "<DISPATCH_ID>" --role implementer --issue "<ISSUE>" \
+>        --tokens-json ".autospec/tokens-<ISSUE>.json"
+>    fi
+>    ```
 > 7. Inner loop (max 3 iterations):
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
@@ -602,6 +610,11 @@ issues unblock the queue before continuing with normal feature work.
 >        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
 >        run **Operator/full verification**
 >        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/ci-wait.sh" <PR>  # fire-and-forget sentinel
+>        if [ -f ".autospec/tokens-<ISSUE>-reviewer.json" ]; then
+>          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
+>            --dispatch-id "<DISPATCH_ID>-reviewer" --role reviewer --issue "<ISSUE>" \
+>            --tokens-json ".autospec/tokens-<ISSUE>-reviewer.json"
+>        fi
 >        # monitor exits to parking state HERE — orchestrator relaunches when ~/.autospec/ci-state/<PR>.signal settles
 >        # On relaunch: run ci-wait-poll.sh <PR>; break SUCCESS if exit 0 (pass)
 >        break SUCCESS if required checks pass.

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -555,6 +555,14 @@ issues unblock the queue before continuing with normal feature work.
 >    fi
 >    ```
 > 6. PR: gh pr create --base main --head <BRANCH> --title "<TITLE>" --body "Closes #<ISSUE>\n\n<summary>". Capture PR.
+>    After the LLM subagent returns, record telemetry (tokens JSON written by the harness to `.autospec/tokens-<ISSUE>.json` if present):
+>    ```bash
+>    if [ -f ".autospec/tokens-<ISSUE>.json" ]; then
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
+>        --dispatch-id "<DISPATCH_ID>" --role implementer --issue "<ISSUE>" \
+>        --tokens-json ".autospec/tokens-<ISSUE>.json"
+>    fi
+>    ```
 > 7. Inner loop (max 3 iterations):
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
@@ -597,6 +605,11 @@ issues unblock the queue before continuing with normal feature work.
 >        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
 >        run **Operator/full verification**
 >        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/ci-wait.sh" <PR>  # fire-and-forget sentinel
+>        if [ -f ".autospec/tokens-<ISSUE>-reviewer.json" ]; then
+>          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
+>            --dispatch-id "<DISPATCH_ID>-reviewer" --role reviewer --issue "<ISSUE>" \
+>            --tokens-json ".autospec/tokens-<ISSUE>-reviewer.json"
+>        fi
 >        # monitor exits to parking state HERE — orchestrator relaunches when ~/.autospec/ci-state/<PR>.signal settles
 >        # On relaunch: run ci-wait-poll.sh <PR>; break SUCCESS if exit 0 (pass)
 >        break SUCCESS if required checks pass.

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -559,6 +559,14 @@ issues unblock the queue before continuing with normal feature work.
 >    fi
 >    ```
 > 6. PR: gh pr create --base main --head <BRANCH> --title "<TITLE>" --body "Closes #<ISSUE>\n\n<summary>". Capture PR.
+>    After the LLM subagent returns, record telemetry (tokens JSON written by the harness to `.autospec/tokens-<ISSUE>.json` if present):
+>    ```bash
+>    if [ -f ".autospec/tokens-<ISSUE>.json" ]; then
+>      bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
+>        --dispatch-id "<DISPATCH_ID>" --role implementer --issue "<ISSUE>" \
+>        --tokens-json ".autospec/tokens-<ISSUE>.json"
+>    fi
+>    ```
 > 7. Inner loop (max 3 iterations):
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
@@ -601,6 +609,11 @@ issues unblock the queue before continuing with normal feature work.
 >        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
 >        run **Operator/full verification**
 >        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/ci-wait.sh" <PR>  # fire-and-forget sentinel
+>        if [ -f ".autospec/tokens-<ISSUE>-reviewer.json" ]; then
+>          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
+>            --dispatch-id "<DISPATCH_ID>-reviewer" --role reviewer --issue "<ISSUE>" \
+>            --tokens-json ".autospec/tokens-<ISSUE>-reviewer.json"
+>        fi
 >        # monitor exits to parking state HERE — orchestrator relaunches when ~/.autospec/ci-state/<PR>.signal settles
 >        # On relaunch: run ci-wait-poll.sh <PR>; break SUCCESS if exit 0 (pass)
 >        break SUCCESS if required checks pass.

--- a/skills/autospec-shared/scripts/record-telemetry.sh
+++ b/skills/autospec-shared/scripts/record-telemetry.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# skills/autospec-shared/scripts/record-telemetry.sh — Append one JSONL telemetry row per dispatch.
+#
+# Usage:
+#   record-telemetry.sh --dispatch-id <id> --role <role> --issue <n> --tokens-json <file>
+#
+# Reads token counts from <file> (JSON with keys: input_tokens, output_tokens,
+# cache_creation_input_tokens, cache_read_input_tokens) and appends one line to
+# $AUTOSPEC_TELEMETRY_FILE (default: ~/.autospec/telemetry.jsonl).
+# Creates the parent directory if missing.
+#
+# Environment overrides (for testing):
+#   AUTOSPEC_TELEMETRY_FILE — path to telemetry JSONL (default: ~/.autospec/telemetry.jsonl)
+#
+# Exit codes:
+#   0  Success
+#   1  Argument/file error
+#
+# Compatible with bash 3.2+
+
+set -eu
+
+DISPATCH_ID=""
+ROLE=""
+ISSUE=""
+TOKENS_JSON=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dispatch-id)
+      if [ $# -lt 2 ]; then printf 'record-telemetry.sh: --dispatch-id requires an argument\n' >&2; exit 1; fi
+      DISPATCH_ID="$2"; shift 2 ;;
+    --role)
+      if [ $# -lt 2 ]; then printf 'record-telemetry.sh: --role requires an argument\n' >&2; exit 1; fi
+      ROLE="$2"; shift 2 ;;
+    --issue)
+      if [ $# -lt 2 ]; then printf 'record-telemetry.sh: --issue requires an argument\n' >&2; exit 1; fi
+      ISSUE="$2"; shift 2 ;;
+    --tokens-json)
+      if [ $# -lt 2 ]; then printf 'record-telemetry.sh: --tokens-json requires an argument\n' >&2; exit 1; fi
+      TOKENS_JSON="$2"; shift 2 ;;
+    -*)
+      printf 'record-telemetry.sh: unknown option: %s\n' "$1" >&2; exit 1 ;;
+    *)
+      printf 'record-telemetry.sh: unexpected argument: %s\n' "$1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$DISPATCH_ID" ] || [ -z "$ROLE" ] || [ -z "$ISSUE" ] || [ -z "$TOKENS_JSON" ]; then
+  printf 'Usage: record-telemetry.sh --dispatch-id <id> --role <role> --issue <n> --tokens-json <file>\n' >&2
+  exit 1
+fi
+
+if [ ! -f "$TOKENS_JSON" ]; then
+  printf 'record-telemetry.sh: tokens-json file not found: %s\n' "$TOKENS_JSON" >&2
+  exit 1
+fi
+
+TELEMETRY_FILE="${AUTOSPEC_TELEMETRY_FILE:-$HOME/.autospec/telemetry.jsonl}"
+mkdir -p "$(dirname "$TELEMETRY_FILE")"
+
+# Read token fields; default missing cache fields to 0
+input_tokens=$(jq '.input_tokens // 0' "$TOKENS_JSON")
+output_tokens=$(jq '.output_tokens // 0' "$TOKENS_JSON")
+cache_creation=$(jq '.cache_creation_input_tokens // 0' "$TOKENS_JSON")
+cache_read=$(jq '.cache_read_input_tokens // 0' "$TOKENS_JSON")
+
+ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+jq -cn \
+  --arg     ts          "$ts" \
+  --arg     role        "$ROLE" \
+  --arg     issue       "$ISSUE" \
+  --argjson input       "$input_tokens" \
+  --argjson cache_c     "$cache_creation" \
+  --argjson cache_r     "$cache_read" \
+  --argjson output      "$output_tokens" \
+  --arg     dispatch_id "$DISPATCH_ID" \
+  '{ts:$ts,role:$role,issue:$issue,input_tokens:$input,cache_creation_input_tokens:$cache_c,cache_read_input_tokens:$cache_r,output_tokens:$output,dispatch_id:$dispatch_id}' \
+  >> "$TELEMETRY_FILE"

--- a/skills/autospec-shared/scripts/telemetry-summary.sh
+++ b/skills/autospec-shared/scripts/telemetry-summary.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# skills/autospec-shared/scripts/telemetry-summary.sh — Summarise cache-hit rate + token usage.
+#
+# Usage:
+#   telemetry-summary.sh [--since <iso-datetime>] [--role <role>]
+#
+# Reads $AUTOSPEC_TELEMETRY_FILE (default: ~/.autospec/telemetry.jsonl) and emits:
+#   - Total dispatches
+#   - Overall cache-hit rate (rows where cache_read_input_tokens > 0)
+#   - Per-role breakdown: dispatches, hits, hit-rate, total tokens
+#
+# Environment overrides (for testing):
+#   AUTOSPEC_TELEMETRY_FILE — path to telemetry JSONL
+#
+# Exit codes:
+#   0  Success (including empty file)
+#   1  File not found or argument error
+#
+# Compatible with bash 3.2+
+
+set -eu
+
+SINCE=""
+ROLE_FILTER=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --since)
+      if [ $# -lt 2 ]; then printf 'telemetry-summary.sh: --since requires an argument\n' >&2; exit 1; fi
+      SINCE="$2"; shift 2 ;;
+    --role)
+      if [ $# -lt 2 ]; then printf 'telemetry-summary.sh: --role requires an argument\n' >&2; exit 1; fi
+      ROLE_FILTER="$2"; shift 2 ;;
+    -*)
+      printf 'telemetry-summary.sh: unknown option: %s\n' "$1" >&2; exit 1 ;;
+    *)
+      printf 'telemetry-summary.sh: unexpected argument: %s\n' "$1" >&2; exit 1 ;;
+  esac
+done
+
+TELEMETRY_FILE="${AUTOSPEC_TELEMETRY_FILE:-$HOME/.autospec/telemetry.jsonl}"
+
+if [ ! -f "$TELEMETRY_FILE" ]; then
+  printf 'telemetry-summary.sh: telemetry file not found: %s\n' "$TELEMETRY_FILE" >&2
+  exit 1
+fi
+
+jq -rs --arg since "$SINCE" --arg role "$ROLE_FILTER" '
+  (. // []) as $all_rows
+  | ($all_rows
+      | map(
+          if $since != "" then select(.ts >= $since) else . end
+        )
+      | map(
+          if $role  != "" then select(.role == $role) else . end
+        )
+    ) as $rows
+  | ($rows | length) as $total
+  | ($rows | map(select(.cache_read_input_tokens > 0)) | length) as $hits
+  | (if $total > 0 then ($hits * 100.0 / $total) else 0 end) as $hit_rate
+  | ($rows | map(.input_tokens // 0) | add // 0) as $total_input
+  | ($rows | map(.output_tokens // 0) | add // 0) as $total_output
+  | ($rows | map(.cache_read_input_tokens // 0) | add // 0) as $total_cache_read
+  | ($rows | group_by(.role) | map({
+      role: .[0].role,
+      dispatches: length,
+      hits: (map(select(.cache_read_input_tokens > 0)) | length),
+      hit_rate: (if length > 0 then ((map(select(.cache_read_input_tokens > 0)) | length) * 100.0 / length) else 0 end),
+      total_tokens: (map((.input_tokens // 0) + (.output_tokens // 0)) | add // 0)
+    })) as $by_role
+  | "=== Autospec Telemetry Summary ===",
+    "Total dispatches : \($total)",
+    "Cache hits        : \($hits)",
+    (if $total > 0
+     then "Overall hit rate  : \($hit_rate | . * 10 | round / 10)%"
+     else "Overall hit rate  : 0%"
+     end),
+    "Total input tokens: \($total_input)",
+    "Total output tokens: \($total_output)",
+    "Total cache reads : \($total_cache_read)",
+    "",
+    "Per-role breakdown:",
+    (if ($by_role | length) > 0
+     then ($by_role[] | "  \(.role): \(.dispatches) dispatch(es), \(.hits) hit(s), \(.hit_rate | . * 10 | round / 10)% hit rate, \(.total_tokens) total tokens")
+     else "  (no data)"
+     end)
+' "$TELEMETRY_FILE"

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -762,6 +762,11 @@ Pass the following prompt verbatim to each background subagent:
 >        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
 >        run **Operator/full verification**
 >        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/ci-wait.sh" <PR>  # fire-and-forget sentinel
+>        if [ -f ".autospec/tokens-<ISSUE>-reviewer.json" ]; then
+>          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
+>            --dispatch-id "<DISPATCH_ID>-reviewer" --role reviewer --issue "<ISSUE>" \
+>            --tokens-json ".autospec/tokens-<ISSUE>-reviewer.json"
+>        fi
 >        # monitor exits to parking state HERE — orchestrator relaunches when ~/.autospec/ci-state/<PR>.signal settles
 >        # On relaunch: run ci-wait-poll.sh <PR>; break SUCCESS if exit 0 (pass)
 >        break SUCCESS if required checks pass.

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -756,6 +756,11 @@ Pass the following prompt verbatim to each background subagent:
 >        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
 >        run **Operator/full verification**
 >        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/ci-wait.sh" <PR>  # fire-and-forget sentinel
+>        if [ -f ".autospec/tokens-<ISSUE>-reviewer.json" ]; then
+>          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
+>            --dispatch-id "<DISPATCH_ID>-reviewer" --role reviewer --issue "<ISSUE>" \
+>            --tokens-json ".autospec/tokens-<ISSUE>-reviewer.json"
+>        fi
 >        # monitor exits to parking state HERE — orchestrator relaunches when ~/.autospec/ci-state/<PR>.signal settles
 >        # On relaunch: run ci-wait-poll.sh <PR>; break SUCCESS if exit 0 (pass)
 >        break SUCCESS if required checks pass.

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -760,6 +760,11 @@ Pass the following prompt verbatim to each background subagent:
 >        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
 >        run **Operator/full verification**
 >        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/ci-wait.sh" <PR>  # fire-and-forget sentinel
+>        if [ -f ".autospec/tokens-<ISSUE>-reviewer.json" ]; then
+>          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
+>            --dispatch-id "<DISPATCH_ID>-reviewer" --role reviewer --issue "<ISSUE>" \
+>            --tokens-json ".autospec/tokens-<ISSUE>-reviewer.json"
+>        fi
 >        # monitor exits to parking state HERE — orchestrator relaunches when ~/.autospec/ci-state/<PR>.signal settles
 >        # On relaunch: run ci-wait-poll.sh <PR>; break SUCCESS if exit 0 (pass)
 >        break SUCCESS if required checks pass.

--- a/tests/record-telemetry.bats
+++ b/tests/record-telemetry.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# tests/record-telemetry.bats — TDD for skills/autospec-shared/scripts/record-telemetry.sh (issue #403)
+
+SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/record-telemetry.sh"
+FIXTURES_DIR="${BATS_TEST_DIRNAME}/fixtures/record-telemetry"
+
+setup() {
+  mkdir -p "$FIXTURES_DIR"
+  TELEMETRY_FILE="$FIXTURES_DIR/telemetry.jsonl"
+  export AUTOSPEC_TELEMETRY_FILE="$TELEMETRY_FILE"
+}
+
+teardown() {
+  rm -rf "$FIXTURES_DIR"
+}
+
+_tokens_json() {
+  local file="$FIXTURES_DIR/tokens-$1.json"
+  printf '%s' "$2" > "$file"
+  printf '%s' "$file"
+}
+
+@test "record-telemetry.sh is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "record-telemetry.sh appends exactly one line per invocation" {
+  tokens_file=$(_tokens_json "basic" '{"input_tokens":1000,"output_tokens":200,"cache_creation_input_tokens":800,"cache_read_input_tokens":0}')
+  run "$SCRIPT" --dispatch-id "abc123" --role "implementer" --issue "403" --tokens-json "$tokens_file"
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$TELEMETRY_FILE")" -eq 1 ]
+}
+
+@test "record-telemetry.sh appends second invocation as new line" {
+  tokens_file=$(_tokens_json "two" '{"input_tokens":500,"output_tokens":100,"cache_creation_input_tokens":400,"cache_read_input_tokens":50}')
+  "$SCRIPT" --dispatch-id "first"  --role "implementer" --issue "403" --tokens-json "$tokens_file"
+  "$SCRIPT" --dispatch-id "second" --role "reviewer"    --issue "403" --tokens-json "$tokens_file"
+  [ "$(wc -l < "$TELEMETRY_FILE")" -eq 2 ]
+}
+
+@test "record-telemetry.sh appended line is valid JSON" {
+  tokens_file=$(_tokens_json "json-valid" '{"input_tokens":1000,"output_tokens":200,"cache_creation_input_tokens":800,"cache_read_input_tokens":0}')
+  "$SCRIPT" --dispatch-id "abc123" --role "implementer" --issue "403" --tokens-json "$tokens_file"
+  run jq -e . "$TELEMETRY_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "record-telemetry.sh schema includes required fields" {
+  tokens_file=$(_tokens_json "schema" '{"input_tokens":1234,"output_tokens":56,"cache_creation_input_tokens":900,"cache_read_input_tokens":300}')
+  "$SCRIPT" --dispatch-id "disp-xyz" --role "implementer" --issue "403" --tokens-json "$tokens_file"
+  line=$(cat "$TELEMETRY_FILE")
+  printf '%s\n' "$line" | jq -e '.ts'           >/dev/null
+  printf '%s\n' "$line" | jq -e '.role'          >/dev/null
+  printf '%s\n' "$line" | jq -e '.issue'         >/dev/null
+  printf '%s\n' "$line" | jq -e '.input_tokens'  >/dev/null
+  printf '%s\n' "$line" | jq -e '.output_tokens' >/dev/null
+  printf '%s\n' "$line" | jq -e '.dispatch_id'   >/dev/null
+  printf '%s\n' "$line" | jq -e '.cache_creation_input_tokens' >/dev/null
+  printf '%s\n' "$line" | jq -e '.cache_read_input_tokens'     >/dev/null
+}
+
+@test "record-telemetry.sh stores correct values" {
+  tokens_file=$(_tokens_json "values" '{"input_tokens":1234,"output_tokens":56,"cache_creation_input_tokens":900,"cache_read_input_tokens":300}')
+  "$SCRIPT" --dispatch-id "disp-xyz" --role "implementer" --issue "403" --tokens-json "$tokens_file"
+  line=$(cat "$TELEMETRY_FILE")
+  [ "$(printf '%s\n' "$line" | jq -r '.dispatch_id')"                  = "disp-xyz" ]
+  [ "$(printf '%s\n' "$line" | jq -r '.role')"                         = "implementer" ]
+  [ "$(printf '%s\n' "$line" | jq -r '.issue')"                        = "403" ]
+  [ "$(printf '%s\n' "$line" | jq    '.input_tokens')"                 = "1234" ]
+  [ "$(printf '%s\n' "$line" | jq    '.cache_creation_input_tokens')"  = "900" ]
+  [ "$(printf '%s\n' "$line" | jq    '.cache_read_input_tokens')"      = "300" ]
+}
+
+@test "record-telemetry.sh missing cache_read_input_tokens defaults to 0" {
+  tokens_file=$(_tokens_json "missing-cache-read" '{"input_tokens":500,"output_tokens":100,"cache_creation_input_tokens":400}')
+  "$SCRIPT" --dispatch-id "no-cache" --role "implementer" --issue "403" --tokens-json "$tokens_file"
+  line=$(cat "$TELEMETRY_FILE")
+  [ "$(printf '%s\n' "$line" | jq '.cache_read_input_tokens')" = "0" ]
+}
+
+@test "record-telemetry.sh missing cache_creation_input_tokens defaults to 0" {
+  tokens_file=$(_tokens_json "missing-cache-creation" '{"input_tokens":500,"output_tokens":100,"cache_read_input_tokens":200}')
+  "$SCRIPT" --dispatch-id "no-creation" --role "implementer" --issue "403" --tokens-json "$tokens_file"
+  line=$(cat "$TELEMETRY_FILE")
+  [ "$(printf '%s\n' "$line" | jq '.cache_creation_input_tokens')" = "0" ]
+}
+
+@test "record-telemetry.sh creates parent directory if missing" {
+  deep_dir="$FIXTURES_DIR/deep/nested/dir"
+  export AUTOSPEC_TELEMETRY_FILE="$deep_dir/telemetry.jsonl"
+  tokens_file=$(_tokens_json "deep" '{"input_tokens":100,"output_tokens":10}')
+  run "$SCRIPT" --dispatch-id "dir-create" --role "implementer" --issue "403" --tokens-json "$tokens_file"
+  [ "$status" -eq 0 ]
+  [ -f "$deep_dir/telemetry.jsonl" ]
+}

--- a/tests/telemetry-summary.bats
+++ b/tests/telemetry-summary.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# tests/telemetry-summary.bats — TDD for skills/autospec-shared/scripts/telemetry-summary.sh (issue #403)
+
+SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/telemetry-summary.sh"
+FIXTURES_DIR="${BATS_TEST_DIRNAME}/fixtures/telemetry-summary"
+
+setup() {
+  mkdir -p "$FIXTURES_DIR"
+  FIXTURE_JSONL="$FIXTURES_DIR/telemetry.jsonl"
+  export AUTOSPEC_TELEMETRY_FILE="$FIXTURE_JSONL"
+
+  # 3-row fixture: 1 miss, 2 hits
+  # Row 1: implementer, cache_read=0    (miss)
+  # Row 2: implementer, cache_read=5000 (hit)
+  # Row 3: reviewer,    cache_read=4800 (hit)
+  printf '%s\n' \
+    '{"ts":"2026-05-22T10:00:00Z","role":"implementer","issue":403,"input_tokens":12000,"cache_creation_input_tokens":8000,"cache_read_input_tokens":0,"output_tokens":3000,"dispatch_id":"d1"}' \
+    '{"ts":"2026-05-22T10:05:00Z","role":"implementer","issue":403,"input_tokens":12000,"cache_creation_input_tokens":0,"cache_read_input_tokens":5000,"output_tokens":2800,"dispatch_id":"d2"}' \
+    '{"ts":"2026-05-22T10:10:00Z","role":"reviewer","issue":403,"input_tokens":11000,"cache_creation_input_tokens":0,"cache_read_input_tokens":4800,"output_tokens":1500,"dispatch_id":"d3"}' \
+    > "$FIXTURE_JSONL"
+}
+
+teardown() {
+  rm -rf "$FIXTURES_DIR"
+}
+
+@test "telemetry-summary.sh is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "telemetry-summary.sh exits 0 on valid JSONL" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "telemetry-summary.sh overall cache-hit rate is 2/3 (66%)" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # 2 rows have cache_read_input_tokens > 0 out of 3 → 66%
+  printf '%s\n' "$output" | grep -qE '6[67](\.[0-9]+)?%'
+}
+
+@test "telemetry-summary.sh shows total dispatches" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qE '(total|dispatches|Total|Dispatches).*3|3.*(total|dispatches|Total|Dispatches)'
+}
+
+@test "telemetry-summary.sh shows per-role breakdown" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qi "implementer"
+  printf '%s\n' "$output" | grep -qi "reviewer"
+}
+
+@test "telemetry-summary.sh --role implementer shows only implementer rows" {
+  run "$SCRIPT" --role implementer
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qi "implementer"
+  # Should not show reviewer in the role-filtered output
+  ! printf '%s\n' "$output" | grep -qi "^reviewer"
+}
+
+@test "telemetry-summary.sh --since filters out old rows" {
+  # Add an old row to the fixture
+  printf '%s\n' \
+    '{"ts":"2026-01-01T00:00:00Z","role":"implementer","issue":100,"input_tokens":5000,"cache_creation_input_tokens":3000,"cache_read_input_tokens":0,"output_tokens":1000,"dispatch_id":"old"}' \
+    >> "$FIXTURE_JSONL"
+  # Filter to only rows from 2026-05 onwards
+  run "$SCRIPT" --since "2026-05-01T00:00:00Z"
+  [ "$status" -eq 0 ]
+  # Should still show 3 dispatches (original fixture) not 4
+  printf '%s\n' "$output" | grep -qE '(total|dispatches|Total|Dispatches).*3|3.*(total|dispatches|Total|Dispatches)'
+}
+
+@test "telemetry-summary.sh on empty JSONL exits 0 and reports 0 dispatches" {
+  printf '' > "$FIXTURE_JSONL"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qE '0'
+}
+
+@test "telemetry-summary.sh exits non-zero when JSONL file missing" {
+  export AUTOSPEC_TELEMETRY_FILE="$FIXTURES_DIR/nonexistent.jsonl"
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Closes #403

## Summary

- Adds `skills/autospec-shared/scripts/record-telemetry.sh`: parses a tokens JSON file and appends a schema-valid JSONL line to `~/.autospec/telemetry.jsonl` (creates parent dir if missing). Handles missing `cache_read_input_tokens` / `cache_creation_input_tokens` fields by defaulting to 0.
- Adds `skills/autospec-shared/scripts/telemetry-summary.sh`: reads the JSONL, computes overall cache-hit rate, total tokens, and per-role breakdown. Supports `--since <iso>` and `--role <r>` filters.
- Adds telemetry hook lines to the Phase 4 implementer dispatch (step 6) and fused guardian+LGTM reviewer dispatch in all 6 lockstep trio files (autospec + autospec-run × SKILL.md / codex/prompt.md / opencode/agent.md).
- 18 bats tests covering schema fields, value correctness, missing-field defaults, directory creation, golden output, filtering, and empty-file edge cases.
- `scripts/validate.sh` exits 0.

## Verification

Primary smoke test passed:
```
bats tests/record-telemetry.bats && bats tests/telemetry-summary.bats && bash scripts/validate.sh
```
All 18 tests: OK. validate.sh: OK.