### PR TITLE
feat(packaging): install.sh glob-ships all repo scripts + ship-completeness guard test

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -4,15 +4,23 @@
 > *Per-symbol reference for all public CLI surfaces and shared scripts.*
 
 <!-- autospec-doc-scope:
-  src: ["scripts/**/*.sh", "skills/autospec-shared/scripts/**/*.mjs", "skills/autospec-shared/scripts/**/*.sh"]
-  reason: "API reference for all autospec shared scripts and CLI surfaces"
+  src: ["scripts/**/*.sh", "scripts/**/*.mjs", "scripts/**/*.ps1", "skills/autospec-shared/scripts/**/*.mjs", "skills/autospec-shared/scripts/**/*.sh", "install.sh", "skills/*/install.sh", "tests/ship-completeness.bats"]
+  reason: "API reference for all autospec shared scripts, their shipping path, and the ship-completeness guard"
   mismatch_action: warn
   generated: true
 -->
 
 ## Shared scripts (`$AUTOSPEC_SCRIPTS_DIR`)
 
-Installed to `~/.autospec/scripts/` by every skill's `install.sh`.
+Installed to `~/.autospec/scripts/`. The top-level `install.sh` globs every repo-root
+`scripts/*.{sh,mjs,ps1}` (excluding the install-time-only `scripts/lib/`) plus the entire
+`skills/autospec-shared/scripts/` tree into `~/.autospec/scripts/` for all harnesses
+(`claude|codex|opencode|all`), so new repo-root helper scripts ship automatically without a
+hand-maintained list. The per-skill standalone installers (`skills/*/install.sh`) enumerate a
+`SHARED_SCRIPT_FILES` subset as a stopgap for curl-based installs that lack the repo checkout.
+The `tests/ship-completeness.bats` guard asserts every `${AUTOSPEC_SCRIPTS_DIR}`-referenced
+script is in the shippable set and that no bare repo-relative script invocation remains in any
+skill surface.
 
 ### `autospec-watchdog.sh`
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -35,7 +35,7 @@ bash install.sh --update
 ### `/autospec-define`
 
 <!-- autospec-doc-scope:
-  src: ["skills/autospec-define/SKILL.md", "skills/autospec-define/install.sh"]
+  src: ["skills/autospec-define/SKILL.md"]
   reason: "User-facing invocation docs for autospec-define"
   generated: true
 -->
@@ -52,7 +52,7 @@ Turns a feature description into a spec PR and a GitHub issue tree.
 ### `/autospec-run`
 
 <!-- autospec-doc-scope:
-  src: ["skills/autospec-run/SKILL.md", "skills/autospec-run/install.sh", "skills/autospec-run/codex/prompt.md", "skills/autospec-run/opencode/agent.md", "skills/autospec-run/scripts/heartbeat-write.sh", "skills/autospec-run/scripts/heartbeat-read.sh", "tests/heartbeat.bats"]
+  src: ["skills/autospec-run/SKILL.md", "skills/autospec-run/codex/prompt.md", "skills/autospec-run/opencode/agent.md", "skills/autospec-run/scripts/heartbeat-write.sh", "skills/autospec-run/scripts/heartbeat-read.sh", "tests/heartbeat.bats"]
   reason: "User-facing invocation docs for autospec-run"
   generated: true
 -->

--- a/install.sh
+++ b/install.sh
@@ -343,14 +343,48 @@ copy_shared_scripts() {
     # Use cp -R with a trailing /. to copy contents (not the directory itself).
     # Then restore executable bits for all .sh and .mjs files.
     cp -R "$shared_scripts_src/." "$autospec_scripts_dir/"
-    # Restore +x on shell scripts and mjs files (cp may strip bits on some platforms)
-    find "$autospec_scripts_dir" -maxdepth 2 \( -name '*.sh' -o -name '*.mjs' \) -exec chmod +x {} \;
+    # Restore +x on shell scripts and mjs files (cp may strip bits on some platforms).
+    # -maxdepth 3 covers nested helper dirs (e.g. gen-docs/architecture.mjs) once they
+    # land under $autospec_scripts_dir/<subdir>/<file>.
+    find "$autospec_scripts_dir" -maxdepth 3 \( -name '*.sh' -o -name '*.mjs' \) -exec chmod +x {} \;
     info "copy_shared_scripts: copied shared scripts to $autospec_scripts_dir/"
+}
+
+copy_repo_scripts() {
+    # Copy repo-root scripts/*.{sh,mjs,ps1} to $AUTOSPEC_SCRIPTS_DIR preserving +x bits.
+    # Globs (does not enumerate) so new repo-root helper scripts ship automatically for
+    # every harness. Excludes scripts/lib/ (install-time-only helpers) and never reaches
+    # per-skill target-repo gate scripts (those live under skills/, not scripts/).
+    repo_scripts_src="$REPO_ROOT/scripts"
+    if [ ! -d "$repo_scripts_src" ]; then
+        warn "copy_repo_scripts: $repo_scripts_src not found; skipping"
+        return 0
+    fi
+
+    autospec_scripts_dir="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        info "[dry-run] copy_repo_scripts: would copy $repo_scripts_src/*.{sh,mjs,ps1} to $autospec_scripts_dir/"
+        return 0
+    fi
+
+    mkdir -p "$autospec_scripts_dir"
+    # Copy only top-level script files (no recursion into scripts/lib/).
+    for ext in sh mjs ps1; do
+        for f in "$repo_scripts_src"/*."$ext"; do
+            [ -e "$f" ] || continue
+            cp "$f" "$autospec_scripts_dir/"
+        done
+    done
+    # Restore +x on shell scripts and mjs files (cp may strip bits on some platforms).
+    find "$autospec_scripts_dir" -maxdepth 1 \( -name '*.sh' -o -name '*.mjs' \) -exec chmod +x {} \;
+    info "copy_repo_scripts: copied repo-root scripts to $autospec_scripts_dir/"
 }
 
 # Integration bootstrap: pull autospec (if --update) + turbo, before per-skill installers run.
 pull_autospec
 copy_shared_scripts
+copy_repo_scripts
 bootstrap_turbo
 check_codex
 merge_claude_md

--- a/skills/autospec-classify/install.sh
+++ b/skills/autospec-classify/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec-define/install.sh
+++ b/skills/autospec-define/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec-listen/install.sh
+++ b/skills/autospec-listen/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec-run/install.sh
+++ b/skills/autospec-run/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec-split/install.sh
+++ b/skills/autospec-split/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec-stop/install.sh
+++ b/skills/autospec-stop/install.sh
@@ -37,7 +37,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 # Scripts that live under skills/autospec-shared/scripts/ rather than the
 # repo-root scripts/ dir, but are still required at runtime by this skill.
 # detect-monitor-exit-mode.sh backs the memory-aware `/autospec-stop --resume`.

--- a/skills/autospec-story/install.sh
+++ b/skills/autospec-story/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec/install.sh
+++ b/skills/autospec/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/tests/ship-completeness.bats
+++ b/tests/ship-completeness.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+# tests/ship-completeness.bats — guard that every script a skill surface invokes
+# via ${AUTOSPEC_SCRIPTS_DIR} is actually shipped by the installers, and that no
+# bare repo-relative shell-script invocation remains in any skill surface file.
+#
+# Rationale (#556): repo-root scripts ship to ~/.autospec/scripts via install.sh's
+# copy_repo_scripts() glob + skills/autospec-shared/scripts via copy_shared_scripts().
+# A runtime reference to a script that the installers never copy would be missing in
+# a target repo. This guard catches such drift at test time.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+# Skill surface files that may reference helper scripts at runtime: per-skill trios,
+# the autospec orchestrator surface, and any prompt files dispatched to subagents.
+surface_files() {
+  {
+    ls "$REPO_ROOT"/skills/*/SKILL.md 2>/dev/null
+    ls "$REPO_ROOT"/skills/*/codex/prompt.md 2>/dev/null
+    ls "$REPO_ROOT"/skills/*/opencode/agent.md 2>/dev/null
+    ls "$REPO_ROOT"/skills/*/prompts/*.md 2>/dev/null
+    find "$REPO_ROOT/skills/autospec" -type f -name '*.md' 2>/dev/null
+  } | sort -u
+}
+
+# The set of relative paths (under ~/.autospec/scripts) the installers ship: repo-root
+# scripts/ globs (.sh/.mjs/.ps1, excluding install-time-only scripts/lib/) land at the
+# top level, while the entire skills/autospec-shared/scripts/ tree is copied preserving
+# its subdirectory layout. We record both the flat relative path and the basename so a
+# reference can be matched whether or not it carries a subdirectory prefix.
+shippable_paths() {
+  {
+    # Repo-root scripts/*.{sh,mjs,ps1} ship flat (basename only); exclude scripts/lib/.
+    ls "$REPO_ROOT"/scripts/*.sh "$REPO_ROOT"/scripts/*.mjs "$REPO_ROOT"/scripts/*.ps1 2>/dev/null \
+      | while read -r f; do basename "$f"; done
+    # Shared scripts ship preserving their tree under ~/.autospec/scripts/.
+    if [ -d "$REPO_ROOT/skills/autospec-shared/scripts" ]; then
+      ( cd "$REPO_ROOT/skills/autospec-shared/scripts" && \
+        find . -type f \( -name '*.sh' -o -name '*.mjs' -o -name '*.ps1' \) \
+          | sed 's#^\./##' )
+    fi
+  } | sort -u
+}
+
+# Every ${AUTOSPEC_SCRIPTS_DIR...}/<path> reference, reduced to the path after the var.
+referenced_paths() {
+  surface_files | while read -r f; do
+    grep -hoE '\$\{AUTOSPEC_SCRIPTS_DIR[^}]*\}/[A-Za-z0-9_./-]+\.(sh|mjs|ps1)' "$f" 2>/dev/null
+  done \
+    | sed -E 's#\$\{AUTOSPEC_SCRIPTS_DIR[^}]*\}/##' \
+    | sort -u
+}
+
+# A referenced path is shipped when it matches a shippable relative path exactly, or
+# (for a bare basename reference) matches the basename of any shipped file.
+is_shipped() {
+  ref="$1"; shippable="$2"
+  # Exact relative-path match (handles subdir refs precisely).
+  printf '%s\n' "$shippable" | grep -qxF "$ref" && return 0
+  # Bare basename reference (no slash): allow matching any shipped file's basename.
+  case "$ref" in
+    */*) return 1 ;;
+    *)
+      printf '%s\n' "$shippable" | while read -r s; do
+        [ "$(basename "$s")" = "$ref" ] && echo MATCH
+      done | grep -q MATCH
+      ;;
+  esac
+}
+
+@test "every \${AUTOSPEC_SCRIPTS_DIR} script reference is shipped by the installers" {
+  shippable="$(shippable_paths)"
+  missing=""
+  while read -r ref; do
+    [ -n "$ref" ] || continue
+    if ! is_shipped "$ref" "$shippable"; then
+      missing="$missing $ref"
+    fi
+  done <<< "$(referenced_paths)"
+  if [ -n "$missing" ]; then
+    echo "Unshipped \${AUTOSPEC_SCRIPTS_DIR} references:$missing" >&2
+    echo "These scripts are invoked at runtime but not copied by install.sh." >&2
+    false
+  fi
+}
+
+@test "no bare repo-relative shell/mjs script invocation in skill surfaces" {
+  # Allow-listed: the autospec-test target-repo gate is an intentional project opt-in
+  # that runs from the target repo checkout, not from ~/.autospec/scripts.
+  offenders="$(
+    surface_files | while read -r f; do
+      grep -nE '(bash[[:space:]]+|\./|[^/A-Za-z._-])scripts/[A-Za-z0-9_./-]+\.(sh|mjs)' "$f" 2>/dev/null \
+        | sed "s#^#${f}:#"
+    done | grep -v 'skills/autospec-test/scripts/run-gate.sh' || true
+  )"
+  if [ -n "$offenders" ]; then
+    echo "Bare repo-relative script invocations found (must use \${AUTOSPEC_SCRIPTS_DIR}):" >&2
+    echo "$offenders" >&2
+    false
+  fi
+}


### PR DESCRIPTION
## Summary

Makes script shipping deterministic — every repo-root helper reaches `~/.autospec/scripts` for all harnesses without a hand-maintained list — and adds a guard test so an unshipped or repo-relative script reference can't silently regress.

Closes #556 (dep #555 merged).

## Changes
- **install.sh**: new `copy_repo_scripts()` globs `scripts/*.{sh,mjs,ps1}` into `$AUTOSPEC_SCRIPTS_DIR` (preserves +x), called unconditionally before the harness loop so it runs for `--harness claude|codex|opencode|all`. Excludes install-time-only `scripts/lib/`. Bumped `copy_shared_scripts` chmod `find -maxdepth 2` → `-maxdepth 3` so nested helper dirs (e.g. `gen-docs/architecture.mjs`) retain +x.
- **Per-skill installers** (`skills/*/install.sh` `SHARED_SCRIPT_FILES`): added the 5 missing names (`ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh`) as a stopgap for standalone curl-installs lacking the repo.
- **tests/ship-completeness.bats** (new): scans all skill surfaces (`SKILL.md`, `codex/prompt.md`, `opencode/agent.md`, `skills/autospec/*`, `skills/*/prompts/*.md`) for `${AUTOSPEC_SCRIPTS_DIR}/<script>` refs and asserts each is in the shippable set, comparing full relative subpaths (not just basenames); plus asserts no bare repo-relative `.sh`/`.mjs` invocation remains (allow-listing the intentional target-repo gate `run-gate.sh`).
- **docs**: `API_REFERENCE.md` documents the deterministic glob-shipping and now owns the installer-shipping doc-scope; narrowed `USER_MANUAL.md` define/run scopes to drop the internal `install.sh` script list (stops recurring false drift).

## Verification
- Primary smoke: `ci-wait.sh`, `gen-implementer-prompt.sh`, `gen-reviewer-prompt.sh` (and the Windows `.ps1` watchdog) now present in `~/.autospec/scripts` after install; `scripts/lib/` correctly excluded.
- Guard FAILS on an injected unshipped ref, a bare invocation, and a wrong-subdir ref; PASSES on main.
- `bash scripts/validate.sh` green; doc-drift gate exit 0.
- Peer-reviewed via Codex; addressed findings (prompts-surface coverage + relative-path precision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)