### PR TITLE
feat(autospec-e2e-clone): snapshot drivers pg + mysql + sqlite (C2, closes #466)

### DIFF
--- a/skills/autospec-e2e-clone/scripts/snapshot/dispatch.sh
+++ b/skills/autospec-e2e-clone/scripts/snapshot/dispatch.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# skills/autospec-e2e-clone/scripts/snapshot/dispatch.sh — snapshot dispatcher
+#
+# Reads resolved contract JSON from stdin (or file path as $1), fans out per
+# source entry to the appropriate per-kind snapshot driver.
+#
+# Usage:
+#   load-contract.sh <repo_root> | dispatch.sh [<snap_base_dir>]
+#   dispatch.sh [<snap_base_dir>] < contract.json
+#
+# Snapshot output:
+#   <snap_base_dir>/<source-id>/<timestamp>/
+#   Default snap_base_dir: .autospec/clone-snapshots
+#
+# Environment (passed through to drivers):
+#   DSN (or MYSQL_HOST/MYSQL_USER/etc.) — set by caller per source
+#
+# Exit codes:
+#   0 = all sources snapshotted
+#   1 = fatal
+#   2 = one or more sources failed (operator-actionable)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+SNAP_BASE_DIR="${1:-.autospec/clone-snapshots}"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+
+# ── Read contract JSON from stdin ─────────────────────────────────────────────
+CONTRACT_JSON="$(cat)"
+
+if [ -z "$CONTRACT_JSON" ] || [ "$CONTRACT_JSON" = "null" ]; then
+    printf 'dispatch.sh: fatal: no contract JSON on stdin\n' >&2
+    exit 1
+fi
+
+# ── Parse sources array ───────────────────────────────────────────────────────
+SOURCE_COUNT=$(printf '%s' "$CONTRACT_JSON" | \
+    python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('sources',[])))" 2>/dev/null || echo 0)
+
+if [ "$SOURCE_COUNT" -eq 0 ]; then
+    printf 'dispatch.sh: fatal: no sources in contract\n' >&2
+    exit 1
+fi
+
+FAILURES=0
+
+# ── Iterate sources ───────────────────────────────────────────────────────────
+for i in $(seq 0 $((SOURCE_COUNT - 1))); do
+    SOURCE=$(printf '%s' "$CONTRACT_JSON" | \
+        python3 -c "import sys,json; d=json.load(sys.stdin); print(json.dumps(d['sources'][$i]))")
+
+    KIND=$(printf '%s' "$SOURCE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('kind',''))")
+    SOURCE_ID="${KIND}-${i}"
+
+    OUT_DIR="${SNAP_BASE_DIR}/${SOURCE_ID}/${TIMESTAMP}"
+    mkdir -p "$OUT_DIR"
+
+    printf 'dispatch.sh: source[%d] kind=%s → %s\n' "$i" "$KIND" "$OUT_DIR" >&2
+
+    case "$KIND" in
+        postgres)
+            TABLES_FULL=$(printf '%s' "$SOURCE" | \
+                python3 -c "import sys,json; d=json.load(sys.stdin); print(','.join(d.get('tables_full',[])))" 2>/dev/null || echo "")
+            TABLES_SAMPLE=$(printf '%s' "$SOURCE" | \
+                python3 -c "import sys,json; d=json.load(sys.stdin); print(json.dumps(d.get('tables_sample',{})))" 2>/dev/null || echo "{}")
+
+            DSN_ENV=$(printf '%s' "$SOURCE" | \
+                python3 -c "import sys,json; print(json.load(sys.stdin).get('dsn_env',''))" 2>/dev/null || echo "")
+            if [ -n "$DSN_ENV" ] && [ -n "${!DSN_ENV:-}" ]; then
+                export DSN="${!DSN_ENV}"
+            fi
+
+            if ! bash "$SCRIPT_DIR/pg.sh" "$TABLES_FULL" "$TABLES_SAMPLE" "$OUT_DIR"; then
+                printf 'dispatch.sh: error: postgres source[%d] snapshot failed\n' "$i" >&2
+                FAILURES=$((FAILURES + 1))
+            fi
+            ;;
+
+        mysql)
+            TABLES_FULL=$(printf '%s' "$SOURCE" | \
+                python3 -c "import sys,json; d=json.load(sys.stdin); print(','.join(d.get('tables_full',[])))" 2>/dev/null || echo "")
+            TABLES_SAMPLE=$(printf '%s' "$SOURCE" | \
+                python3 -c "import sys,json; d=json.load(sys.stdin); print(json.dumps(d.get('tables_sample',{})))" 2>/dev/null || echo "{}")
+
+            DSN_ENV=$(printf '%s' "$SOURCE" | \
+                python3 -c "import sys,json; print(json.load(sys.stdin).get('dsn_env',''))" 2>/dev/null || echo "")
+            if [ -n "$DSN_ENV" ] && [ -n "${!DSN_ENV:-}" ]; then
+                export DSN="${!DSN_ENV}"
+            fi
+
+            if ! bash "$SCRIPT_DIR/mysql.sh" "$TABLES_FULL" "$TABLES_SAMPLE" "$OUT_DIR"; then
+                printf 'dispatch.sh: error: mysql source[%d] snapshot failed\n' "$i" >&2
+                FAILURES=$((FAILURES + 1))
+            fi
+            ;;
+
+        sqlite)
+            DSN_ENV=$(printf '%s' "$SOURCE" | \
+                python3 -c "import sys,json; print(json.load(sys.stdin).get('dsn_env',''))" 2>/dev/null || echo "")
+            SRC_PATH=""
+            if [ -n "$DSN_ENV" ] && [ -n "${!DSN_ENV:-}" ]; then
+                SRC_PATH="${!DSN_ENV}"
+            fi
+
+            if [ -z "$SRC_PATH" ]; then
+                printf 'dispatch.sh: error: sqlite source[%d]: dsn_env not set or empty\n' "$i" >&2
+                FAILURES=$((FAILURES + 1))
+                continue
+            fi
+
+            if ! bash "$SCRIPT_DIR/sqlite.sh" "$SRC_PATH" "$OUT_DIR"; then
+                printf 'dispatch.sh: error: sqlite source[%d] snapshot failed\n' "$i" >&2
+                FAILURES=$((FAILURES + 1))
+            fi
+            ;;
+
+        s3|filesystem|custom_cmd)
+            printf 'dispatch.sh: info: kind=%s not implemented in C2 (deferred to C3)\n' "$KIND" >&2
+            ;;
+
+        *)
+            printf 'dispatch.sh: error: unknown source kind: %s\n' "$KIND" >&2
+            FAILURES=$((FAILURES + 1))
+            ;;
+    esac
+done
+
+if [ "$FAILURES" -gt 0 ]; then
+    printf 'dispatch.sh: %d source(s) failed\n' "$FAILURES" >&2
+    exit 2
+fi
+
+printf 'dispatch.sh: all sources snapshotted → %s\n' "$SNAP_BASE_DIR" >&2

--- a/skills/autospec-e2e-clone/scripts/snapshot/mysql.sh
+++ b/skills/autospec-e2e-clone/scripts/snapshot/mysql.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# skills/autospec-e2e-clone/scripts/snapshot/mysql.sh — MySQL snapshot driver
+#
+# Usage: mysql.sh <tables_full_csv> <tables_sample_json> <out_dir>
+#
+# Environment:
+#   DSN — MySQL connection DSN (e.g. mysql://user:pass@host:3306/db)
+#         or individual vars: MYSQL_HOST, MYSQL_PORT, MYSQL_USER, MYSQL_PASSWORD, MYSQL_DATABASE
+#
+# Output layout:
+#   <out_dir>/schema.sql          — full schema dump (no data)
+#   <out_dir>/<table>.sql         — per-table data dump
+#
+# Exit codes:
+#   0 = ok
+#   1 = fatal
+#   2 = refuse-to-run
+
+set -euo pipefail
+
+TABLES_FULL_CSV="${1:-}"
+TABLES_SAMPLE_JSON="${2:-{}}"
+OUT_DIR="${3:-}"
+
+# ── Validate arguments ────────────────────────────────────────────────────────
+if [ -z "$OUT_DIR" ]; then
+    printf 'mysql.sh: fatal: OUT_DIR argument required\n' >&2
+    exit 1
+fi
+
+# ── Parse DSN or fall back to individual env vars ─────────────────────────────
+_MYSQL_HOST="${MYSQL_HOST:-127.0.0.1}"
+_MYSQL_PORT="${MYSQL_PORT:-3306}"
+_MYSQL_USER="${MYSQL_USER:-root}"
+_MYSQL_PASSWORD="${MYSQL_PASSWORD:-}"
+_MYSQL_DATABASE="${MYSQL_DATABASE:-}"
+
+if [ -n "${DSN:-}" ]; then
+    # Parse mysql://user:pass@host:port/db
+    _MYSQL_USER=$(printf '%s' "$DSN" | python3 -c "import sys,urllib.parse; u=urllib.parse.urlparse(sys.stdin.read().strip()); print(u.username or '')")
+    _MYSQL_PASSWORD=$(printf '%s' "$DSN" | python3 -c "import sys,urllib.parse; u=urllib.parse.urlparse(sys.stdin.read().strip()); print(u.password or '')")
+    _MYSQL_HOST=$(printf '%s' "$DSN" | python3 -c "import sys,urllib.parse; u=urllib.parse.urlparse(sys.stdin.read().strip()); print(u.hostname or '127.0.0.1')")
+    _MYSQL_PORT=$(printf '%s' "$DSN" | python3 -c "import sys,urllib.parse; u=urllib.parse.urlparse(sys.stdin.read().strip()); print(u.port or 3306)")
+    _MYSQL_DATABASE=$(printf '%s' "$DSN" | python3 -c "import sys,urllib.parse; u=urllib.parse.urlparse(sys.stdin.read().strip()); print(u.path.lstrip('/'))")
+fi
+
+if [ -z "$_MYSQL_DATABASE" ]; then
+    printf 'mysql.sh: refuse-to-run: database name not set (set DSN or MYSQL_DATABASE)\n' >&2
+    exit 2
+fi
+
+# ── Dependency check ──────────────────────────────────────────────────────────
+if ! command -v mysqldump >/dev/null 2>&1; then
+    printf 'mysql.sh: fatal: mysqldump not found. Install mysql-client\n' >&2
+    exit 1
+fi
+
+# ── Build connection args ─────────────────────────────────────────────────────
+CONN_ARGS=(-h "$_MYSQL_HOST" -P "$_MYSQL_PORT" -u "$_MYSQL_USER")
+if [ -n "$_MYSQL_PASSWORD" ]; then
+    CONN_ARGS+=("-p${_MYSQL_PASSWORD}")
+fi
+
+# ── Prepare output directory ──────────────────────────────────────────────────
+mkdir -p "$OUT_DIR"
+
+# ── Schema dump (no data) ─────────────────────────────────────────────────────
+printf 'mysql.sh: dumping schema...\n' >&2
+if ! mysqldump "${CONN_ARGS[@]}" --no-data "$_MYSQL_DATABASE" > "$OUT_DIR/schema.sql" 2>&1; then
+    printf 'mysql.sh: fatal: schema dump failed\n' >&2
+    exit 1
+fi
+
+# ── Full-table data dumps ─────────────────────────────────────────────────────
+if [ -n "$TABLES_FULL_CSV" ]; then
+    IFS=',' read -ra FULL_TABLES <<< "$TABLES_FULL_CSV"
+    for table in "${FULL_TABLES[@]}"; do
+        table="${table// /}"
+        [ -z "$table" ] && continue
+        printf 'mysql.sh: dumping full table %s...\n' "$table" >&2
+        if ! mysqldump "${CONN_ARGS[@]}" --no-create-info "$_MYSQL_DATABASE" "$table" > "$OUT_DIR/${table}.sql" 2>&1; then
+            printf 'mysql.sh: fatal: data dump failed for table %s\n' "$table" >&2
+            exit 1
+        fi
+    done
+fi
+
+# ── Sampled-table data dumps ──────────────────────────────────────────────────
+if [ "$TABLES_SAMPLE_JSON" != "{}" ] && [ -n "$TABLES_SAMPLE_JSON" ]; then
+    SAMPLE_TABLES=$(printf '%s' "$TABLES_SAMPLE_JSON" | \
+        python3 -c "import sys,json; d=json.load(sys.stdin); [print(k,v) for k,v in d.items()]" 2>/dev/null || true)
+
+    if command -v mysql >/dev/null 2>&1; then
+        while IFS=' ' read -r table limit; do
+            [ -z "$table" ] && continue
+            printf 'mysql.sh: dumping sampled table %s (limit %s rows)...\n' "$table" "$limit" >&2
+            mysql "${CONN_ARGS[@]}" "$_MYSQL_DATABASE" \
+                -e "SELECT * FROM \`$table\` LIMIT $limit" \
+                --batch --quick \
+                > "$OUT_DIR/${table}.tsv" 2>&1 || {
+                printf 'mysql.sh: fatal: sampled dump failed for table %s\n' "$table" >&2
+                exit 1
+            }
+        done <<< "$SAMPLE_TABLES"
+    else
+        # Fallback: full dump
+        while IFS=' ' read -r table _; do
+            [ -z "$table" ] && continue
+            printf 'mysql.sh: warning: mysql cli not available; full dump for %s\n' "$table" >&2
+            if ! mysqldump "${CONN_ARGS[@]}" --no-create-info "$_MYSQL_DATABASE" "$table" > "$OUT_DIR/${table}.sql" 2>&1; then
+                printf 'mysql.sh: fatal: data dump failed for table %s\n' "$table" >&2
+                exit 1
+            fi
+        done <<< "$SAMPLE_TABLES"
+    fi
+fi
+
+printf 'mysql.sh: snapshot complete → %s\n' "$OUT_DIR" >&2

--- a/skills/autospec-e2e-clone/scripts/snapshot/pg.sh
+++ b/skills/autospec-e2e-clone/scripts/snapshot/pg.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# skills/autospec-e2e-clone/scripts/snapshot/pg.sh — PostgreSQL snapshot driver
+#
+# Usage: pg.sh <tables_full_csv> <tables_sample_json> <out_dir>
+#
+# Environment:
+#   DSN — PostgreSQL connection DSN (e.g. postgres://user:pass@host:5432/db)
+#
+# Output layout:
+#   <out_dir>/schema.sql          — full schema dump
+#   <out_dir>/<table>.sql         — per-table data dump (tables_full + tables_sample keys)
+#
+# Exit codes:
+#   0 = ok
+#   1 = fatal (missing tool, bad DSN, pg_dump error)
+#   2 = refuse-to-run (operator-actionable config error)
+
+set -euo pipefail
+
+TABLES_FULL_CSV="${1:-}"
+TABLES_SAMPLE_JSON="${2:-{}}"
+OUT_DIR="${3:-}"
+
+# ── Validate arguments ────────────────────────────────────────────────────────
+if [ -z "$OUT_DIR" ]; then
+    printf 'pg.sh: fatal: OUT_DIR argument required\n' >&2
+    exit 1
+fi
+
+if [ -z "${DSN:-}" ]; then
+    printf 'pg.sh: refuse-to-run: DSN environment variable not set\n' >&2
+    printf 'Set DSN to a valid PostgreSQL connection string\n' >&2
+    exit 2
+fi
+
+# ── Dependency check ──────────────────────────────────────────────────────────
+if ! command -v pg_dump >/dev/null 2>&1; then
+    printf 'pg.sh: fatal: pg_dump not found. Install postgresql-client\n' >&2
+    exit 1
+fi
+
+# ── Prepare output directory ──────────────────────────────────────────────────
+mkdir -p "$OUT_DIR"
+
+# ── Schema dump ───────────────────────────────────────────────────────────────
+printf 'pg.sh: dumping schema...\n' >&2
+if ! pg_dump --schema-only "$DSN" > "$OUT_DIR/schema.sql" 2>&1; then
+    printf 'pg.sh: fatal: schema dump failed\n' >&2
+    exit 1
+fi
+
+# ── Full-table data dumps ─────────────────────────────────────────────────────
+if [ -n "$TABLES_FULL_CSV" ]; then
+    IFS=',' read -ra FULL_TABLES <<< "$TABLES_FULL_CSV"
+    for table in "${FULL_TABLES[@]}"; do
+        table="${table// /}"  # trim whitespace
+        [ -z "$table" ] && continue
+        printf 'pg.sh: dumping full table %s...\n' "$table" >&2
+        if ! pg_dump --data-only --table="$table" "$DSN" > "$OUT_DIR/${table}.sql" 2>&1; then
+            printf 'pg.sh: fatal: data dump failed for table %s\n' "$table" >&2
+            exit 1
+        fi
+    done
+fi
+
+# ── Sampled-table data dumps ──────────────────────────────────────────────────
+# tables_sample is JSON object: {"events": 10000, "logs": 5000}
+if [ "$TABLES_SAMPLE_JSON" != "{}" ] && [ -n "$TABLES_SAMPLE_JSON" ]; then
+    SAMPLE_TABLES=$(printf '%s' "$TABLES_SAMPLE_JSON" | \
+        python3 -c "import sys,json; d=json.load(sys.stdin); [print(k,v) for k,v in d.items()]" 2>/dev/null || true)
+
+    while IFS=' ' read -r table limit; do
+        [ -z "$table" ] && continue
+        printf 'pg.sh: dumping sampled table %s (limit %s rows)...\n' "$table" "$limit" >&2
+        # Use pg_dump with --where for row-count limiting via CTID sampling approximation
+        # For sampling, we write a temp view then dump it
+        # Simpler approach: dump with row limit via psql COPY
+        if command -v psql >/dev/null 2>&1; then
+            psql "$DSN" -c "\COPY (SELECT * FROM \"$table\" LIMIT $limit) TO '$OUT_DIR/${table}.csv' CSV HEADER" 2>&1 || {
+                printf 'pg.sh: fatal: sampled dump failed for table %s\n' "$table" >&2
+                exit 1
+            }
+        else
+            # Fallback: full dump if psql not available
+            printf 'pg.sh: warning: psql not available; falling back to full dump for %s\n' "$table" >&2
+            if ! pg_dump --data-only --table="$table" "$DSN" > "$OUT_DIR/${table}.sql" 2>&1; then
+                printf 'pg.sh: fatal: data dump failed for table %s\n' "$table" >&2
+                exit 1
+            fi
+        fi
+    done <<< "$SAMPLE_TABLES"
+fi
+
+printf 'pg.sh: snapshot complete → %s\n' "$OUT_DIR" >&2

--- a/skills/autospec-e2e-clone/scripts/snapshot/sqlite.sh
+++ b/skills/autospec-e2e-clone/scripts/snapshot/sqlite.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# skills/autospec-e2e-clone/scripts/snapshot/sqlite.sh — SQLite snapshot driver
+#
+# Usage: sqlite.sh <src_path> <out_dir>
+#
+# Copies the source SQLite database file to <out_dir>/snapshot.db and runs
+# VACUUM to compact it.
+#
+# Exit codes:
+#   0 = ok
+#   1 = fatal
+#   2 = refuse-to-run
+
+set -euo pipefail
+
+SRC_PATH="${1:-}"
+OUT_DIR="${2:-}"
+
+# ── Validate arguments ────────────────────────────────────────────────────────
+if [ -z "$SRC_PATH" ]; then
+    printf 'sqlite.sh: fatal: SRC_PATH argument required\n' >&2
+    exit 1
+fi
+
+if [ -z "$OUT_DIR" ]; then
+    printf 'sqlite.sh: fatal: OUT_DIR argument required\n' >&2
+    exit 1
+fi
+
+if [ ! -f "$SRC_PATH" ]; then
+    printf 'sqlite.sh: refuse-to-run: source database not found: %s\n' "$SRC_PATH" >&2
+    exit 2
+fi
+
+# ── Prepare output directory ──────────────────────────────────────────────────
+mkdir -p "$OUT_DIR"
+
+SNAP_DB="$OUT_DIR/snapshot.db"
+
+# ── Copy database ─────────────────────────────────────────────────────────────
+printf 'sqlite.sh: copying %s → %s...\n' "$SRC_PATH" "$SNAP_DB" >&2
+cp "$SRC_PATH" "$SNAP_DB"
+
+# ── VACUUM to compact ─────────────────────────────────────────────────────────
+if command -v sqlite3 >/dev/null 2>&1; then
+    printf 'sqlite.sh: running VACUUM...\n' >&2
+    sqlite3 "$SNAP_DB" "VACUUM;" 2>&1 || {
+        printf 'sqlite.sh: warning: VACUUM failed (non-fatal)\n' >&2
+    }
+else
+    printf 'sqlite.sh: warning: sqlite3 not found; skipping VACUUM\n' >&2
+fi
+
+printf 'sqlite.sh: snapshot complete → %s\n' "$SNAP_DB" >&2

--- a/skills/autospec-e2e-clone/tests/integration/snapshot-mysql.bats
+++ b/skills/autospec-e2e-clone/tests/integration/snapshot-mysql.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+# Integration tests for snapshot/mysql.sh
+# Requires docker to spin up an ephemeral MySQL container.
+# Skip gracefully if docker is unavailable.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/snapshot"
+
+MYSQL_CONTAINER_NAME="autospec-test-mysql-$$"
+MYSQL_PORT_HOST="13306"
+export MYSQL_HOST="127.0.0.1"
+export MYSQL_PORT="$MYSQL_PORT_HOST"
+export MYSQL_USER="testuser"
+export MYSQL_PASSWORD="testpass"
+export MYSQL_ROOT_PASSWORD="rootpass"
+export MYSQL_DATABASE="testdb"
+
+setup_file() {
+    if ! command -v docker >/dev/null 2>&1; then
+        return 0
+    fi
+    docker run -d \
+        --name "$MYSQL_CONTAINER_NAME" \
+        -e MYSQL_ROOT_PASSWORD="$MYSQL_ROOT_PASSWORD" \
+        -e MYSQL_USER="$MYSQL_USER" \
+        -e MYSQL_PASSWORD="$MYSQL_PASSWORD" \
+        -e MYSQL_DATABASE="$MYSQL_DATABASE" \
+        -p "${MYSQL_PORT_HOST}:3306" \
+        mysql:8-debian \
+        >/dev/null 2>&1 || true
+
+    # Wait for MySQL to be ready (up to 60s)
+    local i=0
+    while [ $i -lt 60 ]; do
+        if docker exec "$MYSQL_CONTAINER_NAME" mysqladmin ping -u root -p"$MYSQL_ROOT_PASSWORD" --silent 2>/dev/null; then
+            break
+        fi
+        sleep 2
+        i=$((i + 2))
+    done
+
+    # Seed test data
+    docker exec "$MYSQL_CONTAINER_NAME" mysql -u root -p"$MYSQL_ROOT_PASSWORD" "$MYSQL_DATABASE" -e "
+        CREATE TABLE IF NOT EXISTS users (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(100), email VARCHAR(100));
+        INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com'), ('Bob', 'bob@example.com');
+        CREATE TABLE IF NOT EXISTS orders (id INT AUTO_INCREMENT PRIMARY KEY, user_id INT, total DECIMAL(10,2));
+        INSERT INTO orders (user_id, total) VALUES (1, 49.99), (2, 19.99);
+    " >/dev/null 2>&1 || true
+}
+
+teardown_file() {
+    if command -v docker >/dev/null 2>&1; then
+        docker rm -f "$MYSQL_CONTAINER_NAME" >/dev/null 2>&1 || true
+    fi
+}
+
+setup() {
+    TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "mysql.sh: schema.sql created for mysql source" {
+    require_docker_and_mysql
+    OUT_DIR="$TMP_DIR/out"
+    run bash "$SCRIPT_DIR/mysql.sh" "users" "{}" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -f "$OUT_DIR/schema.sql" ]
+}
+
+@test "mysql.sh: full table dump creates <table>.sql" {
+    require_docker_and_mysql
+    OUT_DIR="$TMP_DIR/out"
+    run bash "$SCRIPT_DIR/mysql.sh" "users" "{}" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -f "$OUT_DIR/users.sql" ]
+}
+
+@test "mysql.sh: multiple full tables dumped" {
+    require_docker_and_mysql
+    OUT_DIR="$TMP_DIR/out"
+    run bash "$SCRIPT_DIR/mysql.sh" "users,orders" "{}" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -f "$OUT_DIR/users.sql" ]
+    [ -f "$OUT_DIR/orders.sql" ]
+}
+
+@test "mysql.sh: fails with exit 2 if MYSQL_DATABASE not set" {
+    OUT_DIR="$TMP_DIR/out"
+    run env -u MYSQL_DATABASE -u DSN bash "$SCRIPT_DIR/mysql.sh" "users" "{}" "$OUT_DIR"
+    [ "$status" -eq 2 ]
+}
+
+@test "mysql.sh: fails with exit 1 if OUT_DIR not provided" {
+    run bash "$SCRIPT_DIR/mysql.sh"
+    [ "$status" -eq 1 ]
+}
+
+@test "mysql.sh: out_dir is created if it does not exist" {
+    require_docker_and_mysql
+    OUT_DIR="$TMP_DIR/deep/nested/out"
+    run bash "$SCRIPT_DIR/mysql.sh" "" "{}" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -d "$OUT_DIR" ]
+}
+
+@test "dispatch.sh: routes mysql source correctly" {
+    require_docker_and_mysql
+    OUT_BASE="$TMP_DIR/clone-snapshots"
+    export TEST_MYSQL_DSN="mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}"
+    CONTRACT_JSON=$(cat <<JSON
+{
+  "sources": [
+    {
+      "kind": "mysql",
+      "dsn_env": "TEST_MYSQL_DSN",
+      "tables_full": ["users"]
+    }
+  ],
+  "expose": { "kind": "docker_compose" }
+}
+JSON
+)
+    DISPATCH="$SCRIPT_DIR/dispatch.sh"
+    run bash -c "printf '%s' \"\$CONTRACT_JSON\" | bash '$DISPATCH' '$OUT_BASE'"
+    [ "$status" -eq 0 ]
+    SCHEMA_COUNT=$(find "$OUT_BASE" -name "schema.sql" | wc -l | tr -d ' ')
+    [ "$SCHEMA_COUNT" -ge 1 ]
+}
+
+# Helpers
+require_docker_and_mysql() {
+    if ! command -v docker >/dev/null 2>&1; then
+        skip "docker not available"
+    fi
+    if ! command -v mysqldump >/dev/null 2>&1; then
+        skip "mysqldump not available"
+    fi
+    if ! docker ps --filter "name=$MYSQL_CONTAINER_NAME" --format "{{.Names}}" | grep -q "$MYSQL_CONTAINER_NAME"; then
+        skip "mysql container not running"
+    fi
+}

--- a/skills/autospec-e2e-clone/tests/integration/snapshot-pg.bats
+++ b/skills/autospec-e2e-clone/tests/integration/snapshot-pg.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# Integration tests for snapshot/pg.sh
+# Requires docker to spin up an ephemeral PostgreSQL container.
+# Skip gracefully if docker is unavailable.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/snapshot"
+COMPOSE_FILE="$(dirname "$BATS_TEST_FILENAME")/fixtures/docker-compose-pg.yml"
+
+PG_CONTAINER_NAME="autospec-test-pg-$$"
+PG_PORT="15432"
+PG_USER="testuser"
+PG_PASSWORD="testpass"
+PG_DB="testdb"
+export PG_DSN="postgres://${PG_USER}:${PG_PASSWORD}@127.0.0.1:${PG_PORT}/${PG_DB}"
+
+setup_file() {
+    if ! command -v docker >/dev/null 2>&1; then
+        return 0
+    fi
+    docker run -d \
+        --name "$PG_CONTAINER_NAME" \
+        -e POSTGRES_USER="$PG_USER" \
+        -e POSTGRES_PASSWORD="$PG_PASSWORD" \
+        -e POSTGRES_DB="$PG_DB" \
+        -p "${PG_PORT}:5432" \
+        postgres:15-alpine \
+        >/dev/null 2>&1 || true
+
+    # Wait for PG to be ready (up to 30s)
+    local i=0
+    while [ $i -lt 30 ]; do
+        if docker exec "$PG_CONTAINER_NAME" pg_isready -U "$PG_USER" -d "$PG_DB" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+        i=$((i + 1))
+    done
+
+    # Seed test data
+    docker exec "$PG_CONTAINER_NAME" psql -U "$PG_USER" -d "$PG_DB" -c "
+        CREATE TABLE IF NOT EXISTS users (id SERIAL PRIMARY KEY, name TEXT, email TEXT);
+        INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com'), ('Bob', 'bob@example.com');
+        CREATE TABLE IF NOT EXISTS events (id SERIAL PRIMARY KEY, user_id INT, action TEXT);
+        INSERT INTO events (user_id, action) VALUES (1, 'login'), (2, 'logout'), (1, 'purchase');
+    " >/dev/null 2>&1 || true
+}
+
+teardown_file() {
+    if command -v docker >/dev/null 2>&1; then
+        docker rm -f "$PG_CONTAINER_NAME" >/dev/null 2>&1 || true
+    fi
+}
+
+setup() {
+    TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "pg.sh: schema.sql created for postgres source" {
+    require_docker_and_pg
+    OUT_DIR="$TMP_DIR/out"
+    DSN="$PG_DSN" run bash "$SCRIPT_DIR/pg.sh" "users" "{}" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -f "$OUT_DIR/schema.sql" ]
+}
+
+@test "pg.sh: full table dump creates <table>.sql" {
+    require_docker_and_pg
+    OUT_DIR="$TMP_DIR/out"
+    DSN="$PG_DSN" run bash "$SCRIPT_DIR/pg.sh" "users" "{}" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -f "$OUT_DIR/users.sql" ]
+}
+
+@test "pg.sh: multiple full tables dumped" {
+    require_docker_and_pg
+    OUT_DIR="$TMP_DIR/out"
+    DSN="$PG_DSN" run bash "$SCRIPT_DIR/pg.sh" "users,events" "{}" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -f "$OUT_DIR/users.sql" ]
+    [ -f "$OUT_DIR/events.sql" ]
+}
+
+@test "pg.sh: fails with exit 2 if DSN not set" {
+    OUT_DIR="$TMP_DIR/out"
+    run env -u DSN bash "$SCRIPT_DIR/pg.sh" "users" "{}" "$OUT_DIR"
+    [ "$status" -eq 2 ]
+}
+
+@test "pg.sh: fails with exit 1 if OUT_DIR not provided" {
+    run bash "$SCRIPT_DIR/pg.sh"
+    [ "$status" -eq 1 ]
+}
+
+@test "pg.sh: out_dir is created if it does not exist" {
+    require_docker_and_pg
+    OUT_DIR="$TMP_DIR/deep/nested/out"
+    DSN="$PG_DSN" run bash "$SCRIPT_DIR/pg.sh" "" "{}" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -d "$OUT_DIR" ]
+}
+
+@test "dispatch.sh: routes postgres source correctly" {
+    require_docker_and_pg
+    OUT_BASE="$TMP_DIR/clone-snapshots"
+    export TEST_PG_DSN="$PG_DSN"
+    CONTRACT_JSON=$(cat <<JSON
+{
+  "sources": [
+    {
+      "kind": "postgres",
+      "dsn_env": "TEST_PG_DSN",
+      "tables_full": ["users"]
+    }
+  ],
+  "expose": { "kind": "docker_compose" }
+}
+JSON
+)
+    DISPATCH="$SCRIPT_DIR/dispatch.sh"
+    run bash -c "printf '%s' \"\$CONTRACT_JSON\" | bash '$DISPATCH' '$OUT_BASE'"
+    [ "$status" -eq 0 ]
+    SCHEMA_COUNT=$(find "$OUT_BASE" -name "schema.sql" | wc -l | tr -d ' ')
+    [ "$SCHEMA_COUNT" -ge 1 ]
+}
+
+# Helpers
+require_docker_and_pg() {
+    if ! command -v docker >/dev/null 2>&1; then
+        skip "docker not available"
+    fi
+    if ! command -v pg_dump >/dev/null 2>&1; then
+        skip "pg_dump not available"
+    fi
+    if ! docker ps --filter "name=$PG_CONTAINER_NAME" --format "{{.Names}}" | grep -q "$PG_CONTAINER_NAME"; then
+        skip "postgres container not running"
+    fi
+}

--- a/skills/autospec-e2e-clone/tests/integration/snapshot-sqlite.bats
+++ b/skills/autospec-e2e-clone/tests/integration/snapshot-sqlite.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+# Integration tests for snapshot/sqlite.sh
+# These tests use real sqlite3 — no docker required.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/snapshot"
+
+setup() {
+    TMP_DIR="$(mktemp -d)"
+    # Create a fixture SQLite database
+    FIXTURE_DB="$TMP_DIR/source.db"
+    if command -v sqlite3 >/dev/null 2>&1; then
+        sqlite3 "$FIXTURE_DB" <<'SQL'
+CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT);
+INSERT INTO users VALUES (1, 'Alice', 'alice@example.com');
+INSERT INTO users VALUES (2, 'Bob', 'bob@example.com');
+CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
+INSERT INTO products VALUES (1, 'Widget', 9.99);
+SQL
+    else
+        # Create a minimal binary-looking file so we can still test copy behavior
+        printf 'SQLite format 3\x00' > "$FIXTURE_DB"
+    fi
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "sqlite.sh: snapshot.db is created in out_dir" {
+    OUT_DIR="$TMP_DIR/out"
+    run bash "$SCRIPT_DIR/sqlite.sh" "$FIXTURE_DB" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -f "$OUT_DIR/snapshot.db" ]
+}
+
+@test "sqlite.sh: snapshot.db contains the same tables as the source" {
+    skip_if_no_sqlite3
+    OUT_DIR="$TMP_DIR/out"
+    run bash "$SCRIPT_DIR/sqlite.sh" "$FIXTURE_DB" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    # Verify same tables exist (VACUUM may change bytes but not logical content)
+    src_tables=$(sqlite3 "$FIXTURE_DB" ".tables" | tr ' ' '\n' | sort | tr '\n' ',')
+    snap_tables=$(sqlite3 "$OUT_DIR/snapshot.db" ".tables" | tr ' ' '\n' | sort | tr '\n' ',')
+    [ "$src_tables" = "$snap_tables" ]
+}
+
+@test "sqlite.sh: snapshot.db is readable by sqlite3" {
+    skip_if_no_sqlite3
+    OUT_DIR="$TMP_DIR/out"
+    bash "$SCRIPT_DIR/sqlite.sh" "$FIXTURE_DB" "$OUT_DIR"
+    result=$(sqlite3 "$OUT_DIR/snapshot.db" "SELECT COUNT(*) FROM users;")
+    [ "$result" -eq 2 ]
+}
+
+@test "sqlite.sh: out_dir is created if it does not exist" {
+    OUT_DIR="$TMP_DIR/deep/nested/out"
+    run bash "$SCRIPT_DIR/sqlite.sh" "$FIXTURE_DB" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -d "$OUT_DIR" ]
+}
+
+@test "sqlite.sh: fails with exit 2 if source db does not exist" {
+    run bash "$SCRIPT_DIR/sqlite.sh" "/nonexistent/path/db.sqlite" "$TMP_DIR/out"
+    [ "$status" -eq 2 ]
+}
+
+@test "sqlite.sh: fails with exit 1 if no arguments given" {
+    run bash "$SCRIPT_DIR/sqlite.sh"
+    [ "$status" -eq 1 ]
+}
+
+@test "sqlite.sh: fails with exit 1 if only src_path given" {
+    run bash "$SCRIPT_DIR/sqlite.sh" "$FIXTURE_DB"
+    [ "$status" -eq 1 ]
+}
+
+@test "dispatch.sh: routes sqlite source correctly" {
+    skip_if_no_python3
+    OUT_BASE="$TMP_DIR/clone-snapshots"
+    export SQLITE_DB_PATH="$FIXTURE_DB"
+    CONTRACT_JSON=$(cat <<JSON
+{
+  "sources": [
+    {
+      "kind": "sqlite",
+      "dsn_env": "SQLITE_DB_PATH"
+    }
+  ],
+  "expose": { "kind": "docker_compose" }
+}
+JSON
+)
+    DISPATCH="$SCRIPT_DIR/dispatch.sh"
+    run bash -c "printf '%s' '$CONTRACT_JSON' | bash '$DISPATCH' '$OUT_BASE'"
+    [ "$status" -eq 0 ]
+    # Snapshot dir created
+    SNAP_COUNT=$(find "$OUT_BASE" -name "snapshot.db" | wc -l | tr -d ' ')
+    [ "$SNAP_COUNT" -ge 1 ]
+}
+
+# Helper to skip if sqlite3 not available
+skip_if_no_sqlite3() {
+    if ! command -v sqlite3 >/dev/null 2>&1; then
+        skip "sqlite3 not installed"
+    fi
+}
+
+skip_if_no_python3() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        skip "python3 not installed"
+    fi
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/snapshot/pg.sh` — schema dump + per-table `pg_dump --data-only` (full tables) and `psql COPY ... LIMIT N` (sampled tables)
- Adds `scripts/snapshot/mysql.sh` — `mysqldump --no-data` schema + per-table `mysqldump --no-create-info` (full) and `mysql SELECT ... LIMIT N` (sampled)
- Adds `scripts/snapshot/sqlite.sh` — `cp source.db snapshot.db` + `VACUUM` to compact; arg shape: `<src_path> <out_dir>`
- Adds `scripts/snapshot/dispatch.sh` — reads resolved contract JSON from stdin, routes each `sources[].kind` to the appropriate driver; defers `s3/filesystem/custom_cmd` to C3
- Adds bats integration tests: `snapshot-sqlite.bats` (8 tests, no docker), `snapshot-pg.bats` (6 tests, ephemeral docker, skip-safe), `snapshot-mysql.bats` (6 tests, ephemeral docker, skip-safe)

Snapshot output: `.autospec/clone-snapshots/<source-id>/<timestamp>/`

## Test plan

- [x] `bats skills/autospec-e2e-clone/tests/integration/snapshot-sqlite.bats` — 8/8 pass (no external deps)
- [ ] `bats skills/autospec-e2e-clone/tests/integration/snapshot-pg.bats` — requires docker + pg_dump
- [ ] `bats skills/autospec-e2e-clone/tests/integration/snapshot-mysql.bats` — requires docker + mysqldump

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)