### PR TITLE
feat(memory): wire auto-init-memory.sh into all autospec SKILL trios (M4)

### DIFF
--- a/skills/autospec-classify/SKILL.md
+++ b/skills/autospec-classify/SKILL.md
@@ -52,6 +52,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-classify/codex/prompt.md
+++ b/skills/autospec-classify/codex/prompt.md
@@ -48,6 +48,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-classify/opencode/agent.md
+++ b/skills/autospec-classify/opencode/agent.md
@@ -52,6 +52,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -54,6 +54,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -50,6 +50,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -54,6 +54,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-listen/SKILL.md
+++ b/skills/autospec-listen/SKILL.md
@@ -49,6 +49,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-listen/codex/prompt.md
+++ b/skills/autospec-listen/codex/prompt.md
@@ -44,6 +44,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-listen/opencode/agent.md
+++ b/skills/autospec-listen/opencode/agent.md
@@ -48,6 +48,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -51,6 +51,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -47,6 +47,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -51,6 +51,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-shared/tests/unit/skill-trio-memory-wired.bats
+++ b/skills/autospec-shared/tests/unit/skill-trio-memory-wired.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# skill-trio-memory-wired.bats — assert auto-init-memory.sh is wired into every
+# autospec-* SKILL trio (SKILL.md + codex/prompt.md + opencode/agent.md).
+#
+# Run: bats skills/autospec-shared/tests/unit/skill-trio-memory-wired.bats
+# (from repo root)
+
+# tests/unit is 2 levels deep inside autospec-shared, which is inside skills/
+# So go up 4 levels: unit -> tests -> autospec-shared -> skills -> repo root
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../../.." && pwd)"
+
+# Skills that have the startup self-update block and therefore require wiring.
+# autospec-e2e-clone, autospec-review, and autospec-test have no self-update
+# block and are excluded per issue #500 scope.
+WIRED_SKILLS=(
+  autospec
+  autospec-classify
+  autospec-define
+  autospec-listen
+  autospec-run
+  autospec-split
+  autospec-stop
+  autospec-story
+)
+
+# ── SKILL.md checks ──────────────────────────────────────────────────────────
+
+@test "every wired skill SKILL.md contains exactly one auto-init-memory.sh invocation" {
+  for skill in "${WIRED_SKILLS[@]}"; do
+    local f="$REPO_ROOT/skills/$skill/SKILL.md"
+    [ -f "$f" ] || { echo "MISSING: $f" >&2; return 1; }
+    local count
+    count=$(grep -cF 'auto-init-memory.sh' "$f" || true)
+    [ "$count" -eq 1 ] || { echo "$skill/SKILL.md: expected 1 occurrence, got $count" >&2; return 1; }
+  done
+}
+
+# ── codex/prompt.md checks ───────────────────────────────────────────────────
+
+@test "every wired skill codex/prompt.md contains exactly one auto-init-memory.sh invocation" {
+  for skill in "${WIRED_SKILLS[@]}"; do
+    local f="$REPO_ROOT/skills/$skill/codex/prompt.md"
+    [ -f "$f" ] || { echo "MISSING: $f" >&2; return 1; }
+    local count
+    count=$(grep -cF 'auto-init-memory.sh' "$f" || true)
+    [ "$count" -eq 1 ] || { echo "$skill/codex/prompt.md: expected 1 occurrence, got $count" >&2; return 1; }
+  done
+}
+
+# ── opencode/agent.md checks (trio skills only) ──────────────────────────────
+
+@test "every wired trio skill opencode/agent.md contains exactly one auto-init-memory.sh invocation" {
+  for skill in "${WIRED_SKILLS[@]}"; do
+    local f="$REPO_ROOT/skills/$skill/opencode/agent.md"
+    [ -f "$f" ] || { echo "MISSING (expected trio): $f" >&2; return 1; }
+    local count
+    count=$(grep -cF 'auto-init-memory.sh' "$f" || true)
+    [ "$count" -eq 1 ] || { echo "$skill/opencode/agent.md: expected 1 occurrence, got $count" >&2; return 1; }
+  done
+}
+
+# ── Byte-identical two-line block ────────────────────────────────────────────
+
+@test "auto-init block is byte-identical across each skill trio" {
+  for skill in "${WIRED_SKILLS[@]}"; do
+    local skill_md="$REPO_ROOT/skills/$skill/SKILL.md"
+    local codex_md="$REPO_ROOT/skills/$skill/codex/prompt.md"
+    local opencode_md="$REPO_ROOT/skills/$skill/opencode/agent.md"
+
+    local block_skill block_codex block_opencode
+    block_skill=$(grep -A1 '# Auto-init cross-tool memory' "$skill_md" 2>/dev/null || true)
+    block_codex=$(grep -A1 '# Auto-init cross-tool memory' "$codex_md" 2>/dev/null || true)
+    block_opencode=$(grep -A1 '# Auto-init cross-tool memory' "$opencode_md" 2>/dev/null || true)
+
+    [ -n "$block_skill" ] || { echo "$skill/SKILL.md: auto-init comment block not found" >&2; return 1; }
+    [ "$block_skill" = "$block_codex" ] \
+      || { echo "$skill: SKILL.md vs codex/prompt.md auto-init block differs" >&2; return 1; }
+    [ "$block_skill" = "$block_opencode" ] \
+      || { echo "$skill: SKILL.md vs opencode/agent.md auto-init block differs" >&2; return 1; }
+  done
+}
+
+# ── validate.sh passes ───────────────────────────────────────────────────────
+
+@test "bash scripts/validate.sh exits 0" {
+  run bash "$REPO_ROOT/scripts/validate.sh"
+  if [ "$status" -ne 0 ]; then
+    echo "validate.sh output:" >&2
+    echo "$output" >&2
+  fi
+  [ "$status" -eq 0 ]
+}

--- a/skills/autospec-split/SKILL.md
+++ b/skills/autospec-split/SKILL.md
@@ -50,6 +50,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-split/codex/prompt.md
+++ b/skills/autospec-split/codex/prompt.md
@@ -46,6 +46,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-split/opencode/agent.md
+++ b/skills/autospec-split/opencode/agent.md
@@ -50,6 +50,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-stop/SKILL.md
+++ b/skills/autospec-stop/SKILL.md
@@ -49,6 +49,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-stop/codex/prompt.md
+++ b/skills/autospec-stop/codex/prompt.md
@@ -45,6 +45,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-stop/opencode/agent.md
+++ b/skills/autospec-stop/opencode/agent.md
@@ -49,6 +49,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-story/SKILL.md
+++ b/skills/autospec-story/SKILL.md
@@ -53,6 +53,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-story/codex/prompt.md
+++ b/skills/autospec-story/codex/prompt.md
@@ -49,6 +49,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec-story/opencode/agent.md
+++ b/skills/autospec-story/opencode/agent.md
@@ -53,6 +53,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -54,6 +54,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -50,6 +50,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -54,6 +54,8 @@ if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
 fi
 printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
 echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 ```
 


### PR DESCRIPTION
## Summary

- Inserts the two-line `auto-init-memory.sh` block immediately after the startup self-update anchor in all 8 autospec skills with a self-update block: autospec, autospec-classify, autospec-define, autospec-listen, autospec-run, autospec-split, autospec-stop, autospec-story
- Applies byte-identical edit to `SKILL.md`, `codex/prompt.md`, and `opencode/agent.md` for each skill (24 files total)
- Adds `skill-trio-memory-wired.bats` asserting every trio has exactly one `auto-init-memory.sh` invocation and `validate.sh` exits 0

## Verification

```
bats skills/autospec-shared/tests/unit/skill-trio-memory-wired.bats
bash scripts/validate.sh
```

All 5 bats tests pass. validate.sh exits 0.

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)