### PR TITLE
fix(packaging): normalize repo-relative listener-match.sh reference to harness-neutral path

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -146,7 +146,7 @@ Read-only synthesis: produces a cited Markdown report of implementation state, s
   generated: true
 -->
 
-Passive listener — fires mid-conversation when the user mentions filing an issue or starting a spec. It also auto-routes common build/change verbs (`design` / `new feature` / `spec` → `/autospec-define`; `implement` / `build` / `ship` → `/autospec-run`; `review` → `/autospec-review`; `autospec …` → `/autospec`) into the matching skill. Routing is gated by an imperative-intent check (`scripts/listener-match.sh --classify`) biased to false-negatives, and every route prints a one-line opt-out: `Routing to /<skill> — say "plain" to opt out.`
+Passive listener — fires mid-conversation when the user mentions filing an issue or starting a spec. It also auto-routes common build/change verbs (`design` / `new feature` / `spec` → `/autospec-define`; `implement` / `build` / `ship` → `/autospec-run`; `review` → `/autospec-review`; `autospec …` → `/autospec`) into the matching skill. Routing is gated by an imperative-intent check (the deterministic `listener-match.sh --classify` classifier, invoked via `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}`) biased to false-negatives, and every route prints a one-line opt-out: `Routing to /<skill> — say "plain" to opt out.`
 
 ## Configuration
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -141,7 +141,7 @@ Read-only synthesis: produces a cited Markdown report of implementation state, s
 ### `/autospec-listen`
 
 <!-- autospec-doc-scope:
-  src: ["skills/autospec-listen/SKILL.md"]
+  src: ["skills/autospec-listen/SKILL.md", "skills/autospec-listen/codex/prompt.md", "skills/autospec-listen/opencode/agent.md"]
   reason: "User-facing invocation docs for autospec-listen"
   generated: true
 -->

--- a/skills/autospec-listen/SKILL.md
+++ b/skills/autospec-listen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autospec-listen
 description: |
-  Use when the user expresses an imperative intent to file an issue, write a spec, design a feature, implement/build/ship something, review code, or run autospec mid-conversation. Trigger keywords are "file an issue", "new issue", "open an issue", "create a ticket", "write a spec", "design spec", "new spec", "start a spec", "design", "new feature", "implement", "build", "ship", "review", "autospec". On an "issue" trigger, drafts a body from the last ~10 conversation turns and asks the user to approve before running gh issue create. On a "spec" trigger, hands off to /autospec-define. On a build/change verb, gates intent via scripts/listener-match.sh --classify and auto-routes to the mapped autospec skill with a one-line opt-out. Lives at github.com/berlinguyinca/autospec/skills/autospec-listen.
+  Use when the user expresses an imperative intent to file an issue, write a spec, design a feature, implement/build/ship something, review code, or run autospec mid-conversation. Trigger keywords are "file an issue", "new issue", "open an issue", "create a ticket", "write a spec", "design spec", "new spec", "start a spec", "design", "new feature", "implement", "build", "ship", "review", "autospec". On an "issue" trigger, drafts a body from the last ~10 conversation turns and asks the user to approve before running gh issue create. On a "spec" trigger, hands off to /autospec-define. On a build/change verb, gates intent via the deterministic listener-match classifier and auto-routes to the mapped autospec skill with a one-line opt-out. Lives at github.com/berlinguyinca/autospec/skills/autospec-listen.
 ---
 
 # autospec-listen (harness-neutral)
@@ -97,7 +97,7 @@ Beyond the explicit issue/spec triggers, this listener routes common build/chang
 **Intent gate.** Do not classify by eye. Delegate to the deterministic classifier, passing the user's latest message verbatim:
 
 ```bash
-scripts/listener-match.sh --classify "<user message>"
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/listener-match.sh" --classify "<user message>"
 ```
 
 It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidental|none","confidence":0-1}`. The gate is biased to false-negatives: descriptive ("the design is nice"), past-tense ("I reviewed it"), negated ("don't implement yet"), and interrogative ("should we redesign?") uses return `match:false` and MUST NOT route. Prefer no route over a misfire.

--- a/skills/autospec-listen/codex/prompt.md
+++ b/skills/autospec-listen/codex/prompt.md
@@ -92,7 +92,7 @@ Beyond the explicit issue/spec triggers, this listener routes common build/chang
 **Intent gate.** Do not classify by eye. Delegate to the deterministic classifier, passing the user's latest message verbatim:
 
 ```bash
-scripts/listener-match.sh --classify "<user message>"
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/listener-match.sh" --classify "<user message>"
 ```
 
 It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidental|none","confidence":0-1}`. The gate is biased to false-negatives: descriptive ("the design is nice"), past-tense ("I reviewed it"), negated ("don't implement yet"), and interrogative ("should we redesign?") uses return `match:false` and MUST NOT route. Prefer no route over a misfire.

--- a/skills/autospec-listen/opencode/agent.md
+++ b/skills/autospec-listen/opencode/agent.md
@@ -1,5 +1,5 @@
 ---
-description: Use when the user expresses an imperative intent to file an issue, write a spec, design a feature, implement/build/ship something, review code, or run autospec mid-conversation. Trigger keywords are "file an issue", "new issue", "open an issue", "create a ticket", "write a spec", "design spec", "new spec", "start a spec", "design", "new feature", "implement", "build", "ship", "review", "autospec". On an "issue" trigger, drafts a body from the last ~10 conversation turns and asks the user to approve before running gh issue create. On a "spec" trigger, hands off to /autospec-define. On a build/change verb, gates intent via scripts/listener-match.sh --classify and auto-routes to the mapped autospec skill with a one-line opt-out. Lives at github.com/berlinguyinca/autospec/skills/autospec-listen.
+description: Use when the user expresses an imperative intent to file an issue, write a spec, design a feature, implement/build/ship something, review code, or run autospec mid-conversation. Trigger keywords are "file an issue", "new issue", "open an issue", "create a ticket", "write a spec", "design spec", "new spec", "start a spec", "design", "new feature", "implement", "build", "ship", "review", "autospec". On an "issue" trigger, drafts a body from the last ~10 conversation turns and asks the user to approve before running gh issue create. On a "spec" trigger, hands off to /autospec-define. On a build/change verb, gates intent via the deterministic listener-match classifier and auto-routes to the mapped autospec skill with a one-line opt-out. Lives at github.com/berlinguyinca/autospec/skills/autospec-listen.
 mode: primary
 ---
 
@@ -96,7 +96,7 @@ Beyond the explicit issue/spec triggers, this listener routes common build/chang
 **Intent gate.** Do not classify by eye. Delegate to the deterministic classifier, passing the user's latest message verbatim:
 
 ```bash
-scripts/listener-match.sh --classify "<user message>"
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/listener-match.sh" --classify "<user message>"
 ```
 
 It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidental|none","confidence":0-1}`. The gate is biased to false-negatives: descriptive ("the design is nice"), past-tense ("I reviewed it"), negated ("don't implement yet"), and interrogative ("should we redesign?") uses return `match:false` and MUST NOT route. Prefer no route over a misfire.


### PR DESCRIPTION
## What

The autospec-listen keyword auto-routing **intent gate** invoked the deterministic classifier as the repo-relative `scripts/listener-match.sh --classify`. In a target repo (not the autospec repo) there is no `scripts/listener-match.sh`, so classification silently failed and build/change verbs never routed.

The script IS shipped to `~/.autospec/scripts` on install — only the reference style was wrong.

## Fix

Replace the bare invocation with the harness-neutral form used by every other helper in the trio:

```bash
bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/listener-match.sh" --classify "<user message>"
```

Applied **byte-identical** to the autospec-listen trio (LOCKSTEP):
- `skills/autospec-listen/SKILL.md`
- `skills/autospec-listen/codex/prompt.md`
- `skills/autospec-listen/opencode/agent.md`

Also de-referenced the repo-relative path from the `description:` prose ("gates intent via the deterministic listener-match classifier") so the routing surface stays harness-neutral.

## Out of scope (unchanged)

- `skills/autospec-shared/tests/unit/listener-match.bats` keeps `${REPO_ROOT}/scripts/listener-match.sh` — the classifier's own test deliberately runs the in-repo source copy, not an installed copy.

## Verification

- `bash scripts/validate.sh` → OK (lockstep + keyword-routing section checks green)
- Surface smoke test clean: `grep -rn 'scripts/listener-match.sh' skills/ | grep -v AUTOSPEC_SCRIPTS_DIR | grep -v '\.bats'` → no matches
- `bats skills/autospec-shared/tests/unit/listener-match.bats` → 25/25 pass

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)