### PR TITLE
feat(review): remediation mode — broad review + filter + gap JSON emit (gap-remediation Task 4)

### DIFF
--- a/skills/autospec-review/SKILL.md
+++ b/skills/autospec-review/SKILL.md
@@ -91,6 +91,46 @@ CSV ledger, and route regressions back through `/autospec-split` with
 | `--no-autoreview` | Skip the §7a Tier-A reviewer pass |
 | `--since DATE` | Only audit specs whose date prefix ≥ DATE |
 | `--spec-glob PATTERN` | Override default spec discovery globs |
+| `--remediation` | Broad-dimension review (spec-coverage + correctness + test-quality + integration-wiring + docs) with false-positive filter, for the end-of-run gap-remediation loop |
+| `--emit-gaps PATH` | Write the machine-readable gap JSON to PATH (implies `--remediation`) |
+
+## Remediation mode (`--remediation` / `--emit-gaps`)
+
+When `--remediation` (or `--emit-gaps PATH`) is passed, run a **broad-dimension** review instead of the spec-coverage-only audit, and emit a machine-readable gap list for the `/autospec-run` end-of-run gap-remediation loop.
+
+**Model tier:** Tier A (spec work) — broad review is inline analysis and needs opus turn-stamina (per `feedback_monitor_silent_exit.md`).
+
+Dimensions reviewed (all five, not just spec-coverage):
+
+1. **spec-coverage** — acceptance criteria with no shipping issue/PR (the existing audit).
+2. **correctness** — logic bugs, cross-platform shell portability (e.g. GNU-vs-BSD `grep`/`sed`), off-by-one, error-path gaps.
+3. **test-quality** — assertions that never fail, missing negative-path coverage, untested branches.
+4. **integration-wiring** — emitted-but-unconsumed artifacts, dangling references, lock-step drift.
+5. **docs** — stale or contradictory documentation versus shipped behavior.
+
+Pipeline:
+
+1. Dispatch the broad review subagent(s) at Tier A. Collect candidate findings, each tagged with `dimension`, `severity`, `file`, `line`, `title`, `body`, and a stable `dedupe_key`.
+2. **False-positive filter (required before emit):** pipe candidate findings through an evaluate-findings/critic pass. Mark each finding `verdict: keep` or `verdict: false_positive`. When uncertain, drop it (`false_positive`) — never ship a false positive into the auto-implement queue.
+3. Write the surviving findings to a temp findings file, then shape them into the gap contract:
+
+   ```bash
+   bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/emit-gaps.sh" \
+     --findings /tmp/autospec-review/remediation-findings.json \
+     --out "${EMIT_GAPS_PATH:-$HOME/.autospec/gaps-${RUN_ID}.json}"
+   ```
+
+   The emitted gap JSON is an array of objects matching the contract:
+
+   ```json
+   [{"gap_id":"G1","dimension":"correctness","severity":"medium",
+     "file":"skills/autospec-shared/scripts/cross-repo-search.sh","line":77,
+     "title":"trailing pipe matches every line on BSD grep",
+     "body":"<remediation issue body>",
+     "dedupe_key":"cross-repo-search-trailing-pipe"}]
+   ```
+
+4. When `--emit-gaps PATH` is given, write to PATH; otherwise default to `~/.autospec/gaps-<run_id>.json`. The driver (`gap-remediation-loop.sh`) reads this file. On review-subagent failure, write an empty array (`[]`) so the driver converges cleanly, and log a warning — never block run completion.
 
 ## Phase 0 — Preflight
 

--- a/skills/autospec-review/codex/prompt.md
+++ b/skills/autospec-review/codex/prompt.md
@@ -85,6 +85,46 @@ CSV ledger, and route regressions back through `/autospec-split` with
 | `--no-autoreview` | Skip the §7a Tier-A reviewer pass |
 | `--since DATE` | Only audit specs whose date prefix ≥ DATE |
 | `--spec-glob PATTERN` | Override default spec discovery globs |
+| `--remediation` | Broad-dimension review (spec-coverage + correctness + test-quality + integration-wiring + docs) with false-positive filter, for the end-of-run gap-remediation loop |
+| `--emit-gaps PATH` | Write the machine-readable gap JSON to PATH (implies `--remediation`) |
+
+## Remediation mode (`--remediation` / `--emit-gaps`)
+
+When `--remediation` (or `--emit-gaps PATH`) is passed, run a **broad-dimension** review instead of the spec-coverage-only audit, and emit a machine-readable gap list for the `/autospec-run` end-of-run gap-remediation loop.
+
+**Model tier:** Tier A (spec work) — broad review is inline analysis and needs opus turn-stamina (per `feedback_monitor_silent_exit.md`).
+
+Dimensions reviewed (all five, not just spec-coverage):
+
+1. **spec-coverage** — acceptance criteria with no shipping issue/PR (the existing audit).
+2. **correctness** — logic bugs, cross-platform shell portability (e.g. GNU-vs-BSD `grep`/`sed`), off-by-one, error-path gaps.
+3. **test-quality** — assertions that never fail, missing negative-path coverage, untested branches.
+4. **integration-wiring** — emitted-but-unconsumed artifacts, dangling references, lock-step drift.
+5. **docs** — stale or contradictory documentation versus shipped behavior.
+
+Pipeline:
+
+1. Dispatch the broad review subagent(s) at Tier A. Collect candidate findings, each tagged with `dimension`, `severity`, `file`, `line`, `title`, `body`, and a stable `dedupe_key`.
+2. **False-positive filter (required before emit):** pipe candidate findings through an evaluate-findings/critic pass. Mark each finding `verdict: keep` or `verdict: false_positive`. When uncertain, drop it (`false_positive`) — never ship a false positive into the auto-implement queue.
+3. Write the surviving findings to a temp findings file, then shape them into the gap contract:
+
+   ```bash
+   bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/emit-gaps.sh" \
+     --findings /tmp/autospec-review/remediation-findings.json \
+     --out "${EMIT_GAPS_PATH:-$HOME/.autospec/gaps-${RUN_ID}.json}"
+   ```
+
+   The emitted gap JSON is an array of objects matching the contract:
+
+   ```json
+   [{"gap_id":"G1","dimension":"correctness","severity":"medium",
+     "file":"skills/autospec-shared/scripts/cross-repo-search.sh","line":77,
+     "title":"trailing pipe matches every line on BSD grep",
+     "body":"<remediation issue body>",
+     "dedupe_key":"cross-repo-search-trailing-pipe"}]
+   ```
+
+4. When `--emit-gaps PATH` is given, write to PATH; otherwise default to `~/.autospec/gaps-<run_id>.json`. The driver (`gap-remediation-loop.sh`) reads this file. On review-subagent failure, write an empty array (`[]`) so the driver converges cleanly, and log a warning — never block run completion.
 
 ## Phase 0 — Preflight
 

--- a/skills/autospec-review/opencode/agent.md
+++ b/skills/autospec-review/opencode/agent.md
@@ -89,6 +89,46 @@ CSV ledger, and route regressions back through `/autospec-split` with
 | `--no-autoreview` | Skip the §7a Tier-A reviewer pass |
 | `--since DATE` | Only audit specs whose date prefix ≥ DATE |
 | `--spec-glob PATTERN` | Override default spec discovery globs |
+| `--remediation` | Broad-dimension review (spec-coverage + correctness + test-quality + integration-wiring + docs) with false-positive filter, for the end-of-run gap-remediation loop |
+| `--emit-gaps PATH` | Write the machine-readable gap JSON to PATH (implies `--remediation`) |
+
+## Remediation mode (`--remediation` / `--emit-gaps`)
+
+When `--remediation` (or `--emit-gaps PATH`) is passed, run a **broad-dimension** review instead of the spec-coverage-only audit, and emit a machine-readable gap list for the `/autospec-run` end-of-run gap-remediation loop.
+
+**Model tier:** Tier A (spec work) — broad review is inline analysis and needs opus turn-stamina (per `feedback_monitor_silent_exit.md`).
+
+Dimensions reviewed (all five, not just spec-coverage):
+
+1. **spec-coverage** — acceptance criteria with no shipping issue/PR (the existing audit).
+2. **correctness** — logic bugs, cross-platform shell portability (e.g. GNU-vs-BSD `grep`/`sed`), off-by-one, error-path gaps.
+3. **test-quality** — assertions that never fail, missing negative-path coverage, untested branches.
+4. **integration-wiring** — emitted-but-unconsumed artifacts, dangling references, lock-step drift.
+5. **docs** — stale or contradictory documentation versus shipped behavior.
+
+Pipeline:
+
+1. Dispatch the broad review subagent(s) at Tier A. Collect candidate findings, each tagged with `dimension`, `severity`, `file`, `line`, `title`, `body`, and a stable `dedupe_key`.
+2. **False-positive filter (required before emit):** pipe candidate findings through an evaluate-findings/critic pass. Mark each finding `verdict: keep` or `verdict: false_positive`. When uncertain, drop it (`false_positive`) — never ship a false positive into the auto-implement queue.
+3. Write the surviving findings to a temp findings file, then shape them into the gap contract:
+
+   ```bash
+   bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/emit-gaps.sh" \
+     --findings /tmp/autospec-review/remediation-findings.json \
+     --out "${EMIT_GAPS_PATH:-$HOME/.autospec/gaps-${RUN_ID}.json}"
+   ```
+
+   The emitted gap JSON is an array of objects matching the contract:
+
+   ```json
+   [{"gap_id":"G1","dimension":"correctness","severity":"medium",
+     "file":"skills/autospec-shared/scripts/cross-repo-search.sh","line":77,
+     "title":"trailing pipe matches every line on BSD grep",
+     "body":"<remediation issue body>",
+     "dedupe_key":"cross-repo-search-trailing-pipe"}]
+   ```
+
+4. When `--emit-gaps PATH` is given, write to PATH; otherwise default to `~/.autospec/gaps-<run_id>.json`. The driver (`gap-remediation-loop.sh`) reads this file. On review-subagent failure, write an empty array (`[]`) so the driver converges cleanly, and log a warning — never block run completion.
 
 ## Phase 0 — Preflight
 

--- a/skills/autospec-shared/scripts/emit-gaps.sh
+++ b/skills/autospec-shared/scripts/emit-gaps.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# emit-gaps.sh — shape filtered review findings into the gap JSON contract.
+#
+# Input findings JSON: array of objects with at least
+#   {dimension, severity, file, line, title, body, verdict, dedupe_key}
+# where verdict is "keep" or "false_positive" (the evaluate-findings/critic verdict).
+# This shaper keeps only verdict=="keep", assigns a stable gap_id (G<n> in order),
+# fills a dedupe_key fallback (title-hash) when absent, and writes the gap contract:
+#   {gap_id, dimension, severity, file, line, title, body, dedupe_key}
+#
+# Usage:
+#   emit-gaps.sh --findings <path> --out <path>
+#   emit-gaps.sh --help
+#
+# Environment:
+#   AUTOSPEC_SCRIPTS_DIR — sibling scripts dir (default: script dir)
+#
+# Exit codes:
+#   0  success (empty/missing input → empty array written)
+#   1  jq missing
+#
+# Requires: bash 3.2+, jq
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUTOSPEC_SCRIPTS_DIR="${AUTOSPEC_SCRIPTS_DIR:-$SCRIPT_DIR}"
+
+# shellcheck source=gap-json-lib.sh
+. "$AUTOSPEC_SCRIPTS_DIR/gap-json-lib.sh"
+
+FINDINGS=""
+OUT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --findings) FINDINGS="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --help|-h)
+      printf 'Usage: emit-gaps.sh --findings <path> --out <path>\n'
+      exit 0
+      ;;
+    *) shift ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || { printf 'emit-gaps: jq required\n' >&2; exit 1; }
+[ -n "$OUT" ] || { printf 'emit-gaps: --out required\n' >&2; exit 1; }
+
+if [ -z "$FINDINGS" ] || [ ! -f "$FINDINGS" ] || ! jq -e 'type=="array"' "$FINDINGS" >/dev/null 2>&1; then
+  printf '[]\n' > "$OUT"
+  exit 0
+fi
+
+# Keep verdict=="keep" (or missing verdict → treat as keep), shape to contract,
+# assign G<n> gap_ids in order, and fill dedupe_key fallback with title-hash.
+jq -c '[ .[] | select((.verdict // "keep") == "keep") ]' "$FINDINGS" > "$OUT.tmp"
+
+_n="$(jq 'length' "$OUT.tmp")"
+printf '[' > "$OUT"
+_i=0
+while [ "$_i" -lt "$_n" ]; do
+  _f="$(jq -c ".[$_i]" "$OUT.tmp")"
+  _gid="G$((_i + 1))"
+  _dk="$(printf '%s' "$_f" | jq -r '.dedupe_key // empty')"
+  if [ -z "$_dk" ]; then
+    _title="$(printf '%s' "$_f" | jq -r '.title // ""')"
+    _dk="$(gap_title_hash "$_title")"
+  fi
+  _obj="$(printf '%s' "$_f" | jq -c --arg gid "$_gid" --arg dk "$_dk" '{
+    gap_id: $gid,
+    dimension: (.dimension // "correctness"),
+    severity: (.severity // "low"),
+    file: (.file // ""),
+    line: (.line // 0),
+    title: (.title // ""),
+    body: (.body // ""),
+    dedupe_key: $dk
+  }')"
+  [ "$_i" -gt 0 ] && printf ',' >> "$OUT"
+  printf '%s' "$_obj" >> "$OUT"
+  _i=$((_i + 1))
+done
+printf ']\n' >> "$OUT"
+rm -f "$OUT.tmp"
+exit 0

--- a/skills/autospec-shared/tests/unit/autospec-review-remediation.bats
+++ b/skills/autospec-shared/tests/unit/autospec-review-remediation.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# autospec-review-remediation.bats — tests the emit-gaps.sh shaper:
+# valid JSON schema emitted; seeded false-positive dropped; seeded broad defect surfaces.
+
+EMIT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/emit-gaps.sh"
+LIB="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/gap-json-lib.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    # Candidate findings: one genuine correctness defect (keep), one flagged false-positive (drop).
+    cat > "$TEST_TMP/findings.json" <<'EOF'
+[
+  {"dimension":"correctness","severity":"medium","file":"cross-repo-search.sh","line":77,
+   "title":"trailing pipe matches every line on BSD grep","body":"build pattern drops trailing \\|","verdict":"keep","dedupe_key":"cross-repo-search-trailing-pipe"},
+  {"dimension":"test-quality","severity":"low","file":"x.sh","line":1,
+   "title":"phantom defect","body":"reviewer hallucinated","verdict":"false_positive","dedupe_key":"phantom"}
+]
+EOF
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+@test "emit-gaps.sh is executable" {
+    [ -x "$EMIT" ]
+}
+
+@test "emits a JSON array where every object satisfies the gap schema" {
+    run bash "$EMIT" --findings "$TEST_TMP/findings.json" --out "$TEST_TMP/gaps.json"
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_TMP/gaps.json" ]
+    jq -e 'type == "array"' "$TEST_TMP/gaps.json"
+    # each element validates against the shared schema
+    n="$(jq 'length' "$TEST_TMP/gaps.json")"
+    for i in $(seq 0 $((n - 1))); do
+        obj="$(jq -c ".[$i]" "$TEST_TMP/gaps.json")"
+        run bash -c ". '$LIB'; gap_validate_object '$obj'"
+        [ "$status" -eq 0 ]
+    done
+}
+
+@test "false-positive verdict is dropped by the filter" {
+    run bash "$EMIT" --findings "$TEST_TMP/findings.json" --out "$TEST_TMP/gaps.json"
+    [ "$status" -eq 0 ]
+    run jq -r '.[].dedupe_key' "$TEST_TMP/gaps.json"
+    [[ "$output" == *"cross-repo-search-trailing-pipe"* ]]
+    [[ "$output" != *"phantom"* ]]
+}
+
+@test "seeded broad-dimension defect (correctness) surfaces as a gap with gap_id" {
+    run bash "$EMIT" --findings "$TEST_TMP/findings.json" --out "$TEST_TMP/gaps.json"
+    [ "$status" -eq 0 ]
+    run jq -r '.[0].gap_id' "$TEST_TMP/gaps.json"
+    [ -n "$output" ]
+    run jq -r '.[0].dimension' "$TEST_TMP/gaps.json"
+    [ "$output" = "correctness" ]
+}
+
+@test "empty findings produce an empty array" {
+    printf '[]\n' > "$TEST_TMP/findings.json"
+    run bash "$EMIT" --findings "$TEST_TMP/findings.json" --out "$TEST_TMP/gaps.json"
+    [ "$status" -eq 0 ]
+    run jq 'length' "$TEST_TMP/gaps.json"
+    [ "$output" = "0" ]
+}


### PR DESCRIPTION
## Summary

Implements #533 (gap-remediation Task 4): adds `--remediation` / `--emit-gaps <path>` to `/autospec-review`.

- New `skills/autospec-shared/scripts/emit-gaps.sh` shaper: sources `gap-json-lib.sh` (#531), keeps `verdict=="keep"`, assigns `G<n>` ids, fills title-hash dedupe fallback, emits the gap JSON contract `[{gap_id,dimension,severity,file,line,title,body,dedupe_key}]`.
- New bats `autospec-review-remediation.bats` (5 tests): valid schema emitted, false-positive dropped, broad defect surfaces, empty findings → `[]`.
- Trio prose (SKILL.md + codex/prompt.md + opencode/agent.md): two CLI-flag rows + `## Remediation mode` section (five broad dimensions, required false-positive filter before emit, emit contract), applied byte-identically — `scripts/validate.sh` lockstep passes.

## Acceptance criteria
- [x] `bats autospec-review-remediation.bats` — 5 tests, 0 failures
- [x] `bash -n emit-gaps.sh` exits 0 and script is executable
- [x] `grep -q '## Remediation mode' SKILL.md`
- [x] `grep -q -- '--emit-gaps' SKILL.md`
- [x] `bash scripts/validate.sh` ends `validate: OK` and exits 0

Note: the failing-test-first bats used the repo's established `$(dirname "$BATS_TEST_FILENAME")/../..` path convention (matching `gap-json-lib.bats` / `ensure-tool.bats`) rather than the plan's literal `../../../skills/...` path, which resolved incorrectly.

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)