### PR TITLE
fix(docs-drift): check-doc-drift.sh mis-attributes sources across docs on multi-file diffs

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -390,8 +390,16 @@ Usage: bash gen-llms-txt.sh --repo-root <dir> [--cluster-json <file>]
 
 ### `check-doc-drift.sh`
 
+<!-- autospec-doc-scope:
+  src: ["skills/autospec-shared/tests/unit/check-doc-drift.bats"]
+  reason: "Bats unit tests for check-doc-drift.sh including the cross-doc source-attribution regression"
+  mismatch_action: warn
+-->
+
 Deterministic drift checker. Parses `autospec-doc-scope` blocks, computes changed source
 files from a PR diff, and flags sections whose scope matches but whose content wasn't updated.
+Per-section matching-source state is reset on every scope entry so a source matched for one
+doc cannot leak into another doc's section on a multi-file diff.
 
 ```
 Usage: bash check-doc-drift.sh <pr-or-diff> [--repo <owner/repo>]

--- a/skills/autospec-shared/scripts/check-doc-drift.sh
+++ b/skills/autospec-shared/scripts/check-doc-drift.sh
@@ -278,8 +278,14 @@ const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
 process.stdout.write(d.src_globs.join('\n'));
 " 2>/dev/null)"
 
-            # Find matching changed source files
-            touch "$WORK_DIR/matching_sources_${idx}.txt"
+            # Find matching changed source files.
+            # Reset (truncate, not just touch) the per-entry matching-sources file:
+            # these temp files are keyed only by entry index within the shared
+            # work dir, so without clearing it here a source matched for an
+            # earlier doc's entry N would leak into this doc's entry N — including
+            # empty-glob sections that never enter the matching loop below —
+            # causing cross-doc mis-attribution on multi-file diffs.
+            : > "$WORK_DIR/matching_sources_${idx}.txt"
             if [ -s "$WORK_DIR/changed_source.txt" ] && [ -n "$src_globs_str" ]; then
                 while IFS= read -r sf; do
                     [ -z "$sf" ] && continue

--- a/skills/autospec-shared/tests/unit/check-doc-drift.bats
+++ b/skills/autospec-shared/tests/unit/check-doc-drift.bats
@@ -233,6 +233,115 @@ DIFF
     [ "$status" -ne 0 ]
 }
 
+# ── Cross-doc source attribution (multi-file diff) ────────────────────────────
+
+# Regression: per-doc matching-sources state must not leak across docs.
+# A source matched for doc A's section (entry index 0) must NOT be re-attributed
+# to doc B's section at the same entry index when doc B's globs match nothing in
+# the diff. Pre-fix, matching_sources_0.txt persisted across docs in the shared
+# work dir, so doc B inherited doc A's matches → false drift on the wrong doc.
+@test "multi-file diff does not leak sources across docs (no cross-attribution)" {
+    mkdir -p "$TMP_DIR/pkg"
+    printf '#!/bin/bash\n' > "$TMP_DIR/pkg/p.sh"
+    printf '#!/bin/bash\n' > "$TMP_DIR/pkg/q.sh"
+
+    # Two docs, mirrored so that a leak surfaces regardless of find() ordering:
+    #   Doc P: entry 0 matches pkg/p.sh, entry 1 matches nothing in the diff.
+    #   Doc Q: entry 0 matches nothing in the diff, entry 1 matches pkg/q.sh.
+    # Pre-fix, the shared matching_sources_<idx>.txt files were never reset
+    # between docs, so the second-processed doc's empty-match section at entry N
+    # inherited the matches the first-processed doc wrote at entry N — yielding a
+    # drift entry attributing pkg/p.sh to Doc Q (or pkg/q.sh to Doc P).
+    cat > "$TMP_DIR/docs/DOC_P.md" <<'DOCP'
+# Doc P
+
+## P Match
+
+<!-- autospec-doc-scope:
+  src: ["pkg/p.sh"]
+  reason: "Doc P tracks p.sh"
+-->
+
+p content
+
+## P Empty
+
+<!-- autospec-doc-scope:
+  src: ["unmatched/zzz-p.sh"]
+  reason: "Doc P entry that matches nothing in the diff"
+-->
+
+p empty
+DOCP
+
+    cat > "$TMP_DIR/docs/DOC_Q.md" <<'DOCQ'
+# Doc Q
+
+## Q Empty
+
+<!-- autospec-doc-scope:
+  src: ["unmatched/zzz-q.sh"]
+  reason: "Doc Q entry that matches nothing in the diff"
+-->
+
+q empty
+
+## Q Match
+
+<!-- autospec-doc-scope:
+  src: ["pkg/q.sh"]
+  reason: "Doc Q tracks q.sh"
+-->
+
+q content
+DOCQ
+
+    # Multi-file source diff touching pkg/p.sh and pkg/q.sh (both covered, so no
+    # missing_scope). Neither doc is updated → each legitimately drifts on its own
+    # source. The leak would add a cross-attributed entry.
+    DFILE="$(mktemp /tmp/autospec-driftpatch-XXXXXX)"
+    cat > "$DFILE" <<'DIFF'
+diff --git a/pkg/p.sh b/pkg/p.sh
+index abc..def 100755
+--- a/pkg/p.sh
++++ b/pkg/p.sh
+@@ -1 +1,2 @@
+ #!/bin/bash
++echo p
+diff --git a/pkg/q.sh b/pkg/q.sh
+index abc..def 100755
+--- a/pkg/q.sh
++++ b/pkg/q.sh
+@@ -1 +1,2 @@
+ #!/bin/bash
++echo q
+DIFF
+
+    run bash -c "\"$CHECK_DRIFT\" --diff \"$DFILE\" 2>/dev/null"
+    rm -f "$DFILE"
+
+    # Doc P must never list pkg/q.sh; Doc Q must never list pkg/p.sh.
+    leak="$(json_field "$output" "
+[].concat(d.drift, d.drift_warn).some(e =>
+  (e.doc_file === 'docs/DOC_P.md' && (e.matching_source_files||[]).includes('pkg/q.sh')) ||
+  (e.doc_file === 'docs/DOC_Q.md' && (e.matching_source_files||[]).includes('pkg/p.sh'))
+) ? 'LEAK' : 'clean'
+")"
+    [ "$leak" = "clean" ]
+
+    # Sanity: each doc's own source is still attributed correctly (single-file
+    # behavior preserved on the matching sections).
+    own="$(json_field "$output" "
+[].concat(d.drift, d.drift_warn).some(e =>
+  e.doc_file === 'docs/DOC_P.md' && (e.matching_source_files||[]).includes('pkg/p.sh')
+) &&
+[].concat(d.drift, d.drift_warn).some(e =>
+  e.doc_file === 'docs/DOC_Q.md' && (e.matching_source_files||[]).includes('pkg/q.sh')
+) ? 'ok' : 'fail'
+")"
+    [ "$own" = "ok" ]
+}
+
 # ── No docs directory ─────────────────────────────────────────────────────────
 
 @test "no docs directory + changed source → missing_scope + exit 2" {


### PR DESCRIPTION
## Summary

Fixes #552. `scripts/check-doc-drift.sh` (at `skills/autospec-shared/scripts/`) kept per-entry `matching_sources_<idx>.txt` temp files in a single shared work dir keyed only by entry index, and never reset them between docs. On a **multi-file source diff**, a source matched for doc A's entry N leaked into doc B's entry N — including empty-glob sections that never run the matching loop — yielding false drift attributed to the wrong doc. A single-file diff masked it.

## Fix

Truncate (`: >`) rather than `touch` the per-entry matching-sources file at the start of each scope entry, so stale matches from an earlier doc can never carry over. Minimal, single-file behavior preserved.

## Tests (TDD)

Added a regression in `skills/autospec-shared/tests/unit/check-doc-drift.bats` using a mirrored two-doc multi-file diff (Doc P matches `pkg/p.sh` at entry 0 + empty entry 1; Doc Q empty entry 0 + matches `pkg/q.sh` at entry 1) so the leak surfaces regardless of `find` ordering. It fails on the pre-fix logic (RED) and passes after (GREEN). Asserts no cross-attribution while each doc still owns its own source.

Also registered the test file under the `check-doc-drift.sh` API_REFERENCE doc-scope (warn-tier) to clear the pre-existing missing-scope gap.

## Verification

- All 18 `check-doc-drift.bats` tests green; `test_doc_drift_mismatch_action.bats` (7) and `phase4-drift-gate.bats` (7) green.
- `bash scripts/validate.sh` green.
- `bash scripts/lint-implementation.sh --pre-commit --staged` exit 0.
- Self-run docs-drift gate exit 0 (no hard drift, no missing-scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)