### PR TITLE
feat(memory): auto-init-memory.sh state matrix + symlink (M1)

### DIFF
--- a/skills/autospec-shared/scripts/auto-init-memory.sh
+++ b/skills/autospec-shared/scripts/auto-init-memory.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# auto-init-memory.sh — Auto-migrate CC memory to in-repo location on first invocation per repo.
+#
+# Idempotent: subsequent runs are no-op probes (fast-path < 50ms).
+#
+# Usage:
+#   auto-init-memory.sh              # normal run
+#   auto-init-memory.sh --rollback   # restore most-recent .pre-migration-* backup
+#
+# Exit codes:
+#   0 always (git failures are warned but non-blocking)
+#
+# Environment:
+#   AUTOSPEC_SCRIPTS_DIR  — directory containing sibling scripts (default: script dir)
+#   HOME                  — used to compute CC_PATH (~/.claude/projects/<slug>/memory)
+#
+# Requires: bash 3.2+, git, ln, cp, mv, mkdir
+# Optional: gh CLI (for REPO_SLUG; exits 0 silently if absent), rsync (for case 11)
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUTOSPEC_SCRIPTS_DIR="${AUTOSPEC_SCRIPTS_DIR:-$SCRIPT_DIR}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_auto_commit() {
+  local msg="$1"
+  local repo_root="$2"
+  # Best-effort: warn on failure, never block
+  if ! git -C "$repo_root" add -- docs/memory/ AGENTS.md 2>/dev/null; then
+    echo "auto-init-memory: git add failed (continuing)" >&2
+    return 0
+  fi
+  if ! git -C "$repo_root" diff --cached --quiet 2>/dev/null; then
+    if ! git -C "$repo_root" commit -m "$msg" 2>/dev/null; then
+      echo "auto-init-memory: git commit failed — files staged for manual commit" >&2
+    fi
+  fi
+  return 0
+}
+
+_ensure_agents_md_inventory_section() {
+  local agents_md="$1"
+  # Idempotent: skip if block already present
+  if [ -f "$agents_md" ] && grep -q "^## Memory inventory" "$agents_md" 2>/dev/null; then
+    return 0
+  fi
+  # Create file if missing, then append the block
+  cat >> "$agents_md" <<'AGENTS_BLOCK'
+
+## Memory inventory
+
+Persistent cross-session memory lives at [`docs/memory/`](docs/memory/).
+Index: [`docs/memory/MEMORY.md`](docs/memory/MEMORY.md).
+
+Memory types (mempalace wings):
+- **semantic** — codebase facts, architecture, conventions
+- **episodic** — session diary (`docs/memory/diary/`), in-flight project status
+- **procedural** — playbooks, runbooks, recipes (also see SKILL.md files)
+- **synthesis** — lessons learned (feedback patterns, anti-patterns, gotchas)
+
+Read memories relevant to your task at session start. Write new memories by adding/editing files in `docs/memory/` and updating the index. Mempalace MCP layer (`mempalace search`, `mempalace traverse`, `mempalace kg_query`) is available if your tool supports MCP.
+AGENTS_BLOCK
+  return 0
+}
+
+_rollback() {
+  local cc_path="$1"
+  # Find most recent backup
+  local backup
+  backup=$(ls -dt "${cc_path}.pre-migration-"* 2>/dev/null | head -1)
+  if [ -z "$backup" ]; then
+    echo "auto-init-memory: no backup found at ${cc_path}.pre-migration-*" >&2
+    return 0
+  fi
+  # Remove symlink if present
+  if [ -L "$cc_path" ]; then
+    rm "$cc_path"
+  fi
+  # Restore backup
+  mv "$backup" "$cc_path"
+  echo "auto-init-memory: rolled back to $backup" >&2
+  return 0
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+# CC_PATH: ~/.claude/projects/<repo-root-with-slashes-replaced-by-dashes>/memory
+# (matches Claude Code's own path convention)
+CC_SLUG=$(echo "$REPO_ROOT" | tr '/' '-')
+CC_PATH="$HOME/.claude/projects/${CC_SLUG}/memory"
+REPO_PATH="$REPO_ROOT/docs/memory"
+
+# ── Rollback mode ─────────────────────────────────────────────────────────────
+if [ "${1:-}" = "--rollback" ]; then
+  _rollback "$CC_PATH"
+  exit 0
+fi
+
+# ── Fast-path: symlink already correct → no-op ────────────────────────────────
+if [ -L "$CC_PATH" ] && [ "$(readlink "$CC_PATH")" = "$REPO_PATH" ]; then
+  exit 0
+fi
+
+# ── Compute state bits ────────────────────────────────────────────────────────
+if [ -d "$CC_PATH" ] && [ -n "$(ls -A "$CC_PATH"/*.md 2>/dev/null)" ]; then
+  CC_HAS_FILES=1
+else
+  CC_HAS_FILES=0
+fi
+
+if [ -d "$REPO_PATH" ]; then
+  REPO_HAS_DIR=1
+else
+  REPO_HAS_DIR=0
+fi
+
+# ── State matrix ──────────────────────────────────────────────────────────────
+BACKUP_SUFFIX="pre-migration-$(date +%Y%m%d-%H%M%S)"
+
+case "${CC_HAS_FILES}${REPO_HAS_DIR}" in
+  10)
+    # CC has memory files; in-repo dir missing → migrate + symlink
+    mkdir -p "$REPO_PATH"
+    cp -p "$CC_PATH"/*.md "$REPO_PATH"/
+    mv "$CC_PATH" "${CC_PATH}.${BACKUP_SUFFIX}"
+    ln -s "$REPO_PATH" "$CC_PATH"
+    # Stub: mempalace-mine (invoked by M3; skipped here if not present)
+    if [ -x "${AUTOSPEC_SCRIPTS_DIR}/mempalace-mine.sh" ]; then
+      bash "${AUTOSPEC_SCRIPTS_DIR}/mempalace-mine.sh" --root "$REPO_PATH" --quiet
+    fi
+    _auto_commit "feat: auto-migrate cross-tool memory to docs/memory/" "$REPO_ROOT"
+    ;;
+  01)
+    # In-repo dir exists (e.g. from teammate's commit); CC memory missing → symlink only
+    mkdir -p "$(dirname "$CC_PATH")"
+    ln -s "$REPO_PATH" "$CC_PATH"
+    ;;
+  11)
+    # Both exist → sync (repo wins on dup via --ignore-existing) + symlink
+    rsync -a --ignore-existing "$CC_PATH"/*.md "$REPO_PATH"/ 2>/dev/null || \
+      cp -n "$CC_PATH"/*.md "$REPO_PATH"/ 2>/dev/null || true
+    mv "$CC_PATH" "${CC_PATH}.${BACKUP_SUFFIX}"
+    ln -s "$REPO_PATH" "$CC_PATH"
+    # Stub: mempalace-mine (invoked by M3; skipped here if not present)
+    if [ -x "${AUTOSPEC_SCRIPTS_DIR}/mempalace-mine.sh" ]; then
+      bash "${AUTOSPEC_SCRIPTS_DIR}/mempalace-mine.sh" --root "$REPO_PATH" --quiet
+    fi
+    _auto_commit "feat: auto-migrate cross-tool memory to docs/memory/ (merge)" "$REPO_ROOT"
+    ;;
+  00)
+    # Neither exists → create empty in-repo dir + symlink
+    mkdir -p "$REPO_PATH" "$(dirname "$CC_PATH")"
+    touch "$REPO_PATH/MEMORY.md"
+    ln -s "$REPO_PATH" "$CC_PATH"
+    ;;
+esac
+
+# ── Ensure AGENTS.md inventory section ───────────────────────────────────────
+_ensure_agents_md_inventory_section "$REPO_ROOT/AGENTS.md"
+
+exit 0

--- a/skills/autospec-shared/tests/unit/auto-init-memory.bats
+++ b/skills/autospec-shared/tests/unit/auto-init-memory.bats
@@ -1,0 +1,269 @@
+#!/usr/bin/env bats
+# auto-init-memory.bats — Unit tests for auto-init-memory.sh state matrix.
+#
+# Run: bats skills/autospec-shared/tests/unit/auto-init-memory.bats
+# (from repo root, or the script resolves paths relative to itself)
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/auto-init-memory.sh"
+
+setup() {
+  # Each test gets an isolated tmpdir acting as a fake home + fake repo
+  TMP_DIR="$(mktemp -d /tmp/autospec-memtest-XXXXXX)"
+  export HOME="$TMP_DIR/home"
+  mkdir -p "$HOME"
+
+  # Fake git repo (bare minimum: .git dir with HEAD so git rev-parse works)
+  FAKE_REPO="$TMP_DIR/repo"
+  mkdir -p "$FAKE_REPO"
+  git -C "$FAKE_REPO" init -q
+  git -C "$FAKE_REPO" config user.email "test@example.com"
+  git -C "$FAKE_REPO" config user.name "Test"
+  # Initial commit so HEAD is valid
+  touch "$FAKE_REPO/README.md"
+  git -C "$FAKE_REPO" add README.md
+  git -C "$FAKE_REPO" commit -q -m "init"
+
+  # CC_PATH for this fake repo — use git's canonical path (resolves /tmp → /private/tmp on macOS)
+  FAKE_REPO_REAL=$(cd "$FAKE_REPO" && git rev-parse --show-toplevel)
+  CC_SLUG=$(echo "$FAKE_REPO_REAL" | tr '/' '-')
+  CC_PATH="$HOME/.claude/projects/${CC_SLUG}/memory"
+  export CC_PATH FAKE_REPO FAKE_REPO_REAL CC_SLUG
+
+  # Disable mempalace-mine for all tests (no external dependency)
+  export AUTOSPEC_SCRIPTS_DIR="$TMP_DIR/scripts"
+  mkdir -p "$AUTOSPEC_SCRIPTS_DIR"
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+# Helper: run the script inside FAKE_REPO_REAL as cwd (canonical path, matches git rev-parse)
+run_script() {
+  run bash -c "cd \"$FAKE_REPO_REAL\" && HOME=\"$HOME\" AUTOSPEC_SCRIPTS_DIR=\"$AUTOSPEC_SCRIPTS_DIR\" bash \"$SCRIPT\" $*"
+}
+
+# ── Fast-path: symlink already correct ───────────────────────────────────────
+
+@test "fast-path: symlink already correct → exit 0, no-op" {
+  local repo_path="$FAKE_REPO_REAL/docs/memory"
+  mkdir -p "$repo_path"
+  mkdir -p "$(dirname "$CC_PATH")"
+  ln -s "$repo_path" "$CC_PATH"
+
+  # Measure elapsed time in seconds (portable: macOS date lacks %3N)
+  local start_s end_s elapsed_s
+  start_s=$(date +%s)
+  run_script
+  end_s=$(date +%s)
+
+  [ "$status" -eq 0 ]
+
+  # Verify symlink is still correct
+  [ -L "$CC_PATH" ]
+  [ "$(readlink "$CC_PATH")" = "$repo_path" ]
+
+  # Fast-path: should complete well under 1 second
+  elapsed_s=$(( end_s - start_s ))
+  [ "$elapsed_s" -lt 2 ]
+}
+
+# ── State 10: CC has files, in-repo dir missing ───────────────────────────────
+
+@test "state 10: CC has files, in-repo missing → migrate + symlink" {
+  # Set up CC memory dir with files
+  mkdir -p "$CC_PATH"
+  echo "# memory1" > "$CC_PATH/feedback_test.md"
+  echo "# memory2" > "$CC_PATH/project_test.md"
+
+  run_script
+  [ "$status" -eq 0 ]
+
+  local repo_path="$FAKE_REPO_REAL/docs/memory"
+
+  # Symlink created pointing at docs/memory/
+  [ -L "$CC_PATH" ]
+  [ "$(readlink "$CC_PATH")" = "$repo_path" ]
+
+  # Files migrated to in-repo location
+  [ -f "$repo_path/feedback_test.md" ]
+  [ -f "$repo_path/project_test.md" ]
+
+  # Backup of original CC dir created
+  local backup_count
+  backup_count=$(ls -d "${CC_PATH}.pre-migration-"* 2>/dev/null | wc -l | tr -d ' ')
+  [ "$backup_count" -ge 1 ]
+}
+
+# ── State 01: in-repo dir exists, CC missing ─────────────────────────────────
+
+@test "state 01: in-repo dir exists, CC missing → symlink only" {
+  local repo_path="$FAKE_REPO_REAL/docs/memory"
+  mkdir -p "$repo_path"
+  echo "# existing" > "$repo_path/MEMORY.md"
+
+  run_script
+  [ "$status" -eq 0 ]
+
+  # Symlink created
+  [ -L "$CC_PATH" ]
+  [ "$(readlink "$CC_PATH")" = "$repo_path" ]
+
+  # No backup needed (CC dir didn't exist)
+  local backup_count
+  backup_count=$(ls -d "${CC_PATH}.pre-migration-"* 2>/dev/null | wc -l | tr -d ' ')
+  [ "$backup_count" -eq 0 ]
+}
+
+# ── State 11: both exist ──────────────────────────────────────────────────────
+
+@test "state 11: both exist → CC wins on dup, backup, symlink" {
+  # Set up CC memory dir
+  mkdir -p "$CC_PATH"
+  echo "# cc version" > "$CC_PATH/shared.md"
+  echo "# cc only" > "$CC_PATH/cc_only.md"
+
+  # Set up in-repo dir with a different version of shared.md
+  local repo_path="$FAKE_REPO_REAL/docs/memory"
+  mkdir -p "$repo_path"
+  echo "# repo version" > "$repo_path/shared.md"
+  echo "# repo only" > "$repo_path/repo_only.md"
+
+  run_script
+  [ "$status" -eq 0 ]
+
+  # Symlink in place
+  [ -L "$CC_PATH" ]
+  [ "$(readlink "$CC_PATH")" = "$repo_path" ]
+
+  # CC-only file copied to repo
+  [ -f "$repo_path/cc_only.md" ]
+
+  # Repo-only file preserved
+  [ -f "$repo_path/repo_only.md" ]
+
+  # Repo wins on dup: --ignore-existing keeps existing repo file (repo version preserved)
+  grep -q "repo version" "$repo_path/shared.md"
+
+  # Backup created
+  local backup_count
+  backup_count=$(ls -d "${CC_PATH}.pre-migration-"* 2>/dev/null | wc -l | tr -d ' ')
+  [ "$backup_count" -ge 1 ]
+}
+
+# ── State 00: neither exists ──────────────────────────────────────────────────
+
+@test "state 00: neither exists → create empty docs/memory, symlink" {
+  run_script
+  [ "$status" -eq 0 ]
+
+  local repo_path="$FAKE_REPO_REAL/docs/memory"
+
+  # docs/memory/ created
+  [ -d "$repo_path" ]
+
+  # MEMORY.md placeholder created
+  [ -f "$repo_path/MEMORY.md" ]
+
+  # Symlink created
+  [ -L "$CC_PATH" ]
+  [ "$(readlink "$CC_PATH")" = "$repo_path" ]
+}
+
+# ── No-gh-remote case ─────────────────────────────────────────────────────────
+
+@test "no git repo → exit 0 silently, no symlink touched" {
+  # Run from a non-git directory
+  run bash -c "cd /tmp && HOME=\"$HOME\" AUTOSPEC_SCRIPTS_DIR=\"$AUTOSPEC_SCRIPTS_DIR\" bash \"$SCRIPT\""
+  [ "$status" -eq 0 ]
+
+  # No symlink created (CC_PATH parent may not even exist)
+  [ ! -L "$CC_PATH" ]
+}
+
+# ── _auto_commit failure: script still exits 0 ────────────────────────────────
+
+@test "git commit failure → symlink created, warning on stderr, exit 0" {
+  # Set up CC memory dir with a file
+  mkdir -p "$CC_PATH"
+  echo "# memory" > "$CC_PATH/feedback_test.md"
+
+  # Break git by writing a bad config
+  git -C "$FAKE_REPO" config core.hooksPath /nonexistent-hooks-dir
+
+  # Install a pre-commit hook that always fails to simulate commit failure
+  mkdir -p "$FAKE_REPO/.git/hooks"
+  printf '#!/bin/sh\nexit 1\n' > "$FAKE_REPO/.git/hooks/pre-commit"
+  chmod +x "$FAKE_REPO/.git/hooks/pre-commit"
+
+  run_script
+  [ "$status" -eq 0 ]
+
+  # Symlink still created despite git failure
+  local repo_path="$FAKE_REPO_REAL/docs/memory"
+  [ -L "$CC_PATH" ]
+  [ "$(readlink "$CC_PATH")" = "$repo_path" ]
+}
+
+# ── Idempotency: running twice is a no-op ────────────────────────────────────
+
+@test "idempotent: running script twice leaves state clean" {
+  run_script
+  [ "$status" -eq 0 ]
+
+  # Run a second time — should fast-path and exit 0
+  run_script
+  [ "$status" -eq 0 ]
+
+  local repo_path="$FAKE_REPO_REAL/docs/memory"
+  [ -L "$CC_PATH" ]
+  [ "$(readlink "$CC_PATH")" = "$repo_path" ]
+
+  # Only one backup at most (from first run if CC files existed)
+  local backup_count
+  backup_count=$(ls -d "${CC_PATH}.pre-migration-"* 2>/dev/null | wc -l | tr -d ' ')
+  [ "$backup_count" -le 1 ]
+}
+
+# ── AGENTS.md inventory appended ─────────────────────────────────────────────
+
+@test "AGENTS.md: inventory block appended when missing" {
+  run_script
+  [ "$status" -eq 0 ]
+
+  grep -q "^## Memory inventory" "$FAKE_REPO_REAL/AGENTS.md"
+}
+
+@test "AGENTS.md: inventory block not duplicated on second run" {
+  run_script
+  [ "$status" -eq 0 ]
+  run_script
+  [ "$status" -eq 0 ]
+
+  local count
+  count=$(grep -c "^## Memory inventory" "$FAKE_REPO_REAL/AGENTS.md" || echo 0)
+  [ "$count" -eq 1 ]
+}
+
+# ── Rollback ──────────────────────────────────────────────────────────────────
+
+@test "--rollback: restores most-recent backup and removes symlink" {
+  # First run to set up symlink + backup
+  mkdir -p "$CC_PATH"
+  echo "# original" > "$CC_PATH/feedback_test.md"
+
+  run_script
+  [ "$status" -eq 0 ]
+
+  # Confirm symlink is in place
+  [ -L "$CC_PATH" ]
+
+  # Run rollback
+  run bash -c "cd \"$FAKE_REPO_REAL\" && HOME=\"$HOME\" AUTOSPEC_SCRIPTS_DIR=\"$AUTOSPEC_SCRIPTS_DIR\" bash \"$SCRIPT\" --rollback"
+  [ "$status" -eq 0 ]
+
+  # Symlink removed, backup restored as real directory
+  [ ! -L "$CC_PATH" ]
+  [ -d "$CC_PATH" ]
+  [ -f "$CC_PATH/feedback_test.md" ]
+}


### PR DESCRIPTION
## Summary

- Implements `skills/autospec-shared/scripts/auto-init-memory.sh` per spec §4a
- Covers 5 state-matrix cases (fast-path, 10, 01, 11, 00), no-git-repo, commit-failure, idempotency, rollback
- `_ensure_agents_md_inventory_section` helper appended to AGENTS.md on first run
- All 11 bats tests pass; `bash scripts/validate.sh` passes

## Test plan

- [x] `bats skills/autospec-shared/tests/unit/auto-init-memory.bats` → 11/11 ok
- [x] `bash scripts/validate.sh` → OK

Closes #497