### PR TITLE
test(validate): named-section checks for Phase 5.5 + remediation mode (gap-remediation Task 6)

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -320,6 +320,8 @@ Exit: 0 = all checks pass, non-zero = first failure with diagnostic.
 - Monitor batch-exit invariants
 - Stop mode section
 - Keyword auto-routing section present across the autospec-listen trio (`check_keyword_routing_section`)
+- Phase 5.5 end-of-run gap-remediation section present across the autospec-run trio (`check_gap_remediation_section`)
+- Remediation mode section present across the autospec-review trio (`check_review_remediation_section`)
 - Phase 4 guardian block lockstep
 - Phase 4 adaptive-retry loop
 - Docs presence: `docs/USER_MANUAL.md`, `llms.txt`, `docs/.llm-manifest.json`

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -157,7 +157,7 @@ check_gap_remediation_section() {
         [ -d "$skill_dir" ] || continue
         info "gap-remediation: $s"
         for trio in SKILL.md opencode/agent.md codex/prompt.md; do
-            grep -q '^## Phase 5.5 — End-of-run gap remediation' "$skill_dir/$trio" \
+            grep -q '^## Phase 5[.]5 — End-of-run gap remediation' "$skill_dir/$trio" \
                 || fail "$s: $trio missing '## Phase 5.5 — End-of-run gap remediation' section"
         done
     done

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -146,6 +146,37 @@ check_keyword_routing_section() {
     done
 }
 
+# Gap-remediation invariants (issue #535, deps #533/#534): the autospec-run
+# trio must carry a `## Phase 5.5 — End-of-run gap remediation` heading in all
+# three trio files (SKILL.md, opencode/agent.md, codex/prompt.md) so the
+# end-of-run gap-remediation loop stays in lockstep. Parallels
+# check_stop_mode_section.
+check_gap_remediation_section() {
+    for s in autospec-run; do
+        skill_dir="skills/$s"
+        [ -d "$skill_dir" ] || continue
+        info "gap-remediation: $s"
+        for trio in SKILL.md opencode/agent.md codex/prompt.md; do
+            grep -q '^## Phase 5.5 — End-of-run gap remediation' "$skill_dir/$trio" \
+                || fail "$s: $trio missing '## Phase 5.5 — End-of-run gap remediation' section"
+        done
+    done
+}
+
+# Remediation-mode invariants (issue #535, dep #533): the autospec-review trio
+# must carry a `## Remediation mode` heading in all three trio files
+# (SKILL.md, opencode/agent.md, codex/prompt.md) so the broad-review/gap-emit
+# remediation mode stays in lockstep. Parallels check_stop_mode_section.
+check_review_remediation_section() {
+    skill_dir="skills/autospec-review"
+    [ -d "$skill_dir" ] || return 0
+    info "review-remediation: autospec-review"
+    for trio in SKILL.md opencode/agent.md codex/prompt.md; do
+        grep -q '^## Remediation mode' "$skill_dir/$trio" \
+            || fail "autospec-review: $trio missing '## Remediation mode' section"
+    done
+}
+
 # Self-update invariants (introduced by issue #10): every multi-harness skill
 # must document `## Self-update mode` in all three trio files, and its
 # install.sh must accept the `--update` flag.
@@ -649,6 +680,8 @@ main() {
     check_startup_preflight
     check_stop_mode_section
     check_keyword_routing_section
+    check_gap_remediation_section
+    check_review_remediation_section
     check_codex_skills_install
     check_shared_script_install
 


### PR DESCRIPTION
## Summary
Adds two `validate.sh` lockstep checks guarding the gap-remediation prose sections shipped by deps #533/#534:

- `check_gap_remediation_section` — asserts the **autospec-run** trio (SKILL.md / opencode/agent.md / codex/prompt.md) carries `## Phase 5.5 — End-of-run gap remediation`.
- `check_review_remediation_section` — asserts the **autospec-review** trio carries `## Remediation mode`.

Both clone the existing `check_stop_mode_section` / `check_keyword_routing_section` pattern and are registered in `main()` immediately after the existing section checks. Also documents both in the `docs/API_REFERENCE.md` validate.sh check list.

## TDD
- GREEN: `bash scripts/validate.sh` ends `validate: OK`, exit 0.
- RED: breaking the heading across all three trio files (lockstep intact) fires each new guard with the expected missing-section FAIL.
- Peer review (codex) flagged the unescaped `.` in `5.5` as a regex wildcard; fixed to `5[.]5` literal match. A deliberate `5X5` drift now fails the guard; the real heading still matches.

## Acceptance criteria
- [x] `grep -q 'check_gap_remediation_section' scripts/validate.sh`
- [x] `grep -q 'check_review_remediation_section' scripts/validate.sh`
- [x] Renaming the Phase 5.5 heading makes `bash scripts/validate.sh` exit non-zero (verified, reverted)
- [x] `bash scripts/validate.sh` ends `validate: OK` and exits 0

## Notes
`scripts/validate.sh` is a script — no trio lockstep applies to this PR. Docs-drift gate flags only non-editable historical specs/plans (2026-05-22 design + plan) plus a false-positive `/autospec-split` scope mapping whose `autospec-doc-scope` src does not include `scripts/validate.sh`; handled via `docs: skip` per §3b (never hand-edit historical specs).

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)