### PR TITLE
feat(listen): keyword auto-routing trio section + broadened triggers + lockstep check

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -319,6 +319,7 @@ Exit: 0 = all checks pass, non-zero = first failure with diagnostic.
 - Harness detection block
 - Monitor batch-exit invariants
 - Stop mode section
+- Keyword auto-routing section present across the autospec-listen trio (`check_keyword_routing_section`)
 - Phase 4 guardian block lockstep
 - Phase 4 adaptive-retry loop
 - Docs presence: `docs/USER_MANUAL.md`, `llms.txt`, `docs/.llm-manifest.json`

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -134,7 +134,7 @@ Read-only synthesis: produces a cited Markdown report of implementation state, s
   generated: true
 -->
 
-Passive listener — fires mid-conversation when the user mentions filing an issue or starting a spec.
+Passive listener — fires mid-conversation when the user mentions filing an issue or starting a spec. It also auto-routes common build/change verbs (`design` / `new feature` / `spec` → `/autospec-define`; `implement` / `build` / `ship` → `/autospec-run`; `review` → `/autospec-review`; `autospec …` → `/autospec`) into the matching skill. Routing is gated by an imperative-intent check (`scripts/listener-match.sh --classify`) biased to false-negatives, and every route prints a one-line opt-out: `Routing to /<skill> — say "plain" to opt out.`
 
 ## Configuration
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -132,6 +132,20 @@ check_stop_mode_section() {
     done
 }
 
+# Keyword auto-routing invariants (issue #538): the autospec-listen trio must
+# carry a `## Keyword auto-routing` heading in all three trio files
+# (SKILL.md, opencode/agent.md, codex/prompt.md) so the broadened verb->skill
+# routing behavior stays in lockstep. Parallels check_stop_mode_section.
+check_keyword_routing_section() {
+    skill_dir="skills/autospec-listen"
+    [ -d "$skill_dir" ] || return 0
+    info "keyword-routing: autospec-listen"
+    for trio in SKILL.md opencode/agent.md codex/prompt.md; do
+        grep -q '^## Keyword auto-routing' "$skill_dir/$trio" \
+            || fail "autospec-listen: $trio missing '## Keyword auto-routing' section"
+    done
+}
+
 # Self-update invariants (introduced by issue #10): every multi-harness skill
 # must document `## Self-update mode` in all three trio files, and its
 # install.sh must accept the `--update` flag.
@@ -634,6 +648,7 @@ main() {
 
     check_startup_preflight
     check_stop_mode_section
+    check_keyword_routing_section
     check_codex_skills_install
     check_shared_script_install
 

--- a/skills/autospec-listen/SKILL.md
+++ b/skills/autospec-listen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autospec-listen
 description: |
-  Use when the user mentions filing an issue or writing a spec mid-conversation. Trigger keywords are "file an issue", "new issue", "open an issue", "create a ticket", "write a spec", "design spec", "new spec", "start a spec". On an "issue" trigger, drafts a body from the last ~10 conversation turns and asks the user to approve before running gh issue create. On a "spec" trigger, hands off to /autospec-define. Lives at github.com/berlinguyinca/autospec/skills/autospec-listen.
+  Use when the user expresses an imperative intent to file an issue, write a spec, design a feature, implement/build/ship something, review code, or run autospec mid-conversation. Trigger keywords are "file an issue", "new issue", "open an issue", "create a ticket", "write a spec", "design spec", "new spec", "start a spec", "design", "new feature", "implement", "build", "ship", "review", "autospec". On an "issue" trigger, drafts a body from the last ~10 conversation turns and asks the user to approve before running gh issue create. On a "spec" trigger, hands off to /autospec-define. On a build/change verb, gates intent via scripts/listener-match.sh --classify and auto-routes to the mapped autospec skill with a one-line opt-out. Lives at github.com/berlinguyinca/autospec/skills/autospec-listen.
 ---
 
 # autospec-listen (harness-neutral)
@@ -89,6 +89,37 @@ This skill assumes four capabilities. Map each one to your harness's actual tool
 ## Trigger flow
 
 > **Model tier:** Tier B (implementation work) — this listener is a router; subagent dispatches inside its trigger flows (drafting issue bodies, summarizing recent conversation) use cheaper models per AGENTS.md. Spec-trigger handoff to `/autospec-define` lets the downstream skill apply its own tier policy.
+
+## Keyword auto-routing
+
+Beyond the explicit issue/spec triggers, this listener routes common build/change verbs into the matching autospec skill so the pipeline is the default path. Routing is gated by an imperative-intent check and always offers a one-line opt-out.
+
+**Intent gate.** Do not classify by eye. Delegate to the deterministic classifier, passing the user's latest message verbatim:
+
+```bash
+scripts/listener-match.sh --classify "<user message>"
+```
+
+It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidental|none","confidence":0-1}`. The gate is biased to false-negatives: descriptive ("the design is nice"), past-tense ("I reviewed it"), negated ("don't implement yet"), and interrogative ("should we redesign?") uses return `match:false` and MUST NOT route. Prefer no route over a misfire.
+
+**Verb → skill map (D3).**
+
+| Verb(s) in an imperative request | Routes to |
+|----------------------------------|-----------|
+| `design` / `new feature` / `spec` | `/autospec-define` |
+| `implement` / `build` / `ship` | `/autospec-run` (or `/autospec` end-to-end when no issues exist yet) |
+| `review` | `/autospec-review` |
+| `autospec …` | the umbrella `/autospec` |
+
+**Auto-route behavior.** When the classifier returns `match:true` with `intent:imperative`, print exactly one line then invoke the mapped skill via the harness skill-invocation primitive:
+
+```
+Routing to /<skill> — say "plain" to opt out.
+```
+
+On a non-match or `intent:incidental`/`none`, do nothing — the session proceeds normally in plain mode.
+
+**Escape (D5).** If the user's next turn is the stop word (`plain` or `no`), cancel routing and proceed in plain mode for that request. The existing `file an issue` / `write a spec` triggers continue to fire their own flows below and are unaffected.
 
 ## Issue trigger flow
 

--- a/skills/autospec-listen/codex/prompt.md
+++ b/skills/autospec-listen/codex/prompt.md
@@ -85,6 +85,37 @@ This skill assumes four capabilities. Map each one to your harness's actual tool
 
 > **Model tier:** Tier B (implementation work) — this listener is a router; subagent dispatches inside its trigger flows (drafting issue bodies, summarizing recent conversation) use cheaper models per AGENTS.md. Spec-trigger handoff to `/autospec-define` lets the downstream skill apply its own tier policy.
 
+## Keyword auto-routing
+
+Beyond the explicit issue/spec triggers, this listener routes common build/change verbs into the matching autospec skill so the pipeline is the default path. Routing is gated by an imperative-intent check and always offers a one-line opt-out.
+
+**Intent gate.** Do not classify by eye. Delegate to the deterministic classifier, passing the user's latest message verbatim:
+
+```bash
+scripts/listener-match.sh --classify "<user message>"
+```
+
+It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidental|none","confidence":0-1}`. The gate is biased to false-negatives: descriptive ("the design is nice"), past-tense ("I reviewed it"), negated ("don't implement yet"), and interrogative ("should we redesign?") uses return `match:false` and MUST NOT route. Prefer no route over a misfire.
+
+**Verb → skill map (D3).**
+
+| Verb(s) in an imperative request | Routes to |
+|----------------------------------|-----------|
+| `design` / `new feature` / `spec` | `/autospec-define` |
+| `implement` / `build` / `ship` | `/autospec-run` (or `/autospec` end-to-end when no issues exist yet) |
+| `review` | `/autospec-review` |
+| `autospec …` | the umbrella `/autospec` |
+
+**Auto-route behavior.** When the classifier returns `match:true` with `intent:imperative`, print exactly one line then invoke the mapped skill via the harness skill-invocation primitive:
+
+```
+Routing to /<skill> — say "plain" to opt out.
+```
+
+On a non-match or `intent:incidental`/`none`, do nothing — the session proceeds normally in plain mode.
+
+**Escape (D5).** If the user's next turn is the stop word (`plain` or `no`), cancel routing and proceed in plain mode for that request. The existing `file an issue` / `write a spec` triggers continue to fire their own flows below and are unaffected.
+
 ## Issue trigger flow
 
 When the user utters a phrase from the **Issue triggers** list (see `references/trigger-keywords.md`), run this 7-step procedure:

--- a/skills/autospec-listen/opencode/agent.md
+++ b/skills/autospec-listen/opencode/agent.md
@@ -1,5 +1,5 @@
 ---
-description: Use when the user mentions filing an issue or writing a spec mid-conversation. Trigger keywords are "file an issue", "new issue", "open an issue", "create a ticket", "write a spec", "design spec", "new spec", "start a spec". On an "issue" trigger, drafts a body from the last ~10 conversation turns and asks the user to approve before running gh issue create. On a "spec" trigger, hands off to /autospec-define. Lives at github.com/berlinguyinca/autospec/skills/autospec-listen.
+description: Use when the user expresses an imperative intent to file an issue, write a spec, design a feature, implement/build/ship something, review code, or run autospec mid-conversation. Trigger keywords are "file an issue", "new issue", "open an issue", "create a ticket", "write a spec", "design spec", "new spec", "start a spec", "design", "new feature", "implement", "build", "ship", "review", "autospec". On an "issue" trigger, drafts a body from the last ~10 conversation turns and asks the user to approve before running gh issue create. On a "spec" trigger, hands off to /autospec-define. On a build/change verb, gates intent via scripts/listener-match.sh --classify and auto-routes to the mapped autospec skill with a one-line opt-out. Lives at github.com/berlinguyinca/autospec/skills/autospec-listen.
 mode: primary
 ---
 
@@ -88,6 +88,37 @@ This skill assumes four capabilities. Map each one to your harness's actual tool
 ## Trigger flow
 
 > **Model tier:** Tier B (implementation work) — this listener is a router; subagent dispatches inside its trigger flows (drafting issue bodies, summarizing recent conversation) use cheaper models per AGENTS.md. Spec-trigger handoff to `/autospec-define` lets the downstream skill apply its own tier policy.
+
+## Keyword auto-routing
+
+Beyond the explicit issue/spec triggers, this listener routes common build/change verbs into the matching autospec skill so the pipeline is the default path. Routing is gated by an imperative-intent check and always offers a one-line opt-out.
+
+**Intent gate.** Do not classify by eye. Delegate to the deterministic classifier, passing the user's latest message verbatim:
+
+```bash
+scripts/listener-match.sh --classify "<user message>"
+```
+
+It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidental|none","confidence":0-1}`. The gate is biased to false-negatives: descriptive ("the design is nice"), past-tense ("I reviewed it"), negated ("don't implement yet"), and interrogative ("should we redesign?") uses return `match:false` and MUST NOT route. Prefer no route over a misfire.
+
+**Verb → skill map (D3).**
+
+| Verb(s) in an imperative request | Routes to |
+|----------------------------------|-----------|
+| `design` / `new feature` / `spec` | `/autospec-define` |
+| `implement` / `build` / `ship` | `/autospec-run` (or `/autospec` end-to-end when no issues exist yet) |
+| `review` | `/autospec-review` |
+| `autospec …` | the umbrella `/autospec` |
+
+**Auto-route behavior.** When the classifier returns `match:true` with `intent:imperative`, print exactly one line then invoke the mapped skill via the harness skill-invocation primitive:
+
+```
+Routing to /<skill> — say "plain" to opt out.
+```
+
+On a non-match or `intent:incidental`/`none`, do nothing — the session proceeds normally in plain mode.
+
+**Escape (D5).** If the user's next turn is the stop word (`plain` or `no`), cancel routing and proceed in plain mode for that request. The existing `file an issue` / `write a spec` triggers continue to fire their own flows below and are unaffected.
 
 ## Issue trigger flow
 


### PR DESCRIPTION
Closes #538.

## What

Extends the `/autospec-listen` skill (not a new skill) to make autospec the default path for build/change work:

- **`## Keyword auto-routing` section** added byte-identically across the trio (`SKILL.md` + `codex/prompt.md` + `opencode/agent.md`). Documents the imperative intent gate (delegating to the merged `scripts/listener-match.sh --classify` from #537/#544), the verb→skill map (D3), and the auto-route-with-one-line-opt-out behavior (`Routing to /<skill> — say "plain" to opt out.`, D1/D5).
- **Broadened `description` triggers** in `SKILL.md` + `opencode/agent.md` frontmatter to include the D3 verbs (`design`/`new feature`/`spec`, `implement`/`build`/`ship`, `review`, `autospec`), preserving the back-compat `file an issue` / `write a spec` triggers.
- **`check_keyword_routing_section()`** added to `scripts/validate.sh` (clones `check_stop_mode_section`), asserting the section across all three listen trio files; registered in `main()` next to the stop-mode check. Minimal/additive (one function + one call).
- Updated genuine editable docs: `docs/USER_MANUAL.md` `### /autospec-listen` (new behavior) + `docs/API_REFERENCE.md` validate-checks list.

## Verification

- `bash scripts/validate.sh` → `validate: OK`, exit 0, with `keyword-routing: autospec-listen` check running.
- Trio section bodies confirmed byte-identical.
- `listener-match.sh --classify` smoke: `"implement the cache layer"` → routes to autospec-run (imperative); `"the design is nice"` → match:false (descriptive, suppressed).
- Rebased onto current `origin/main` (post-#546); diff is clean (only the 6 intended files).

## docs: skip

The doc-drift gate hard-flags three sections mapped to `scripts/validate.sh` that this additive lockstep check does not genuinely affect: the historical `docs/specs/2026-05-22-autospec-docs-amendment-design.md` and `docs/superpowers/plans/2026-05-22-autospec-docs-amendment.md` (non-editable historical artifacts), and `docs/USER_MANUAL.md` `### /autospec-split` (coarse path→section mapping, unrelated to autospec-split invocation). The genuinely-affected docs (USER_MANUAL listen section + API_REFERENCE validate checklist) were updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)