### PR TITLE
feat(dist-d2): bin/status + bin/upgrade + bin/uninstall + bats coverage

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -45,6 +45,48 @@ autospec install [--dry-run] [--skill <name>] [--harness <name>] [--update]
 
 Delegates to the canonical `install.sh` in the autospec repo root.
 
+### `autospec status`
+
+List installed autospec skills, their versions, and optional cache-hit-rate from telemetry.
+
+```bash
+autospec status [--help]
+```
+
+Reads skill directories from `~/.claude/skills/autospec-*` (or `$AUTOSPEC_SKILLS_DIR`). Extracts version from each skill's `SKILL.md` frontmatter. Appends last cache-hit-rate from `~/.autospec/telemetry.jsonl` if present.
+
+### `autospec upgrade`
+
+Fetch the latest autospec from upstream and reinstall skills.
+
+```bash
+autospec upgrade [--dry-run] [--help]
+```
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Print what would be done without making changes |
+
+Runs `git pull --ff-only origin main` in the autospec repo (if it is a git repo), then delegates to `install.sh --update`.
+
+### `autospec uninstall`
+
+Remove autospec skills from your harness paths, preserving `~/.autospec/`.
+
+```bash
+autospec uninstall [--yes] [--help]
+```
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--yes` | Skip confirmation prompt |
+
+Removes `autospec-*` directories from `~/.claude/skills/`, `~/.config/opencode/skills/`, and `~/.codex/skills/`. Preserves `~/.autospec/` (config, telemetry, memory).
+
 ### `autospec --version` / `-v`
 
 Print the installed `@autospec/cli` version.

--- a/packages/cli/bin/autospec.js
+++ b/packages/cli/bin/autospec.js
@@ -24,15 +24,21 @@ function usage() {
 Usage: autospec <subcommand> [options]
 
 Subcommands:
-  init       Bootstrap a target repo (.autospec/test.yml + initial scopes)
-  install    Install autospec skills and scripts into your harness
-  --version  Print version
-  --help     Show this help
+  init        Bootstrap a target repo (.autospec/test.yml + initial scopes)
+  install     Install autospec skills and scripts into your harness
+  status      List installed skills, versions, and cache-hit-rate
+  upgrade     Fetch latest autospec and reinstall skills
+  uninstall   Remove autospec skills from harness paths (preserves ~/.autospec/)
+  --version   Print version
+  --help      Show this help
 
 Examples:
   autospec init
   autospec install
   autospec install --dry-run
+  autospec status
+  autospec upgrade --dry-run
+  autospec uninstall --yes
 `);
 }
 
@@ -56,6 +62,15 @@ switch (cmd) {
     break;
   case 'install':
     runScript('install', rest);
+    break;
+  case 'status':
+    runScript('status', rest);
+    break;
+  case 'upgrade':
+    runScript('upgrade', rest);
+    break;
+  case 'uninstall':
+    runScript('uninstall', rest);
     break;
   case '--version':
   case '-v':

--- a/packages/cli/scripts/status.sh
+++ b/packages/cli/scripts/status.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# packages/cli/scripts/status.sh — list installed autospec skills + versions + cache-hit-rate
+# Called by: autospec status [--help]
+#
+# Reads:
+#   $AUTOSPEC_SKILLS_DIR or ~/.claude/skills/   — skill directories
+#   ~/.autospec/telemetry.jsonl                  — optional telemetry for cache-hit-rate
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+autospec status — list installed autospec skills and cache-hit-rate
+
+Usage:
+  autospec status [--help]
+
+Options:
+  --help    Show this help
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h) usage; exit 0 ;;
+    *) echo "autospec status: unknown flag '$arg'" >&2; exit 1 ;;
+  esac
+done
+
+SKILLS_DIR="${AUTOSPEC_SKILLS_DIR:-$HOME/.claude/skills}"
+
+if [ ! -d "$SKILLS_DIR" ]; then
+  echo "autospec status: no skills directory found at $SKILLS_DIR"
+  echo "  Run 'autospec install' to install autospec skills."
+  exit 0
+fi
+
+found=0
+for skill_dir in "$SKILLS_DIR"/autospec-*/; do
+  [ -d "$skill_dir" ] || continue
+  skill_name="$(basename "$skill_dir")"
+  skill_md="$skill_dir/SKILL.md"
+
+  if [ -f "$skill_md" ]; then
+    # Extract version from YAML frontmatter: version: X.Y.Z
+    version="$(awk '/^---$/{c++; next} c==1 && /^version:/{gsub(/^version:[[:space:]]*/, ""); print; exit} c>=2{exit}' "$skill_md" 2>/dev/null || true)"
+    version="${version:-unknown}"
+  else
+    version="unknown"
+  fi
+
+  printf '%-30s %s\n' "$skill_name" "$version"
+  found=$((found + 1))
+done
+
+if [ "$found" -eq 0 ]; then
+  echo "autospec status: no autospec-* skills found in $SKILLS_DIR"
+  echo "  Run 'autospec install' to install autospec skills."
+  exit 0
+fi
+
+# Cache-hit-rate from telemetry (optional)
+TELEMETRY_FILE="${AUTOSPEC_TELEMETRY:-$HOME/.autospec/telemetry.jsonl}"
+if [ -f "$TELEMETRY_FILE" ]; then
+  # Compute cache-hit-rate: average of cache_hit_rate field across last 20 entries
+  rate="$(tail -n 20 "$TELEMETRY_FILE" | \
+    python3 -c "
+import sys, json
+rates = []
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        obj = json.loads(line)
+        r = obj.get('cache_hit_rate')
+        if r is not None:
+            rates.append(float(r))
+    except Exception:
+        pass
+if rates:
+    avg = sum(rates) / len(rates)
+    print(f'{avg:.1%}')
+else:
+    print('n/a')
+" 2>/dev/null || echo "n/a")"
+  echo ""
+  echo "cache-hit-rate: $rate (last ≤20 runs)"
+fi

--- a/packages/cli/scripts/uninstall.sh
+++ b/packages/cli/scripts/uninstall.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# packages/cli/scripts/uninstall.sh — remove autospec skills from harness paths
+# Called by: autospec uninstall [--yes] [--help]
+#
+# Removes:
+#   ~/.claude/skills/autospec-*         (Claude Code)
+#   ~/.config/opencode/skills/autospec-* (OpenCode, if present)
+#   ~/.codex/skills/autospec-*          (Codex CLI, if present)
+#
+# Preserves:
+#   ~/.autospec/     — config, telemetry, memory
+#   ~/.claude/       — everything except autospec skills
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+autospec uninstall — remove autospec skills from your harness paths
+
+Removes autospec-* directories from harness skill paths.
+Preserves ~/.autospec/ (config, telemetry, memory) and all other harness config.
+
+Usage:
+  autospec uninstall [--yes] [--help]
+
+Options:
+  --yes     Skip confirmation prompt
+  --help    Show this help
+EOF
+}
+
+YES=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h) usage; exit 0 ;;
+    --yes|-y) YES=1 ;;
+    *) echo "autospec uninstall: unknown flag '$arg'" >&2; exit 1 ;;
+  esac
+done
+
+# Allow test override of skills directory
+CLAUDE_SKILLS="${AUTOSPEC_SKILLS_DIR:-$HOME/.claude/skills}"
+OPENCODE_SKILLS="${OPENCODE_SKILLS_DIR:-$HOME/.config/opencode/skills}"
+CODEX_SKILLS="${CODEX_SKILLS_DIR:-$HOME/.codex/skills}"
+
+# Collect what would be removed
+to_remove=()
+for base in "$CLAUDE_SKILLS" "$OPENCODE_SKILLS" "$CODEX_SKILLS"; do
+  [ -d "$base" ] || continue
+  for skill_dir in "$base"/autospec-*/; do
+    [ -d "$skill_dir" ] || continue
+    to_remove+=("$skill_dir")
+  done
+done
+
+if [ "${#to_remove[@]}" -eq 0 ]; then
+  echo "autospec uninstall: no autospec-* skills found to remove."
+  exit 0
+fi
+
+echo "autospec uninstall: the following skill directories will be removed:"
+for d in "${to_remove[@]}"; do
+  echo "  $d"
+done
+echo ""
+echo "Preserved: ~/.autospec/ (config, telemetry, memory)"
+
+if [ "$YES" -eq 0 ]; then
+  printf 'Continue? [y/N] '
+  read -r answer
+  case "$answer" in
+    y|Y|yes|YES) ;;
+    *) echo "Aborted."; exit 0 ;;
+  esac
+fi
+
+removed=0
+for d in "${to_remove[@]}"; do
+  rm -rf "$d"
+  echo "removed: $d"
+  removed=$((removed + 1))
+done
+
+echo ""
+echo "autospec uninstall: removed $removed skill director$([ "$removed" -eq 1 ] && echo y || echo ies)."
+echo "  Your ~/.autospec/ configuration has been preserved."
+echo "  Re-install with: autospec install"

--- a/packages/cli/scripts/upgrade.sh
+++ b/packages/cli/scripts/upgrade.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# packages/cli/scripts/upgrade.sh — re-fetch upstream and re-run install.sh
+# Called by: autospec upgrade [--dry-run] [--help]
+#
+# Resolution order for canonical install.sh (same as install.sh):
+#   1. $AUTOSPEC_REPO_ROOT/install.sh
+#   2. Relative: ../../../install.sh (packages/cli/scripts/ → repo root)
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+autospec upgrade — fetch latest autospec and reinstall skills
+
+Usage:
+  autospec upgrade [--dry-run] [--help]
+
+Options:
+  --dry-run    Print what would be installed without writing files
+  --help       Show this help
+EOF
+}
+
+DRY_RUN=0
+PASS_ARGS=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h) usage; exit 0 ;;
+    --dry-run) DRY_RUN=1; PASS_ARGS+=(--dry-run) ;;
+    *) PASS_ARGS+=("$arg") ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Resolve canonical install.sh
+if [ -n "${AUTOSPEC_REPO_ROOT:-}" ] && [ -f "$AUTOSPEC_REPO_ROOT/install.sh" ]; then
+  INSTALL_SH="$AUTOSPEC_REPO_ROOT/install.sh"
+  REPO_ROOT="$AUTOSPEC_REPO_ROOT"
+else
+  CANDIDATE_ROOT="$(cd "$SCRIPT_DIR/../../.." 2>/dev/null && pwd)"
+  CANDIDATE="$CANDIDATE_ROOT/install.sh"
+  if [ -f "$CANDIDATE" ]; then
+    INSTALL_SH="$CANDIDATE"
+    REPO_ROOT="$CANDIDATE_ROOT"
+  else
+    echo "autospec upgrade: cannot locate install.sh." >&2
+    echo "  Set AUTOSPEC_REPO_ROOT to the autospec repo root." >&2
+    exit 1
+  fi
+fi
+
+# Pull latest from upstream (skip in dry-run)
+if [ "$DRY_RUN" -eq 0 ]; then
+  if [ -d "$REPO_ROOT/.git" ]; then
+    echo "autospec upgrade: pulling latest changes in $REPO_ROOT"
+    git -C "$REPO_ROOT" pull --ff-only origin main 2>&1 || {
+      echo "autospec upgrade: git pull failed; proceeding with reinstall on current version" >&2
+    }
+  else
+    echo "autospec upgrade: $REPO_ROOT is not a git repo; skipping git pull"
+  fi
+else
+  echo "autospec upgrade: [dry-run] would git pull origin main in $REPO_ROOT"
+fi
+
+echo "autospec upgrade: delegating to $INSTALL_SH --update ${PASS_ARGS[*]+"${PASS_ARGS[@]}"}"
+exec bash "$INSTALL_SH" --update "${PASS_ARGS[@]+"${PASS_ARGS[@]}"}"

--- a/tests/cli/test_status_upgrade_uninstall.bats
+++ b/tests/cli/test_status_upgrade_uninstall.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# tests/cli/test_status_upgrade_uninstall.bats — bats coverage for status, upgrade, uninstall
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+CLI_BIN="$REPO_ROOT/packages/cli/bin/autospec.js"
+
+setup() {
+  TMPDIR_WORK="$(mktemp -d)"
+  # Mock ~/.claude/skills/autospec-run with a minimal SKILL.md
+  MOCK_SKILLS_DIR="$TMPDIR_WORK/mock-skills"
+  mkdir -p "$MOCK_SKILLS_DIR/autospec-run"
+  cat > "$MOCK_SKILLS_DIR/autospec-run/SKILL.md" <<'EOF'
+---
+name: autospec-run
+version: 1.2.3
+description: Test skill
+---
+
+# autospec-run
+EOF
+  # Mock .autospec dir (to verify uninstall preserves it)
+  MOCK_AUTOSPEC_DIR="$TMPDIR_WORK/dot-autospec"
+  mkdir -p "$MOCK_AUTOSPEC_DIR"
+  echo "version: 1" > "$MOCK_AUTOSPEC_DIR/test.yml"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_WORK"
+}
+
+@test "autospec status prints skill version lines" {
+  run env AUTOSPEC_SKILLS_DIR="$MOCK_SKILLS_DIR" node "$CLI_BIN" status
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "autospec-run" ]]
+}
+
+@test "autospec uninstall removes skill dirs and preserves .autospec" {
+  run env AUTOSPEC_SKILLS_DIR="$MOCK_SKILLS_DIR" AUTOSPEC_DOT_DIR="$MOCK_AUTOSPEC_DIR" node "$CLI_BIN" uninstall --yes
+  [ "$status" -eq 0 ]
+  # Skill dirs should be gone
+  [ ! -d "$MOCK_SKILLS_DIR/autospec-run" ]
+  # .autospec/ should be preserved
+  [ -f "$MOCK_AUTOSPEC_DIR/test.yml" ]
+}
+
+@test "autospec upgrade invokes install.sh and exits 0" {
+  run env AUTOSPEC_REPO_ROOT="$REPO_ROOT" node "$CLI_BIN" upgrade --dry-run
+  [ "$status" -eq 0 ]
+}
+
+@test "unknown subcommand exits non-zero with usage line" {
+  run node "$CLI_BIN" foobar-unknown
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "unknown subcommand" ]]
+}


### PR DESCRIPTION
Closes #455

## Summary

Extends `@autospec/cli` (landed in #453/PR#475) with the three remaining subcommands specified in the distribution design §3.

## What landed

- **`packages/cli/scripts/status.sh`** — lists `autospec-*` skill dirs from `~/.claude/skills/` (or `$AUTOSPEC_SKILLS_DIR`), extracts version from SKILL.md frontmatter, appends optional cache-hit-rate from `~/.autospec/telemetry.jsonl`
- **`packages/cli/scripts/upgrade.sh`** — `git pull --ff-only origin main` (if `.git` present) then `install.sh --update`; supports `--dry-run`
- **`packages/cli/scripts/uninstall.sh`** — removes `autospec-*` from Claude/OpenCode/Codex skill paths; preserves `~/.autospec/`; requires `--yes` or interactive confirm
- **`packages/cli/bin/autospec.js`** — extended dispatch for `status`, `upgrade`, `uninstall`; updated `--help` text
- **`tests/cli/test_status_upgrade_uninstall.bats`** — 4 bats fixtures covering status output, uninstall removes skills + preserves .autospec, upgrade dry-run exits 0, unknown subcommand exits non-zero

## Verification

```
bats tests/cli/test_status_upgrade_uninstall.bats   # 4/4 pass
bats tests/cli/                                      # all pass
bash scripts/validate.sh                             # all checks pass
cd packages/cli && npm pack --dry-run               # lists all 5 scripts
```

Peer-review: codex not on PATH, skipping