### PR TITLE
feat(mutation-m3): per-language adapters (Stryker / mutmut / go-mutesting)

### DIFF
--- a/mutation-adapters/go-mutesting.sh
+++ b/mutation-adapters/go-mutesting.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# mutation-adapters/go-mutesting.sh — go-mutesting adapter for Go packages.
+#
+# Usage:
+#   bash mutation-adapters/go-mutesting.sh <package-path> [<unused>]
+#
+# Invokes `go-mutesting <package-path>` and parses the summary line to count
+# total and killed mutants. Emits JSON matching M2 contract:
+#   { total: N, killed: K, file: "<package-path>" }
+#
+# Exit codes:
+#   0 — all mutants killed (or tool absent — exits 0 with warning)
+#   1 — one or more mutants survived
+#   2 — usage/setup error
+#
+# Tool-absent fallback (spec §10): emits warning to stderr and exits 0.
+#
+# go-mutesting summary line format:
+#   The mutation score is 0.82 (9 passed, 2 failed, 0 skipped, 11 total)
+
+set -eu
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+if [ $# -lt 1 ]; then
+    printf 'Usage: bash mutation-adapters/go-mutesting.sh <package-path>\n' >&2
+    exit 2
+fi
+
+PACKAGE_PATH="$1"
+
+# ── Tool-absent fallback ──────────────────────────────────────────────────────
+
+if ! command -v go-mutesting >/dev/null 2>&1; then
+    printf 'go-mutesting.sh: go-mutesting not found — skipping mutation testing (tool absent)\n' >&2
+    printf '{"total":0,"killed":0,"file":"%s"}\n' "$PACKAGE_PATH"
+    exit 0
+fi
+
+# ── Run go-mutesting ──────────────────────────────────────────────────────────
+
+WORK_DIR="$(mktemp -d -t go-mutesting-adapter-XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT INT TERM
+
+OUTPUT_FILE="$WORK_DIR/output.txt"
+
+set +e
+go-mutesting "$PACKAGE_PATH" > "$OUTPUT_FILE" 2>&1
+GO_MUTESTING_EXIT=$?
+set -e
+
+# ── Parse go-mutesting summary line ──────────────────────────────────────────
+
+# Summary format: "The mutation score is X.XX (N passed, M failed, P skipped, T total)"
+SUMMARY="$(grep -E 'mutation score' "$OUTPUT_FILE" 2>/dev/null | tail -1 || echo '')"
+
+TOTAL=0
+KILLED=0
+
+if [ -n "$SUMMARY" ]; then
+    TOTAL="$(printf '%s\n' "$SUMMARY" | grep -oE '[0-9]+ total' | grep -oE '[0-9]+' | head -1 || echo 0)"
+    KILLED="$(printf '%s\n' "$SUMMARY" | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' | head -1 || echo 0)"
+fi
+
+TOTAL="${TOTAL:-0}"
+KILLED="${KILLED:-0}"
+
+printf '{"total":%d,"killed":%d,"file":"%s"}\n' "$TOTAL" "$KILLED" "$PACKAGE_PATH"
+
+SURVIVED=$(( TOTAL - KILLED ))
+if [ "$SURVIVED" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/mutation-adapters/mutmut.sh
+++ b/mutation-adapters/mutmut.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# mutation-adapters/mutmut.sh — mutmut mutation testing adapter for Python.
+#
+# Usage:
+#   bash mutation-adapters/mutmut.sh <source-file.py> [<test-dir>]
+#
+# Invokes `mutmut run --paths-to-mutate <file>` then parses `mutmut results`
+# to count total and killed mutants. Emits JSON matching M2 contract:
+#   { total: N, killed: K, file: "<path>" }
+#
+# Exit codes:
+#   0 — all mutants killed (or tool absent — exits 0 with warning)
+#   1 — one or more mutants survived
+#   2 — usage/setup error
+#
+# Tool-absent fallback (spec §10): emits warning to stderr and exits 0.
+
+set -eu
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+if [ $# -lt 1 ]; then
+    printf 'Usage: bash mutation-adapters/mutmut.sh <source-file.py> [<test-dir>]\n' >&2
+    exit 2
+fi
+
+SOURCE_FILE="$1"
+TEST_DIR="${2:-}"
+
+# ── Tool-absent fallback ──────────────────────────────────────────────────────
+
+if ! command -v mutmut >/dev/null 2>&1; then
+    printf 'mutmut.sh: mutmut not found — skipping mutation testing (tool absent)\n' >&2
+    printf '{"total":0,"killed":0,"file":"%s"}\n' "$SOURCE_FILE"
+    exit 0
+fi
+
+if [ ! -f "$SOURCE_FILE" ]; then
+    printf 'mutmut.sh: source file not found: %s\n' "$SOURCE_FILE" >&2
+    exit 2
+fi
+
+# ── Run mutmut ────────────────────────────────────────────────────────────────
+
+WORK_DIR="$(mktemp -d -t mutmut-adapter-XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT INT TERM
+
+# Run mutation testing on the specific file
+set +e
+mutmut run --paths-to-mutate "$SOURCE_FILE" >/dev/null 2>&1
+set -e
+
+# ── Parse mutmut results ──────────────────────────────────────────────────────
+
+# mutmut results output format:
+#   KILLED mutants:     12
+#   SURVIVED mutants:   2
+#   TIMEOUT mutants:    0
+#   SUSPICIOUS mutants: 0
+
+RESULTS="$(mutmut results 2>/dev/null || echo '')"
+
+KILLED=0
+SURVIVED=0
+TIMEOUT_COUNT=0
+
+if [ -n "$RESULTS" ]; then
+    KILLED="$(printf '%s\n' "$RESULTS" | grep -iE '^KILLED' | grep -oE '[0-9]+' | head -1 || echo 0)"
+    SURVIVED="$(printf '%s\n' "$RESULTS" | grep -iE '^SURVIVED' | grep -oE '[0-9]+' | head -1 || echo 0)"
+    TIMEOUT_COUNT="$(printf '%s\n' "$RESULTS" | grep -iE '^TIMEOUT' | grep -oE '[0-9]+' | head -1 || echo 0)"
+fi
+
+KILLED="${KILLED:-0}"
+SURVIVED="${SURVIVED:-0}"
+TIMEOUT_COUNT="${TIMEOUT_COUNT:-0}"
+TOTAL=$(( KILLED + SURVIVED + TIMEOUT_COUNT ))
+
+printf '{"total":%d,"killed":%d,"file":"%s"}\n' "$TOTAL" "$KILLED" "$SOURCE_FILE"
+
+if [ "$SURVIVED" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/mutation-adapters/stryker.sh
+++ b/mutation-adapters/stryker.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# mutation-adapters/stryker.sh — Stryker mutation testing adapter for Node/TS/JS.
+#
+# Usage:
+#   bash mutation-adapters/stryker.sh <source-file> [<test-dir>]
+#
+# Invokes `npx stryker run` for the given source file and emits aggregate
+# JSON to stdout matching the M2 contract: { total: N, killed: K, file: "<path>" }
+#
+# Exit codes:
+#   0 — all mutants killed (or tool absent — exits 0 with warning)
+#   1 — one or more mutants survived
+#   2 — usage/setup error
+#
+# Tool-absent fallback (spec §10): emits warning to stderr and exits 0.
+
+set -eu
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+if [ $# -lt 1 ]; then
+    printf 'Usage: bash mutation-adapters/stryker.sh <source-file> [<test-dir>]\n' >&2
+    exit 2
+fi
+
+SOURCE_FILE="$1"
+TEST_DIR="${2:-}"
+
+# ── Tool-absent fallback ──────────────────────────────────────────────────────
+
+if ! command -v npx >/dev/null 2>&1; then
+    printf 'stryker.sh: npx not found — skipping mutation testing (tool absent)\n' >&2
+    printf '{"total":0,"killed":0,"file":"%s"}\n' "$SOURCE_FILE"
+    exit 0
+fi
+
+# Check if stryker is available
+if ! npx stryker --version >/dev/null 2>&1; then
+    printf 'stryker.sh: stryker not installed — skipping mutation testing (tool absent)\n' >&2
+    printf '{"total":0,"killed":0,"file":"%s"}\n' "$SOURCE_FILE"
+    exit 0
+fi
+
+if [ ! -f "$SOURCE_FILE" ]; then
+    printf 'stryker.sh: source file not found: %s\n' "$SOURCE_FILE" >&2
+    exit 2
+fi
+
+# ── Locate repo root ──────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Run Stryker ───────────────────────────────────────────────────────────────
+
+WORK_DIR="$(mktemp -d -t stryker-adapter-XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT INT TERM
+
+STRYKER_REPORT="$WORK_DIR/stryker-report.json"
+
+# Build stryker config targeting the single source file
+STRYKER_CFG="$WORK_DIR/stryker.config.json"
+cat > "$STRYKER_CFG" << STRYKER_JSON
+{
+  "mutate": ["${SOURCE_FILE}"],
+  "reporters": ["json"],
+  "jsonReporter": { "fileName": "${STRYKER_REPORT}" },
+  "testRunner": "command",
+  "commandRunner": { "command": "${TEST_DIR:+bats $TEST_DIR}" }
+}
+STRYKER_JSON
+
+cd "$REPO_ROOT"
+set +e
+npx stryker run "$STRYKER_CFG" >/dev/null 2>&1
+STRYKER_EXIT=$?
+set -e
+
+# ── Parse Stryker JSON report ─────────────────────────────────────────────────
+
+if [ ! -f "$STRYKER_REPORT" ]; then
+    printf 'stryker.sh: stryker did not produce a JSON report\n' >&2
+    printf '{"total":0,"killed":0,"file":"%s"}\n' "$SOURCE_FILE"
+    exit 1
+fi
+
+TOTAL=0
+KILLED=0
+
+if command -v node >/dev/null 2>&1; then
+    TOTAL="$(node -e "
+const r=JSON.parse(require('fs').readFileSync('$STRYKER_REPORT','utf8'));
+const files=r.files||{};
+let t=0;
+for(const f of Object.values(files)){for(const m of f.mutants||[]){t++;}}
+process.stdout.write(String(t));
+" 2>/dev/null || echo 0)"
+
+    KILLED="$(node -e "
+const r=JSON.parse(require('fs').readFileSync('$STRYKER_REPORT','utf8'));
+const files=r.files||{};
+let k=0;
+for(const f of Object.values(files)){for(const m of f.mutants||[]){if(m.status==='Killed')k++;}}
+process.stdout.write(String(k));
+" 2>/dev/null || echo 0)"
+fi
+
+printf '{"total":%d,"killed":%d,"file":"%s"}\n' "$TOTAL" "$KILLED" "$SOURCE_FILE"
+
+SURVIVED=$(( TOTAL - KILLED ))
+if [ "$SURVIVED" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tests/mutation-adapters.bats
+++ b/tests/mutation-adapters.bats
@@ -1,0 +1,181 @@
+#!/usr/bin/env bats
+# tests/mutation-adapters.bats — unit tests for per-language mutation adapters.
+# Uses stubbed external tools to avoid requiring stryker/mutmut/go-mutesting installed.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    STRYKER_ADAPTER="$REPO_ROOT/mutation-adapters/stryker.sh"
+    MUTMUT_ADAPTER="$REPO_ROOT/mutation-adapters/mutmut.sh"
+    GOMUT_ADAPTER="$REPO_ROOT/mutation-adapters/go-mutesting.sh"
+
+    WORK="$(mktemp -d -t mutation-adapter-test.XXXXXX)"
+
+    # Create a minimal source fixture for each language
+    printf 'function foo() { return x === "val"; }\n' > "$WORK/sample.ts"
+    printf 'def check(x):\n    return x == "expected"\n' > "$WORK/sample.py"
+
+    # Stub bin dir — only contains our stubs, no system tools.
+    # For tool-absent tests: use PATH with only safe tools (no stryker/mutmut/go-mutesting/npx).
+    STUB_BIN="$WORK/stub-bin"
+    mkdir -p "$STUB_BIN"
+
+    # SAFE_PATH: minimal PATH with essential tools but not mutation testing tools
+    # We use the stub-bin first so stubs shadow system tools when present
+    SAFE_PATH="$STUB_BIN:/usr/bin:/bin"
+    export ORIGINAL_PATH="$PATH"
+}
+
+teardown() {
+    [ -d "${WORK:-}" ] && rm -rf "$WORK"
+}
+
+# ── Helper: write a stub executable ──────────────────────────────────────────
+
+_write_stub() {
+    local name="$1"
+    local body="$2"
+    printf '#!/usr/bin/env bash\n%s\n' "$body" > "$STUB_BIN/$name"
+    chmod +x "$STUB_BIN/$name"
+}
+
+# ── Syntax checks ─────────────────────────────────────────────────────────────
+
+@test "stryker.sh: bash -n syntax check" {
+    run bash -n "$STRYKER_ADAPTER"
+    [ "$status" -eq 0 ]
+}
+
+@test "mutmut.sh: bash -n syntax check" {
+    run bash -n "$MUTMUT_ADAPTER"
+    [ "$status" -eq 0 ]
+}
+
+@test "go-mutesting.sh: bash -n syntax check" {
+    run bash -n "$GOMUT_ADAPTER"
+    [ "$status" -eq 0 ]
+}
+
+# ── stryker.sh ────────────────────────────────────────────────────────────────
+
+@test "stryker.sh: tool-absent exits 0 with warning when npx missing" {
+    # Run via a wrapper script that restricts PATH to exclude npx
+    run bash -c "PATH='$SAFE_PATH' bash '$STRYKER_ADAPTER' '$WORK/sample.ts' 2>/dev/null"
+    [ "$status" -eq 0 ]
+}
+
+@test "stryker.sh: tool-absent emits JSON with total:0" {
+    run bash -c "PATH='$SAFE_PATH' bash '$STRYKER_ADAPTER' '$WORK/sample.ts' 2>/dev/null"
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read().strip())
+assert d['total'] == 0, f'Expected total=0 but got {d}'
+assert 'killed' in d, 'Missing killed key'
+assert 'file' in d, 'Missing file key'
+"
+}
+
+@test "stryker.sh: emits JSON matching M2 contract shape" {
+    # Tool absent → still emits valid JSON with required keys
+    run bash -c "PATH='$SAFE_PATH' bash '$STRYKER_ADAPTER' '$WORK/sample.ts' 2>/dev/null"
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read().strip())
+for k in ['total', 'killed', 'file']:
+    assert k in d, f'Missing key: {k}'
+assert isinstance(d['total'], int), 'total must be int'
+assert isinstance(d['killed'], int), 'killed must be int'
+"
+}
+
+# ── mutmut.sh ─────────────────────────────────────────────────────────────────
+
+@test "mutmut.sh: tool-absent exits 0 with warning when mutmut missing" {
+    run bash -c "PATH='$SAFE_PATH' bash '$MUTMUT_ADAPTER' '$WORK/sample.py' 2>/dev/null"
+    [ "$status" -eq 0 ]
+}
+
+@test "mutmut.sh: tool-absent emits JSON with total:0" {
+    run bash -c "PATH='$SAFE_PATH' bash '$MUTMUT_ADAPTER' '$WORK/sample.py' 2>/dev/null"
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read().strip())
+assert d['total'] == 0, f'Expected total=0 but got {d}'
+assert 'killed' in d
+assert 'file' in d
+"
+}
+
+@test "mutmut.sh: parses mutmut results format when tool present" {
+    # Stub mutmut to emit known results format
+    _write_stub "mutmut" '
+if [ "${1:-}" = "run" ]; then exit 0; fi
+if [ "${1:-}" = "results" ]; then
+    printf "KILLED mutants:\t5\nSURVIVED mutants:\t1\nTIMEOUT mutants:\t0\nSUSPICIOUS mutants:\t0\n"
+    exit 0
+fi
+exit 0
+'
+    run env PATH="$STUB_BIN:$ORIGINAL_PATH" bash "$MUTMUT_ADAPTER" "$WORK/sample.py"
+    # Survived=1 → exit 1
+    [ "$status" -eq 1 ]
+    echo "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read().strip())
+assert d['total'] == 6, f'Expected total=6 but got {d}'
+assert d['killed'] == 5, f'Expected killed=5 but got {d}'
+"
+}
+
+# ── go-mutesting.sh ───────────────────────────────────────────────────────────
+
+@test "go-mutesting.sh: tool-absent exits 0 with warning when go-mutesting missing" {
+    run bash -c "PATH='$SAFE_PATH' bash '$GOMUT_ADAPTER' './...' 2>/dev/null"
+    [ "$status" -eq 0 ]
+}
+
+@test "go-mutesting.sh: tool-absent emits JSON with total:0" {
+    run bash -c "PATH='$SAFE_PATH' bash '$GOMUT_ADAPTER' './...' 2>/dev/null"
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read().strip())
+assert d['total'] == 0, f'Expected total=0 but got {d}'
+assert 'killed' in d
+assert 'file' in d
+"
+}
+
+@test "go-mutesting.sh: parses go-mutesting summary line when tool present" {
+    # Stub go-mutesting to emit known summary
+    _write_stub "go-mutesting" '
+printf "The mutation score is 0.82 (9 passed, 2 failed, 0 skipped, 11 total)\n"
+exit 0
+'
+    run env PATH="$STUB_BIN:$ORIGINAL_PATH" bash "$GOMUT_ADAPTER" "./..."
+    # 2 survived → exit 1
+    [ "$status" -eq 1 ]
+    echo "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read().strip())
+assert d['total'] == 11, f'Expected total=11 but got {d}'
+assert d['killed'] == 9, f'Expected killed=9 but got {d}'
+"
+}
+
+@test "go-mutesting.sh: all-killed exits 0" {
+    _write_stub "go-mutesting" '
+printf "The mutation score is 1.00 (5 passed, 0 failed, 0 skipped, 5 total)\n"
+exit 0
+'
+    run env PATH="$STUB_BIN:$ORIGINAL_PATH" bash "$GOMUT_ADAPTER" "./..."
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read().strip())
+assert d['total'] == 5
+assert d['killed'] == 5
+"
+}


### PR DESCRIPTION
## Summary

- Adds `mutation-adapters/stryker.sh` — wraps `npx stryker run` for Node/TS/JS files, parses JSON report for total/killed mutant counts
- Adds `mutation-adapters/mutmut.sh` — wraps `mutmut run + results` for Python files, parses `KILLED/SURVIVED` text output
- Adds `mutation-adapters/go-mutesting.sh` — wraps `go-mutesting <pkg>`, parses summary line `(N passed, M failed, P skipped, T total)`
- All three follow M2 (`bash-mutate.sh`) wrapper pattern and emit `{ total, killed, file }` JSON to stdout
- Tool-absent fallback: each adapter exits 0 with stderr warning when the external tool is not installed (spec §10)
- Adds `tests/mutation-adapters.bats` with 13 tests covering syntax, tool-absent, stubbed-tool-present, and JSON shape cases

## Test plan

- [x] `bats tests/mutation-adapters.bats` — 13/13 pass
- [x] `bash scripts/validate.sh` — OK
- [x] `bash -n mutation-adapters/stryker.sh` — syntax OK
- [x] `bash -n mutation-adapters/mutmut.sh` — syntax OK
- [x] `bash -n mutation-adapters/go-mutesting.sh` — syntax OK

docs: skip

Closes #440