### PR TITLE
feat(autospec-docs): --init + Phase 4 drift gate wiring (phase 9a)

### DIFF
--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -488,3 +488,45 @@ No daemon auto-detection — always ask explicitly.
 If the gate answer was `run`, hand off to `/autospec-run --profile <name>`
 to begin implementation. If the answer was `defer`, the run ends here and
 the queue is left for an external monitor.
+
+## Init mode
+
+Triggered by `--init` flag or auto-detected when code exists but `docs/specs/` is empty or no doc carries an `autospec-doc-scope` annotation.
+
+### Auto-detect prompt
+
+When auto-detecting, ask once:
+
+> This repo has source code but no autospec docs. Run reverse-engineer first?
+> **[yes / no / always-this-repo]**
+
+- `yes` — run `--init` once for this invocation.
+- `no` — skip; proceed to Phase 1 normally.
+- `always-this-repo` — run `--init` and write `.autospec/init-done.flag`; future invocations skip this prompt.
+
+If `.autospec/init-done.flag` exists, skip the prompt entirely.
+
+### --init execution
+
+1. Run tree-sitter scan across the repo source tree to enumerate modules, public symbols, and entry points.
+2. Emit one ARCHITECTURE-level spec to `docs/specs/<repo-slug>-architecture.md`.
+3. Emit per-module specs to `docs/specs/<module>-spec.md` for each discovered module.
+4. Generate initial docs via `gen-docs-from-spec.mjs`:
+   - `docs/USER_MANUAL.md`
+   - `docs/API_REFERENCE.md`
+   - `docs/ARCHITECTURE.md`
+   - `llms.txt`
+   - `.llm-manifest.json`
+5. Open a `feat/spec-reverse-engineer-init` PR with all generated artifacts.
+6. Admin-merge the doc PR before proceeding to Phase 3 decomposition.
+
+### Auto-docs step (after spec PR merges)
+
+After any spec PR merges in normal `autospec-define` flow, invoke:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-docs-from-spec.mjs" \
+  --spec "<spec-path>" --out docs/
+```
+
+Open a `docs/` update PR and admin-merge it before Phase 3 begins. Skip if the spec change touches only non-public implementation details (no change to public API surface, no new CLI flags, no new env vars).

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -481,3 +481,45 @@ No daemon auto-detection — always ask explicitly.
 If the gate answer was `run`, hand off to `/autospec-run --profile <name>`
 to begin implementation. If the answer was `defer`, the run ends here and
 the queue is left for an external monitor.
+
+## Init mode
+
+Triggered by `--init` flag or auto-detected when code exists but `docs/specs/` is empty or no doc carries an `autospec-doc-scope` annotation.
+
+### Auto-detect prompt
+
+When auto-detecting, ask once:
+
+> This repo has source code but no autospec docs. Run reverse-engineer first?
+> **[yes / no / always-this-repo]**
+
+- `yes` — run `--init` once for this invocation.
+- `no` — skip; proceed to Phase 1 normally.
+- `always-this-repo` — run `--init` and write `.autospec/init-done.flag`; future invocations skip this prompt.
+
+If `.autospec/init-done.flag` exists, skip the prompt entirely.
+
+### --init execution
+
+1. Run tree-sitter scan across the repo source tree to enumerate modules, public symbols, and entry points.
+2. Emit one ARCHITECTURE-level spec to `docs/specs/<repo-slug>-architecture.md`.
+3. Emit per-module specs to `docs/specs/<module>-spec.md` for each discovered module.
+4. Generate initial docs via `gen-docs-from-spec.mjs`:
+   - `docs/USER_MANUAL.md`
+   - `docs/API_REFERENCE.md`
+   - `docs/ARCHITECTURE.md`
+   - `llms.txt`
+   - `.llm-manifest.json`
+5. Open a `feat/spec-reverse-engineer-init` PR with all generated artifacts.
+6. Admin-merge the doc PR before proceeding to Phase 3 decomposition.
+
+### Auto-docs step (after spec PR merges)
+
+After any spec PR merges in normal `autospec-define` flow, invoke:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-docs-from-spec.mjs" \
+  --spec "<spec-path>" --out docs/
+```
+
+Open a `docs/` update PR and admin-merge it before Phase 3 begins. Skip if the spec change touches only non-public implementation details (no change to public API surface, no new CLI flags, no new env vars).

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -485,3 +485,45 @@ No daemon auto-detection — always ask explicitly.
 If the gate answer was `run`, hand off to `/autospec-run --profile <name>`
 to begin implementation. If the answer was `defer`, the run ends here and
 the queue is left for an external monitor.
+
+## Init mode
+
+Triggered by `--init` flag or auto-detected when code exists but `docs/specs/` is empty or no doc carries an `autospec-doc-scope` annotation.
+
+### Auto-detect prompt
+
+When auto-detecting, ask once:
+
+> This repo has source code but no autospec docs. Run reverse-engineer first?
+> **[yes / no / always-this-repo]**
+
+- `yes` — run `--init` once for this invocation.
+- `no` — skip; proceed to Phase 1 normally.
+- `always-this-repo` — run `--init` and write `.autospec/init-done.flag`; future invocations skip this prompt.
+
+If `.autospec/init-done.flag` exists, skip the prompt entirely.
+
+### --init execution
+
+1. Run tree-sitter scan across the repo source tree to enumerate modules, public symbols, and entry points.
+2. Emit one ARCHITECTURE-level spec to `docs/specs/<repo-slug>-architecture.md`.
+3. Emit per-module specs to `docs/specs/<module>-spec.md` for each discovered module.
+4. Generate initial docs via `gen-docs-from-spec.mjs`:
+   - `docs/USER_MANUAL.md`
+   - `docs/API_REFERENCE.md`
+   - `docs/ARCHITECTURE.md`
+   - `llms.txt`
+   - `.llm-manifest.json`
+5. Open a `feat/spec-reverse-engineer-init` PR with all generated artifacts.
+6. Admin-merge the doc PR before proceeding to Phase 3 decomposition.
+
+### Auto-docs step (after spec PR merges)
+
+After any spec PR merges in normal `autospec-define` flow, invoke:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-docs-from-spec.mjs" \
+  --spec "<spec-path>" --out docs/
+```
+
+Open a `docs/` update PR and admin-merge it before Phase 3 begins. Skip if the spec change touches only non-public implementation details (no change to public API surface, no new CLI flags, no new env vars).

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -517,6 +517,35 @@ issues unblock the queue before continuing with normal feature work.
 >    fi
 >    ```
 >    Exit 0: proceed to merge. Exit 1: block PR (post comment + labels; do NOT merge; treat as review finding). Exit 2: halt entire batch (comment on issue, label `in-progress-by-bot` → `auto-implement`, exit monitor).
+> 3b. <!-- docs-drift-gate:begin -->
+> ## Docs drift gate
+> Run after autospec-test gate, before LGTM review. Skip if issue body contains a line matching `^docs:\s*skip\s*$` (case-insensitive):
+>    ```bash
+>    if ! grep -qiE '^docs:[[:space:]]*skip[[:space:]]*$' <(gh issue view <ISSUE> --json body --jq .body 2>/dev/null || true); then
+>      DRIFT_JSON="$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/check-doc-drift.sh" --pr "<PR>" 2>/tmp/drift-<PR>.err)"; drift_exit=$?
+>      case "$drift_exit" in
+>        0) ;;  # no drift — continue to LGTM
+>        1)
+>          # Drift detected — feed self-heal loop via docs-extension classifier
+>          node "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/loop-classifier-docs-extension.mjs" \
+>            --drift-json "$DRIFT_JSON" --issue "<ISSUE>" --pr "<PR>" 2>/dev/null || true
+>          gh pr comment <PR> --body "$(printf 'docs drift detected — self-heal queued:\n\n```json\n%s\n```' "$DRIFT_JSON")"
+>          gh issue edit <ISSUE> --add-label "docs:drift" 2>/dev/null || true
+>          ;;
+>        2)
+>          # Missing scope — needs human review
+>          gh pr comment <PR> --body "$(printf 'docs: missing scope — changed files not covered by any doc scope. Operator review needed.\n\n```json\n%s\n```' "$DRIFT_JSON")"
+>          gh issue edit <ISSUE> --add-label "docs:missing-scope" 2>/dev/null || true
+>          gh issue edit <ISSUE> --add-label "needs-human-review" 2>/dev/null || true
+>          exit 1
+>          ;;
+>      esac
+>    else
+>      gh pr comment <PR> --body "docs: drift check skipped (docs:skip in issue body)" 2>/dev/null || true
+>      gh issue edit <ISSUE> --add-label "docs:skipped" 2>/dev/null || true
+>    fi
+>    ```
+>    <!-- docs-drift-gate:end -->
 > 4. <!-- RETRY-LOOP:begin --> Adaptive commit loop (MAX_IMPL_RETRIES):
 >    ```bash
 >    attempt=1

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -512,6 +512,35 @@ issues unblock the queue before continuing with normal feature work.
 >    fi
 >    ```
 >    Exit 0: proceed to merge. Exit 1: block PR (post comment + labels; do NOT merge; treat as review finding). Exit 2: halt entire batch (comment on issue, label `in-progress-by-bot` → `auto-implement`, exit monitor).
+> 3b. <!-- docs-drift-gate:begin -->
+> ## Docs drift gate
+> Run after autospec-test gate, before LGTM review. Skip if issue body contains a line matching `^docs:\s*skip\s*$` (case-insensitive):
+>    ```bash
+>    if ! grep -qiE '^docs:[[:space:]]*skip[[:space:]]*$' <(gh issue view <ISSUE> --json body --jq .body 2>/dev/null || true); then
+>      DRIFT_JSON="$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/check-doc-drift.sh" --pr "<PR>" 2>/tmp/drift-<PR>.err)"; drift_exit=$?
+>      case "$drift_exit" in
+>        0) ;;  # no drift — continue to LGTM
+>        1)
+>          # Drift detected — feed self-heal loop via docs-extension classifier
+>          node "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/loop-classifier-docs-extension.mjs" \
+>            --drift-json "$DRIFT_JSON" --issue "<ISSUE>" --pr "<PR>" 2>/dev/null || true
+>          gh pr comment <PR> --body "$(printf 'docs drift detected — self-heal queued:\n\n```json\n%s\n```' "$DRIFT_JSON")"
+>          gh issue edit <ISSUE> --add-label "docs:drift" 2>/dev/null || true
+>          ;;
+>        2)
+>          # Missing scope — needs human review
+>          gh pr comment <PR> --body "$(printf 'docs: missing scope — changed files not covered by any doc scope. Operator review needed.\n\n```json\n%s\n```' "$DRIFT_JSON")"
+>          gh issue edit <ISSUE> --add-label "docs:missing-scope" 2>/dev/null || true
+>          gh issue edit <ISSUE> --add-label "needs-human-review" 2>/dev/null || true
+>          exit 1
+>          ;;
+>      esac
+>    else
+>      gh pr comment <PR> --body "docs: drift check skipped (docs:skip in issue body)" 2>/dev/null || true
+>      gh issue edit <ISSUE> --add-label "docs:skipped" 2>/dev/null || true
+>    fi
+>    ```
+>    <!-- docs-drift-gate:end -->
 > 4. <!-- RETRY-LOOP:begin --> Adaptive commit loop (MAX_IMPL_RETRIES):
 >    ```bash
 >    attempt=1

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -516,6 +516,35 @@ issues unblock the queue before continuing with normal feature work.
 >    fi
 >    ```
 >    Exit 0: proceed to merge. Exit 1: block PR (post comment + labels; do NOT merge; treat as review finding). Exit 2: halt entire batch (comment on issue, label `in-progress-by-bot` → `auto-implement`, exit monitor).
+> 3b. <!-- docs-drift-gate:begin -->
+> ## Docs drift gate
+> Run after autospec-test gate, before LGTM review. Skip if issue body contains a line matching `^docs:\s*skip\s*$` (case-insensitive):
+>    ```bash
+>    if ! grep -qiE '^docs:[[:space:]]*skip[[:space:]]*$' <(gh issue view <ISSUE> --json body --jq .body 2>/dev/null || true); then
+>      DRIFT_JSON="$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/check-doc-drift.sh" --pr "<PR>" 2>/tmp/drift-<PR>.err)"; drift_exit=$?
+>      case "$drift_exit" in
+>        0) ;;  # no drift — continue to LGTM
+>        1)
+>          # Drift detected — feed self-heal loop via docs-extension classifier
+>          node "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/loop-classifier-docs-extension.mjs" \
+>            --drift-json "$DRIFT_JSON" --issue "<ISSUE>" --pr "<PR>" 2>/dev/null || true
+>          gh pr comment <PR> --body "$(printf 'docs drift detected — self-heal queued:\n\n```json\n%s\n```' "$DRIFT_JSON")"
+>          gh issue edit <ISSUE> --add-label "docs:drift" 2>/dev/null || true
+>          ;;
+>        2)
+>          # Missing scope — needs human review
+>          gh pr comment <PR> --body "$(printf 'docs: missing scope — changed files not covered by any doc scope. Operator review needed.\n\n```json\n%s\n```' "$DRIFT_JSON")"
+>          gh issue edit <ISSUE> --add-label "docs:missing-scope" 2>/dev/null || true
+>          gh issue edit <ISSUE> --add-label "needs-human-review" 2>/dev/null || true
+>          exit 1
+>          ;;
+>      esac
+>    else
+>      gh pr comment <PR> --body "docs: drift check skipped (docs:skip in issue body)" 2>/dev/null || true
+>      gh issue edit <ISSUE> --add-label "docs:skipped" 2>/dev/null || true
+>    fi
+>    ```
+>    <!-- docs-drift-gate:end -->
 > 4. <!-- RETRY-LOOP:begin --> Adaptive commit loop (MAX_IMPL_RETRIES):
 >    ```bash
 >    attempt=1

--- a/skills/autospec-run/prompts/phase4-implementer.md
+++ b/skills/autospec-run/prompts/phase4-implementer.md
@@ -103,6 +103,31 @@ a broken migration replay.
 3. Verify the diff matches the issue's scope. If you ended up touching more than the issue called for, either split the extra work into a separate issue or revert it from this branch.
 4. Commit message follows the repo's existing style (see recent `git log --oneline`).
 
+### Docs drift gate
+
+After tests pass and before creating the PR, run `check-doc-drift.sh --pr` on the branch diff to detect documentation drift. Skip if the issue body contains a line matching `^docs:\s*skip` (case-insensitive).
+
+```bash
+# check-doc-drift.sh --pr mode requires gh CLI and an open PR.
+# For pre-PR use, run with --working-tree to check against HEAD:
+if ! grep -qiE '^docs:[[:space:]]*skip' <(gh issue view <ISSUE> --json body --jq .body 2>/dev/null || true); then
+  DRIFT_JSON="$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/check-doc-drift.sh" \
+    --working-tree 2>/dev/null)"; drift_exit=$?
+  case "$drift_exit" in
+    0) echo "[drift] docs clean" ;;
+    1)
+      echo "[drift] doc drift detected — self-heal loop will handle after PR opens"
+      ;;
+    2)
+      echo "[drift] missing doc scope — post comment and pause"
+      gh issue comment <ISSUE> --body "$(printf 'docs: missing scope. Operator review needed before merge.\n\n```json\n%s\n```' "$DRIFT_JSON")" 2>/dev/null || true
+      ;;
+  esac
+fi
+```
+
+Exit 0: continue. Exit 1: log drift, continue (the Phase 4 monitor's reviewer dispatch handles it post-PR). Exit 2: comment on issue, continue (non-fatal in implementer path; monitor handles escalation).
+
 ## Peer-review
 
 If the `codex` CLI is on PATH, get a second opinion on the diff:

--- a/skills/autospec-run/tests/integration/phase4-drift-gate.bats
+++ b/skills/autospec-run/tests/integration/phase4-drift-gate.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# skills/autospec-run/tests/integration/phase4-drift-gate.bats
+# Tests for Phase 4 docs drift gate wiring (issue #369)
+#
+# Uses --working-tree mode of check-doc-drift.sh (no gh CLI needed).
+# Stubs AUTOSPEC_SCRIPTS_DIR to point at fixture scripts for exit-code branches.
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/../../../.."
+FIXTURES_DIR="${BATS_TEST_DIRNAME}/fixtures"
+
+setup() {
+  mkdir -p "$FIXTURES_DIR/scripts"
+
+  # Stub check-doc-drift.sh that exits 0 (clean)
+  cat > "$FIXTURES_DIR/scripts/check-doc-drift-exit0.sh" <<'STUB'
+#!/usr/bin/env bash
+printf '{"status":"clean","drift":[]}\n'
+exit 0
+STUB
+  chmod 0755 "$FIXTURES_DIR/scripts/check-doc-drift-exit0.sh"
+
+  # Stub check-doc-drift.sh that exits 1 (drift detected)
+  cat > "$FIXTURES_DIR/scripts/check-doc-drift-exit1.sh" <<'STUB'
+#!/usr/bin/env bash
+printf '{"status":"drift","drift":[{"file":"src/foo.sh","section":"## Usage"}]}\n'
+exit 1
+STUB
+  chmod 0755 "$FIXTURES_DIR/scripts/check-doc-drift-exit1.sh"
+
+  # Stub check-doc-drift.sh that exits 2 (missing scope)
+  cat > "$FIXTURES_DIR/scripts/check-doc-drift-exit2.sh" <<'STUB'
+#!/usr/bin/env bash
+printf '{"status":"missing-scope","missing":["src/new-module.sh"]}\n'
+exit 2
+STUB
+  chmod 0755 "$FIXTURES_DIR/scripts/check-doc-drift-exit2.sh"
+}
+
+teardown() {
+  rm -rf "$FIXTURES_DIR"
+}
+
+# ── SKILL.md presence checks ────────────────────────────────────────────────
+
+@test "autospec-run SKILL.md includes ## Docs drift gate section" {
+  grep -qF "## Docs drift gate" "$REPO_ROOT/skills/autospec-run/SKILL.md"
+}
+
+@test "autospec-define SKILL.md includes ## Init mode section" {
+  grep -qF "## Init mode" "$REPO_ROOT/skills/autospec-define/SKILL.md"
+}
+
+@test "autospec-define SKILL.md documents auto-docs step" {
+  grep -q "gen-docs-from-spec\|auto-docs\|doc-PR" "$REPO_ROOT/skills/autospec-define/SKILL.md"
+}
+
+# ── Drift gate exit-code branches ────────────────────────────────────────────
+
+@test "drift gate exit 0 (clean) — proceeds without error" {
+  run bash "$FIXTURES_DIR/scripts/check-doc-drift-exit0.sh" --pr 999
+  [ "$status" -eq 0 ]
+}
+
+@test "drift gate exit 1 (drift) — emits drift JSON" {
+  run bash "$FIXTURES_DIR/scripts/check-doc-drift-exit1.sh" --pr 999
+  [ "$status" -eq 1 ]
+  printf '%s\n' "$output" | grep -q "drift"
+}
+
+@test "drift gate exit 2 (missing scope) — reports missing-scope" {
+  run bash "$FIXTURES_DIR/scripts/check-doc-drift-exit2.sh" --pr 999
+  [ "$status" -eq 2 ]
+  printf '%s\n' "$output" | grep -q "missing-scope"
+}
+
+# ── phase4-implementer.md includes drift gate ────────────────────────────────
+
+@test "phase4-implementer.md includes check-doc-drift.sh reference" {
+  grep -q "check-doc-drift.sh" "$REPO_ROOT/skills/autospec-run/prompts/phase4-implementer.md"
+}

--- a/tests/phase4/test_docs_drift_gate.sh
+++ b/tests/phase4/test_docs_drift_gate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# tests/phase4/test_docs_drift_gate.sh — Verifies Phase 4 docs drift gate wiring (issue #369).
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# ── autospec-define SKILL.md: Init mode section ──────────────────────────────
+
+define_skill="$SCRIPT_DIR/skills/autospec-define/SKILL.md"
+if [ ! -f "$define_skill" ]; then
+    echo "FAIL: autospec-define/SKILL.md missing"
+    exit 1
+fi
+
+if ! grep -qF "## Init mode" "$define_skill"; then
+    echo "FAIL: autospec-define/SKILL.md missing '## Init mode' section"
+    exit 1
+fi
+
+if ! grep -q "gen-docs-from-spec\|auto-docs\|doc-PR" "$define_skill"; then
+    echo "FAIL: autospec-define/SKILL.md missing auto-docs step documentation"
+    exit 1
+fi
+
+# ── autospec-run SKILL.md: Docs drift gate section ───────────────────────────
+
+run_skill="$SCRIPT_DIR/skills/autospec-run/SKILL.md"
+if ! grep -qF "## Docs drift gate" "$run_skill"; then
+    echo "FAIL: autospec-run/SKILL.md missing '## Docs drift gate' section"
+    exit 1
+fi
+
+if ! grep -q "check-doc-drift.sh" "$run_skill"; then
+    echo "FAIL: autospec-run/SKILL.md missing check-doc-drift.sh reference"
+    exit 1
+fi
+
+# ── phase4-implementer.md: drift gate call ───────────────────────────────────
+
+phase4_prompt="$SCRIPT_DIR/skills/autospec-run/prompts/phase4-implementer.md"
+if ! grep -q "check-doc-drift.sh" "$phase4_prompt"; then
+    echo "FAIL: phase4-implementer.md missing check-doc-drift.sh reference"
+    exit 1
+fi
+
+echo "OK: Phase 4 docs drift gate wiring verified"


### PR DESCRIPTION
Closes #369

## Summary

- Adds `## Init mode` section to `autospec-define/SKILL.md` (+ lockstep mirrors) documenting: `--init` flag, auto-detect prompt (yes/no/always-this-repo with `.autospec/init-done.flag`), init execution flow (tree-sitter scan → specs → docs → PR → admin-merge), and auto-docs step after spec PR merges.
- Adds `## Docs drift gate` section (step 3b) to `autospec-run/SKILL.md` (+ lockstep mirrors) between the autospec-test gate and the LGTM review, branching on `check-doc-drift.sh --pr` exit 0/1/2: clean → continue; drift → self-heal loop + label; missing-scope → human review label + exit 1.
- Amends `phase4-implementer.md` with a `### Docs drift gate` subsection using `--working-tree` mode for pre-PR drift detection.
- All 6 lockstep files updated (autospec-define × 3, autospec-run × 3).
- 7 bats tests + 1 shell test for validate.sh; all pass.
- `scripts/validate.sh` exits 0.

## Verification

```
bats skills/autospec-run/tests/integration/phase4-drift-gate.bats
bash validate.sh
grep -n "Docs drift gate" skills/autospec-run/SKILL.md
grep -n "Init mode" skills/autospec-define/SKILL.md
```

All checks: OK.

## Peer-review note
Codex not on PATH, skipping peer-review.