### PR TITLE
feat(memory): mempalace-mine.sh wrapper + wing/room inference (M3)

### DIFF
--- a/skills/autospec-shared/scripts/mempalace-mine.sh
+++ b/skills/autospec-shared/scripts/mempalace-mine.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# mempalace-mine.sh — Mine existing memory files and inject wing + drawer_class frontmatter.
+#
+# Iterates *.md files under --root, reads metadata.type:, injects wing: and drawer_class:
+# lines per spec §3b inference table. Idempotent: skips files already having wing:.
+# Best-effort mempalace kg-rebuild after the loop (silent fallback if CLI absent).
+#
+# Usage:
+#   mempalace-mine.sh --root <dir>            # required: memory root dir
+#   mempalace-mine.sh --root <dir> --quiet    # suppress per-file logging
+#
+# Exit codes:
+#   0 always (failures are warned but non-blocking)
+#
+# Inference table (spec §3b):
+#   metadata.type: feedback  → wing: synthesis,  drawer_class: lesson
+#   metadata.type: project   → wing: episodic,   drawer_class: session-log
+#   metadata.type: reference → wing: semantic,   drawer_class: reference
+#   metadata.type: user      → wing: semantic,   drawer_class: reference
+#   (default/unknown)        → wing: synthesis,  drawer_class: lesson
+#
+# Requires: bash 3.2+, awk, grep, cp, mv
+
+set +e
+
+ROOT=""
+QUIET=0
+
+# ── Argument parse ────────────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root)
+      ROOT="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET=1
+      shift
+      ;;
+    *)
+      echo "mempalace-mine: unknown argument: $1" >&2
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$ROOT" ]; then
+  echo "mempalace-mine: --root is required" >&2
+  exit 0
+fi
+
+if [ ! -d "$ROOT" ]; then
+  echo "mempalace-mine: root dir not found: $ROOT" >&2
+  exit 0
+fi
+
+# ── Inference table ───────────────────────────────────────────────────────────
+# Returns wing and drawer_class for a given metadata.type value
+_infer_wing_drawer() {
+  local type_val="$1"
+  case "$type_val" in
+    feedback)
+      echo "synthesis" "lesson"
+      ;;
+    project)
+      echo "episodic" "session-log"
+      ;;
+    reference)
+      echo "semantic" "reference"
+      ;;
+    user)
+      echo "semantic" "reference"
+      ;;
+    *)
+      # Default: synthesis + lesson
+      echo "synthesis" "lesson"
+      ;;
+  esac
+}
+
+# ── Inject frontmatter lines via awk ─────────────────────────────────────────
+# Inserts "  wing: <w>" and "  drawer_class: <d>" after the "  type:" line if present,
+# or after the "metadata:" line if there is no type: field.
+_inject_frontmatter() {
+  local file="$1"
+  local wing="$2"
+  local drawer="$3"
+  local has_type
+  has_type=$(grep -c "^  type:" "$file" 2>/dev/null || echo 0)
+  local tmp
+  tmp=$(mktemp /tmp/mempalace-mine-XXXXXX.md)
+
+  if [ "$has_type" -gt 0 ]; then
+    # Insert after the type: line
+    awk -v wing="$wing" -v drawer="$drawer" '
+      /^  type:/ {
+        print
+        print "  wing: " wing
+        print "  drawer_class: " drawer
+        next
+      }
+      { print }
+    ' "$file" > "$tmp" && mv "$tmp" "$file" || rm -f "$tmp"
+  else
+    # No type: line — insert after metadata: line
+    awk -v wing="$wing" -v drawer="$drawer" '
+      /^metadata:/ {
+        print
+        print "  wing: " wing
+        print "  drawer_class: " drawer
+        next
+      }
+      { print }
+    ' "$file" > "$tmp" && mv "$tmp" "$file" || rm -f "$tmp"
+  fi
+}
+
+# ── Main loop ────────────────────────────────────────────────────────────────
+processed=0
+skipped=0
+
+for md_file in "$ROOT"/*.md; do
+  # Skip if glob matched nothing
+  [ -f "$md_file" ] || continue
+
+  # Skip MEMORY.md index file
+  basename_file=$(basename "$md_file")
+  [ "$basename_file" = "MEMORY.md" ] && continue
+
+  # Idempotency guard: skip if already has wing: in frontmatter
+  if grep -q "^  wing:" "$md_file" 2>/dev/null; then
+    [ "$QUIET" -eq 0 ] && echo "mempalace-mine: skip (already mined): $basename_file"
+    skipped=$(( skipped + 1 ))
+    continue
+  fi
+
+  # Extract metadata.type value (look for "  type: <val>" in frontmatter)
+  type_val=$(grep "^  type:" "$md_file" 2>/dev/null | head -1 | sed 's/^  type:[[:space:]]*//' | tr -d '\r')
+
+  # Infer wing + drawer_class
+  read -r wing drawer <<< "$(_infer_wing_drawer "$type_val")"
+
+  [ "$QUIET" -eq 0 ] && echo "mempalace-mine: processing $basename_file (type=$type_val → wing=$wing, drawer_class=$drawer)"
+
+  _inject_frontmatter "$md_file" "$wing" "$drawer"
+  processed=$(( processed + 1 ))
+done
+
+[ "$QUIET" -eq 0 ] && echo "mempalace-mine: done — processed=$processed skipped=$skipped"
+
+# ── Best-effort KG rebuild ────────────────────────────────────────────────────
+if command -v mempalace > /dev/null 2>&1; then
+  mempalace kg-rebuild --root "$ROOT" 2>/dev/null || true
+fi
+
+exit 0

--- a/skills/autospec-shared/tests/fixtures/memory-mine/feedback_example.md
+++ b/skills/autospec-shared/tests/fixtures/memory-mine/feedback_example.md
@@ -1,0 +1,9 @@
+---
+name: feedback-example
+description: Example feedback memory file for testing.
+metadata:
+  type: feedback
+  tags: [test, example]
+---
+
+Body of the feedback memory.

--- a/skills/autospec-shared/tests/fixtures/memory-mine/project_example.md
+++ b/skills/autospec-shared/tests/fixtures/memory-mine/project_example.md
@@ -1,0 +1,9 @@
+---
+name: project-example
+description: Example project memory file for testing.
+metadata:
+  type: project
+  tags: [test, example]
+---
+
+Body of the project memory.

--- a/skills/autospec-shared/tests/fixtures/memory-mine/reference_example.md
+++ b/skills/autospec-shared/tests/fixtures/memory-mine/reference_example.md
@@ -1,0 +1,9 @@
+---
+name: reference-example
+description: Example reference memory file for testing.
+metadata:
+  type: reference
+  tags: [test, example]
+---
+
+Body of the reference memory.

--- a/skills/autospec-shared/tests/fixtures/memory-mine/user_example.md
+++ b/skills/autospec-shared/tests/fixtures/memory-mine/user_example.md
@@ -1,0 +1,9 @@
+---
+name: user-example
+description: Example user memory file for testing.
+metadata:
+  type: user
+  tags: [test, example]
+---
+
+Body of the user memory.

--- a/skills/autospec-shared/tests/unit/mempalace-mine.bats
+++ b/skills/autospec-shared/tests/unit/mempalace-mine.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+# mempalace-mine.bats — Unit tests for mempalace-mine.sh wing+drawer_class inference.
+#
+# Run: bats skills/autospec-shared/tests/unit/mempalace-mine.bats
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/mempalace-mine.sh"
+FIXTURES="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/tests/fixtures/memory-mine"
+
+setup() {
+  TMP_DIR="$(mktemp -d /tmp/autospec-minetest-XXXXXX)"
+  # Copy fixtures into tmpdir so each test gets a fresh mutable copy
+  cp "$FIXTURES"/*.md "$TMP_DIR"/
+  export TMP_DIR
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+# ── Inference: feedback → synthesis / lesson ──────────────────────────────────
+
+@test "feedback type → wing: synthesis, drawer_class: lesson" {
+  run bash "$SCRIPT" --root "$TMP_DIR" --quiet
+  [ "$status" -eq 0 ]
+
+  grep -q "^  wing: synthesis" "$TMP_DIR/feedback_example.md"
+  grep -q "^  drawer_class: lesson" "$TMP_DIR/feedback_example.md"
+}
+
+# ── Inference: project → episodic / session-log ───────────────────────────────
+
+@test "project type → wing: episodic, drawer_class: session-log" {
+  run bash "$SCRIPT" --root "$TMP_DIR" --quiet
+  [ "$status" -eq 0 ]
+
+  grep -q "^  wing: episodic" "$TMP_DIR/project_example.md"
+  grep -q "^  drawer_class: session-log" "$TMP_DIR/project_example.md"
+}
+
+# ── Inference: reference → semantic / reference ───────────────────────────────
+
+@test "reference type → wing: semantic, drawer_class: reference" {
+  run bash "$SCRIPT" --root "$TMP_DIR" --quiet
+  [ "$status" -eq 0 ]
+
+  grep -q "^  wing: semantic" "$TMP_DIR/reference_example.md"
+  grep -q "^  drawer_class: reference" "$TMP_DIR/reference_example.md"
+}
+
+# ── Inference: user → semantic / reference ────────────────────────────────────
+
+@test "user type → wing: semantic, drawer_class: reference" {
+  run bash "$SCRIPT" --root "$TMP_DIR" --quiet
+  [ "$status" -eq 0 ]
+
+  grep -q "^  wing: semantic" "$TMP_DIR/user_example.md"
+  grep -q "^  drawer_class: reference" "$TMP_DIR/user_example.md"
+}
+
+# ── Inference: unknown/missing type → synthesis / lesson (default) ────────────
+
+@test "unknown type → default wing: synthesis, drawer_class: lesson" {
+  # Create a file with no type field
+  cat > "$TMP_DIR/unknown_example.md" <<'EOF'
+---
+name: unknown-example
+description: No type field.
+metadata:
+  tags: [test]
+---
+
+Body.
+EOF
+
+  run bash "$SCRIPT" --root "$TMP_DIR" --quiet
+  [ "$status" -eq 0 ]
+
+  grep -q "^  wing: synthesis" "$TMP_DIR/unknown_example.md"
+  grep -q "^  drawer_class: lesson" "$TMP_DIR/unknown_example.md"
+}
+
+# ── MEMORY.md index file is skipped ──────────────────────────────────────────
+
+@test "MEMORY.md is skipped (not modified)" {
+  cat > "$TMP_DIR/MEMORY.md" <<'EOF'
+# Memory Index
+
+- [feedback_example](feedback_example.md)
+EOF
+  local before
+  before=$(cat "$TMP_DIR/MEMORY.md")
+
+  run bash "$SCRIPT" --root "$TMP_DIR" --quiet
+  [ "$status" -eq 0 ]
+
+  local after
+  after=$(cat "$TMP_DIR/MEMORY.md")
+  [ "$before" = "$after" ]
+}
+
+# ── Idempotency: running twice leaves frontmatter unchanged ───────────────────
+
+@test "idempotent: running miner twice produces same frontmatter" {
+  run bash "$SCRIPT" --root "$TMP_DIR" --quiet
+  [ "$status" -eq 0 ]
+
+  local after_first
+  after_first=$(cat "$TMP_DIR/feedback_example.md")
+
+  run bash "$SCRIPT" --root "$TMP_DIR" --quiet
+  [ "$status" -eq 0 ]
+
+  local after_second
+  after_second=$(cat "$TMP_DIR/feedback_example.md")
+
+  [ "$after_first" = "$after_second" ]
+}
+
+@test "idempotent: wing: appears exactly once after two runs" {
+  run bash "$SCRIPT" --root "$TMP_DIR" --quiet
+  [ "$status" -eq 0 ]
+  run bash "$SCRIPT" --root "$TMP_DIR" --quiet
+  [ "$status" -eq 0 ]
+
+  local count
+  count=$(grep -c "^  wing:" "$TMP_DIR/feedback_example.md")
+  [ "$count" -eq 1 ]
+}
+
+# ── Missing --root exits 0 silently ──────────────────────────────────────────
+
+@test "missing --root → exit 0 with error to stderr" {
+  run bash "$SCRIPT" --quiet
+  [ "$status" -eq 0 ]
+}
+
+# ── Non-existent root dir exits 0 silently ────────────────────────────────────
+
+@test "non-existent root dir → exit 0 with error to stderr" {
+  run bash "$SCRIPT" --root /nonexistent-dir-xyz --quiet
+  [ "$status" -eq 0 ]
+}
+
+# ── Frontmatter lines inserted in correct order ───────────────────────────────
+
+@test "wing: and drawer_class: inserted after type: line" {
+  run bash "$SCRIPT" --root "$TMP_DIR" --quiet
+  [ "$status" -eq 0 ]
+
+  # Find line numbers: type must come before wing, wing before drawer_class
+  local type_line wing_line drawer_line
+  type_line=$(grep -n "^  type:" "$TMP_DIR/feedback_example.md" | head -1 | cut -d: -f1)
+  wing_line=$(grep -n "^  wing:" "$TMP_DIR/feedback_example.md" | head -1 | cut -d: -f1)
+  drawer_line=$(grep -n "^  drawer_class:" "$TMP_DIR/feedback_example.md" | head -1 | cut -d: -f1)
+
+  [ "$type_line" -lt "$wing_line" ]
+  [ "$wing_line" -lt "$drawer_line" ]
+}


### PR DESCRIPTION
## Summary

- Implements `skills/autospec-shared/scripts/mempalace-mine.sh` per spec §3b inference table
- Injects `wing:` and `drawer_class:` frontmatter fields for all 4 `metadata.type` values (feedback/project/reference/user) plus unknown/missing type default
- Handles files with no `type:` field by inserting after `metadata:` line
- Idempotent: skips files already having `wing:` in frontmatter
- Best-effort `mempalace kg-rebuild` when CLI is available
- 4 fixture files covering each inference case
- All 11 bats tests pass; `bash scripts/validate.sh` passes

## Test plan

- [x] `bats skills/autospec-shared/tests/unit/mempalace-mine.bats` → 11/11 ok
- [x] `bash scripts/validate.sh` → OK

Closes #499