### PR TITLE
feat(memory): inject relevant memory into skill prompts (#512)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,7 @@ Scripts for managing project memory files under `AUTOSPEC_MEMORY_DIR`
 | `scripts/install-implementer-precommit.sh` | Installs blocking pre-commit lint hook into an implementer worktree | `<worktree-path>` positional arg |
 | `skills/autospec-shared/scripts/mempalace-compress.sh` | AAAK compression GC: wraps `mempalace compress`; no-op below LOC threshold | `--dir DIR`, `--threshold LOC`, `--dry-run`, `--quiet` |
 | `skills/autospec-shared/scripts/mine-pr-history.sh` | Extract lessons from merged PR descriptions into `docs/memory/lesson_*.md` | `--repo OWNER/REPO`, `--output-dir DIR`, `--quiet` |
+| `skills/autospec-shared/scripts/inject-relevant-memory.sh` | Grep/search `docs/memory/*.md` for keyword matches; emit top-k context block for skill prompt injection | `--context KEYWORDS`, `--top-k N`, `--memory-dir DIR` |
 
 `AUTOSPEC_MEMORY_DIR` — override for the memory directory path (default: auto-detected
 from `$HOME/.claude/projects/`).

--- a/skills/autospec-classify/SKILL.md
+++ b/skills/autospec-classify/SKILL.md
@@ -132,6 +132,19 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Relevant memory injection (run-start, once)
+
+Before executing the main pipeline phases, call the injector to surface relevant saved lessons:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh" \
+  --context "<skill-relevant keywords from request/issue/spec>" \
+  --top-k 5
+```
+
+Prepend the output block (if non-empty) to your working context. This surfaces lessons like
+`feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
+
 ## Pre-flight
 
 1. Verify `gh auth status` is authenticated.

--- a/skills/autospec-classify/codex/prompt.md
+++ b/skills/autospec-classify/codex/prompt.md
@@ -127,6 +127,19 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Relevant memory injection (run-start, once)
+
+Before executing the main pipeline phases, call the injector to surface relevant saved lessons:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh" \
+  --context "<skill-relevant keywords from request/issue/spec>" \
+  --top-k 5
+```
+
+Prepend the output block (if non-empty) to your working context. This surfaces lessons like
+`feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
+
 ## Pre-flight
 
 1. Verify `gh auth status` is authenticated.

--- a/skills/autospec-classify/opencode/agent.md
+++ b/skills/autospec-classify/opencode/agent.md
@@ -131,6 +131,19 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Relevant memory injection (run-start, once)
+
+Before executing the main pipeline phases, call the injector to surface relevant saved lessons:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh" \
+  --context "<skill-relevant keywords from request/issue/spec>" \
+  --top-k 5
+```
+
+Prepend the output block (if non-empty) to your working context. This surfaces lessons like
+`feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
+
 ## Pre-flight
 
 1. Verify `gh auth status` is authenticated.

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -162,6 +162,19 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Relevant memory injection (run-start, once)
+
+Before executing the main pipeline phases, call the injector to surface relevant saved lessons:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh" \
+  --context "<skill-relevant keywords from request/issue/spec>" \
+  --top-k 5
+```
+
+Prepend the output block (if non-empty) to your working context. This surfaces lessons like
+`feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
+
 ## Phase 0 — Bootstrap repo (if missing)
 
 Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -156,6 +156,19 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Relevant memory injection (run-start, once)
+
+Before executing the main pipeline phases, call the injector to surface relevant saved lessons:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh" \
+  --context "<skill-relevant keywords from request/issue/spec>" \
+  --top-k 5
+```
+
+Prepend the output block (if non-empty) to your working context. This surfaces lessons like
+`feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
+
 ## Phase 0 — Bootstrap repo (if missing)
 
 Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -160,6 +160,19 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Relevant memory injection (run-start, once)
+
+Before executing the main pipeline phases, call the injector to surface relevant saved lessons:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh" \
+  --context "<skill-relevant keywords from request/issue/spec>" \
+  --top-k 5
+```
+
+Prepend the output block (if non-empty) to your working context. This surfaces lessons like
+`feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
+
 ## Phase 0 — Bootstrap repo (if missing)
 
 Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.

--- a/skills/autospec-review/SKILL.md
+++ b/skills/autospec-review/SKILL.md
@@ -53,6 +53,19 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Relevant memory injection (run-start, once)
+
+Before executing the main pipeline phases, call the injector to surface relevant saved lessons:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh" \
+  --context "<skill-relevant keywords from request/issue/spec>" \
+  --top-k 5
+```
+
+Prepend the output block (if non-empty) to your working context. This surfaces lessons like
+`feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
+
 ---
 
 # autospec-review

--- a/skills/autospec-review/codex/prompt.md
+++ b/skills/autospec-review/codex/prompt.md
@@ -48,6 +48,19 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Relevant memory injection (run-start, once)
+
+Before executing the main pipeline phases, call the injector to surface relevant saved lessons:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh" \
+  --context "<skill-relevant keywords from request/issue/spec>" \
+  --top-k 5
+```
+
+Prepend the output block (if non-empty) to your working context. This surfaces lessons like
+`feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
+
 
 # autospec-review
 

--- a/skills/autospec-review/opencode/agent.md
+++ b/skills/autospec-review/opencode/agent.md
@@ -52,6 +52,19 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Relevant memory injection (run-start, once)
+
+Before executing the main pipeline phases, call the injector to surface relevant saved lessons:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh" \
+  --context "<skill-relevant keywords from request/issue/spec>" \
+  --top-k 5
+```
+
+Prepend the output block (if non-empty) to your working context. This surfaces lessons like
+`feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
+
 
 # autospec-review
 

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -197,6 +197,19 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Relevant memory injection (run-start, once)
+
+Before executing the main pipeline phases, call the injector to surface relevant saved lessons:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh" \
+  --context "<skill-relevant keywords from request/issue/spec>" \
+  --top-k 5
+```
+
+Prepend the output block (if non-empty) to your working context. This surfaces lessons like
+`feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
+
 ## Phase 4 — Background autonomous monitor
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -192,6 +192,19 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Relevant memory injection (run-start, once)
+
+Before executing the main pipeline phases, call the injector to surface relevant saved lessons:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh" \
+  --context "<skill-relevant keywords from request/issue/spec>" \
+  --top-k 5
+```
+
+Prepend the output block (if non-empty) to your working context. This surfaces lessons like
+`feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
+
 ## Phase 4 — Background autonomous monitor
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -196,6 +196,19 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Relevant memory injection (run-start, once)
+
+Before executing the main pipeline phases, call the injector to surface relevant saved lessons:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh" \
+  --context "<skill-relevant keywords from request/issue/spec>" \
+  --top-k 5
+```
+
+Prepend the output block (if non-empty) to your working context. This surfaces lessons like
+`feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
+
 ## Phase 4 — Background autonomous monitor
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):

--- a/skills/autospec-shared/scripts/inject-relevant-memory.sh
+++ b/skills/autospec-shared/scripts/inject-relevant-memory.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# inject-relevant-memory.sh — Grep docs/memory/*.md for keyword matches; emit top-k
+# filenames + first 200 chars as a context block for skill prompt injection.
+#
+# Falls back to mempalace search if the CLI is present; otherwise uses grep.
+#
+# Usage:
+#   inject-relevant-memory.sh --context "RETURN trap bash" [--top-k 3] [--memory-dir DIR]
+#
+# Output (stdout): formatted context block — one section per matched file:
+#   ### Memory: <filename>
+#   <first 200 chars of file content>
+#
+# Exit codes:
+#   0 always (missing dir / no matches are silent no-ops)
+#
+# Environment:
+#   AUTOSPEC_MEMORY_DIR  — override memory directory (default: auto-detected)
+#   AUTOSPEC_SCRIPTS_DIR — directory containing sibling scripts (default: script dir)
+#
+# Requires: bash 3.2+, grep
+# Optional: mempalace CLI (falls back to grep when absent)
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CONTEXT=""
+TOP_K=5
+MEMORY_DIR=""
+
+# ── Argument parse ────────────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --context)
+      CONTEXT="$2"
+      shift 2
+      ;;
+    --top-k)
+      TOP_K="$2"
+      shift 2
+      ;;
+    --memory-dir)
+      MEMORY_DIR="$2"
+      shift 2
+      ;;
+    --help|-h)
+      printf 'Usage: inject-relevant-memory.sh --context <keywords> [--top-k N] [--memory-dir DIR]\n'
+      exit 0
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+# ── Resolve memory dir ────────────────────────────────────────────────────────
+if [ -z "$MEMORY_DIR" ]; then
+  # Try to auto-detect from git repo root
+  _repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -n "$_repo_root" ] && [ -d "$_repo_root/docs/memory" ]; then
+    MEMORY_DIR="$_repo_root/docs/memory"
+  elif [ -n "${AUTOSPEC_MEMORY_DIR:-}" ] && [ -d "$AUTOSPEC_MEMORY_DIR" ]; then
+    MEMORY_DIR="$AUTOSPEC_MEMORY_DIR"
+  fi
+fi
+
+# ── Guard: no context or no dir → silent no-op ───────────────────────────────
+if [ -z "$CONTEXT" ] || [ -z "$MEMORY_DIR" ] || [ ! -d "$MEMORY_DIR" ]; then
+  exit 0
+fi
+
+# ── Build search terms (split context into words) ────────────────────────────
+# Convert context to a grep alternation pattern
+_pattern=$(printf '%s' "$CONTEXT" | tr ' ' '|' | sed 's/|$//')
+
+# ── Search: mempalace if available, else grep ─────────────────────────────────
+_matched_files=""
+
+if command -v mempalace > /dev/null 2>&1; then
+  # Use mempalace search — returns filenames one per line
+  _matched_files=$(mempalace search "$CONTEXT" 2>/dev/null \
+    | grep -o '[^/]*\.md' \
+    | grep -v "^MEMORY\.md$" \
+    | head -"$TOP_K" || true)
+fi
+
+if [ -z "$_matched_files" ]; then
+  # Grep fallback: score files by number of pattern matches, sort descending
+  _matched_files=$(grep -ril -E "$_pattern" "$MEMORY_DIR"/*.md 2>/dev/null \
+    | grep -v "/MEMORY\.md$" \
+    | while IFS= read -r f; do
+        count=$(grep -ci -E "$_pattern" "$f" 2>/dev/null || echo 0)
+        printf '%s\t%s\n' "$count" "$f"
+      done \
+    | sort -rn \
+    | head -"$TOP_K" \
+    | awk '{print $2}' || true)
+fi
+
+# ── Emit context block ────────────────────────────────────────────────────────
+if [ -z "$_matched_files" ]; then
+  exit 0
+fi
+
+printf '<!-- inject-relevant-memory: context="%s" top-k=%s -->\n' "$CONTEXT" "$TOP_K"
+printf '## Relevant memory\n\n'
+
+while IFS= read -r _file; do
+  [ -z "$_file" ] && continue
+  [ -f "$_file" ] || _file="$MEMORY_DIR/$_file"
+  [ -f "$_file" ] || continue
+
+  _basename=$(basename "$_file")
+  # Skip MEMORY.md index
+  [ "$_basename" = "MEMORY.md" ] && continue
+
+  # First 200 chars of content (strip frontmatter)
+  _content=$(awk '/^---/{c++; next} c>=2{print}' "$_file" 2>/dev/null | head -5 | tr '\n' ' ')
+  [ -z "$_content" ] && _content=$(head -5 "$_file" 2>/dev/null | tr '\n' ' ')
+  _content=$(printf '%s' "$_content" | cut -c1-200)
+
+  printf '### Memory: %s\n%s\n\n' "$_basename" "$_content"
+done <<< "$_matched_files"
+
+exit 0

--- a/tests/inject-relevant-memory.bats
+++ b/tests/inject-relevant-memory.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+# tests/inject-relevant-memory.bats — tests for skills/autospec-shared/scripts/inject-relevant-memory.sh
+# Covers: keyword match returns file, top-k limit, missing-dir fallback, empty context
+
+SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/inject-relevant-memory.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    MEMORY_DIR="$TEST_TMP/docs/memory"
+    mkdir -p "$MEMORY_DIR"
+
+    # Create test memory files
+    cat > "$MEMORY_DIR/feedback_bash_return_trap_leak.md" <<'EOF'
+---
+type: feedback
+---
+# RETURN trap bash
+RETURN traps in bash functions leak into caller frames; never use for local cleanup under set -u.
+EOF
+
+    cat > "$MEMORY_DIR/feedback_bash_set_e_short_circuit.md" <<'EOF'
+---
+type: feedback
+---
+# bash set -e short circuit
+`[ test ] && action` aborts under set -e when test fails; use if/then/fi.
+EOF
+
+    cat > "$MEMORY_DIR/feedback_validate_sh_lockstep_checks.md" <<'EOF'
+---
+type: feedback
+---
+# validate lockstep
+Renaming SKILL.md prose sections requires updating validate.sh checks too.
+EOF
+
+    cat > "$MEMORY_DIR/MEMORY.md" <<'EOF'
+# Memory index
+EOF
+
+    export TEST_TMP MEMORY_DIR
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+# ── basic sanity ──────────────────────────────────────────────────────────────
+
+@test "inject-relevant-memory.sh exists and is executable" {
+    [ -x "$SCRIPT" ]
+}
+
+@test "inject-relevant-memory.sh --help exits 0" {
+    run bash "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+}
+
+# ── keyword matching ──────────────────────────────────────────────────────────
+
+@test "RETURN trap bash: returns feedback_bash_return_trap_leak.md in output" {
+    run bash "$SCRIPT" --context "RETURN trap bash" --memory-dir "$MEMORY_DIR" --top-k 3
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "feedback_bash_return_trap_leak"
+}
+
+@test "lockstep validate: returns feedback_validate_sh_lockstep_checks.md" {
+    run bash "$SCRIPT" --context "lockstep validate" --memory-dir "$MEMORY_DIR" --top-k 3
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "feedback_validate_sh_lockstep_checks"
+}
+
+@test "set -e short circuit: returns relevant file" {
+    run bash "$SCRIPT" --context "set -e short circuit" --memory-dir "$MEMORY_DIR" --top-k 3
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "feedback_bash_set_e_short_circuit"
+}
+
+# ── top-k limit ───────────────────────────────────────────────────────────────
+
+@test "top-k 1: returns at most 1 result" {
+    run bash "$SCRIPT" --context "bash" --memory-dir "$MEMORY_DIR" --top-k 1
+    [ "$status" -eq 0 ]
+    # Count lines containing file references (## lines or filenames)
+    local match_count
+    match_count=$(echo "$output" | grep -c "feedback_" || true)
+    [ "$match_count" -le 1 ]
+}
+
+# ── output format ─────────────────────────────────────────────────────────────
+
+@test "output includes filename and first 200 chars of content" {
+    run bash "$SCRIPT" --context "RETURN trap bash" --memory-dir "$MEMORY_DIR" --top-k 3
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "feedback_bash_return_trap_leak"
+    # Should include some content from the file
+    echo "$output" | grep -qi "RETURN"
+}
+
+@test "MEMORY.md index file is not returned as a match" {
+    run bash "$SCRIPT" --context "Memory index" --memory-dir "$MEMORY_DIR" --top-k 3
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qv "^MEMORY.md" || true
+}
+
+# ── graceful fallbacks ────────────────────────────────────────────────────────
+
+@test "missing --memory-dir: exits 0 with empty output" {
+    run bash "$SCRIPT" --context "bash" --memory-dir "$TEST_TMP/nonexistent" --top-k 3
+    [ "$status" -eq 0 ]
+}
+
+@test "empty --context: exits 0" {
+    run bash "$SCRIPT" --context "" --memory-dir "$MEMORY_DIR" --top-k 3
+    [ "$status" -eq 0 ]
+}
+
+@test "missing --context: exits 0" {
+    run bash "$SCRIPT" --memory-dir "$MEMORY_DIR" --top-k 3
+    [ "$status" -eq 0 ]
+}
+
+# ── default memory dir resolution ─────────────────────────────────────────────
+
+@test "without --memory-dir: exits 0 (uses default or no-op)" {
+    run bash "$SCRIPT" --context "bash trap"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #512

## Summary

- Adds `skills/autospec-shared/scripts/inject-relevant-memory.sh` — greps `docs/memory/*.md` for keyword matches, returns top-k filenames + first 200 chars as a formatted context block. Falls back from mempalace search to grep when CLI absent.
- Wires a `## Relevant memory injection` section into all 4 skill trios (autospec-review, autospec-classify, autospec-define, autospec-run) — identical prose block in SKILL.md + codex/prompt.md + opencode/agent.md per lockstep rule.
- Updates AGENTS.md with script table row and `AUTOSPEC_MEMORY_DIR` env var note.
- Adds `tests/inject-relevant-memory.bats` with 12 tests covering all acceptance criteria.

## Test plan

- [x] `--context "RETURN trap bash"` returns `feedback_bash_return_trap_leak.md` (test 3)
- [x] `--context "lockstep validate"` returns correct file (test 4)
- [x] `--top-k 1` returns at most 1 result (test 6)
- [x] Output includes filename and first 200 chars (test 7)
- [x] MEMORY.md index excluded from results (test 8)
- [x] Missing dir, empty context, missing context all exit 0 (tests 9-12)
- [x] All 12 bats tests green
- [x] `bash -n` syntax check passes
- [x] `validate.bats` lockstep alignment passes (4/4) — all 12 trio files are in sync