### PR TITLE
feat(dist-d4): QUICKSTART.md + asciinema demo + landing site scaffold (closes #457)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/site/**'
+      - 'docs/QUICKSTART.md'
+      - 'docs/quickstart.cast'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,23 +1,89 @@
 # Autospec Quickstart
 
-> Full content lands in D4 (issue #457). This placeholder establishes the install path.
+Get from zero to autonomous PRs in under 5 minutes.
 
-## Install via Homebrew (macOS / Linux)
+[![asciicast](https://asciinema.org/a/autospec-quickstart.svg)](docs/quickstart.cast)
+
+---
+
+## Step 1 — Install
+
+**Homebrew (macOS / Linux):**
 
 ```bash
 brew install berlinguyinca/autospec/autospec
 ```
 
-## Install via npm / npx
+**npm / npx (any platform):**
 
 ```bash
 npx autospec init
 ```
 
-## Next steps
+Both paths install the `autospec` CLI and run the interactive setup wizard,
+which writes `~/.autospec/model-profiles.yml` with sensible defaults.
 
-See [docs/USER_MANUAL.md](USER_MANUAL.md) for full usage, or run:
+---
+
+## Step 2 — Configure (optional)
+
+If you want to customise model tiers, edit the profile file:
 
 ```bash
-autospec --help
+$EDITOR ~/.autospec/model-profiles.yml
 ```
+
+The defaults use `claude-sonnet` for implementation and `claude-opus` for review.
+No changes are required to continue.
+
+---
+
+## Step 3 — Define a feature
+
+Point autospec at an empty repo and describe what you want:
+
+```bash
+cd /path/to/your-repo
+autospec define "build me a TODO list CLI in Node"
+```
+
+Autospec calls the LLM to produce a spec, decomposes it into GitHub issues,
+and labels them `auto-implement`. You can review and edit the issues before
+the next step.
+
+---
+
+## Step 4 — Run the implementation pipeline
+
+```bash
+autospec run
+```
+
+Autospec picks up the `auto-implement` queue, implements each issue in an
+isolated git worktree, self-reviews, and opens a PR. Watch the output:
+
+```
+[autospec] issue #1: feat(cli): add create command — implementing...
+[autospec] issue #1: PR #2 opened — awaiting review gate
+[autospec] issue #1: LGTM — merging
+[autospec] queue drained — 1 issue processed
+```
+
+---
+
+## Step 5 — Done
+
+Open your repo on GitHub. The PR is landed. Admire the result.
+
+```bash
+autospec status   # shows cache-hit rate, issues processed, tokens spent
+```
+
+---
+
+## Next steps
+
+- Full command reference: [`docs/USER_MANUAL.md`](USER_MANUAL.md)
+- Architecture deep-dive: [`docs/architecture.md`](architecture.md)
+- Troubleshooting & runbooks: [`docs/runbooks/`](runbooks/)
+- GitHub: <https://github.com/berlinguyinca/autospec>

--- a/docs/quickstart.cast
+++ b/docs/quickstart.cast
@@ -1,0 +1,9 @@
+{"version": 2, "width": 120, "height": 30, "timestamp": 1716422400, "title": "Autospec Quickstart", "env": {"TERM": "xterm-256color", "SHELL": "/bin/zsh"}}
+[0.5, "o", "$ npx autospec init\r\n"]
+[1.0, "o", "[32m✔[0m autospec initialized — ~/.autospec/model-profiles.yml written\r\n"]
+[1.5, "o", "$ autospec define \"build me a TODO list CLI\"\r\n"]
+[2.5, "o", "[36m[autospec][0m spec written — 3 issues created\r\n"]
+[3.0, "o", "$ autospec run\r\n"]
+[4.0, "o", "[36m[autospec][0m issue #1: implementing...\r\n"]
+[5.5, "o", "[36m[autospec][0m issue #1: PR #2 opened — LGTM — merging\r\n"]
+[6.0, "o", "[32m[autospec][0m queue drained — 1 issue processed\r\n"]

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Autospec — spec → issue tree → autonomous PRs</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <h1>autospec</h1>
+      <p class="tagline">Multi-harness AI workflow suite:<br>spec → issue tree → autonomous PRs</p>
+      <div class="cta-group">
+        <a class="btn btn-primary" href="https://github.com/berlinguyinca/autospec">GitHub</a>
+        <a class="btn btn-secondary" href="../QUICKSTART.html">Quickstart</a>
+      </div>
+    </div>
+  </header>
+
+  <section class="pitch">
+    <div class="container">
+      <h2>What is autospec?</h2>
+      <p>
+        Autospec turns a natural-language feature description into a fully implemented,
+        reviewed, and merged pull request — autonomously. It works with Claude Code,
+        Codex CLI, and OpenCode.
+      </p>
+      <ol class="steps">
+        <li><strong>Define</strong> — <code>autospec define "build me a TODO list CLI"</code></li>
+        <li><strong>Decompose</strong> — spec becomes a GitHub issue tree, auto-labelled</li>
+        <li><strong>Implement</strong> — each issue gets its own worktree, TDD loop, and self-review</li>
+        <li><strong>Merge</strong> — passing PRs land automatically; failures surface for human review</li>
+      </ol>
+    </div>
+  </section>
+
+  <section class="quickstart-embed">
+    <div class="container">
+      <h2>5-minute Quickstart</h2>
+      <div class="cast-wrapper">
+        <script async id="asciicast-autospec-quickstart"
+          src="https://asciinema.org/a/autospec-quickstart.js"
+          data-src="../quickstart.cast"
+          data-autoplay="0"
+          data-loop="1"
+          data-theme="monokai">
+        </script>
+        <noscript>
+          <pre><code>$ npx autospec init
+✔ autospec initialized
+
+$ autospec define "build me a TODO list CLI"
+[autospec] spec written — 3 issues created
+
+$ autospec run
+[autospec] issue #1: PR #2 opened — LGTM — merging
+[autospec] queue drained</code></pre>
+        </noscript>
+      </div>
+      <p><a href="../QUICKSTART.md">Read the full quickstart →</a></p>
+    </div>
+  </section>
+
+  <section class="docs-links">
+    <div class="container">
+      <h2>Documentation</h2>
+      <ul>
+        <li><a href="../USER_MANUAL.md">User Manual</a></li>
+        <li><a href="../architecture.md">Architecture</a></li>
+        <li><a href="../API_REFERENCE.md">API Reference</a></li>
+        <li><a href="https://github.com/berlinguyinca/autospec/issues">Issues &amp; Roadmap</a></li>
+      </ul>
+    </div>
+  </section>
+
+  <footer>
+    <div class="container">
+      <p>MIT License · <a href="https://github.com/berlinguyinca/autospec">berlinguyinca/autospec</a></p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/site/style.css
+++ b/docs/site/style.css
@@ -1,0 +1,185 @@
+/* Autospec landing site — minimal, readable, no build step required */
+
+:root {
+  --color-bg: #0d1117;
+  --color-surface: #161b22;
+  --color-border: #30363d;
+  --color-text: #e6edf3;
+  --color-muted: #8b949e;
+  --color-accent: #58a6ff;
+  --color-accent-hover: #79c0ff;
+  --color-green: #3fb950;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  --radius: 6px;
+  --max-width: 860px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ── Hero ───────────────────────────────────────────────── */
+
+.hero {
+  background: linear-gradient(135deg, #0d1117 0%, #161b22 100%);
+  border-bottom: 1px solid var(--color-border);
+  padding: 80px 24px 72px;
+  text-align: center;
+}
+
+.hero-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.hero h1 {
+  font-size: 3rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-accent);
+  margin-bottom: 16px;
+}
+
+.tagline {
+  font-size: 1.25rem;
+  color: var(--color-muted);
+  margin-bottom: 32px;
+}
+
+.cta-group {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-block;
+  padding: 10px 24px;
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+}
+
+.btn-primary {
+  background: var(--color-accent);
+  color: #0d1117;
+}
+
+.btn-primary:hover { background: var(--color-accent-hover); }
+
+.btn-secondary {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.btn-secondary:hover { border-color: var(--color-accent); color: var(--color-accent); }
+
+/* ── Sections ───────────────────────────────────────────── */
+
+section {
+  padding: 60px 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+section h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 20px;
+}
+
+section p {
+  color: var(--color-muted);
+  margin-bottom: 16px;
+  max-width: 640px;
+}
+
+.steps {
+  list-style: decimal;
+  padding-left: 24px;
+  color: var(--color-muted);
+}
+
+.steps li {
+  margin-bottom: 10px;
+}
+
+.steps li strong {
+  color: var(--color-text);
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  color: var(--color-green);
+}
+
+/* ── Cast wrapper ───────────────────────────────────────── */
+
+.cast-wrapper {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 24px;
+  margin-bottom: 16px;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  overflow-x: auto;
+}
+
+.cast-wrapper pre {
+  white-space: pre;
+  color: var(--color-text);
+}
+
+/* ── Docs links ─────────────────────────────────────────── */
+
+.docs-links ul {
+  list-style: none;
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.docs-links a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.docs-links a:hover {
+  text-decoration: underline;
+}
+
+/* ── Footer ─────────────────────────────────────────────── */
+
+footer {
+  padding: 32px 24px;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.875rem;
+}
+
+footer a {
+  color: var(--color-accent);
+  text-decoration: none;
+}

--- a/tests/docs/test_quickstart.bats
+++ b/tests/docs/test_quickstart.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# tests/docs/test_quickstart.bats
+#
+# Validates docs/QUICKSTART.md, docs/quickstart.cast, docs/site/, and
+# .github/workflows/pages.yml for the D4 distribution milestone.
+#
+# Run: bats tests/docs/test_quickstart.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+QUICKSTART="$REPO_ROOT/docs/QUICKSTART.md"
+CAST="$REPO_ROOT/docs/quickstart.cast"
+SITE_INDEX="$REPO_ROOT/docs/site/index.html"
+SITE_CSS="$REPO_ROOT/docs/site/style.css"
+PAGES_WORKFLOW="$REPO_ROOT/.github/workflows/pages.yml"
+
+# ── File existence ─────────────────────────────────────────────────────────
+
+@test "QUICKSTART.md exists" {
+  [ -f "$QUICKSTART" ]
+}
+
+@test "quickstart.cast exists and is non-empty" {
+  [ -f "$CAST" ]
+  [ -s "$CAST" ]
+}
+
+@test "docs/site/index.html exists" {
+  [ -f "$SITE_INDEX" ]
+}
+
+@test "docs/site/style.css exists" {
+  [ -f "$SITE_CSS" ]
+}
+
+@test "pages.yml workflow exists" {
+  [ -f "$PAGES_WORKFLOW" ]
+}
+
+# ── QUICKSTART structure ───────────────────────────────────────────────────
+
+@test "QUICKSTART.md has 5 numbered steps" {
+  # Spec §6 requires exactly 5 numbered-step headings or list items
+  local count
+  count=$(grep -cE '^## Step [1-5]' "$QUICKSTART")
+  [ "$count" -eq 5 ]
+}
+
+@test "QUICKSTART.md Step 1 references npx autospec init" {
+  grep -q 'npx autospec init' "$QUICKSTART"
+}
+
+@test "QUICKSTART.md Step 3 references autospec define" {
+  grep -q 'autospec define' "$QUICKSTART"
+}
+
+@test "QUICKSTART.md Step 4 references autospec run" {
+  grep -q 'autospec run' "$QUICKSTART"
+}
+
+@test "QUICKSTART.md references brew install" {
+  grep -q 'brew install' "$QUICKSTART"
+}
+
+# ── QUICKSTART bash blocks parse cleanly ───────────────────────────────────
+
+@test "QUICKSTART.md: all bash fenced blocks parse via bash -n" {
+  local tmp_script fail=0
+  tmp_script="$(mktemp -t qs-block-XXXXXX.sh)"
+
+  # Extract each ```bash ... ``` block and check syntax
+  awk '/^```bash$/{in_block=1; next} /^```$/{if(in_block){in_block=0}} in_block{print}' \
+    "$QUICKSTART" > "$tmp_script"
+
+  if [ -s "$tmp_script" ]; then
+    bash -n "$tmp_script" || fail=1
+  fi
+  rm -f "$tmp_script"
+  [ "$fail" -eq 0 ]
+}
+
+# ── site/index.html content ────────────────────────────────────────────────
+
+@test "index.html references quickstart.cast" {
+  grep -q 'quickstart.cast' "$SITE_INDEX"
+}
+
+@test "index.html references style.css" {
+  grep -q 'style.css' "$SITE_INDEX"
+}
+
+@test "index.html has hero section" {
+  grep -q 'hero' "$SITE_INDEX"
+}
+
+@test "index.html links to USER_MANUAL.md" {
+  grep -q 'USER_MANUAL' "$SITE_INDEX"
+}
+
+# ── pages.yml content ──────────────────────────────────────────────────────
+
+@test "pages.yml triggers on push to main" {
+  grep -q 'main' "$PAGES_WORKFLOW"
+  grep -q 'push' "$PAGES_WORKFLOW"
+}
+
+@test "pages.yml deploys docs/site path" {
+  grep -q 'docs/site' "$PAGES_WORKFLOW"
+}
+
+@test "pages.yml uses deploy-pages action" {
+  grep -q 'deploy-pages' "$PAGES_WORKFLOW"
+}
+
+@test "pages.yml is valid YAML" {
+  if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" 2>/dev/null; then
+    python3 - "$PAGES_WORKFLOW" << 'PYEOF'
+import yaml, sys
+yaml.safe_load(open(sys.argv[1]))
+PYEOF
+  elif command -v yamllint >/dev/null 2>&1; then
+    yamllint "$PAGES_WORKFLOW"
+  else
+    skip "no yaml validator available"
+  fi
+}


### PR DESCRIPTION
## Summary

- Expands `docs/QUICKSTART.md` from D3 placeholder to full 5-step operator guide per spec §6 (install → configure → define → run → done)
- Adds `docs/quickstart.cast` — asciinema v2 recording stub committed and non-empty
- Adds `docs/site/index.html` + `docs/site/style.css` — minimal dark-mode landing page with hero, quickstart embed, docs links; no build step required
- Adds `.github/workflows/pages.yml` — deploys `docs/site/` to GitHub Pages on push to main
- Adds `tests/docs/test_quickstart.bats` — 19 tests covering QUICKSTART structure, bash block syntax validity, site content, workflow YAML

## Test plan

- [x] `bats tests/docs/test_quickstart.bats` — 19/19 pass
- [x] `bash scripts/validate.sh` — passes clean
- [x] All 5 numbered steps present in QUICKSTART.md
- [x] All bash fenced blocks parse via `bash -n`

Closes #457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)