### PR TITLE
feat(autospec-e2e-clone): edge-case seed consumer + catalog overlay (C6)

### DIFF
--- a/skills/autospec-e2e-clone/scripts/edge-case-seed.mjs
+++ b/skills/autospec-e2e-clone/scripts/edge-case-seed.mjs
@@ -1,0 +1,588 @@
+#!/usr/bin/env node
+// skills/autospec-e2e-clone/scripts/edge-case-seed.mjs
+//
+// Edge-case seed consumer (C6).
+//
+// Reads .autospec/test.yml's edge_case_seeds.require_shapes (autospec-test v2 §5b).
+// For each declared shape, checks the snapshot CSV has >= count_min rows matching
+// the shape's predicate_sql. If short, INSERTs synthetic rows from the seed catalog
+// template into the snapshot CSV. Synthetic rows are flagged _autospec_synthetic=true.
+//
+// Catalog merge order:
+//   1. autospec-test canonical catalog  ($AUTOSPEC_SCRIPTS_DIR/seed-shapes/catalog.yml)
+//   2. clone overlay                    (skills/autospec-e2e-clone/scripts/seed-shapes/overlay.yml)
+//   Overlay entries win (shallow merge per shape key).
+//
+// Usage:
+//   node edge-case-seed.mjs <snapshot-dir> [--contract <path>] [--repo-root <path>]
+//                           [--catalog <path>] [--overlay <path>]
+//
+// Exit codes:
+//   0  success (or nothing-to-do)
+//   1  fatal (missing deps, bad files)
+//   2  refuse-to-run (contract invalid / shape not in catalog)
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  appendFileSync,
+} from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+import { createInterface } from 'node:readline';
+import { createReadStream } from 'node:fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+const { values: args, positionals } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    contract: { type: 'string', short: 'c' },
+    'repo-root': { type: 'string', short: 'r' },
+    catalog: { type: 'string' },
+    overlay: { type: 'string' },
+    help: { type: 'boolean', short: 'h' },
+  },
+  allowPositionals: true,
+  strict: true,
+});
+
+if (args.help) {
+  console.log(
+    'Usage: node edge-case-seed.mjs <snapshot-dir> [--contract <test.yml>] [--repo-root <root>] [--catalog <catalog.yml>] [--overlay <overlay.yml>]',
+  );
+  process.exit(0);
+}
+
+const snapshotDir = positionals[0];
+if (!snapshotDir) {
+  console.error('edge-case-seed: fatal: <snapshot-dir> is required');
+  process.exit(1);
+}
+
+const resolvedSnapshot = resolve(snapshotDir);
+if (!existsSync(resolvedSnapshot)) {
+  console.error(`edge-case-seed: fatal: snapshot-dir not found: ${resolvedSnapshot}`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Locate repo root
+// ---------------------------------------------------------------------------
+
+function findRepoRoot(startDir) {
+  let dir = startDir;
+  for (let i = 0; i < 20; i++) {
+    if (existsSync(join(dir, '.autospec'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+const repoRoot = args['repo-root']
+  ? resolve(args['repo-root'])
+  : findRepoRoot(resolvedSnapshot);
+
+if (!repoRoot) {
+  console.error(
+    'edge-case-seed: fatal: could not locate repo root (no .autospec/ directory found)',
+  );
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Tools check
+// ---------------------------------------------------------------------------
+
+function requireTool(tool) {
+  try {
+    execFileSync('which', [tool], { stdio: 'ignore' });
+  } catch {
+    console.error(
+      `edge-case-seed: fatal: ${tool} not found. Install with: brew install ${tool}`,
+    );
+    process.exit(1);
+  }
+}
+
+requireTool('yq');
+
+// ---------------------------------------------------------------------------
+// Load .autospec/test.yml contract
+// ---------------------------------------------------------------------------
+
+const contractPath = args.contract
+  ? resolve(args.contract)
+  : join(repoRoot, '.autospec', 'test.yml');
+
+if (!existsSync(contractPath)) {
+  console.error(`edge-case-seed: refuse-to-run: test.yml not found: ${contractPath}`);
+  process.exit(2);
+}
+
+let testContract;
+try {
+  testContract = JSON.parse(
+    execFileSync('yq', ['-o=json', '.', contractPath], { encoding: 'utf8' }),
+  );
+} catch (err) {
+  console.error(`edge-case-seed: fatal: failed to parse test.yml: ${err.message}`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Extract require_shapes from all entity keys
+// ---------------------------------------------------------------------------
+
+/**
+ * Collects all require_shapes entries from edge_case_seeds across all entity keys.
+ * Schema: edge_case_seeds.<entity>.require_shapes[{name, count_min}]
+ * @returns {{ name: string, count_min: number, entity: string }[]}
+ */
+function extractRequireShapes(contract) {
+  const edgeCaseSeeds = contract?.edge_case_seeds ?? {};
+  const shapes = [];
+  for (const [entityKey, entityVal] of Object.entries(edgeCaseSeeds)) {
+    if (entityKey === 'enforcement') continue;
+    if (typeof entityVal !== 'object' || !Array.isArray(entityVal.require_shapes)) continue;
+    for (const shape of entityVal.require_shapes) {
+      if (typeof shape === 'object' && shape.name && typeof shape.count_min === 'number') {
+        shapes.push({ name: shape.name, count_min: shape.count_min, entity: entityKey });
+      }
+    }
+  }
+  return shapes;
+}
+
+const requireShapes = extractRequireShapes(testContract);
+
+if (requireShapes.length === 0) {
+  console.log('edge-case-seed: no require_shapes declared — nothing to do');
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Load seed catalog (with overlay merge)
+// ---------------------------------------------------------------------------
+
+// Default catalog path: $AUTOSPEC_SCRIPTS_DIR/seed-shapes/catalog.yml or sibling in autospec-test
+function defaultCatalogPath() {
+  const fromEnv = process.env.AUTOSPEC_SCRIPTS_DIR
+    ? join(process.env.AUTOSPEC_SCRIPTS_DIR, 'seed-shapes', 'catalog.yml')
+    : null;
+  if (fromEnv && existsSync(fromEnv)) return fromEnv;
+  // Fallback: look relative to skills/autospec-test from this script's location
+  const fromSkill = resolve(__dirname, '..', '..', '..', 'autospec-test', 'scripts', 'seed-shapes', 'catalog.yml');
+  if (existsSync(fromSkill)) return fromSkill;
+  return null;
+}
+
+const catalogPath = args.catalog ? resolve(args.catalog) : defaultCatalogPath();
+
+if (!catalogPath || !existsSync(catalogPath)) {
+  console.error(
+    `edge-case-seed: fatal: seed catalog not found. ` +
+    `Set AUTOSPEC_SCRIPTS_DIR or pass --catalog. Tried: ${catalogPath ?? '(not found)'}`,
+  );
+  process.exit(1);
+}
+
+// Default overlay path: scripts/seed-shapes/overlay.yml sibling to this script
+const defaultOverlayPath = join(__dirname, 'seed-shapes', 'overlay.yml');
+const overlayPath = args.overlay ? resolve(args.overlay) : defaultOverlayPath;
+
+function loadYaml(filePath) {
+  try {
+    return JSON.parse(execFileSync('yq', ['-o=json', '.', filePath], { encoding: 'utf8' }));
+  } catch (err) {
+    console.error(`edge-case-seed: fatal: failed to parse ${filePath}: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+const catalogRaw = loadYaml(catalogPath);
+
+// Merge overlay (shallow per shape key — overlay wins)
+let mergedCatalog = { ...catalogRaw };
+if (existsSync(overlayPath)) {
+  const overlayRaw = loadYaml(overlayPath);
+  if (overlayRaw && typeof overlayRaw === 'object') {
+    for (const [shapeKey, shapeVal] of Object.entries(overlayRaw)) {
+      mergedCatalog[shapeKey] = { ...(mergedCatalog[shapeKey] ?? {}), ...shapeVal };
+    }
+    console.log(`edge-case-seed: loaded overlay from ${overlayPath}`);
+  }
+} else {
+  console.log(`edge-case-seed: no overlay found at ${overlayPath} — using base catalog only`);
+}
+
+// ---------------------------------------------------------------------------
+// Find snapshot CSV files
+// ---------------------------------------------------------------------------
+
+/**
+ * Discovers CSV files in the snapshot dir.
+ * Naming convention: <table>.csv or <source-id>/<table>.csv
+ * Returns a flat map of tableName -> absolutePath (last wins for duplicates).
+ */
+function discoverCsvs(snapshotRoot) {
+  const map = {};
+  function walk(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith('.csv')) {
+        const tableName = entry.name.replace(/\.csv$/, '');
+        map[tableName] = full;
+      }
+    }
+  }
+  walk(snapshotRoot);
+  return map;
+}
+
+const csvMap = discoverCsvs(resolvedSnapshot);
+
+// ---------------------------------------------------------------------------
+// CSV helpers (header-aware, no external deps)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads a CSV file and returns { headers: string[], rows: string[][] }.
+ */
+async function readCsv(filePath) {
+  const headers = [];
+  const rows = [];
+  let firstLine = true;
+  const rl = createInterface({ input: createReadStream(filePath), crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    const cols = parseCsvLine(line);
+    if (firstLine) {
+      headers.push(...cols);
+      firstLine = false;
+    } else {
+      rows.push(cols);
+    }
+  }
+  return { headers, rows };
+}
+
+/**
+ * Naive CSV line parser (handles double-quoted fields with embedded commas).
+ */
+function parseCsvLine(line) {
+  const result = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') { current += '"'; i++; }
+      else { inQuotes = !inQuotes; }
+    } else if (ch === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+function toCsvLine(fields) {
+  return fields
+    .map((f) => {
+      const s = String(f ?? '');
+      return s.includes(',') || s.includes('"') || s.includes('\n')
+        ? `"${s.replace(/"/g, '""')}"`
+        : s;
+    })
+    .join(',');
+}
+
+// ---------------------------------------------------------------------------
+// Predicate evaluation (SQLite-compatible SQL WHERE fragment)
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluates a predicate_sql fragment against rows in a CSV using SQLite.
+ * Writes the CSV to a temp SQLite DB, runs SELECT COUNT(*) WHERE <predicate>.
+ * Returns the count of matching rows.
+ */
+function countMatchingRowsSqlite(csvPath, predicate, tableName = 'data') {
+  try {
+    execFileSync('which', ['sqlite3'], { stdio: 'ignore' });
+  } catch {
+    console.error('edge-case-seed: fatal: sqlite3 not found. Install with: brew install sqlite3');
+    process.exit(1);
+  }
+
+  // Use sqlite3's .import to load the CSV and run the predicate
+  const sql = [
+    `.mode csv`,
+    `.import "${csvPath.replace(/"/g, '\\"')}" ${tableName}`,
+    `SELECT COUNT(*) FROM ${tableName} WHERE ${predicate};`,
+  ].join('\n');
+
+  try {
+    const out = execFileSync('sqlite3', [':memory:'], {
+      input: sql,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return parseInt(out.trim(), 10) || 0;
+  } catch (err) {
+    // If predicate uses columns not present in CSV, treat as 0 matches
+    console.warn(
+      `edge-case-seed: warn: predicate evaluation failed for "${predicate}": ${err.message.split('\n')[0]}`,
+    );
+    return 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic row generation from catalog template
+// ---------------------------------------------------------------------------
+
+let faker;
+async function getFaker() {
+  if (!faker) {
+    try {
+      const { faker: f } = await import('@faker-js/faker');
+      faker = f;
+    } catch {
+      console.warn('edge-case-seed: warn: @faker-js/faker not available — using fallback values');
+      faker = null;
+    }
+  }
+  return faker;
+}
+
+/**
+ * Generates `count` synthetic rows for the given shape.
+ * The catalog entry's `template` map provides column -> value expressions.
+ * Falls back to sensible defaults per shape name if no template is provided.
+ */
+async function generateSyntheticRows(shapeName, catalogEntry, existingHeaders, count) {
+  const f = await getFaker();
+  const template = catalogEntry.template ?? {};
+  const rows = [];
+
+  for (let i = 0; i < count; i++) {
+    const row = {};
+
+    // Apply template values (support simple string | "faker:<method>" syntax)
+    for (const [col, expr] of Object.entries(template)) {
+      if (typeof expr === 'string' && expr.startsWith('faker:')) {
+        const method = expr.slice(6); // e.g. "date.recent"
+        row[col] = f ? resolveFaker(f, method) : `synthetic_${col}_${i}`;
+      } else {
+        row[col] = expr;
+      }
+    }
+
+    // Built-in shape defaults (when no template or partial template)
+    applyShapeDefaults(shapeName, row, i, f);
+
+    // Always set the synthetic flag
+    row['_autospec_synthetic'] = 'true';
+
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+function resolveFaker(f, dotPath) {
+  const parts = dotPath.split('.');
+  let obj = f;
+  for (const part of parts) {
+    if (obj == null) return `synthetic_${dotPath}`;
+    obj = obj[part];
+  }
+  return typeof obj === 'function' ? obj() : String(obj ?? `synthetic_${dotPath}`);
+}
+
+/**
+ * Applies sensible defaults per known shape name if the template didn't set the column.
+ */
+function applyShapeDefaults(shapeName, row, idx, f) {
+  const now = new Date();
+  const todayIso = now.toISOString().slice(0, 10);
+  const yesterdayIso = new Date(now - 86400000).toISOString().slice(0, 10);
+
+  switch (shapeName) {
+    case 'task_done_today':
+      row.done_at ??= `${todayIso}T12:00:00Z`;
+      break;
+    case 'task_done_yesterday':
+      row.done_at ??= `${yesterdayIso}T12:00:00Z`;
+      break;
+    case 'task_done_2_to_6_days_ago': {
+      const daysAgo = 2 + (idx % 5);
+      const d = new Date(now - daysAgo * 86400000);
+      row.done_at ??= d.toISOString().slice(0, 10) + 'T12:00:00Z';
+      break;
+    }
+    case 'task_done_around_midnight':
+      row.done_at ??= `${todayIso}T23:57:00Z`;
+      break;
+    case 'multiple_tasks_same_day':
+      row.done_at ??= `${todayIso}T${String(10 + idx).padStart(2, '0')}:00:00Z`;
+      break;
+    case 'task_in_collapsed_foldout':
+      row.foldout_collapsed ??= '1';
+      break;
+    case 'last_item_in_long_list':
+      row.list_position ??= String(51 + idx);
+      break;
+    default:
+      break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ensure _autospec_synthetic column exists in CSV header
+// ---------------------------------------------------------------------------
+
+/**
+ * Rewrites a CSV file to add the _autospec_synthetic column if absent.
+ * Returns the (possibly updated) headers array.
+ */
+async function ensureSyntheticColumn(csvPath) {
+  const { headers, rows } = await readCsv(csvPath);
+  if (headers.includes('_autospec_synthetic')) return headers;
+
+  const newHeaders = [...headers, '_autospec_synthetic'];
+  const newRows = rows.map((r) => [...r, '']);
+  const lines = [
+    toCsvLine(newHeaders),
+    ...newRows.map(toCsvLine),
+  ].join('\n') + '\n';
+  writeFileSync(csvPath, lines, 'utf8');
+  console.log(`edge-case-seed: added _autospec_synthetic column to ${csvPath}`);
+  return newHeaders;
+}
+
+// ---------------------------------------------------------------------------
+// Append synthetic rows to CSV
+// ---------------------------------------------------------------------------
+
+async function appendSyntheticRows(csvPath, syntheticRows) {
+  const headers = await ensureSyntheticColumn(csvPath);
+
+  const lines = syntheticRows.map((row) => {
+    const fields = headers.map((h) => row[h] ?? '');
+    return toCsvLine(fields);
+  });
+  appendFileSync(csvPath, lines.join('\n') + '\n', 'utf8');
+  console.log(`edge-case-seed: inserted ${syntheticRows.length} synthetic row(s) into ${csvPath}`);
+}
+
+// ---------------------------------------------------------------------------
+// Main processing loop
+// ---------------------------------------------------------------------------
+
+const results = [];
+
+for (const { name: shapeName, count_min: countMin, entity } of requireShapes) {
+  // Locate shape in merged catalog
+  const catalogEntry = mergedCatalog[shapeName];
+  if (!catalogEntry) {
+    console.error(
+      `edge-case-seed: refuse-to-run: shape "${shapeName}" not found in catalog. ` +
+      `Register it in catalog.yml or overlay.yml.`,
+    );
+    process.exit(2);
+  }
+
+  const predicate = catalogEntry.predicate_sql;
+  if (!predicate) {
+    console.error(
+      `edge-case-seed: refuse-to-run: shape "${shapeName}" has no predicate_sql in catalog.`,
+    );
+    process.exit(2);
+  }
+
+  // Determine which table CSV to use.
+  // Entity key is used as table name hint; fall back to searching all CSVs.
+  const candidateTables = entity !== 'enforcement' ? [entity] : [];
+  // Also try known shape-related table names
+  const additionalGuesses = ['tasks', 'items', 'records'];
+  const tableCandidates = [...candidateTables, ...additionalGuesses];
+
+  let csvPath = null;
+  let tableName = null;
+  for (const t of tableCandidates) {
+    if (csvMap[t]) {
+      csvPath = csvMap[t];
+      tableName = t;
+      break;
+    }
+  }
+
+  if (!csvPath) {
+    // If only one CSV exists, use it
+    const allCsvs = Object.entries(csvMap);
+    if (allCsvs.length === 1) {
+      [tableName, csvPath] = allCsvs[0];
+    } else {
+      console.warn(
+        `edge-case-seed: warn: no CSV found for entity "${entity}" (shape "${shapeName}") — skipping`,
+      );
+      results.push({ shape: shapeName, status: 'skipped', reason: 'no-csv' });
+      continue;
+    }
+  }
+
+  // Count matching rows
+  const currentCount = countMatchingRowsSqlite(csvPath, predicate, tableName);
+  const shortfall = countMin - currentCount;
+
+  console.log(
+    `edge-case-seed: shape "${shapeName}" → table "${tableName}": ` +
+    `${currentCount} matching / ${countMin} required (shortfall: ${Math.max(0, shortfall)})`,
+  );
+
+  if (shortfall <= 0) {
+    console.log(`edge-case-seed: shape "${shapeName}" — surplus, no-op`);
+    results.push({ shape: shapeName, status: 'surplus', currentCount, countMin });
+    continue;
+  }
+
+  // Generate and insert synthetic rows
+  const syntheticRows = await generateSyntheticRows(shapeName, catalogEntry, [], shortfall);
+  await appendSyntheticRows(csvPath, syntheticRows);
+  results.push({ shape: shapeName, status: 'seeded', inserted: shortfall, currentCount, countMin });
+}
+
+// ---------------------------------------------------------------------------
+// Emit seed-report.json
+// ---------------------------------------------------------------------------
+
+const reportPath = join(resolvedSnapshot, 'seed-report.json');
+writeFileSync(reportPath, JSON.stringify({ shapes: results }, null, 2) + '\n', 'utf8');
+console.log(`edge-case-seed: wrote ${reportPath}`);
+
+const seededCount = results.filter((r) => r.status === 'seeded').length;
+const skippedCount = results.filter((r) => r.status === 'skipped').length;
+console.log(
+  `edge-case-seed: done — ${seededCount} shape(s) seeded, ` +
+  `${results.length - seededCount - skippedCount} surplus, ${skippedCount} skipped`,
+);
+process.exit(0);

--- a/skills/autospec-e2e-clone/scripts/seed-shapes/overlay.yml
+++ b/skills/autospec-e2e-clone/scripts/seed-shapes/overlay.yml
@@ -1,0 +1,23 @@
+# seed-shapes/overlay.yml — Clone-specific shape overrides for autospec-e2e-clone.
+#
+# Merge order (shallow per shape key):
+#   1. autospec-test canonical catalog  ($AUTOSPEC_SCRIPTS_DIR/seed-shapes/catalog.yml)
+#   2. This overlay                     (skills/autospec-e2e-clone/scripts/seed-shapes/overlay.yml)
+#   Overlay entries win over catalog entries for the same shape key.
+#
+# To override a shape, add an entry here with the same key as in catalog.yml.
+# Supported fields per shape:
+#   description:     (string) human-readable override description
+#   predicate_sql:   (string) SQL WHERE fragment override
+#   predicate_jsonpath: (string) JSONPath filter override
+#   template:        (map) column -> value or "faker:<method>" expression
+#
+# Example — override task_done_today to use a non-default column name:
+#
+# task_done_today:
+#   predicate_sql: "completed_at >= date('now') AND completed_at < date('now', '+1 day')"
+#   template:
+#     completed_at: "faker:date.recent"
+#
+# This file is intentionally empty by default. Add entries when the clone's
+# snapshot schema differs from the canonical catalog assumptions.

--- a/skills/autospec-e2e-clone/tests/unit/edge-case-seed.bats
+++ b/skills/autospec-e2e-clone/tests/unit/edge-case-seed.bats
@@ -1,0 +1,253 @@
+#!/usr/bin/env bats
+# skills/autospec-e2e-clone/tests/unit/edge-case-seed.bats
+#
+# TDD unit tests for the C6 edge-case seed consumer (edge-case-seed.mjs).
+#
+# Key scenario (from issue AC):
+#   Fixture has 2 rows of task_done_today, count_min=5 → assert 3 synthetic rows
+#   inserted with _autospec_synthetic=true flag column.
+#
+# Run: bats skills/autospec-e2e-clone/tests/unit/edge-case-seed.bats
+
+SKILL_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+SEED_SCRIPT="$SKILL_DIR/scripts/edge-case-seed.mjs"
+FIX_BASE="$SKILL_DIR/tests/unit/fixtures/edge-case-seed-fixture"
+FIX_SURPLUS="$SKILL_DIR/tests/unit/fixtures/edge-case-seed-fixture-surplus"
+# Canonical catalog lives in the autospec-test skill (sibling)
+CATALOG="$(cd "$SKILL_DIR/../autospec-test/scripts/seed-shapes" 2>/dev/null && pwd)/catalog.yml"
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+setup() {
+  TEST_SNAPSHOT="$(mktemp -d -t edge-case-seed-snap-XXXXXX)"
+  TEST_REPO="$(mktemp -d -t edge-case-seed-repo-XXXXXX)"
+  mkdir -p "$TEST_REPO/.autospec"
+  cp "$FIX_BASE/.autospec/test.yml" "$TEST_REPO/.autospec/test.yml"
+
+  # Build snapshot CSV with today's UTC date so the predicate
+  # "done_at >= date('now') AND done_at < date('now', '+1 day')" matches.
+  local today
+  today="$(date -u +%Y-%m-%d)"
+  mkdir -p "$TEST_SNAPSHOT"
+  printf 'id,done_at,foldout_collapsed,list_position\n' > "$TEST_SNAPSHOT/tasks.csv"
+  printf '1,%sT08:00:00Z,0,1\n' "$today"                >> "$TEST_SNAPSHOT/tasks.csv"
+  printf '2,%sT10:00:00Z,0,2\n' "$today"                >> "$TEST_SNAPSHOT/tasks.csv"
+}
+
+teardown() {
+  rm -rf "$TEST_SNAPSHOT" "$TEST_REPO"
+}
+
+# ── Basic invocation ──────────────────────────────────────────────────────────
+
+@test "edge-case-seed.mjs: exits 0 on valid snapshot + contract" {
+  run node "$SEED_SCRIPT" "$TEST_SNAPSHOT" \
+      --contract "$TEST_REPO/.autospec/test.yml" \
+      --repo-root "$TEST_REPO" \
+      --catalog "$CATALOG"
+  [ "$status" -eq 0 ]
+}
+
+@test "edge-case-seed.mjs: exits 1 when snapshot-dir missing" {
+  run node "$SEED_SCRIPT" /nonexistent/dir \
+      --contract "$TEST_REPO/.autospec/test.yml" \
+      --repo-root "$TEST_REPO" \
+      --catalog "$CATALOG"
+  [ "$status" -eq 1 ]
+}
+
+@test "edge-case-seed.mjs: exits 2 when test.yml not found" {
+  run node "$SEED_SCRIPT" "$TEST_SNAPSHOT" \
+      --contract /nonexistent/test.yml \
+      --repo-root "$TEST_REPO" \
+      --catalog "$CATALOG"
+  [ "$status" -eq 2 ]
+}
+
+# ── Shortfall scenario (2 rows present, count_min=5) ─────────────────────────
+
+@test "edge-case-seed.mjs: inserts 3 synthetic rows when 2 present and count_min=5" {
+  node "$SEED_SCRIPT" "$TEST_SNAPSHOT" \
+      --contract "$TEST_REPO/.autospec/test.yml" \
+      --repo-root "$TEST_REPO" \
+      --catalog "$CATALOG"
+
+  # Count total rows in CSV (excluding header)
+  local total_rows
+  total_rows=$(tail -n +2 "$TEST_SNAPSHOT/tasks.csv" | grep -c '.' || true)
+  [ "$total_rows" -eq 5 ]
+}
+
+@test "edge-case-seed.mjs: synthetic rows carry _autospec_synthetic=true" {
+  node "$SEED_SCRIPT" "$TEST_SNAPSHOT" \
+      --contract "$TEST_REPO/.autospec/test.yml" \
+      --repo-root "$TEST_REPO" \
+      --catalog "$CATALOG"
+
+  # Count rows with _autospec_synthetic=true
+  local synthetic_count
+  synthetic_count=$(grep -c 'true' "$TEST_SNAPSHOT/tasks.csv" || true)
+  [ "$synthetic_count" -eq 3 ]
+}
+
+@test "edge-case-seed.mjs: _autospec_synthetic column added to header when absent" {
+  node "$SEED_SCRIPT" "$TEST_SNAPSHOT" \
+      --contract "$TEST_REPO/.autospec/test.yml" \
+      --repo-root "$TEST_REPO" \
+      --catalog "$CATALOG"
+
+  local header
+  header=$(head -1 "$TEST_SNAPSHOT/tasks.csv")
+  [[ "$header" == *"_autospec_synthetic"* ]]
+}
+
+@test "edge-case-seed.mjs: original 2 rows preserved after seeding" {
+  node "$SEED_SCRIPT" "$TEST_SNAPSHOT" \
+      --contract "$TEST_REPO/.autospec/test.yml" \
+      --repo-root "$TEST_REPO" \
+      --catalog "$CATALOG"
+
+  # Original rows should still be in the CSV
+  grep -q '^1,' "$TEST_SNAPSHOT/tasks.csv"
+  grep -q '^2,' "$TEST_SNAPSHOT/tasks.csv"
+}
+
+# ── Surplus scenario (3 rows present, count_min=1) ────────────────────────────
+
+@test "edge-case-seed.mjs: surplus is a no-op (no rows inserted)" {
+  local SURPLUS_SNAP
+  SURPLUS_SNAP="$(mktemp -d -t edge-case-seed-surplus-XXXXXX)"
+  local SURPLUS_REPO
+  SURPLUS_REPO="$(mktemp -d -t edge-case-seed-surplus-repo-XXXXXX)"
+  mkdir -p "$SURPLUS_REPO/.autospec"
+  cp "$FIX_SURPLUS/.autospec/test.yml" "$SURPLUS_REPO/.autospec/test.yml"
+  local today
+  today="$(date -u +%Y-%m-%d)"
+  printf 'id,done_at,foldout_collapsed,list_position\n' > "$SURPLUS_SNAP/tasks.csv"
+  printf '1,%sT08:00:00Z,0,1\n' "$today" >> "$SURPLUS_SNAP/tasks.csv"
+  printf '2,%sT09:00:00Z,0,2\n' "$today" >> "$SURPLUS_SNAP/tasks.csv"
+  printf '3,%sT10:00:00Z,0,3\n' "$today" >> "$SURPLUS_SNAP/tasks.csv"
+
+  run node "$SEED_SCRIPT" "$SURPLUS_SNAP" \
+      --contract "$SURPLUS_REPO/.autospec/test.yml" \
+      --repo-root "$SURPLUS_REPO" \
+      --catalog "$CATALOG"
+
+  [ "$status" -eq 0 ]
+
+  # Total rows should still be 3 (no inserts)
+  local total_rows
+  total_rows=$(tail -n +2 "$SURPLUS_SNAP/tasks.csv" | grep -c '.' || true)
+  [ "$total_rows" -eq 3 ]
+
+  rm -rf "$SURPLUS_SNAP" "$SURPLUS_REPO"
+}
+
+@test "edge-case-seed.mjs: surplus output mentions surplus" {
+  local SURPLUS_SNAP
+  SURPLUS_SNAP="$(mktemp -d -t edge-case-seed-surplus2-XXXXXX)"
+  local SURPLUS_REPO
+  SURPLUS_REPO="$(mktemp -d -t edge-case-seed-surplus2-repo-XXXXXX)"
+  mkdir -p "$SURPLUS_REPO/.autospec"
+  cp "$FIX_SURPLUS/.autospec/test.yml" "$SURPLUS_REPO/.autospec/test.yml"
+  local today
+  today="$(date -u +%Y-%m-%d)"
+  printf 'id,done_at,foldout_collapsed,list_position\n' > "$SURPLUS_SNAP/tasks.csv"
+  printf '1,%sT08:00:00Z,0,1\n' "$today" >> "$SURPLUS_SNAP/tasks.csv"
+  printf '2,%sT09:00:00Z,0,2\n' "$today" >> "$SURPLUS_SNAP/tasks.csv"
+  printf '3,%sT10:00:00Z,0,3\n' "$today" >> "$SURPLUS_SNAP/tasks.csv"
+
+  run node "$SEED_SCRIPT" "$SURPLUS_SNAP" \
+      --contract "$SURPLUS_REPO/.autospec/test.yml" \
+      --repo-root "$SURPLUS_REPO" \
+      --catalog "$CATALOG"
+
+  [[ "$output" == *"surplus"* ]]
+
+  rm -rf "$SURPLUS_SNAP" "$SURPLUS_REPO"
+}
+
+# ── Seed report ───────────────────────────────────────────────────────────────
+
+@test "edge-case-seed.mjs: emits seed-report.json" {
+  node "$SEED_SCRIPT" "$TEST_SNAPSHOT" \
+      --contract "$TEST_REPO/.autospec/test.yml" \
+      --repo-root "$TEST_REPO" \
+      --catalog "$CATALOG"
+
+  [ -f "$TEST_SNAPSHOT/seed-report.json" ]
+}
+
+@test "edge-case-seed.mjs: seed-report.json is valid JSON" {
+  node "$SEED_SCRIPT" "$TEST_SNAPSHOT" \
+      --contract "$TEST_REPO/.autospec/test.yml" \
+      --repo-root "$TEST_REPO" \
+      --catalog "$CATALOG"
+
+  node -e "JSON.parse(require('fs').readFileSync('$TEST_SNAPSHOT/seed-report.json','utf8'))"
+}
+
+@test "edge-case-seed.mjs: seed-report.json records seeded status and inserted count" {
+  node "$SEED_SCRIPT" "$TEST_SNAPSHOT" \
+      --contract "$TEST_REPO/.autospec/test.yml" \
+      --repo-root "$TEST_REPO" \
+      --catalog "$CATALOG"
+
+  local status_val inserted_val
+  status_val=$(node -e "const r=JSON.parse(require('fs').readFileSync('$TEST_SNAPSHOT/seed-report.json','utf8')); console.log(r.shapes[0].status)")
+  inserted_val=$(node -e "const r=JSON.parse(require('fs').readFileSync('$TEST_SNAPSHOT/seed-report.json','utf8')); console.log(r.shapes[0].inserted)")
+
+  [ "$status_val" = "seeded" ]
+  [ "$inserted_val" = "3" ]
+}
+
+# ── Catalog overlay ───────────────────────────────────────────────────────────
+
+@test "edge-case-seed.mjs: loads overlay.yml when present" {
+  # Create a temp overlay that overrides task_done_today predicate to always match 0 rows
+  local OVERLAY
+  OVERLAY="$(mktemp -t overlay-XXXXXX.yml)"
+  printf 'task_done_today:\n  predicate_sql: "1 = 0"\n' > "$OVERLAY"
+
+  # With predicate always false, shortfall = count_min = 5 → 5 rows inserted
+  run node "$SEED_SCRIPT" "$TEST_SNAPSHOT" \
+      --contract "$TEST_REPO/.autospec/test.yml" \
+      --repo-root "$TEST_REPO" \
+      --catalog "$CATALOG" \
+      --overlay "$OVERLAY"
+
+  [ "$status" -eq 0 ]
+
+  # 5 synthetic rows should be inserted (predicate matches 0, count_min=5)
+  local total_rows
+  total_rows=$(tail -n +2 "$TEST_SNAPSHOT/tasks.csv" | grep -c '.' || true)
+  [ "$total_rows" -eq 7 ]
+
+  rm -f "$OVERLAY"
+}
+
+@test "edge-case-seed.mjs: missing overlay is a no-op (base catalog used)" {
+  run node "$SEED_SCRIPT" "$TEST_SNAPSHOT" \
+      --contract "$TEST_REPO/.autospec/test.yml" \
+      --repo-root "$TEST_REPO" \
+      --catalog "$CATALOG" \
+      --overlay /nonexistent/overlay.yml
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no overlay found"* ]]
+}
+
+# ── No require_shapes ─────────────────────────────────────────────────────────
+
+@test "edge-case-seed.mjs: exits 0 with nothing-to-do when no require_shapes" {
+  # Write a test.yml with no edge_case_seeds
+  printf 'e2e:\n  clone_url_env: CLONE_URL\n' > "$TEST_REPO/.autospec/test.yml"
+
+  run node "$SEED_SCRIPT" "$TEST_SNAPSHOT" \
+      --contract "$TEST_REPO/.autospec/test.yml" \
+      --repo-root "$TEST_REPO" \
+      --catalog "$CATALOG"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nothing to do"* ]]
+}

--- a/skills/autospec-e2e-clone/tests/unit/fixtures/edge-case-seed-fixture-surplus/.autospec/test.yml
+++ b/skills/autospec-e2e-clone/tests/unit/fixtures/edge-case-seed-fixture-surplus/.autospec/test.yml
@@ -1,0 +1,6 @@
+edge_case_seeds:
+  enforcement: warn_if_missing
+  tasks:
+    require_shapes:
+      - name: task_done_today
+        count_min: 1

--- a/skills/autospec-e2e-clone/tests/unit/fixtures/edge-case-seed-fixture-surplus/snapshot/tasks.csv
+++ b/skills/autospec-e2e-clone/tests/unit/fixtures/edge-case-seed-fixture-surplus/snapshot/tasks.csv
@@ -1,0 +1,4 @@
+id,done_at,foldout_collapsed,list_position
+1,2026-05-22T08:00:00Z,0,1
+2,2026-05-22T10:00:00Z,0,2
+3,2026-05-22T11:00:00Z,0,3

--- a/skills/autospec-e2e-clone/tests/unit/fixtures/edge-case-seed-fixture/.autospec/test.yml
+++ b/skills/autospec-e2e-clone/tests/unit/fixtures/edge-case-seed-fixture/.autospec/test.yml
@@ -1,0 +1,6 @@
+edge_case_seeds:
+  enforcement: warn_if_missing
+  tasks:
+    require_shapes:
+      - name: task_done_today
+        count_min: 5

--- a/skills/autospec-e2e-clone/tests/unit/fixtures/edge-case-seed-fixture/snapshot/tasks.csv
+++ b/skills/autospec-e2e-clone/tests/unit/fixtures/edge-case-seed-fixture/snapshot/tasks.csv
@@ -1,0 +1,3 @@
+id,done_at,foldout_collapsed,list_position
+1,2026-05-22T08:00:00Z,0,1
+2,2026-05-22T10:00:00Z,0,2


### PR DESCRIPTION
## Summary

- Implements C6: edge-case seed consumer per spec §6 of `docs/specs/2026-05-22-autospec-e2e-clone-design.md`
- Adds `scripts/edge-case-seed.mjs`: reads `.autospec/test.yml` `edge_case_seeds.require_shapes`, checks snapshot CSV row counts via `sqlite3` predicate, INSERTs synthetic rows from catalog template when short, marks them `_autospec_synthetic=true`
- Adds `scripts/seed-shapes/overlay.yml`: documented clone-specific shape override file with merge contract (autospec-test catalog → overlay, overlay wins)
- Emits `seed-report.json` per run with per-shape status (`seeded`/`surplus`/`skipped`)
- 15 bats unit tests covering: shortfall insert (2 rows present, count_min=5 → 3 synthetic inserted), surplus no-op, overlay merge, synthetic flag, seed-report JSON, nothing-to-do path

## Test plan

- [x] `bats skills/autospec-e2e-clone/tests/unit/edge-case-seed.bats` — 15/15 pass
- [x] Key AC verified: fixture with 2 `task_done_today` rows + `count_min: 5` → 3 synthetic rows inserted with `_autospec_synthetic=true`
- [x] Surplus (3 rows present, `count_min: 1`) → no-op confirmed
- [x] Overlay merge documented and tested (predicate override → different insert count)

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)