### PR TITLE
feat(memory): auto-install mempalace CLI on first migration

### DIFF
--- a/skills/autospec-shared/scripts/auto-init-memory.sh
+++ b/skills/autospec-shared/scripts/auto-init-memory.sh
@@ -60,8 +60,32 @@ Memory types (mempalace wings):
 - **procedural** — playbooks, runbooks, recipes (also see SKILL.md files)
 - **synthesis** — lessons learned (feedback patterns, anti-patterns, gotchas)
 
-Read memories relevant to your task at session start. Write new memories by adding/editing files in `docs/memory/` and updating the index. Mempalace MCP layer (`mempalace search`, `mempalace traverse`, `mempalace kg_query`) is available if your tool supports MCP.
+Read memories relevant to your task at session start. Write new memories by adding/editing files in `docs/memory/` and updating the index. Mempalace MCP layer (`mempalace search`, `mempalace traverse`, `mempalace kg_query`) is auto-installed on first run via pipx/uv/pip (opt out: `AUTOSPEC_SKIP_MEMPALACE_INSTALL=1`).
 AGENTS_BLOCK
+  return 0
+}
+
+_ensure_mempalace_installed() {
+  # Best-effort install of mempalace CLI on first migration. Idempotent — no-op
+  # if already on PATH. Opt out with AUTOSPEC_SKIP_MEMPALACE_INSTALL=1.
+  [ "${AUTOSPEC_SKIP_MEMPALACE_INSTALL:-0}" = "1" ] && return 0
+  command -v mempalace > /dev/null 2>&1 && return 0
+
+  # Prefer pipx (isolated venv per tool), then uv, then pip --user. All silent
+  # failures — mempalace is optional; absence only loses the KG/search overlay.
+  if command -v pipx > /dev/null 2>&1; then
+    pipx install mempalace > /dev/null 2>&1 && \
+      echo "auto-init-memory: installed mempalace via pipx" >&2
+  elif command -v uv > /dev/null 2>&1; then
+    uv tool install mempalace > /dev/null 2>&1 && \
+      echo "auto-init-memory: installed mempalace via uv" >&2
+  elif command -v pip3 > /dev/null 2>&1; then
+    pip3 install --user --quiet mempalace > /dev/null 2>&1 && \
+      echo "auto-init-memory: installed mempalace via pip3 --user" >&2
+  elif command -v pip > /dev/null 2>&1; then
+    pip install --user --quiet mempalace > /dev/null 2>&1 && \
+      echo "auto-init-memory: installed mempalace via pip --user" >&2
+  fi
   return 0
 }
 
@@ -120,6 +144,9 @@ if [ -d "$REPO_PATH" ]; then
 else
   REPO_HAS_DIR=0
 fi
+
+# ── Ensure mempalace CLI (best-effort, optional KG overlay) ──────────────────
+_ensure_mempalace_installed
 
 # ── State matrix ──────────────────────────────────────────────────────────────
 BACKUP_SUFFIX="pre-migration-$(date +%Y%m%d-%H%M%S)"

--- a/skills/autospec-shared/tests/unit/auto-init-memory.bats
+++ b/skills/autospec-shared/tests/unit/auto-init-memory.bats
@@ -32,6 +32,9 @@ setup() {
   # Disable mempalace-mine for all tests (no external dependency)
   export AUTOSPEC_SCRIPTS_DIR="$TMP_DIR/scripts"
   mkdir -p "$AUTOSPEC_SCRIPTS_DIR"
+
+  # Suppress mempalace auto-install in all tests (network + pipx/pip side effects)
+  export AUTOSPEC_SKIP_MEMPALACE_INSTALL=1
 }
 
 teardown() {
@@ -266,4 +269,36 @@ run_script() {
   [ ! -L "$CC_PATH" ]
   [ -d "$CC_PATH" ]
   [ -f "$CC_PATH/feedback_test.md" ]
+}
+
+# ── Mempalace auto-install opt-out ────────────────────────────────────────────
+
+@test "AUTOSPEC_SKIP_MEMPALACE_INSTALL=1 → no install attempted" {
+  # Run a fresh CC_HAS_FILES migration; helper must be a no-op under SKIP=1
+  mkdir -p "$CC_PATH"
+  echo "# m" > "$CC_PATH/feedback_t.md"
+
+  run_script
+  [ "$status" -eq 0 ]
+  # Stderr must NOT mention any installer (pipx/uv/pip)
+  [[ "$output" != *"installed mempalace via"* ]]
+}
+
+@test "mempalace already on PATH → helper is no-op (no install lines logged)" {
+  # Shim a fake mempalace into a tmp bindir at the front of PATH
+  local BIN="$TMP_DIR/bin"
+  mkdir -p "$BIN"
+  cat > "$BIN/mempalace" <<'SHIM'
+#!/usr/bin/env bash
+exit 0
+SHIM
+  chmod +x "$BIN/mempalace"
+
+  mkdir -p "$CC_PATH"
+  echo "# m" > "$CC_PATH/feedback_t.md"
+
+  # Re-run with SKIP unset but mempalace on PATH (helper short-circuits via command -v)
+  run bash -c "cd \"$FAKE_REPO_REAL\" && HOME=\"$HOME\" PATH=\"$BIN:$PATH\" AUTOSPEC_SCRIPTS_DIR=\"$AUTOSPEC_SCRIPTS_DIR\" AUTOSPEC_SKIP_MEMPALACE_INSTALL=0 bash \"$SCRIPT\""
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"installed mempalace via"* ]]
 }


### PR DESCRIPTION
## Summary

- `auto-init-memory.sh` now installs the mempalace CLI on first run when missing (tries pipx → uv → pip3 --user → pip --user).
- All install attempts are silent best-effort: mempalace is optional, so failure only loses the KG/search overlay; the shared-memory floor still works.
- Opt out via `AUTOSPEC_SKIP_MEMPALACE_INSTALL=1` (set by default in bats setup so tests don't hit the network).

## Test plan

- [x] `bats skills/autospec-shared/tests/unit/auto-init-memory.bats` — 13/13 pass
- [x] Verified on this repo: helper short-circuits because mempalace is already on PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)