### PR TITLE
feat(tooling-opt-t4): gen-implementer-prompt.sh + orchestrator wire-up

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -143,6 +143,26 @@ Exit: 0 = success, 1 = usage/file error, 2 = LLM escalation failed.
   generated: false
 -->
 
+### `gen-implementer-prompt.sh`
+
+Composes the Phase 4 implementer dispatch prompt via `bundle-static-context.sh --role implementer`
+(static cached prefix) plus a deterministic dynamic suffix from the issue body and branch name.
+Zero LLM calls. Standalone alternative to `bundle-and-dispatch.sh`.
+
+```
+Usage: bash scripts/gen-implementer-prompt.sh --issue-body <file> --branch <name>
+                                               [--issue-labels <csv>] [--repo <owner/repo>]
+```
+
+Exit: 0 = success, 1 = missing required arg or file not found.
+
+<!-- autospec-doc-scope:
+  src: ["tests/gen-implementer-prompt.bats", "tests/fixtures/gen-implementer-prompt/issue-438.md"]
+  reason: "Bats unit tests and fixtures for gen-implementer-prompt.sh"
+  mismatch_action: warn
+  generated: false
+-->
+
 ### `gen-pr-report.sh`
 
 100% template-driven PR comment renderer. Reads gate JSON (Stage 1 + Stage 2 + Stage 2.5 results),

--- a/scripts/gen-implementer-prompt.sh
+++ b/scripts/gen-implementer-prompt.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# scripts/gen-implementer-prompt.sh — compose Phase 4 implementer dispatch prompt.
+#
+# Wraps bundle-static-context.sh --role implementer (static cached prefix) with a
+# deterministic dynamic suffix derived from the issue body and branch name.
+# Zero LLM calls.
+#
+# Usage:
+#   scripts/gen-implementer-prompt.sh --issue-body <file> --branch <name>
+#                                      [--issue-labels <csv>] [--repo <owner/repo>]
+#   scripts/gen-implementer-prompt.sh --help
+#
+# Output (stdout):
+#   <static cached prefix from bundle-static-context.sh>
+#
+#   <dynamic suffix: issue body sections + branch/worktree commands + "begin coding now">
+#
+# Dependencies:
+#   skills/autospec-shared/scripts/bundle-static-context.sh (or $AUTOSPEC_SCRIPTS_DIR)
+#
+# Exit codes:
+#   0  success
+#   1  missing required arg or file not found
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Locate bundle-static-context.sh
+BUNDLE_STATIC="${AUTOSPEC_SCRIPTS_DIR:-}"/bundle-static-context.sh
+if [ ! -f "$BUNDLE_STATIC" ] 2>/dev/null; then
+  # Fall back to shared scripts in the repo
+  BUNDLE_STATIC="$REPO_ROOT/skills/autospec-shared/scripts/bundle-static-context.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+ISSUE_BODY_FILE=""
+BRANCH=""
+ISSUE_LABELS=""
+REPO="${AUTOSPEC_REPO:-}"
+
+usage() {
+  cat <<'EOF'
+gen-implementer-prompt.sh — compose Phase 4 implementer dispatch prompt
+
+Usage:
+  scripts/gen-implementer-prompt.sh --issue-body <file> --branch <name>
+                                     [--issue-labels <csv>] [--repo <owner/repo>]
+  scripts/gen-implementer-prompt.sh --help
+
+Required:
+  --issue-body <file>   Path to issue body markdown file
+  --branch <name>       Target branch name for the implementation
+
+Optional:
+  --issue-labels <csv>  Comma-separated issue labels (for cache-prefix tagging)
+  --repo <owner/repo>   Repository slug (default: from AUTOSPEC_REPO env)
+
+Exit: 0=success 1=error
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --help|-h) usage; exit 0 ;;
+    --issue-body)
+      [ -z "${2:-}" ] && { printf 'MISSING_ARG:issue-body\n' >&2; exit 1; }
+      ISSUE_BODY_FILE="$2"; shift 2 ;;
+    --branch)
+      [ -z "${2:-}" ] && { printf 'MISSING_ARG:branch\n' >&2; exit 1; }
+      BRANCH="$2"; shift 2 ;;
+    --issue-labels)
+      [ -z "${2:-}" ] && { printf 'gen-implementer-prompt.sh: --issue-labels requires a value\n' >&2; exit 1; }
+      ISSUE_LABELS="$2"; shift 2 ;;
+    --repo)
+      [ -z "${2:-}" ] && { printf 'gen-implementer-prompt.sh: --repo requires a value\n' >&2; exit 1; }
+      REPO="$2"; shift 2 ;;
+    *)
+      printf 'gen-implementer-prompt.sh: unknown option: %s\n' "$1" >&2; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+if [ -z "$ISSUE_BODY_FILE" ]; then
+  printf 'MISSING_ARG:issue-body\n' >&2
+  exit 1
+fi
+
+if [ -z "$BRANCH" ]; then
+  printf 'MISSING_ARG:branch\n' >&2
+  exit 1
+fi
+
+if [ ! -f "$ISSUE_BODY_FILE" ]; then
+  printf 'gen-implementer-prompt.sh: issue body file not found: %s\n' "$ISSUE_BODY_FILE" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Emit static cached prefix via bundle-static-context.sh
+# ---------------------------------------------------------------------------
+if [ -f "$BUNDLE_STATIC" ]; then
+  if [ -n "$ISSUE_LABELS" ]; then
+    bash "$BUNDLE_STATIC" --role implementer --issue-labels "$ISSUE_LABELS" 2>/dev/null || true
+  else
+    bash "$BUNDLE_STATIC" --role implementer 2>/dev/null || true
+  fi
+else
+  # Graceful fallback: emit a minimal cache boundary stub
+  printf '<!-- CACHE BOUNDARY -->\n'
+  printf '(bundle-static-context.sh not found; static prefix skipped)\n'
+  printf '<!-- CACHE BOUNDARY -->\n'
+fi
+
+# ---------------------------------------------------------------------------
+# Emit dynamic suffix
+# ---------------------------------------------------------------------------
+ISSUE_BODY="$(cat "$ISSUE_BODY_FILE")"
+REPO_SLUG="${REPO:-berlinguyinca/autospec}"
+WT_PATH="/private/tmp/wt-$(echo "$BRANCH" | tr '/' '-' | tr '_' '-')"
+
+printf '\n\n'
+cat <<SUFFIX
+---
+
+## Your implementation assignment
+
+**Branch:** \`${BRANCH}\`
+**Repository:** \`${REPO_SLUG}\`
+
+### Worktree setup
+
+\`\`\`bash
+cd /path/to/autospec
+git fetch origin
+git worktree add ${WT_PATH} -b ${BRANCH} origin/main
+cd ${WT_PATH}
+\`\`\`
+
+### Issue body
+
+${ISSUE_BODY}
+
+---
+
+begin coding now
+SUFFIX

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -451,7 +451,21 @@ issues unblock the queue before continuing with normal feature work.
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
 >
 > **Prompt construction (cache-prefix + dynamic suffix):**
-> Before dispatch, the orchestrator builds the subagent prompt using `bundle-and-dispatch.sh`:
+> Before dispatch, the orchestrator builds the subagent prompt. Two options:
+>
+> **Option A (recommended): `gen-implementer-prompt.sh`** — standalone assembler:
+>    ```bash
+>    _body_file=$(mktemp -t autospec-body-XXXXXX.md)
+>    trap 'rm -f "$_body_file"' EXIT
+>    gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
+>    combined_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-implementer-prompt.sh" \
+>      --issue-body "$_body_file" \
+>      --branch "<BRANCH>" \
+>      --issue-labels "<ISSUE_LABELS>" \
+>      --repo "<REPO>")
+>    ```
+>
+> **Option B (legacy): `bundle-and-dispatch.sh`** — wraps bundle-static-context internally:
 >
 > 1. **Static cached prefix + dynamic suffix** — call `bundle-and-dispatch.sh` to assemble the combined prompt:
 >    ```bash

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -446,7 +446,21 @@ issues unblock the queue before continuing with normal feature work.
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
 >
 > **Prompt construction (cache-prefix + dynamic suffix):**
-> Before dispatch, the orchestrator builds the subagent prompt using `bundle-and-dispatch.sh`:
+> Before dispatch, the orchestrator builds the subagent prompt. Two options:
+>
+> **Option A (recommended): `gen-implementer-prompt.sh`** — standalone assembler:
+>    ```bash
+>    _body_file=$(mktemp -t autospec-body-XXXXXX.md)
+>    trap 'rm -f "$_body_file"' EXIT
+>    gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
+>    combined_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-implementer-prompt.sh" \
+>      --issue-body "$_body_file" \
+>      --branch "<BRANCH>" \
+>      --issue-labels "<ISSUE_LABELS>" \
+>      --repo "<REPO>")
+>    ```
+>
+> **Option B (legacy): `bundle-and-dispatch.sh`** — wraps bundle-static-context internally:
 >
 > 1. **Static cached prefix + dynamic suffix** — call `bundle-and-dispatch.sh` to assemble the combined prompt:
 >    ```bash

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -450,7 +450,21 @@ issues unblock the queue before continuing with normal feature work.
 > `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
 >
 > **Prompt construction (cache-prefix + dynamic suffix):**
-> Before dispatch, the orchestrator builds the subagent prompt using `bundle-and-dispatch.sh`:
+> Before dispatch, the orchestrator builds the subagent prompt. Two options:
+>
+> **Option A (recommended): `gen-implementer-prompt.sh`** — standalone assembler:
+>    ```bash
+>    _body_file=$(mktemp -t autospec-body-XXXXXX.md)
+>    trap 'rm -f "$_body_file"' EXIT
+>    gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
+>    combined_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-implementer-prompt.sh" \
+>      --issue-body "$_body_file" \
+>      --branch "<BRANCH>" \
+>      --issue-labels "<ISSUE_LABELS>" \
+>      --repo "<REPO>")
+>    ```
+>
+> **Option B (legacy): `bundle-and-dispatch.sh`** — wraps bundle-static-context internally:
 >
 > 1. **Static cached prefix + dynamic suffix** — call `bundle-and-dispatch.sh` to assemble the combined prompt:
 >    ```bash

--- a/tests/fixtures/gen-implementer-prompt/issue-438.md
+++ b/tests/fixtures/gen-implementer-prompt/issue-438.md
@@ -1,0 +1,28 @@
+## Goal
+
+Add a simple example script that prints "hello world".
+
+## Files to read first
+
+- `scripts/lint-issue.sh`
+
+## Implementation scope
+
+- `scripts/hello.sh`
+
+## Acceptance criteria
+
+- [ ] `bash scripts/hello.sh` prints "hello world"
+- [ ] `bats tests/hello.bats` passes
+
+## Verification
+
+### Primary smoke test
+
+```
+bats tests/hello.bats
+```
+
+## Branch name
+
+`feat/example-hello`

--- a/tests/gen-implementer-prompt.bats
+++ b/tests/gen-implementer-prompt.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# tests/gen-implementer-prompt.bats — bats coverage for gen-implementer-prompt.sh
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+BIN="$REPO_ROOT/scripts/gen-implementer-prompt.sh"
+FIX="$REPO_ROOT/tests/fixtures/gen-implementer-prompt"
+
+# Case 1: output contains "begin coding now" (dynamic suffix verification)
+@test "suffix-substitution: output contains 'begin coding now'" {
+  run bash "$BIN" \
+    --issue-body "$FIX/issue-438.md" \
+    --branch feat/example-hello
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "begin coding now"
+}
+
+# Case 2: output contains branch name in suffix
+@test "suffix-substitution: output contains branch name" {
+  run bash "$BIN" \
+    --issue-body "$FIX/issue-438.md" \
+    --branch feat/example-hello
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "feat/example-hello"
+}
+
+# Case 3: output contains issue body content
+@test "suffix-substitution: output contains issue body text" {
+  run bash "$BIN" \
+    --issue-body "$FIX/issue-438.md" \
+    --branch feat/example-hello
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "hello world"
+}
+
+# Case 4: missing --issue-body exits non-zero with MISSING_ARG on stderr
+@test "missing --issue-body: exits non-zero with MISSING_ARG on stderr" {
+  run bash "$BIN" --branch feat/example-hello
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "MISSING_ARG" || echo "${lines[@]}" | grep -q "MISSING_ARG"
+}
+
+# Case 5: missing --branch exits non-zero
+@test "missing --branch: exits non-zero with MISSING_ARG on stderr" {
+  run bash "$BIN" --issue-body "$FIX/issue-438.md"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "MISSING_ARG" || echo "${lines[@]}" | grep -q "MISSING_ARG"
+}
+
+# Case 6: script contains zero LLM CLI invocations
+@test "script contains zero claude/codex/gemini CLI invocations" {
+  run grep -E "\bclaude\b|\bcodex\b|\bgemini\b" "$BIN"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/gen-implementer-prompt.sh`: standalone implementer prompt assembler per spec §6
- Wraps `bundle-static-context.sh --role implementer` (static cached prefix) + deterministic dynamic suffix (issue body + branch + "begin coding now")
- Wires into `skills/autospec-run` SKILL trio as Option A (recommended) alongside existing `bundle-and-dispatch.sh` (Option B/legacy)
- Lockstep mirrored to `codex/prompt.md` + `opencode/agent.md` — `bash scripts/validate.sh` passes
- 6 bats cases in `tests/gen-implementer-prompt.bats` + fixture

## Test plan

- [x] `bats tests/gen-implementer-prompt.bats` — 6/6 pass
- [x] Output contains `begin coding now`
- [x] Zero `claude`/`codex`/`gemini` CLI invocations in script
- [x] Missing `--issue-body` exits with `MISSING_ARG` on stderr
- [x] Missing `--branch` exits with `MISSING_ARG` on stderr
- [x] `bash scripts/validate.sh` — all checks pass (lockstep ok)

docs: skip

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)