### PR TITLE
feat(run): run-start BATCH_START timestamp helper + wiring (#530)

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -210,6 +210,16 @@ bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh
 Prepend the output block (if non-empty) to your working context. This surfaces lessons like
 `feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
 
+## Run-start batch timestamp (run-start, once)
+
+Capture the run-start instant so the end-of-run gap-remediation phase (Phase 5.5) can scope its review to work shipped during THIS run. Run exactly once, before the Phase 4 monitor launches:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/run-batch-start.sh" --write
+```
+
+This writes the UTC ISO 8601 timestamp to `~/.autospec/.run-batch-start` (idempotent within a run; pass `--force` only when intentionally starting a fresh batch window). Phase 5.5 reads it back via `run-batch-start.sh --read`, which yields `BATCH_START_DATE`.
+
 ## Phase 4 — Background autonomous monitor
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -205,6 +205,16 @@ bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh
 Prepend the output block (if non-empty) to your working context. This surfaces lessons like
 `feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
 
+## Run-start batch timestamp (run-start, once)
+
+Capture the run-start instant so the end-of-run gap-remediation phase (Phase 5.5) can scope its review to work shipped during THIS run. Run exactly once, before the Phase 4 monitor launches:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/run-batch-start.sh" --write
+```
+
+This writes the UTC ISO 8601 timestamp to `~/.autospec/.run-batch-start` (idempotent within a run; pass `--force` only when intentionally starting a fresh batch window). Phase 5.5 reads it back via `run-batch-start.sh --read`, which yields `BATCH_START_DATE`.
+
 ## Phase 4 — Background autonomous monitor
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -209,6 +209,16 @@ bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/inject-relevant-memory.sh
 Prepend the output block (if non-empty) to your working context. This surfaces lessons like
 `feedback_bash_return_trap_leak.md` that prevent re-occurrence of known pitfalls.
 
+## Run-start batch timestamp (run-start, once)
+
+Capture the run-start instant so the end-of-run gap-remediation phase (Phase 5.5) can scope its review to work shipped during THIS run. Run exactly once, before the Phase 4 monitor launches:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/run-batch-start.sh" --write
+```
+
+This writes the UTC ISO 8601 timestamp to `~/.autospec/.run-batch-start` (idempotent within a run; pass `--force` only when intentionally starting a fresh batch window). Phase 5.5 reads it back via `run-batch-start.sh --read`, which yields `BATCH_START_DATE`.
+
 ## Phase 4 — Background autonomous monitor
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):

--- a/skills/autospec-shared/scripts/run-batch-start.sh
+++ b/skills/autospec-shared/scripts/run-batch-start.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# run-batch-start.sh — record / read the UTC run-start timestamp for an autospec run.
+#
+# autospec-run writes this once at run-start so the end-of-run gap-remediation
+# phase can scope `/autospec-review --since` to work shipped during THIS run.
+# Format: ISO 8601 UTC, e.g. 2026-05-24T18:42:11Z (matches `date -u +%Y-%m-%dT%H:%M:%SZ`).
+#
+# Usage:
+#   run-batch-start.sh --write [--force]   # write now() unless file exists (--force overwrites)
+#   run-batch-start.sh --read              # echo stored timestamp (epoch sentinel if absent)
+#   run-batch-start.sh --help
+#
+# Environment:
+#   AUTOSPEC_STATE_DIR  — override state directory (default: ~/.autospec)
+#
+# Exit codes:
+#   0  always (best-effort; missing file on --read returns epoch sentinel)
+#
+# Requires: bash 3.2+, date
+
+set +e
+
+STATE_DIR="${AUTOSPEC_STATE_DIR:-$HOME/.autospec}"
+BATCH_FILE="$STATE_DIR/.run-batch-start"
+EPOCH_SENTINEL="1970-01-01T00:00:00Z"
+
+MODE=""
+FORCE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --write) MODE="write"; shift ;;
+    --read)  MODE="read";  shift ;;
+    --force) FORCE=1;      shift ;;
+    --help|-h)
+      printf 'Usage: run-batch-start.sh --write [--force] | --read\n'
+      exit 0
+      ;;
+    *) shift ;;
+  esac
+done
+
+case "$MODE" in
+  write)
+    mkdir -p "$STATE_DIR" 2>/dev/null
+    if [ -f "$BATCH_FILE" ] && [ "$FORCE" -ne 1 ]; then
+      exit 0
+    fi
+    date -u +%Y-%m-%dT%H:%M:%SZ > "$BATCH_FILE" 2>/dev/null
+    exit 0
+    ;;
+  read)
+    if [ -f "$BATCH_FILE" ]; then
+      cat "$BATCH_FILE"
+    else
+      printf '%s\n' "$EPOCH_SENTINEL"
+    fi
+    exit 0
+    ;;
+  *)
+    printf 'Usage: run-batch-start.sh --write [--force] | --read\n' >&2
+    exit 0
+    ;;
+esac

--- a/skills/autospec-shared/tests/unit/run-batch-start.bats
+++ b/skills/autospec-shared/tests/unit/run-batch-start.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# run-batch-start.bats — tests for run-batch-start.sh (write/read of ~/.autospec/.run-batch-start)
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/run-batch-start.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    export AUTOSPEC_STATE_DIR="$TEST_TMP"
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+@test "run-batch-start.sh is executable" {
+    [ -x "$SCRIPT" ]
+}
+
+@test "run-batch-start.sh --help exits 0 and prints Usage" {
+    run bash "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "--write creates the batch-start file with a UTC ISO timestamp" {
+    run bash "$SCRIPT" --write
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_TMP/.run-batch-start" ]
+    # ISO 8601 UTC, e.g. 2026-05-24T18:42:11Z
+    run cat "$TEST_TMP/.run-batch-start"
+    [[ "$output" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+@test "--read echoes the previously written timestamp" {
+    printf '2026-05-24T00:00:00Z\n' > "$TEST_TMP/.run-batch-start"
+    run bash "$SCRIPT" --read
+    [ "$status" -eq 0 ]
+    [ "$output" = "2026-05-24T00:00:00Z" ]
+}
+
+@test "--read with no file falls back to epoch sentinel and exits 0" {
+    run bash "$SCRIPT" --read
+    [ "$status" -eq 0 ]
+    [ "$output" = "1970-01-01T00:00:00Z" ]
+}
+
+@test "--write does not overwrite an existing batch-start (idempotent within a run)" {
+    printf '2026-05-24T00:00:00Z\n' > "$TEST_TMP/.run-batch-start"
+    run bash "$SCRIPT" --write
+    [ "$status" -eq 0 ]
+    run cat "$TEST_TMP/.run-batch-start"
+    [ "$output" = "2026-05-24T00:00:00Z" ]
+}
+
+@test "--write --force overwrites an existing batch-start" {
+    printf '2026-05-24T00:00:00Z\n' > "$TEST_TMP/.run-batch-start"
+    run bash "$SCRIPT" --write --force
+    [ "$status" -eq 0 ]
+    run cat "$TEST_TMP/.run-batch-start"
+    [ "$output" != "2026-05-24T00:00:00Z" ]
+}


### PR DESCRIPTION
## Summary
Implements Task 1 of the end-of-run gap remediation plan: a run-start BATCH_START timestamp helper, wired into the autospec-run trio.

- New `skills/autospec-shared/scripts/run-batch-start.sh` — write/read helper for `~/.autospec/.run-batch-start` (UTC ISO 8601). Supports `--write [--force]`, `--read` (epoch sentinel `1970-01-01T00:00:00Z` when absent), `--help`; honors `AUTOSPEC_STATE_DIR`; `set +e`; always exits 0.
- New `skills/autospec-shared/tests/unit/run-batch-start.bats` — 7 unit tests (TDD: written failing first).
- Wired the `--write` invocation into a new `## Run-start batch timestamp (run-start, once)` subsection of the autospec-run trio (SKILL.md + codex/prompt.md + opencode/agent.md), byte-identical for lockstep.

## Acceptance criteria
- `bats skills/autospec-shared/tests/unit/run-batch-start.bats` — 7 tests, 0 failures
- `bash -n skills/autospec-shared/scripts/run-batch-start.sh` exits 0
- `test -x` script — yes
- `grep -q '## Run-start batch timestamp' skills/autospec-run/SKILL.md` — yes (all 3 trio files)
- `bash scripts/validate.sh` ends with `validate: OK` and exits 0

Note: the plan's literal test SCRIPT path (`BATS_TEST_DIRNAME/../../../skills/...`) double-counted the `skills/` segment; corrected to the repo's established `$(dirname "$BATS_TEST_FILENAME")/../..` sibling convention so the 7-test acceptance criterion actually passes.

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)