### PR TITLE
fix(docs-drift): scan-doc-scope.mjs ignores scope tokens inside fenced code blocks

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -475,7 +475,17 @@ Generates mermaid module dependency graph embedded in `docs/ARCHITECTURE.md`.
 
 ### `scan-doc-scope.mjs`
 
+<!-- autospec-doc-scope:
+  src: ["skills/autospec-shared/tests/unit/scan-doc-scope.test.mjs", "skills/autospec-shared/tests/fixtures/doc-scope/fenced-scope.md"]
+  reason: "Node unit tests and fixtures for scan-doc-scope.mjs, including fenced-code-block awareness"
+  mismatch_action: warn
+  generated: false
+-->
+
 Parses `<!-- autospec-doc-scope: ... -->` blocks into `{ section_path → globs }` map.
+Declarations inside markdown fenced code blocks (``` or ~~~, with or without a
+language tag) are ignored so illustrative example tokens are not treated as live
+scope claims.
 
 ```js
 import { scanDocScope } from './scan-doc-scope.mjs';

--- a/skills/autospec-shared/scripts/scan-doc-scope.mjs
+++ b/skills/autospec-shared/scripts/scan-doc-scope.mjs
@@ -97,6 +97,21 @@ function headingLevel(line) {
     return m ? m[1].length : 0;
 }
 
+// ── Fenced-code-block helpers ───────────────────────────────────────────────────
+// A fence delimiter is a line whose first non-whitespace run is 3+ backticks or
+// 3+ tildes. Opening fences may carry an info string (e.g. ```bash); closing
+// fences match the same character, are at least as long, and carry no info string.
+
+/**
+ * Parse a fence delimiter from a line.
+ * @returns {{ char: string, len: number, info: string } | null}
+ */
+function fenceDelimiter(line) {
+    const m = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
+    if (!m) return null;
+    return { char: m[1][0], len: m[1].length, info: m[2].trim() };
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 const SCOPE_OPEN_RE  = /<!--\s*autospec-doc-scope\s*:/;
@@ -127,10 +142,42 @@ export function parse(markdownPath) {
     // Track headings and sections
     let currentHeading = null;
     let currentHeadingLevel = 0;
+    // Track fenced-code-block state. `fence` holds the open delimiter
+    // ({ char, len }) while inside a fence, or null while outside.
+    let fence = null;
     let i = 0;
 
     while (i < lines.length) {
         const line = lines[i];
+
+        // Fenced-code-block tracking: while inside a fence, ignore everything
+        // (headings and scope declarations alike) until the fence closes, so
+        // illustrative scope tokens in examples are not parsed as live claims.
+        const delim = fenceDelimiter(line);
+        if (delim) {
+            if (fence === null) {
+                // Opening fence (info string allowed, e.g. ```bash).
+                fence = { char: delim.char, len: delim.len };
+                i++;
+                continue;
+            }
+            // Inside a fence: a matching closing delimiter must use the same
+            // character, be at least as long, and carry no info string.
+            if (delim.char === fence.char && delim.len >= fence.len && delim.info === '') {
+                fence = null;
+                i++;
+                continue;
+            }
+            // Non-matching fence-like line inside a fence: still code content.
+            i++;
+            continue;
+        }
+        if (fence !== null) {
+            // Any other line inside an open fence is code content — skip it.
+            i++;
+            continue;
+        }
+
         const lvl = headingLevel(line);
 
         if (lvl > 0) {

--- a/skills/autospec-shared/tests/fixtures/doc-scope/fenced-scope.md
+++ b/skills/autospec-shared/tests/fixtures/doc-scope/fenced-scope.md
@@ -1,0 +1,51 @@
+# Fenced Code Block Handling
+
+This document exercises fenced-code-block awareness in scan-doc-scope.
+
+## Real Declaration
+
+This is a real prose declaration and must be honored.
+
+<!-- autospec-doc-scope:
+  src: ["scripts/real.sh"]
+  reason: "live prose declaration"
+-->
+
+Body for the real section.
+
+## Illustrative Example
+
+The following fenced block shows the syntax but must NOT be parsed as a live claim:
+
+```markdown
+<!-- autospec-doc-scope:
+  src: ["scripts/example-in-fence.sh"]
+  reason: "illustrative only"
+-->
+```
+
+And a language-tagged fence, also ignored:
+
+```bash
+<!-- autospec-doc-scope:
+  src: ["scripts/another-in-fence.sh"]
+-->
+```
+
+A tilde fence, also ignored:
+
+~~~
+<!-- autospec-doc-scope:
+  src: ["scripts/tilde-in-fence.sh"]
+-->
+~~~
+
+## Post Fence Declaration
+
+After all fences are closed, this prose declaration must be honored again.
+
+<!-- autospec-doc-scope:
+  src: ["scripts/post-fence.sh"]
+-->
+
+Body for the post-fence section.

--- a/skills/autospec-shared/tests/unit/scan-doc-scope.test.mjs
+++ b/skills/autospec-shared/tests/unit/scan-doc-scope.test.mjs
@@ -117,6 +117,55 @@ test('generated-section.md: parses generated:true entry', async () => {
     assert.ok(result[0].src_globs.some(g => g.includes('**')), 'should have glob pattern');
 });
 
+// ── Fenced code block awareness (#561) ─────────────────────────────────────────
+
+test('fenced-scope.md: only prose declarations are honored, in-fence tokens ignored', async () => {
+    const result = parse(fixture('fenced-scope.md'));
+    const globs = result.flatMap(e => e.src_globs);
+    // In-fence tokens must NOT appear
+    assert.ok(!globs.includes('scripts/example-in-fence.sh'), 'token inside ``` fence must be ignored');
+    assert.ok(!globs.includes('scripts/another-in-fence.sh'), 'token inside language-tagged fence must be ignored');
+    assert.ok(!globs.includes('scripts/tilde-in-fence.sh'), 'token inside ~~~ fence must be ignored');
+    // Prose declarations (before and after fences) must be honored
+    assert.ok(globs.includes('scripts/real.sh'), 'prose declaration before fence must be honored');
+    assert.ok(globs.includes('scripts/post-fence.sh'), 'prose declaration after closed fences must be honored');
+    assert.equal(result.length, 2, `expected exactly 2 honored entries, got ${result.length}`);
+});
+
+test('scope token inside a fenced block is ignored', async () => {
+    const tmp = path.join(os.tmpdir(), `autospec-test-scope-fence-${Date.now()}.md`);
+    fs.writeFileSync(tmp, `## Section\n\n\`\`\`\n<!-- autospec-doc-scope:\n  src: ["in-fence.sh"]\n-->\n\`\`\`\n\nBody.\n`);
+    try {
+        const result = parse(tmp);
+        assert.equal(result.length, 0, 'in-fence declaration must yield no entries');
+    } finally {
+        fs.unlinkSync(tmp);
+    }
+});
+
+test('scope token after a closed fence is honored', async () => {
+    const tmp = path.join(os.tmpdir(), `autospec-test-scope-postfence-${Date.now()}.md`);
+    fs.writeFileSync(tmp, `## Section\n\n\`\`\`bash\necho hi\n\`\`\`\n\n<!-- autospec-doc-scope:\n  src: ["after.sh"]\n-->\n\nBody.\n`);
+    try {
+        const result = parse(tmp);
+        assert.equal(result.length, 1);
+        assert.deepEqual(result[0].src_globs, ['after.sh']);
+    } finally {
+        fs.unlinkSync(tmp);
+    }
+});
+
+test('unclosed trailing fence swallows declarations inside it', async () => {
+    const tmp = path.join(os.tmpdir(), `autospec-test-scope-unclosed-${Date.now()}.md`);
+    fs.writeFileSync(tmp, `## Section\n\n\`\`\`\n<!-- autospec-doc-scope:\n  src: ["trailing.sh"]\n-->\n`);
+    try {
+        const result = parse(tmp);
+        assert.equal(result.length, 0, 'declaration inside an unclosed trailing fence must be ignored');
+    } finally {
+        fs.unlinkSync(tmp);
+    }
+});
+
 // ── Inline fixture via temp file ──────────────────────────────────────────────
 
 test('single-glob src in flow syntax', async () => {


### PR DESCRIPTION
## What
`scripts/scan-doc-scope.mjs` (at `skills/autospec-shared/scripts/scan-doc-scope.mjs`) scanned every line for `<!-- autospec-doc-scope: ... -->` declarations with no awareness of markdown code fences. Illustrative/example scope tokens inside ``` or ~~~ blocks in historical specs parsed as LIVE scope claims, producing recurring warn-level docs-drift false-positives.

## How
- Added `fenceDelimiter()` helper and line-by-line fence-state tracking in `parse()`. Toggles on opening/closing ``` or ~~~ fences (language-tagged openers like ```bash supported); closing requires the same fence char, length >= opener, and no info string. While inside a fence, headings and scope declarations are skipped. Handles multiple fences and an unclosed trailing fence (state stays open to EOF).
- Added warn-level doc-scope block in `docs/API_REFERENCE.md` covering the new test + fixture so the docs-drift gate stays clean.

## Tests (TDD)
New RED-before/GREEN-after tests in `scan-doc-scope.test.mjs` + fixture `fenced-scope.md`:
- token inside ``` / language-tagged / ~~~ fence is ignored
- identical token in prose is honored
- token after a closed fence is honored
- declaration inside an unclosed trailing fence is ignored

## Verification
- `node scan-doc-scope.test.mjs` — 21/21 pass (17 original + 4 new)
- `bash scripts/validate.sh` — OK
- `check-doc-drift.sh --working-tree` — exit 0, passed:true, no hard drift, no missing_scope
- `tests/phase4/test_docs_drift_gate.sh` (drift gate consumer) — green via validate.sh

## Out of scope
No glob-matching semantics change, no #551 de-tokenization reverts, no historical spec edits.

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)