### PR TITLE
fix(memory): diary-write entry separator must not collide with YAML frontmatter fence (#526)

### DIFF
--- a/skills/autospec-shared/scripts/diary-write.sh
+++ b/skills/autospec-shared/scripts/diary-write.sh
@@ -25,7 +25,15 @@
 #   phase: <n>
 #   event: <slug>
 #
-# Append-safe: multiple events on the same day go into one file, separated by ---.
+# Append-safe: multiple events on the same day go into one file, separated by a
+# distinct HTML-comment marker `<!-- diary-entry -->`. This marker is deliberately
+# NOT a bare `---` line so it can never collide with a YAML frontmatter fence or a
+# `---` line inside a body (common in pasted markdown / PR text), keeping entry
+# boundaries unambiguous for diary readers.
+#
+# Compat note: prior versions separated entries with a bare `---` line. Existing
+# diary files written that way still parse (each entry begins with its own `---`
+# frontmatter fence); only the inter-entry separator marker changed.
 
 set +e
 
@@ -79,8 +87,9 @@ DIARY_FILE="$DIARY_DIR/$TODAY.md"
 # Append-safe: if the file already exists, add a separator first.
 
 if [ -f "$DIARY_FILE" ]; then
-  # Separator between entries
-  printf '\n---\n' >> "$DIARY_FILE"
+  # Distinct inter-entry separator — never a bare '---' line, so it cannot be
+  # confused with a YAML frontmatter fence or a '---' line within a body.
+  printf '\n<!-- diary-entry -->\n\n' >> "$DIARY_FILE"
 fi
 
 cat >> "$DIARY_FILE" <<ENTRY

--- a/skills/autospec-shared/tests/unit/diary-write.bats
+++ b/skills/autospec-shared/tests/unit/diary-write.bats
@@ -84,15 +84,42 @@ run_diary() {
   grep -q "Second entry" "$f"
 }
 
-@test "diary-write same-day file has multiple entry separators" {
+@test "diary-write same-day file separates entries with a distinct marker" {
   run_diary --phase 1 --event brainstorm-locked --body "Entry A" --memory-dir "$MEMORY_DIR"
   run_diary --phase 4 --event monitor-exit --body "Entry B" --memory-dir "$MEMORY_DIR"
 
   local today
   today=$(date -u +%Y-%m-%d)
+  # One append => exactly one distinct inter-entry marker (not a bare '---').
   local sep_count
-  sep_count=$(grep -c "^---$" "$MEMORY_DIR/diary/$today.md" || true)
-  [ "$sep_count" -ge 2 ]
+  sep_count=$(grep -c "^<!-- diary-entry -->$" "$MEMORY_DIR/diary/$today.md" || true)
+  [ "$sep_count" -eq 1 ]
+}
+
+# ── Body containing a --- line (separator/fence collision) ────────────────────
+
+@test "diary-write entry separator is distinct from a --- body line" {
+  # A body that itself contains a bare '---' line (common in pasted markdown / PR text).
+  run_diary --phase 1 --event brainstorm-locked --body $'line1\n---\nline2' --memory-dir "$MEMORY_DIR"
+  [ "$status" -eq 0 ]
+  run_diary --phase 4 --event monitor-exit --body $'line3\n---\nline4' --memory-dir "$MEMORY_DIR"
+  [ "$status" -eq 0 ]
+
+  local today f
+  today=$(date -u +%Y-%m-%d)
+  f="$MEMORY_DIR/diary/$today.md"
+
+  # The inter-entry separator must be a distinct marker that cannot be confused
+  # with a bare '---' line (used by both YAML frontmatter fences and body text).
+  local sep_count
+  sep_count=$(grep -c '^<!-- diary-entry -->$' "$f" || true)
+  [ "$sep_count" -eq 1 ]
+
+  # Both bodies (each containing their own '---' line) must be preserved verbatim.
+  grep -q "^line1$" "$f"
+  grep -q "^line2$" "$f"
+  grep -q "^line3$" "$f"
+  grep -q "^line4$" "$f"
 }
 
 # ── Auto-create memory dir ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #526.

## What

`skills/autospec-shared/scripts/diary-write.sh` separated appended
same-day entries with a bare `---` line — identical to the YAML
frontmatter fence and to any `---` line inside a `--body` (common in
pasted markdown / PR text). Entry boundaries were therefore ambiguous to
diary readers (`mempalace_diary_read` / consumer #1 / #512).

## Fix

- Inter-entry separator changed from `\n---\n` to a distinct
  `<!-- diary-entry -->` HTML-comment marker that can never collide with
  a frontmatter fence or a body `---` line.
- Existing-format diary files still parse (each entry begins with its
  own `---` frontmatter fence); only the separator marker changed.
  Compat note added to the script header.
- New bats case: `--body` containing a `---` line asserts the separator
  stays distinct (exactly one marker) and both bodies survive verbatim.

## Acceptance criteria

- [x] Entry separator is distinct from a `---` body line.
- [x] Existing-format entries still parse; compat note documents the change.
- [x] New bats covers a body-with-`---` case; all 12 green.
- [x] `bash scripts/validate.sh` green.

## Out of scope

Frontmatter schema; the diary reader implementation (consumer #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)