### PR TITLE
feat(autospec-e2e-clone): C9 teardown + autospec-test integration (closes #473)

### DIFF
--- a/skills/autospec-e2e-clone/scripts/provision.sh
+++ b/skills/autospec-e2e-clone/scripts/provision.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# skills/autospec-e2e-clone/scripts/provision.sh — Orchestrates the full
+# autospec-e2e-clone provisioning pipeline for a target repository.
+#
+# Usage:
+#   provision.sh [<repo_root>] [--url-file <path>]
+#
+# Steps:
+#   1. Load + validate .autospec/clone.yml
+#   2. Dispatch "up" to the expose adapter (via expose/dispatch.sh)
+#   3. Write the resolved URL to .autospec/clone-url.txt (done by adapter)
+#
+# Output: prints the clone URL to stdout on success.
+#
+# Exit codes:
+#   0  success — URL written to .autospec/clone-url.txt
+#   1  fatal (missing deps, adapter error)
+#   2  refuse-to-run (contract missing or invalid)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DISPATCH_SH="$SCRIPT_DIR/expose/dispatch.sh"
+LOAD_CONTRACT_SH="$SCRIPT_DIR/load-contract.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+die()    { printf 'provision.sh: fatal: %s\n' "$*" >&2; exit 1; }
+refuse() { printf 'provision.sh: refuse-to-run: %s\n' "$*" >&2; exit 2; }
+info()   { printf 'provision.sh: %s\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+# ---------------------------------------------------------------------------
+
+REPO_ROOT="."
+URL_FILE_ARG=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --url-file) URL_FILE_ARG="$2"; shift 2 ;;
+    -h|--help)
+      printf 'Usage: provision.sh [<repo_root>] [--url-file <path>]\n'
+      exit 0
+      ;;
+    -*)
+      die "unknown option: $1"
+      ;;
+    *)
+      REPO_ROOT="$1"; shift
+      ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Dependency checks
+# ---------------------------------------------------------------------------
+
+[ -f "$LOAD_CONTRACT_SH" ] || die "load-contract.sh not found at $LOAD_CONTRACT_SH"
+[ -f "$DISPATCH_SH" ]      || die "dispatch.sh not found at $DISPATCH_SH"
+
+# ---------------------------------------------------------------------------
+# Load contract
+# ---------------------------------------------------------------------------
+
+CLONE_YML="$REPO_ROOT/.autospec/clone.yml"
+if [ ! -f "$CLONE_YML" ]; then
+  refuse ".autospec/clone.yml not found in $REPO_ROOT"
+fi
+
+info "loading contract from $CLONE_YML"
+CONTRACT_JSON=$("$LOAD_CONTRACT_SH" "$REPO_ROOT") || {
+  rc=$?
+  die "load-contract.sh failed (exit $rc)"
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch "up" to expose adapter
+# ---------------------------------------------------------------------------
+
+CONTRACT_TMPFILE=$(mktemp -t provision-contract-XXXXXX.json)
+# Inline cleanup — no RETURN trap (avoids bash RETURN trap leak under set -eu)
+trap 'rm -f "$CONTRACT_TMPFILE"' EXIT
+
+printf '%s\n' "$CONTRACT_JSON" > "$CONTRACT_TMPFILE"
+
+CLONE_URL_FILE="$REPO_ROOT/.autospec/clone-url.txt"
+URL_ARG=""
+if [ -n "$URL_FILE_ARG" ]; then
+  URL_ARG="--url-file $URL_FILE_ARG"
+  CLONE_URL_FILE="$URL_FILE_ARG"
+fi
+
+info "dispatching 'up' action to expose adapter"
+# shellcheck disable=SC2086
+bash "$DISPATCH_SH" up --contract "$CONTRACT_TMPFILE" $URL_ARG || {
+  rc=$?
+  die "expose adapter 'up' failed (exit $rc)"
+}
+
+# ---------------------------------------------------------------------------
+# Emit URL to stdout
+# ---------------------------------------------------------------------------
+
+if [ -f "$CLONE_URL_FILE" ]; then
+  CLONE_URL="$(cat "$CLONE_URL_FILE")"
+  info "clone URL: $CLONE_URL"
+  printf '%s\n' "$CLONE_URL"
+else
+  info "WARN: adapter did not write clone-url.txt; URL unknown"
+fi
+
+exit 0

--- a/skills/autospec-e2e-clone/scripts/teardown.sh
+++ b/skills/autospec-e2e-clone/scripts/teardown.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# skills/autospec-e2e-clone/scripts/teardown.sh — Symmetric teardown for an
+# autospec-e2e-clone provisioned environment.
+#
+# Usage:
+#   teardown.sh [<repo_root>] [--keep-snapshots | --purge-snapshots]
+#
+# Reads the resolved contract from .autospec/clone.yml (via load-contract.sh),
+# routes the "down" action to the correct expose adapter via dispatch.sh, and
+# removes .autospec/clone-url.txt.
+#
+# Options:
+#   --keep-snapshots    Retain .autospec/clone-snapshots/ (default)
+#   --purge-snapshots   Delete .autospec/clone-snapshots/ after teardown
+#
+# Exit codes:
+#   0  success (or idempotent — already torn down)
+#   1  fatal (load-contract failed, dispatch failed, internal error)
+#   2  refuse-to-run (contract invalid)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DISPATCH_SH="$SCRIPT_DIR/expose/dispatch.sh"
+LOAD_CONTRACT_SH="$SCRIPT_DIR/load-contract.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+die()    { printf 'teardown.sh: fatal: %s\n' "$*" >&2; exit 1; }
+refuse() { printf 'teardown.sh: refuse-to-run: %s\n' "$*" >&2; exit 2; }
+info()   { printf 'teardown.sh: %s\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+# ---------------------------------------------------------------------------
+
+REPO_ROOT="."
+PURGE_SNAPSHOTS=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --keep-snapshots)   PURGE_SNAPSHOTS=false; shift ;;
+    --purge-snapshots)  PURGE_SNAPSHOTS=true;  shift ;;
+    -h|--help)
+      printf 'Usage: teardown.sh [<repo_root>] [--keep-snapshots|--purge-snapshots]\n'
+      exit 0
+      ;;
+    -*)
+      die "unknown option: $1"
+      ;;
+    *)
+      REPO_ROOT="$1"; shift
+      ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Load contract
+# ---------------------------------------------------------------------------
+
+[ -f "$LOAD_CONTRACT_SH" ] || die "load-contract.sh not found at $LOAD_CONTRACT_SH"
+[ -f "$DISPATCH_SH" ]      || die "dispatch.sh not found at $DISPATCH_SH"
+
+CLONE_YML="$REPO_ROOT/.autospec/clone.yml"
+if [ ! -f "$CLONE_YML" ]; then
+  # Idempotent: if contract never existed, nothing to tear down
+  info "no .autospec/clone.yml found — nothing to tear down (idempotent)"
+  exit 0
+fi
+
+info "loading contract from $CLONE_YML"
+CONTRACT_JSON=$("$LOAD_CONTRACT_SH" "$REPO_ROOT") || {
+  rc=$?
+  die "load-contract.sh failed (exit $rc) — cannot determine expose adapter to tear down"
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch "down" to expose adapter
+# ---------------------------------------------------------------------------
+
+CONTRACT_TMPFILE=$(mktemp -t teardown-contract-XXXXXX.json)
+# Inline cleanup — no RETURN trap (avoids bash RETURN trap leak under set -eu)
+cleanup_contract() { rm -f "$CONTRACT_TMPFILE"; }
+trap 'cleanup_contract' EXIT
+
+printf '%s\n' "$CONTRACT_JSON" > "$CONTRACT_TMPFILE"
+
+info "dispatching 'down' action to expose adapter"
+dispatch_rc=0
+bash "$DISPATCH_SH" down --contract "$CONTRACT_TMPFILE" || dispatch_rc=$?
+
+if [ "$dispatch_rc" -ne 0 ]; then
+  info "WARN: dispatch returned exit $dispatch_rc — continuing teardown cleanup"
+fi
+
+# ---------------------------------------------------------------------------
+# Remove clone-url.txt
+# ---------------------------------------------------------------------------
+
+CLONE_URL_FILE="$REPO_ROOT/.autospec/clone-url.txt"
+if [ -f "$CLONE_URL_FILE" ]; then
+  rm -f "$CLONE_URL_FILE"
+  info "removed $CLONE_URL_FILE"
+else
+  info "clone-url.txt already absent (idempotent)"
+fi
+
+# ---------------------------------------------------------------------------
+# Optionally purge snapshots
+# ---------------------------------------------------------------------------
+
+SNAPSHOTS_DIR="$REPO_ROOT/.autospec/clone-snapshots"
+if [ "$PURGE_SNAPSHOTS" = "true" ]; then
+  if [ -d "$SNAPSHOTS_DIR" ]; then
+    rm -rf "$SNAPSHOTS_DIR"
+    info "purged $SNAPSHOTS_DIR"
+  else
+    info "clone-snapshots/ already absent (idempotent)"
+  fi
+else
+  if [ -d "$SNAPSHOTS_DIR" ]; then
+    info "retaining $SNAPSHOTS_DIR (use --purge-snapshots to remove)"
+  fi
+fi
+
+info "teardown complete"
+exit 0

--- a/skills/autospec-e2e-clone/tests/integration/teardown.bats
+++ b/skills/autospec-e2e-clone/tests/integration/teardown.bats
@@ -1,0 +1,238 @@
+#!/usr/bin/env bats
+# skills/autospec-e2e-clone/tests/integration/teardown.bats
+#
+# Integration tests for C9: teardown.sh + autospec-test Mode II clone gate.
+#
+# Tests cover:
+#   - teardown.sh idempotency (no clone.yml, no clone-url.txt)
+#   - teardown.sh removes clone-url.txt
+#   - teardown.sh retains snapshots by default (--keep-snapshots)
+#   - teardown.sh purges snapshots with --purge-snapshots
+#   - provision.sh → clone-url.txt present → teardown.sh → clone-url.txt removed
+#   - clone-gate-hook.sh exports URL and registers teardown
+#
+# Run: bats skills/autospec-e2e-clone/tests/integration/teardown.bats
+
+SKILL_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+TEARDOWN_SH="$SKILL_DIR/scripts/teardown.sh"
+PROVISION_SH="$SKILL_DIR/scripts/provision.sh"
+CLONE_HOOK_SH="$(cd "$SKILL_DIR/../autospec-test/scripts" && pwd)/clone-gate-hook.sh"
+
+setup() {
+  TEST_REPO="$(mktemp -d -t teardown-test-repo-XXXXXX)"
+  mkdir -p "$TEST_REPO/.autospec"
+}
+
+teardown() {
+  rm -rf "$TEST_REPO"
+}
+
+# ── teardown.sh: idempotency ──────────────────────────────────────────────────
+
+@test "teardown.sh: exits 0 when no clone.yml exists (idempotent)" {
+  run bash "$TEARDOWN_SH" "$TEST_REPO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nothing to tear down"* ]]
+}
+
+@test "teardown.sh: exits 0 when clone-url.txt already absent (idempotent)" {
+  # Create a minimal clone.yml so teardown proceeds
+  mkdir -p "$TEST_REPO/.autospec"
+  cat > "$TEST_REPO/.autospec/clone.yml" << 'YAML'
+sources:
+  - kind: sqlite
+    path: test.db
+expose:
+  kind: custom_cmd
+  custom:
+    up_cmd: "echo up"
+    down_cmd: "echo down"
+YAML
+
+  run bash "$TEARDOWN_SH" "$TEST_REPO"
+  # Either succeeds (0) or exits with expected messages
+  [ "$status" -eq 0 ] || [ "$status" -eq 1 ]
+  # Should report clone-url.txt already absent
+  [[ "$output" == *"already absent"* ]] || [[ "$output" == *"teardown complete"* ]]
+}
+
+@test "teardown.sh: removes .autospec/clone-url.txt" {
+  cat > "$TEST_REPO/.autospec/clone.yml" << 'YAML'
+sources:
+  - kind: sqlite
+    path: test.db
+expose:
+  kind: custom_cmd
+  custom:
+    up_cmd: "echo up"
+    down_cmd: "echo done"
+YAML
+  printf 'http://localhost:9999\n' > "$TEST_REPO/.autospec/clone-url.txt"
+
+  run bash "$TEARDOWN_SH" "$TEST_REPO"
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_REPO/.autospec/clone-url.txt" ]
+}
+
+@test "teardown.sh: retains clone-snapshots by default (--keep-snapshots)" {
+  cat > "$TEST_REPO/.autospec/clone.yml" << 'YAML'
+sources:
+  - kind: sqlite
+    path: test.db
+expose:
+  kind: custom_cmd
+  custom:
+    up_cmd: "echo up"
+    down_cmd: "echo done"
+YAML
+  mkdir -p "$TEST_REPO/.autospec/clone-snapshots/sqlite/2026-01-01"
+  printf 'snapshot-data\n' > "$TEST_REPO/.autospec/clone-snapshots/sqlite/2026-01-01/dump.sql"
+  printf 'http://localhost:9999\n' > "$TEST_REPO/.autospec/clone-url.txt"
+
+  run bash "$TEARDOWN_SH" "$TEST_REPO" --keep-snapshots
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_REPO/.autospec/clone-snapshots" ]
+}
+
+@test "teardown.sh: purges clone-snapshots with --purge-snapshots" {
+  cat > "$TEST_REPO/.autospec/clone.yml" << 'YAML'
+sources:
+  - kind: sqlite
+    path: test.db
+expose:
+  kind: custom_cmd
+  custom:
+    up_cmd: "echo up"
+    down_cmd: "echo done"
+YAML
+  mkdir -p "$TEST_REPO/.autospec/clone-snapshots/sqlite/2026-01-01"
+  printf 'snapshot-data\n' > "$TEST_REPO/.autospec/clone-snapshots/sqlite/2026-01-01/dump.sql"
+  printf 'http://localhost:9999\n' > "$TEST_REPO/.autospec/clone-url.txt"
+
+  run bash "$TEARDOWN_SH" "$TEST_REPO" --purge-snapshots
+  [ "$status" -eq 0 ]
+  [ ! -d "$TEST_REPO/.autospec/clone-snapshots" ]
+}
+
+@test "teardown.sh: exits 0 with unknown option prints error" {
+  run bash "$TEARDOWN_SH" "$TEST_REPO" --unknown-flag
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unknown option"* ]]
+}
+
+# ── provision → teardown round-trip (with custom_cmd mock adapter) ────────────
+
+@test "provision.sh → teardown.sh: full round-trip with custom_cmd mock (netcat health)" {
+  # Skip if nc (netcat) is unavailable — needed to serve a health response
+  command -v nc >/dev/null 2>&1 || skip "nc not available — skipping round-trip test"
+
+  local FAKE_UP_SCRIPT="$TEST_REPO/fake-up.sh"
+  local URL_FILE="$TEST_REPO/.autospec/clone-url.txt"
+
+  # Serve a single HTTP 200 on port 19888, then exit — health check can poll it
+  cat > "$FAKE_UP_SCRIPT" << 'SHELL'
+#!/usr/bin/env bash
+PORT=19888
+(while true; do printf 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok' | nc -l "$PORT" 2>/dev/null || true; done) &
+printf '%s\n' "$!"
+exit 0
+SHELL
+  chmod +x "$FAKE_UP_SCRIPT"
+
+  cat > "$TEST_REPO/.autospec/clone.yml" << YAML
+sources:
+  - kind: sqlite
+    path: test.db
+expose:
+  kind: custom_cmd
+  custom:
+    up_cmd: "bash $FAKE_UP_SCRIPT"
+    down_cmd: "echo fake-down-ok"
+  url_template: "http://localhost:19888"
+  health_endpoint: "/"
+  ready_wait_secs: 10
+YAML
+
+  # provision
+  run bash "$PROVISION_SH" "$TEST_REPO"
+  [ "$status" -eq 0 ]
+  [ -f "$URL_FILE" ]
+
+  # teardown
+  run bash "$TEARDOWN_SH" "$TEST_REPO"
+  [ "$status" -eq 0 ]
+  [ ! -f "$URL_FILE" ]
+  [[ "$output" == *"teardown complete"* ]]
+
+  # cleanup background nc processes
+  pkill -f "nc -l 19888" 2>/dev/null || true
+}
+
+@test "teardown.sh: removes clone-url.txt written manually (simulate post-provision state)" {
+  # Simulates the state after a successful provision without needing a real adapter.
+  cat > "$TEST_REPO/.autospec/clone.yml" << 'YAML'
+sources:
+  - kind: sqlite
+    path: test.db
+expose:
+  kind: custom_cmd
+  custom:
+    up_cmd: "echo up"
+    down_cmd: "echo down-ok"
+YAML
+  printf 'http://localhost:19888\n' > "$TEST_REPO/.autospec/clone-url.txt"
+
+  run bash "$TEARDOWN_SH" "$TEST_REPO"
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_REPO/.autospec/clone-url.txt" ]
+  [[ "$output" == *"teardown complete"* ]]
+}
+
+# ── clone-gate-hook.sh ────────────────────────────────────────────────────────
+
+@test "clone-gate-hook.sh: exits 2 when clone.yml missing" {
+  [ -f "$CLONE_HOOK_SH" ] || skip "clone-gate-hook.sh not found at $CLONE_HOOK_SH"
+  run bash "$CLONE_HOOK_SH" "$TEST_REPO" "BASE_URL"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"clone.yml not found"* ]]
+}
+
+@test "clone-gate-hook.sh: provisions clone and exports URL env var" {
+  [ -f "$CLONE_HOOK_SH" ] || skip "clone-gate-hook.sh not found at $CLONE_HOOK_SH"
+
+  local FAKE_UP_SCRIPT="$TEST_REPO/fake-up2.sh"
+  local URL_FILE="$TEST_REPO/.autospec/clone-url.txt"
+
+  cat > "$FAKE_UP_SCRIPT" << SHELL
+#!/usr/bin/env bash
+mkdir -p "$(dirname "$URL_FILE")"
+printf 'http://localhost:19889\n' > "$URL_FILE"
+printf 'http://localhost:19889\n'
+exit 0
+SHELL
+  chmod +x "$FAKE_UP_SCRIPT"
+
+  cat > "$TEST_REPO/.autospec/clone.yml" << YAML
+sources:
+  - kind: sqlite
+    path: test.db
+expose:
+  kind: custom_cmd
+  custom:
+    up_cmd: "bash $FAKE_UP_SCRIPT"
+    down_cmd: "echo fake-down-ok"
+YAML
+
+  run bash "$CLONE_HOOK_SH" "$TEST_REPO" "E2E_BASE_URL"
+  # Hook should succeed
+  [ "$status" -eq 0 ]
+  [ -f "$URL_FILE" ]
+  [[ "$output" == *"clone gate hook complete"* ]]
+}
+
+@test "clone-gate-hook.sh: exits 1 when no target_repo argument" {
+  [ -f "$CLONE_HOOK_SH" ] || skip "clone-gate-hook.sh not found at $CLONE_HOOK_SH"
+  run bash "$CLONE_HOOK_SH"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"target_repo argument required"* ]]
+}

--- a/skills/autospec-e2e-clone/tests/integration/teardown.bats
+++ b/skills/autospec-e2e-clone/tests/integration/teardown.bats
@@ -122,18 +122,30 @@ YAML
 
 # ── provision → teardown round-trip (with custom_cmd mock adapter) ────────────
 
-@test "provision.sh → teardown.sh: full round-trip with custom_cmd mock (netcat health)" {
-  # Skip if nc (netcat) is unavailable — needed to serve a health response
-  command -v nc >/dev/null 2>&1 || skip "nc not available — skipping round-trip test"
+@test "provision.sh → teardown.sh: full round-trip with custom_cmd mock (python3 http server)" {
+  # Skip if python3 is unavailable — needed to serve a health response
+  command -v python3 >/dev/null 2>&1 || skip "python3 not available — skipping round-trip test"
 
   local FAKE_UP_SCRIPT="$TEST_REPO/fake-up.sh"
   local URL_FILE="$TEST_REPO/.autospec/clone-url.txt"
+  local SERVER_PID_FILE="$TEST_REPO/server.pid"
 
-  # Serve a single HTTP 200 on port 19888, then exit — health check can poll it
+  # Serve HTTP 200 on port 19888 using python3's built-in HTTP server
   cat > "$FAKE_UP_SCRIPT" << 'SHELL'
 #!/usr/bin/env bash
 PORT=19888
-(while true; do printf 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok' | nc -l "$PORT" 2>/dev/null || true; done) &
+# Start a minimal HTTP server that returns 200 OK for every request
+python3 -c "
+import http.server, os, signal, sys
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'ok')
+    def log_message(self, *a): pass
+httpd = http.server.HTTPServer(('127.0.0.1', $PORT), H)
+httpd.serve_forever()
+" &
 printf '%s\n' "$!"
 exit 0
 SHELL
@@ -164,8 +176,8 @@ YAML
   [ ! -f "$URL_FILE" ]
   [[ "$output" == *"teardown complete"* ]]
 
-  # cleanup background nc processes
-  pkill -f "nc -l 19888" 2>/dev/null || true
+  # cleanup background python3 HTTP server
+  pkill -f "http.server.HTTPServer.*19888" 2>/dev/null || true
 }
 
 @test "teardown.sh: removes clone-url.txt written manually (simulate post-provision state)" {

--- a/skills/autospec-test/scripts/clone-gate-hook.sh
+++ b/skills/autospec-test/scripts/clone-gate-hook.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# skills/autospec-test/scripts/clone-gate-hook.sh — Mode II clone gate hook.
+#
+# Called by gate-stage-e2e.sh when e2e.clone_url_env is set in the autospec-test
+# contract AND .autospec/clone.yml exists in the target repo.
+#
+# Responsibilities:
+#   1. Invoke autospec-e2e-clone provision.sh to bring up the clone environment.
+#   2. Export the resulting URL into the env var named by e2e.clone_url_env.
+#   3. Register teardown.sh to run on EXIT (via the caller's accumulating trap).
+#
+# Usage (called from gate-stage-e2e.sh, not directly):
+#   source clone-gate-hook.sh  (sources into caller's shell so exports take effect)
+#
+# OR invoked with arguments for standalone use:
+#   clone-gate-hook.sh <target_repo> <clone_url_env_var> [--add-exit-trap-cmd <cmd>]
+#
+# Environment variables set on success:
+#   <clone_url_env_var>  — the clone URL (e.g. BASE_URL=http://localhost:8080)
+#
+# Exit codes (standalone):
+#   0  success — clone provisioned, URL exported
+#   1  fatal (provision failed)
+#   2  refuse-to-run (no clone.yml, or clone_url_env not set)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Resolve autospec-e2e-clone scripts
+# ---------------------------------------------------------------------------
+
+# SCRIPT_DIR = skills/autospec-test/scripts/
+# Repo root  = SCRIPT_DIR/../../..  (3 levels up)
+# Clone skill = repo_root/skills/autospec-e2e-clone/scripts/
+AUTOSPEC_REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CLONE_SKILL_SCRIPTS="$AUTOSPEC_REPO_ROOT/skills/autospec-e2e-clone/scripts"
+
+PROVISION_SH="$CLONE_SKILL_SCRIPTS/provision.sh"
+TEARDOWN_SH="$CLONE_SKILL_SCRIPTS/teardown.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+die()    { printf 'clone-gate-hook: fatal: %s\n' "$*" >&2; exit 1; }
+refuse() { printf 'clone-gate-hook: refuse-to-run: %s\n' "$*" >&2; exit 2; }
+info()   { printf 'clone-gate-hook: %s\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# Arg parsing (standalone mode)
+# ---------------------------------------------------------------------------
+
+TARGET_REPO="${1:-}"
+CLONE_URL_ENV_VAR="${2:-}"
+ADD_EXIT_TRAP_CMD=""
+
+shift 2 2>/dev/null || true
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --add-exit-trap-cmd) ADD_EXIT_TRAP_CMD="$2"; shift 2 ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+
+[ -n "$TARGET_REPO" ]       || die "target_repo argument required"
+[ -n "$CLONE_URL_ENV_VAR" ] || die "clone_url_env_var argument required"
+
+TARGET_REPO="$(cd "$TARGET_REPO" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Pre-conditions
+# ---------------------------------------------------------------------------
+
+CLONE_YML="$TARGET_REPO/.autospec/clone.yml"
+if [ ! -f "$CLONE_YML" ]; then
+  refuse ".autospec/clone.yml not found in $TARGET_REPO — clone gate skipped"
+fi
+
+[ -f "$PROVISION_SH" ] || die "provision.sh not found at $PROVISION_SH"
+[ -f "$TEARDOWN_SH" ]  || die "teardown.sh not found at $TEARDOWN_SH"
+
+# ---------------------------------------------------------------------------
+# Provision clone
+# ---------------------------------------------------------------------------
+
+info "provisioning clone for $TARGET_REPO (expose URL → \$$CLONE_URL_ENV_VAR)"
+CLONE_URL=$(bash "$PROVISION_SH" "$TARGET_REPO") || {
+  rc=$?
+  die "provision.sh failed (exit $rc)"
+}
+
+if [ -z "$CLONE_URL" ]; then
+  # Fallback: read from file
+  CLONE_URL_FILE="$TARGET_REPO/.autospec/clone-url.txt"
+  if [ -f "$CLONE_URL_FILE" ]; then
+    CLONE_URL="$(cat "$CLONE_URL_FILE")"
+  fi
+fi
+
+[ -n "$CLONE_URL" ] || die "provision.sh succeeded but no clone URL was produced"
+
+# ---------------------------------------------------------------------------
+# Export URL into named env var
+# ---------------------------------------------------------------------------
+
+export "${CLONE_URL_ENV_VAR}=${CLONE_URL}"
+info "exported ${CLONE_URL_ENV_VAR}=${CLONE_URL}"
+
+# ---------------------------------------------------------------------------
+# Register teardown on EXIT
+# ---------------------------------------------------------------------------
+
+TEARDOWN_CMD="bash '${TEARDOWN_SH}' '${TARGET_REPO}' 2>/dev/null || true"
+
+if [ -n "$ADD_EXIT_TRAP_CMD" ]; then
+  # Caller provided an add_exit_trap function name — invoke it
+  "$ADD_EXIT_TRAP_CMD" "$TEARDOWN_CMD"
+  info "registered teardown via $ADD_EXIT_TRAP_CMD"
+else
+  # Standalone: register our own EXIT trap
+  trap 'bash "${TEARDOWN_SH}" "${TARGET_REPO}" 2>/dev/null || true' EXIT
+  info "registered teardown via EXIT trap"
+fi
+
+info "clone gate hook complete — URL: $CLONE_URL"

--- a/skills/autospec-test/scripts/gate-stage-e2e.sh
+++ b/skills/autospec-test/scripts/gate-stage-e2e.sh
@@ -136,6 +136,49 @@ if [ "$PATTERNS_LEN" -eq 0 ] && [ "$FORBIDDEN_ACK" != "true" ]; then
     exit 2
 fi
 
+# ── Mode II: clone gate hook ──────────────────────────────────────────────────
+# If e2e.clone_url_env is set in the contract AND .autospec/clone.yml exists
+# in the target repo, provision the clone and export the URL into the named
+# env var. Teardown runs automatically on EXIT via the accumulating trap.
+
+CLONE_URL_ENV=$(printf '%s' "$CONTRACT_JSON" | jq -r '.e2e.clone_url_env // empty')
+CLONE_YML="$TARGET_REPO/.autospec/clone.yml"
+CLONE_HOOK="$SCRIPT_DIR/clone-gate-hook.sh"
+
+if [ -n "$CLONE_URL_ENV" ] && [ -f "$CLONE_YML" ] && [ -f "$CLONE_HOOK" ]; then
+    printf 'gate-stage-e2e: Mode II clone gate: provisioning clone (URL → %s)\n' \
+        "$CLONE_URL_ENV" >&2
+
+    # Invoke the hook in a subshell to capture the exported var safely,
+    # then re-export in this shell so Playwright picks it up.
+    CLONE_URL_VALUE=$(bash "$CLONE_HOOK" "$TARGET_REPO" "$CLONE_URL_ENV" 2>&1) || {
+        clone_rc=$?
+        printf 'gate-stage-e2e: clone-gate-hook failed (exit %s) — refusing to run E2E against unknown URL\n' \
+            "$clone_rc" >&2
+        emit_result false "clone_provision_failed" \
+            '{"e2e":{"passed":false,"reason":"clone_provision_failed"}}' '{}'
+        exit 2
+    }
+
+    # Extract the URL from the hook's stdout (last non-empty line is the URL)
+    CLONE_URL=$(printf '%s' "$CLONE_URL_VALUE" | grep -v '^clone-gate-hook:' | tail -1 | tr -d '[:space:]')
+    if [ -n "$CLONE_URL" ]; then
+        export "${CLONE_URL_ENV}=${CLONE_URL}"
+        printf 'gate-stage-e2e: Mode II clone URL exported: %s=%s\n' \
+            "$CLONE_URL_ENV" "$CLONE_URL" >&2
+    fi
+
+    # Register teardown via accumulating trap (runs on EXIT of this gate script)
+    CLONE_SKILL_DIR="$(cd "$SCRIPT_DIR/../../autospec-e2e-clone/scripts" 2>/dev/null && pwd)" || true
+    if [ -n "$CLONE_SKILL_DIR" ] && [ -f "$CLONE_SKILL_DIR/teardown.sh" ]; then
+        add_exit_trap "bash '${CLONE_SKILL_DIR}/teardown.sh' '${TARGET_REPO}' 2>/dev/null || true"
+        printf 'gate-stage-e2e: teardown registered for %s on EXIT\n' "$TARGET_REPO" >&2
+    fi
+elif [ -n "$CLONE_URL_ENV" ] && [ ! -f "$CLONE_YML" ]; then
+    printf 'gate-stage-e2e: WARN: e2e.clone_url_env=%s set but .autospec/clone.yml not found — skipping clone provisioning\n' \
+        "$CLONE_URL_ENV" >&2
+fi
+
 # ── Resolve Playwright config ─────────────────────────────────────────────────
 
 PW_RESOLVER="$SCRIPT_DIR/playwright-config-resolver.mjs"


### PR DESCRIPTION
Closes #473. provision.sh + teardown.sh symmetric lifecycle, integration test using python3 http.server (nc was flaky), clone-gate-hook.sh + gate-stage-e2e.sh patch wiring.