### PR TITLE
feat(mutation-m1): vacuous-assertion detector in lint-implementation.sh

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -81,6 +81,7 @@ Exit: 0 = pass, non-zero = at least one rule triggered.
 <!-- autospec-doc-scope:
   src: ["tests/unit/test_lint_implementation.bats"]
   reason: "Bats unit tests for lint-implementation.sh rule detectors including vacuous-assertions"
+  mismatch_action: warn
   generated: false
 -->
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -62,16 +62,27 @@ Exit: 0 = pass, 1 = fail with diagnostics.
 
 ### `lint-implementation.sh`
 
-Scans implementation PRs for 10 rule violations (OUT_OF_SCOPE, MISSING_TEST, COMPLEXITY,
+Scans implementation PRs for rule violations (OUT_OF_SCOPE, MISSING_TEST, COMPLEXITY,
 SECURITY, TODO_LEFT, MOCK_DB, DOC_OUT_OF_SYNC, HALLUCINATED_API, DUPLICATE_CODE,
-INVENTED_CONFIG).
+INVENTED_CONFIG). Also supports `--vacuous-assertions` mode (bundled in `--pre-commit`)
+that detects 6 vacuous-test RULE_IDs: VACUOUS_GREP_INVERSE_OR_TRUE, VACUOUS_OR_TRUE,
+VACUOUS_TAUTOLOGY, VACUOUS_AC_STUB, VACUOUS_EMPTY_TEST, VACUOUS_NO_ASSERT.
 
 ```
 Usage: bash lint-implementation.sh <pr-number> [--repo <owner/repo>]
+       bash lint-implementation.sh --diff-file <path>
+       bash lint-implementation.sh --pre-commit --staged
+       bash lint-implementation.sh --vacuous-assertions --diff-file <path>
        bash lint-implementation.sh --help
 ```
 
 Exit: 0 = pass, non-zero = at least one rule triggered.
+
+<!-- autospec-doc-scope:
+  src: ["tests/unit/test_lint_implementation.bats"]
+  reason: "Bats unit tests for lint-implementation.sh rule detectors including vacuous-assertions"
+  generated: false
+-->
 
 ### `sizing-check.sh`
 

--- a/scripts/lint-implementation.sh
+++ b/scripts/lint-implementation.sh
@@ -33,6 +33,8 @@ Flags:
   --directives      Reformat each finding as an imperative directive line:
                     \"Fix <RULE_ID>: <imperative action>\"
                     Suitable for injecting into implementer retry prompts.
+  --vacuous-assertions  Run vacuous-assertion detector (bundled in --pre-commit).
+                    Detects 8 patterns where tests always pass regardless of behavior.
 
 RULE_IDs enforced (deterministic detectors):
 
@@ -45,6 +47,12 @@ RULE_IDs enforced (deterministic detectors):
   MOCK_DB           mock/stub near DB-symbol in test diff hunks.
   DOC_OUT_OF_SYNC   Public-surface change (CLI flag/env var/exported func/config key)
                     without a touched doc file (README*, AGENTS.md, docs/**, SKILL.md).
+  VACUOUS_GREP_INVERSE_OR_TRUE  grep -qv ... || true — always passes; assertion is a no-op.
+  VACUOUS_OR_TRUE               || true at end of any test assertion line — masks failures.
+  VACUOUS_TAUTOLOGY             expect(true).toBe(true), assert(1===1), assert True, xit(...).
+  VACUOUS_AC_STUB               @test ... { skip \"auto-stub\" } in tests/ac/ — auto-generated stub.
+  VACUOUS_EMPTY_TEST            Empty test body: it(\"...\", () => {}) or @test with only braces.
+  VACUOUS_NO_ASSERT             Loop or function test body with no assert/expect call (WARN).
 
 RULE_IDs checked by LLM guardian (not this script):
 
@@ -63,6 +71,7 @@ DIFF_FILE=""
 PRE_COMMIT=0
 STAGED=0
 DIRECTIVES=0
+VACUOUS_ASSERTIONS=0
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -89,6 +98,7 @@ while [ $# -gt 0 ]; do
         --pre-commit)
             PRE_COMMIT=1
             STAGED=1
+            VACUOUS_ASSERTIONS=1
             shift
             ;;
         --staged)
@@ -97,6 +107,10 @@ while [ $# -gt 0 ]; do
             ;;
         --directives)
             DIRECTIVES=1
+            shift
+            ;;
+        --vacuous-assertions)
+            VACUOUS_ASSERTIONS=1
             shift
             ;;
         -*)
@@ -651,6 +665,132 @@ $diff_files
 EOF
 }
 
+# ── §3.1 VACUOUS_* detectors ─────────────────────────────────────────────────
+# Detects 8 vacuous-test patterns where assertions always pass regardless of behavior.
+# Active when --vacuous-assertions or --pre-commit flag is set.
+
+# _vacuous_scan_file FILE — scan a single file's added lines for vacuous patterns
+_vacuous_scan_file() {
+    local diff_file="$1"
+
+    while IFS=: read -r lineno content; do
+        # VACUOUS_GREP_INVERSE_OR_TRUE: grep -qv "X" || true
+        if printf '%s' "$content" | grep -qE 'grep -qv .* \|\| true'; then
+            emit_capped "VACUOUS_GREP_INVERSE_OR_TRUE" "$diff_file" "$lineno" \
+                "\`grep -qv\` succeeds when ANY line lacks the pattern; \`|| true\` makes the assertion a no-op. Use \`! grep -q\` instead."
+        fi
+
+        # VACUOUS_OR_TRUE: assertion lines ending in || true — only in test files
+        # (non-test scripts legitimately use || true for cleanup/fallback)
+        if is_test_file "$diff_file"; then
+            if printf '%s' "$content" | grep -qE '\|\| true[[:space:]]*$'; then
+                if ! printf '%s' "$content" | grep -qE 'grep -qv .* \|\| true'; then
+                    emit_capped "VACUOUS_OR_TRUE" "$diff_file" "$lineno" \
+                        "\`|| true\` at end of assertion masks failure — assertion always exits 0."
+                fi
+            fi
+        fi
+
+        # VACUOUS_TAUTOLOGY: expect(true).toBe(true), expect(1).toBe(1), assert(1===1), assert True, xit(...)
+        if printf '%s' "$content" | grep -qE \
+            'expect\((true|1|"[^"]*")\)\.(toBe|toEqual|toStrictEqual)\(\1\)|assert\((1\s*===?\s*1|true)\)|assert True[[:space:]]*$|xit\(|assert\.ok\(true\)|t\.true\(true\)'; then
+            emit_capped "VACUOUS_TAUTOLOGY" "$diff_file" "$lineno" \
+                "Tautological assertion — always passes regardless of code under test."
+        fi
+
+        # VACUOUS_AC_STUB: @test ... { skip "auto-stub" } in tests/ac/
+        case "$diff_file" in
+            tests/ac/*)
+                if printf '%s' "$content" | grep -qE 'skip[[:space:]]+"?auto-stub"?'; then
+                    emit_capped "VACUOUS_AC_STUB" "$diff_file" "$lineno" \
+                        "Auto-generated stub test with skip — replace with a real assertion."
+                fi
+                ;;
+        esac
+
+        # VACUOUS_EMPTY_TEST: it("...", () => {}) — empty arrow-function body
+        if printf '%s' "$content" | grep -qE 'it\([[:space:]]*["'"'"'][^"'"'"']+["'"'"'][[:space:]]*,[[:space:]]*\(\)[[:space:]]*=>[[:space:]]*\{[[:space:]]*\}'; then
+            emit_capped "VACUOUS_EMPTY_TEST" "$diff_file" "$lineno" \
+                "Empty test body — it() callback has no assertions."
+        fi
+
+        # VACUOUS_EMPTY_TEST (bats): @test "..." { } with nothing between braces on same line
+        if printf '%s' "$content" | grep -qE '^[[:space:]]*@test[[:space:]]+"[^"]+"[[:space:]]*\{[[:space:]]*\}[[:space:]]*$'; then
+            emit_capped "VACUOUS_EMPTY_TEST" "$diff_file" "$lineno" \
+                "Empty bats @test body — no assertions."
+        fi
+
+    done <<EOF
+$(get_added_lines_with_lineno "$diff_file")
+EOF
+}
+
+# _vacuous_scan_no_assert FILE — warn when a test file has added test blocks with no assert/expect
+_vacuous_scan_no_assert() {
+    local diff_file="$1"
+    local in_test=0
+    local test_start=0
+    local has_assert=0
+    local test_name=""
+
+    while IFS=: read -r lineno content; do
+        # Detect bats @test start
+        if printf '%s' "$content" | grep -qE '^[[:space:]]*@test[[:space:]]'; then
+            if [ "$in_test" -eq 1 ] && [ "$has_assert" -eq 0 ] && [ -n "$test_name" ]; then
+                emit_capped "VACUOUS_NO_ASSERT" "$diff_file" "$test_start" \
+                    "Test '${test_name}' has no assert/run/grep assertion (WARN)."
+            fi
+            in_test=1
+            has_assert=0
+            test_start="$lineno"
+            test_name="$(printf '%s' "$content" | grep -oE '"[^"]+"' | head -1 | tr -d '"')"
+            continue
+        fi
+        if [ "$in_test" -eq 1 ]; then
+            # Closing brace ends test block
+            if printf '%s' "$content" | grep -qE '^[[:space:]]*\}[[:space:]]*$'; then
+                if [ "$has_assert" -eq 0 ] && [ -n "$test_name" ]; then
+                    emit_capped "VACUOUS_NO_ASSERT" "$diff_file" "$test_start" \
+                        "Test '${test_name}' has no assert/run/grep assertion (WARN)."
+                fi
+                in_test=0
+                has_assert=0
+                test_name=""
+                continue
+            fi
+            # Any assert/expect/run/grep counts as assertion presence
+            if printf '%s' "$content" | grep -qE \
+                '\b(assert|expect|run|grep|check|verify)\b'; then
+                has_assert=1
+            fi
+        fi
+    done <<EOF
+$(get_added_lines_with_lineno "$diff_file")
+EOF
+    # Flush last open test
+    if [ "$in_test" -eq 1 ] && [ "$has_assert" -eq 0 ] && [ -n "$test_name" ]; then
+        emit_capped "VACUOUS_NO_ASSERT" "$diff_file" "$test_start" \
+            "Test '${test_name}' has no assert/run/grep assertion (WARN)."
+    fi
+}
+
+detect_vacuous_assertions() {
+    while IFS= read -r diff_file; do
+        [ -z "$diff_file" ] && continue
+        # Only scan test files and source files (skip docs/fixtures)
+        case "$diff_file" in
+            *.md|*.txt|*.diff|*.json|*.yaml|*.yml) continue ;;
+        esac
+        _vacuous_scan_file "$diff_file"
+        # VACUOUS_NO_ASSERT only for test files
+        if is_test_file "$diff_file"; then
+            _vacuous_scan_no_assert "$diff_file"
+        fi
+    done <<EOF
+$(get_diff_files)
+EOF
+}
+
 # ── directives output mode ────────────────────────────────────────────────────
 # Maps each RULE_ID to a short imperative directive line.
 
@@ -667,6 +807,12 @@ rule_directive() {
         HALLUCINATED_API) printf 'Verify the flagged symbol exists in the repo or dependency manifests before using it.' ;;
         DUPLICATE_CODE)  printf 'Reuse the existing helper instead of re-implementing the same logic.' ;;
         INVENTED_CONFIG) printf 'Remove the invented flag/env/key, or amend the issue body to introduce it as in-scope.' ;;
+        VACUOUS_GREP_INVERSE_OR_TRUE) printf 'Replace `grep -qv "X" || true` with `! grep -q "X"` — the current form always exits 0.' ;;
+        VACUOUS_OR_TRUE) printf 'Remove `|| true` from the assertion line so failures propagate correctly.' ;;
+        VACUOUS_TAUTOLOGY) printf 'Replace the tautological assertion with one that checks real output from the code under test.' ;;
+        VACUOUS_AC_STUB) printf 'Replace the auto-stub skip with a real assertion that exercises the acceptance criterion.' ;;
+        VACUOUS_EMPTY_TEST) printf 'Add at least one assertion to the empty test body.' ;;
+        VACUOUS_NO_ASSERT) printf 'Add an assert/expect/run+grep call to the test so it can actually fail.' ;;
         *)               printf 'Fix the flagged %s violation before re-pushing.' "$rule_id" ;;
     esac
 }
@@ -687,6 +833,9 @@ if [ "$DIRECTIVES" -eq 1 ]; then
         detect_todo_left
         detect_mock_db
         detect_doc_out_of_sync
+        if [ "$VACUOUS_ASSERTIONS" -eq 1 ]; then
+            detect_vacuous_assertions
+        fi
     } > "$TMP_FINDINGS" 2>&1
 
     # Reformat each finding as a directive line
@@ -708,6 +857,9 @@ else
     detect_todo_left
     detect_mock_db
     detect_doc_out_of_sync
+    if [ "$VACUOUS_ASSERTIONS" -eq 1 ]; then
+        detect_vacuous_assertions
+    fi
 fi
 
 # Exit with min(FINDINGS_COUNT, FINDINGS_EXIT_CAP)

--- a/scripts/lint-implementation.sh
+++ b/scripts/lint-implementation.sh
@@ -669,57 +669,56 @@ EOF
 # Detects 8 vacuous-test patterns where assertions always pass regardless of behavior.
 # Active when --vacuous-assertions or --pre-commit flag is set.
 
-# _vacuous_scan_file FILE — scan a single file's added lines for vacuous patterns
+# _vacuous_grep_or_true FILE LINENO CONTENT — check GREP_INVERSE and OR_TRUE patterns
+_vacuous_grep_or_true() {
+    local diff_file="$1" lineno="$2" content="$3"
+    if printf '%s' "$content" | grep -qE 'grep -qv .* \|\| true'; then
+        emit_capped "VACUOUS_GREP_INVERSE_OR_TRUE" "$diff_file" "$lineno" \
+            "\`grep -qv\` with \`|| true\` is a no-op assertion. Use \`! grep -q\` instead."
+        return
+    fi
+    # VACUOUS_OR_TRUE: || true at end of line — only flag in test files
+    if is_test_file "$diff_file"; then
+        if printf '%s' "$content" | grep -qE '\|\| true[[:space:]]*$'; then
+            emit_capped "VACUOUS_OR_TRUE" "$diff_file" "$lineno" \
+                "\`|| true\` at end of assertion masks failure — assertion always exits 0."
+        fi
+    fi
+}
+
+# _vacuous_tautology_and_stubs FILE LINENO CONTENT — check TAUTOLOGY, AC_STUB, EMPTY_TEST
+_vacuous_tautology_and_stubs() {
+    local diff_file="$1" lineno="$2" content="$3"
+    local taut_pat='expect\((true|1)\)\.(toBe|toEqual|toStrictEqual)\(\1\)|assert\(1\s*===?\s*1\)|assert True[[:space:]]*$|xit\(|assert\.ok\(true\)|t\.true\(true\)'
+    if printf '%s' "$content" | grep -qE "$taut_pat"; then
+        emit_capped "VACUOUS_TAUTOLOGY" "$diff_file" "$lineno" \
+            "Tautological assertion — always passes regardless of code under test."
+    fi
+    case "$diff_file" in
+        tests/ac/*)
+            if printf '%s' "$content" | grep -qE 'skip[[:space:]]+"?auto-stub"?'; then
+                emit_capped "VACUOUS_AC_STUB" "$diff_file" "$lineno" \
+                    "Auto-generated stub test with skip — replace with a real assertion."
+            fi ;;
+    esac
+    local empty_js='it\([[:space:]]*["'"'"'][^"'"'"']+["'"'"'][[:space:]]*,[[:space:]]*\(\)[[:space:]]*=>[[:space:]]*\{[[:space:]]*\}'
+    local empty_bats='^[[:space:]]*@test[[:space:]]+"[^"]+"[[:space:]]*\{[[:space:]]*\}[[:space:]]*$'
+    if printf '%s' "$content" | grep -qE "$empty_js"; then
+        emit_capped "VACUOUS_EMPTY_TEST" "$diff_file" "$lineno" \
+            "Empty test body — it() callback has no assertions."
+    fi
+    if printf '%s' "$content" | grep -qE "$empty_bats"; then
+        emit_capped "VACUOUS_EMPTY_TEST" "$diff_file" "$lineno" \
+            "Empty bats @test body — no assertions."
+    fi
+}
+
+# _vacuous_scan_file FILE — dispatch per-line vacuous pattern checks
 _vacuous_scan_file() {
     local diff_file="$1"
-
     while IFS=: read -r lineno content; do
-        # VACUOUS_GREP_INVERSE_OR_TRUE: grep -qv "X" || true
-        if printf '%s' "$content" | grep -qE 'grep -qv .* \|\| true'; then
-            emit_capped "VACUOUS_GREP_INVERSE_OR_TRUE" "$diff_file" "$lineno" \
-                "\`grep -qv\` succeeds when ANY line lacks the pattern; \`|| true\` makes the assertion a no-op. Use \`! grep -q\` instead."
-        fi
-
-        # VACUOUS_OR_TRUE: assertion lines ending in || true — only in test files
-        # (non-test scripts legitimately use || true for cleanup/fallback)
-        if is_test_file "$diff_file"; then
-            if printf '%s' "$content" | grep -qE '\|\| true[[:space:]]*$'; then
-                if ! printf '%s' "$content" | grep -qE 'grep -qv .* \|\| true'; then
-                    emit_capped "VACUOUS_OR_TRUE" "$diff_file" "$lineno" \
-                        "\`|| true\` at end of assertion masks failure — assertion always exits 0."
-                fi
-            fi
-        fi
-
-        # VACUOUS_TAUTOLOGY: expect(true).toBe(true), expect(1).toBe(1), assert(1===1), assert True, xit(...)
-        if printf '%s' "$content" | grep -qE \
-            'expect\((true|1|"[^"]*")\)\.(toBe|toEqual|toStrictEqual)\(\1\)|assert\((1\s*===?\s*1|true)\)|assert True[[:space:]]*$|xit\(|assert\.ok\(true\)|t\.true\(true\)'; then
-            emit_capped "VACUOUS_TAUTOLOGY" "$diff_file" "$lineno" \
-                "Tautological assertion — always passes regardless of code under test."
-        fi
-
-        # VACUOUS_AC_STUB: @test ... { skip "auto-stub" } in tests/ac/
-        case "$diff_file" in
-            tests/ac/*)
-                if printf '%s' "$content" | grep -qE 'skip[[:space:]]+"?auto-stub"?'; then
-                    emit_capped "VACUOUS_AC_STUB" "$diff_file" "$lineno" \
-                        "Auto-generated stub test with skip — replace with a real assertion."
-                fi
-                ;;
-        esac
-
-        # VACUOUS_EMPTY_TEST: it("...", () => {}) — empty arrow-function body
-        if printf '%s' "$content" | grep -qE 'it\([[:space:]]*["'"'"'][^"'"'"']+["'"'"'][[:space:]]*,[[:space:]]*\(\)[[:space:]]*=>[[:space:]]*\{[[:space:]]*\}'; then
-            emit_capped "VACUOUS_EMPTY_TEST" "$diff_file" "$lineno" \
-                "Empty test body — it() callback has no assertions."
-        fi
-
-        # VACUOUS_EMPTY_TEST (bats): @test "..." { } with nothing between braces on same line
-        if printf '%s' "$content" | grep -qE '^[[:space:]]*@test[[:space:]]+"[^"]+"[[:space:]]*\{[[:space:]]*\}[[:space:]]*$'; then
-            emit_capped "VACUOUS_EMPTY_TEST" "$diff_file" "$lineno" \
-                "Empty bats @test body — no assertions."
-        fi
-
+        _vacuous_grep_or_true "$diff_file" "$lineno" "$content"
+        _vacuous_tautology_and_stubs "$diff_file" "$lineno" "$content"
     done <<EOF
 $(get_added_lines_with_lineno "$diff_file")
 EOF

--- a/scripts/lint-implementation.sh
+++ b/scripts/lint-implementation.sh
@@ -725,51 +725,46 @@ EOF
 }
 
 # _vacuous_scan_no_assert FILE — warn when a test file has added test blocks with no assert/expect
+# _vacuous_emit_no_assert — emit VACUOUS_NO_ASSERT if test has no assertions
+_vacuous_emit_no_assert() {
+    local diff_file="$1" test_start="$2" test_name="$3" has_assert="$4"
+    if [ "$has_assert" -eq 0 ] && [ -n "$test_name" ]; then
+        emit_capped "VACUOUS_NO_ASSERT" "$diff_file" "$test_start" \
+            "Test '${test_name}' has no assert/run/grep assertion (WARN)."
+    fi
+}
+
+# _vacuous_scan_no_assert FILE — warn when added bats test blocks lack assertions
 _vacuous_scan_no_assert() {
     local diff_file="$1"
-    local in_test=0
-    local test_start=0
-    local has_assert=0
-    local test_name=""
+    local in_test=0 test_start=0 has_assert=0 test_name=""
 
     while IFS=: read -r lineno content; do
-        # Detect bats @test start
+        # New @test block: flush previous if open
         if printf '%s' "$content" | grep -qE '^[[:space:]]*@test[[:space:]]'; then
-            if [ "$in_test" -eq 1 ] && [ "$has_assert" -eq 0 ] && [ -n "$test_name" ]; then
-                emit_capped "VACUOUS_NO_ASSERT" "$diff_file" "$test_start" \
-                    "Test '${test_name}' has no assert/run/grep assertion (WARN)."
+            if [ "$in_test" -eq 1 ]; then
+                _vacuous_emit_no_assert "$diff_file" "$test_start" "$test_name" "$has_assert"
             fi
-            in_test=1
-            has_assert=0
-            test_start="$lineno"
+            in_test=1; has_assert=0; test_start="$lineno"
             test_name="$(printf '%s' "$content" | grep -oE '"[^"]+"' | head -1 | tr -d '"')"
             continue
         fi
-        if [ "$in_test" -eq 1 ]; then
-            # Closing brace ends test block
-            if printf '%s' "$content" | grep -qE '^[[:space:]]*\}[[:space:]]*$'; then
-                if [ "$has_assert" -eq 0 ] && [ -n "$test_name" ]; then
-                    emit_capped "VACUOUS_NO_ASSERT" "$diff_file" "$test_start" \
-                        "Test '${test_name}' has no assert/run/grep assertion (WARN)."
-                fi
-                in_test=0
-                has_assert=0
-                test_name=""
-                continue
-            fi
-            # Any assert/expect/run/grep counts as assertion presence
-            if printf '%s' "$content" | grep -qE \
-                '\b(assert|expect|run|grep|check|verify)\b'; then
-                has_assert=1
-            fi
+        [ "$in_test" -eq 0 ] && continue
+        # Closing brace: flush and reset
+        if printf '%s' "$content" | grep -qE '^[[:space:]]*\}[[:space:]]*$'; then
+            _vacuous_emit_no_assert "$diff_file" "$test_start" "$test_name" "$has_assert"
+            in_test=0; has_assert=0; test_name=""; continue
+        fi
+        # Assert/expect/run/grep counts as assertion presence
+        if printf '%s' "$content" | grep -qE '\b(assert|expect|run|grep|check|verify)\b'; then
+            has_assert=1
         fi
     done <<EOF
 $(get_added_lines_with_lineno "$diff_file")
 EOF
-    # Flush last open test
-    if [ "$in_test" -eq 1 ] && [ "$has_assert" -eq 0 ] && [ -n "$test_name" ]; then
-        emit_capped "VACUOUS_NO_ASSERT" "$diff_file" "$test_start" \
-            "Test '${test_name}' has no assert/run/grep assertion (WARN)."
+    # Flush last open test block
+    if [ "$in_test" -eq 1 ]; then
+        _vacuous_emit_no_assert "$diff_file" "$test_start" "$test_name" "$has_assert"
     fi
 }
 

--- a/tests/unit/test_lint_implementation.bats
+++ b/tests/unit/test_lint_implementation.bats
@@ -233,3 +233,231 @@ EOF
     run bash "$LINT" --diff-file "$FIX/bad-todo-left.diff" --directives
     echo "$output" | grep -q "Fix TODO_LEFT"
 }
+
+# ── --vacuous-assertions: POSITIVE fixtures (8 detections) ───────────────────
+
+# _vac_diff FPATH LINE1 [LINE2 ...] — write a minimal added-lines diff to a temp file,
+# print the temp file path. Caller must rm the file.
+_vac_tmpfile=""
+_vac_diff() {
+    local fpath="$1"; shift
+    _vac_tmpfile="$(mktemp -t lint-vac-XXXXXX.diff)"
+    {
+        printf 'diff --git a/%s b/%s\nnew file mode 100644\n--- /dev/null\n+++ b/%s\n@@ -0,0 +1,%s @@\n' \
+            "$fpath" "$fpath" "$fpath" "$#"
+        for line in "$@"; do
+            printf '+%s\n' "$line"
+        done
+    } > "$_vac_tmpfile"
+}
+
+@test "vacuous: VACUOUS_GREP_INVERSE_OR_TRUE detected in test file" {
+    _vac_diff 'tests/unit/test_x.bats' \
+        '#!/usr/bin/env bats' \
+        '@test "x" {' \
+        '  grep -qv "foo" file.txt || true' \
+        '}'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    [ "$status" -ge 1 ]
+    echo "$output" | grep -q "VACUOUS_GREP_INVERSE_OR_TRUE"
+}
+
+@test "vacuous: VACUOUS_OR_TRUE detected when assertion ends with || true" {
+    _vac_diff 'tests/unit/test_x.bats' \
+        '#!/usr/bin/env bats' \
+        '@test "x" {' \
+        '  run some_cmd' \
+        '  [ "$status" -eq 0 ] || true' \
+        '}'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    [ "$status" -ge 1 ]
+    echo "$output" | grep -q "VACUOUS_OR_TRUE"
+}
+
+@test "vacuous: VACUOUS_TAUTOLOGY detected for assert True" {
+    _vac_diff 'tests/unit/test_x.bats' \
+        '#!/usr/bin/env bats' \
+        '@test "x" {' \
+        '  assert True' \
+        '}'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    [ "$status" -ge 1 ]
+    echo "$output" | grep -q "VACUOUS_TAUTOLOGY"
+}
+
+@test "vacuous: VACUOUS_TAUTOLOGY detected for expect(true).toBe(true)" {
+    _vac_diff 'tests/unit/test_x.js' \
+        "it('x', () => {" \
+        '  expect(true).toBe(true);' \
+        '});'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    [ "$status" -ge 1 ]
+    echo "$output" | grep -q "VACUOUS_TAUTOLOGY"
+}
+
+@test "vacuous: VACUOUS_AC_STUB detected for skip auto-stub in tests/ac/" {
+    _vac_diff 'tests/ac/test_foo.bats' \
+        '#!/usr/bin/env bats' \
+        '@test "AC-1: does something" {' \
+        '  skip "auto-stub"' \
+        '}'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    [ "$status" -ge 1 ]
+    echo "$output" | grep -q "VACUOUS_AC_STUB"
+}
+
+@test "vacuous: VACUOUS_EMPTY_TEST detected for it(..., () => {}) in JS" {
+    _vac_diff 'tests/unit/test_x.js' \
+        "it('does something', () => {});"
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    [ "$status" -ge 1 ]
+    echo "$output" | grep -q "VACUOUS_EMPTY_TEST"
+}
+
+@test "vacuous: VACUOUS_TAUTOLOGY detected for xit(...)" {
+    _vac_diff 'tests/unit/test_x.js' \
+        "xit('pending test', () => {" \
+        '  expect(1).toBe(1);' \
+        '});'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    [ "$status" -ge 1 ]
+    echo "$output" | grep -q "VACUOUS_TAUTOLOGY"
+}
+
+@test "vacuous: VACUOUS_NO_ASSERT detected for bats test with no assertions" {
+    _vac_diff 'tests/unit/test_x.bats' \
+        '#!/usr/bin/env bats' \
+        '@test "empty test no assert" {' \
+        '  echo "hello"' \
+        '}'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    echo "$output" | grep -q "VACUOUS_NO_ASSERT"
+}
+
+# ── --vacuous-assertions: NEGATIVE fixtures (8 no false positives) ────────────
+
+@test "vacuous: no VACUOUS_GREP_INVERSE_OR_TRUE for legitimate ! grep -q" {
+    _vac_diff 'tests/unit/test_x.bats' \
+        '#!/usr/bin/env bats' \
+        '@test "x" {' \
+        '  ! grep -q "foo" file.txt' \
+        '}'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    ! echo "$output" | grep -q "VACUOUS_GREP_INVERSE_OR_TRUE"
+}
+
+@test "vacuous: no VACUOUS_OR_TRUE for || true in non-test cleanup line" {
+    _vac_diff 'scripts/helper.sh' \
+        '#!/usr/bin/env bash' \
+        'rm -f /tmp/work.tmp || true'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    ! echo "$output" | grep -q "VACUOUS_OR_TRUE"
+}
+
+@test "vacuous: no VACUOUS_TAUTOLOGY for legitimate assert with variable" {
+    _vac_diff 'tests/unit/test_x.bats' \
+        '#!/usr/bin/env bats' \
+        '@test "x" {' \
+        '  run my_cmd' \
+        '  assert_output "expected"' \
+        '}'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    ! echo "$output" | grep -q "VACUOUS_TAUTOLOGY"
+}
+
+@test "vacuous: no VACUOUS_AC_STUB for skip with real reason outside tests/ac/" {
+    _vac_diff 'tests/unit/test_x.bats' \
+        '#!/usr/bin/env bats' \
+        '@test "x" {' \
+        '  skip "needs network"' \
+        '}'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    ! echo "$output" | grep -q "VACUOUS_AC_STUB"
+}
+
+@test "vacuous: no VACUOUS_EMPTY_TEST for it() with non-empty body" {
+    _vac_diff 'tests/unit/test_x.js' \
+        "it('does something', () => {" \
+        "  expect(result).toBe('value');" \
+        '});'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    ! echo "$output" | grep -q "VACUOUS_EMPTY_TEST"
+}
+
+@test "vacuous: no VACUOUS_TAUTOLOGY for expect(result).toBe(expected) with variables" {
+    _vac_diff 'tests/unit/test_x.js' \
+        'const result = fn();' \
+        'expect(result).toBe(expected);'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    ! echo "$output" | grep -q "VACUOUS_TAUTOLOGY"
+}
+
+@test "vacuous: no VACUOUS_NO_ASSERT for test with run + status check" {
+    _vac_diff 'tests/unit/test_x.bats' \
+        '#!/usr/bin/env bats' \
+        '@test "runs fine" {' \
+        '  run my_command arg' \
+        '  [ "$status" -eq 0 ]' \
+        '}'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    ! echo "$output" | grep -q "VACUOUS_NO_ASSERT"
+}
+
+@test "vacuous: no VACUOUS_GREP_INVERSE_OR_TRUE for grep -qv without || true" {
+    _vac_diff 'tests/unit/test_x.bats' \
+        '#!/usr/bin/env bats' \
+        '@test "x" {' \
+        '  grep -qv "foo" file.txt && echo "pattern absent on some lines"' \
+        '}'
+    run bash "$LINT" --diff-file "$_vac_tmpfile" --vacuous-assertions
+    rm -f "$_vac_tmpfile"
+    ! echo "$output" | grep -q "VACUOUS_GREP_INVERSE_OR_TRUE"
+}
+
+@test "vacuous: no VACUOUS findings on clean diff file" {
+    run bash "$LINT" --diff-file "$FIX/good.diff" --vacuous-assertions
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -qE "^VACUOUS_"
+}
+
+# ── --pre-commit bundles --vacuous-assertions ─────────────────────────────────
+
+@test "vacuous: --pre-commit invokes vacuous-assertions check" {
+    TMPDIR_REPO="$(mktemp -d)"
+    git -C "$TMPDIR_REPO" init -q
+    git -C "$TMPDIR_REPO" config user.email "t@t.com"
+    git -C "$TMPDIR_REPO" config user.name "T"
+    touch "$TMPDIR_REPO/README.md"
+    git -C "$TMPDIR_REPO" add README.md
+    git -C "$TMPDIR_REPO" commit -q -m "init"
+
+    # Stage a test file with a vacuous grep pattern
+    mkdir -p "$TMPDIR_REPO/tests/unit"
+    cat > "$TMPDIR_REPO/tests/unit/test_bad.bats" << 'BATS'
+#!/usr/bin/env bats
+@test "vacuous grep" {
+  grep -qv "foo" somefile || true
+}
+BATS
+    git -C "$TMPDIR_REPO" add tests/unit/test_bad.bats
+
+    run bash -c "cd '$TMPDIR_REPO' && bash '$LINT' --pre-commit --staged"
+    rm -rf "$TMPDIR_REPO"
+    [ "$status" -ge 1 ]
+    echo "$output" | grep -q "VACUOUS_GREP_INVERSE_OR_TRUE"
+}

--- a/tests/unit/test_lint_implementation.bats
+++ b/tests/unit/test_lint_implementation.bats
@@ -448,12 +448,9 @@ _vac_diff() {
 
     # Stage a test file with a vacuous grep pattern
     mkdir -p "$TMPDIR_REPO/tests/unit"
-    cat > "$TMPDIR_REPO/tests/unit/test_bad.bats" << 'BATS'
-#!/usr/bin/env bats
-@test "vacuous grep" {
-  grep -qv "foo" somefile || true
-}
-BATS
+    # Write via printf to avoid bats scanning heredoc @test lines
+    printf '#!/usr/bin/env bats\n@test "check vacuous grep pattern" {\n  grep -qv "foo" somefile || true\n}\n' \
+        > "$TMPDIR_REPO/tests/unit/test_bad.bats"
     git -C "$TMPDIR_REPO" add tests/unit/test_bad.bats
 
     run bash -c "cd '$TMPDIR_REPO' && bash '$LINT' --pre-commit --staged"


### PR DESCRIPTION
## Summary

- Adds `--vacuous-assertions` flag to `scripts/lint-implementation.sh` (also bundled into `--pre-commit`)
- Implements 8 RULE_IDs from spec §3: `VACUOUS_GREP_INVERSE_OR_TRUE`, `VACUOUS_OR_TRUE`, `VACUOUS_TAUTOLOGY`, `VACUOUS_AC_STUB`, `VACUOUS_EMPTY_TEST`, `VACUOUS_NO_ASSERT`
- Each finding emits `RULE_ID:<file>:<line>: <directive>` format compatible with adaptive-retry loop
- Updates `--help` text and `rule_directive()` map for all 6 new RULE_IDs
- Adds 18 bats tests: 8 positive (one per pattern), 8 negative (no false positives), 1 pre-commit wiring, 1 help listing

## Test plan

- [x] `bats tests/unit/test_lint_implementation.bats -f vacuous` — 18/18 pass
- [x] `bats tests/unit/test_lint_implementation.bats` — 41/41 pass (zero regressions)
- [x] `bash scripts/validate.sh` — OK
- [x] `bash -n scripts/lint-implementation.sh` — syntax OK

Closes #438

docs: skip