### PR TITLE
fix(memory): cross-repo-search grep pattern strips trailing/duplicate pipe (+ negative test)

### DIFF
--- a/skills/autospec-shared/scripts/cross-repo-search.sh
+++ b/skills/autospec-shared/scripts/cross-repo-search.sh
@@ -73,8 +73,17 @@ fi
 _found_any=0
 _result_count=0
 
-# Build grep pattern from query words
-_pattern=$(printf '%s' "$QUERY" | tr ' ' '|')
+# Build grep pattern from query words.
+# Mirror inject-relevant-memory.sh sanitization so trailing/internal/duplicate
+# spaces cannot produce a match-all pattern (e.g. 'foo|') that behaves
+# differently on GNU vs BSD grep: collapse duplicate pipes, strip leading and
+# trailing pipe.
+_pattern=$(printf '%s' "$QUERY" | tr ' ' '|' | sed 's/|\{2,\}/|/g; s/^|//; s/|$//')
+
+# Guard: all-whitespace / empty query → empty pattern ⇒ no results, exit 0.
+if [ -z "$_pattern" ]; then
+  exit 0
+fi
 
 # ── Search each indexed repo ──────────────────────────────────────────────────
 for _link in "$INDEX_DIR"/*; do

--- a/tests/cross-repo-memory.bats
+++ b/tests/cross-repo-memory.bats
@@ -178,6 +178,45 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+# ── grep-fallback pattern sanitization (G1/G2) ───────────────────────────────
+# These force the grep branch by hiding `mempalace` from PATH, so the
+# pattern-building code path (not the mempalace branch) is exercised.
+
+@test "search (grep fallback): trailing-space query returns only genuine matches, not match-all" {
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    # Query for a term that does NOT appear in any indexed file, plus a trailing
+    # space. A buggy 'foo|' pattern matches every line on GNU grep (match-all).
+    run env PATH="/usr/bin:/bin" bash "$SEARCH_SCRIPT" "zzznotpresent " --index-dir "$HOME/.autospec/memory-index"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "search (grep fallback): internal double-space query does not match-all" {
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    # Internal duplicate space → naive tr gives 'zzznotpresent||' (empty alt → match-all).
+    run env PATH="/usr/bin:/bin" bash "$SEARCH_SCRIPT" "zzznotpresent  alsoabsent" --index-dir "$HOME/.autospec/memory-index"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "search (grep fallback): genuine match still found with trailing space" {
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    run env PATH="/usr/bin:/bin" bash "$SEARCH_SCRIPT" "RETURN trap " --index-dir "$HOME/.autospec/memory-index"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qi "RETURN"
+}
+
+@test "search (grep fallback): all-whitespace query returns empty, exit 0" {
+    run bash "$INDEX_SCRIPT" --repo-root "$REPO_A"
+    [ "$status" -eq 0 ]
+    run env PATH="/usr/bin:/bin" bash "$SEARCH_SCRIPT" "   " --index-dir "$HOME/.autospec/memory-index"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
 # ── inject-relevant-memory --cross-repo ───────────────────────────────────────
 
 @test "inject-relevant-memory: --cross-repo flag accepted without error" {


### PR DESCRIPTION
## Summary
Closes #525. `cross-repo-search.sh` built its `grep -E` alternation via `tr ' ' '|'` without the trailing/leading/duplicate-pipe sanitization its sibling `inject-relevant-memory.sh` does. A query with trailing/internal spaces produced a pattern like `foo|` — match-all on GNU grep (Linux CI/prod), error-to-empty on BSD grep (macOS) — so the same query gave opposite results per platform.

## Changes
- `cross-repo-search.sh` (~line 77): collapse duplicate pipes (`||`→`|`), strip leading and trailing `|`; guard all-whitespace/empty query (empty pattern ⇒ no results, exit 0).
- `tests/cross-repo-memory.bats`: 4 new tests that force the grep fallback (mempalace hidden from PATH) — trailing-space no-match, internal-double-space no-match, all-whitespace empty/exit-0, and genuine-match-with-trailing-space.

## Acceptance criteria
- [x] Identical sanitized pattern to `inject-relevant-memory.sh` (no leading/trailing/duplicate `|`)
- [x] Trailing-space query returns only genuine matches (no match-all) on GNU + BSD grep
- [x] All-whitespace/empty query → empty results, exit 0, no error
- [x] New bats force grep fallback covering trailing-space + empty-query negative paths; all 21 green
- [x] `bash scripts/validate.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)