### PR TITLE
feat(autospec-docs): language matrix (phase 10b, closes #373)

### DIFF
--- a/skills/autospec-shared/test-targets/lang-matrix/go/cmd/cli/main.go
+++ b/skills/autospec-shared/test-targets/lang-matrix/go/cmd/cli/main.go
@@ -1,0 +1,27 @@
+// main.go — CLI entry point using cobra
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "hello <name>",
+		Short: "CLI greeter",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(greet(args[0]))
+		},
+	}
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func greet(name string) string {
+	return "Hello, " + name + "!"
+}

--- a/skills/autospec-shared/test-targets/lang-matrix/go/go.mod
+++ b/skills/autospec-shared/test-targets/lang-matrix/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/lang-matrix-go
+
+go 1.21

--- a/skills/autospec-shared/test-targets/lang-matrix/go/golden/walker.json
+++ b/skills/autospec-shared/test-targets/lang-matrix/go/golden/walker.json
@@ -1,0 +1,57 @@
+[
+  {
+    "language": "go",
+    "exports": [],
+    "entry_points": [
+      {
+        "kind": "cli_command",
+        "identifier": "main",
+        "line": 11
+      }
+    ],
+    "imports": [
+      {
+        "source": "fmt",
+        "names": []
+      },
+      {
+        "source": "os",
+        "names": []
+      },
+      {
+        "source": "github.com/spf13/cobra",
+        "names": []
+      }
+    ],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/go/cmd/cli/main.go"
+  },
+  {
+    "language": "go",
+    "exports": [
+      {
+        "name": "StartServer",
+        "kind": "function",
+        "signature": "func StartServer(addr string) error {",
+        "line": 11
+      }
+    ],
+    "entry_points": [
+      {
+        "kind": "http_route",
+        "identifier": "/greet/:name",
+        "line": 13
+      }
+    ],
+    "imports": [
+      {
+        "source": "net/http",
+        "names": []
+      },
+      {
+        "source": "github.com/gin-gonic/gin",
+        "names": []
+      }
+    ],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/go/internal/server.go"
+  }
+]

--- a/skills/autospec-shared/test-targets/lang-matrix/go/internal/server.go
+++ b/skills/autospec-shared/test-targets/lang-matrix/go/internal/server.go
@@ -1,0 +1,18 @@
+// server.go — Gin HTTP server
+package internal
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// StartServer starts the HTTP server on addr.
+func StartServer(addr string) error {
+	r := gin.Default()
+	r.GET("/greet/:name", func(c *gin.Context) {
+		name := c.Param("name")
+		c.JSON(http.StatusOK, gin.H{"message": "Hello, " + name + "!"})
+	})
+	return r.Run(addr)
+}

--- a/skills/autospec-shared/test-targets/lang-matrix/jvm/golden/walker.json
+++ b/skills/autospec-shared/test-targets/lang-matrix/jvm/golden/walker.json
@@ -1,0 +1,106 @@
+[
+  {
+    "language": "java",
+    "exports": [
+      {
+        "name": "Cli",
+        "kind": "class",
+        "signature": "public class Cli {",
+        "line": 4
+      },
+      {
+        "name": "main",
+        "kind": "function",
+        "signature": "public static void main(String[] args) {",
+        "line": 5
+      }
+    ],
+    "entry_points": [
+      {
+        "kind": "cli_command",
+        "identifier": "main",
+        "line": 5
+      }
+    ],
+    "imports": [],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/jvm/src/main/java/com/example/Cli.java"
+  },
+  {
+    "language": "java",
+    "exports": [
+      {
+        "name": "Server",
+        "kind": "class",
+        "signature": "public class Server {",
+        "line": 12
+      },
+      {
+        "name": "main",
+        "kind": "function",
+        "signature": "public static void main(String[] args) {",
+        "line": 13
+      },
+      {
+        "name": "greet",
+        "kind": "function",
+        "signature": "public String greet(@PathVariable String name) {",
+        "line": 18
+      }
+    ],
+    "entry_points": [
+      {
+        "kind": "cli_command",
+        "identifier": "main",
+        "line": 13
+      },
+      {
+        "kind": "http_route",
+        "identifier": "/greet/{name}",
+        "line": 17
+      }
+    ],
+    "imports": [
+      {
+        "source": "org.springframework.boot.SpringApplication",
+        "names": []
+      },
+      {
+        "source": "org.springframework.boot.autoconfigure.SpringBootApplication",
+        "names": []
+      },
+      {
+        "source": "org.springframework.web.bind.annotation.GetMapping",
+        "names": []
+      },
+      {
+        "source": "org.springframework.web.bind.annotation.PathVariable",
+        "names": []
+      },
+      {
+        "source": "org.springframework.web.bind.annotation.RestController",
+        "names": []
+      }
+    ],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/jvm/src/main/java/com/example/Server.java"
+  },
+  {
+    "language": "java",
+    "exports": [
+      {
+        "name": "Lib",
+        "kind": "class",
+        "signature": "public class Lib {",
+        "line": 4
+      },
+      {
+        "name": "greet",
+        "kind": "function",
+        "signature": "public static String greet(String name) {",
+        "line": 5
+      }
+    ],
+    "entry_points": [],
+    "imports": [],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/jvm/src/main/java/com/example/Lib.java"
+  }
+]

--- a/skills/autospec-shared/test-targets/lang-matrix/jvm/pom.xml
+++ b/skills/autospec-shared/test-targets/lang-matrix/jvm/pom.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>lang-matrix-jvm</artifactId>
+  <version>1.0.0</version>
+  <description>Language matrix: JVM/Java scaffold</description>
+</project>

--- a/skills/autospec-shared/test-targets/lang-matrix/jvm/src/main/java/com/example/Cli.java
+++ b/skills/autospec-shared/test-targets/lang-matrix/jvm/src/main/java/com/example/Cli.java
@@ -1,0 +1,12 @@
+// Cli.java — CLI entry point
+package com.example;
+
+public class Cli {
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.err.println("Usage: hello <name>");
+            System.exit(1);
+        }
+        System.out.println(Lib.greet(args[0]));
+    }
+}

--- a/skills/autospec-shared/test-targets/lang-matrix/jvm/src/main/java/com/example/Lib.java
+++ b/skills/autospec-shared/test-targets/lang-matrix/jvm/src/main/java/com/example/Lib.java
@@ -1,0 +1,8 @@
+// Lib.java — exported utility
+package com.example;
+
+public class Lib {
+    public static String greet(String name) {
+        return "Hello, " + name + "!";
+    }
+}

--- a/skills/autospec-shared/test-targets/lang-matrix/jvm/src/main/java/com/example/Server.java
+++ b/skills/autospec-shared/test-targets/lang-matrix/jvm/src/main/java/com/example/Server.java
@@ -1,0 +1,21 @@
+// Server.java — Spring Boot HTTP server
+package com.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootApplication
+@RestController
+public class Server {
+    public static void main(String[] args) {
+        SpringApplication.run(Server.class, args);
+    }
+
+    @GetMapping("/greet/{name}")
+    public String greet(@PathVariable String name) {
+        return Lib.greet(name);
+    }
+}

--- a/skills/autospec-shared/test-targets/lang-matrix/node/golden/walker.json
+++ b/skills/autospec-shared/test-targets/lang-matrix/node/golden/walker.json
@@ -1,0 +1,75 @@
+[
+  {
+    "language": "typescript",
+    "exports": [],
+    "entry_points": [
+      {
+        "kind": "cli_command",
+        "identifier": "cli.ts",
+        "line": 1
+      }
+    ],
+    "imports": [
+      {
+        "source": "commander",
+        "names": [
+          "Command"
+        ]
+      },
+      {
+        "source": "./lib.js",
+        "names": [
+          "greet"
+        ]
+      }
+    ],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/node/src/cli.ts"
+  },
+  {
+    "language": "typescript",
+    "exports": [
+      {
+        "name": "startServer",
+        "kind": "function",
+        "signature": "export function startServer(port = 3000) {",
+        "line": 11
+      }
+    ],
+    "entry_points": [
+      {
+        "kind": "http_route",
+        "identifier": "/greet/:name",
+        "line": 7
+      }
+    ],
+    "imports": [
+      {
+        "source": "express",
+        "names": [
+          "express"
+        ]
+      },
+      {
+        "source": "./lib.js",
+        "names": [
+          "greet"
+        ]
+      }
+    ],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/node/src/server.ts"
+  },
+  {
+    "language": "typescript",
+    "exports": [
+      {
+        "name": "greet",
+        "kind": "function",
+        "signature": "export function greet(name: string): string {",
+        "line": 2
+      }
+    ],
+    "entry_points": [],
+    "imports": [],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/node/src/lib.ts"
+  }
+]

--- a/skills/autospec-shared/test-targets/lang-matrix/node/package.json
+++ b/skills/autospec-shared/test-targets/lang-matrix/node/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lang-matrix-node",
+  "version": "1.0.0",
+  "description": "Language matrix: Node/TypeScript scaffold"
+}

--- a/skills/autospec-shared/test-targets/lang-matrix/node/src/cli.ts
+++ b/skills/autospec-shared/test-targets/lang-matrix/node/src/cli.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// cli.ts — CLI entry point
+import { Command } from 'commander';
+import { greet } from './lib.js';
+
+const program = new Command();
+program
+  .name('hello')
+  .description('CLI greeter')
+  .argument('<name>', 'name to greet')
+  .action((name: string) => {
+    console.log(greet(name));
+  });
+
+program.parse();

--- a/skills/autospec-shared/test-targets/lang-matrix/node/src/lib.ts
+++ b/skills/autospec-shared/test-targets/lang-matrix/node/src/lib.ts
@@ -1,0 +1,4 @@
+// lib.ts — exported utility
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}

--- a/skills/autospec-shared/test-targets/lang-matrix/node/src/server.ts
+++ b/skills/autospec-shared/test-targets/lang-matrix/node/src/server.ts
@@ -1,0 +1,13 @@
+// server.ts — Express HTTP server
+import express from 'express';
+import { greet } from './lib.js';
+
+const app = express();
+
+app.get('/greet/:name', (req, res) => {
+  res.json({ message: greet(req.params.name) });
+});
+
+export function startServer(port = 3000) {
+  return app.listen(port);
+}

--- a/skills/autospec-shared/test-targets/lang-matrix/python/golden/walker.json
+++ b/skills/autospec-shared/test-targets/lang-matrix/python/golden/walker.json
@@ -1,0 +1,68 @@
+[
+  {
+    "language": "python",
+    "exports": [
+      {
+        "name": "main",
+        "kind": "function",
+        "signature": "def main(name: str) -> None:",
+        "line": 9
+      }
+    ],
+    "entry_points": [
+      {
+        "kind": "cli_command",
+        "identifier": "__main__",
+        "line": 14
+      }
+    ],
+    "imports": [
+      {
+        "source": "click",
+        "names": []
+      }
+    ],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/python/src/cli.py"
+  },
+  {
+    "language": "python",
+    "exports": [
+      {
+        "name": "greet_endpoint",
+        "kind": "function",
+        "signature": "def greet_endpoint(name: str) -> dict:",
+        "line": 9
+      }
+    ],
+    "entry_points": [
+      {
+        "kind": "http_route",
+        "identifier": "/greet/{name}",
+        "line": 8
+      }
+    ],
+    "imports": [
+      {
+        "source": "fastapi",
+        "names": [
+          "FastAPI"
+        ]
+      }
+    ],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/python/src/server.py"
+  },
+  {
+    "language": "python",
+    "exports": [
+      {
+        "name": "greet",
+        "kind": "function",
+        "signature": "def greet(name: str) -> str:",
+        "line": 4
+      }
+    ],
+    "entry_points": [],
+    "imports": [],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/python/src/lib.py"
+  }
+]

--- a/skills/autospec-shared/test-targets/lang-matrix/python/pyproject.toml
+++ b/skills/autospec-shared/test-targets/lang-matrix/python/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "lang-matrix-python"
+version = "1.0.0"
+description = "Language matrix: Python scaffold"

--- a/skills/autospec-shared/test-targets/lang-matrix/python/src/cli.py
+++ b/skills/autospec-shared/test-targets/lang-matrix/python/src/cli.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""cli.py — CLI entry point using click."""
+import click
+from .lib import greet
+
+
+@click.command()
+@click.argument("name")
+def main(name: str) -> None:
+    """Greet NAME."""
+    click.echo(greet(name))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/autospec-shared/test-targets/lang-matrix/python/src/lib.py
+++ b/skills/autospec-shared/test-targets/lang-matrix/python/src/lib.py
@@ -1,0 +1,6 @@
+"""lib.py — exported utility."""
+
+
+def greet(name: str) -> str:
+    """Return a greeting string."""
+    return f"Hello, {name}!"

--- a/skills/autospec-shared/test-targets/lang-matrix/python/src/server.py
+++ b/skills/autospec-shared/test-targets/lang-matrix/python/src/server.py
@@ -1,0 +1,11 @@
+"""server.py — FastAPI HTTP server."""
+from fastapi import FastAPI
+from .lib import greet
+
+app = FastAPI()
+
+
+@app.get("/greet/{name}")
+def greet_endpoint(name: str) -> dict:
+    """Return a greeting for name."""
+    return {"message": greet(name)}

--- a/skills/autospec-shared/test-targets/lang-matrix/rust/Cargo.toml
+++ b/skills/autospec-shared/test-targets/lang-matrix/rust/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "lang-matrix-rust"
+version = "1.0.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+actix-web = "4"
+serde_json = "1"

--- a/skills/autospec-shared/test-targets/lang-matrix/rust/golden/walker.json
+++ b/skills/autospec-shared/test-targets/lang-matrix/rust/golden/walker.json
@@ -1,0 +1,67 @@
+[
+  {
+    "language": "rust",
+    "exports": [],
+    "entry_points": [
+      {
+        "kind": "cli_command",
+        "identifier": "main",
+        "line": 15
+      }
+    ],
+    "imports": [
+      {
+        "source": "clap::Parser",
+        "names": []
+      },
+      {
+        "source": "lib::greet",
+        "names": []
+      }
+    ],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/rust/src/main.rs"
+  },
+  {
+    "language": "rust",
+    "exports": [
+      {
+        "name": "start_server",
+        "kind": "function",
+        "signature": "pub async fn start_server(addr: &str) -> std::io::Result<()> {",
+        "line": 10
+      }
+    ],
+    "entry_points": [
+      {
+        "kind": "http_route",
+        "identifier": "/greet/{name}",
+        "line": 5
+      }
+    ],
+    "imports": [
+      {
+        "source": "actix_web::{get, web, App, HttpResponse, HttpServer, Responder}",
+        "names": []
+      },
+      {
+        "source": "crate::lib::greet",
+        "names": []
+      }
+    ],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/rust/src/server.rs"
+  },
+  {
+    "language": "rust",
+    "exports": [
+      {
+        "name": "greet",
+        "kind": "function",
+        "signature": "pub fn greet(name: &str) -> String {",
+        "line": 2
+      }
+    ],
+    "entry_points": [],
+    "imports": [],
+    "file_path": "/private/tmp/wt-373-phase10b/skills/autospec-shared/test-targets/lang-matrix/rust/src/lib.rs"
+  }
+]

--- a/skills/autospec-shared/test-targets/lang-matrix/rust/src/lib.rs
+++ b/skills/autospec-shared/test-targets/lang-matrix/rust/src/lib.rs
@@ -1,0 +1,4 @@
+// lib.rs — exported utility
+pub fn greet(name: &str) -> String {
+    format!("Hello, {}!", name)
+}

--- a/skills/autospec-shared/test-targets/lang-matrix/rust/src/main.rs
+++ b/skills/autospec-shared/test-targets/lang-matrix/rust/src/main.rs
@@ -1,0 +1,18 @@
+// main.rs — CLI entry point using clap
+use clap::Parser;
+
+mod lib;
+use lib::greet;
+
+/// CLI greeter
+#[derive(Parser)]
+#[command(name = "hello")]
+struct Args {
+    /// Name to greet
+    name: String,
+}
+
+fn main() {
+    let args = Args::parse();
+    println!("{}", greet(&args.name));
+}

--- a/skills/autospec-shared/test-targets/lang-matrix/rust/src/server.rs
+++ b/skills/autospec-shared/test-targets/lang-matrix/rust/src/server.rs
@@ -1,0 +1,15 @@
+// server.rs — Actix-web HTTP server
+use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
+use crate::lib::greet;
+
+#[get("/greet/{name}")]
+async fn greet_handler(name: web::Path<String>) -> impl Responder {
+    HttpResponse::Ok().json(serde_json::json!({ "message": greet(&name) }))
+}
+
+pub async fn start_server(addr: &str) -> std::io::Result<()> {
+    HttpServer::new(|| App::new().service(greet_handler))
+        .bind(addr)?
+        .run()
+        .await
+}

--- a/skills/autospec-shared/tests/integration/lang-matrix.bats
+++ b/skills/autospec-shared/tests/integration/lang-matrix.bats
@@ -1,0 +1,342 @@
+#!/usr/bin/env bats
+# lang-matrix.bats — Integration harness for autospec-shared language matrix.
+#
+# Runs walker.mjs against each language fixture and diffs actual output
+# against the golden walker.json.
+#
+# Run: bats skills/autospec-shared/tests/integration/lang-matrix.bats
+# (from repo root)
+
+setup() {
+    BATS_FILE_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+    REPO_ROOT="$(cd "${BATS_FILE_DIR}/../../../.." && pwd)"
+    SHARED_DIR="${REPO_ROOT}/skills/autospec-shared"
+    WALKER_MJS="${SHARED_DIR}/scripts/tree-sitter-walk/walker.mjs"
+    MATRIX_DIR="${SHARED_DIR}/test-targets/lang-matrix"
+
+    # Ensure node_modules are available (run npm install if needed)
+    if [ ! -d "${SHARED_DIR}/node_modules" ]; then
+        npm install --prefix "${SHARED_DIR}" --silent 2>/dev/null || true
+    fi
+}
+
+# Helper: run walker.mjs on a list of files, returns JSON array
+run_walker() {
+    local lang_dir="$1"
+    shift
+    local files=("$@")
+
+    node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+import { writeFileSync } from 'node:fs';
+const files = ${files_json};
+const results = [];
+for (const f of files) {
+  results.push(await walk(f));
+}
+process.stdout.write(JSON.stringify(results, null, 2));
+EOF
+}
+
+# Helper: normalise walker JSON for comparison (strip absolute file_path → relative)
+normalise_walker() {
+    local json="$1"
+    local lang_dir="$2"
+    echo "$json" | node -e "
+const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+// Normalise file_path to relative (strip absolute prefix)
+for(const e of d) {
+  if(e.file_path) e.file_path = e.file_path.replace(/.*lang-matrix\\//, 'lang-matrix/');
+}
+process.stdout.write(JSON.stringify(d));
+" 2>/dev/null
+}
+
+# Helper: run walker on all source files of a language and compare to golden
+check_lang() {
+    local lang="$1"
+    shift
+    local src_files=("$@")
+
+    local lang_dir="${MATRIX_DIR}/${lang}"
+    local golden_file="${lang_dir}/golden/walker.json"
+
+    # Build absolute paths
+    local abs_files=()
+    for f in "${src_files[@]}"; do
+        abs_files+=("${lang_dir}/${f}")
+    done
+
+    # Build JS array literal
+    local files_js="["
+    for f in "${abs_files[@]}"; do
+        files_js+="\"${f}\","
+    done
+    files_js="${files_js%,}]"
+
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const files = ${files_js};
+const results = [];
+for (const f of files) {
+  results.push(await walk(f));
+}
+process.stdout.write(JSON.stringify(results, null, 2));
+EOF
+)"
+
+    golden="$(cat "${golden_file}")"
+
+    norm_actual="$(normalise_walker "$actual" "$lang_dir")"
+    norm_golden="$(normalise_walker "$golden" "$lang_dir")"
+
+    [ "$norm_actual" = "$norm_golden" ]
+}
+
+# ── Node / TypeScript ─────────────────────────────────────────────────────────
+
+@test "node: walker detects typescript language" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/node/src/cli.ts');
+process.stdout.write(r.language);
+EOF
+)"
+    [ "$actual" = "typescript" ]
+}
+
+@test "node: walker detects cli_command entry_point in cli.ts" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/node/src/cli.ts');
+const ep = r.entry_points.find(e => e.kind === 'cli_command');
+process.stdout.write(ep ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "node: walker detects http_route entry_point in server.ts" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/node/src/server.ts');
+const ep = r.entry_points.find(e => e.kind === 'http_route');
+process.stdout.write(ep ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "node: walker detects exported function greet in lib.ts" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/node/src/lib.ts');
+const exp = r.exports.find(e => e.name === 'greet');
+process.stdout.write(exp ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "node: actual walker.json byte-equal to golden" {
+    check_lang "node" "src/cli.ts" "src/server.ts" "src/lib.ts"
+}
+
+# ── Python ────────────────────────────────────────────────────────────────────
+
+@test "python: walker detects python language" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/python/src/cli.py');
+process.stdout.write(r.language);
+EOF
+)"
+    [ "$actual" = "python" ]
+}
+
+@test "python: walker detects cli_command entry_point in cli.py" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/python/src/cli.py');
+const ep = r.entry_points.find(e => e.kind === 'cli_command');
+process.stdout.write(ep ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "python: walker detects http_route entry_point in server.py" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/python/src/server.py');
+const ep = r.entry_points.find(e => e.kind === 'http_route');
+process.stdout.write(ep ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "python: walker detects exported function greet in lib.py" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/python/src/lib.py');
+const exp = r.exports.find(e => e.name === 'greet');
+process.stdout.write(exp ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "python: actual walker.json byte-equal to golden" {
+    check_lang "python" "src/cli.py" "src/server.py" "src/lib.py"
+}
+
+# ── Go ────────────────────────────────────────────────────────────────────────
+
+@test "go: walker detects go language" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/go/cmd/cli/main.go');
+process.stdout.write(r.language);
+EOF
+)"
+    [ "$actual" = "go" ]
+}
+
+@test "go: walker detects cli_command entry_point in main.go" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/go/cmd/cli/main.go');
+const ep = r.entry_points.find(e => e.kind === 'cli_command');
+process.stdout.write(ep ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "go: walker detects http_route entry_point in server.go" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/go/internal/server.go');
+const ep = r.entry_points.find(e => e.kind === 'http_route');
+process.stdout.write(ep ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "go: walker detects exported function StartServer in server.go" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/go/internal/server.go');
+const exp = r.exports.find(e => e.name === 'StartServer');
+process.stdout.write(exp ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "go: actual walker.json byte-equal to golden" {
+    check_lang "go" "cmd/cli/main.go" "internal/server.go"
+}
+
+# ── Rust ──────────────────────────────────────────────────────────────────────
+
+@test "rust: walker detects rust language" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/rust/src/main.rs');
+process.stdout.write(r.language);
+EOF
+)"
+    [ "$actual" = "rust" ]
+}
+
+@test "rust: walker detects cli_command entry_point in main.rs" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/rust/src/main.rs');
+const ep = r.entry_points.find(e => e.kind === 'cli_command');
+process.stdout.write(ep ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "rust: walker detects http_route entry_point in server.rs" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/rust/src/server.rs');
+const ep = r.entry_points.find(e => e.kind === 'http_route');
+process.stdout.write(ep ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "rust: walker detects exported function greet in lib.rs" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/rust/src/lib.rs');
+const exp = r.exports.find(e => e.name === 'greet');
+process.stdout.write(exp ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "rust: actual walker.json byte-equal to golden" {
+    check_lang "rust" "src/main.rs" "src/server.rs" "src/lib.rs"
+}
+
+# ── JVM / Java ────────────────────────────────────────────────────────────────
+
+@test "jvm: walker detects java language" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/jvm/src/main/java/com/example/Cli.java');
+process.stdout.write(r.language);
+EOF
+)"
+    [ "$actual" = "java" ]
+}
+
+@test "jvm: walker detects cli_command entry_point in Cli.java" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/jvm/src/main/java/com/example/Cli.java');
+const ep = r.entry_points.find(e => e.kind === 'cli_command');
+process.stdout.write(ep ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "jvm: walker detects http_route entry_point in Server.java" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/jvm/src/main/java/com/example/Server.java');
+const ep = r.entry_points.find(e => e.kind === 'http_route');
+process.stdout.write(ep ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "jvm: walker detects exported function greet in Lib.java" {
+    actual="$(node --input-type=module <<EOF 2>/dev/null
+import { walk } from '${WALKER_MJS}';
+const r = await walk('${MATRIX_DIR}/jvm/src/main/java/com/example/Lib.java');
+const exp = r.exports.find(e => e.name === 'greet');
+process.stdout.write(exp ? 'found' : 'missing');
+EOF
+)"
+    [ "$actual" = "found" ]
+}
+
+@test "jvm: actual walker.json byte-equal to golden" {
+    check_lang "jvm" \
+        "src/main/java/com/example/Cli.java" \
+        "src/main/java/com/example/Server.java" \
+        "src/main/java/com/example/Lib.java"
+}


### PR DESCRIPTION
docs: skip

## Summary

- 5-language scaffold under `skills/autospec-shared/test-targets/lang-matrix/`:
  - `node` (TypeScript): cli.ts + server.ts + lib.ts (commander/express)
  - `python`: cli.py + server.py + lib.py (click/fastapi)
  - `go`: cmd/cli/main.go + internal/server.go (cobra/gin)
  - `rust`: src/main.rs + src/server.rs + src/lib.rs (clap/actix-web)
  - `jvm`: Cli.java + Server.java + Lib.java (Spring Boot)
- Each scaffold carries `golden/walker.json` generated from actual `tree-sitter-walk` output
- `lang-matrix.bats` integration harness (25/25 tests pass)
- Tests assert: language detection, CLI entry point, HTTP route, exported function, and byte-equal golden for all 5 languages

## Test plan

- [x] 25/25 bats integration tests pass (`bats skills/autospec-shared/tests/integration/lang-matrix.bats`)
- [x] All 5 languages detected correctly
- [x] CLI entry points detected: TypeScript(commander), Python(click), Go(cobra), Rust(clap), Java(main)
- [x] HTTP routes detected: TypeScript(express), Python(fastapi), Go(gin), Rust(actix-web), Java(Spring)
- [x] Exported functions detected in all 5 languages
- [x] Golden walker.json byte-equal to actual output

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)