### PR TITLE
feat(dist-d3): Homebrew formula + CI release flow (closes #456)

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,83 @@
+name: Release CLI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish-npm:
+    name: Publish @autospec/cli to npm
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pkg.outputs.version }}
+      tarball_url: ${{ steps.pkg.outputs.tarball_url }}
+      sha256: ${{ steps.sha.outputs.sha256 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Read package version
+        id: pkg
+        working-directory: packages/cli
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tarball_url=https://registry.npmjs.org/@autospec/cli/-/cli-${VERSION}.tgz" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to npm
+        working-directory: packages/cli
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Compute tarball sha256
+        id: sha
+        run: |
+          TARBALL_URL="https://registry.npmjs.org/@autospec/cli/-/cli-${{ steps.pkg.outputs.version }}.tgz"
+          SHA256="$(curl -fsSL "$TARBALL_URL" | sha256sum | awk '{print $1}')"
+          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
+
+  update-tap:
+    name: Open PR on homebrew-autospec tap
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tap repo
+        uses: actions/checkout@v4
+        with:
+          repository: berlinguyinca/homebrew-autospec
+          token: ${{ secrets.TAP_REPO_TOKEN }}
+          path: tap
+
+      - name: Update formula url and sha256
+        run: |
+          VERSION="${{ needs.publish-npm.outputs.version }}"
+          SHA256="${{ needs.publish-npm.outputs.sha256 }}"
+          TARBALL_URL="${{ needs.publish-npm.outputs.tarball_url }}"
+          sed -i "s|url \".*\"|url \"${TARBALL_URL}\"|" tap/Formula/autospec.rb
+          sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" tap/Formula/autospec.rb
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.TAP_REPO_TOKEN }}
+          path: tap
+          commit-message: "autospec ${{ needs.publish-npm.outputs.version }}"
+          title: "autospec ${{ needs.publish-npm.outputs.version }}"
+          body: |
+            Automated formula bump for autospec ${{ needs.publish-npm.outputs.version }}.
+
+            - url: ${{ needs.publish-npm.outputs.tarball_url }}
+            - sha256: ${{ needs.publish-npm.outputs.sha256 }}
+          branch: "bump/autospec-${{ needs.publish-npm.outputs.version }}"
+          base: main

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,11 @@ __pycache__/
 venv/
 env/
 node_modules/
-dist/
+dist/*
+# Allow dist/homebrew/ for the Homebrew formula source (D3)
+!dist/homebrew
+dist/homebrew/*
+!dist/homebrew/autospec.rb
 build/
 *.log
 *.tmp

--- a/dist/homebrew/autospec.rb
+++ b/dist/homebrew/autospec.rb
@@ -1,0 +1,18 @@
+class Autospec < Formula
+  desc "Multi-harness AI workflow suite: spec → issue tree → autonomous PRs"
+  homepage "https://github.com/berlinguyinca/autospec"
+  url "https://registry.npmjs.org/@autospec/cli/-/cli-0.1.0.tgz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", "-g", "--prefix=#{libexec}", buildpath/"package.json"
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    system bin/"autospec", "--version"
+  end
+end

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,23 @@
+# Autospec Quickstart
+
+> Full content lands in D4 (issue #457). This placeholder establishes the install path.
+
+## Install via Homebrew (macOS / Linux)
+
+```bash
+brew install berlinguyinca/autospec/autospec
+```
+
+## Install via npm / npx
+
+```bash
+npx autospec init
+```
+
+## Next steps
+
+See [docs/USER_MANUAL.md](USER_MANUAL.md) for full usage, or run:
+
+```bash
+autospec --help
+```

--- a/tests/cli/test_homebrew_formula.bats
+++ b/tests/cli/test_homebrew_formula.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# tests/cli/test_homebrew_formula.bats
+#
+# Smoke tests for the Homebrew formula and release workflow.
+# brew-audit test skips when brew binary is absent (CI Linux runners).
+#
+# Run: bats tests/cli/test_homebrew_formula.bats
+
+FORMULA="dist/homebrew/autospec.rb"
+WORKFLOW=".github/workflows/release-cli.yml"
+
+# Resolve repo root relative to this file
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+@test "formula file exists" {
+  [ -f "$REPO_ROOT/$FORMULA" ]
+}
+
+@test "formula parses as valid Ruby" {
+  command -v ruby >/dev/null 2>&1 || skip "ruby not found"
+  ruby -c "$REPO_ROOT/$FORMULA"
+}
+
+@test "formula contains required fields: desc, homepage, url, sha256, license" {
+  [ -f "$REPO_ROOT/$FORMULA" ]
+  grep -q 'desc ' "$REPO_ROOT/$FORMULA"
+  grep -q 'homepage ' "$REPO_ROOT/$FORMULA"
+  grep -q 'url ' "$REPO_ROOT/$FORMULA"
+  grep -q 'sha256 ' "$REPO_ROOT/$FORMULA"
+  grep -q 'license ' "$REPO_ROOT/$FORMULA"
+}
+
+@test "formula depends_on node" {
+  grep -q 'depends_on "node"' "$REPO_ROOT/$FORMULA"
+}
+
+@test "formula has install and test blocks" {
+  grep -q 'def install' "$REPO_ROOT/$FORMULA"
+  grep -q 'test do' "$REPO_ROOT/$FORMULA"
+}
+
+@test "formula install block references libexec" {
+  grep -q 'libexec' "$REPO_ROOT/$FORMULA"
+}
+
+@test "release workflow file exists" {
+  [ -f "$REPO_ROOT/$WORKFLOW" ]
+}
+
+@test "release workflow is valid YAML" {
+  if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" 2>/dev/null; then
+    python3 - "$REPO_ROOT/$WORKFLOW" << 'PYEOF'
+import yaml, sys
+yaml.safe_load(open(sys.argv[1]))
+PYEOF
+  elif command -v yamllint >/dev/null 2>&1; then
+    yamllint "$REPO_ROOT/$WORKFLOW"
+  else
+    skip "no yaml validator available (python3+yaml or yamllint)"
+  fi
+}
+
+@test "release workflow triggers on v* tags" {
+  grep -q "tags:" "$REPO_ROOT/$WORKFLOW"
+  grep -q "'v\*'" "$REPO_ROOT/$WORKFLOW"
+}
+
+@test "release workflow has npm publish step" {
+  grep -q "npm publish" "$REPO_ROOT/$WORKFLOW"
+}
+
+@test "release workflow references NPM_TOKEN secret" {
+  grep -q "NPM_TOKEN" "$REPO_ROOT/$WORKFLOW"
+}
+
+@test "release workflow references TAP_REPO_TOKEN secret" {
+  grep -q "TAP_REPO_TOKEN" "$REPO_ROOT/$WORKFLOW"
+}
+
+@test "brew audit passes (skip if brew absent or formula not tapped)" {
+  command -v brew >/dev/null 2>&1 || skip "brew not found — skipping audit"
+  # brew audit only accepts formula names, not file paths.
+  # We can only run it after the formula is installed via a tap.
+  # At PR time, the tap does not yet exist, so skip gracefully.
+  brew tap berlinguyinca/autospec 2>/dev/null || skip "tap berlinguyinca/autospec not available — skipping audit"
+  run brew audit --strict berlinguyinca/autospec/autospec
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Adds `dist/homebrew/autospec.rb` — Homebrew formula matching spec §4 template (`depends_on "node"`, install + test blocks, npm registry url)
- Adds `.github/workflows/release-cli.yml` — triggers on `v*` tags; publishes `@autospec/cli` to npm, computes tarball sha256, opens PR on `berlinguyinca/homebrew-autospec` tap updating url + sha256
- Adds `tests/cli/test_homebrew_formula.bats` — 13 tests: formula fields, Ruby syntax (`ruby -c`), workflow YAML validity, `brew audit` (skips gracefully when tap unavailable)
- Adds `docs/QUICKSTART.md` placeholder noting `brew install berlinguyinca/autospec/autospec` install path (full content in D4 #457)

## Test plan

- [x] `bats tests/cli/test_homebrew_formula.bats` — 13/13 pass (brew audit skips, tap not yet published)
- [x] `bash scripts/validate.sh` — passes clean
- [x] `ruby -c dist/homebrew/autospec.rb` — valid Ruby

Closes #456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)