### PR TITLE
feat(listen): listener-match.sh intent gate + verb->skill classifier + bats (keyword-routing a)

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -98,8 +98,29 @@ Usage: bash sizing-check.sh <issue-number> [--repo <owner/repo>]
 Pattern-matches a conversation snippet against autospec-listen trigger keywords.
 
 ```
-Usage: bash listener-match.sh [--text <text>]
+Usage: bash listener-match.sh "<phrase>"              # word mode (default)
+       bash listener-match.sh --classify "<phrase>"   # JSON classify mode
+       echo "<phrase>" | bash listener-match.sh [--classify]
 ```
+
+Word mode (default, back-compat) prints exactly one of `issue`, `spec`, `none`
+and always exits 0.
+
+Classify mode (`--classify`) emits a JSON object and always exits 0. It applies
+the keyword-routing verb->skill map and an imperative-intent gate:
+
+```
+{"match":bool,"skill":"autospec-define|autospec-run|autospec-review|autospec|null",
+ "trigger":"<verb>|null","intent":"imperative|incidental|none","confidence":0-1}
+```
+
+Verb->skill map: `design`/`new feature`/`spec` -> `autospec-define`;
+`implement`/`build`/`ship` -> `autospec-run`; `review` -> `autospec-review`;
+`autospec ...` -> `autospec`. The existing `file an issue` / `write a spec`
+back-compat phrases route to `autospec-define`. The intent gate is biased to
+false-negatives: past-tense, negated, interrogative, and descriptive uses are
+suppressed (`match:false` / `intent:incidental`) so incidental mentions never
+misfire a route.
 
 ### `ci-wait.sh`
 

--- a/scripts/listener-match.sh
+++ b/scripts/listener-match.sh
@@ -2,17 +2,30 @@
 # scripts/listener-match.sh — classify a chat phrase as an autospec-listen
 # trigger.
 #
-# Usage:
-#   scripts/listener-match.sh "<phrase>"     # phrase as $1
-#   echo "<phrase>" | scripts/listener-match.sh   # phrase on stdin
+# Two modes:
 #
-# Prints exactly one of: issue, spec, none. Always exits 0.
+#   Word mode (default, back-compat):
+#     scripts/listener-match.sh "<phrase>"           # phrase as $1
+#     echo "<phrase>" | scripts/listener-match.sh    # phrase on stdin
+#   Prints exactly one of: issue, spec, none. Always exits 0.
 #
-# The set of trigger phrases is sourced from
+#   Classify mode (keyword routing, issue #537):
+#     scripts/listener-match.sh --classify "<phrase>"
+#     echo "<phrase>" | scripts/listener-match.sh --classify
+#   Prints JSON
+#     {"match":bool,"skill":<skill|null>,"trigger":<verb|null>,
+#      "intent":"imperative|incidental|none","confidence":0-1}
+#   on stdout. A non-match is {"match":false,...}. Always exits 0.
+#
+# The word-mode trigger phrases are sourced from
 # `skills/autospec-listen/references/trigger-keywords.md` so the script and
 # the documentation can never drift. Matching is case-insensitive and
 # word-boundary anchored. Bare nouns ("issue", "spec", "ticket") are NOT
 # triggers.
+#
+# Classify mode adds a verb->skill map (D3) and an imperative-intent gate
+# (D4) biased to false-negatives: prefer no route over a misfire (see
+# feedback_autospec_design_prefs + feedback_omc_autopilot_misfire).
 
 set -eu
 
@@ -123,12 +136,168 @@ EOF
     printf 'none\n'
 }
 
+# ── Classify mode (keyword routing, issue #537) ────────────────────────────────
+#
+# Emit the classifier JSON object. All fields always present.
+emit_classify_json() {
+    # $1=match(true|false) $2=skill $3=trigger $4=intent $5=confidence
+    match="$1"; skill="$2"; trigger="$3"; intent="$4"; conf="$5"
+    skill_json="null"; [ -n "$skill" ] && skill_json="\"$skill\""
+    trigger_json="null"; [ -n "$trigger" ] && trigger_json="\"$trigger\""
+    printf '{"match":%s,"skill":%s,"trigger":%s,"intent":"%s","confidence":%s}\n' \
+        "$match" "$skill_json" "$trigger_json" "$intent" "$conf"
+}
+
+# Whole-word match of a single token in the (already lower-cased) needle.
+# Word boundaries are non-[a-z0-9_-] characters or string ends.
+has_word() {
+    needle="$1"; word="$2"
+    printf '%s' "$needle" | awk -v p="$word" '
+        BEGIN { found = 0 }
+        {
+            s = $0; pl = length(p); sl = length(s)
+            for (i = 1; i <= sl - pl + 1; i++) {
+                if (substr(s, i, pl) == p) {
+                    if (i == 1) { left_ok = 1 }
+                    else { lc = substr(s, i-1, 1); left_ok = (lc !~ /[A-Za-z0-9_-]/) }
+                    end_pos = i + pl
+                    if (end_pos > sl) { right_ok = 1 }
+                    else { rc = substr(s, end_pos, 1); right_ok = (rc !~ /[A-Za-z0-9_-]/) }
+                    if (left_ok && right_ok) { found = 1; exit }
+                }
+            }
+        }
+        END { exit found ? 0 : 1 }'
+}
+
+# Intent gate (D4). Returns 0 (imperative — route) or 1 (incidental — suppress).
+# Biased to false-negatives: any suppressor wins.
+is_imperative() {
+    text="$1"   # lower-cased
+
+    # Suppressor 1: question. A trailing "?" or an interrogative lead-in.
+    case "$text" in
+        *\?*) return 1 ;;
+    esac
+    for q in should could would shall "do we" "do you" "can we" "can you" \
+             "should we" "should i" "could we" "could you" "would you" \
+             why what how when "are we" "is it" "are you"; do
+        case "$text" in
+            "$q "*|"$q") return 1 ;;
+        esac
+    done
+
+    # Suppressor 2: negation anywhere.
+    for neg in "don't" "do not" "doesn't" "does not" "didn't" "did not" \
+               "won't" "will not" "wouldn't" "shouldn't" "can't" "cannot" \
+               "no need" "not yet" "never" "instead of" "rather than"; do
+        if has_word "$text" "$neg" 2>/dev/null; then return 1; fi
+        case "$text" in
+            *"$neg"*) return 1 ;;
+        esac
+    done
+    # Bare "not" as its own word.
+    if has_word "$text" "not"; then return 1; fi
+
+    # Suppressor 3: past tense / already-done.
+    for past in already reviewed implemented designed built shipped \
+                created filed wrote written reviewing done finished completed; do
+        if has_word "$text" "$past"; then return 1; fi
+    done
+    # "have/has/had <verb>" and "was/were" markers.
+    for pmark in "have " "has " "had " "was " "were " "i've " "we've "; do
+        case "$text" in
+            *"$pmark"*) return 1 ;;
+        esac
+    done
+
+    # Suppressor 4: descriptive use (verb as a noun behind an article, or a
+    # copular description). "the design ...", "this review ...", "a spec ...".
+    for art in "the design" "the review" "the spec" "the build" "this design" \
+               "this review" "this spec" "that design" "a design" "the implementation"; do
+        case "$text" in
+            *"$art"*) return 1 ;;
+        esac
+    done
+
+    return 0
+}
+
+# Classify a phrase into the verb→skill map (D3), gated by intent (D4).
+classify_phrase() {
+    text_lc="$(to_lower "$1")"
+
+    # Back-compat: explicit "file an issue" / "write a spec" phrases are
+    # already imperative triggers and bypass the verb intent-gate (they route
+    # to autospec-define, the listen skill's define handoff).
+    if match_against_list "$text_lc" <<EOF
+$(parse_trigger_md "Issue triggers")
+EOF
+    then
+        emit_classify_json true autospec-define issue imperative 0.6
+        return 0
+    fi
+    if match_against_list "$text_lc" <<EOF
+$(parse_trigger_md "Spec triggers")
+EOF
+    then
+        emit_classify_json true autospec-define spec imperative 0.6
+        return 0
+    fi
+
+    # Verb → skill map (D3). Order matters: most specific first.
+    skill=""; trigger=""
+    if has_word "$text_lc" "autospec"; then
+        skill="autospec"; trigger="autospec"
+    elif has_word "$text_lc" "implement" || has_word "$text_lc" "build" \
+        || has_word "$text_lc" "ship"; then
+        skill="autospec-run"
+        if has_word "$text_lc" "implement"; then trigger="implement"
+        elif has_word "$text_lc" "build"; then trigger="build"
+        else trigger="ship"; fi
+    elif has_word "$text_lc" "design" || has_word "$text_lc" "redesign" \
+        || has_word "$text_lc" "new feature" \
+        || (has_word "$text_lc" "spec" && ! has_word "$text_lc" "specification"); then
+        skill="autospec-define"
+        if has_word "$text_lc" "design" || has_word "$text_lc" "redesign"; then
+            trigger="design"
+        elif has_word "$text_lc" "new feature"; then trigger="new feature"
+        else trigger="spec"; fi
+    elif has_word "$text_lc" "review"; then
+        skill="autospec-review"; trigger="review"
+    fi
+
+    # No verb matched (and no back-compat phrase above) — non-match.
+    if [ -z "$skill" ]; then
+        emit_classify_json false "" "" none 0
+        return 0
+    fi
+
+    # A verb matched — apply the intent gate.
+    if is_imperative "$text_lc"; then
+        emit_classify_json true "$skill" "$trigger" imperative 0.8
+    else
+        emit_classify_json false "$skill" "$trigger" incidental 0.2
+    fi
+}
+
 main() {
+    mode="word"
+    if [ "${1:-}" = "--classify" ]; then
+        mode="classify"
+        shift
+    fi
+
     if [ "$#" -ge 1 ]; then
-        match_phrase "$1"
+        candidate="$1"
     else
         # Read all of stdin into one buffer so multi-line input still works.
         candidate="$(cat)"
+    fi
+
+    if [ "$mode" = "classify" ]; then
+        classify_phrase "$candidate"
+    else
         match_phrase "$candidate"
     fi
 }

--- a/skills/autospec-shared/tests/unit/listener-match.bats
+++ b/skills/autospec-shared/tests/unit/listener-match.bats
@@ -1,0 +1,203 @@
+#!/usr/bin/env bats
+# listener-match.bats — Bats tests for scripts/listener-match.sh in its
+# verb→skill classifier (`--classify`) mode.
+#
+# Run: bats skills/autospec-shared/tests/unit/listener-match.bats
+#
+# Covers the keyword-routing classifier (issue #537):
+#   * positive routes for each verb in the D3 map
+#   * the D4 intent gate suppressing incidental/past/negated/question uses
+#   * JSON schema {match,skill,trigger,intent,confidence}
+#   * back-compat: default (no-flag) word mode + file-an-issue/write-a-spec
+
+setup() {
+    # The shared tests live under skills/autospec-shared/tests/unit; the
+    # script lives at the repo root scripts/. Walk up to the repo root.
+    REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../../../.." && pwd)"
+    MATCH="${REPO_ROOT}/scripts/listener-match.sh"
+}
+
+# Parse a JSON field from the output via node (available in this repo).
+json_field() {
+    local json="$1"
+    local expr="$2"
+    printf '%s' "$json" | node -e "
+const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+process.stdout.write(String($expr));
+" 2>/dev/null || echo "PARSE_ERROR"
+}
+
+# ── exit code / schema ────────────────────────────────────────────────────────
+
+@test "classify mode always exits 0" {
+    run "$MATCH" --classify "implement the cache layer"
+    [ "$status" -eq 0 ]
+}
+
+@test "classify mode emits valid JSON with required keys" {
+    run "$MATCH" --classify "implement the cache layer"
+    [ "$status" -eq 0 ]
+    result="$(json_field "$output" "
+typeof d.match==='boolean' &&
+('skill' in d) && ('trigger' in d) &&
+('intent' in d) && ('confidence' in d) ? 'ok' : 'fail'")"
+    [ "$result" = "ok" ]
+}
+
+@test "non-match emits {match:false} (valid JSON, exit 0)" {
+    run "$MATCH" --classify "what a lovely afternoon"
+    [ "$status" -eq 0 ]
+    m="$(json_field "$output" "d.match")"
+    [ "$m" = "false" ]
+}
+
+# ── positive routes (one per verb) ─────────────────────────────────────────────
+
+@test "positive: 'implement the cache layer' → autospec-run / imperative" {
+    run "$MATCH" --classify "implement the cache layer"
+    [ "$(json_field "$output" "d.match")" = "true" ]
+    [ "$(json_field "$output" "d.skill")" = "autospec-run" ]
+    [ "$(json_field "$output" "d.intent")" = "imperative" ]
+    [ "$(json_field "$output" "d.trigger")" = "implement" ]
+}
+
+@test "positive: 'build the auth service' → autospec-run" {
+    run "$MATCH" --classify "build the auth service"
+    [ "$(json_field "$output" "d.match")" = "true" ]
+    [ "$(json_field "$output" "d.skill")" = "autospec-run" ]
+}
+
+@test "positive: 'ship the new billing flow' → autospec-run" {
+    run "$MATCH" --classify "ship the new billing flow"
+    [ "$(json_field "$output" "d.match")" = "true" ]
+    [ "$(json_field "$output" "d.skill")" = "autospec-run" ]
+}
+
+@test "positive: 'design a webhook system' → autospec-define" {
+    run "$MATCH" --classify "design a webhook system"
+    [ "$(json_field "$output" "d.match")" = "true" ]
+    [ "$(json_field "$output" "d.skill")" = "autospec-define" ]
+    [ "$(json_field "$output" "d.intent")" = "imperative" ]
+}
+
+@test "positive: 'spec out the import pipeline' → autospec-define" {
+    run "$MATCH" --classify "spec out the import pipeline"
+    [ "$(json_field "$output" "d.match")" = "true" ]
+    [ "$(json_field "$output" "d.skill")" = "autospec-define" ]
+}
+
+@test "positive: 'add a new feature for exports' → autospec-define" {
+    run "$MATCH" --classify "add a new feature for exports"
+    [ "$(json_field "$output" "d.match")" = "true" ]
+    [ "$(json_field "$output" "d.skill")" = "autospec-define" ]
+}
+
+@test "positive: 'review the PR' → autospec-review" {
+    run "$MATCH" --classify "review the PR"
+    [ "$(json_field "$output" "d.match")" = "true" ]
+    [ "$(json_field "$output" "d.skill")" = "autospec-review" ]
+    [ "$(json_field "$output" "d.intent")" = "imperative" ]
+}
+
+@test "positive: 'autospec the billing module' → autospec" {
+    run "$MATCH" --classify "autospec the billing module"
+    [ "$(json_field "$output" "d.match")" = "true" ]
+    [ "$(json_field "$output" "d.skill")" = "autospec" ]
+}
+
+# ── negatives (must NOT route) ──────────────────────────────────────────────────
+
+@test "negative: 'I already reviewed it' → no route" {
+    run "$MATCH" --classify "I already reviewed it"
+    m="$(json_field "$output" "d.match")"
+    intent="$(json_field "$output" "d.intent")"
+    [ "$m" = "false" ] || [ "$intent" = "incidental" ]
+}
+
+@test "negative: 'the design looks nice' → no route" {
+    run "$MATCH" --classify "the design looks nice"
+    m="$(json_field "$output" "d.match")"
+    intent="$(json_field "$output" "d.intent")"
+    [ "$m" = "false" ] || [ "$intent" = "incidental" ]
+}
+
+@test "negative: \"don't implement that yet\" → no route" {
+    run "$MATCH" --classify "don't implement that yet"
+    m="$(json_field "$output" "d.match")"
+    intent="$(json_field "$output" "d.intent")"
+    [ "$m" = "false" ] || [ "$intent" = "incidental" ]
+}
+
+@test "negative: 'should we redesign this?' → no route" {
+    run "$MATCH" --classify "should we redesign this?"
+    m="$(json_field "$output" "d.match")"
+    intent="$(json_field "$output" "d.intent")"
+    [ "$m" = "false" ] || [ "$intent" = "incidental" ]
+}
+
+@test "negative: 'the review went well' → no route" {
+    run "$MATCH" --classify "the review went well"
+    m="$(json_field "$output" "d.match")"
+    intent="$(json_field "$output" "d.intent")"
+    [ "$m" = "false" ] || [ "$intent" = "incidental" ]
+}
+
+@test "negative: 'we already shipped that' → no route" {
+    run "$MATCH" --classify "we already shipped that"
+    m="$(json_field "$output" "d.match")"
+    intent="$(json_field "$output" "d.intent")"
+    [ "$m" = "false" ] || [ "$intent" = "incidental" ]
+}
+
+@test "negative: 'do not build it' → no route" {
+    run "$MATCH" --classify "do not build it"
+    m="$(json_field "$output" "d.match")"
+    intent="$(json_field "$output" "d.intent")"
+    [ "$m" = "false" ] || [ "$intent" = "incidental" ]
+}
+
+@test "negative: 'how should I implement this?' → no route" {
+    run "$MATCH" --classify "how should I implement this?"
+    m="$(json_field "$output" "d.match")"
+    intent="$(json_field "$output" "d.intent")"
+    [ "$m" = "false" ] || [ "$intent" = "incidental" ]
+}
+
+# ── back-compat: classify mode still surfaces file-an-issue / write-a-spec ──────
+
+@test "back-compat classify: 'file an issue' → autospec-define (trigger=issue)" {
+    run "$MATCH" --classify "file an issue for that"
+    [ "$(json_field "$output" "d.match")" = "true" ]
+    [ "$(json_field "$output" "d.skill")" = "autospec-define" ]
+}
+
+@test "back-compat classify: 'write a spec' → autospec-define" {
+    run "$MATCH" --classify "could you write a spec for this"
+    [ "$(json_field "$output" "d.match")" = "true" ]
+    [ "$(json_field "$output" "d.skill")" = "autospec-define" ]
+}
+
+# ── back-compat: default word mode unchanged ────────────────────────────────────
+
+@test "back-compat word mode: 'file an issue' → issue" {
+    run "$MATCH" "file an issue"
+    [ "$status" -eq 0 ]
+    [ "$output" = "issue" ]
+}
+
+@test "back-compat word mode: 'write a spec' → spec" {
+    run "$MATCH" "write a spec"
+    [ "$output" = "spec" ]
+}
+
+@test "back-compat word mode: bare 'issue' → none" {
+    run "$MATCH" "issue"
+    [ "$output" = "none" ]
+}
+
+# ── syntax ──────────────────────────────────────────────────────────────────────
+
+@test "bash -n passes on the script" {
+    run bash -n "$MATCH"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #537.

## What

Adds a `--classify` mode to `scripts/listener-match.sh` that classifies a chat message into JSON `{match,skill,trigger,intent,confidence}` using a verb->skill map (D3) and an imperative-intent gate (D4).

- **Verb -> skill map (D3):** `design`/`new feature`/`spec` -> `autospec-define`; `implement`/`build`/`ship` -> `autospec-run`; `review` -> `autospec-review`; `autospec ...` -> `autospec`.
- **Intent gate (D4):** fires only on imperative build/change requests; suppresses past-tense, negated, interrogative, and descriptive uses. Biased to false-negatives (prefer no route over a misfire).
- **Back-compat:** default word mode (`issue`/`spec`/`none`) is unchanged; explicit `file an issue` / `write a spec` phrases still route (to `autospec-define`), bypassing the verb gate.
- Documented the new mode in `docs/API_REFERENCE.md`.

## Tests

New bats suite `skills/autospec-shared/tests/unit/listener-match.bats` (25 tests, 0 failures): positive routes per verb, the four required negative cases (`"I already reviewed it"`, `"the design looks nice"`, `"don't implement that yet"`, `"should we redesign this?"`), back-compat phrases, JSON schema, and `bash -n`. Existing `tests/unit/test_listener_keywords.bats` (39 tests) still green. `validate.sh` passes.

## Scope

Task a only. The skill-body `## Keyword auto-routing` section + broadened triggers (Task b) are out of scope. Modifies an existing script — no trio lockstep.

docs: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)