### PR TITLE
feat(memory): generalize ensure-tool helper for bats/jq/gh/mempalace (consumer #4)

### DIFF
--- a/skills/autospec-shared/scripts/auto-init-memory.sh
+++ b/skills/autospec-shared/scripts/auto-init-memory.sh
@@ -67,24 +67,15 @@ AGENTS_BLOCK
 
 _ensure_mempalace_installed() {
   # Best-effort install of mempalace CLI on first migration. Idempotent — no-op
-  # if already on PATH. Opt out with AUTOSPEC_SKIP_MEMPALACE_INSTALL=1.
+  # if already on PATH. Delegates to the shared ensure-tool.sh installer, which
+  # bakes the pipx → uv → pip --user fallback chain into its tool table.
+  #
+  # Opt-out: AUTOSPEC_SKIP_MEMPALACE_INSTALL=1 (legacy, honored here for
+  # back-compat). ensure-tool.sh additionally respects its own
+  # AUTOSPEC_SKIP_ENSURE_TOOL[_MEMPALACE] gates.
   [ "${AUTOSPEC_SKIP_MEMPALACE_INSTALL:-0}" = "1" ] && return 0
-  command -v mempalace > /dev/null 2>&1 && return 0
-
-  # Prefer pipx (isolated venv per tool), then uv, then pip --user. All silent
-  # failures — mempalace is optional; absence only loses the KG/search overlay.
-  if command -v pipx > /dev/null 2>&1; then
-    pipx install mempalace > /dev/null 2>&1 && \
-      echo "auto-init-memory: installed mempalace via pipx" >&2
-  elif command -v uv > /dev/null 2>&1; then
-    uv tool install mempalace > /dev/null 2>&1 && \
-      echo "auto-init-memory: installed mempalace via uv" >&2
-  elif command -v pip3 > /dev/null 2>&1; then
-    pip3 install --user --quiet mempalace > /dev/null 2>&1 && \
-      echo "auto-init-memory: installed mempalace via pip3 --user" >&2
-  elif command -v pip > /dev/null 2>&1; then
-    pip install --user --quiet mempalace > /dev/null 2>&1 && \
-      echo "auto-init-memory: installed mempalace via pip --user" >&2
+  if [ -f "${AUTOSPEC_SCRIPTS_DIR}/ensure-tool.sh" ]; then
+    bash "${AUTOSPEC_SCRIPTS_DIR}/ensure-tool.sh" mempalace
   fi
   return 0
 }

--- a/skills/autospec-shared/scripts/ensure-tool.sh
+++ b/skills/autospec-shared/scripts/ensure-tool.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# ensure-tool.sh — Best-effort, idempotent installer for autospec's optional CLI deps.
+#
+# Generalizes the _ensure_mempalace_installed helper (PR #509) into a reusable
+# tool-installer with a baked-in tool table and a platform-appropriate fallback
+# chain (brew / apt-get / npm / pipx / uv / pip). Every install is a silent
+# best-effort: a missing or failed installer never blocks the caller.
+#
+# Usage:
+#   ensure-tool.sh <tool>          # ensure <tool> is on PATH; install if absent
+#
+# Supported tools (baked-in table): bats, jq, gh, mempalace
+# Unknown tools are a silent no-op (exit 0).
+#
+# Exit codes:
+#   0 always (best-effort by design — see "## ROI-check" / project rules)
+#
+# Environment:
+#   AUTOSPEC_SKIP_ENSURE_TOOL=1          — disable ALL auto-installs
+#   AUTOSPEC_SKIP_ENSURE_TOOL_<TOOL>=1   — disable auto-install for one tool
+#                                          (<TOOL> uppercased, non-alnum → _)
+#
+# Requires: bash 3.2+, command. Installers are probed, never assumed present.
+
+set +e
+
+TOOL="${1:-}"
+
+# No tool requested → nothing to do.
+[ -n "$TOOL" ] || exit 0
+
+# ── Opt-out gates ─────────────────────────────────────────────────────────────
+# Global opt-out.
+[ "${AUTOSPEC_SKIP_ENSURE_TOOL:-0}" = "1" ] && exit 0
+
+# Per-tool opt-out: AUTOSPEC_SKIP_ENSURE_TOOL_<TOOL> with <TOOL> uppercased and
+# any non-alphanumeric char replaced by underscore (e.g. some-tool → SOME_TOOL).
+_tool_upper=$(printf '%s' "$TOOL" | tr '[:lower:]' '[:upper:]' | tr -c 'A-Z0-9' '_')
+_skip_var="AUTOSPEC_SKIP_ENSURE_TOOL_${_tool_upper}"
+# Strip a possible trailing underscore left by tr on the final char.
+_skip_var="${_skip_var%_}"
+eval "_skip_val=\${${_skip_var}:-0}"
+[ "$_skip_val" = "1" ] && exit 0
+
+# ── Already present → no-op ───────────────────────────────────────────────────
+if command -v "$TOOL" > /dev/null 2>&1; then
+  exit 0
+fi
+
+# ── Installer helpers (each is silent best-effort) ────────────────────────────
+# A helper logs a one-line success notice to stderr and returns 0 on success so
+# the caller's chain can short-circuit; returns 1 if its installer is absent or
+# the install failed.
+
+_try_brew() {  # _try_brew <pkg>
+  command -v brew > /dev/null 2>&1 || return 1
+  brew install "$1" > /dev/null 2>&1 \
+    && { echo "ensure-tool: installed $TOOL via brew" >&2; return 0; }
+  return 1
+}
+
+_try_apt() {  # _try_apt <pkg>
+  command -v apt-get > /dev/null 2>&1 || return 1
+  # -y non-interactive; sudo only if not already root and available.
+  local sudo=""
+  if [ "$(id -u 2>/dev/null || echo 1)" != "0" ] && command -v sudo > /dev/null 2>&1; then
+    sudo="sudo"
+  fi
+  $sudo apt-get install -y "$1" > /dev/null 2>&1 \
+    && { echo "ensure-tool: installed $TOOL via apt-get" >&2; return 0; }
+  return 1
+}
+
+_try_npm() {  # _try_npm <pkg>
+  command -v npm > /dev/null 2>&1 || return 1
+  npm install -g "$1" > /dev/null 2>&1 \
+    && { echo "ensure-tool: installed $TOOL via npm" >&2; return 0; }
+  return 1
+}
+
+_try_pipx() {  # _try_pipx <pkg>
+  command -v pipx > /dev/null 2>&1 || return 1
+  pipx install "$1" > /dev/null 2>&1 \
+    && { echo "ensure-tool: installed $TOOL via pipx" >&2; return 0; }
+  return 1
+}
+
+_try_uv() {  # _try_uv <pkg>
+  command -v uv > /dev/null 2>&1 || return 1
+  uv tool install "$1" > /dev/null 2>&1 \
+    && { echo "ensure-tool: installed $TOOL via uv" >&2; return 0; }
+  return 1
+}
+
+_try_pip() {  # _try_pip <pkg>
+  if command -v pip3 > /dev/null 2>&1; then
+    pip3 install --user --quiet "$1" > /dev/null 2>&1 \
+      && { echo "ensure-tool: installed $TOOL via pip3 --user" >&2; return 0; }
+  elif command -v pip > /dev/null 2>&1; then
+    pip install --user --quiet "$1" > /dev/null 2>&1 \
+      && { echo "ensure-tool: installed $TOOL via pip --user" >&2; return 0; }
+  fi
+  return 1
+}
+
+# ── Baked-in tool table → ordered installer chain ────────────────────────────
+# Each case tries installers in preference order; first success wins. Package
+# name may differ from the command name (kept explicit per installer).
+case "$TOOL" in
+  bats)
+    _try_brew bats-core || _try_apt bats || _try_npm bats || true
+    ;;
+  jq)
+    _try_brew jq || _try_apt jq || true
+    ;;
+  gh)
+    _try_brew gh || _try_apt gh || true
+    ;;
+  mempalace)
+    # Python tool: pipx (isolated venv) → uv → pip --user. Mirrors PR #509.
+    _try_pipx mempalace || _try_uv mempalace || _try_pip mempalace || true
+    ;;
+  *)
+    # Unknown tool: no table entry. Best-effort silent no-op.
+    : ;;
+esac
+
+# Always succeed: absence of an optional tool must never block the caller.
+exit 0

--- a/skills/autospec-shared/tests/unit/ensure-tool.bats
+++ b/skills/autospec-shared/tests/unit/ensure-tool.bats
@@ -1,0 +1,210 @@
+#!/usr/bin/env bats
+# ensure-tool.bats — Unit tests for ensure-tool.sh.
+#
+# Run: bats skills/autospec-shared/tests/unit/ensure-tool.bats
+#
+# Strategy: each test builds an isolated fake PATH containing only the stub
+# binaries it wants the script to "see" (command -v resolves against PATH).
+# Installer stubs (brew/apt-get/pipx/uv/pip3/npm) log their invocation to a
+# file so we can assert which installer branch fired. No real installs happen.
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/ensure-tool.sh"
+
+setup() {
+  TMP_DIR="$(mktemp -d /tmp/autospec-ensuretool-XXXXXX)"
+  BIN="$TMP_DIR/bin"
+  mkdir -p "$BIN"
+  LOG="$TMP_DIR/installer.log"
+  export TMP_DIR BIN LOG
+  # Keep a minimal real PATH for coreutils the script itself needs.
+  REAL_PATH="$PATH"
+  export REAL_PATH
+
+  # Coreutils-only dir: symlink ONLY the basic commands ensure-tool.sh needs
+  # (bash/env/tr/printf/id) so the script runs, while the target tool and all
+  # installers stay genuinely absent unless we stub them into $BIN.
+  CORE="$TMP_DIR/core"
+  mkdir -p "$CORE"
+  local c
+  for c in bash env tr printf id cat dirname; do
+    local p
+    p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$CORE/$c"
+  done
+  export CORE
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+# Create a stub installer that records "<name> <args>" to $LOG and exits 0.
+mk_installer() {
+  local name="$1" rc="${2:-0}"
+  cat > "$BIN/$name" <<SHIM
+#!/usr/bin/env bash
+echo "$name \$*" >> "$LOG"
+exit $rc
+SHIM
+  chmod +x "$BIN/$name"
+}
+
+# Create a stub of the target tool so command -v finds it.
+mk_tool() {
+  local name="$1"
+  cat > "$BIN/$name" <<'SHIM'
+#!/usr/bin/env bash
+exit 0
+SHIM
+  chmod +x "$BIN/$name"
+}
+
+# Run ensure-tool.sh with PATH = our fake bin first, then the real PATH
+# (so bash/cat/etc. still resolve). The script's own command -v probes see
+# only what we put in $BIN ahead of everything.
+run_ensure() {
+  run env PATH="$BIN:$REAL_PATH" HOME="$TMP_DIR/home" bash "$SCRIPT" "$@"
+}
+
+# Run with the fake bin + a coreutils-only dir on PATH, so the target tool and
+# every installer are genuinely absent unless we stubbed them into $BIN.
+run_ensure_isolated() {
+  run env PATH="$BIN:$CORE" HOME="$TMP_DIR/home" bash "$SCRIPT" "$@"
+}
+
+# ── No-op when tool already present ──────────────────────────────────────────
+
+@test "bats present → no-op, no installer invoked" {
+  mk_tool bats
+  mk_installer brew
+  run_ensure bats
+  [ "$status" -eq 0 ]
+  [ ! -f "$LOG" ]
+}
+
+@test "jq present → no-op" {
+  mk_tool jq
+  mk_installer apt-get
+  run_ensure jq
+  [ "$status" -eq 0 ]
+  [ ! -f "$LOG" ]
+}
+
+@test "gh present → no-op" {
+  mk_tool gh
+  mk_installer brew
+  run_ensure gh
+  [ "$status" -eq 0 ]
+  [ ! -f "$LOG" ]
+}
+
+@test "mempalace present → no-op" {
+  mk_tool mempalace
+  mk_installer pipx
+  run_ensure mempalace
+  [ "$status" -eq 0 ]
+  [ ! -f "$LOG" ]
+}
+
+# ── Install branch fires when tool absent ────────────────────────────────────
+
+@test "bats absent + brew available → installs via brew" {
+  mk_installer brew
+  run_ensure_isolated bats
+  [ "$status" -eq 0 ]
+  grep -q "brew .*bats" "$LOG"
+}
+
+@test "jq absent + brew available → installs via brew" {
+  mk_installer brew
+  run_ensure_isolated jq
+  [ "$status" -eq 0 ]
+  grep -q "brew .*jq" "$LOG"
+}
+
+@test "gh absent + brew available → installs via brew" {
+  mk_installer brew
+  run_ensure_isolated gh
+  [ "$status" -eq 0 ]
+  grep -q "brew .*gh" "$LOG"
+}
+
+@test "mempalace absent + pipx available → installs via pipx" {
+  mk_installer pipx
+  run_ensure_isolated mempalace
+  [ "$status" -eq 0 ]
+  grep -q "pipx .*mempalace" "$LOG"
+}
+
+# ── Fallback chain (no brew, apt-get available) ──────────────────────────────
+
+@test "bats absent + no brew + apt-get available → installs via apt-get" {
+  mk_installer apt-get
+  run_ensure_isolated bats
+  [ "$status" -eq 0 ]
+  grep -q "apt-get .*bats" "$LOG"
+}
+
+# ── mempalace pip fallback chain ─────────────────────────────────────────────
+
+@test "mempalace absent + no pipx + uv available → installs via uv" {
+  mk_installer uv
+  run_ensure_isolated mempalace
+  [ "$status" -eq 0 ]
+  grep -q "uv .*mempalace" "$LOG"
+}
+
+@test "mempalace absent + only pip3 available → installs via pip3" {
+  mk_installer pip3
+  run_ensure_isolated mempalace
+  [ "$status" -eq 0 ]
+  grep -q "pip3 .*mempalace" "$LOG"
+}
+
+# ── Best-effort silent failure: installer fails, exit still 0 ────────────────
+
+@test "installer fails (rc=1) → ensure-tool still exits 0" {
+  mk_installer brew 1
+  run_ensure_isolated bats
+  [ "$status" -eq 0 ]
+}
+
+@test "no installer available at all → exit 0 silently" {
+  # $BIN has nothing; tool absent and no installer present
+  run_ensure_isolated bats
+  [ "$status" -eq 0 ]
+}
+
+# ── Opt-out env vars ──────────────────────────────────────────────────────────
+
+@test "AUTOSPEC_SKIP_ENSURE_TOOL=1 → no install attempted" {
+  mk_installer brew
+  run env PATH="$BIN:$CORE" HOME="$TMP_DIR/home" AUTOSPEC_SKIP_ENSURE_TOOL=1 bash "$SCRIPT" bats
+  [ "$status" -eq 0 ]
+  [ ! -f "$LOG" ]
+}
+
+@test "AUTOSPEC_SKIP_ENSURE_TOOL_BATS=1 → bats skipped, jq still installs" {
+  mk_installer brew
+  run env PATH="$BIN:$CORE" HOME="$TMP_DIR/home" AUTOSPEC_SKIP_ENSURE_TOOL_BATS=1 bash "$SCRIPT" bats
+  [ "$status" -eq 0 ]
+  [ ! -f "$LOG" ]
+
+  # Same per-tool opt-out must NOT block a different tool
+  run env PATH="$BIN:$CORE" HOME="$TMP_DIR/home" AUTOSPEC_SKIP_ENSURE_TOOL_BATS=1 bash "$SCRIPT" jq
+  [ "$status" -eq 0 ]
+  grep -q "brew .*jq" "$LOG"
+}
+
+# ── Unknown tool ──────────────────────────────────────────────────────────────
+
+@test "unknown tool → exit 0 silently (no table entry, best-effort)" {
+  run_ensure_isolated some-unknown-tool-xyz
+  [ "$status" -eq 0 ]
+}
+
+# ── Missing argument ──────────────────────────────────────────────────────────
+
+@test "no argument → exit 0 (no-op)" {
+  run_ensure_isolated
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #515

Generalizes the `_ensure_mempalace_installed` helper (PR #509) into a reusable `ensure-tool.sh`.

## What changed
- **New `skills/autospec-shared/scripts/ensure-tool.sh`** — `ensure-tool.sh <tool>`; `command -v` probe then a baked-in tool table with platform-appropriate installer chains:
  - `bats` → brew (bats-core) / apt-get / npm
  - `jq`, `gh` → brew / apt-get
  - `mempalace` → pipx / uv / pip --user (mirrors PR #509)
  - Unknown tools and missing args are silent no-ops.
- **Opt-outs**: `AUTOSPEC_SKIP_ENSURE_TOOL=1` (all) and `AUTOSPEC_SKIP_ENSURE_TOOL_<TOOL>=1` (per-tool).
- All installs are best-effort silent failures (always exit 0) — an absent optional tool never blocks the caller.
- **`auto-init-memory.sh`** now delegates mempalace install to the shared helper, keeping the legacy `AUTOSPEC_SKIP_MEMPALACE_INSTALL` opt-out for back-compat.

## Tests
- New `tests/unit/ensure-tool.bats` — 17 cases (mocked installers via PATH-isolated stubs): no-op-when-present for each tool, install-branch selection, fallback chains, silent-failure, both opt-out vars, unknown tool, no-arg.
- Full unit suite: 82/82 green. `scripts/validate.sh`: OK.

## Acceptance criteria
- [x] `ensure-tool.sh bats` no-op if present; installs via brew/apt/npm otherwise
- [x] Same for jq, gh, mempalace
- [x] All installs best-effort silent failures (exit 0)
- [x] Opt-out env vars honored
- [x] Bats unit tests for each tool's branch (mocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)