### PR TITLE
docs: add STL design guardrails to autospec

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -507,6 +507,30 @@ check_governance_headings() {
         || fail "SKILLS.md: missing 'autospec-story' reference"
 }
 
+check_autospec_stl_design_guardrails() {
+    info "autospec STL/CAD design guardrails"
+    for f in \
+        "skills/autospec/SKILL.md" \
+        "skills/autospec/opencode/agent.md" \
+        "skills/autospec/codex/prompt.md"
+    do
+        grep -q '^## Physical STL / CAD design guardrails' "$f" \
+            || fail "$f missing physical STL/CAD design guardrails section"
+        grep -q 'at least 5 mm of free working clearance' "$f" \
+            || fail "$f missing 5 mm fitting/tool clearance rule"
+        grep -q 'at least 5 mm of continuous plastic margin' "$f" \
+            || fail "$f missing 5 mm gasket plastic margin rule"
+        grep -q 'relief valves, vents, restriction' "$f" \
+            || fail "$f missing low-flow vacuum no-restrictor rule"
+        grep -q 'gas/fluid/vacuum/dust-flow simulation' "$f" \
+            || fail "$f missing sealed/flowing simulation rule"
+        grep -q 'visual QA from at least 16 angles' "$f" \
+            || fail "$f missing 16-angle visual QA rule"
+        grep -q 'Regenerate from a clean build directory' "$f" \
+            || fail "$f missing clean-build regeneration rule"
+    done
+}
+
 # Existing spec mode invariants: autospec, autospec-split, and autospec-define must expose the
 # shortcut that skips Phase 1/2 and reuses Phase 3 + Phase 3.5 for a tracked
 # docs/specs/*.md file. Enforce all trio files so harness variants cannot drift.
@@ -641,6 +665,7 @@ main() {
     check_autospec_listen_files
     check_examples_dir
     check_governance_headings
+    check_autospec_stl_design_guardrails
     check_existing_spec_mode
     check_lint_issue_helpers
     check_lint_implementation_helpers

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -161,6 +161,48 @@ This workflow assumes five capabilities. Map each one to your harness's actual t
 
 **Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work (research, decompose, review/label); Tier B (cheaper model + medium thinking) for implementation work (Phase 4 implementer + LGTM review). The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
 
+## Physical STL / CAD design guardrails
+
+When the request involves STL, CAD, 3D-printable fixtures, workholding,
+vacuum, pneumatic, hydraulic, dust-collection, hose, fitting, gasket, or
+other physical models, carry these requirements into Phase 2 specs, Phase 3
+child issues, and Phase 4 verification:
+
+- Treat physical function as acceptance criteria, not visual intent. Verify
+  mountability, tool access, fitting clearance, gasket compression, storage fit,
+  printer build volume, and expected operating orientation.
+- Do not allow blocked ports, obstructed hoses/tubes, capped passages, hidden
+  dead-end channels, or geometry that interferes with the model's purpose.
+- Around every port, fitting, connector, tap bore, hose socket, screw head, and
+  service tool path, require at least 5 mm of free working clearance in every
+  direction unless the user explicitly specifies a tighter envelope.
+- Around every gasket path, require at least 5 mm of continuous plastic margin
+  outside the gasket. Gasket grooves must not expose an edge or be crossed by
+  mounts, screws, ribs, channels, holders, or workpiece contact geometry.
+- For NPT or other tapped ports, prove the tap and installed fitting can enter
+  straight or along the specified angled axis without collisions. Ports and
+  fitting bosses must be integrated into reinforced body geometry, not left as
+  fragile stand-alone protrusions.
+- For low-flow vacuum systems, do not add relief valves, vents, restriction
+  orifices, small balancing holes, or intentional leaks unless the user
+  explicitly asks for them and the spec records why the pump can tolerate them.
+- For sealed or flowing parts, require gas/fluid/vacuum/dust-flow simulation or
+  deterministic geometry checks that prove no leaks, no disconnected internal
+  circuits, no blocked passages, and adequate inlet-to-outlet connectivity.
+- For dust collection, preserve maximum practical duct cross-section and
+  suction path continuity. No vacuum tubing, air port, dust passage, or hose
+  connection may be narrowed or blocked by ribs, mounts, bosses, decorative
+  geometry, or slicer support assumptions.
+- For every generated STL, require visual QA from at least 16 angles: right,
+  left, front, back, top, bottom, top-right 45, top-left 45, top-front 45,
+  top-back 45, front-right 45, front-left 45, back-right 45, back-left 45,
+  bottom-right 45, and bottom-left 45. Renders must be nonblank, well-framed,
+  and reviewed for obvious gaps, overlaps, obstructions, unsupported fragile
+  features, and unexpected protrusions.
+- Regenerate from a clean build directory before release, then verify the build
+  directory contains every expected STL plus any PDFs, sections, renders, and
+  acceptance artifacts named by the spec.
+
 ---
 
 ## Harness detection (run once at skill start, before Phase 0)

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -193,6 +193,10 @@ child issues, and Phase 4 verification:
   suction path continuity. No vacuum tubing, air port, dust passage, or hose
   connection may be narrowed or blocked by ribs, mounts, bosses, decorative
   geometry, or slicer support assumptions.
+- For functional openings such as dust hood mouths, plenum intakes, vacuum
+  channels, gasket windows, and hose throats, add deterministic projection or
+  section keepout checks. Prove that reinforcements, sockets, bosses, ribs, and
+  cutters do not intrude into the working opening from any operating angle.
 - For every generated STL, require visual QA from at least 16 angles: right,
   left, front, back, top, bottom, top-right 45, top-left 45, top-front 45,
   top-back 45, front-right 45, front-left 45, back-right 45, back-left 45,

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -188,6 +188,10 @@ child issues, and Phase 4 verification:
   suction path continuity. No vacuum tubing, air port, dust passage, or hose
   connection may be narrowed or blocked by ribs, mounts, bosses, decorative
   geometry, or slicer support assumptions.
+- For functional openings such as dust hood mouths, plenum intakes, vacuum
+  channels, gasket windows, and hose throats, add deterministic projection or
+  section keepout checks. Prove that reinforcements, sockets, bosses, ribs, and
+  cutters do not intrude into the working opening from any operating angle.
 - For every generated STL, require visual QA from at least 16 angles: right,
   left, front, back, top, bottom, top-right 45, top-left 45, top-front 45,
   top-back 45, front-right 45, front-left 45, back-right 45, back-left 45,

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -156,6 +156,48 @@ This workflow assumes five capabilities. Map each one to your harness's actual t
 
 **Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work (research, decompose, review/label); Tier B (cheaper model + medium thinking) for implementation work (Phase 4 implementer + LGTM review). The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
 
+## Physical STL / CAD design guardrails
+
+When the request involves STL, CAD, 3D-printable fixtures, workholding,
+vacuum, pneumatic, hydraulic, dust-collection, hose, fitting, gasket, or
+other physical models, carry these requirements into Phase 2 specs, Phase 3
+child issues, and Phase 4 verification:
+
+- Treat physical function as acceptance criteria, not visual intent. Verify
+  mountability, tool access, fitting clearance, gasket compression, storage fit,
+  printer build volume, and expected operating orientation.
+- Do not allow blocked ports, obstructed hoses/tubes, capped passages, hidden
+  dead-end channels, or geometry that interferes with the model's purpose.
+- Around every port, fitting, connector, tap bore, hose socket, screw head, and
+  service tool path, require at least 5 mm of free working clearance in every
+  direction unless the user explicitly specifies a tighter envelope.
+- Around every gasket path, require at least 5 mm of continuous plastic margin
+  outside the gasket. Gasket grooves must not expose an edge or be crossed by
+  mounts, screws, ribs, channels, holders, or workpiece contact geometry.
+- For NPT or other tapped ports, prove the tap and installed fitting can enter
+  straight or along the specified angled axis without collisions. Ports and
+  fitting bosses must be integrated into reinforced body geometry, not left as
+  fragile stand-alone protrusions.
+- For low-flow vacuum systems, do not add relief valves, vents, restriction
+  orifices, small balancing holes, or intentional leaks unless the user
+  explicitly asks for them and the spec records why the pump can tolerate them.
+- For sealed or flowing parts, require gas/fluid/vacuum/dust-flow simulation or
+  deterministic geometry checks that prove no leaks, no disconnected internal
+  circuits, no blocked passages, and adequate inlet-to-outlet connectivity.
+- For dust collection, preserve maximum practical duct cross-section and
+  suction path continuity. No vacuum tubing, air port, dust passage, or hose
+  connection may be narrowed or blocked by ribs, mounts, bosses, decorative
+  geometry, or slicer support assumptions.
+- For every generated STL, require visual QA from at least 16 angles: right,
+  left, front, back, top, bottom, top-right 45, top-left 45, top-front 45,
+  top-back 45, front-right 45, front-left 45, back-right 45, back-left 45,
+  bottom-right 45, and bottom-left 45. Renders must be nonblank, well-framed,
+  and reviewed for obvious gaps, overlaps, obstructions, unsupported fragile
+  features, and unexpected protrusions.
+- Regenerate from a clean build directory before release, then verify the build
+  directory contains every expected STL plus any PDFs, sections, renders, and
+  acceptance artifacts named by the spec.
+
 
 ## Harness detection (run once at skill start, before Phase 0)
 

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -160,6 +160,48 @@ This workflow assumes five capabilities. Map each one to your harness's actual t
 
 **Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work (research, decompose, review/label); Tier B (cheaper model + medium thinking) for implementation work (Phase 4 implementer + LGTM review). The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
 
+## Physical STL / CAD design guardrails
+
+When the request involves STL, CAD, 3D-printable fixtures, workholding,
+vacuum, pneumatic, hydraulic, dust-collection, hose, fitting, gasket, or
+other physical models, carry these requirements into Phase 2 specs, Phase 3
+child issues, and Phase 4 verification:
+
+- Treat physical function as acceptance criteria, not visual intent. Verify
+  mountability, tool access, fitting clearance, gasket compression, storage fit,
+  printer build volume, and expected operating orientation.
+- Do not allow blocked ports, obstructed hoses/tubes, capped passages, hidden
+  dead-end channels, or geometry that interferes with the model's purpose.
+- Around every port, fitting, connector, tap bore, hose socket, screw head, and
+  service tool path, require at least 5 mm of free working clearance in every
+  direction unless the user explicitly specifies a tighter envelope.
+- Around every gasket path, require at least 5 mm of continuous plastic margin
+  outside the gasket. Gasket grooves must not expose an edge or be crossed by
+  mounts, screws, ribs, channels, holders, or workpiece contact geometry.
+- For NPT or other tapped ports, prove the tap and installed fitting can enter
+  straight or along the specified angled axis without collisions. Ports and
+  fitting bosses must be integrated into reinforced body geometry, not left as
+  fragile stand-alone protrusions.
+- For low-flow vacuum systems, do not add relief valves, vents, restriction
+  orifices, small balancing holes, or intentional leaks unless the user
+  explicitly asks for them and the spec records why the pump can tolerate them.
+- For sealed or flowing parts, require gas/fluid/vacuum/dust-flow simulation or
+  deterministic geometry checks that prove no leaks, no disconnected internal
+  circuits, no blocked passages, and adequate inlet-to-outlet connectivity.
+- For dust collection, preserve maximum practical duct cross-section and
+  suction path continuity. No vacuum tubing, air port, dust passage, or hose
+  connection may be narrowed or blocked by ribs, mounts, bosses, decorative
+  geometry, or slicer support assumptions.
+- For every generated STL, require visual QA from at least 16 angles: right,
+  left, front, back, top, bottom, top-right 45, top-left 45, top-front 45,
+  top-back 45, front-right 45, front-left 45, back-right 45, back-left 45,
+  bottom-right 45, and bottom-left 45. Renders must be nonblank, well-framed,
+  and reviewed for obvious gaps, overlaps, obstructions, unsupported fragile
+  features, and unexpected protrusions.
+- Regenerate from a clean build directory before release, then verify the build
+  directory contains every expected STL plus any PDFs, sections, renders, and
+  acceptance artifacts named by the spec.
+
 
 ## Harness detection (run once at skill start, before Phase 0)
 

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -192,6 +192,10 @@ child issues, and Phase 4 verification:
   suction path continuity. No vacuum tubing, air port, dust passage, or hose
   connection may be narrowed or blocked by ribs, mounts, bosses, decorative
   geometry, or slicer support assumptions.
+- For functional openings such as dust hood mouths, plenum intakes, vacuum
+  channels, gasket windows, and hose throats, add deterministic projection or
+  section keepout checks. Prove that reinforcements, sockets, bosses, ribs, and
+  cutters do not intrude into the working opening from any operating angle.
 - For every generated STL, require visual QA from at least 16 angles: right,
   left, front, back, top, bottom, top-right 45, top-left 45, top-front 45,
   top-back 45, front-right 45, front-left 45, back-right 45, back-left 45,


### PR DESCRIPTION
## Summary
- Add Physical STL / CAD design guardrails to the autospec skill trio.
- Require physical-function checks for ports, gaskets, fittings, low-flow vacuum, dust flow, simulations, clean regeneration, and 16-angle visual QA.
- Extend scripts/validate.sh so the rules stay present across the Claude/OpenCode/Codex autospec surfaces.

## Validation
- bash scripts/validate.sh