### PR TITLE
feat(autospec-run): reviewer prompt cache structure (Fix #2)

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -588,6 +588,15 @@ issues unblock the queue before continuing with normal feature work.
 >
 >      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
 >
+>      **Static cached prefix** — call `bundle-static-context.sh` to emit the reviewer blob:
+>      ```bash
+>      reviewer_prefix=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-static-context.sh" \
+>        --role reviewer \
+>        --issue-labels "<ISSUE_LABELS>")
+>      ```
+>      Pass this blob as the first content block of the reviewer subagent prompt with `cache_control: { type: "ephemeral" }`.
+>      Append the dynamic suffix: deterministic lint findings from `/tmp/guardian-<PR>.md`, PR diff, issue body, previous-iteration findings (if iter > 1).
+>
 >      Dispatch ONE **foreground subagent** with this brief:
 >        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
 >        >

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -583,6 +583,15 @@ issues unblock the queue before continuing with normal feature work.
 >
 >      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
 >
+>      **Static cached prefix** — call `bundle-static-context.sh` to emit the reviewer blob:
+>      ```bash
+>      reviewer_prefix=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-static-context.sh" \
+>        --role reviewer \
+>        --issue-labels "<ISSUE_LABELS>")
+>      ```
+>      Pass this blob as the first content block of the reviewer subagent prompt with `cache_control: { type: "ephemeral" }`.
+>      Append the dynamic suffix: deterministic lint findings from `/tmp/guardian-<PR>.md`, PR diff, issue body, previous-iteration findings (if iter > 1).
+>
 >      Dispatch ONE **foreground subagent** with this brief:
 >        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
 >        >

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -587,6 +587,15 @@ issues unblock the queue before continuing with normal feature work.
 >
 >      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
 >
+>      **Static cached prefix** — call `bundle-static-context.sh` to emit the reviewer blob:
+>      ```bash
+>      reviewer_prefix=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-static-context.sh" \
+>        --role reviewer \
+>        --issue-labels "<ISSUE_LABELS>")
+>      ```
+>      Pass this blob as the first content block of the reviewer subagent prompt with `cache_control: { type: "ephemeral" }`.
+>      Append the dynamic suffix: deterministic lint findings from `/tmp/guardian-<PR>.md`, PR diff, issue body, previous-iteration findings (if iter > 1).
+>
 >      Dispatch ONE **foreground subagent** with this brief:
 >        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
 >        >

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -740,6 +740,15 @@ Pass the following prompt verbatim to each background subagent:
 >
 >      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
 >
+>      **Static cached prefix** — call `bundle-static-context.sh` to emit the reviewer blob:
+>      ```bash
+>      reviewer_prefix=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-static-context.sh" \
+>        --role reviewer \
+>        --issue-labels "<ISSUE_LABELS>")
+>      ```
+>      Pass this blob as the first content block of the reviewer subagent prompt with `cache_control: { type: "ephemeral" }`.
+>      Append the dynamic suffix: deterministic lint findings from `/tmp/guardian-<PR>.md`, PR diff, issue body, previous-iteration findings (if iter > 1).
+>
 >      Dispatch ONE **foreground subagent** with this brief:
 >        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
 >        >

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -734,6 +734,15 @@ Pass the following prompt verbatim to each background subagent:
 >
 >      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
 >
+>      **Static cached prefix** — call `bundle-static-context.sh` to emit the reviewer blob:
+>      ```bash
+>      reviewer_prefix=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-static-context.sh" \
+>        --role reviewer \
+>        --issue-labels "<ISSUE_LABELS>")
+>      ```
+>      Pass this blob as the first content block of the reviewer subagent prompt with `cache_control: { type: "ephemeral" }`.
+>      Append the dynamic suffix: deterministic lint findings from `/tmp/guardian-<PR>.md`, PR diff, issue body, previous-iteration findings (if iter > 1).
+>
 >      Dispatch ONE **foreground subagent** with this brief:
 >        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
 >        >

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -738,6 +738,15 @@ Pass the following prompt verbatim to each background subagent:
 >
 >      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
 >
+>      **Static cached prefix** — call `bundle-static-context.sh` to emit the reviewer blob:
+>      ```bash
+>      reviewer_prefix=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-static-context.sh" \
+>        --role reviewer \
+>        --issue-labels "<ISSUE_LABELS>")
+>      ```
+>      Pass this blob as the first content block of the reviewer subagent prompt with `cache_control: { type: "ephemeral" }`.
+>      Append the dynamic suffix: deterministic lint findings from `/tmp/guardian-<PR>.md`, PR diff, issue body, previous-iteration findings (if iter > 1).
+>
 >      Dispatch ONE **foreground subagent** with this brief:
 >        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
 >        >

--- a/tests/bundle-static-context-reviewer.bats
+++ b/tests/bundle-static-context-reviewer.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# tests/bundle-static-context-reviewer.bats — TDD for --role reviewer in
+# skills/autospec-shared/scripts/bundle-static-context.sh (issue #404)
+
+SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/bundle-static-context.sh"
+
+@test "bundle-static-context.sh --role reviewer exits 0" {
+  run "$SCRIPT" --role reviewer
+  [ "$status" -eq 0 ]
+}
+
+@test "bundle-static-context.sh --role reviewer emits opening CACHE BOUNDARY marker" {
+  run "$SCRIPT" --role reviewer
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | head -1 | grep -q "CACHE BOUNDARY"
+}
+
+@test "bundle-static-context.sh --role reviewer emits closing CACHE BOUNDARY marker" {
+  run "$SCRIPT" --role reviewer
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | tail -1 | grep -q "CACHE BOUNDARY"
+}
+
+@test "bundle-static-context.sh --role reviewer output contains Implementation-quality contract" {
+  run "$SCRIPT" --role reviewer
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q "Implementation-quality contract"
+}
+
+@test "bundle-static-context.sh --role reviewer output contains RULE_ID table" {
+  run "$SCRIPT" --role reviewer
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q "OUT_OF_SCOPE"
+}
+
+@test "bundle-static-context.sh --role reviewer output contains reviewer-verdict-format block" {
+  run "$SCRIPT" --role reviewer
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qi "verdict\|LGTM"
+}
+
+@test "bundle-static-context.sh --role reviewer output contains lint-implementation.sh schema" {
+  run "$SCRIPT" --role reviewer
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q "lint-implementation.sh"
+}
+
+@test "bundle-static-context.sh --role reviewer output is idempotent" {
+  out1=$("$SCRIPT" --role reviewer)
+  out2=$("$SCRIPT" --role reviewer)
+  [ "$out1" = "$out2" ]
+}


### PR DESCRIPTION
Closes #404

## Summary

- Extends the fused guardian+LGTM reviewer dispatch in all 6 lockstep trio files (autospec + autospec-run × SKILL.md / codex/prompt.md / opencode/agent.md) to call `bundle-static-context.sh --role reviewer` before dispatching the reviewer subagent, symmetric with the implementer dispatch added in C1 (#402).
- The reviewer static cached prefix contains: AGENTS.md `## Implementation-quality contract`, RULE_ID table, `lint-implementation.sh` output schema, and reviewer verdict format — annotated for `cache_control: { type: "ephemeral" }`.
- The dynamic suffix (lint findings, PR diff, issue body, previous-iteration findings) is appended after the cached prefix.
- Adds `tests/bundle-static-context-reviewer.bats` with 8 tests covering CACHE BOUNDARY markers, contract section, RULE_ID table, verdict format, lint schema reference, and idempotency.
- `scripts/validate.sh` exits 0, guardian-block lockstep confirmed across all 6 files.

## Verification

Primary smoke test passed:
```
bash skills/autospec-shared/scripts/bundle-static-context.sh --role reviewer | grep -q "CACHE BOUNDARY" && bats tests/bundle-static-context-reviewer.bats && bash scripts/validate.sh
```
All 8 bats tests: OK. validate.sh: OK.

## Peer-review note
Codex not on PATH, skipping peer-review.