### PR TITLE
fix(packaging): gen-implementer/reviewer-prompt.sh resolve bundle-static-context.sh under flat install

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -184,6 +184,30 @@ Exit: 0 = success, 1 = missing required arg or file not found.
   generated: false
 -->
 
+### `gen-reviewer-prompt.sh`
+
+Composes the Phase 4 fused guardian+LGTM reviewer prompt via `bundle-static-context.sh --role reviewer`
+(static cached prefix) plus a deterministic dynamic suffix from the PR diff and previous-iteration findings.
+Diffs over 8000 lines are clipped with a `[diff clipped at 8000 lines]` marker. Zero LLM calls.
+
+Both this script and `gen-implementer-prompt.sh` resolve their sibling `bundle-static-context.sh` by
+preferring `$AUTOSPEC_SCRIPTS_DIR/bundle-static-context.sh`, then the flat-install sibling in the script's
+own directory, then the repo-layout `skills/autospec-shared/scripts/` copy.
+
+```
+Usage: bash scripts/gen-reviewer-prompt.sh --pr-diff <file> [--prev-findings <file>]
+                                           [--issue-labels <csv>] [--repo <owner/repo>]
+```
+
+Exit: 0 = success, 1 = missing required arg or file not found.
+
+<!-- autospec-doc-scope:
+  src: ["tests/gen-reviewer-prompt.bats", "tests/fixtures/gen-reviewer-prompt/pr-303.diff", "tests/fixtures/gen-reviewer-prompt/findings-empty.json", "tests/fixtures/gen-reviewer-prompt/findings-example.txt"]
+  reason: "Bats unit tests and fixtures for gen-reviewer-prompt.sh"
+  mismatch_action: warn
+  generated: false
+-->
+
 ### `gen-pr-report.sh`
 
 100% template-driven PR comment renderer. Reads gate JSON (Stage 1 + Stage 2 + Stage 2.5 results),

--- a/scripts/gen-implementer-prompt.sh
+++ b/scripts/gen-implementer-prompt.sh
@@ -30,8 +30,13 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Locate bundle-static-context.sh
 BUNDLE_STATIC="${AUTOSPEC_SCRIPTS_DIR:-}"/bundle-static-context.sh
 if [ ! -f "$BUNDLE_STATIC" ] 2>/dev/null; then
-  # Fall back to shared scripts in the repo
-  BUNDLE_STATIC="$REPO_ROOT/skills/autospec-shared/scripts/bundle-static-context.sh"
+  # Flat install: bundle-static-context.sh ships as a sibling in the same dir.
+  if [ -f "$SCRIPT_DIR/bundle-static-context.sh" ]; then
+    BUNDLE_STATIC="$SCRIPT_DIR/bundle-static-context.sh"
+  else
+    # Fall back to shared scripts in the repo
+    BUNDLE_STATIC="$REPO_ROOT/skills/autospec-shared/scripts/bundle-static-context.sh"
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/gen-reviewer-prompt.sh
+++ b/scripts/gen-reviewer-prompt.sh
@@ -32,8 +32,13 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Locate bundle-static-context.sh
 BUNDLE_STATIC="${AUTOSPEC_SCRIPTS_DIR:-}"/bundle-static-context.sh
 if [ ! -f "$BUNDLE_STATIC" ] 2>/dev/null; then
-  # Fall back to shared scripts in the repo
-  BUNDLE_STATIC="$REPO_ROOT/skills/autospec-shared/scripts/bundle-static-context.sh"
+  # Flat install: bundle-static-context.sh ships as a sibling in the same dir.
+  if [ -f "$SCRIPT_DIR/bundle-static-context.sh" ]; then
+    BUNDLE_STATIC="$SCRIPT_DIR/bundle-static-context.sh"
+  else
+    # Fall back to shared scripts in the repo
+    BUNDLE_STATIC="$REPO_ROOT/skills/autospec-shared/scripts/bundle-static-context.sh"
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/gen-implementer-prompt.bats
+++ b/tests/gen-implementer-prompt.bats
@@ -51,3 +51,25 @@ FIX="$REPO_ROOT/tests/fixtures/gen-implementer-prompt"
   run grep -E "\bclaude\b|\bcodex\b|\bgemini\b" "$BIN"
   [ "$status" -ne 0 ]
 }
+
+# Case 7: flat-install resolution — script finds bundle-static-context.sh as a
+# sibling in the same dir when AUTOSPEC_SCRIPTS_DIR is unset and no repo layout exists
+@test "flat-install: resolves sibling bundle-static-context.sh with no repo layout" {
+  flatdir="$(mktemp -d)"
+  cp "$BIN" "$flatdir/gen-implementer-prompt.sh"
+  # Sibling bundle stamps a sentinel so we can prove the sibling (not the repo
+  # copy) was the one that ran.
+  cat > "$flatdir/bundle-static-context.sh" <<'STUB'
+#!/usr/bin/env bash
+printf 'FLAT_SIBLING_BUNDLE_RAN\n'
+STUB
+  chmod +x "$flatdir/bundle-static-context.sh"
+  printf 'hello world body\n' > "$flatdir/issue.md"
+  # Run from / with AUTOSPEC_SCRIPTS_DIR unset and no repo layout above $flatdir.
+  run env -u AUTOSPEC_SCRIPTS_DIR bash "$flatdir/gen-implementer-prompt.sh" \
+    --issue-body "$flatdir/issue.md" --branch feat/flat
+  rm -rf "$flatdir"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "FLAT_SIBLING_BUNDLE_RAN"
+  echo "$output" | grep -qv "bundle-static-context.sh not found"
+}

--- a/tests/gen-reviewer-prompt.bats
+++ b/tests/gen-reviewer-prompt.bats
@@ -72,3 +72,25 @@ for i in range(8100):
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "DUPLICATE_CODE"
 }
+
+# Case 9: flat-install resolution — script finds bundle-static-context.sh as a
+# sibling in the same dir when AUTOSPEC_SCRIPTS_DIR is unset and no repo layout exists
+@test "flat-install: resolves sibling bundle-static-context.sh with no repo layout" {
+  flatdir="$(mktemp -d)"
+  cp "$BIN" "$flatdir/gen-reviewer-prompt.sh"
+  # Sibling bundle stamps a sentinel so we can prove the sibling (not the repo
+  # copy) was the one that ran.
+  cat > "$flatdir/bundle-static-context.sh" <<'STUB'
+#!/usr/bin/env bash
+printf 'FLAT_SIBLING_BUNDLE_RAN\n'
+STUB
+  chmod +x "$flatdir/bundle-static-context.sh"
+  printf '+example diff line\n' > "$flatdir/pr.diff"
+  # Run from / with AUTOSPEC_SCRIPTS_DIR unset and no repo layout above $flatdir.
+  run env -u AUTOSPEC_SCRIPTS_DIR bash "$flatdir/gen-reviewer-prompt.sh" \
+    --pr-diff "$flatdir/pr.diff"
+  rm -rf "$flatdir"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "FLAT_SIBLING_BUNDLE_RAN"
+  echo "$output" | grep -qv "bundle-static-context.sh not found"
+}


### PR DESCRIPTION
## Summary

`gen-implementer-prompt.sh` and `gen-reviewer-prompt.sh` resolved their sibling `bundle-static-context.sh` via `${AUTOSPEC_SCRIPTS_DIR:-}/...` then a repo-layout fallback (`$REPO_ROOT/skills/autospec-shared/scripts/...`). No skill exports `AUTOSPEC_SCRIPTS_DIR`, and that repo path does not exist under a flat install (`~/.autospec/scripts/`) where `bundle-static-context.sh` ships as a sibling — so resolution failed at runtime.

This adds `$SCRIPT_DIR/bundle-static-context.sh` (the flat-install sibling) as the **first** fallback before the repo path, keeping repo-layout resolution intact.

## Changes
- `scripts/gen-implementer-prompt.sh`, `scripts/gen-reviewer-prompt.sh`: flat-install sibling resolution before repo-layout fallback.
- `tests/gen-implementer-prompt.bats`, `tests/gen-reviewer-prompt.bats`: bats simulating a flat-install temp dir (script + sibling bundle, no repo, `AUTOSPEC_SCRIPTS_DIR` unset) asserting resolution succeeds via a sibling sentinel. RED before / GREEN after.
- `docs/API_REFERENCE.md`: added the missing `gen-reviewer-prompt.sh` section with its doc-scope block (closes a missing-scope drift for `tests/gen-reviewer-prompt.bats`).

## Verification
- `bash scripts/validate.sh` green.
- Targeted bats (gen-implementer/reviewer-prompt + bundle-static-context) all pass.
- Primary smoke from issue body: flat-dir copy of the script resolves the sibling with `AUTOSPEC_SCRIPTS_DIR` unset and no repo, exits 0 with no resolution error.

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)