### PR TITLE
feat(autospec-e2e-clone): snapshot drivers s3 + filesystem + custom_cmd (C3, closes #467)

### DIFF
--- a/skills/autospec-e2e-clone/scripts/snapshot/custom.sh
+++ b/skills/autospec-e2e-clone/scripts/snapshot/custom.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# skills/autospec-e2e-clone/scripts/snapshot/custom.sh — Custom snapshot driver
+#
+# Usage: custom.sh <cmd> <out_dir>
+#
+# Invokes the operator-provided command with <out_dir> as $1.
+# Non-zero exit from <cmd> causes snapshot failure.
+#
+# Exit codes:
+#   0 = ok (cmd exited 0)
+#   1 = fatal (missing args)
+#   2 = refuse-to-run (cmd not found)
+#   <cmd exit code> = propagated on cmd failure
+
+set -euo pipefail
+
+CMD="${1:-}"
+OUT_DIR="${2:-}"
+
+# ── Validate arguments ────────────────────────────────────────────────────────
+if [ -z "$CMD" ]; then
+    printf 'custom.sh: fatal: CMD argument required\n' >&2
+    exit 1
+fi
+
+if [ -z "$OUT_DIR" ]; then
+    printf 'custom.sh: fatal: OUT_DIR argument required\n' >&2
+    exit 1
+fi
+
+# ── Prepare output directory ──────────────────────────────────────────────────
+mkdir -p "$OUT_DIR"
+
+# ── Validate cmd exists ───────────────────────────────────────────────────────
+# Extract binary name (first token) for existence check
+CMD_BIN="${CMD%% *}"
+if [ ! -x "$CMD_BIN" ] && ! command -v "$CMD_BIN" >/dev/null 2>&1; then
+    printf 'custom.sh: refuse-to-run: command not found: %s\n' "$CMD_BIN" >&2
+    printf 'Ensure the snapshot_cmd binary is installed and on PATH\n' >&2
+    exit 2
+fi
+
+# ── Execute operator command ──────────────────────────────────────────────────
+printf 'custom.sh: executing: %s %s\n' "$CMD" "$OUT_DIR" >&2
+eval "$CMD" "$OUT_DIR"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+    printf 'custom.sh: fatal: command exited with code %d\n' "$rc" >&2
+    exit "$rc"
+fi
+
+printf 'custom.sh: snapshot complete → %s\n' "$OUT_DIR" >&2

--- a/skills/autospec-e2e-clone/scripts/snapshot/dispatch.sh
+++ b/skills/autospec-e2e-clone/scripts/snapshot/dispatch.sh
@@ -116,8 +116,54 @@ for i in $(seq 0 $((SOURCE_COUNT - 1))); do
             fi
             ;;
 
-        s3|filesystem|custom_cmd)
-            printf 'dispatch.sh: info: kind=%s not implemented in C2 (deferred to C3)\n' "$KIND" >&2
+        s3)
+            BUCKET_VAL=$(printf '%s' "$SOURCE" | \
+                python3 -c "import sys,json; print(json.load(sys.stdin).get('bucket',''))" 2>/dev/null || echo "")
+            SAMPLE_PREFIX_COUNT=$(printf '%s' "$SOURCE" | \
+                python3 -c "import sys,json; print(json.load(sys.stdin).get('sample_prefix_count',100))" 2>/dev/null || echo "100")
+
+            if [ -n "$BUCKET_VAL" ]; then
+                export BUCKET="$BUCKET_VAL"
+            fi
+
+            if ! bash "$SCRIPT_DIR/s3.sh" "$SAMPLE_PREFIX_COUNT" "$OUT_DIR"; then
+                printf 'dispatch.sh: error: s3 source[%d] snapshot failed\n' "$i" >&2
+                FAILURES=$((FAILURES + 1))
+            fi
+            ;;
+
+        filesystem)
+            PATHS_CSV=$(printf '%s' "$SOURCE" | \
+                python3 -c "import sys,json; d=json.load(sys.stdin); print(','.join(d.get('paths',[])))" 2>/dev/null || echo "")
+            SAMPLE_FILES_PER_DIR=$(printf '%s' "$SOURCE" | \
+                python3 -c "import sys,json; print(json.load(sys.stdin).get('sample_files_per_dir',50))" 2>/dev/null || echo "50")
+
+            if [ -z "$PATHS_CSV" ]; then
+                printf 'dispatch.sh: error: filesystem source[%d]: paths is empty\n' "$i" >&2
+                FAILURES=$((FAILURES + 1))
+                continue
+            fi
+
+            if ! bash "$SCRIPT_DIR/fs.sh" "$PATHS_CSV" "$SAMPLE_FILES_PER_DIR" "$OUT_DIR"; then
+                printf 'dispatch.sh: error: filesystem source[%d] snapshot failed\n' "$i" >&2
+                FAILURES=$((FAILURES + 1))
+            fi
+            ;;
+
+        custom_cmd)
+            SNAP_CMD=$(printf '%s' "$SOURCE" | \
+                python3 -c "import sys,json; print(json.load(sys.stdin).get('snapshot_cmd',''))" 2>/dev/null || echo "")
+
+            if [ -z "$SNAP_CMD" ]; then
+                printf 'dispatch.sh: error: custom_cmd source[%d]: snapshot_cmd is empty\n' "$i" >&2
+                FAILURES=$((FAILURES + 1))
+                continue
+            fi
+
+            if ! bash "$SCRIPT_DIR/custom.sh" "$SNAP_CMD" "$OUT_DIR"; then
+                printf 'dispatch.sh: error: custom_cmd source[%d] snapshot failed\n' "$i" >&2
+                FAILURES=$((FAILURES + 1))
+            fi
             ;;
 
         *)

--- a/skills/autospec-e2e-clone/scripts/snapshot/fs.sh
+++ b/skills/autospec-e2e-clone/scripts/snapshot/fs.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# skills/autospec-e2e-clone/scripts/snapshot/fs.sh — Filesystem snapshot driver
+#
+# Usage: fs.sh <paths_csv> <sample_files_per_dir> <out_dir>
+#
+# Copies each path in paths_csv into <out_dir>, preserving directory structure,
+# but capping files per directory to sample_files_per_dir.
+#
+# Exit codes:
+#   0 = ok
+#   1 = fatal
+#   2 = refuse-to-run
+
+set -euo pipefail
+
+PATHS_CSV="${1:-}"
+SAMPLE_FILES_PER_DIR="${2:-50}"
+OUT_DIR="${3:-}"
+
+# ── Validate arguments ────────────────────────────────────────────────────────
+if [ -z "$PATHS_CSV" ]; then
+    printf 'fs.sh: fatal: PATHS_CSV argument required\n' >&2
+    exit 1
+fi
+
+if [ -z "$OUT_DIR" ]; then
+    printf 'fs.sh: fatal: OUT_DIR argument required\n' >&2
+    exit 1
+fi
+
+if ! [[ "$SAMPLE_FILES_PER_DIR" =~ ^[0-9]+$ ]] || [ "$SAMPLE_FILES_PER_DIR" -lt 1 ]; then
+    printf 'fs.sh: fatal: SAMPLE_FILES_PER_DIR must be a positive integer, got: %s\n' "$SAMPLE_FILES_PER_DIR" >&2
+    exit 1
+fi
+
+# ── Prepare output directory ──────────────────────────────────────────────────
+mkdir -p "$OUT_DIR"
+
+TOTAL_FILES=0
+TOTAL_DIRS=0
+
+# ── Process each path ─────────────────────────────────────────────────────────
+IFS=',' read -ra PATHS <<< "$PATHS_CSV"
+for src_path in "${PATHS[@]}"; do
+    src_path="${src_path// /}"  # trim whitespace
+    [ -z "$src_path" ] && continue
+
+    if [ ! -e "$src_path" ]; then
+        printf 'fs.sh: refuse-to-run: path does not exist: %s\n' "$src_path" >&2
+        exit 2
+    fi
+
+    printf 'fs.sh: snapshotting path %s (cap %d files/dir)...\n' "$src_path" "$SAMPLE_FILES_PER_DIR" >&2
+
+    if [ -f "$src_path" ]; then
+        # Single file — copy directly
+        dest_dir="${OUT_DIR}/$(dirname "$src_path")"
+        mkdir -p "$dest_dir"
+        cp "$src_path" "$dest_dir/" 2>&1 || {
+            printf 'fs.sh: fatal: failed to copy %s\n' "$src_path" >&2
+            exit 1
+        }
+        TOTAL_FILES=$((TOTAL_FILES + 1))
+        continue
+    fi
+
+    # Directory — walk and cap files per sub-directory
+    while IFS= read -r -d '' dir; do
+        # Compute relative path for destination
+        rel_dir="${dir#$src_path}"
+        rel_dir="${rel_dir#/}"
+        dest_dir="${OUT_DIR}/${src_path#/}/${rel_dir}"
+        mkdir -p "$dest_dir"
+        TOTAL_DIRS=$((TOTAL_DIRS + 1))
+
+        # List files in this dir only (non-recursive), cap to sample_files_per_dir
+        file_count=0
+        while IFS= read -r -d '' file; do
+            [ "$file_count" -ge "$SAMPLE_FILES_PER_DIR" ] && break
+            cp "$file" "$dest_dir/" 2>&1 || {
+                printf 'fs.sh: warning: failed to copy %s\n' "$file" >&2
+                continue
+            }
+            file_count=$((file_count + 1))
+            TOTAL_FILES=$((TOTAL_FILES + 1))
+        done < <(find "$dir" -maxdepth 1 -type f -print0 | sort -z)
+    done < <(find "$src_path" -type d -print0 | sort -z)
+done
+
+printf 'fs.sh: snapshot complete — %d file(s) from %d dir(s) → %s\n' "$TOTAL_FILES" "$TOTAL_DIRS" "$OUT_DIR" >&2

--- a/skills/autospec-e2e-clone/scripts/snapshot/s3.sh
+++ b/skills/autospec-e2e-clone/scripts/snapshot/s3.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# skills/autospec-e2e-clone/scripts/snapshot/s3.sh — S3 snapshot driver
+#
+# Usage: s3.sh <sample_prefix_count> <out_dir>
+#
+# Environment:
+#   BUCKET              — S3 bucket name (required)
+#   AWS_PROFILE         — optional AWS profile
+#   AWS_ENDPOINT_URL    — optional endpoint override (for minio/localstack)
+#
+# Behavior:
+#   Lists top-level prefixes in BUCKET, then for each prefix syncs up to
+#   sample_prefix_count objects into <out_dir>/<prefix>/
+#
+# Output layout:
+#   <out_dir>/<prefix>/...  — synced objects per prefix
+#
+# Exit codes:
+#   0 = ok
+#   1 = fatal (missing tool, aws error)
+#   2 = refuse-to-run (operator-actionable config error)
+
+set -euo pipefail
+
+SAMPLE_PREFIX_COUNT="${1:-100}"
+OUT_DIR="${2:-}"
+
+# ── Validate arguments ────────────────────────────────────────────────────────
+if [ -z "$OUT_DIR" ]; then
+    printf 's3.sh: fatal: OUT_DIR argument required\n' >&2
+    exit 1
+fi
+
+if [ -z "${BUCKET:-}" ]; then
+    printf 's3.sh: refuse-to-run: BUCKET environment variable not set\n' >&2
+    printf 'Set BUCKET to the S3 bucket name to snapshot\n' >&2
+    exit 2
+fi
+
+# ── Dependency check ──────────────────────────────────────────────────────────
+if ! command -v aws >/dev/null 2>&1; then
+    printf 's3.sh: fatal: aws CLI not found. Install awscli\n' >&2
+    exit 1
+fi
+
+# ── Build aws base args ───────────────────────────────────────────────────────
+AWS_ARGS=()
+if [ -n "${AWS_ENDPOINT_URL:-}" ]; then
+    AWS_ARGS+=(--endpoint-url "$AWS_ENDPOINT_URL")
+fi
+
+# ── Prepare output directory ──────────────────────────────────────────────────
+mkdir -p "$OUT_DIR"
+
+# ── List top-level prefixes ───────────────────────────────────────────────────
+printf 's3.sh: listing prefixes in s3://%s...\n' "$BUCKET" >&2
+
+PREFIXES=$(aws "${AWS_ARGS[@]}" s3api list-objects-v2 \
+    --bucket "$BUCKET" \
+    --delimiter "/" \
+    --query "CommonPrefixes[].Prefix" \
+    --output text 2>&1) || {
+    printf 's3.sh: fatal: failed to list prefixes in bucket %s\n' "$BUCKET" >&2
+    exit 1
+}
+
+if [ -z "$PREFIXES" ] || [ "$PREFIXES" = "None" ]; then
+    # No prefixes — treat entire bucket as flat, sync with object cap
+    printf 's3.sh: no prefixes found; syncing flat bucket (cap: %s objects)...\n' "$SAMPLE_PREFIX_COUNT" >&2
+    KEYS=$(aws "${AWS_ARGS[@]}" s3api list-objects-v2 \
+        --bucket "$BUCKET" \
+        --max-items "$SAMPLE_PREFIX_COUNT" \
+        --query "Contents[].Key" \
+        --output text 2>/dev/null || echo "")
+    if [ -n "$KEYS" ] && [ "$KEYS" != "None" ]; then
+        while IFS=$'\t' read -r key; do
+            [ -z "$key" ] && continue
+            aws "${AWS_ARGS[@]}" s3 cp "s3://${BUCKET}/${key}" "$OUT_DIR/${key}" \
+                --quiet 2>&1 || printf 's3.sh: warning: failed to copy %s\n' "$key" >&2
+        done <<< "$KEYS"
+    fi
+    printf 's3.sh: snapshot complete → %s\n' "$OUT_DIR" >&2
+    exit 0
+fi
+
+# ── Sync per prefix with cap ──────────────────────────────────────────────────
+PREFIX_COUNT=0
+while IFS=$'\t' read -r prefix; do
+    [ -z "$prefix" ] && continue
+    PREFIX_DIR="${OUT_DIR}/${prefix%/}"
+    mkdir -p "$PREFIX_DIR"
+
+    printf 's3.sh: syncing prefix %s (cap: %s)...\n' "$prefix" "$SAMPLE_PREFIX_COUNT" >&2
+
+    # List objects under this prefix, cap to sample_prefix_count
+    KEYS=$(aws "${AWS_ARGS[@]}" s3api list-objects-v2 \
+        --bucket "$BUCKET" \
+        --prefix "$prefix" \
+        --max-items "$SAMPLE_PREFIX_COUNT" \
+        --query "Contents[].Key" \
+        --output text 2>/dev/null || echo "")
+
+    if [ -n "$KEYS" ] && [ "$KEYS" != "None" ]; then
+        while IFS=$'\t' read -r key; do
+            [ -z "$key" ] && continue
+            rel_key="${key#$prefix}"
+            aws "${AWS_ARGS[@]}" s3 cp "s3://${BUCKET}/${key}" "${PREFIX_DIR}/${rel_key}" \
+                --quiet 2>&1 || printf 's3.sh: warning: failed to copy %s\n' "$key" >&2
+        done <<< "$KEYS"
+    fi
+
+    PREFIX_COUNT=$((PREFIX_COUNT + 1))
+done <<< "$PREFIXES"
+
+printf 's3.sh: snapshot complete — %d prefix(es) → %s\n' "$PREFIX_COUNT" "$OUT_DIR" >&2

--- a/skills/autospec-e2e-clone/tests/integration/snapshot-custom.bats
+++ b/skills/autospec-e2e-clone/tests/integration/snapshot-custom.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# Integration tests for snapshot/custom.sh
+# No external deps — uses simple shell commands as the operator cmd.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/snapshot"
+
+setup() {
+    TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "custom.sh: runs operator command with out_dir as arg" {
+    OUT_DIR="$TMP_DIR/out"
+    # Command creates a sentinel file in the out_dir
+    CMD="touch"
+    # touch <out_dir>/sentinel — we use a wrapper script
+    WRAPPER="$TMP_DIR/my-snap.sh"
+    cat > "$WRAPPER" <<'SCRIPT'
+#!/usr/bin/env bash
+mkdir -p "$1"
+printf 'snapshot-complete\n' > "$1/result.txt"
+SCRIPT
+    chmod +x "$WRAPPER"
+    run bash "$SCRIPT_DIR/custom.sh" "$WRAPPER" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -f "$OUT_DIR/result.txt" ]
+}
+
+@test "custom.sh: out_dir is created if it does not exist" {
+    OUT_DIR="$TMP_DIR/deep/nested/out"
+    WRAPPER="$TMP_DIR/noop.sh"
+    cat > "$WRAPPER" <<'SCRIPT'
+#!/usr/bin/env bash
+mkdir -p "$1"
+SCRIPT
+    chmod +x "$WRAPPER"
+    run bash "$SCRIPT_DIR/custom.sh" "$WRAPPER" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -d "$OUT_DIR" ]
+}
+
+@test "custom.sh: propagates non-zero exit from operator command" {
+    OUT_DIR="$TMP_DIR/out"
+    WRAPPER="$TMP_DIR/fail.sh"
+    cat > "$WRAPPER" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 42
+SCRIPT
+    chmod +x "$WRAPPER"
+    run bash "$SCRIPT_DIR/custom.sh" "$WRAPPER" "$OUT_DIR"
+    [ "$status" -eq 42 ]
+}
+
+@test "custom.sh: fails with exit 1 if CMD not provided" {
+    run bash "$SCRIPT_DIR/custom.sh"
+    [ "$status" -eq 1 ]
+}
+
+@test "custom.sh: fails with exit 1 if OUT_DIR not provided" {
+    run bash "$SCRIPT_DIR/custom.sh" "echo"
+    [ "$status" -eq 1 ]
+}
+
+@test "custom.sh: fails with exit 2 if command not found" {
+    OUT_DIR="$TMP_DIR/out"
+    run bash "$SCRIPT_DIR/custom.sh" "/nonexistent/binary" "$OUT_DIR"
+    [ "$status" -eq 2 ]
+}
+
+@test "custom.sh: passes out_dir as first argument to operator command" {
+    OUT_DIR="$TMP_DIR/out"
+    WRAPPER="$TMP_DIR/record-arg.sh"
+    cat > "$WRAPPER" <<'SCRIPT'
+#!/usr/bin/env bash
+mkdir -p "$1"
+printf '%s\n' "$1" > "$1/received-arg.txt"
+SCRIPT
+    chmod +x "$WRAPPER"
+    run bash "$SCRIPT_DIR/custom.sh" "$WRAPPER" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    RECORDED=$(cat "$OUT_DIR/received-arg.txt")
+    [ "$RECORDED" = "$OUT_DIR" ]
+}
+
+@test "dispatch.sh: routes custom_cmd source correctly" {
+    OUT_BASE="$TMP_DIR/clone-snapshots"
+    WRAPPER="$TMP_DIR/dispatch-snap.sh"
+    cat > "$WRAPPER" <<'SCRIPT'
+#!/usr/bin/env bash
+mkdir -p "$1"
+printf 'custom-done\n' > "$1/custom-result.txt"
+SCRIPT
+    chmod +x "$WRAPPER"
+
+    CONTRACT_JSON="{\"sources\":[{\"kind\":\"custom_cmd\",\"snapshot_cmd\":\"$WRAPPER\"}],\"expose\":{\"kind\":\"docker_compose\"}}"
+    DISPATCH="$SCRIPT_DIR/dispatch.sh"
+    run bash -c "printf '%s' '$CONTRACT_JSON' | bash '$DISPATCH' '$OUT_BASE'"
+    [ "$status" -eq 0 ]
+    RESULT_COUNT=$(find "$OUT_BASE" -name "custom-result.txt" | wc -l | tr -d ' ')
+    [ "$RESULT_COUNT" -ge 1 ]
+}

--- a/skills/autospec-e2e-clone/tests/integration/snapshot-fs.bats
+++ b/skills/autospec-e2e-clone/tests/integration/snapshot-fs.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# Integration tests for snapshot/fs.sh
+# Uses temp directories only — no external deps required.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/snapshot"
+
+setup() {
+    TMP_DIR="$(mktemp -d)"
+    # Create a fixture directory tree
+    SRC_DIR="$TMP_DIR/src"
+    mkdir -p "$SRC_DIR/subdir_a" "$SRC_DIR/subdir_b" "$SRC_DIR/subdir_a/nested"
+
+    # Populate files
+    for i in $(seq 1 5); do
+        printf 'content %d\n' "$i" > "$SRC_DIR/file_${i}.txt"
+    done
+    for i in $(seq 1 3); do
+        printf 'subdir_a content %d\n' "$i" > "$SRC_DIR/subdir_a/a_${i}.txt"
+    done
+    for i in $(seq 1 4); do
+        printf 'subdir_b content %d\n' "$i" > "$SRC_DIR/subdir_b/b_${i}.txt"
+    done
+    printf 'nested content\n' > "$SRC_DIR/subdir_a/nested/deep.txt"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "fs.sh: out_dir is created if it does not exist" {
+    OUT_DIR="$TMP_DIR/deep/nested/out"
+    run bash "$SCRIPT_DIR/fs.sh" "$SRC_DIR" "50" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -d "$OUT_DIR" ]
+}
+
+@test "fs.sh: copies files from source directory" {
+    OUT_DIR="$TMP_DIR/out"
+    run bash "$SCRIPT_DIR/fs.sh" "$SRC_DIR" "50" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    # Some files should be present under out_dir
+    FILE_COUNT=$(find "$OUT_DIR" -type f | wc -l | tr -d ' ')
+    [ "$FILE_COUNT" -gt 0 ]
+}
+
+@test "fs.sh: sampling cap is honored per directory" {
+    OUT_DIR="$TMP_DIR/out"
+    # Cap at 2 files per directory
+    run bash "$SCRIPT_DIR/fs.sh" "$SRC_DIR" "2" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    # Root dir has 5 files → capped at 2
+    ROOT_OUT="${OUT_DIR}/${SRC_DIR#/}"
+    ROOT_COUNT=$(find "$ROOT_OUT" -maxdepth 1 -type f | wc -l | tr -d ' ')
+    [ "$ROOT_COUNT" -le 2 ]
+}
+
+@test "fs.sh: subdir_b capped at 2 files" {
+    OUT_DIR="$TMP_DIR/out"
+    run bash "$SCRIPT_DIR/fs.sh" "$SRC_DIR" "2" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    SUBDIR_B_OUT="${OUT_DIR}/${SRC_DIR#/}/subdir_b"
+    if [ -d "$SUBDIR_B_OUT" ]; then
+        B_COUNT=$(find "$SUBDIR_B_OUT" -maxdepth 1 -type f | wc -l | tr -d ' ')
+        [ "$B_COUNT" -le 2 ]
+    fi
+}
+
+@test "fs.sh: nested directories are preserved in output" {
+    OUT_DIR="$TMP_DIR/out"
+    run bash "$SCRIPT_DIR/fs.sh" "$SRC_DIR" "50" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    NESTED_OUT="${OUT_DIR}/${SRC_DIR#/}/subdir_a/nested"
+    [ -d "$NESTED_OUT" ]
+}
+
+@test "fs.sh: exits 0 with cap=1, only 1 file per dir copied" {
+    OUT_DIR="$TMP_DIR/out"
+    run bash "$SCRIPT_DIR/fs.sh" "$SRC_DIR" "1" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    ROOT_OUT="${OUT_DIR}/${SRC_DIR#/}"
+    ROOT_COUNT=$(find "$ROOT_OUT" -maxdepth 1 -type f | wc -l | tr -d ' ')
+    [ "$ROOT_COUNT" -le 1 ]
+}
+
+@test "fs.sh: fails with exit 1 if no PATHS_CSV given" {
+    run bash "$SCRIPT_DIR/fs.sh"
+    [ "$status" -eq 1 ]
+}
+
+@test "fs.sh: fails with exit 1 if OUT_DIR not given" {
+    run bash "$SCRIPT_DIR/fs.sh" "$SRC_DIR"
+    [ "$status" -eq 1 ]
+}
+
+@test "fs.sh: fails with exit 2 if path does not exist" {
+    run bash "$SCRIPT_DIR/fs.sh" "/nonexistent/path" "50" "$TMP_DIR/out"
+    [ "$status" -eq 2 ]
+}
+
+@test "fs.sh: handles multiple comma-separated paths" {
+    OUT_DIR="$TMP_DIR/out"
+    DIR_A="$SRC_DIR/subdir_a"
+    DIR_B="$SRC_DIR/subdir_b"
+    run bash "$SCRIPT_DIR/fs.sh" "${DIR_A},${DIR_B}" "50" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    FILE_COUNT=$(find "$OUT_DIR" -type f | wc -l | tr -d ' ')
+    [ "$FILE_COUNT" -gt 0 ]
+}
+
+@test "dispatch.sh: routes filesystem source correctly" {
+    OUT_BASE="$TMP_DIR/clone-snapshots"
+    CONTRACT_JSON=$(cat <<JSON
+{
+  "sources": [
+    {
+      "kind": "filesystem",
+      "paths": ["$SRC_DIR/subdir_a"],
+      "sample_files_per_dir": 10
+    }
+  ],
+  "expose": { "kind": "docker_compose" }
+}
+JSON
+)
+    DISPATCH="$SCRIPT_DIR/dispatch.sh"
+    run bash -c "printf '%s' '$CONTRACT_JSON' | bash '$DISPATCH' '$OUT_BASE'"
+    [ "$status" -eq 0 ]
+    FILE_COUNT=$(find "$OUT_BASE" -type f | wc -l | tr -d ' ')
+    [ "$FILE_COUNT" -gt 0 ]
+}

--- a/skills/autospec-e2e-clone/tests/integration/snapshot-s3.bats
+++ b/skills/autospec-e2e-clone/tests/integration/snapshot-s3.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# Integration tests for snapshot/s3.sh
+# Requires docker + minio. Skip gracefully if unavailable.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/snapshot"
+
+MINIO_CONTAINER="autospec-test-minio-$$"
+MINIO_PORT="19000"
+MINIO_CONSOLE_PORT="19001"
+MINIO_ROOT_USER="minioadmin"
+MINIO_ROOT_PASSWORD="minioadmin"
+MINIO_BUCKET="test-bucket"
+export AWS_ENDPOINT_URL="http://127.0.0.1:${MINIO_PORT}"
+export AWS_ACCESS_KEY_ID="$MINIO_ROOT_USER"
+export AWS_SECRET_ACCESS_KEY="$MINIO_ROOT_PASSWORD"
+export AWS_DEFAULT_REGION="us-east-1"
+export BUCKET="$MINIO_BUCKET"
+
+setup_file() {
+    if ! command -v docker >/dev/null 2>&1; then
+        return 0
+    fi
+    docker run -d \
+        --name "$MINIO_CONTAINER" \
+        -p "${MINIO_PORT}:9000" \
+        -p "${MINIO_CONSOLE_PORT}:9001" \
+        -e MINIO_ROOT_USER="$MINIO_ROOT_USER" \
+        -e MINIO_ROOT_PASSWORD="$MINIO_ROOT_PASSWORD" \
+        minio/minio:latest server /data --console-address ":9001" \
+        >/dev/null 2>&1 || true
+
+    # Wait for minio to be ready (up to 20s)
+    local i=0
+    while [ $i -lt 20 ]; do
+        if curl -sf "http://127.0.0.1:${MINIO_PORT}/minio/health/live" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+        i=$((i + 1))
+    done
+
+    # Create bucket and seed test objects
+    if command -v aws >/dev/null 2>&1; then
+        aws --endpoint-url "$AWS_ENDPOINT_URL" s3 mb "s3://${MINIO_BUCKET}" >/dev/null 2>&1 || true
+        for prefix in alpha beta gamma; do
+            for i in $(seq 1 5); do
+                printf 'object-%d\n' "$i" | \
+                    aws --endpoint-url "$AWS_ENDPOINT_URL" s3 cp - \
+                    "s3://${MINIO_BUCKET}/${prefix}/file_${i}.txt" >/dev/null 2>&1 || true
+            done
+        done
+    fi
+}
+
+teardown_file() {
+    if command -v docker >/dev/null 2>&1; then
+        docker rm -f "$MINIO_CONTAINER" >/dev/null 2>&1 || true
+    fi
+}
+
+setup() {
+    TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "s3.sh: creates out_dir and syncs objects" {
+    require_minio
+    OUT_DIR="$TMP_DIR/out"
+    run bash "$SCRIPT_DIR/s3.sh" "100" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    [ -d "$OUT_DIR" ]
+    FILE_COUNT=$(find "$OUT_DIR" -type f | wc -l | tr -d ' ')
+    [ "$FILE_COUNT" -gt 0 ]
+}
+
+@test "s3.sh: sampling cap limits objects per prefix" {
+    require_minio
+    OUT_DIR="$TMP_DIR/out"
+    # Cap at 2 objects per prefix (each prefix has 5)
+    run bash "$SCRIPT_DIR/s3.sh" "2" "$OUT_DIR"
+    [ "$status" -eq 0 ]
+    # Count files under alpha prefix — should be <= 2
+    ALPHA_DIR="$OUT_DIR/alpha"
+    if [ -d "$ALPHA_DIR" ]; then
+        ALPHA_COUNT=$(find "$ALPHA_DIR" -type f | wc -l | tr -d ' ')
+        [ "$ALPHA_COUNT" -le 2 ]
+    fi
+}
+
+@test "s3.sh: fails with exit 2 if BUCKET not set" {
+    OUT_DIR="$TMP_DIR/out"
+    run env -u BUCKET bash "$SCRIPT_DIR/s3.sh" "100" "$OUT_DIR"
+    [ "$status" -eq 2 ]
+}
+
+@test "s3.sh: fails with exit 1 if OUT_DIR not provided" {
+    run bash "$SCRIPT_DIR/s3.sh"
+    [ "$status" -eq 1 ]
+}
+
+@test "dispatch.sh: routes s3 source correctly" {
+    require_minio
+    OUT_BASE="$TMP_DIR/clone-snapshots"
+    CONTRACT_JSON=$(cat <<JSON
+{
+  "sources": [
+    {
+      "kind": "s3",
+      "bucket": "$MINIO_BUCKET",
+      "sample_prefix_count": 3
+    }
+  ],
+  "expose": { "kind": "docker_compose" }
+}
+JSON
+)
+    DISPATCH="$SCRIPT_DIR/dispatch.sh"
+    run bash -c "printf '%s' '$CONTRACT_JSON' | bash '$DISPATCH' '$OUT_BASE'"
+    [ "$status" -eq 0 ]
+    FILE_COUNT=$(find "$OUT_BASE" -type f | wc -l | tr -d ' ')
+    [ "$FILE_COUNT" -gt 0 ]
+}
+
+# Helpers
+require_minio() {
+    if ! command -v docker >/dev/null 2>&1; then
+        skip "docker not available"
+    fi
+    if ! command -v aws >/dev/null 2>&1; then
+        skip "aws CLI not available"
+    fi
+    if ! docker ps --filter "name=$MINIO_CONTAINER" --format "{{.Names}}" | grep -q "$MINIO_CONTAINER"; then
+        skip "minio container not running"
+    fi
+    if ! curl -sf "http://127.0.0.1:${MINIO_PORT}/minio/health/live" >/dev/null 2>&1; then
+        skip "minio not reachable"
+    fi
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/snapshot/s3.sh` — lists bucket prefixes via `aws s3api list-objects-v2`, syncs up to `sample_prefix_count` objects per prefix; handles flat buckets too
- Adds `scripts/snapshot/fs.sh` — walks directory tree, copies up to `sample_files_per_dir` files per directory preserving structure; supports comma-separated multi-path input
- Adds `scripts/snapshot/custom.sh` — executes operator-provided `snapshot_cmd` with `<out_dir>` as `$1`; propagates exact exit code on failure
- Updates `dispatch.sh` — replaces C2 "deferred to C3" stubs with real routing for `s3`, `filesystem`, and `custom_cmd` source kinds
- Adds bats integration tests: `snapshot-fs.bats` (11 tests, no deps), `snapshot-custom.bats` (8 tests, no deps), `snapshot-s3.bats` (5 tests, minio/docker skip-safe)

## Test plan

- [x] `bats skills/autospec-e2e-clone/tests/integration/snapshot-fs.bats` — 11/11 pass
- [x] `bats skills/autospec-e2e-clone/tests/integration/snapshot-custom.bats` — 8/8 pass
- [ ] `bats skills/autospec-e2e-clone/tests/integration/snapshot-s3.bats` — requires docker + minio + aws CLI

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)