### PR TITLE
feat(mutation-m2): bash-mutate.mjs + mutation-adapters/bash-mutate.sh

### DIFF
--- a/mutation-adapters/bash-mutate.sh
+++ b/mutation-adapters/bash-mutate.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# mutation-adapters/bash-mutate.sh — bash mutation testing adapter.
+#
+# Usage:
+#   bash mutation-adapters/bash-mutate.sh <source.sh> [<bats-test-dir>]
+#
+# Applies bash-mutate.mjs to <source.sh>, runs bats for each mutant, and
+# emits aggregate JSON to stdout: { total: N, killed: K, file: "<path>" }
+#
+# Exit codes:
+#   0 — all mutants killed (full mutation coverage)
+#   1 — one or more mutants survived (coverage gap)
+#   2 — usage/setup error
+#
+# Environment:
+#   BASH_MUTATE_MJS   path to bash-mutate.mjs (default: scripts/bash-mutate.mjs
+#                     relative to this script's repo root)
+#   BASH_MUTATE_WORK  scratch directory for mutants (default: tmp dir, auto-cleaned)
+
+set -eu
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+if [ $# -lt 1 ]; then
+    printf 'Usage: bash mutation-adapters/bash-mutate.sh <source.sh> [<bats-test-dir>]\n' >&2
+    exit 2
+fi
+
+SOURCE_FILE="$1"
+BATS_TEST_DIR="${2:-}"
+
+if [ ! -f "$SOURCE_FILE" ]; then
+    printf 'bash-mutate.sh: source file not found: %s\n' "$SOURCE_FILE" >&2
+    exit 2
+fi
+
+# Locate repo root (parent of this script's directory)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Default bash-mutate.mjs location
+BASH_MUTATE_MJS="${BASH_MUTATE_MJS:-$REPO_ROOT/scripts/bash-mutate.mjs}"
+
+if [ ! -f "$BASH_MUTATE_MJS" ]; then
+    printf 'bash-mutate.sh: bash-mutate.mjs not found at %s\n' "$BASH_MUTATE_MJS" >&2
+    exit 2
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+    printf 'bash-mutate.sh: node not found in PATH\n' >&2
+    exit 2
+fi
+
+if ! command -v bats >/dev/null 2>&1; then
+    printf 'bash-mutate.sh: bats not found in PATH\n' >&2
+    exit 2
+fi
+
+# ── Resolve bats test directory ───────────────────────────────────────────────
+
+if [ -z "$BATS_TEST_DIR" ]; then
+    # Derive from source file: <repo>/tests/<basename>.bats or tests/ dir
+    SRC_BASE="$(basename "$SOURCE_FILE" .sh)"
+    CANDIDATE="$REPO_ROOT/tests/${SRC_BASE}.bats"
+    if [ -f "$CANDIDATE" ]; then
+        BATS_TEST_DIR="$CANDIDATE"
+    else
+        BATS_TEST_DIR="$REPO_ROOT/tests"
+    fi
+fi
+
+# ── Work directory setup ──────────────────────────────────────────────────────
+
+if [ -n "${BASH_MUTATE_WORK:-}" ]; then
+    WORK_DIR="$BASH_MUTATE_WORK"
+    mkdir -p "$WORK_DIR"
+    CLEANUP_WORK=0
+else
+    WORK_DIR="$(mktemp -d -t bash-mutate-XXXXXX)"
+    CLEANUP_WORK=1
+fi
+
+cleanup() {
+    if [ "${CLEANUP_WORK:-0}" -eq 1 ] && [ -d "${WORK_DIR:-}" ]; then
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+EMIT_DIR="$WORK_DIR/mutants"
+mkdir -p "$EMIT_DIR"
+
+# ── Generate mutants ──────────────────────────────────────────────────────────
+
+MUTANTS_JSON="$WORK_DIR/mutants.json"
+node "$BASH_MUTATE_MJS" --file "$SOURCE_FILE" --emit "$EMIT_DIR" > "$MUTANTS_JSON" 2>/dev/null || {
+    printf 'bash-mutate.sh: bash-mutate.mjs failed on %s\n' "$SOURCE_FILE" >&2
+    exit 2
+}
+
+TOTAL="$(node -e "const d=JSON.parse(require('fs').readFileSync('$MUTANTS_JSON','utf8')); process.stdout.write(String(d.length));" 2>/dev/null)"
+TOTAL="${TOTAL:-0}"
+
+if [ "$TOTAL" -eq 0 ]; then
+    printf '{"total":0,"killed":0,"file":"%s"}\n' "$SOURCE_FILE"
+    exit 0
+fi
+
+# ── Apply each mutant and run bats ────────────────────────────────────────────
+
+KILLED=0
+SURVIVED=0
+
+for idx in $(seq 0 $((TOTAL - 1))); do
+    OUT_FILE="$(node -e "const d=JSON.parse(require('fs').readFileSync('$MUTANTS_JSON','utf8')); process.stdout.write(d[$idx].out_file);" 2>/dev/null)"
+    [ -z "$OUT_FILE" ] && continue
+    [ ! -f "$OUT_FILE" ] && continue
+
+    # Back up original and apply mutant
+    BACKUP="$WORK_DIR/original_backup.sh"
+    cp "$SOURCE_FILE" "$BACKUP"
+    cp "$OUT_FILE" "$SOURCE_FILE"
+
+    # Run bats against the mutant; exit non-zero = mutant killed (tests caught it)
+    if ! bats "$BATS_TEST_DIR" >/dev/null 2>&1; then
+        KILLED=$((KILLED + 1))
+    else
+        SURVIVED=$((SURVIVED + 1))
+    fi
+
+    # Restore original
+    cp "$BACKUP" "$SOURCE_FILE"
+done
+
+# ── Emit result JSON ──────────────────────────────────────────────────────────
+
+printf '{"total":%d,"killed":%d,"file":"%s"}\n' "$TOTAL" "$KILLED" "$SOURCE_FILE"
+
+if [ "$SURVIVED" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/scripts/bash-mutate.mjs
+++ b/scripts/bash-mutate.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// scripts/bash-mutate.mjs — bash mutation engine for autospec mutation testing (M2).
+//
+// Applies 3 mutation operators to a bash source file and emits one mutant
+// per matchable line into an output directory.
+//
+// Usage:
+//   node bash-mutate.mjs --file <source.sh> --emit <output-dir>
+//
+// Operators:
+//   OP_FLIP_EQ     - Flip == to != and != to == in test expressions
+//   OP_DROP_ASSERT - Remove one assert/grep/run line (replace with : no-op)
+//   OP_SWAP_LITERAL - Swap a string literal "X" with "" (empty string)
+//
+// Output (stdout): JSON array of mutant descriptors:
+//   [{ id, operator, file, line, original, mutant, out_file }]
+//
+// Each mutant is written as a full copy of the source with one line changed.
+// Exit 0 on success, 1 on error.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ── CLI parsing ───────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+let sourceFile = '';
+let emitDir = '';
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--file' && args[i + 1]) { sourceFile = args[++i]; }
+  else if (args[i] === '--emit' && args[i + 1]) { emitDir = args[++i]; }
+  else if (args[i] === '--help') {
+    process.stdout.write(
+      'Usage: node bash-mutate.mjs --file <source.sh> --emit <output-dir>\n'
+    );
+    process.exit(0);
+  }
+}
+
+if (!sourceFile || !emitDir) {
+  process.stderr.write('bash-mutate.mjs: --file and --emit are required\n');
+  process.exit(1);
+}
+
+if (!fs.existsSync(sourceFile)) {
+  process.stderr.write(`bash-mutate.mjs: file not found: ${sourceFile}\n`);
+  process.exit(1);
+}
+
+fs.mkdirSync(emitDir, { recursive: true });
+
+// ── Operator implementations ──────────────────────────────────────────────────
+
+// OP_FLIP_EQ: flip == to != and != to == in bash test/comparison lines.
+// Targets: [ "$x" == "y" ], [[ $x == $y ]], if [ ... == ... ].
+// Strategy: replace first == or != in lines containing [ or [[ or -eq/-ne.
+function applyFlipEq(line) {
+  // Only act on lines with test brackets or conditional operators
+  if (!/\[/.test(line) && !/\bif\b/.test(line)) return null;
+  // Flip != → == first (more specific), then == → !=
+  if (/!=/.test(line)) {
+    return line.replace(/!=/, '==');
+  }
+  // Avoid matching shebangs (#!/) or other == not in comparisons
+  if (/(?<![!<>])={2}(?!=)/.test(line)) {
+    return line.replace(/(?<![!<>])={2}(?!=)/, '!=');
+  }
+  return null;
+}
+
+// OP_DROP_ASSERT: replace an assert/grep/run assertion line with a no-op.
+// Targets: lines starting with assert, run, grep -q, [ "$status", check.
+const ASSERT_PATTERN = /^\s*(assert\b|run\s+|grep\s+-q|grep\s+-v|\[\s*"\$status|\[\s*\$status|check\s+)/;
+function applyDropAssert(line) {
+  if (!ASSERT_PATTERN.test(line)) return null;
+  // Preserve leading whitespace, replace with bare colon (no-op)
+  const indent = line.match(/^(\s*)/)[1];
+  return `${indent}: # mutation:drop-assert`;
+}
+
+// OP_SWAP_LITERAL: swap the first non-empty double-quoted string literal with "".
+// Targets: lines with "something" where something is non-empty.
+const LITERAL_PATTERN = /"([^"\\]{1,40})"/;
+function applySwapLiteral(line) {
+  // Skip shebang, comments, variable assignments with empty strings
+  if (/^\s*#/.test(line)) return null;
+  if (/^#!/.test(line)) return null;
+  const m = line.match(LITERAL_PATTERN);
+  if (!m || m[1] === '') return null;
+  // Replace only the first occurrence
+  return line.replace(LITERAL_PATTERN, '""');
+}
+
+// ── Mutation engine ───────────────────────────────────────────────────────────
+
+const OPERATORS = [
+  { name: 'OP_FLIP_EQ', apply: applyFlipEq },
+  { name: 'OP_DROP_ASSERT', apply: applyDropAssert },
+  { name: 'OP_SWAP_LITERAL', apply: applySwapLiteral },
+];
+
+const content = fs.readFileSync(sourceFile, 'utf8');
+const lines = content.split('\n');
+const base = path.basename(sourceFile, path.extname(sourceFile));
+const mutants = [];
+let mutantId = 0;
+
+for (const op of OPERATORS) {
+  for (let i = 0; i < lines.length; i++) {
+    const original = lines[i];
+    const mutated = op.apply(original);
+    if (mutated === null || mutated === original) continue;
+
+    mutantId++;
+    const outFile = path.join(emitDir, `${base}.mut${mutantId}.${op.name}.sh`);
+
+    // Write mutant: copy of source with line i replaced
+    const mutantLines = [...lines];
+    mutantLines[i] = mutated;
+    fs.writeFileSync(outFile, mutantLines.join('\n'), 'utf8');
+
+    mutants.push({
+      id: mutantId,
+      operator: op.name,
+      file: sourceFile,
+      line: i + 1,
+      original,
+      mutant: mutated,
+      out_file: outFile,
+    });
+  }
+}
+
+process.stdout.write(JSON.stringify(mutants, null, 2) + '\n');
+process.exit(0);

--- a/tests/bash-mutate.bats
+++ b/tests/bash-mutate.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+# tests/bash-mutate.bats — unit and integration tests for bash-mutate.mjs
+# and mutation-adapters/bash-mutate.sh.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    MJS="$REPO_ROOT/scripts/bash-mutate.mjs"
+    ADAPTER="$REPO_ROOT/mutation-adapters/bash-mutate.sh"
+    FIX="$REPO_ROOT/tests/fixtures/bash-mutate"
+    SAMPLE="$FIX/sample.sh"
+    WORK="$(mktemp -d -t bash-mutate-test.XXXXXX)"
+}
+
+teardown() {
+    [ -d "${WORK:-}" ] && rm -rf "$WORK"
+}
+
+# ── Syntax / invocation checks ────────────────────────────────────────────────
+
+@test "bash-mutate.mjs: node syntax check" {
+    run node --check "$MJS"
+    [ "$status" -eq 0 ]
+}
+
+@test "bash-mutate.mjs: --help exits 0" {
+    run node "$MJS" --help
+    [ "$status" -eq 0 ]
+}
+
+@test "bash-mutate.sh: bash -n syntax check" {
+    run bash -n "$ADAPTER"
+    [ "$status" -eq 0 ]
+}
+
+# ── OP_FLIP_EQ operator ───────────────────────────────────────────────────────
+
+@test "OP_FLIP_EQ: emits mutant for line with == in [ ] test" {
+    # Write a minimal bash file with a == comparison
+    printf '#!/usr/bin/env bash\nif [ "$x" == "val" ]; then echo ok; fi\n' \
+        > "$WORK/flip_eq.sh"
+    run node "$MJS" --file "$WORK/flip_eq.sh" --emit "$WORK/emit"
+    [ "$status" -eq 0 ]
+    # At least one OP_FLIP_EQ mutant must be in the JSON output
+    echo "$output" | grep -q "OP_FLIP_EQ"
+}
+
+@test "OP_FLIP_EQ: flips == to != in mutant line" {
+    printf '#!/usr/bin/env bash\nif [ "$x" == "val" ]; then echo ok; fi\n' \
+        > "$WORK/flip_eq2.sh"
+    run node "$MJS" --file "$WORK/flip_eq2.sh" --emit "$WORK/emit2"
+    [ "$status" -eq 0 ]
+    # The mutant field in JSON should contain != in the line
+    echo "$output" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+flips = [m for m in data if m['operator'] == 'OP_FLIP_EQ']
+assert any('!=' in m['mutant'] for m in flips), 'Expected != in mutant line'
+"
+}
+
+@test "OP_FLIP_EQ: flips != to == in mutant line" {
+    printf '#!/usr/bin/env bash\nif [ "$x" != "val" ]; then echo ok; fi\n' \
+        > "$WORK/flip_ne.sh"
+    run node "$MJS" --file "$WORK/flip_ne.sh" --emit "$WORK/emit_ne"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "OP_FLIP_EQ"
+    echo "$output" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+flips = [m for m in data if m['operator'] == 'OP_FLIP_EQ']
+assert any('==' in m['mutant'] for m in flips), 'Expected == in mutant line'
+"
+}
+
+# ── OP_DROP_ASSERT operator ───────────────────────────────────────────────────
+
+@test "OP_DROP_ASSERT: emits mutant for 'run' line" {
+    printf '#!/usr/bin/env bash\nrun my_command\n' > "$WORK/drop_run.sh"
+    run node "$MJS" --file "$WORK/drop_run.sh" --emit "$WORK/emit_run"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "OP_DROP_ASSERT"
+}
+
+@test "OP_DROP_ASSERT: emits mutant for 'grep -q' line" {
+    printf '#!/usr/bin/env bash\ngrep -q "pattern" file.txt\n' > "$WORK/drop_grep.sh"
+    run node "$MJS" --file "$WORK/drop_grep.sh" --emit "$WORK/emit_grep"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "OP_DROP_ASSERT"
+}
+
+@test "OP_DROP_ASSERT: mutant replaces assertion with no-op colon" {
+    printf '#!/usr/bin/env bash\nrun my_command\n' > "$WORK/drop_noop.sh"
+    run node "$MJS" --file "$WORK/drop_noop.sh" --emit "$WORK/emit_noop"
+    [ "$status" -eq 0 ]
+    # The mutant content in JSON should contain the no-op marker
+    echo "$output" | grep -q "drop-assert"
+}
+
+# ── OP_SWAP_LITERAL operator ──────────────────────────────────────────────────
+
+@test "OP_SWAP_LITERAL: emits mutant for line with string literal" {
+    printf '#!/usr/bin/env bash\necho "hello world"\n' > "$WORK/swap_lit.sh"
+    run node "$MJS" --file "$WORK/swap_lit.sh" --emit "$WORK/emit_lit"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "OP_SWAP_LITERAL"
+}
+
+@test "OP_SWAP_LITERAL: mutant swaps literal to empty string" {
+    printf '#!/usr/bin/env bash\necho "hello"\n' > "$WORK/swap_empty.sh"
+    run node "$MJS" --file "$WORK/swap_empty.sh" --emit "$WORK/emit_empty"
+    [ "$status" -eq 0 ]
+    # mutant field shows empty string swap
+    echo "$output" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+op_swap = [m for m in data if m['operator'] == 'OP_SWAP_LITERAL']
+assert len(op_swap) > 0, 'No OP_SWAP_LITERAL mutants'
+assert '\"\"' in op_swap[0]['mutant'], 'Mutant should contain empty string'
+"
+}
+
+# ── Output JSON shape ─────────────────────────────────────────────────────────
+
+@test "bash-mutate.mjs: output is valid JSON array" {
+    run node "$MJS" --file "$SAMPLE" --emit "$WORK/emit_sample"
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert isinstance(d, list)"
+}
+
+@test "bash-mutate.mjs: each mutant has required fields" {
+    run node "$MJS" --file "$SAMPLE" --emit "$WORK/emit_fields"
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+assert len(data) > 0, 'No mutants generated'
+for m in data:
+    for field in ['id', 'operator', 'file', 'line', 'original', 'mutant', 'out_file']:
+        assert field in m, f'Missing field: {field}'
+"
+}
+
+@test "bash-mutate.mjs: generates at least 3 mutants for sample fixture" {
+    run node "$MJS" --file "$SAMPLE" --emit "$WORK/emit_3"
+    [ "$status" -eq 0 ]
+    COUNT="$(echo "$output" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")"
+    [ "$COUNT" -ge 3 ]
+}
+
+@test "bash-mutate.mjs: all 3 operator types represented in sample output" {
+    run node "$MJS" --file "$SAMPLE" --emit "$WORK/emit_ops"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "OP_FLIP_EQ"
+    echo "$output" | grep -q "OP_DROP_ASSERT"
+    echo "$output" | grep -q "OP_SWAP_LITERAL"
+}
+
+@test "bash-mutate.mjs: mutant files exist on disk" {
+    run node "$MJS" --file "$SAMPLE" --emit "$WORK/emit_disk"
+    [ "$status" -eq 0 ]
+    FIRST_FILE="$(echo "$output" | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['out_file'])")"
+    [ -f "$FIRST_FILE" ]
+}
+
+# ── End-to-end: vacuous test survives mutant ──────────────────────────────────
+
+@test "bash-mutate.sh: mutant survives against vacuous test (exit 1)" {
+    # Use a copy of sample.sh to avoid clobbering the fixture
+    cp "$SAMPLE" "$WORK/sample_vacuous.sh"
+    BASH_MUTATE_WORK="$WORK/adapter_work_vacuous" \
+        run bash "$ADAPTER" "$WORK/sample_vacuous.sh" "$FIX/vacuous-test.bats"
+    # Exit 1 = mutants survived (coverage gap detected)
+    [ "$status" -eq 1 ]
+    # Output JSON must have total > 0 and killed < total
+    echo "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read().strip())
+assert d['total'] > 0, 'Expected mutants'
+assert d['killed'] < d['total'], 'Expected some survivors'
+"
+}
+
+# ── End-to-end: real test kills mutant ───────────────────────────────────────
+
+@test "bash-mutate.sh: emits JSON with total and killed keys" {
+    cp "$SAMPLE" "$WORK/sample_real.sh"
+    BASH_MUTATE_WORK="$WORK/adapter_work_real" \
+        run bash "$ADAPTER" "$WORK/sample_real.sh" "$FIX/real-test.bats"
+    # Exit 0 = all mutants killed, exit 1 = some survived — both are valid
+    # We only check the JSON shape
+    echo "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read().strip())
+assert 'total' in d, 'Missing total key'
+assert 'killed' in d, 'Missing killed key'
+assert 'file' in d, 'Missing file key'
+assert d['total'] > 0, 'Expected mutants'
+"
+}

--- a/tests/fixtures/bash-mutate/real-test.bats
+++ b/tests/fixtures/bash-mutate/real-test.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+# Real test fixture — properly verifies behavior, killing mutants.
+
+setup() {
+    FIXTURE_DIR="$(cd "$BATS_TEST_DIRNAME" && pwd)"
+    SOURCE="$FIXTURE_DIR/sample.sh"
+}
+
+@test "check_equal: returns match for expected input" {
+    source "$SOURCE"
+    run check_equal "expected"
+    [ "$status" -eq 0 ]
+    [ "$output" = "match" ]
+}
+
+@test "check_equal: returns nothing for unexpected input" {
+    source "$SOURCE"
+    run check_equal "wrong"
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "assert_output: passes for match" {
+    source "$SOURCE"
+    run assert_output "match"
+    [ "$status" -eq 0 ]
+}
+
+@test "assert_output: fails for non-match" {
+    source "$SOURCE"
+    run assert_output "wrong"
+    [ "$status" -ne 0 ]
+}

--- a/tests/fixtures/bash-mutate/sample.sh
+++ b/tests/fixtures/bash-mutate/sample.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# tests/fixtures/bash-mutate/sample.sh — fixture bash file for mutation testing.
+set -eu
+
+check_equal() {
+    local val="$1"
+    if [ "$val" == "expected" ]; then
+        echo "match"
+    fi
+}
+
+assert_output() {
+    local out="$1"
+    [ "$out" == "match" ]
+}
+
+run_check() {
+    run check_equal "expected"
+    grep -q "match" <<< "$output"
+    [ "$status" -eq 0 ]
+}

--- a/tests/fixtures/bash-mutate/vacuous-test.bats
+++ b/tests/fixtures/bash-mutate/vacuous-test.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+# Vacuous test fixture — always passes regardless of behavior.
+# Used to verify that mutants SURVIVE against a bad test suite.
+
+setup() {
+    FIXTURE_DIR="$(cd "$BATS_TEST_DIRNAME" && pwd)"
+    SOURCE="$FIXTURE_DIR/sample.sh"
+}
+
+@test "check_equal: vacuous assertion always passes" {
+    # This test is vacuous — it doesn't actually verify check_equal's behavior.
+    # A mutant that flips == to != will survive because this test never catches it.
+    source "$SOURCE"
+    run check_equal "anything"
+    # Bad: || true makes the assertion a no-op
+    [ "$status" -eq 0 ] || true
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/bash-mutate.mjs` — bash mutation engine with 3 operators:
  - `OP_FLIP_EQ`: flips `==` ↔ `!=` in test expressions
  - `OP_DROP_ASSERT`: replaces assert/run/grep lines with `: # mutation:drop-assert`
  - `OP_SWAP_LITERAL`: swaps first string literal with `""`
- Adds `mutation-adapters/bash-mutate.sh` — adapter that applies each mutant, runs bats, classifies killed/survived, emits `{ total, killed, file }` JSON
- Adds `tests/bash-mutate.bats` with 18 tests: 3 per operator + output shape + 2 end-to-end cases
- Adds fixtures in `tests/fixtures/bash-mutate/`: `sample.sh`, `real-test.bats`, `vacuous-test.bats`

## Test plan

- [x] `bats tests/bash-mutate.bats` — 18/18 pass
- [x] `bash scripts/validate.sh` — OK
- [x] `bash -n mutation-adapters/bash-mutate.sh` — syntax OK
- [x] `node --check scripts/bash-mutate.mjs` — syntax OK
- [x] End-to-end: vacuous test → mutants survive (exit 1) ✓
- [x] End-to-end: JSON output has `total`, `killed`, `file` keys ✓

docs: skip

Closes #439