### PR TITLE
feat(autospec-e2e-clone): skill scaffold + clone.yml contract + JSON schema (C1, closes #465)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ build/
 # Allow .autospec/ inside synthetic test targets
 !skills/autospec-shared/test-targets/**/.autospec/
 !skills/autospec-shared/test-targets/**/.autospec/**
+# Allow .autospec/ inside autospec-e2e-clone contract-loader fixtures
+!skills/autospec-e2e-clone/tests/unit/fixtures/**/.autospec/
+!skills/autospec-e2e-clone/tests/unit/fixtures/**/.autospec/**

--- a/schemas/autospec-clone-contract.schema.json
+++ b/schemas/autospec-clone-contract.schema.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-clone-contract.schema.json",
+  "title": "autospec-e2e-clone contract",
+  "description": "Schema for .autospec/clone.yml — the autospec-e2e-clone skill contract file. Declares snapshot sources, anonymization rules, scale-down config, edge-case seeding, and expose adapter.",
+  "type": "object",
+  "required": ["sources", "expose"],
+  "additionalProperties": false,
+  "properties": {
+    "sources": {
+      "type": "array",
+      "description": "List of data sources to snapshot. At least one required.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["kind"],
+        "additionalProperties": true,
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["postgres", "mysql", "sqlite", "s3", "filesystem", "custom_cmd"],
+            "description": "Source adapter kind."
+          },
+          "dsn_env": {
+            "type": "string",
+            "description": "Environment variable name containing the connection DSN (postgres/mysql/sqlite)."
+          },
+          "tables_full": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Tables to clone in full (no sampling)."
+          },
+          "tables_sample": {
+            "type": "object",
+            "additionalProperties": { "type": "integer", "minimum": 1 },
+            "description": "Tables to clone with row-count sampling. Keys are table names, values are row counts."
+          },
+          "bucket": {
+            "type": "string",
+            "description": "S3 bucket name (kind: s3)."
+          },
+          "sample_prefix_count": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Maximum number of objects per S3 prefix to include (kind: s3)."
+          },
+          "paths": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Filesystem paths to snapshot (kind: filesystem)."
+          },
+          "sample_files_per_dir": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Maximum files per directory to include (kind: filesystem)."
+          },
+          "snapshot_cmd": {
+            "type": "string",
+            "description": "Custom command to run for snapshot (kind: custom_cmd)."
+          }
+        }
+      }
+    },
+    "anonymize": {
+      "type": "object",
+      "description": "PII anonymization configuration.",
+      "additionalProperties": false,
+      "properties": {
+        "rules": {
+          "type": "array",
+          "description": "Per-table anonymization rules.",
+          "items": {
+            "type": "object",
+            "required": ["table", "columns"],
+            "additionalProperties": false,
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name to apply rules to."
+              },
+              "columns": {
+                "type": "object",
+                "description": "Column → anonymization strategy mapping.",
+                "additionalProperties": {
+                  "type": "string",
+                  "enum": [
+                    "hash_with_domain",
+                    "redact",
+                    "scrub_to_country_code",
+                    "replace_with_faker",
+                    "scrub_to_subnet"
+                  ]
+                }
+              },
+              "pii_assertions": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "SQL assertions that must return 0 rows post-anonymization."
+              }
+            }
+          }
+        },
+        "reversible_map_path": {
+          "type": "string",
+          "description": "Path template for the reversible mapping file (supports <sha> placeholder)."
+        }
+      }
+    },
+    "scale_down": {
+      "type": "object",
+      "description": "Scale-down sampling configuration.",
+      "additionalProperties": false,
+      "properties": {
+        "default_sample": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Default row count for sampled tables not explicitly listed in tables_sample."
+        },
+        "foreign_key_aware": {
+          "type": "boolean",
+          "description": "When true, rows referenced by sampled rows are included (referential integrity)."
+        }
+      }
+    },
+    "edge_case_seed": {
+      "type": "object",
+      "description": "Edge-case seed configuration.",
+      "additionalProperties": false,
+      "properties": {
+        "consume_from": {
+          "type": "string",
+          "description": "Path to autospec-test contract file to read edge_case_seeds.require_shapes from."
+        },
+        "seed_shapes_catalog": {
+          "type": "string",
+          "description": "Path to seed-shapes catalog YAML (default: $AUTOSPEC_SCRIPTS_DIR/seed-shapes/catalog.yml)."
+        }
+      }
+    },
+    "expose": {
+      "type": "object",
+      "description": "URL exposure adapter configuration.",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["docker_compose", "k8s_ephemeral_namespace", "dedicated_staging_slot", "custom_cmd"],
+          "description": "Expose adapter kind."
+        },
+        "compose_file": {
+          "type": "string",
+          "description": "Path to docker-compose file (kind: docker_compose)."
+        },
+        "url_template": {
+          "type": "string",
+          "description": "URL template for the exposed clone (e.g. http://localhost:8080)."
+        },
+        "health_endpoint": {
+          "type": "string",
+          "description": "HTTP path for health check polling (e.g. /health)."
+        },
+        "ready_wait_secs": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Seconds to wait for health endpoint to respond before failing."
+        },
+        "up_cmd": {
+          "type": "string",
+          "description": "Custom command to bring the clone up (kind: custom_cmd)."
+        },
+        "down_cmd": {
+          "type": "string",
+          "description": "Custom command to bring the clone down (kind: custom_cmd)."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Kubernetes namespace to create (kind: k8s_ephemeral_namespace)."
+        },
+        "manifests_dir": {
+          "type": "string",
+          "description": "Directory containing Kubernetes manifests (kind: k8s_ephemeral_namespace)."
+        },
+        "slot_name": {
+          "type": "string",
+          "description": "Staging slot name (kind: dedicated_staging_slot)."
+        }
+      }
+    }
+  }
+}

--- a/skills/autospec-e2e-clone/README.md
+++ b/skills/autospec-e2e-clone/README.md
@@ -1,0 +1,34 @@
+# autospec-e2e-clone
+
+Clone environment provisioner for autospec-test Mode II E2E testing.
+
+Provisions an isolated, scaled-down, anonymized clone of a production environment.
+Outputs a routable URL to `.autospec/clone-url.txt` for autospec-test to consume.
+
+## Install
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-e2e-clone/install.sh) --harness all
+```
+
+## Contract
+
+Create `.autospec/clone.yml` in your target repository:
+
+```yaml
+sources:
+  - kind: postgres
+    dsn_env: PROD_DB_URL
+
+expose:
+  kind: docker_compose
+  compose_file: deploy/docker-compose.clone.yml
+  url_template: "http://localhost:8080"
+```
+
+See [design spec](../../docs/specs/2026-05-22-autospec-e2e-clone-design.md) for full contract reference.
+
+## Components
+
+C1 (this PR) — Skill scaffold + contract loader + JSON Schema.
+C2–C10 — Snapshot drivers, anonymize, scale-down, seed, expose, teardown (pending).

--- a/skills/autospec-e2e-clone/SKILL.md
+++ b/skills/autospec-e2e-clone/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: autospec-e2e-clone
+description: Use when you need to provision an isolated, scaled-down, anonymized clone of a production environment for autospec-test E2E testing (Mode II). Handles snapshot capture, PII anonymization, edge-case data seeding, and URL exposure.
+---
+
+# autospec-e2e-clone — Clone Environment Provisioner
+
+Provision an isolated, scaled-down, anonymized clone of a production environment that `autospec-test` can run E2E tests against. The clone exposes a routable URL the autospec-test contract consumes via `e2e.clone_url_env`.
+
+## Self-update mode
+
+Decide this purely from the request text the harness handed you. Do NOT shell out to test the user's free-form request. Read the request, normalize it in your reasoning (collapse whitespace, trim, lowercase), and if the result is exactly `update`, this skill enters self-update mode and does NOT run the normal pipeline.
+
+Placeholder for autospec-discovery registration. The live self-update bash block lands in C10 per lockstep convention. Required here so the decomposer scans a complete structural set during family registration.
+
+1. Detect harness by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-e2e-clone/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-e2e-clone.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-e2e-clone.md`
+2. Re-install from `main` by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-e2e-clone/install.sh) --harness <detected> --update
+   ```
+3. Show the diff between the prior installed file(s) and the freshly fetched copy.
+4. Stop. Do not enter any pipeline phase.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-e2e-clone found; run install.sh first.` and exit.
+
+## Model tier
+
+`reasoning:standard, ctx:120k`
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool.
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                             | Fallback if missing                    |
+|-----------------------------|-----------------------------------------|---------------------------------------|---------------------------------------|----------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)         | `task` agent in read-only mode        | shell `grep`                          | Do the search in-thread                |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent                   | spawn nested CLI session              | Do the work in-thread                  |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                         | Ask in response and wait               |
+| Subagent model tier         | **Model tier:** `TIER_B` for provisioning work; `TIER_A` for review | top task model + high reasoning | top GPT + reasoning_effort=high | Honor per-phase tier mapping |
+
+## Harness detection
+
+Detect your harness by checking available tools before any phase:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`
+   - `TIER_B` = `sonnet`
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available.
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is unavailable (quota, capacity, or auth failure), silently retry with `TIER_A`. Never ask the user.
+
+## Adapter row
+
+| Skill | Trigger | Output |
+| --- | --- | --- |
+| autospec-e2e-clone | `/autospec-e2e-clone` or autospec-test Mode II gate | `.autospec/clone-url.txt` + provisioned routable URL |
+
+## Contract
+
+Contract file: `.autospec/clone.yml` in the target repository. Load and validate with:
+
+```bash
+bash "${AUTOSPEC_SKILLS_DIR:-$HOME/.autospec/skills}/autospec-e2e-clone/scripts/load-contract.sh" <repo_root>
+```
+
+Exit codes from `load-contract.sh`:
+- `0` — resolved contract JSON on stdout
+- `1` — fatal (tool missing, parse error, internal error)
+- `2` — refuse-to-run (contract invalid or missing required fields)
+
+Required contract fields:
+- `sources` — array of ≥1 source entries (each with `kind`)
+- `expose.kind` — one of `docker_compose | k8s_ephemeral_namespace | dedicated_staging_slot | custom_cmd`
+
+Example `.autospec/clone.yml`:
+
+```yaml
+sources:
+  - kind: postgres
+    dsn_env: PROD_DB_URL
+    tables_full: [users, products]
+    tables_sample: { events: 10000, logs: 5000 }
+
+anonymize:
+  rules:
+    - table: users
+      columns:
+        email: hash_with_domain
+        ssn: redact
+
+scale_down:
+  default_sample: 10000
+  foreign_key_aware: true
+
+edge_case_seed:
+  consume_from: .autospec/test.yml
+
+expose:
+  kind: docker_compose
+  compose_file: deploy/docker-compose.clone.yml
+  url_template: "http://localhost:8080"
+  health_endpoint: /health
+  ready_wait_secs: 60
+```
+
+## Pipeline
+
+```
+1. Snapshot          → capture DB + filesystem + S3 state
+2. Anonymize         → redact PII per declarative rules
+3. Scale down        → sample large tables (foreign-key-aware)
+4. Edge-case seed    → consume edge_case_seeds.require_shapes from .autospec/test.yml
+5. Expose URL        → provision routable URL + credentials
+6. Health check      → verify URL responds; matrix of expected endpoints
+7. Output            → writes .autospec/clone-url.txt for autospec-test gate to read
+```
+
+## Components (C1–C10)
+
+| Component | Description | Status |
+|-----------|-------------|--------|
+| C1 | Skill scaffold + clone.yml contract + JSON Schema | This PR |
+| C2 | Snapshot drivers: pg + mysql + sqlite | Pending |
+| C3 | Snapshot drivers: s3 + filesystem + custom_cmd | Pending |
+| C4 | Anonymize engine + reversible map + pii_assertions | Pending |
+| C5 | Scale-down with foreign-key reachability | Pending |
+| C6 | Edge-case seed consumer + catalog overlay | Pending |
+| C7 | Expose adapter: docker_compose | Pending |
+| C8 | Expose adapters: k8s + staging_slot + custom_cmd | Pending |
+| C9 | Teardown + autospec-test contract integration | Pending |
+| C10 | Synthetic targets + integration tests + dogfood | Pending |
+
+## Constraints
+
+- Source DSNs are never logged.
+- Snapshot artifacts go to `.autospec/clone-snapshots/` (gitignored).
+- PII assertions must pass post-anonymization or provisioning fails (fail-closed).
+- Teardown runs automatically on test completion (success or failure).

--- a/skills/autospec-e2e-clone/codex/prompt.md
+++ b/skills/autospec-e2e-clone/codex/prompt.md
@@ -1,0 +1,144 @@
+
+# autospec-e2e-clone — Clone Environment Provisioner
+
+Provision an isolated, scaled-down, anonymized clone of a production environment that `autospec-test` can run E2E tests against. The clone exposes a routable URL the autospec-test contract consumes via `e2e.clone_url_env`.
+
+## Self-update mode
+
+Decide this purely from the request text the harness handed you. Do NOT shell out to test the user's free-form request. Read the request, normalize it in your reasoning (collapse whitespace, trim, lowercase), and if the result is exactly `update`, this skill enters self-update mode and does NOT run the normal pipeline.
+
+Placeholder for autospec-discovery registration. The live self-update bash block lands in C10 per lockstep convention. Required here so the decomposer scans a complete structural set during family registration.
+
+1. Detect harness by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-e2e-clone/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-e2e-clone.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-e2e-clone.md`
+2. Re-install from `main` by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-e2e-clone/install.sh) --harness <detected> --update
+   ```
+3. Show the diff between the prior installed file(s) and the freshly fetched copy.
+4. Stop. Do not enter any pipeline phase.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-e2e-clone found; run install.sh first.` and exit.
+
+## Model tier
+
+`reasoning:standard, ctx:120k`
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool.
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                             | Fallback if missing                    |
+|-----------------------------|-----------------------------------------|---------------------------------------|---------------------------------------|----------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)         | `task` agent in read-only mode        | shell `grep`                          | Do the search in-thread                |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent                   | spawn nested CLI session              | Do the work in-thread                  |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                         | Ask in response and wait               |
+| Subagent model tier         | **Model tier:** `TIER_B` for provisioning work; `TIER_A` for review | top task model + high reasoning | top GPT + reasoning_effort=high | Honor per-phase tier mapping |
+
+## Harness detection
+
+Detect your harness by checking available tools before any phase:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`
+   - `TIER_B` = `sonnet`
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available.
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is unavailable (quota, capacity, or auth failure), silently retry with `TIER_A`. Never ask the user.
+
+## Adapter row
+
+| Skill | Trigger | Output |
+| --- | --- | --- |
+| autospec-e2e-clone | `/autospec-e2e-clone` or autospec-test Mode II gate | `.autospec/clone-url.txt` + provisioned routable URL |
+
+## Contract
+
+Contract file: `.autospec/clone.yml` in the target repository. Load and validate with:
+
+```bash
+bash "${AUTOSPEC_SKILLS_DIR:-$HOME/.autospec/skills}/autospec-e2e-clone/scripts/load-contract.sh" <repo_root>
+```
+
+Exit codes from `load-contract.sh`:
+- `0` — resolved contract JSON on stdout
+- `1` — fatal (tool missing, parse error, internal error)
+- `2` — refuse-to-run (contract invalid or missing required fields)
+
+Required contract fields:
+- `sources` — array of ≥1 source entries (each with `kind`)
+- `expose.kind` — one of `docker_compose | k8s_ephemeral_namespace | dedicated_staging_slot | custom_cmd`
+
+Example `.autospec/clone.yml`:
+
+```yaml
+sources:
+  - kind: postgres
+    dsn_env: PROD_DB_URL
+    tables_full: [users, products]
+    tables_sample: { events: 10000, logs: 5000 }
+
+anonymize:
+  rules:
+    - table: users
+      columns:
+        email: hash_with_domain
+        ssn: redact
+
+scale_down:
+  default_sample: 10000
+  foreign_key_aware: true
+
+edge_case_seed:
+  consume_from: .autospec/test.yml
+
+expose:
+  kind: docker_compose
+  compose_file: deploy/docker-compose.clone.yml
+  url_template: "http://localhost:8080"
+  health_endpoint: /health
+  ready_wait_secs: 60
+```
+
+## Pipeline
+
+```
+1. Snapshot          → capture DB + filesystem + S3 state
+2. Anonymize         → redact PII per declarative rules
+3. Scale down        → sample large tables (foreign-key-aware)
+4. Edge-case seed    → consume edge_case_seeds.require_shapes from .autospec/test.yml
+5. Expose URL        → provision routable URL + credentials
+6. Health check      → verify URL responds; matrix of expected endpoints
+7. Output            → writes .autospec/clone-url.txt for autospec-test gate to read
+```
+
+## Components (C1–C10)
+
+| Component | Description | Status |
+|-----------|-------------|--------|
+| C1 | Skill scaffold + clone.yml contract + JSON Schema | This PR |
+| C2 | Snapshot drivers: pg + mysql + sqlite | Pending |
+| C3 | Snapshot drivers: s3 + filesystem + custom_cmd | Pending |
+| C4 | Anonymize engine + reversible map + pii_assertions | Pending |
+| C5 | Scale-down with foreign-key reachability | Pending |
+| C6 | Edge-case seed consumer + catalog overlay | Pending |
+| C7 | Expose adapter: docker_compose | Pending |
+| C8 | Expose adapters: k8s + staging_slot + custom_cmd | Pending |
+| C9 | Teardown + autospec-test contract integration | Pending |
+| C10 | Synthetic targets + integration tests + dogfood | Pending |
+
+## Constraints
+
+- Source DSNs are never logged.
+- Snapshot artifacts go to `.autospec/clone-snapshots/` (gitignored).
+- PII assertions must pass post-anonymization or provisioning fails (fail-closed).
+- Teardown runs automatically on test completion (success or failure).

--- a/skills/autospec-e2e-clone/install.sh
+++ b/skills/autospec-e2e-clone/install.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec-e2e-clone skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --update            # update an existing install
+#   ./install.sh --symlink           # symlink instead of copy
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-e2e-clone/install.sh \
+#     | sh -s -- --harness all
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPEC_E2E_CLONE_REF         (default: main)
+#   AUTOSPEC_E2E_CLONE_RAW_BASE    (override raw URL base)
+
+set -eu
+
+SKILL_NAME="autospec-e2e-clone"
+SKILL_RAW_BASE="${AUTOSPEC_E2E_CLONE_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_E2E_CLONE_REF:-main}/skills/autospec-e2e-clone}"
+
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+SYMLINK=0
+DRY_RUN=0
+UPDATE=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--update] [--symlink] [--dry-run]
+
+Installs the ${SKILL_NAME} skill into the chosen harness.
+EOF
+}
+
+run_cmd() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+fetch_file() {
+    src="$1"
+    dst="$2"
+    if [ -n "$SKILL_DIR" ] && [ -f "$SKILL_DIR/$src" ]; then
+        run_cmd "cp \"$SKILL_DIR/$src\" \"$dst\""
+    else
+        run_cmd "curl -fsSL \"$SKILL_RAW_BASE/$src\" -o \"$dst\""
+    fi
+}
+
+install_one() {
+    target="$1"
+    src_file="${2:-SKILL.md}"
+    target_dir="$(dirname "$target")"
+    run_cmd "mkdir -p \"$target_dir\""
+    fetch_file "$src_file" "$target"
+    info "  installed: $target"
+}
+
+# ---------- arg parse -------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift; HARNESS="${1:-}" ;;
+        --harness=*)
+            HARNESS="${1#--harness=}" ;;
+        --update)
+            UPDATE=1 ;;
+        --symlink)
+            SYMLINK=1 ;;
+        --dry-run)
+            DRY_RUN=1 ;;
+        -h|--help)
+            usage; exit 0 ;;
+        *)
+            err "unknown arg: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install into?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths -----------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+CODEX_SKILLS_DEST="$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+
+# ---------- install ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_DEST" "SKILL.md"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_DEST" "opencode/agent.md"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_DEST" "codex/prompt.md"
+    install_one "$CODEX_SKILLS_DEST" "SKILL.md"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    info "Done. Run /autospec-e2e-clone to provision a clone environment."
+fi
+
+exit 0

--- a/skills/autospec-e2e-clone/opencode/agent.md
+++ b/skills/autospec-e2e-clone/opencode/agent.md
@@ -1,0 +1,148 @@
+---
+name: autospec-e2e-clone
+description: Use when you need to provision an isolated, scaled-down, anonymized clone of a production environment for autospec-test E2E testing (Mode II). Handles snapshot capture, PII anonymization, edge-case data seeding, and URL exposure.
+---
+
+# autospec-e2e-clone — Clone Environment Provisioner
+
+Provision an isolated, scaled-down, anonymized clone of a production environment that `autospec-test` can run E2E tests against. The clone exposes a routable URL the autospec-test contract consumes via `e2e.clone_url_env`.
+
+## Self-update mode
+
+Decide this purely from the request text the harness handed you. Do NOT shell out to test the user's free-form request. Read the request, normalize it in your reasoning (collapse whitespace, trim, lowercase), and if the result is exactly `update`, this skill enters self-update mode and does NOT run the normal pipeline.
+
+Placeholder for autospec-discovery registration. The live self-update bash block lands in C10 per lockstep convention. Required here so the decomposer scans a complete structural set during family registration.
+
+1. Detect harness by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-e2e-clone/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-e2e-clone.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-e2e-clone.md`
+2. Re-install from `main` by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-e2e-clone/install.sh) --harness <detected> --update
+   ```
+3. Show the diff between the prior installed file(s) and the freshly fetched copy.
+4. Stop. Do not enter any pipeline phase.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-e2e-clone found; run install.sh first.` and exit.
+
+## Model tier
+
+`reasoning:standard, ctx:120k`
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool.
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                             | Fallback if missing                    |
+|-----------------------------|-----------------------------------------|---------------------------------------|---------------------------------------|----------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)         | `task` agent in read-only mode        | shell `grep`                          | Do the search in-thread                |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent                   | spawn nested CLI session              | Do the work in-thread                  |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                         | Ask in response and wait               |
+| Subagent model tier         | **Model tier:** `TIER_B` for provisioning work; `TIER_A` for review | top task model + high reasoning | top GPT + reasoning_effort=high | Honor per-phase tier mapping |
+
+## Harness detection
+
+Detect your harness by checking available tools before any phase:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`
+   - `TIER_B` = `sonnet`
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available.
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is unavailable (quota, capacity, or auth failure), silently retry with `TIER_A`. Never ask the user.
+
+## Adapter row
+
+| Skill | Trigger | Output |
+| --- | --- | --- |
+| autospec-e2e-clone | `/autospec-e2e-clone` or autospec-test Mode II gate | `.autospec/clone-url.txt` + provisioned routable URL |
+
+## Contract
+
+Contract file: `.autospec/clone.yml` in the target repository. Load and validate with:
+
+```bash
+bash "${AUTOSPEC_SKILLS_DIR:-$HOME/.autospec/skills}/autospec-e2e-clone/scripts/load-contract.sh" <repo_root>
+```
+
+Exit codes from `load-contract.sh`:
+- `0` — resolved contract JSON on stdout
+- `1` — fatal (tool missing, parse error, internal error)
+- `2` — refuse-to-run (contract invalid or missing required fields)
+
+Required contract fields:
+- `sources` — array of ≥1 source entries (each with `kind`)
+- `expose.kind` — one of `docker_compose | k8s_ephemeral_namespace | dedicated_staging_slot | custom_cmd`
+
+Example `.autospec/clone.yml`:
+
+```yaml
+sources:
+  - kind: postgres
+    dsn_env: PROD_DB_URL
+    tables_full: [users, products]
+    tables_sample: { events: 10000, logs: 5000 }
+
+anonymize:
+  rules:
+    - table: users
+      columns:
+        email: hash_with_domain
+        ssn: redact
+
+scale_down:
+  default_sample: 10000
+  foreign_key_aware: true
+
+edge_case_seed:
+  consume_from: .autospec/test.yml
+
+expose:
+  kind: docker_compose
+  compose_file: deploy/docker-compose.clone.yml
+  url_template: "http://localhost:8080"
+  health_endpoint: /health
+  ready_wait_secs: 60
+```
+
+## Pipeline
+
+```
+1. Snapshot          → capture DB + filesystem + S3 state
+2. Anonymize         → redact PII per declarative rules
+3. Scale down        → sample large tables (foreign-key-aware)
+4. Edge-case seed    → consume edge_case_seeds.require_shapes from .autospec/test.yml
+5. Expose URL        → provision routable URL + credentials
+6. Health check      → verify URL responds; matrix of expected endpoints
+7. Output            → writes .autospec/clone-url.txt for autospec-test gate to read
+```
+
+## Components (C1–C10)
+
+| Component | Description | Status |
+|-----------|-------------|--------|
+| C1 | Skill scaffold + clone.yml contract + JSON Schema | This PR |
+| C2 | Snapshot drivers: pg + mysql + sqlite | Pending |
+| C3 | Snapshot drivers: s3 + filesystem + custom_cmd | Pending |
+| C4 | Anonymize engine + reversible map + pii_assertions | Pending |
+| C5 | Scale-down with foreign-key reachability | Pending |
+| C6 | Edge-case seed consumer + catalog overlay | Pending |
+| C7 | Expose adapter: docker_compose | Pending |
+| C8 | Expose adapters: k8s + staging_slot + custom_cmd | Pending |
+| C9 | Teardown + autospec-test contract integration | Pending |
+| C10 | Synthetic targets + integration tests + dogfood | Pending |
+
+## Constraints
+
+- Source DSNs are never logged.
+- Snapshot artifacts go to `.autospec/clone-snapshots/` (gitignored).
+- PII assertions must pass post-anonymization or provisioning fails (fail-closed).
+- Teardown runs automatically on test completion (success or failure).

--- a/skills/autospec-e2e-clone/scripts/load-contract.sh
+++ b/skills/autospec-e2e-clone/scripts/load-contract.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# skills/autospec-e2e-clone/scripts/load-contract.sh — load and validate the
+# autospec-e2e-clone contract (.autospec/clone.yml) for a target repository.
+#
+# Usage: load-contract.sh <repo_root>
+#   Outputs resolved contract JSON to stdout.
+#
+# Exit codes:
+#   0 = ok — resolved contract JSON on stdout
+#   1 = fatal — tool missing, unreadable file, internal error
+#   2 = refuse-to-run — contract invalid or missing required fields
+#       (operator-actionable; stderr explains what to fix)
+#
+# Dependencies: yq (YAML→JSON), ajv (JSON Schema validation)
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+
+SCHEMA_FILE="$REPO_ROOT/schemas/autospec-clone-contract.schema.json"
+
+load_contract() {
+    local repo_root="${1:-.}"
+
+    # ── Validate repo_root exists ──────────────────────────────────────────────
+    if [ ! -d "$repo_root" ]; then
+        printf 'load-contract: fatal: repo_root not found: %s\n' "$repo_root" >&2
+        exit 1
+    fi
+
+    # ── Check for contract file ────────────────────────────────────────────────
+    local contract_file="$repo_root/.autospec/clone.yml"
+    if [ ! -f "$contract_file" ]; then
+        printf 'load-contract: refuse-to-run: .autospec/clone.yml not found in %s\n' "$repo_root" >&2
+        printf 'Create .autospec/clone.yml with required fields: sources (>=1 item), expose.kind\n' >&2
+        exit 2
+    fi
+
+    # ── Dependency checks ──────────────────────────────────────────────────────
+    if ! command -v yq >/dev/null 2>&1; then
+        printf 'load-contract: fatal: yq not found. Install with: brew install yq\n' >&2
+        exit 1
+    fi
+
+    # ── Parse YAML → JSON ─────────────────────────────────────────────────────
+    local contract_json
+    local yq_err
+    yq_err=$(mktemp -t load-contract-yq-err-XXXXXX.txt)
+    # shellcheck disable=SC2064
+    trap "rm -f '$yq_err'" EXIT
+
+    if ! contract_json=$(yq -o=json '.' "$contract_file" 2>"$yq_err"); then
+        printf 'load-contract: fatal: failed to parse %s:\n' "$contract_file" >&2
+        cat "$yq_err" >&2
+        exit 1
+    fi
+
+    # yq emits "null" for empty files
+    if [ "$contract_json" = "null" ] || [ -z "$contract_json" ]; then
+        printf 'load-contract: refuse-to-run: %s is empty or unparseable\n' "$contract_file" >&2
+        exit 2
+    fi
+
+    # ── Validate required fields inline (fast path, no ajv needed for basics) ─
+    local has_sources has_expose_kind
+    has_sources=$(printf '%s' "$contract_json" | \
+        python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('sources') and len(d['sources'])>=1 else 'no')" 2>/dev/null || echo "no")
+    has_expose_kind=$(printf '%s' "$contract_json" | \
+        python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('expose',{}).get('kind') else 'no')" 2>/dev/null || echo "no")
+
+    if [ "$has_sources" != "yes" ]; then
+        printf 'load-contract: refuse-to-run: sources is missing or empty in %s\n' "$contract_file" >&2
+        printf 'Add at least one source entry with kind: (postgres|mysql|sqlite|s3|filesystem|custom_cmd)\n' >&2
+        exit 2
+    fi
+
+    if [ "$has_expose_kind" != "yes" ]; then
+        printf 'load-contract: refuse-to-run: expose.kind is missing in %s\n' "$contract_file" >&2
+        printf 'Add expose.kind: (docker_compose|k8s_ephemeral_namespace|dedicated_staging_slot|custom_cmd)\n' >&2
+        exit 2
+    fi
+
+    # ── JSON Schema validation via ajv (if available) ─────────────────────────
+    if command -v ajv >/dev/null 2>&1 && [ -f "$SCHEMA_FILE" ]; then
+        local tmpjson
+        tmpjson=$(mktemp -t load-contract-XXXXXX.json)
+        # shellcheck disable=SC2064
+        trap "rm -f '$yq_err' '$tmpjson'" EXIT
+        printf '%s\n' "$contract_json" > "$tmpjson"
+
+        local ajv_out ajv_rc=0
+        ajv_out=$(ajv validate -s "$SCHEMA_FILE" -d "$tmpjson" --spec=draft2020 2>&1) || ajv_rc=$?
+        if [ "$ajv_rc" -ne 0 ]; then
+            printf 'load-contract: refuse-to-run: schema validation failed:\n' >&2
+            printf '%s\n' "$ajv_out" >&2
+            exit 2
+        fi
+    fi
+
+    # ── Emit resolved contract JSON ────────────────────────────────────────────
+    printf '%s\n' "$contract_json"
+}
+
+load_contract "${1:-.}"

--- a/skills/autospec-e2e-clone/tests/unit/contract-loader.bats
+++ b/skills/autospec-e2e-clone/tests/unit/contract-loader.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# skills/autospec-e2e-clone/tests/unit/contract-loader.bats
+# TDD: bats fixtures for load-contract.sh (C1 scaffold)
+# Exit codes: 0=ok, 1=fatal, 2=refuse-to-run (contract invalid / missing required fields)
+
+SKILL_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+LOADER="$SKILL_DIR/scripts/load-contract.sh"
+FIX="$SKILL_DIR/tests/unit/fixtures"
+
+# Case 1: minimal-valid fixture — exits 0, emits JSON with sources and expose
+@test "minimal-valid: exits 0 and emits JSON with sources and expose" {
+  run bash "$LOADER" "$FIX/minimal-valid"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"sources"'
+  echo "$output" | grep -q '"expose"'
+}
+
+# Case 2: missing-sources fixture — exits 2 (refuse-to-run)
+@test "missing-sources: exits 2 when sources is absent" {
+  run bash "$LOADER" "$FIX/missing-sources"
+  [ "$status" -eq 2 ]
+}
+
+# Case 3: missing-expose fixture — exits 2 (refuse-to-run)
+@test "missing-expose: exits 2 when expose is absent" {
+  run bash "$LOADER" "$FIX/missing-expose"
+  [ "$status" -eq 2 ]
+}
+
+# Case 4: full-shape fixture — exits 0 and all top-level keys present
+@test "full-shape: exits 0 and emits JSON with all declared top-level keys" {
+  run bash "$LOADER" "$FIX/full-shape"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"sources"'
+  echo "$output" | grep -q '"expose"'
+  echo "$output" | grep -q '"anonymize"'
+  echo "$output" | grep -q '"scale_down"'
+  echo "$output" | grep -q '"edge_case_seed"'
+}
+
+# Case 5: unparseable fixture — exits 1 (fatal: parse error)
+@test "unparseable: exits 1 on YAML parse error" {
+  run bash "$LOADER" "$FIX/unparseable"
+  [ "$status" -eq 1 ]
+}
+
+# Case 6: missing .autospec/clone.yml — exits 2 (refuse-to-run: contract missing)
+@test "missing clone.yml: exits 2 when .autospec/clone.yml does not exist" {
+  tmpdir=$(mktemp -d)
+  mkdir -p "$tmpdir/.autospec"
+  run bash "$LOADER" "$tmpdir"
+  rm -rf "$tmpdir"
+  [ "$status" -eq 2 ]
+}
+
+# Case 7: missing repo_root — exits 1 (fatal)
+@test "missing repo_root: exits 1 when repo_root directory does not exist" {
+  run bash "$LOADER" /tmp/does-not-exist-clone-fixture-xyz
+  [ "$status" -eq 1 ]
+}

--- a/skills/autospec-e2e-clone/tests/unit/fixtures/full-shape/.autospec/clone.yml
+++ b/skills/autospec-e2e-clone/tests/unit/fixtures/full-shape/.autospec/clone.yml
@@ -1,0 +1,39 @@
+sources:
+  - kind: postgres
+    dsn_env: PROD_DB_URL
+    tables_full:
+      - users
+      - products
+    tables_sample:
+      events: 10000
+      logs: 5000
+  - kind: s3
+    bucket: prod-assets
+    sample_prefix_count: 100
+  - kind: filesystem
+    paths:
+      - /var/data/uploads
+    sample_files_per_dir: 50
+
+anonymize:
+  rules:
+    - table: users
+      columns:
+        email: hash_with_domain
+        ssn: redact
+        name: replace_with_faker
+
+scale_down:
+  default_sample: 10000
+  foreign_key_aware: true
+
+edge_case_seed:
+  consume_from: .autospec/test.yml
+  seed_shapes_catalog: seed-shapes/catalog.yml
+
+expose:
+  kind: docker_compose
+  compose_file: deploy/docker-compose.clone.yml
+  url_template: "http://localhost:8080"
+  health_endpoint: /health
+  ready_wait_secs: 60

--- a/skills/autospec-e2e-clone/tests/unit/fixtures/minimal-valid/.autospec/clone.yml
+++ b/skills/autospec-e2e-clone/tests/unit/fixtures/minimal-valid/.autospec/clone.yml
@@ -1,0 +1,8 @@
+sources:
+  - kind: postgres
+    dsn_env: PROD_DB_URL
+
+expose:
+  kind: docker_compose
+  compose_file: deploy/docker-compose.clone.yml
+  url_template: "http://localhost:8080"

--- a/skills/autospec-e2e-clone/tests/unit/fixtures/missing-expose/.autospec/clone.yml
+++ b/skills/autospec-e2e-clone/tests/unit/fixtures/missing-expose/.autospec/clone.yml
@@ -1,0 +1,3 @@
+sources:
+  - kind: postgres
+    dsn_env: PROD_DB_URL

--- a/skills/autospec-e2e-clone/tests/unit/fixtures/missing-sources/.autospec/clone.yml
+++ b/skills/autospec-e2e-clone/tests/unit/fixtures/missing-sources/.autospec/clone.yml
@@ -1,0 +1,4 @@
+expose:
+  kind: docker_compose
+  compose_file: deploy/docker-compose.clone.yml
+  url_template: "http://localhost:8080"

--- a/skills/autospec-e2e-clone/tests/unit/fixtures/unparseable/.autospec/clone.yml
+++ b/skills/autospec-e2e-clone/tests/unit/fixtures/unparseable/.autospec/clone.yml
@@ -1,0 +1,3 @@
+sources: [
+  bad yaml: {unclosed bracket
+  - not valid

--- a/skills/autospec-e2e-clone/uninstall.sh
+++ b/skills/autospec-e2e-clone/uninstall.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec-e2e-clone skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autospec-e2e-clone"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run_cmd() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run_cmd "rm -f \"$target\""
+        info "  removed: $target"
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse -------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift; HARNESS="${1:-}" ;;
+        --harness=*)
+            HARNESS="${1#--harness=}" ;;
+        --dry-run)
+            DRY_RUN=1 ;;
+        -h|--help)
+            usage; exit 0 ;;
+        *)
+            err "unknown arg: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=opencode ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths -----------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+CODEX_SKILLS_DEST="$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+
+# ---------- remove ----------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+    remove_one "$CODEX_SKILLS_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0


### PR DESCRIPTION
Closes #465.

Adds the `autospec-e2e-clone` skill family foundation (Component C1).

## Changes

- `skills/autospec-e2e-clone/{SKILL.md,opencode/agent.md,codex/prompt.md}`: lockstep trio — pipeline description, Self-update mode, Harness detection (TIER_A/B + silently fallback), Model tier, adapter row, contract reference
- `schemas/autospec-clone-contract.schema.json`: JSON Schema Draft 2020-12 covering `sources` (≥1 required), `anonymize`, `scale_down`, `edge_case_seed`, `expose` (kind required)
- `skills/autospec-e2e-clone/scripts/load-contract.sh`: yq+ajv loader with exit 0/1/2 contract (mirrors autospec-test pattern)
- `skills/autospec-e2e-clone/tests/unit/contract-loader.bats`: 7 bats cases
- `skills/autospec-e2e-clone/tests/unit/fixtures/`: 5 fixture sets (minimal-valid, missing-sources, missing-expose, full-shape, unparseable)
- `skills/autospec-e2e-clone/{install.sh,uninstall.sh,README.md}`
- `.gitignore`: allow `.autospec/` inside e2e-clone fixture dirs

## Validation

- `bats skills/autospec-e2e-clone/tests/unit/contract-loader.bats`: 7/7 pass
- `ajv compile -s schemas/autospec-clone-contract.schema.json --spec=draft2020`: valid
- `bash skills/autospec-e2e-clone/scripts/load-contract.sh <minimal-valid-fixture>`: exit 0, JSON with sources + expose
- `bash scripts/validate.sh`: OK — all validation checks passed