### PR TITLE
feat(model-tier): Haiku trial profile + select-model-profile routing (closes #417)

### DIFF
--- a/examples/model-profiles.yml
+++ b/examples/model-profiles.yml
@@ -28,3 +28,12 @@ qwen3-32b-laptop:
   ctx: 32000
   reasoning: low
   allowed: ctx:small,reasoning:low
+
+# Phase 2 Haiku trial — cost-optimised tier for shallow/medium-reasoning implementer dispatches.
+# LGTM-first-pass rate and iteration count tracked in telemetry to gate rollback.
+# Rollback: set AUTOSPEC_TIER_B_PROFILE=claude-sonnet-cloud in ~/.autospec/env to revert.
+claude-haiku-cloud:
+  model: claude-haiku-4-5
+  ctx: 64000
+  reasoning: medium
+  allowed: ctx:small,ctx:medium,reasoning:shallow,reasoning:medium

--- a/skills/autospec-run/scripts/select-model-profile.sh
+++ b/skills/autospec-run/scripts/select-model-profile.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# select-model-profile.sh — Select the TIER_B implementer profile for a given issue.
+#
+# Usage:
+#   select-model-profile.sh --labels <comma-separated-labels> [--profiles-file <path>]
+#
+# Prints the profile name to stdout (e.g. "claude-haiku-cloud" or "claude-sonnet-cloud").
+#
+# Routing rules (Phase 2 Haiku trial):
+#   - reasoning:shallow  → claude-haiku-cloud  (if available in profiles file)
+#   - reasoning:medium   → claude-haiku-cloud  (if available in profiles file)
+#   - reasoning:deep     → claude-sonnet-cloud (always)
+#   - default (no reasoning label) → AUTOSPEC_TIER_B_PROFILE or claude-sonnet-cloud
+#
+# Environment:
+#   AUTOSPEC_TIER_B_PROFILE   override default TIER_B profile name
+#   AUTOSPEC_MODEL_PROFILES   path to model-profiles.yml (default: ~/.autospec/model-profiles.yml)
+
+set -eu
+
+LABELS=""
+PROFILES_FILE="${AUTOSPEC_MODEL_PROFILES:-$HOME/.autospec/model-profiles.yml}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --labels)
+            LABELS="${2:-}"
+            shift 2
+            ;;
+        --profiles-file)
+            PROFILES_FILE="${2:-}"
+            shift 2
+            ;;
+        --help|-h)
+            printf 'Usage: select-model-profile.sh --labels <labels> [--profiles-file <path>]\n'
+            exit 0
+            ;;
+        *)
+            printf 'select-model-profile.sh: unknown option: %s\n' "$1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ── Default TIER_B profile ─────────────────────────────────────────────────────
+DEFAULT_PROFILE="${AUTOSPEC_TIER_B_PROFILE:-claude-sonnet-cloud}"
+HAIKU_PROFILE="claude-haiku-cloud"
+
+# ── Check if Haiku profile exists in profiles file ────────────────────────────
+_haiku_available() {
+    if [ ! -f "$PROFILES_FILE" ]; then
+        return 1
+    fi
+    grep -q "^${HAIKU_PROFILE}:" "$PROFILES_FILE" 2>/dev/null || \
+    grep -q "^  ${HAIKU_PROFILE}:" "$PROFILES_FILE" 2>/dev/null || \
+    grep -q "^    ${HAIKU_PROFILE}:" "$PROFILES_FILE" 2>/dev/null
+}
+
+# ── Routing decision ──────────────────────────────────────────────────────────
+# Parse reasoning label from comma-separated labels
+reasoning_label=""
+IFS=',' read -ra label_arr <<< "$LABELS"
+for lbl in "${label_arr[@]}"; do
+    lbl="$(printf '%s' "$lbl" | tr -d ' ')"
+    case "$lbl" in
+        reasoning:shallow|reasoning:medium|reasoning:deep)
+            reasoning_label="$lbl"
+            break
+            ;;
+    esac
+done
+
+case "$reasoning_label" in
+    reasoning:shallow|reasoning:medium)
+        if _haiku_available; then
+            printf '%s\n' "$HAIKU_PROFILE"
+        else
+            printf '%s\n' "$DEFAULT_PROFILE"
+        fi
+        ;;
+    reasoning:deep)
+        printf '%s\n' "$DEFAULT_PROFILE"
+        ;;
+    *)
+        printf '%s\n' "$DEFAULT_PROFILE"
+        ;;
+esac

--- a/skills/autospec-shared/scripts/record-telemetry.sh
+++ b/skills/autospec-shared/scripts/record-telemetry.sh
@@ -24,6 +24,7 @@ DISPATCH_ID=""
 ROLE=""
 ISSUE=""
 TOKENS_JSON=""
+PROFILE_ID=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -39,6 +40,9 @@ while [ $# -gt 0 ]; do
     --tokens-json)
       if [ $# -lt 2 ]; then printf 'record-telemetry.sh: --tokens-json requires an argument\n' >&2; exit 1; fi
       TOKENS_JSON="$2"; shift 2 ;;
+    --profile-id)
+      if [ $# -lt 2 ]; then printf 'record-telemetry.sh: --profile-id requires an argument\n' >&2; exit 1; fi
+      PROFILE_ID="$2"; shift 2 ;;
     -*)
       printf 'record-telemetry.sh: unknown option: %s\n' "$1" >&2; exit 1 ;;
     *)
@@ -47,7 +51,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$DISPATCH_ID" ] || [ -z "$ROLE" ] || [ -z "$ISSUE" ] || [ -z "$TOKENS_JSON" ]; then
-  printf 'Usage: record-telemetry.sh --dispatch-id <id> --role <role> --issue <n> --tokens-json <file>\n' >&2
+  printf 'Usage: record-telemetry.sh --dispatch-id <id> --role <role> --issue <n> --tokens-json <file> [--profile-id <id>]\n' >&2
   exit 1
 fi
 
@@ -76,5 +80,6 @@ jq -cn \
   --argjson cache_r     "$cache_read" \
   --argjson output      "$output_tokens" \
   --arg     dispatch_id "$DISPATCH_ID" \
-  '{ts:$ts,role:$role,issue:$issue,input_tokens:$input,cache_creation_input_tokens:$cache_c,cache_read_input_tokens:$cache_r,output_tokens:$output,dispatch_id:$dispatch_id}' \
+  --arg     profile_id  "${PROFILE_ID:-}" \
+  '{ts:$ts,role:$role,issue:$issue,input_tokens:$input,cache_creation_input_tokens:$cache_c,cache_read_input_tokens:$cache_r,output_tokens:$output,dispatch_id:$dispatch_id,profile_id:$profile_id}' \
   >> "$TELEMETRY_FILE"

--- a/tests/record-telemetry.bats
+++ b/tests/record-telemetry.bats
@@ -93,3 +93,24 @@ _tokens_json() {
   [ "$status" -eq 0 ]
   [ -f "$deep_dir/telemetry.jsonl" ]
 }
+
+@test "record-telemetry.sh stores profile_id when --profile-id given" {
+  tokens_file=$(_tokens_json "profile" '{"input_tokens":500,"output_tokens":100,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}')
+  run "$SCRIPT" --dispatch-id "pid-test" --role "implementer" --issue "417" \
+      --tokens-json "$tokens_file" --profile-id "claude-haiku-cloud"
+  [ "$status" -eq 0 ]
+  line="$(tail -1 "$TELEMETRY_FILE")"
+  profile="$(printf '%s\n' "$line" | jq -r '.profile_id')"
+  [ "$profile" = "claude-haiku-cloud" ]
+}
+
+@test "record-telemetry.sh profile_id defaults to empty string when omitted" {
+  tokens_file=$(_tokens_json "no-profile" '{"input_tokens":100,"output_tokens":20}')
+  run "$SCRIPT" --dispatch-id "no-pid" --role "implementer" --issue "417" \
+      --tokens-json "$tokens_file"
+  [ "$status" -eq 0 ]
+  line="$(tail -1 "$TELEMETRY_FILE")"
+  # profile_id key must exist and be empty string
+  profile="$(printf '%s\n' "$line" | jq -r '.profile_id')"
+  [ "$profile" = "" ]
+}

--- a/tests/select-model-profile.bats
+++ b/tests/select-model-profile.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# tests/select-model-profile.bats — TDD for skills/autospec-run/scripts/select-model-profile.sh
+# Covers routing of reasoning:shallow/medium → Haiku, reasoning:deep → sonnet.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-run/scripts/select-model-profile.sh"
+FIXTURES_DIR="${BATS_TEST_DIRNAME}/fixtures/select-model-profile"
+
+setup() {
+    mkdir -p "$FIXTURES_DIR"
+
+    # Create a profiles file with both haiku and sonnet profiles
+    PROFILES_FILE="$FIXTURES_DIR/model-profiles.yml"
+    export AUTOSPEC_MODEL_PROFILES="$PROFILES_FILE"
+
+    cat > "$PROFILES_FILE" <<'EOF'
+claude-sonnet-cloud:
+  model: claude-sonnet-4-6
+  ctx: 200000
+  reasoning: medium
+  allowed: ctx:small,ctx:medium,reasoning:shallow,reasoning:medium
+
+claude-haiku-cloud:
+  model: claude-haiku-4-5
+  ctx: 64000
+  reasoning: medium
+  allowed: ctx:small,ctx:medium,reasoning:shallow,reasoning:medium
+EOF
+}
+
+teardown() {
+    rm -rf "$FIXTURES_DIR"
+    unset AUTOSPEC_MODEL_PROFILES
+    unset AUTOSPEC_TIER_B_PROFILE
+}
+
+@test "select-model-profile.sh is executable" {
+    [ -x "$SCRIPT" ]
+}
+
+@test "select-model-profile.sh --help exits 0" {
+    run bash "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+}
+
+@test "reasoning:shallow routes to claude-haiku-cloud" {
+    run bash "$SCRIPT" --labels "auto-implement,reasoning:shallow,ctx:64k"
+    [ "$status" -eq 0 ]
+    [ "$output" = "claude-haiku-cloud" ]
+}
+
+@test "reasoning:medium routes to claude-haiku-cloud" {
+    run bash "$SCRIPT" --labels "auto-implement,reasoning:medium,ctx:64k"
+    [ "$status" -eq 0 ]
+    [ "$output" = "claude-haiku-cloud" ]
+}
+
+@test "reasoning:deep routes to claude-sonnet-cloud" {
+    run bash "$SCRIPT" --labels "auto-implement,reasoning:deep,ctx:120k"
+    [ "$status" -eq 0 ]
+    [ "$output" = "claude-sonnet-cloud" ]
+}
+
+@test "no reasoning label falls back to default (sonnet)" {
+    run bash "$SCRIPT" --labels "auto-implement,area:hardening"
+    [ "$status" -eq 0 ]
+    [ "$output" = "claude-sonnet-cloud" ]
+}
+
+@test "AUTOSPEC_TIER_B_PROFILE overrides default for reasoning:deep" {
+    export AUTOSPEC_TIER_B_PROFILE="claude-opus-cloud"
+    run bash "$SCRIPT" --labels "auto-implement,reasoning:deep"
+    [ "$status" -eq 0 ]
+    [ "$output" = "claude-opus-cloud" ]
+}
+
+@test "reasoning:shallow falls back to sonnet when haiku profile absent" {
+    # Use a profiles file without haiku
+    cat > "$FIXTURES_DIR/model-profiles.yml" <<'EOF'
+claude-sonnet-cloud:
+  model: claude-sonnet-4-6
+  ctx: 200000
+  reasoning: medium
+EOF
+    run bash "$SCRIPT" --labels "auto-implement,reasoning:shallow"
+    [ "$status" -eq 0 ]
+    [ "$output" = "claude-sonnet-cloud" ]
+}
+
+@test "reasoning:medium falls back to sonnet when profiles file missing" {
+    export AUTOSPEC_MODEL_PROFILES="/nonexistent/path/model-profiles.yml"
+    run bash "$SCRIPT" --labels "auto-implement,reasoning:medium"
+    [ "$status" -eq 0 ]
+    [ "$output" = "claude-sonnet-cloud" ]
+}


### PR DESCRIPTION
## Summary

- Adds `claude-haiku-cloud` profile to `examples/model-profiles.yml` (ctx:64k, model:claude-haiku-4-5, reasoning:medium)
- Creates `skills/autospec-run/scripts/select-model-profile.sh` — routes `reasoning:shallow` and `reasoning:medium` dispatches to Haiku (when profile present), `reasoning:deep` stays on sonnet
- Extends `skills/autospec-shared/scripts/record-telemetry.sh` with `--profile-id` flag so implementer rows carry the dispatched profile for quality tracking
- Adds `tests/select-model-profile.bats` with 9 routing tests
- Adds 2 profile_id tests to `tests/record-telemetry.bats`

## Test plan

- [x] `bats tests/select-model-profile.bats` — all 9 tests pass
- [x] `bats tests/record-telemetry.bats` — all 11 tests pass (2 new)
- [x] `bash scripts/validate.sh` — exits 0
- [x] reasoning:shallow → claude-haiku-cloud
- [x] reasoning:medium → claude-haiku-cloud
- [x] reasoning:deep → claude-sonnet-cloud
- [x] Haiku absent → falls back to sonnet
- [x] Telemetry rows include profile_id field

docs: skip

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)