### PR TITLE
feat(memory): cross-repo memory traversal via ~/.autospec/memory-index/ (consumer #7)

### DIFF
--- a/skills/autospec-shared/scripts/auto-init-memory.sh
+++ b/skills/autospec-shared/scripts/auto-init-memory.sh
@@ -192,6 +192,11 @@ esac
 # ── Ensure AGENTS.md inventory section ───────────────────────────────────────
 _ensure_agents_md_inventory_section "$REPO_ROOT/AGENTS.md"
 
+# ── Register repo in cross-repo memory index (best-effort, silent fail) ──────
+if [ -x "${AUTOSPEC_SCRIPTS_DIR}/cross-repo-index.sh" ]; then
+  bash "${AUTOSPEC_SCRIPTS_DIR}/cross-repo-index.sh" --repo-root "$REPO_ROOT" 2>/dev/null || true
+fi
+
 # ── Lazy AAAK compression gate ───────────────────────────────────────────────
 # Trigger once per N invocations (default: every 10) to keep memory LOC small.
 # Falls through silently if mempalace-compress.sh is absent or mempalace is not installed.

--- a/skills/autospec-shared/scripts/cross-repo-index.sh
+++ b/skills/autospec-shared/scripts/cross-repo-index.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# cross-repo-index.sh — Register current repo into ~/.autospec/memory-index/<slug>
+#
+# Idempotent: re-running produces the same result.
+# Also performs GC: stale entries whose docs/memory/ no longer exists are purged.
+#
+# Usage:
+#   cross-repo-index.sh [--repo-root DIR]
+#
+# Options:
+#   --repo-root DIR   Override repo root (default: git rev-parse --show-toplevel)
+#   --index-dir DIR   Override index dir (default: ~/.autospec/memory-index)
+#   --help            Show usage and exit 0
+#
+# Exit codes:
+#   0 always (best-effort; errors are silent)
+#
+# Environment:
+#   AUTOSPEC_SKIP_CROSS_REPO_INDEX=1  — skip registration silently (opt-out)
+
+set +e
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+REPO_ROOT=""
+INDEX_DIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-root)
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --index-dir)
+      INDEX_DIR="$2"
+      shift 2
+      ;;
+    --help|-h)
+      printf 'Usage: cross-repo-index.sh [--repo-root DIR] [--index-dir DIR]\n'
+      exit 0
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+# ── Opt-out ───────────────────────────────────────────────────────────────────
+[ "${AUTOSPEC_SKIP_CROSS_REPO_INDEX:-0}" = "1" ] && exit 0
+
+# ── Resolve repo root ─────────────────────────────────────────────────────────
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+fi
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+MEMORY_DIR="$REPO_ROOT/docs/memory"
+
+# ── Resolve index dir ─────────────────────────────────────────────────────────
+if [ -z "$INDEX_DIR" ]; then
+  INDEX_DIR="${HOME}/.autospec/memory-index"
+fi
+mkdir -p "$INDEX_DIR"
+
+# ── GC: remove stale entries ──────────────────────────────────────────────────
+# A symlink is stale if its target docs/memory/ dir no longer exists.
+if [ -d "$INDEX_DIR" ]; then
+  for _link in "$INDEX_DIR"/*; do
+    [ -L "$_link" ] || continue
+    _target=$(readlink "$_link" 2>/dev/null)
+    if [ -z "$_target" ] || [ ! -d "$_target" ]; then
+      rm -f "$_link"
+    fi
+  done
+fi
+
+# ── Register current repo ─────────────────────────────────────────────────────
+# Only register if docs/memory/ exists
+[ -d "$MEMORY_DIR" ] || exit 0
+
+# Compute slug: repo root path with slashes → dashes, strip leading dash
+_slug=$(printf '%s' "$REPO_ROOT" | sed 's|^/||' | tr '/' '-')
+_link_path="$INDEX_DIR/$_slug"
+
+# Idempotent: skip if symlink already points to the right target
+if [ -L "$_link_path" ] && [ "$(readlink "$_link_path")" = "$MEMORY_DIR" ]; then
+  exit 0
+fi
+
+# Remove stale link for this slug (different target) if present
+[ -L "$_link_path" ] && rm -f "$_link_path"
+[ -e "$_link_path" ] && rm -rf "$_link_path"
+
+ln -s "$MEMORY_DIR" "$_link_path"
+
+exit 0

--- a/skills/autospec-shared/scripts/cross-repo-search.sh
+++ b/skills/autospec-shared/scripts/cross-repo-search.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# cross-repo-search.sh — Search memory files across all indexed repos.
+#
+# Wraps `mempalace search` across all indexed repos, falling back to grep -r.
+# Tags each hit with the source repo slug.
+#
+# Usage:
+#   cross-repo-search.sh "query" [--index-dir DIR] [--top-k N]
+#
+# Options:
+#   --index-dir DIR   Override index dir (default: ~/.autospec/memory-index)
+#   --top-k N         Limit results (default: 10)
+#   --help            Show usage and exit 0
+#
+# Exit codes:
+#   0 always (no matches is a silent no-op)
+#
+# Environment:
+#   AUTOSPEC_SKIP_CROSS_REPO_INDEX=1  — skip search (opt-out, exits 0 empty)
+
+set +e
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+QUERY=""
+INDEX_DIR=""
+TOP_K=10
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --index-dir)
+      INDEX_DIR="$2"
+      shift 2
+      ;;
+    --top-k)
+      TOP_K="$2"
+      shift 2
+      ;;
+    --help|-h)
+      printf 'Usage: cross-repo-search.sh "query" [--index-dir DIR] [--top-k N]\n'
+      exit 0
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      # First positional arg is the query
+      if [ -z "$QUERY" ]; then
+        QUERY="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+# ── Opt-out ───────────────────────────────────────────────────────────────────
+[ "${AUTOSPEC_SKIP_CROSS_REPO_INDEX:-0}" = "1" ] && exit 0
+
+# ── Guard: empty query ────────────────────────────────────────────────────────
+if [ -z "$QUERY" ]; then
+  exit 0
+fi
+
+# ── Resolve index dir ─────────────────────────────────────────────────────────
+if [ -z "$INDEX_DIR" ]; then
+  INDEX_DIR="${HOME}/.autospec/memory-index"
+fi
+
+# ── Guard: empty or missing index ─────────────────────────────────────────────
+if [ ! -d "$INDEX_DIR" ]; then
+  exit 0
+fi
+
+_found_any=0
+_result_count=0
+
+# Build grep pattern from query words
+_pattern=$(printf '%s' "$QUERY" | tr ' ' '|')
+
+# ── Search each indexed repo ──────────────────────────────────────────────────
+for _link in "$INDEX_DIR"/*; do
+  [ -L "$_link" ] || continue
+  _target=$(readlink "$_link" 2>/dev/null)
+  [ -d "$_target" ] || continue
+
+  _slug=$(basename "$_link")
+
+  # Try mempalace search first (repo-local, with correct cwd)
+  _mp_results=""
+  if command -v mempalace > /dev/null 2>&1; then
+    _mp_results=$(cd "$_target" && mempalace search "$QUERY" 2>/dev/null \
+      | grep -o '[^/]*\.md' \
+      | grep -v "^MEMORY\.md$" \
+      | head -"$TOP_K" || true)
+  fi
+
+  if [ -n "$_mp_results" ]; then
+    while IFS= read -r _fname; do
+      [ -z "$_fname" ] && continue
+      _file="$_target/$_fname"
+      [ -f "$_file" ] || continue
+      [ "$_result_count" -ge "$TOP_K" ] && break
+      _content=$(head -5 "$_file" 2>/dev/null | tr '\n' ' ' | cut -c1-200)
+      printf '### Memory: %s [source: %s]\n%s\n\n' "$_fname" "$_slug" "$_content"
+      _found_any=1
+      _result_count=$((_result_count + 1))
+    done <<< "$_mp_results"
+  else
+    # Grep fallback: score files by match count, sort descending
+    _grep_hits=$(grep -ril -E "$_pattern" "$_target"/*.md 2>/dev/null \
+      | grep -v "/MEMORY\.md$" \
+      | while IFS= read -r _f; do
+          _count=$(grep -ci -E "$_pattern" "$_f" 2>/dev/null || echo 0)
+          printf '%s\t%s\n' "$_count" "$_f"
+        done \
+      | sort -rn \
+      | head -"$TOP_K" \
+      | awk '{print $2}')
+
+    if [ -n "$_grep_hits" ]; then
+      while IFS= read -r _file; do
+        [ -z "$_file" ] && continue
+        [ -f "$_file" ] || continue
+        [ "$_result_count" -ge "$TOP_K" ] && break
+        _fname=$(basename "$_file")
+        _content=$(head -5 "$_file" 2>/dev/null | tr '\n' ' ' | cut -c1-200)
+        printf '### Memory: %s [source: %s]\n%s\n\n' "$_fname" "$_slug" "$_content"
+        _found_any=1
+        _result_count=$((_result_count + 1))
+      done <<< "$_grep_hits"
+    fi
+  fi
+
+  [ "$_result_count" -ge "$TOP_K" ] && break
+done
+
+exit 0

--- a/skills/autospec-shared/scripts/inject-relevant-memory.sh
+++ b/skills/autospec-shared/scripts/inject-relevant-memory.sh
@@ -24,10 +24,13 @@
 set +e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUTOSPEC_SCRIPTS_DIR="${AUTOSPEC_SCRIPTS_DIR:-$SCRIPT_DIR}"
 
 CONTEXT=""
 TOP_K=5
 MEMORY_DIR=""
+CROSS_REPO=0
+INDEX_DIR=""
 
 # ── Argument parse ────────────────────────────────────────────────────────────
 while [ $# -gt 0 ]; do
@@ -44,8 +47,16 @@ while [ $# -gt 0 ]; do
       MEMORY_DIR="$2"
       shift 2
       ;;
+    --cross-repo)
+      CROSS_REPO=1
+      shift
+      ;;
+    --index-dir)
+      INDEX_DIR="$2"
+      shift 2
+      ;;
     --help|-h)
-      printf 'Usage: inject-relevant-memory.sh --context <keywords> [--top-k N] [--memory-dir DIR]\n'
+      printf 'Usage: inject-relevant-memory.sh --context <keywords> [--top-k N] [--memory-dir DIR] [--cross-repo [--index-dir DIR]]\n'
       exit 0
       ;;
     *)
@@ -122,5 +133,13 @@ while IFS= read -r _file; do
 
   printf '### Memory: %s\n%s\n\n' "$_basename" "$_content"
 done <<< "$_matched_files"
+
+# ── Cross-repo search (optional) ─────────────────────────────────────────────
+if [ "$CROSS_REPO" = "1" ] && [ -x "${AUTOSPEC_SCRIPTS_DIR}/cross-repo-search.sh" ]; then
+  _cr_index_dir="${INDEX_DIR:-${HOME}/.autospec/memory-index}"
+  bash "${AUTOSPEC_SCRIPTS_DIR}/cross-repo-search.sh" "$CONTEXT" \
+    --index-dir "$_cr_index_dir" \
+    --top-k "$TOP_K"
+fi
 
 exit 0

--- a/tests/cross-repo-memory.bats
+++ b/tests/cross-repo-memory.bats
@@ -1,0 +1,200 @@
+#!/usr/bin/env bats
+# tests/cross-repo-memory.bats — tests for cross-repo memory index scripts
+# Covers: register / search / GC / missing-mempalace fallback / opt-out
+
+INDEX_SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/cross-repo-index.sh"
+SEARCH_SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/cross-repo-search.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+
+    # Fake home to isolate ~/.autospec/memory-index/
+    export HOME="$TEST_TMP/home"
+    mkdir -p "$HOME"
+
+    # Repo A: has docs/memory/ with our target file
+    REPO_A="$TEST_TMP/repo-a"
+    mkdir -p "$REPO_A/docs/memory"
+    git -C "$REPO_A" init -q
+    git -C "$REPO_A" commit --allow-empty -m "init" -q 2>/dev/null || true
+    cat > "$REPO_A/docs/memory/feedback_bash_return_trap_leak.md" <<'EOF'
+---
+type: feedback
+---
+# RETURN trap bash
+RETURN traps in bash functions leak into caller frames; never use for local cleanup under set -u.
+EOF
+
+    # Repo B: has docs/memory/ with a different file
+    REPO_B="$TEST_TMP/repo-b"
+    mkdir -p "$REPO_B/docs/memory"
+    git -C "$REPO_B" init -q
+    git -C "$REPO_B" commit --allow-empty -m "init" -q 2>/dev/null || true
+    cat > "$REPO_B/docs/memory/feedback_omc_autopilot_misfire.md" <<'EOF'
+---
+type: feedback
+---
+# OMC autopilot misfire
+system reminders containing AUTOPILOT auto-activate OMC autopilot mid-session.
+EOF
+
+    export TEST_TMP REPO_A REPO_B
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+# ── sanity ────────────────────────────────────────────────────────────────────
+
+@test "cross-repo-index.sh exists and is executable" {
+    [ -x "$INDEX_SCRIPT" ]
+}
+
+@test "cross-repo-search.sh exists and is executable" {
+    [ -x "$SEARCH_SCRIPT" ]
+}
+
+@test "cross-repo-index.sh --help exits 0" {
+    run bash "$INDEX_SCRIPT" --help
+    [ "$status" -eq 0 ]
+}
+
+@test "cross-repo-search.sh --help exits 0" {
+    run bash "$SEARCH_SCRIPT" --help
+    [ "$status" -eq 0 ]
+}
+
+# ── registration ──────────────────────────────────────────────────────────────
+
+@test "register: creates symlink in ~/.autospec/memory-index/<slug>" {
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    # A symlink must exist somewhere under the index dir
+    INDEX_DIR="$HOME/.autospec/memory-index"
+    [ -d "$INDEX_DIR" ]
+    local found
+    found=$(find "$INDEX_DIR" -maxdepth 1 -type l | head -1)
+    [ -n "$found" ]
+}
+
+@test "register: symlink points to repo docs/memory/" {
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    INDEX_DIR="$HOME/.autospec/memory-index"
+    local target
+    target=$(readlink "$(find "$INDEX_DIR" -maxdepth 1 -type l | head -1)")
+    [ "$target" = "$REPO_A/docs/memory" ]
+}
+
+@test "register: idempotent — second call does not create duplicate" {
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    INDEX_DIR="$HOME/.autospec/memory-index"
+    local count
+    count=$(find "$INDEX_DIR" -maxdepth 1 -type l | wc -l | tr -d ' ')
+    [ "$count" -eq 1 ]
+}
+
+@test "register: two different repos create two symlinks" {
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_B"
+    [ "$status" -eq 0 ]
+    INDEX_DIR="$HOME/.autospec/memory-index"
+    local count
+    count=$(find "$INDEX_DIR" -maxdepth 1 -type l | wc -l | tr -d ' ')
+    [ "$count" -eq 2 ]
+}
+
+# ── opt-out ───────────────────────────────────────────────────────────────────
+
+@test "register: AUTOSPEC_SKIP_CROSS_REPO_INDEX=1 is a no-op" {
+    AUTOSPEC_SKIP_CROSS_REPO_INDEX=1 run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    INDEX_DIR="$HOME/.autospec/memory-index"
+    local count
+    count=$(find "$INDEX_DIR" -maxdepth 1 -type l 2>/dev/null | wc -l | tr -d ' ')
+    [ "$count" -eq 0 ]
+}
+
+# ── GC (stale entry removal) ─────────────────────────────────────────────────
+
+@test "GC: stale entry (docs/memory/ deleted) is removed on next register call" {
+    # Register repo A, then remove its docs/memory/
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    rm -rf "$REPO_A/docs/memory"
+    # Re-run from any repo — GC runs on every call
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_B"
+    [ "$status" -eq 0 ]
+    INDEX_DIR="$HOME/.autospec/memory-index"
+    # Only repo-b symlink should remain (repo-a was GC'd)
+    local count
+    count=$(find "$INDEX_DIR" -maxdepth 1 -type l | wc -l | tr -d ' ')
+    [ "$count" -eq 1 ]
+}
+
+# ── search ────────────────────────────────────────────────────────────────────
+
+@test "search: finds RETURN trap match from indexed repo A" {
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    run bash "$SEARCH_SCRIPT" "RETURN trap" --index-dir "$HOME/.autospec/memory-index"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qi "RETURN"
+}
+
+@test "search: tags hit with source repo slug" {
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    run bash "$SEARCH_SCRIPT" "RETURN trap" --index-dir "$HOME/.autospec/memory-index"
+    [ "$status" -eq 0 ]
+    # Output should mention the source (filename or repo slug)
+    echo "$output" | grep -qi "feedback_bash_return_trap_leak\|repo-a"
+}
+
+@test "search: finds match from repo B when both indexed" {
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_B"
+    [ "$status" -eq 0 ]
+    run bash "$SEARCH_SCRIPT" "autopilot misfire" --index-dir "$HOME/.autospec/memory-index"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qi "autopilot\|omc"
+}
+
+@test "search: no results exits 0 with empty output" {
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    run bash "$SEARCH_SCRIPT" "xyzzy_no_match_expected_12345" --index-dir "$HOME/.autospec/memory-index"
+    [ "$status" -eq 0 ]
+}
+
+@test "search: empty index exits 0" {
+    run bash "$SEARCH_SCRIPT" "RETURN trap" --index-dir "$HOME/.autospec/memory-index"
+    [ "$status" -eq 0 ]
+}
+
+# ── inject-relevant-memory --cross-repo ───────────────────────────────────────
+
+@test "inject-relevant-memory: --cross-repo flag accepted without error" {
+    INJECT_SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/inject-relevant-memory.sh"
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    run bash "$INJECT_SCRIPT" --context "RETURN trap" --cross-repo \
+        --index-dir "$HOME/.autospec/memory-index"
+    [ "$status" -eq 0 ]
+}
+
+@test "inject-relevant-memory: --cross-repo returns cross-repo hit" {
+    INJECT_SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/inject-relevant-memory.sh"
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    run bash "$INJECT_SCRIPT" --context "RETURN trap bash" --cross-repo \
+        --index-dir "$HOME/.autospec/memory-index"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qi "RETURN\|return_trap"
+}


### PR DESCRIPTION
## Summary

- Adds `cross-repo-index.sh`: registers current repo's `docs/memory/` as a symlink in `~/.autospec/memory-index/<slug>`. Idempotent + GC on every call (stale entries purged automatically). Opt-out via `AUTOSPEC_SKIP_CROSS_REPO_INDEX=1`.
- Adds `cross-repo-search.sh`: searches across all indexed repos using mempalace-search or grep fallback; tags each hit with source repo slug.
- Hooks `cross-repo-index.sh` into `auto-init-memory.sh` (best-effort, silent fail).
- Adds `--cross-repo [--index-dir DIR]` flag to `inject-relevant-memory.sh` to search the global index.
- 17 bats tests covering: register, idempotency, two-repo isolation, opt-out, GC, search, cross-repo inject, empty/no-results graceful exit.

## Test plan

- [x] `bats tests/cross-repo-memory.bats` — 17/17 pass
- [x] `bats tests/inject-relevant-memory.bats` — 12/12 pass (no regressions)
- [x] `bash scripts/validate.sh` — all checks passed

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)