### PR TITLE
feat: orchestrator wires bundle-and-dispatch.sh for cached prompt assembly (#418)

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -451,20 +451,28 @@ issues unblock the queue before continuing with normal feature work.
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
 >
 > **Prompt construction (cache-prefix + dynamic suffix):**
-> Before dispatch, the orchestrator builds the subagent prompt in two parts:
+> Before dispatch, the orchestrator builds the subagent prompt using `bundle-and-dispatch.sh`:
 >
-> 1. **Static cached prefix** — call `bundle-static-context.sh` to emit the static blob:
+> 1. **Static cached prefix + dynamic suffix** — call `bundle-and-dispatch.sh` to assemble the combined prompt:
 >    ```bash
->    static_prefix=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-static-context.sh" \
+>    # Write dynamic suffix to a temp file first
+>    _suffix_file=$(mktemp -t autospec-suffix-XXXXXX.txt)
+>    trap 'rm -f "$_suffix_file"' EXIT
+>    printf '%s\n' "<ISSUE_BODY_AND_DIRECTIVES>" > "$_suffix_file"
+>    combined_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-and-dispatch.sh" \
 >      --role implementer \
->      --issue-labels "<ISSUE_LABELS>")
+>      --issue-labels "<ISSUE_LABELS>" \
+>      --dynamic-suffix-file "$_suffix_file")
 >    ```
->    The blob is framed by `<!-- CACHE BOUNDARY -->` markers and contains:
->    SKILL.md + AGENTS.md + RULE_ID table + tag-filtered saved-memory + lockstep rules + implementer scaffolding.
->    Pass this blob as the first content block of the subagent prompt with `cache_control: { type: "ephemeral" }`
->    so Anthropic's prompt cache can reuse it across dispatches in the same monitor session (5-min TTL).
+>    `bundle-and-dispatch.sh` calls `bundle-static-context.sh` internally to emit the static cached
+>    prefix (framed by `<!-- CACHE BOUNDARY -->` markers, containing SKILL.md + AGENTS.md + RULE_ID
+>    table + tag-filtered saved-memory + lockstep rules + implementer scaffolding), then appends the
+>    dynamic suffix verbatim after the closing marker.
+>    Pass the prefix block (up to and including the closing `<!-- CACHE BOUNDARY -->`) with
+>    `cache_control: { type: "ephemeral" }` so Anthropic's prompt cache can reuse it across
+>    dispatches in the same monitor session (5-min TTL).
 >
-> 2. **Dynamic uncached suffix** — append after the cached prefix:
+> 2. **Dynamic uncached suffix** — appended by `bundle-and-dispatch.sh` after the cached prefix:
 >    the issue body, per-iteration findings (if retry > 1), branch name, and "begin coding now".
 >
 > The combined prompt sent to the subagent is:

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -446,20 +446,28 @@ issues unblock the queue before continuing with normal feature work.
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
 >
 > **Prompt construction (cache-prefix + dynamic suffix):**
-> Before dispatch, the orchestrator builds the subagent prompt in two parts:
+> Before dispatch, the orchestrator builds the subagent prompt using `bundle-and-dispatch.sh`:
 >
-> 1. **Static cached prefix** — call `bundle-static-context.sh` to emit the static blob:
+> 1. **Static cached prefix + dynamic suffix** — call `bundle-and-dispatch.sh` to assemble the combined prompt:
 >    ```bash
->    static_prefix=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-static-context.sh" \
+>    # Write dynamic suffix to a temp file first
+>    _suffix_file=$(mktemp -t autospec-suffix-XXXXXX.txt)
+>    trap 'rm -f "$_suffix_file"' EXIT
+>    printf '%s\n' "<ISSUE_BODY_AND_DIRECTIVES>" > "$_suffix_file"
+>    combined_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-and-dispatch.sh" \
 >      --role implementer \
->      --issue-labels "<ISSUE_LABELS>")
+>      --issue-labels "<ISSUE_LABELS>" \
+>      --dynamic-suffix-file "$_suffix_file")
 >    ```
->    The blob is framed by `<!-- CACHE BOUNDARY -->` markers and contains:
->    SKILL.md + AGENTS.md + RULE_ID table + tag-filtered saved-memory + lockstep rules + implementer scaffolding.
->    Pass this blob as the first content block of the subagent prompt with `cache_control: { type: "ephemeral" }`
->    so Anthropic's prompt cache can reuse it across dispatches in the same monitor session (5-min TTL).
+>    `bundle-and-dispatch.sh` calls `bundle-static-context.sh` internally to emit the static cached
+>    prefix (framed by `<!-- CACHE BOUNDARY -->` markers, containing SKILL.md + AGENTS.md + RULE_ID
+>    table + tag-filtered saved-memory + lockstep rules + implementer scaffolding), then appends the
+>    dynamic suffix verbatim after the closing marker.
+>    Pass the prefix block (up to and including the closing `<!-- CACHE BOUNDARY -->`) with
+>    `cache_control: { type: "ephemeral" }` so Anthropic's prompt cache can reuse it across
+>    dispatches in the same monitor session (5-min TTL).
 >
-> 2. **Dynamic uncached suffix** — append after the cached prefix:
+> 2. **Dynamic uncached suffix** — appended by `bundle-and-dispatch.sh` after the cached prefix:
 >    the issue body, per-iteration findings (if retry > 1), branch name, and "begin coding now".
 >
 > The combined prompt sent to the subagent is:

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -450,20 +450,28 @@ issues unblock the queue before continuing with normal feature work.
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
 >
 > **Prompt construction (cache-prefix + dynamic suffix):**
-> Before dispatch, the orchestrator builds the subagent prompt in two parts:
+> Before dispatch, the orchestrator builds the subagent prompt using `bundle-and-dispatch.sh`:
 >
-> 1. **Static cached prefix** — call `bundle-static-context.sh` to emit the static blob:
+> 1. **Static cached prefix + dynamic suffix** — call `bundle-and-dispatch.sh` to assemble the combined prompt:
 >    ```bash
->    static_prefix=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-static-context.sh" \
+>    # Write dynamic suffix to a temp file first
+>    _suffix_file=$(mktemp -t autospec-suffix-XXXXXX.txt)
+>    trap 'rm -f "$_suffix_file"' EXIT
+>    printf '%s\n' "<ISSUE_BODY_AND_DIRECTIVES>" > "$_suffix_file"
+>    combined_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/bundle-and-dispatch.sh" \
 >      --role implementer \
->      --issue-labels "<ISSUE_LABELS>")
+>      --issue-labels "<ISSUE_LABELS>" \
+>      --dynamic-suffix-file "$_suffix_file")
 >    ```
->    The blob is framed by `<!-- CACHE BOUNDARY -->` markers and contains:
->    SKILL.md + AGENTS.md + RULE_ID table + tag-filtered saved-memory + lockstep rules + implementer scaffolding.
->    Pass this blob as the first content block of the subagent prompt with `cache_control: { type: "ephemeral" }`
->    so Anthropic's prompt cache can reuse it across dispatches in the same monitor session (5-min TTL).
+>    `bundle-and-dispatch.sh` calls `bundle-static-context.sh` internally to emit the static cached
+>    prefix (framed by `<!-- CACHE BOUNDARY -->` markers, containing SKILL.md + AGENTS.md + RULE_ID
+>    table + tag-filtered saved-memory + lockstep rules + implementer scaffolding), then appends the
+>    dynamic suffix verbatim after the closing marker.
+>    Pass the prefix block (up to and including the closing `<!-- CACHE BOUNDARY -->`) with
+>    `cache_control: { type: "ephemeral" }` so Anthropic's prompt cache can reuse it across
+>    dispatches in the same monitor session (5-min TTL).
 >
-> 2. **Dynamic uncached suffix** — append after the cached prefix:
+> 2. **Dynamic uncached suffix** — appended by `bundle-and-dispatch.sh` after the cached prefix:
 >    the issue body, per-iteration findings (if retry > 1), branch name, and "begin coding now".
 >
 > The combined prompt sent to the subagent is:

--- a/skills/autospec-shared/scripts/bundle-and-dispatch.sh
+++ b/skills/autospec-shared/scripts/bundle-and-dispatch.sh
@@ -33,10 +33,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BUNDLER="$SCRIPT_DIR/bundle-static-context.sh"
 
 HELP_TEXT='Usage:
-  bundle-and-dispatch.sh --role implementer|reviewer|decomposer|classifier
-                         --dynamic-suffix-file <path>
-                         [--issue-labels "label1,label2,..."]
-  bundle-and-dispatch.sh --help
+bundle-and-dispatch.sh --role implementer|reviewer|decomposer|classifier
+  --dynamic-suffix-file <path>
+  [--issue-labels "label1,label2,..."]
+bundle-and-dispatch.sh --help
 
 Assemble the two-part subagent prompt: static cached prefix (from bundle-static-context.sh)
 followed by the dynamic suffix from <path>. Emit combined output to stdout.'

--- a/skills/autospec-shared/scripts/bundle-and-dispatch.sh
+++ b/skills/autospec-shared/scripts/bundle-and-dispatch.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# skills/autospec-shared/scripts/bundle-and-dispatch.sh — Orchestrator helper: assemble cached
+# prefix via bundle-static-context.sh, append dynamic suffix, and emit the combined prompt.
+#
+# Usage:
+#   bundle-and-dispatch.sh --role implementer|reviewer|decomposer|classifier
+#                          --dynamic-suffix-file <path>
+#                          [--issue-labels "label1,label2,..."]
+#
+# Output (stdout): combined prompt — static cached prefix (framed by <!-- CACHE BOUNDARY -->)
+#                  followed by the dynamic suffix contents.
+#
+# The caller is responsible for passing the output to the Agent/task subagent tool with
+# cache_control: { type: "ephemeral" } on the prefix block (framed by CACHE BOUNDARY markers).
+#
+# Idempotent + deterministic: same inputs → byte-identical output (inherits from bundler).
+#
+# Environment overrides (forwarded to bundle-static-context.sh):
+#   AUTOSPEC_REPO_ROOT    — repo root
+#   AUTOSPEC_MEMORY_DIR   — path to memory files
+#   AUTOSPEC_SCRIPTS_DIR  — path to scripts dir
+#   AUTOSPEC_MANIFEST     — path to memory-tags.yml
+#
+# Exit codes:
+#   0  Success
+#   1  Argument/file error
+#
+# Compatible with bash 3.2+
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUNDLER="$SCRIPT_DIR/bundle-static-context.sh"
+
+HELP_TEXT='Usage:
+  bundle-and-dispatch.sh --role implementer|reviewer|decomposer|classifier
+                         --dynamic-suffix-file <path>
+                         [--issue-labels "label1,label2,..."]
+  bundle-and-dispatch.sh --help
+
+Assemble the two-part subagent prompt: static cached prefix (from bundle-static-context.sh)
+followed by the dynamic suffix from <path>. Emit combined output to stdout.'
+
+ROLE=""
+ISSUE_LABELS=""
+DYNAMIC_SUFFIX_FILE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --help|-h)
+      printf '%s\n' "$HELP_TEXT"
+      exit 0
+      ;;
+    --role)
+      if [ $# -lt 2 ]; then printf 'bundle-and-dispatch.sh: --role requires an argument\n' >&2; exit 1; fi
+      ROLE="$2"
+      shift 2
+      ;;
+    --issue-labels)
+      if [ $# -lt 2 ]; then printf 'bundle-and-dispatch.sh: --issue-labels requires an argument\n' >&2; exit 1; fi
+      ISSUE_LABELS="$2"
+      shift 2
+      ;;
+    --dynamic-suffix-file)
+      if [ $# -lt 2 ]; then printf 'bundle-and-dispatch.sh: --dynamic-suffix-file requires an argument\n' >&2; exit 1; fi
+      DYNAMIC_SUFFIX_FILE="$2"
+      shift 2
+      ;;
+    -*)
+      printf 'bundle-and-dispatch.sh: unknown option: %s\n' "$1" >&2
+      exit 1
+      ;;
+    *)
+      printf 'bundle-and-dispatch.sh: unexpected argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required args
+if [ -z "$ROLE" ]; then
+  printf 'bundle-and-dispatch.sh: --role is required\n' >&2
+  printf '%s\n' "$HELP_TEXT" >&2
+  exit 1
+fi
+
+if [ -z "$DYNAMIC_SUFFIX_FILE" ]; then
+  printf 'bundle-and-dispatch.sh: --dynamic-suffix-file is required\n' >&2
+  printf '%s\n' "$HELP_TEXT" >&2
+  exit 1
+fi
+
+if [ ! -f "$DYNAMIC_SUFFIX_FILE" ]; then
+  printf 'bundle-and-dispatch.sh: dynamic suffix file not found: %s\n' "$DYNAMIC_SUFFIX_FILE" >&2
+  exit 1
+fi
+
+if [ ! -f "$BUNDLER" ]; then
+  printf 'bundle-and-dispatch.sh: bundler not found: %s\n' "$BUNDLER" >&2
+  exit 1
+fi
+
+# ── emit combined output ──────────────────────────────────────────────────────
+
+# 1. Static cached prefix (framed by <!-- CACHE BOUNDARY --> markers)
+if [ -n "$ISSUE_LABELS" ]; then
+  bash "$BUNDLER" --role "$ROLE" --issue-labels "$ISSUE_LABELS"
+else
+  bash "$BUNDLER" --role "$ROLE"
+fi
+
+# 2. Dynamic suffix (appended after the closing CACHE BOUNDARY marker)
+printf '\n'
+cat "$DYNAMIC_SUFFIX_FILE"

--- a/tests/bundle-and-dispatch.bats
+++ b/tests/bundle-and-dispatch.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+# tests/bundle-and-dispatch.bats — TDD for skills/autospec-shared/scripts/bundle-and-dispatch.sh (issue #418)
+
+SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/bundle-and-dispatch.sh"
+BUNDLER="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/bundle-static-context.sh"
+FIXTURES_DIR="${BATS_TEST_DIRNAME}/fixtures/bundle-and-dispatch"
+
+setup() {
+  mkdir -p "$FIXTURES_DIR/memory"
+  mkdir -p "$FIXTURES_DIR/skills/autospec-run"
+  mkdir -p "$FIXTURES_DIR/skills/autospec-shared/scripts"
+
+  # Fixture SKILL.md for implementer role
+  cat > "$FIXTURES_DIR/skills/autospec-run/SKILL.md" <<'EOF'
+---
+name: autospec-run
+description: test fixture
+---
+
+# autospec-run workflow
+
+This is the SKILL.md content for testing.
+EOF
+
+  # Fixture AGENTS.md with RULE_ID table
+  cat > "$FIXTURES_DIR/AGENTS.md" <<'EOF'
+# AGENTS.md
+
+## Implementation-quality contract
+
+### RULE_ID table
+
+| RULE_ID | Detector | Tier | Threshold / regex |
+|---------|----------|------|-------------------|
+| `OUT_OF_SCOPE` | det | path-list compare | files touched not listed |
+| `MISSING_TEST` | det | path-prefix scan | required test absent |
+
+### Other section
+EOF
+
+  # Fixture dynamic suffix file
+  cat > "$FIXTURES_DIR/dynamic-suffix.txt" <<'EOF'
+## Issue Body
+
+Implement the feature described here.
+Branch: feat/test-branch
+EOF
+
+  # Fixture memory-tags.yml (empty — no memory files needed for these tests)
+  cat > "$FIXTURES_DIR/memory-tags.yml" <<'EOF'
+EOF
+}
+
+teardown() {
+  rm -rf "$FIXTURES_DIR"
+}
+
+@test "bundle-and-dispatch.sh is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "bundle-and-dispatch.sh --help exits 0" {
+  run "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+}
+
+@test "bundle-and-dispatch.sh exits 1 without required --role" {
+  run "$SCRIPT" --issue-labels "ctx:64k" --dynamic-suffix-file "$FIXTURES_DIR/dynamic-suffix.txt"
+  [ "$status" -ne 0 ]
+}
+
+@test "bundle-and-dispatch.sh exits 1 without required --dynamic-suffix-file" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "ctx:64k"
+  [ "$status" -ne 0 ]
+}
+
+@test "bundle-and-dispatch.sh exits 1 if --dynamic-suffix-file does not exist" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "ctx:64k" --dynamic-suffix-file "/nonexistent/path.txt"
+  [ "$status" -ne 0 ]
+}
+
+@test "bundle-and-dispatch.sh output contains opening CACHE BOUNDARY marker" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "ctx:64k" \
+    --dynamic-suffix-file "$FIXTURES_DIR/dynamic-suffix.txt"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q "CACHE BOUNDARY"
+}
+
+@test "bundle-and-dispatch.sh output contains cached prefix from bundle-static-context.sh verbatim" {
+  prefix=$(env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$BUNDLER" --role implementer --issue-labels "ctx:64k")
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "ctx:64k" \
+    --dynamic-suffix-file "$FIXTURES_DIR/dynamic-suffix.txt"
+  [ "$status" -eq 0 ]
+  # Spot-check: a distinctive line from the prefix appears in combined output
+  printf '%s\n' "$output" | grep -q "SKILL.md (implementer role)"
+}
+
+@test "bundle-and-dispatch.sh output appends dynamic suffix after cache boundary" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "ctx:64k" \
+    --dynamic-suffix-file "$FIXTURES_DIR/dynamic-suffix.txt"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q "Implement the feature described here"
+}
+
+@test "bundle-and-dispatch.sh dynamic suffix appears after the closing CACHE BOUNDARY marker" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "ctx:64k" \
+    --dynamic-suffix-file "$FIXTURES_DIR/dynamic-suffix.txt"
+  [ "$status" -eq 0 ]
+  # Find line numbers of closing CACHE BOUNDARY and dynamic suffix content
+  boundary_line=$(printf '%s\n' "$output" | grep -n "CACHE BOUNDARY" | tail -1 | cut -d: -f1)
+  suffix_line=$(printf '%s\n' "$output" | grep -n "Implement the feature described here" | head -1 | cut -d: -f1)
+  [ -n "$boundary_line" ]
+  [ -n "$suffix_line" ]
+  [ "$suffix_line" -gt "$boundary_line" ]
+}
+
+@test "bundle-and-dispatch.sh output is idempotent (two identical runs produce byte-identical stdout)" {
+  out1=$(env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "ctx:64k" \
+    --dynamic-suffix-file "$FIXTURES_DIR/dynamic-suffix.txt")
+  out2=$(env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "ctx:64k" \
+    --dynamic-suffix-file "$FIXTURES_DIR/dynamic-suffix.txt")
+  [ "$out1" = "$out2" ]
+}
+
+@test "SKILL.md orchestrator dispatch section references bundle-and-dispatch.sh" {
+  skill_md="${BATS_TEST_DIRNAME}/../skills/autospec-run/SKILL.md"
+  [ -f "$skill_md" ]
+  grep -q "bundle-and-dispatch.sh" "$skill_md"
+}
+
+@test "codex/prompt.md orchestrator dispatch section references bundle-and-dispatch.sh" {
+  codex_md="${BATS_TEST_DIRNAME}/../skills/autospec-run/codex/prompt.md"
+  [ -f "$codex_md" ]
+  grep -q "bundle-and-dispatch.sh" "$codex_md"
+}
+
+@test "opencode/agent.md orchestrator dispatch section references bundle-and-dispatch.sh" {
+  opencode_md="${BATS_TEST_DIRNAME}/../skills/autospec-run/opencode/agent.md"
+  [ -f "$opencode_md" ]
+  grep -q "bundle-and-dispatch.sh" "$opencode_md"
+}


### PR DESCRIPTION
Closes #418

## Summary

Add `bundle-and-dispatch.sh` orchestrator helper that assembles the two-part subagent prompt: static cached prefix (via `bundle-static-context.sh`) framed by `<!-- CACHE BOUNDARY -->` markers, followed by the dynamic suffix from a file. Update `skills/autospec-run/SKILL.md` and lockstep mirrors to call the helper instead of constructing prompts inline.

## Changes

- **New:** `skills/autospec-shared/scripts/bundle-and-dispatch.sh` — accepts `--role`, `--issue-labels`, `--dynamic-suffix-file`; calls `bundle-static-context.sh` internally; emits combined prompt to stdout
- **Updated:** `skills/autospec-run/SKILL.md` orchestrator dispatch section references `bundle-and-dispatch.sh`
- **Updated:** `skills/autospec-run/codex/prompt.md` — lockstep mirror (byte-identical body)
- **Updated:** `skills/autospec-run/opencode/agent.md` — lockstep mirror (byte-identical body)
- **New:** `tests/bundle-and-dispatch.bats` — 13 bats tests covering shape, idempotency, error cases, and lockstep reference checks

## Verification

- `bats tests/bundle-and-dispatch.bats` — 13/13 pass
- `bash scripts/validate.sh` — exits 0, all lockstep checks pass