### PR TITLE
feat(shared): gap JSON contract validator + title-hash helper (gap-remediation Task 2)

### DIFF
--- a/skills/autospec-shared/scripts/gap-json-lib.sh
+++ b/skills/autospec-shared/scripts/gap-json-lib.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# gap-json-lib.sh — shared helpers for the gap JSON contract.
+#
+# Gap object schema (emitted by `/autospec-review --remediation --emit-gaps`):
+#   {gap_id, dimension, severity, file, line, title, body, dedupe_key}
+#
+# Sourceable OR runnable:
+#   bash gap-json-lib.sh --validate-file <path>   # exit 0 if file holds a valid gap object
+#   bash gap-json-lib.sh --title-hash "<title>"   # print 10-char sha1 hex (dedupe fallback)
+#   bash gap-json-lib.sh --selftest               # internal smoke check
+#   bash gap-json-lib.sh --help                   # usage
+#
+# When sourced, exposes:
+#   gap_required_keys                  # echoes the required key list
+#   gap_validate_object <json-string>  # returns 0/1
+#   gap_title_hash <title-string>      # prints 10-char hex
+#
+# Exit codes:
+#   0  ok / valid
+#   1  invalid object, missing file, or missing jq
+#
+# Requires: bash 3.2+, jq, shasum (or sha1sum)
+
+set +e
+
+GAP_REQUIRED_KEYS="gap_id dimension severity file line title body dedupe_key"
+
+gap_required_keys() { printf '%s\n' "$GAP_REQUIRED_KEYS"; }
+
+# gap_validate_object <json-string> — 0 if all required keys present (non-null).
+gap_validate_object() {
+  local obj="$1" key
+  command -v jq >/dev/null 2>&1 || return 1
+  printf '%s' "$obj" | jq -e 'type == "object"' >/dev/null 2>&1 || return 1
+  for key in $GAP_REQUIRED_KEYS; do
+    printf '%s' "$obj" | jq -e --arg k "$key" 'has($k) and (.[$k] != null)' >/dev/null 2>&1 || return 1
+  done
+  return 0
+}
+
+# gap_title_hash <title> — deterministic 10-char hex for dedupe fallback.
+gap_title_hash() {
+  local title="$1" sum
+  if command -v shasum >/dev/null 2>&1; then
+    sum="$(printf '%s' "$title" | shasum | awk '{print $1}')"
+  else
+    sum="$(printf '%s' "$title" | sha1sum | awk '{print $1}')"
+  fi
+  printf '%s' "${sum:0:10}"
+}
+
+# ── Runnable entrypoint (skipped when sourced) ────────────────────────────────
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  case "${1:-}" in
+    --validate-file)
+      [ -f "${2:-}" ] || exit 1
+      gap_validate_object "$(cat "$2")" || exit 1
+      exit 0
+      ;;
+    --title-hash)
+      gap_title_hash "${2:-}"
+      printf '\n'
+      exit 0
+      ;;
+    --selftest)
+      gap_validate_object '{"gap_id":"G1","dimension":"correctness","severity":"low","file":"a","line":1,"title":"t","body":"b","dedupe_key":"k"}' || exit 1
+      gap_validate_object '{"gap_id":"G1"}' && exit 1
+      h="$(gap_title_hash "abc")"; [ "${#h}" -eq 10 ] || exit 1
+      exit 0
+      ;;
+    --help|-h)
+      printf 'Usage: gap-json-lib.sh --validate-file <path> | --title-hash <title> | --selftest\n'
+      exit 0
+      ;;
+    *)
+      printf 'Usage: gap-json-lib.sh --validate-file <path> | --title-hash <title> | --selftest\n' >&2
+      exit 0
+      ;;
+  esac
+fi

--- a/skills/autospec-shared/tests/unit/gap-json-lib.bats
+++ b/skills/autospec-shared/tests/unit/gap-json-lib.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# gap-json-lib.bats — tests for gap-json-lib.sh schema validation + title-hash.
+
+LIB="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/gap-json-lib.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+}
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+@test "gap-json-lib.sh --selftest exits 0" {
+    run bash "$LIB" --selftest
+    [ "$status" -eq 0 ]
+}
+
+@test "validate accepts a complete gap object" {
+    cat > "$TEST_TMP/gap.json" <<'EOF'
+{"gap_id":"G1","dimension":"correctness","severity":"medium","file":"a.sh","line":7,"title":"t","body":"b","dedupe_key":"k1"}
+EOF
+    run bash "$LIB" --validate-file "$TEST_TMP/gap.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate rejects a gap object missing required keys" {
+    cat > "$TEST_TMP/bad.json" <<'EOF'
+{"gap_id":"G1","dimension":"correctness"}
+EOF
+    run bash "$LIB" --validate-file "$TEST_TMP/bad.json"
+    [ "$status" -ne 0 ]
+}
+
+@test "title-hash is stable and lowercase-hex" {
+    run bash "$LIB" --title-hash "cross-repo-search trailing pipe"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ ^[0-9a-f]{10}$ ]]
+    first="$output"
+    run bash "$LIB" --title-hash "cross-repo-search trailing pipe"
+    [ "$output" = "$first" ]
+}


### PR DESCRIPTION
Closes #531.

## Summary
Adds `skills/autospec-shared/scripts/gap-json-lib.sh` — a sourceable + runnable helper that keeps the gap JSON contract in one place (DRY) for the loop driver (Task 3) and review-mode shaper/tests (Task 4).

- `gap_required_keys` / `gap_validate_object <json>` / `gap_title_hash <title>` exposed when sourced.
- Runnable: `--validate-file <path>`, `--title-hash <title>`, `--selftest`, `--help`.
- Validates the `{gap_id,dimension,severity,file,line,title,body,dedupe_key}` schema via `jq` (all keys present + non-null).
- 10-char lowercase-hex title-hash via `shasum`/`sha1sum` for dedupe fallback.
- `set +e` (no `gh`; best-effort lib).

## Tests
`skills/autospec-shared/tests/unit/gap-json-lib.bats` — 4 tests, TDD failing-first then green.

## Acceptance criteria
- [x] `bats skills/autospec-shared/tests/unit/gap-json-lib.bats` passes (4/0)
- [x] `--selftest` exits 0
- [x] `bash -n` exits 0
- [x] `test -x` passes
- [x] `scripts/validate.sh` OK

Note: the bats LIB path uses the repo's established `dirname/../../scripts/` convention rather than the plan's `../../../skills/...` (which double-counts `skills/` for this layout).

## Out of scope
Loop driver + review shaper that source this lib (Tasks 3, 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)