### PR TITLE
feat(memory): AAAK compression GC for growing memory dirs (#510)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,9 +291,13 @@ Scripts for managing project memory files under `AUTOSPEC_MEMORY_DIR`
 | `scripts/memory-tags.yml` | Manifest mapping each `feedback_*.md` to 4–5 tags | — (data file) |
 | `scripts/apply-memory-tags.sh` | Idempotent tagger: prepends `tags:` YAML frontmatter to each `feedback_*.md` | `--dry-run`, `--memory-dir DIR`, `--manifest FILE` |
 | `scripts/install-implementer-precommit.sh` | Installs blocking pre-commit lint hook into an implementer worktree | `<worktree-path>` positional arg |
+| `skills/autospec-shared/scripts/mempalace-compress.sh` | AAAK compression GC: wraps `mempalace compress`; no-op below LOC threshold | `--dir DIR`, `--threshold LOC`, `--dry-run`, `--quiet` |
 
 `AUTOSPEC_MEMORY_DIR` — override for the memory directory path (default: auto-detected
 from `$HOME/.claude/projects/`).
+
+`AUTOSPEC_COMPRESS_THRESHOLD` — LOC threshold for `mempalace-compress.sh` (default: `5000`).
+`AUTOSPEC_COMPRESS_EVERY` — invoke compress every N calls to `auto-init-memory.sh` (default: `10`).
 
 ## Pre-commit lint hook
 

--- a/skills/autospec-shared/scripts/auto-init-memory.sh
+++ b/skills/autospec-shared/scripts/auto-init-memory.sh
@@ -192,4 +192,21 @@ esac
 # ── Ensure AGENTS.md inventory section ───────────────────────────────────────
 _ensure_agents_md_inventory_section "$REPO_ROOT/AGENTS.md"
 
+# ── Lazy AAAK compression gate ───────────────────────────────────────────────
+# Trigger once per N invocations (default: every 10) to keep memory LOC small.
+# Falls through silently if mempalace-compress.sh is absent or mempalace is not installed.
+if [ -x "${AUTOSPEC_SCRIPTS_DIR}/mempalace-compress.sh" ]; then
+  _invoke_counter_file="$HOME/.autospec/auto-init-memory-count"
+  _invoke_count=$(cat "$_invoke_counter_file" 2>/dev/null || echo 0)
+  _invoke_count=$(( _invoke_count + 1 ))
+  printf '%s\n' "$_invoke_count" > "$_invoke_counter_file"
+  _compress_every="${AUTOSPEC_COMPRESS_EVERY:-10}"
+  if [ "$(( _invoke_count % _compress_every ))" -eq 0 ]; then
+    bash "${AUTOSPEC_SCRIPTS_DIR}/mempalace-compress.sh" \
+      --dir "$REPO_PATH" \
+      --threshold "${AUTOSPEC_COMPRESS_THRESHOLD:-5000}" \
+      --quiet
+  fi
+fi
+
 exit 0

--- a/skills/autospec-shared/scripts/mempalace-compress.sh
+++ b/skills/autospec-shared/scripts/mempalace-compress.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# mempalace-compress.sh — Trigger AAAK compression when memory dir exceeds a LOC threshold.
+#
+# Wraps `mempalace compress` — no-op when below threshold or when mempalace is absent.
+#
+# Usage:
+#   mempalace-compress.sh --dir <path>              # required: memory dir to measure
+#   mempalace-compress.sh --dir <path> --threshold <loc>   # default: 5000
+#   mempalace-compress.sh --dir <path> --threshold <loc> --dry-run
+#   mempalace-compress.sh --dir <path> --threshold <loc> --quiet
+#
+# Exit codes:
+#   0 always (mempalace absence is a silent skip, not a failure)
+#
+# Environment:
+#   AUTOSPEC_COMPRESS_THRESHOLD  — fallback default threshold if --threshold not given
+#
+# Requires: bash 3.2+, wc
+# Optional: mempalace CLI (silent skip when absent)
+
+set +e
+
+DIR=""
+THRESHOLD="${AUTOSPEC_COMPRESS_THRESHOLD:-5000}"
+DRY_RUN=0
+QUIET=0
+
+# ── Argument parse ────────────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dir)
+      DIR="$2"
+      shift 2
+      ;;
+    --threshold)
+      THRESHOLD="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --quiet)
+      QUIET=1
+      shift
+      ;;
+    --help|-h)
+      printf 'Usage: mempalace-compress.sh --dir <path> [--threshold <loc>] [--dry-run] [--quiet]\n'
+      exit 0
+      ;;
+    *)
+      [ "$QUIET" -eq 0 ] && echo "mempalace-compress: unknown argument: $1" >&2
+      shift
+      ;;
+  esac
+done
+
+# ── Guard: missing or empty dir → silent no-op ───────────────────────────────
+if [ -z "$DIR" ] || [ ! -d "$DIR" ]; then
+  exit 0
+fi
+
+# ── Guard: mempalace absent → silent skip ────────────────────────────────────
+# MEMPALACE_CMD may be overridden for testing; defaults to the system mempalace.
+MEMPALACE_CMD="${MEMPALACE_CMD:-mempalace}"
+if ! command -v "$MEMPALACE_CMD" > /dev/null 2>&1; then
+  exit 0
+fi
+
+# ── Measure total LOC in dir ─────────────────────────────────────────────────
+total_loc=$(find "$DIR" -maxdepth 3 -name "*.md" -exec wc -l {} + 2>/dev/null \
+  | awk '/total$/{print $1}' | tail -1)
+total_loc="${total_loc:-0}"
+
+[ "$QUIET" -eq 0 ] && echo "mempalace-compress: dir=$DIR loc=$total_loc threshold=$THRESHOLD"
+
+# ── Below threshold → no-op ──────────────────────────────────────────────────
+if [ "$total_loc" -le "$THRESHOLD" ] 2>/dev/null; then
+  [ "$QUIET" -eq 0 ] && echo "mempalace-compress: below threshold; no compression needed"
+  exit 0
+fi
+
+# ── Above threshold → compress ───────────────────────────────────────────────
+[ "$QUIET" -eq 0 ] && echo "mempalace-compress: threshold exceeded ($total_loc > $THRESHOLD); compressing"
+
+_compress_args="compress"
+if [ "$DRY_RUN" -eq 1 ]; then
+  _compress_args="$_compress_args --dry-run"
+fi
+
+"$MEMPALACE_CMD" $_compress_args
+exit 0

--- a/tests/mempalace-compress.bats
+++ b/tests/mempalace-compress.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+# tests/mempalace-compress.bats — tests for skills/autospec-shared/scripts/mempalace-compress.sh
+# Covers: below-threshold no-op, above-threshold compress, missing-mempalace silent skip
+
+SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/mempalace-compress.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    # Create a small fake memory dir with a few .md files (5 lines total)
+    mkdir -p "$TEST_TMP/docs/memory"
+    printf 'line1\nline2\nline3\n' > "$TEST_TMP/docs/memory/a.md"
+    printf 'line1\nline2\n'       > "$TEST_TMP/docs/memory/b.md"
+
+    # Stub mempalace: records calls to a log file, exits 0
+    STUB_MEMPALACE="$TEST_TMP/stub_mempalace"
+    CALLS_LOG="$TEST_TMP/mempalace-calls.log"
+    cat > "$STUB_MEMPALACE" <<STUB
+#!/usr/bin/env bash
+echo "mempalace \$*" >> "$CALLS_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_MEMPALACE"
+
+    export TEST_TMP STUB_MEMPALACE CALLS_LOG
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+# ── basic sanity ──────────────────────────────────────────────────────────────
+
+@test "mempalace-compress.sh exists and is executable" {
+    [ -x "$SCRIPT" ]
+}
+
+@test "mempalace-compress.sh --help exits 0" {
+    run bash "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+}
+
+# ── below-threshold: no-op ────────────────────────────────────────────────────
+
+@test "below-threshold: exits 0 and does not invoke mempalace" {
+    # 5 lines total; threshold 10000 → no-op
+    run env MEMPALACE_CMD="$STUB_MEMPALACE" \
+        bash "$SCRIPT" --dir "$TEST_TMP/docs/memory" --threshold 10000
+    [ "$status" -eq 0 ]
+    [ ! -f "$CALLS_LOG" ]
+}
+
+@test "below-threshold with --dry-run: exits 0 and does not invoke mempalace" {
+    run env MEMPALACE_CMD="$STUB_MEMPALACE" \
+        bash "$SCRIPT" --dir "$TEST_TMP/docs/memory" --threshold 10000 --dry-run
+    [ "$status" -eq 0 ]
+    [ ! -f "$CALLS_LOG" ]
+}
+
+# ── above-threshold: triggers compression ────────────────────────────────────
+
+@test "above-threshold: exits 0 and invokes mempalace compress" {
+    # 5 lines; threshold 1 → above → compress
+    run env MEMPALACE_CMD="$STUB_MEMPALACE" \
+        bash "$SCRIPT" --dir "$TEST_TMP/docs/memory" --threshold 1
+    [ "$status" -eq 0 ]
+    [ -f "$CALLS_LOG" ]
+    grep -q "compress" "$CALLS_LOG"
+}
+
+@test "above-threshold with --dry-run: passes --dry-run to mempalace" {
+    run env MEMPALACE_CMD="$STUB_MEMPALACE" \
+        bash "$SCRIPT" --dir "$TEST_TMP/docs/memory" --threshold 1 --dry-run
+    [ "$status" -eq 0 ]
+    [ -f "$CALLS_LOG" ]
+    grep -q "\-\-dry-run" "$CALLS_LOG"
+}
+
+@test "above-threshold with --quiet: suppresses stdout" {
+    run env MEMPALACE_CMD="$STUB_MEMPALACE" \
+        bash "$SCRIPT" --dir "$TEST_TMP/docs/memory" --threshold 1 --quiet
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ── missing mempalace: silent skip ────────────────────────────────────────────
+
+@test "missing mempalace: exits 0 silently" {
+    # Point MEMPALACE_CMD at a nonexistent path so command -v fails
+    run env MEMPALACE_CMD="$TEST_TMP/no_such_mempalace" \
+        bash "$SCRIPT" --dir "$TEST_TMP/docs/memory" --threshold 1
+    [ "$status" -eq 0 ]
+}
+
+@test "missing mempalace: no error output when --quiet" {
+    run env MEMPALACE_CMD="$TEST_TMP/no_such_mempalace" \
+        bash "$SCRIPT" --dir "$TEST_TMP/docs/memory" --threshold 1 --quiet
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ── missing dir: graceful ─────────────────────────────────────────────────────
+
+@test "missing --dir: exits 0 (no-op)" {
+    run env MEMPALACE_CMD="$STUB_MEMPALACE" \
+        bash "$SCRIPT" --dir "$TEST_TMP/nonexistent" --threshold 100
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #510

## Summary

- Adds `skills/autospec-shared/scripts/mempalace-compress.sh` — wraps `mempalace compress` with a `--threshold <loc>` gate; no-op below threshold, compresses above. Supports `--dry-run`, `--quiet`, and gracefully skips when mempalace is absent.
- Wires compress step into `auto-init-memory.sh` as a lazy periodic call (every `AUTOSPEC_COMPRESS_EVERY` invocations, default 10) against the resolved `REPO_PATH`.
- Adds `tests/mempalace-compress.bats` with 10 tests covering all acceptance criteria.

## Test plan

- [x] `--threshold 10000` on a small dir is a no-op (test 3)
- [x] `--threshold 1` triggers compression (test 5)
- [x] Bats covers below-threshold no-op, above-threshold compress, missing-mempalace silent skip (tests 3,5,8,9)
- [x] `--dry-run` passed through to mempalace (test 6)
- [x] `--quiet` suppresses output (test 7)
- [x] All 10 bats tests green
- [x] `bash -n` syntax check passes on both scripts
- [x] Existing `validate.bats` still passes (4/4)