### PR TITLE
feat: preserve autospec team-review context

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It gives you:
 - Model-fit metadata on each issue with `ctx:*` and `reasoning:*` labels.
 - Implementation queues that can be filtered by model profile.
 - Quality gates for issue shape and implementation scope.
-- Autonomous PR creation, self-review, CI checks, and admin squash-merge.
+- Autonomous PR creation, counter-team review, CI checks, and admin squash-merge.
 - Stop/resume controls for long-running monitors.
 - A read-only story mode that explains the current application state from local
   docs plus GitHub issues and PRs.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -201,7 +201,8 @@ Exit: 0 = success, 1 = missing required arg or file not found.
 ### `gen-reviewer-prompt.sh`
 
 Composes the Phase 4 fused guardian+LGTM reviewer prompt via `bundle-static-context.sh --role reviewer`
-(static cached prefix) plus a deterministic dynamic suffix from the PR diff and previous-iteration findings.
+(static cached prefix) plus a deterministic dynamic suffix from the PR diff, issue body, and
+previous-iteration findings.
 Diffs over 8000 lines are clipped with a `[diff clipped at 8000 lines]` marker. Zero LLM calls.
 
 Both this script and `gen-implementer-prompt.sh` resolve their sibling `bundle-static-context.sh` by
@@ -210,6 +211,7 @@ own directory, then the repo-layout `skills/autospec-shared/scripts/` copy.
 
 ```
 Usage: bash scripts/gen-reviewer-prompt.sh --pr-diff <file> [--prev-findings <file>]
+                                           [--issue-body <file>]
                                            [--issue-labels <csv>] [--repo <owner/repo>]
 ```
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -140,12 +140,18 @@ Usage: bash ci-wait.sh <pr-number> [--repo <owner/repo>] [--timeout-secs N]
 
 ### `gen-issue-skeleton.sh`
 
-Renders a structured YAML input into an 11-section issue body and validates it via `lint-issue.sh`.
+Renders a structured YAML input into a team-lensed issue body and validates it via `lint-issue.sh`.
 
 ```
 Usage: bash scripts/gen-issue-skeleton.sh --input <file>
        bash scripts/gen-issue-skeleton.sh < input.yaml
 ```
+
+Required YAML keys: `issue_id`, `spec_path`, `spec_url`, `goal_sentence`,
+`team_personality`, `review_counter_team`, `files_to_read`,
+`implementation_scope`, `out_of_scope`, `implementation_outline_lines`,
+`tests_required`, `acceptance_criteria`, `verification.primary_smoke`,
+`verification.operator_full`, and `branch_name`.
 
 Exit: 0 = lint pass, 1 = MISSING_FIELD or render error, N = lint finding count.
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -45,7 +45,7 @@ Turns a feature description into a spec PR and a GitHub issue tree.
 **Triggers:** `autospec-define`, `write a spec`, `define feature`, `create spec`, `decompose feature`
 
 **Modes:**
-- Normal: brainstorm → draft spec → decompose into issues
+- Normal: choose implementation team + review counter-team → brainstorm → draft spec → decompose into issues
 - Existing spec: skip Phases 1-2, reuse tracked `docs/specs/*.md`
 - `--init`: reverse-engineer existing repo → bootstrap docs + specs
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -15,7 +15,8 @@ implementation → passive listener.
 `/autospec` is the umbrella end-to-end skill: a single feature request
 goes in and a series of merged PRs (closing the auto-generated issues)
 comes out. Internally it runs Phase 0 (bootstrap repo if missing),
-Phase 1 (investigate), Phase 2 (brainstorm + design), Phase 3
+Phase 1 (investigate), Phase 2 (team personality + review counter-team +
+brainstorm + design), Phase 3
 (decompose into linked GitHub issues), Phase 3.5 (review-and-label
 with `ctx:*`/`reasoning:*`), the Phase 3 pre-impl gate (default
 `run`), then Phase 4–6 (background autonomous monitor + status
@@ -34,7 +35,7 @@ to author a spec by hand.
 /autospec "add OIDC support behind a feature flag"
 Phase 0: bootstrap — repo present, skipping
 Phase 1: investigate — staged 6 files, 2 spec sections
-Phase 2: brainstorm — 4 design questions answered
+Phase 2: team personality + review counter-team selected, 4 design questions answered
 Phase 3: decompose — 9 child issues filed (#102…#110)
 Phase 3.5: classify — labeled with ctx:* and reasoning:*
 Spec written, 9 issues filed. Start /autospec-run now, defer to your

--- a/scripts/gen-issue-skeleton.sh
+++ b/scripts/gen-issue-skeleton.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/gen-issue-skeleton.sh — render a structured YAML input into an 11-section issue body.
+# scripts/gen-issue-skeleton.sh — render a structured YAML input into a team-lensed issue body.
 #
 # Usage:
 #   scripts/gen-issue-skeleton.sh --input <file>   # read YAML from file
@@ -8,12 +8,13 @@
 #
 # Required YAML keys:
 #   issue_id, spec_path, spec_url, goal_sentence,
-#   files_to_read (list), implementation_scope (list), out_of_scope (list),
+#   team_personality (list), review_counter_team (list), files_to_read (list),
+#   implementation_scope (list), out_of_scope (list),
 #   implementation_outline_lines (list), tests_required (list),
 #   acceptance_criteria (list), verification.primary_smoke,
 #   verification.operator_full, branch_name
 #
-# Output: 11-section markdown body on stdout.
+# Output: structured markdown issue body on stdout.
 # The output is piped through scripts/lint-issue.sh; non-zero exits propagate.
 #
 # Exit codes:
@@ -28,7 +29,7 @@ LINT_BIN="$SCRIPT_DIR/lint-issue.sh"
 
 usage() {
   cat <<'EOF'
-gen-issue-skeleton.sh — render a structured YAML input into an 11-section issue body
+gen-issue-skeleton.sh — render a structured YAML input into a team-lensed issue body
 
 Usage:
   scripts/gen-issue-skeleton.sh --input <file>
@@ -37,6 +38,7 @@ Usage:
 
 Required YAML keys:
   issue_id, spec_path, spec_url, goal_sentence,
+  team_personality, review_counter_team,
   files_to_read, implementation_scope, out_of_scope,
   implementation_outline_lines, tests_required, acceptance_criteria,
   verification.primary_smoke, verification.operator_full, branch_name
@@ -162,12 +164,16 @@ OPERATOR_FULL="$(yaml_get_nested verification operator_full)"
 
 # Lists (rendered as bullet lists)
 FILES_TO_READ="$(yaml_get_list files_to_read)"
+TEAM_PERSONALITY="$(yaml_get_list team_personality)"
+REVIEW_COUNTER_TEAM="$(yaml_get_list review_counter_team)"
 IMPL_SCOPE="$(yaml_get_list implementation_scope)"
 OUT_OF_SCOPE="$(yaml_get_list out_of_scope)"
 IMPL_OUTLINE="$(yaml_get_list implementation_outline_lines)"
 TESTS_REQUIRED="$(yaml_get_list tests_required)"
 ACCEPTANCE_CRITERIA="$(yaml_get_list acceptance_criteria)"
 
+[ -n "$TEAM_PERSONALITY" ]   || missing_field "team_personality"
+[ -n "$REVIEW_COUNTER_TEAM" ] || missing_field "review_counter_team"
 [ -n "$FILES_TO_READ" ]       || missing_field "files_to_read"
 [ -n "$IMPL_SCOPE" ]          || missing_field "implementation_scope"
 [ -n "$IMPL_OUTLINE" ]        || missing_field "implementation_outline_lines"
@@ -196,7 +202,7 @@ format_checkboxes() {
   done
 }
 
-# ── Render 11-section template ────────────────────────────────────────────────
+# ── Render issue body template ────────────────────────────────────────────────
 RENDERED_BODY="$(cat <<MARKDOWN
 ## Goal
 
@@ -205,6 +211,14 @@ ${GOAL_SENTENCE}
 ## Source spec section anchor
 
 \`${SPEC_PATH}\` — ${SPEC_URL}
+
+## Team personality
+
+$(printf '%s\n' "$TEAM_PERSONALITY" | format_bullets)
+
+## Review counter-team
+
+$(printf '%s\n' "$REVIEW_COUNTER_TEAM" | format_bullets)
 
 ## Files to read first
 

--- a/scripts/gen-reviewer-prompt.sh
+++ b/scripts/gen-reviewer-prompt.sh
@@ -7,6 +7,7 @@
 #
 # Usage:
 #   scripts/gen-reviewer-prompt.sh --pr-diff <file> [--prev-findings <file>]
+#                                   [--issue-body <file>]
 #                                   [--issue-labels <csv>] [--repo <owner/repo>]
 #   scripts/gen-reviewer-prompt.sh --help
 #
@@ -46,6 +47,7 @@ fi
 # ---------------------------------------------------------------------------
 PR_DIFF_FILE=""
 PREV_FINDINGS_FILE=""
+ISSUE_BODY_FILE=""
 ISSUE_LABELS=""
 REPO="${AUTOSPEC_REPO:-}"
 
@@ -57,6 +59,7 @@ gen-reviewer-prompt.sh — compose Phase 4 fused guardian+LGTM reviewer prompt
 
 Usage:
   scripts/gen-reviewer-prompt.sh --pr-diff <file> [--prev-findings <file>]
+                                  [--issue-body <file>]
                                   [--issue-labels <csv>] [--repo <owner/repo>]
   scripts/gen-reviewer-prompt.sh --help
 
@@ -65,6 +68,7 @@ Required:
 
 Optional:
   --prev-findings <file>   Path to previous-iteration findings file (JSON or text)
+  --issue-body <file>      Path to issue body markdown, including team lenses
   --issue-labels <csv>     Comma-separated issue labels (for cache-prefix tagging)
   --repo <owner/repo>      Repository slug (default: from AUTOSPEC_REPO env)
 
@@ -83,6 +87,9 @@ while [ $# -gt 0 ]; do
     --prev-findings)
       [ -z "${2:-}" ] && { printf 'gen-reviewer-prompt.sh: --prev-findings requires a value\n' >&2; exit 1; }
       PREV_FINDINGS_FILE="$2"; shift 2 ;;
+    --issue-body)
+      [ -z "${2:-}" ] && { printf 'gen-reviewer-prompt.sh: --issue-body requires a value\n' >&2; exit 1; }
+      ISSUE_BODY_FILE="$2"; shift 2 ;;
     --issue-labels)
       [ -z "${2:-}" ] && { printf 'gen-reviewer-prompt.sh: --issue-labels requires a value\n' >&2; exit 1; }
       ISSUE_LABELS="$2"; shift 2 ;;
@@ -109,6 +116,11 @@ fi
 
 if [ -n "$PREV_FINDINGS_FILE" ] && [ ! -f "$PREV_FINDINGS_FILE" ]; then
   printf 'gen-reviewer-prompt.sh: prev-findings file not found: %s\n' "$PREV_FINDINGS_FILE" >&2
+  exit 1
+fi
+
+if [ -n "$ISSUE_BODY_FILE" ] && [ ! -f "$ISSUE_BODY_FILE" ]; then
+  printf 'gen-reviewer-prompt.sh: issue-body file not found: %s\n' "$ISSUE_BODY_FILE" >&2
   exit 1
 fi
 
@@ -148,6 +160,11 @@ if [ -n "$PREV_FINDINGS_FILE" ]; then
   PREV_FINDINGS=$(cat "$PREV_FINDINGS_FILE")
 fi
 
+ISSUE_BODY=""
+if [ -n "$ISSUE_BODY_FILE" ]; then
+  ISSUE_BODY=$(cat "$ISSUE_BODY_FILE")
+fi
+
 # ---------------------------------------------------------------------------
 # Emit dynamic suffix
 # ---------------------------------------------------------------------------
@@ -179,6 +196,10 @@ cat <<SUFFIX2
 \`\`\`
 ${PREV_FINDINGS}
 \`\`\`
+
+### Issue body
+
+${ISSUE_BODY:-"(Issue body not provided. Fetch it before applying issue-scope, Team personality, or Review counter-team checks.)"}
 
 ---
 

--- a/scripts/gen-reviewer-prompt.sh
+++ b/scripts/gen-reviewer-prompt.sh
@@ -7,8 +7,7 @@
 #
 # Usage:
 #   scripts/gen-reviewer-prompt.sh --pr-diff <file> [--prev-findings <file>]
-#                                   [--issue-body <file>]
-#                                   [--issue-labels <csv>] [--repo <owner/repo>]
+#     [--issue-body <file>] [--issue-labels <csv>] [--repo <owner/repo>]
 #   scripts/gen-reviewer-prompt.sh --help
 #
 # Output (stdout):
@@ -59,8 +58,7 @@ gen-reviewer-prompt.sh — compose Phase 4 fused guardian+LGTM reviewer prompt
 
 Usage:
   scripts/gen-reviewer-prompt.sh --pr-diff <file> [--prev-findings <file>]
-                                  [--issue-body <file>]
-                                  [--issue-labels <csv>] [--repo <owner/repo>]
+    [--issue-body <file>] [--issue-labels <csv>] [--repo <owner/repo>]
   scripts/gen-reviewer-prompt.sh --help
 
 Required:

--- a/scripts/lint-issue.sh
+++ b/scripts/lint-issue.sh
@@ -67,7 +67,13 @@ if [ -z "$BODY_FILE" ]; then
     exit 1
 fi
 
-if [ ! -f "$BODY_FILE" ]; then
+STDIN_TMP=""
+if [ "$BODY_FILE" = "-" ] || [ "$BODY_FILE" = "/dev/stdin" ]; then
+    STDIN_TMP="$(mktemp)"
+    cat > "$STDIN_TMP"
+    BODY_FILE="$STDIN_TMP"
+    trap 'rm -f "$STDIN_TMP"' EXIT
+elif [ ! -f "$BODY_FILE" ]; then
     printf 'lint-issue.sh: file not found: %s\n' "$BODY_FILE" >&2
     exit 1
 fi

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -528,6 +528,65 @@ check_phase4_adaptive_retry() {
     done
 }
 
+# Team-personality contract: autospec should infer the right solving team from
+# the request, repository evidence, memories, and prior specs. If confidence is
+# low, it must ask explicitly with five concrete starter combinations, carry
+# the choice into the design spec, include it in child issues, and teach Phase 4
+# implementers to honor it as the execution lens.
+check_team_personality_contract() {
+    info "team personality contract: autospec / autospec-define / autospec-run"
+    for f in "skills/autospec/SKILL.md" "skills/autospec-define/SKILL.md"; do
+        grep -q '## Team personality selection' "$f" \
+            || fail "$f missing Team personality selection section"
+        grep -q 'past specs' "$f" \
+            || fail "$f missing past-spec inference input"
+        grep -q 'confidence is low' "$f" \
+            || fail "$f missing low-confidence ask rule"
+        grep -q 'five starter combinations' "$f" \
+            || fail "$f missing five starter combinations rule"
+        grep -q 'Core product engineering' "$f" \
+            || fail "$f missing Core product engineering starter team"
+        grep -q 'Security-sensitive' "$f" \
+            || fail "$f missing Security-sensitive starter team"
+        grep -q 'Team personality' "$f" \
+            || fail "$f missing Team personality issue/spec section"
+        grep -q 'Review counter-team' "$f" \
+            || fail "$f missing Review counter-team issue/spec section"
+        grep -q 'challenge likely blind spots' "$f" \
+            || fail "$f missing counter-team blind-spot directive"
+    done
+    for f in "skills/autospec/SKILL.md" "skills/autospec-define/SKILL.md" "skills/autospec-split/SKILL.md"; do
+        grep -q -- '- \*\*Team personality\*\*' "$f" \
+            || fail "$f missing Team personality child issue section"
+        grep -q -- '- \*\*Review counter-team\*\*' "$f" \
+            || fail "$f missing Review counter-team child issue section"
+        grep -q 'body should already contain `## Files to read first`, `## Implementation scope`, `## Team personality`, and `## Review counter-team`' "$f" \
+            || fail "$f missing Phase 3.5 team-lens template gate"
+    done
+    for f in "skills/autospec/SKILL.md" "skills/autospec-run/SKILL.md"; do
+        grep -q '## Team personality as execution lens' "$f" \
+            || fail "$f missing Phase 4 team personality execution lens"
+        grep -q '## Review counter-team as review lens' "$f" \
+            || fail "$f missing Phase 4 review counter-team lens"
+    done
+    grep -q 'team_personality' scripts/gen-issue-skeleton.sh \
+        || fail "scripts/gen-issue-skeleton.sh missing team_personality input"
+    grep -q 'review_counter_team' scripts/gen-issue-skeleton.sh \
+        || fail "scripts/gen-issue-skeleton.sh missing review_counter_team input"
+    grep -q -- '--issue-body' scripts/gen-reviewer-prompt.sh \
+        || fail "scripts/gen-reviewer-prompt.sh missing --issue-body support"
+    grep -q -- '--issue-body "$_body_file"' skills/autospec-run/SKILL.md \
+        || fail "skills/autospec-run/SKILL.md reviewer prompt does not pass issue body"
+    grep -q 'team_personality' docs/API_REFERENCE.md \
+        || fail "docs/API_REFERENCE.md missing gen-issue-skeleton team_personality schema"
+    grep -q 'review_counter_team' docs/API_REFERENCE.md \
+        || fail "docs/API_REFERENCE.md missing gen-issue-skeleton review_counter_team schema"
+    grep -q 'Team personality' skills/autospec/README.md \
+        || fail "skills/autospec/README.md missing Team personality docs"
+    grep -q 'Review counter-team' skills/autospec-define/README.md \
+        || fail "skills/autospec-define/README.md missing Review counter-team docs"
+}
+
 # Governance copy: the listener lifecycle and anti-loop guardrails must be
 # documented in AGENTS.md, and the listener skill must appear in both the
 # top-level README.md and SKILLS.md skill index. Spec §6.1, §7.1.
@@ -696,6 +755,7 @@ main() {
     check_phase4_issue_start_summary
     check_phase4_immediate_next_issue_pickup
     check_phase4_adaptive_retry
+    check_team_personality_contract
     check_autospec_run_priority_sort_lockstep
     check_autospec_run_regression_review_lockstep
     check_autospec_review_skill_present

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -533,8 +533,7 @@ check_phase4_adaptive_retry() {
 # low, it must ask explicitly with five concrete starter combinations, carry
 # the choice into the design spec, include it in child issues, and teach Phase 4
 # implementers to honor it as the execution lens.
-check_team_personality_contract() {
-    info "team personality contract: autospec / autospec-define / autospec-run"
+check_team_personality_selection_contract() {
     for f in "skills/autospec/SKILL.md" "skills/autospec-define/SKILL.md"; do
         grep -q '## Team personality selection' "$f" \
             || fail "$f missing Team personality selection section"
@@ -555,6 +554,9 @@ check_team_personality_contract() {
         grep -q 'challenge likely blind spots' "$f" \
             || fail "$f missing counter-team blind-spot directive"
     done
+}
+
+check_team_personality_issue_template_contract() {
     for f in "skills/autospec/SKILL.md" "skills/autospec-define/SKILL.md" "skills/autospec-split/SKILL.md"; do
         grep -q -- '- \*\*Team personality\*\*' "$f" \
             || fail "$f missing Team personality child issue section"
@@ -563,6 +565,9 @@ check_team_personality_contract() {
         grep -q 'body should already contain `## Files to read first`, `## Implementation scope`, `## Team personality`, and `## Review counter-team`' "$f" \
             || fail "$f missing Phase 3.5 team-lens template gate"
     done
+}
+
+check_team_personality_phase4_and_docs_contract() {
     for f in "skills/autospec/SKILL.md" "skills/autospec-run/SKILL.md"; do
         grep -q '## Team personality as execution lens' "$f" \
             || fail "$f missing Phase 4 team personality execution lens"
@@ -585,6 +590,13 @@ check_team_personality_contract() {
         || fail "skills/autospec/README.md missing Team personality docs"
     grep -q 'Review counter-team' skills/autospec-define/README.md \
         || fail "skills/autospec-define/README.md missing Review counter-team docs"
+}
+
+check_team_personality_contract() {
+    info "team personality contract: autospec / autospec-define / autospec-run"
+    check_team_personality_selection_contract
+    check_team_personality_issue_template_contract
+    check_team_personality_phase4_and_docs_contract
 }
 
 # Governance copy: the listener lifecycle and anti-loop guardrails must be

--- a/skills/autospec-define/README.md
+++ b/skills/autospec-define/README.md
@@ -41,10 +41,12 @@ cd skills/autospec-define
 - **Phase 0** — Bootstrap a fresh GitHub repo if the cwd has no git/remote (asks
   name / visibility / owner once).
 - **Phase 1** — Read-only research subagent maps the codebase.
-- **Phase 2** — Structured 5-section brainstorm (architecture / API / data / errors /
+- **Phase 2** — Selects a `Team personality` plus independent `Review counter-team`,
+  then runs the structured 5-section brainstorm (architecture / API / data / errors /
   testing), written to `docs/specs/YYYY-MM-DD-<topic>-design.md`.
 - **Phase 3** — Foreground subagent decomposes the spec into an EPIC umbrella plus
-  N self-contained children pre-staged for 32B-class local LLMs.
+  N self-contained children pre-staged for 32B-class local LLMs, carrying both
+  the implementation team lens and review counter-team lens.
 
 In existing spec mode, the skill verifies the selected spec is present on
 `origin/main`, skips Phases 1–2, then runs Phase 3 and Phase 3.5 against that

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -224,6 +224,48 @@ For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Pha
 
 > **Spec quality is the bottleneck.** Phase 2's output drives every downstream cycle's cost; if you care about spec quality, invoke this skill with your top-tier model (Claude Code: `claude-code --model opus`; Codex: top GPT). Phase 2 itself runs in the orchestrator (no subagent dispatch) — your invocation model IS the spec model. Subagents in Phases 1, 3, 3.5 follow this lead by selecting Tier A; Phase 4 implementation work uses Tier B. See AGENTS.md.
 
+## Team personality selection
+
+Before the Architecture question, decide what kind of team should solve this
+request. Infer the team personality from the user's request, Phase 1 evidence,
+repository labels, relevant memory files, and past specs under `docs/specs/`.
+The goal is to shape the design as a fitting team would reason about it, not to
+treat every request as a generic "fix this bug" task.
+
+Write a **Team personality** section into the design spec with:
+- the selected team name,
+- 3-6 roles,
+- why this team fits the request,
+- the risks this team is expected to notice,
+- any team emphasis that should carry into child issues.
+
+Also write a **Review counter-team** subsection. It must be a different
+emphasis from the implementation team and should challenge likely blind spots,
+not duplicate the same perspective. Include:
+- the counter-team name,
+- 2-5 roles,
+- which assumptions or failure modes this team should challenge,
+- how review should stay inside the issue scope while applying that lens.
+
+If confidence is low, ask the user explicitly: `What kind of team should solve this problem?`
+Offer exactly these five starter combinations:
+1. **Core product engineering** — product manager, architect, backend developer, frontend developer, test engineer.
+2. **Reliability/backend** — backend developer, platform engineer, sysadmin/SRE, database engineer, security advisor.
+3. **Frontend/product** — frontend developer, UX designer, accessibility reviewer, API/backend developer, QA engineer.
+4. **Security-sensitive** — security advisor, architect, backend developer, platform engineer, test engineer.
+5. **Legacy/refactor** — architect, maintainer, backend/frontend developer as needed, test engineer, documentation owner.
+
+If one option is clearly best, proceed without asking and record the confidence
+and evidence in the spec. If two or more options are plausible and would change
+the architecture, tests, or decomposition, ask before continuing.
+
+Derive the Review counter-team after choosing the implementation team:
+- Frontend/product implementation teams should be reviewed by accessibility, API contract, and QA perspectives.
+- Reliability/backend implementation teams should be reviewed by security, operations, and data-integrity perspectives.
+- Security-sensitive implementation teams should be reviewed by product/UX, maintainer, and test perspectives.
+- Legacy/refactor implementation teams should be reviewed by maintainer, regression-test, and architecture perspectives.
+- Core product engineering implementation teams should be reviewed by security, operations, accessibility, and maintainability perspectives.
+
 Run a structured brainstorm — one question at a time, get explicit approval after each section:
 
 1. **Architecture** — where does new code live, what existing patterns does it follow.
@@ -275,6 +317,8 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > - **Goal** — 1 sentence outcome.
 > - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
+> - **Team personality** — copy the spec's selected team name, roles, and issue-relevant emphasis. If the selected spec lacks this section, infer it from the request, past specs, repository labels, and memory; if confidence is low, stop and ask the operator to choose from the five starter combinations in Phase 2 before filing issues.
+> - **Review counter-team** — copy the spec's counter-team name, roles, and issue-relevant blind spots to challenge. If the selected spec lacks this section, derive a different review emphasis from the Team personality and issue risk before filing.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
@@ -337,8 +381,7 @@ labels and patches each body with a `## Model fit` block.
 > `type:tracker` label). For each:
 >
 > 1. **Stage context.** Read `gh issue view <N> --repo {repo} --json title,body,labels`. The
->    body should already contain `## Files to read first` and
->    `## Implementation scope`. If either is missing, add label
+>    body should already contain `## Files to read first`, `## Implementation scope`, `## Team personality`, and `## Review counter-team`. If any is missing, add label
 >    `needs-autospec-template` (idempotent `gh label create --force` once at run
 >    start) and skip — do not classify or patch.
 >

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -218,6 +218,48 @@ For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Pha
 
 > **Spec quality is the bottleneck.** Phase 2's output drives every downstream cycle's cost; if you care about spec quality, invoke this skill with your top-tier model (Claude Code: `claude-code --model opus`; Codex: top GPT). Phase 2 itself runs in the orchestrator (no subagent dispatch) — your invocation model IS the spec model. Subagents in Phases 1, 3, 3.5 follow this lead by selecting Tier A; Phase 4 implementation work uses Tier B. See AGENTS.md.
 
+## Team personality selection
+
+Before the Architecture question, decide what kind of team should solve this
+request. Infer the team personality from the user's request, Phase 1 evidence,
+repository labels, relevant memory files, and past specs under `docs/specs/`.
+The goal is to shape the design as a fitting team would reason about it, not to
+treat every request as a generic "fix this bug" task.
+
+Write a **Team personality** section into the design spec with:
+- the selected team name,
+- 3-6 roles,
+- why this team fits the request,
+- the risks this team is expected to notice,
+- any team emphasis that should carry into child issues.
+
+Also write a **Review counter-team** subsection. It must be a different
+emphasis from the implementation team and should challenge likely blind spots,
+not duplicate the same perspective. Include:
+- the counter-team name,
+- 2-5 roles,
+- which assumptions or failure modes this team should challenge,
+- how review should stay inside the issue scope while applying that lens.
+
+If confidence is low, ask the user explicitly: `What kind of team should solve this problem?`
+Offer exactly these five starter combinations:
+1. **Core product engineering** — product manager, architect, backend developer, frontend developer, test engineer.
+2. **Reliability/backend** — backend developer, platform engineer, sysadmin/SRE, database engineer, security advisor.
+3. **Frontend/product** — frontend developer, UX designer, accessibility reviewer, API/backend developer, QA engineer.
+4. **Security-sensitive** — security advisor, architect, backend developer, platform engineer, test engineer.
+5. **Legacy/refactor** — architect, maintainer, backend/frontend developer as needed, test engineer, documentation owner.
+
+If one option is clearly best, proceed without asking and record the confidence
+and evidence in the spec. If two or more options are plausible and would change
+the architecture, tests, or decomposition, ask before continuing.
+
+Derive the Review counter-team after choosing the implementation team:
+- Frontend/product implementation teams should be reviewed by accessibility, API contract, and QA perspectives.
+- Reliability/backend implementation teams should be reviewed by security, operations, and data-integrity perspectives.
+- Security-sensitive implementation teams should be reviewed by product/UX, maintainer, and test perspectives.
+- Legacy/refactor implementation teams should be reviewed by maintainer, regression-test, and architecture perspectives.
+- Core product engineering implementation teams should be reviewed by security, operations, accessibility, and maintainability perspectives.
+
 Run a structured brainstorm — one question at a time, get explicit approval after each section:
 
 1. **Architecture** — where does new code live, what existing patterns does it follow.
@@ -269,6 +311,8 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > - **Goal** — 1 sentence outcome.
 > - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
+> - **Team personality** — copy the spec's selected team name, roles, and issue-relevant emphasis. If the selected spec lacks this section, infer it from the request, past specs, repository labels, and memory; if confidence is low, stop and ask the operator to choose from the five starter combinations in Phase 2 before filing issues.
+> - **Review counter-team** — copy the spec's counter-team name, roles, and issue-relevant blind spots to challenge. If the selected spec lacks this section, derive a different review emphasis from the Team personality and issue risk before filing.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
@@ -331,8 +375,7 @@ labels and patches each body with a `## Model fit` block.
 > `type:tracker` label). For each:
 >
 > 1. **Stage context.** Read `gh issue view <N> --repo {repo} --json title,body,labels`. The
->    body should already contain `## Files to read first` and
->    `## Implementation scope`. If either is missing, add label
+>    body should already contain `## Files to read first`, `## Implementation scope`, `## Team personality`, and `## Review counter-team`. If any is missing, add label
 >    `needs-autospec-template` (idempotent `gh label create --force` once at run
 >    start) and skip — do not classify or patch.
 >

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -222,6 +222,48 @@ For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Pha
 
 > **Spec quality is the bottleneck.** Phase 2's output drives every downstream cycle's cost; if you care about spec quality, invoke this skill with your top-tier model (Claude Code: `claude-code --model opus`; Codex: top GPT). Phase 2 itself runs in the orchestrator (no subagent dispatch) — your invocation model IS the spec model. Subagents in Phases 1, 3, 3.5 follow this lead by selecting Tier A; Phase 4 implementation work uses Tier B. See AGENTS.md.
 
+## Team personality selection
+
+Before the Architecture question, decide what kind of team should solve this
+request. Infer the team personality from the user's request, Phase 1 evidence,
+repository labels, relevant memory files, and past specs under `docs/specs/`.
+The goal is to shape the design as a fitting team would reason about it, not to
+treat every request as a generic "fix this bug" task.
+
+Write a **Team personality** section into the design spec with:
+- the selected team name,
+- 3-6 roles,
+- why this team fits the request,
+- the risks this team is expected to notice,
+- any team emphasis that should carry into child issues.
+
+Also write a **Review counter-team** subsection. It must be a different
+emphasis from the implementation team and should challenge likely blind spots,
+not duplicate the same perspective. Include:
+- the counter-team name,
+- 2-5 roles,
+- which assumptions or failure modes this team should challenge,
+- how review should stay inside the issue scope while applying that lens.
+
+If confidence is low, ask the user explicitly: `What kind of team should solve this problem?`
+Offer exactly these five starter combinations:
+1. **Core product engineering** — product manager, architect, backend developer, frontend developer, test engineer.
+2. **Reliability/backend** — backend developer, platform engineer, sysadmin/SRE, database engineer, security advisor.
+3. **Frontend/product** — frontend developer, UX designer, accessibility reviewer, API/backend developer, QA engineer.
+4. **Security-sensitive** — security advisor, architect, backend developer, platform engineer, test engineer.
+5. **Legacy/refactor** — architect, maintainer, backend/frontend developer as needed, test engineer, documentation owner.
+
+If one option is clearly best, proceed without asking and record the confidence
+and evidence in the spec. If two or more options are plausible and would change
+the architecture, tests, or decomposition, ask before continuing.
+
+Derive the Review counter-team after choosing the implementation team:
+- Frontend/product implementation teams should be reviewed by accessibility, API contract, and QA perspectives.
+- Reliability/backend implementation teams should be reviewed by security, operations, and data-integrity perspectives.
+- Security-sensitive implementation teams should be reviewed by product/UX, maintainer, and test perspectives.
+- Legacy/refactor implementation teams should be reviewed by maintainer, regression-test, and architecture perspectives.
+- Core product engineering implementation teams should be reviewed by security, operations, accessibility, and maintainability perspectives.
+
 Run a structured brainstorm — one question at a time, get explicit approval after each section:
 
 1. **Architecture** — where does new code live, what existing patterns does it follow.
@@ -273,6 +315,8 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > - **Goal** — 1 sentence outcome.
 > - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
+> - **Team personality** — copy the spec's selected team name, roles, and issue-relevant emphasis. If the selected spec lacks this section, infer it from the request, past specs, repository labels, and memory; if confidence is low, stop and ask the operator to choose from the five starter combinations in Phase 2 before filing issues.
+> - **Review counter-team** — copy the spec's counter-team name, roles, and issue-relevant blind spots to challenge. If the selected spec lacks this section, derive a different review emphasis from the Team personality and issue risk before filing.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
@@ -335,8 +379,7 @@ labels and patches each body with a `## Model fit` block.
 > `type:tracker` label). For each:
 >
 > 1. **Stage context.** Read `gh issue view <N> --repo {repo} --json title,body,labels`. The
->    body should already contain `## Files to read first` and
->    `## Implementation scope`. If either is missing, add label
+>    body should already contain `## Files to read first`, `## Implementation scope`, `## Team personality`, and `## Review counter-team`. If any is missing, add label
 >    `needs-autospec-template` (idempotent `gh label create --force` once at run
 >    start) and skip — do not classify or patch.
 >

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -539,6 +539,17 @@ issues unblock the queue before continuing with normal feature work.
 > <BODY>
 > ===END===
 >
+> ## Team personality as execution lens
+>
+> Read the issue body's **Team personality** section before choosing an
+> approach. Let that team shape what you emphasize: a reliability/backend team
+> should scrutinize operational safety and data boundaries, a frontend/product
+> team should scrutinize user workflow and accessibility, a security-sensitive
+> team should scrutinize trust boundaries and abuse cases, and so on. Do not
+> invent extra scope; use the team personality to decide which risks deserve
+> extra attention while still satisfying the issue's concrete acceptance
+> criteria.
+>
 > Keep a progress heartbeat so the monitor can prove forward movement:
 > - Create/update `~/.autospec/process-heartbeats/<repo-slug>/<ISSUE>.json` at each major step:
 >   - `claimed`, `worktree_ready`, `tests_started`, `tests_passed`, `pr_created`, `smoke_retry`, `reviewed`, `merged`, `failed`
@@ -680,10 +691,13 @@ issues unblock the queue before continuing with normal feature work.
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
 >      _pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
->      trap 'rm -f "$_pr_diff_file"' EXIT
+>      _body_file=$(mktemp -t autospec-issue-body-XXXXXX.md)
+>      trap 'rm -f "$_pr_diff_file" "$_body_file"' EXIT
 >      gh pr diff <PR> > "$_pr_diff_file"
+>      gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
 >      combined_reviewer_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-reviewer-prompt.sh" \
 >        --pr-diff "$_pr_diff_file" \
+>        --issue-body "$_body_file" \
 >        --prev-findings "/tmp/guardian-<PR>.md" \
 >        --issue-labels "<ISSUE_LABELS>" \
 >        --repo "<REPO>")
@@ -692,6 +706,14 @@ issues unblock the queue before continuing with normal feature work.
 >
 >      Dispatch ONE **foreground subagent** with this brief:
 >        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
+>        >
+>        > ## Review counter-team as review lens
+>        >
+>        > Read the issue body's **Review counter-team** section before reviewing.
+>        > Review from that independent team's perspective and challenge likely blind spots
+>        > from the implementation team's **Team personality**. Stay inside the issue
+>        > scope: do not request unrelated rewrites, but do raise findings when the PR
+>        > misses risks the counter-team was selected to notice.
 >        >
 >        > **Part 1 — Guardian (contract compliance)** — skip if `AUTOSPEC_NO_GUARDIAN=1`:
 >        > 1. Read AGENTS.md `## Implementation-quality contract` for the RULE_ID table and directive map.

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -534,6 +534,17 @@ issues unblock the queue before continuing with normal feature work.
 > <BODY>
 > ===END===
 >
+> ## Team personality as execution lens
+>
+> Read the issue body's **Team personality** section before choosing an
+> approach. Let that team shape what you emphasize: a reliability/backend team
+> should scrutinize operational safety and data boundaries, a frontend/product
+> team should scrutinize user workflow and accessibility, a security-sensitive
+> team should scrutinize trust boundaries and abuse cases, and so on. Do not
+> invent extra scope; use the team personality to decide which risks deserve
+> extra attention while still satisfying the issue's concrete acceptance
+> criteria.
+>
 > Keep a progress heartbeat so the monitor can prove forward movement:
 > - Create/update `~/.autospec/process-heartbeats/<repo-slug>/<ISSUE>.json` at each major step:
 >   - `claimed`, `worktree_ready`, `tests_started`, `tests_passed`, `pr_created`, `smoke_retry`, `reviewed`, `merged`, `failed`
@@ -675,10 +686,13 @@ issues unblock the queue before continuing with normal feature work.
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
 >      _pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
->      trap 'rm -f "$_pr_diff_file"' EXIT
+>      _body_file=$(mktemp -t autospec-issue-body-XXXXXX.md)
+>      trap 'rm -f "$_pr_diff_file" "$_body_file"' EXIT
 >      gh pr diff <PR> > "$_pr_diff_file"
+>      gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
 >      combined_reviewer_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-reviewer-prompt.sh" \
 >        --pr-diff "$_pr_diff_file" \
+>        --issue-body "$_body_file" \
 >        --prev-findings "/tmp/guardian-<PR>.md" \
 >        --issue-labels "<ISSUE_LABELS>" \
 >        --repo "<REPO>")
@@ -687,6 +701,14 @@ issues unblock the queue before continuing with normal feature work.
 >
 >      Dispatch ONE **foreground subagent** with this brief:
 >        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
+>        >
+>        > ## Review counter-team as review lens
+>        >
+>        > Read the issue body's **Review counter-team** section before reviewing.
+>        > Review from that independent team's perspective and challenge likely blind spots
+>        > from the implementation team's **Team personality**. Stay inside the issue
+>        > scope: do not request unrelated rewrites, but do raise findings when the PR
+>        > misses risks the counter-team was selected to notice.
 >        >
 >        > **Part 1 — Guardian (contract compliance)** — skip if `AUTOSPEC_NO_GUARDIAN=1`:
 >        > 1. Read AGENTS.md `## Implementation-quality contract` for the RULE_ID table and directive map.

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -538,6 +538,17 @@ issues unblock the queue before continuing with normal feature work.
 > <BODY>
 > ===END===
 >
+> ## Team personality as execution lens
+>
+> Read the issue body's **Team personality** section before choosing an
+> approach. Let that team shape what you emphasize: a reliability/backend team
+> should scrutinize operational safety and data boundaries, a frontend/product
+> team should scrutinize user workflow and accessibility, a security-sensitive
+> team should scrutinize trust boundaries and abuse cases, and so on. Do not
+> invent extra scope; use the team personality to decide which risks deserve
+> extra attention while still satisfying the issue's concrete acceptance
+> criteria.
+>
 > Keep a progress heartbeat so the monitor can prove forward movement:
 > - Create/update `~/.autospec/process-heartbeats/<repo-slug>/<ISSUE>.json` at each major step:
 >   - `claimed`, `worktree_ready`, `tests_started`, `tests_passed`, `pr_created`, `smoke_retry`, `reviewed`, `merged`, `failed`
@@ -679,10 +690,13 @@ issues unblock the queue before continuing with normal feature work.
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
 >      _pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
->      trap 'rm -f "$_pr_diff_file"' EXIT
+>      _body_file=$(mktemp -t autospec-issue-body-XXXXXX.md)
+>      trap 'rm -f "$_pr_diff_file" "$_body_file"' EXIT
 >      gh pr diff <PR> > "$_pr_diff_file"
+>      gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
 >      combined_reviewer_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-reviewer-prompt.sh" \
 >        --pr-diff "$_pr_diff_file" \
+>        --issue-body "$_body_file" \
 >        --prev-findings "/tmp/guardian-<PR>.md" \
 >        --issue-labels "<ISSUE_LABELS>" \
 >        --repo "<REPO>")
@@ -691,6 +705,14 @@ issues unblock the queue before continuing with normal feature work.
 >
 >      Dispatch ONE **foreground subagent** with this brief:
 >        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
+>        >
+>        > ## Review counter-team as review lens
+>        >
+>        > Read the issue body's **Review counter-team** section before reviewing.
+>        > Review from that independent team's perspective and challenge likely blind spots
+>        > from the implementation team's **Team personality**. Stay inside the issue
+>        > scope: do not request unrelated rewrites, but do raise findings when the PR
+>        > misses risks the counter-team was selected to notice.
 >        >
 >        > **Part 1 — Guardian (contract compliance)** — skip if `AUTOSPEC_NO_GUARDIAN=1`:
 >        > 1. Read AGENTS.md `## Implementation-quality contract` for the RULE_ID table and directive map.

--- a/skills/autospec-split/SKILL.md
+++ b/skills/autospec-split/SKILL.md
@@ -217,12 +217,22 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Read the selected design spec at `<spec-path>` (`<spec-github-url>`) and split it into linked GitHub issues for {repo}.
 >
+> Before drafting issues, identify the implementation **Team personality** and independent **Review counter-team** from the selected spec. If the spec lacks those sections, infer them from the request, past specs under `docs/specs/`, repository labels, and relevant memory. If confidence is low, stop and ask the operator: `What kind of team should solve this problem?` Offer exactly these five starter combinations:
+> 1. **Core product engineering** — product manager, architect, backend developer, frontend developer, test engineer.
+> 2. **Reliability/backend** — backend developer, platform engineer, sysadmin/SRE, database engineer, security advisor.
+> 3. **Frontend/product** — frontend developer, UX designer, accessibility reviewer, API/backend developer, QA engineer.
+> 4. **Security-sensitive** — security advisor, architect, backend developer, platform engineer, test engineer.
+> 5. **Legacy/refactor** — architect, maintainer, backend/frontend developer as needed, test engineer, documentation owner.
+> Derive the Review counter-team with a different emphasis that will challenge likely blind spots while staying inside the issue scope.
+>
 > Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
 >
 > Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
 >
 > - **Goal** — 1 sentence outcome.
 > - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
+> - **Team personality** — copy the selected team name, roles, and issue-relevant emphasis.
+> - **Review counter-team** — copy the counter-team name, roles, and issue-relevant blind spots to challenge.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
@@ -285,8 +295,7 @@ labels and patches each body with a `## Model fit` block.
 > `type:tracker` label). For each:
 >
 > 1. **Stage context.** Read `gh issue view <N> --repo {repo} --json title,body,labels`. The
->    body should already contain `## Files to read first` and
->    `## Implementation scope`. If either is missing, add label
+>    body should already contain `## Files to read first`, `## Implementation scope`, `## Team personality`, and `## Review counter-team`. If any is missing, add label
 >    `needs-autospec-template` (idempotent `gh label create --force` once at run
 >    start) and skip — do not classify or patch.
 >

--- a/skills/autospec-split/codex/prompt.md
+++ b/skills/autospec-split/codex/prompt.md
@@ -211,12 +211,22 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Read the selected design spec at `<spec-path>` (`<spec-github-url>`) and split it into linked GitHub issues for {repo}.
 >
+> Before drafting issues, identify the implementation **Team personality** and independent **Review counter-team** from the selected spec. If the spec lacks those sections, infer them from the request, past specs under `docs/specs/`, repository labels, and relevant memory. If confidence is low, stop and ask the operator: `What kind of team should solve this problem?` Offer exactly these five starter combinations:
+> 1. **Core product engineering** — product manager, architect, backend developer, frontend developer, test engineer.
+> 2. **Reliability/backend** — backend developer, platform engineer, sysadmin/SRE, database engineer, security advisor.
+> 3. **Frontend/product** — frontend developer, UX designer, accessibility reviewer, API/backend developer, QA engineer.
+> 4. **Security-sensitive** — security advisor, architect, backend developer, platform engineer, test engineer.
+> 5. **Legacy/refactor** — architect, maintainer, backend/frontend developer as needed, test engineer, documentation owner.
+> Derive the Review counter-team with a different emphasis that will challenge likely blind spots while staying inside the issue scope.
+>
 > Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
 >
 > Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
 >
 > - **Goal** — 1 sentence outcome.
 > - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
+> - **Team personality** — copy the selected team name, roles, and issue-relevant emphasis.
+> - **Review counter-team** — copy the counter-team name, roles, and issue-relevant blind spots to challenge.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
@@ -279,8 +289,7 @@ labels and patches each body with a `## Model fit` block.
 > `type:tracker` label). For each:
 >
 > 1. **Stage context.** Read `gh issue view <N> --repo {repo} --json title,body,labels`. The
->    body should already contain `## Files to read first` and
->    `## Implementation scope`. If either is missing, add label
+>    body should already contain `## Files to read first`, `## Implementation scope`, `## Team personality`, and `## Review counter-team`. If any is missing, add label
 >    `needs-autospec-template` (idempotent `gh label create --force` once at run
 >    start) and skip — do not classify or patch.
 >

--- a/skills/autospec-split/opencode/agent.md
+++ b/skills/autospec-split/opencode/agent.md
@@ -215,12 +215,22 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Read the selected design spec at `<spec-path>` (`<spec-github-url>`) and split it into linked GitHub issues for {repo}.
 >
+> Before drafting issues, identify the implementation **Team personality** and independent **Review counter-team** from the selected spec. If the spec lacks those sections, infer them from the request, past specs under `docs/specs/`, repository labels, and relevant memory. If confidence is low, stop and ask the operator: `What kind of team should solve this problem?` Offer exactly these five starter combinations:
+> 1. **Core product engineering** — product manager, architect, backend developer, frontend developer, test engineer.
+> 2. **Reliability/backend** — backend developer, platform engineer, sysadmin/SRE, database engineer, security advisor.
+> 3. **Frontend/product** — frontend developer, UX designer, accessibility reviewer, API/backend developer, QA engineer.
+> 4. **Security-sensitive** — security advisor, architect, backend developer, platform engineer, test engineer.
+> 5. **Legacy/refactor** — architect, maintainer, backend/frontend developer as needed, test engineer, documentation owner.
+> Derive the Review counter-team with a different emphasis that will challenge likely blind spots while staying inside the issue scope.
+>
 > Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
 >
 > Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
 >
 > - **Goal** — 1 sentence outcome.
 > - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
+> - **Team personality** — copy the selected team name, roles, and issue-relevant emphasis.
+> - **Review counter-team** — copy the counter-team name, roles, and issue-relevant blind spots to challenge.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
@@ -283,8 +293,7 @@ labels and patches each body with a `## Model fit` block.
 > `type:tracker` label). For each:
 >
 > 1. **Stage context.** Read `gh issue view <N> --repo {repo} --json title,body,labels`. The
->    body should already contain `## Files to read first` and
->    `## Implementation scope`. If either is missing, add label
+>    body should already contain `## Files to read first`, `## Implementation scope`, `## Team personality`, and `## Review counter-team`. If any is missing, add label
 >    `needs-autospec-template` (idempotent `gh label create --force` once at run
 >    start) and skip — do not classify or patch.
 >

--- a/skills/autospec/README.md
+++ b/skills/autospec/README.md
@@ -101,8 +101,8 @@ Reach for this skill when:
 |---|---|---|
 | **0** | Bootstrap repo (if missing) | Detect missing git/GitHub remote, ask name/visibility/owner once, scaffold `.gitignore` + `AGENTS.md` + `README.md`, push. |
 | **1** | Investigate (delegate) | Read-only research subagent maps relevant files, schema, services. Real queries against remote systems if the feature touches them. |
-| **2** | Brainstorm + design | Structured 5-section brainstorm (architecture / API / data / errors / testing) with explicit per-section approval, written to `docs/specs/YYYY-MM-DD-<topic>-design.md`. |
-| **3** | Decompose into linked GitHub issues (delegate) | Foreground subagent creates labels, an EPIC umbrella, and N self-contained mini-specs sized for 32B-class local LLMs: file pointers, section anchors, checkbox AC, primary smoke test. |
+| **2** | Brainstorm + design | Selects a `Team personality` plus independent `Review counter-team`, then runs the structured 5-section brainstorm (architecture / API / data / errors / testing) with explicit per-section approval, written to `docs/specs/YYYY-MM-DD-<topic>-design.md`. |
+| **3** | Decompose into linked GitHub issues (delegate) | Foreground subagent creates labels, an EPIC umbrella, and N self-contained mini-specs sized for 32B-class local LLMs: team lens, review counter-team, file pointers, section anchors, checkbox AC, primary smoke test. |
 | **3.5** | Review and label (delegate) | Foreground subagent applies the `ctx:*` / `reasoning:*` rubric to each child, writes a `## Model fit` block into the body (idempotent), runs sibling-normalization across split children, and validates dep edges (closed-dep / child-less-tracker warnings; circular sibling-dep hard fail). Optional board assignment via `~/.autospec/project-map.yml` (full reader lands in PR B3 / #16). |
 | **4** | Background autonomous monitor | Background subagent loops: pick next ready issue → worktree → TDD → push → PR → self-review → admin-squash-merge → repeat until drained. |
 | **5** | Periodic status updates | Self-paced ~25 min wakeups posting deltas (closed issues, merged PRs, failures, blockers); slows to ~50 min when quiet. |

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -234,6 +234,48 @@ For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Pha
 
 > **Spec quality is the bottleneck.** Phase 2's output drives every downstream cycle's cost; if you care about spec quality, invoke this skill with your top-tier model (Claude Code: `claude-code --model opus`; Codex: top GPT). Phase 2 itself runs in the orchestrator (no subagent dispatch) — your invocation model IS the spec model. Subagents in Phases 1, 3, 3.5 follow this lead by selecting Tier A; Phase 4 implementation work uses Tier B. See AGENTS.md.
 
+## Team personality selection
+
+Before the Architecture question, decide what kind of team should solve this
+request. Infer the team personality from the user's request, Phase 1 evidence,
+repository labels, relevant memory files, and past specs under `docs/specs/`.
+The goal is to shape the design as a fitting team would reason about it, not to
+treat every request as a generic "fix this bug" task.
+
+Write a **Team personality** section into the design spec with:
+- the selected team name,
+- 3-6 roles,
+- why this team fits the request,
+- the risks this team is expected to notice,
+- any team emphasis that should carry into child issues.
+
+Also write a **Review counter-team** subsection. It must be a different
+emphasis from the implementation team and should challenge likely blind spots,
+not duplicate the same perspective. Include:
+- the counter-team name,
+- 2-5 roles,
+- which assumptions or failure modes this team should challenge,
+- how review should stay inside the issue scope while applying that lens.
+
+If confidence is low, ask the user explicitly: `What kind of team should solve this problem?`
+Offer exactly these five starter combinations:
+1. **Core product engineering** — product manager, architect, backend developer, frontend developer, test engineer.
+2. **Reliability/backend** — backend developer, platform engineer, sysadmin/SRE, database engineer, security advisor.
+3. **Frontend/product** — frontend developer, UX designer, accessibility reviewer, API/backend developer, QA engineer.
+4. **Security-sensitive** — security advisor, architect, backend developer, platform engineer, test engineer.
+5. **Legacy/refactor** — architect, maintainer, backend/frontend developer as needed, test engineer, documentation owner.
+
+If one option is clearly best, proceed without asking and record the confidence
+and evidence in the spec. If two or more options are plausible and would change
+the architecture, tests, or decomposition, ask before continuing.
+
+Derive the Review counter-team after choosing the implementation team:
+- Frontend/product implementation teams should be reviewed by accessibility, API contract, and QA perspectives.
+- Reliability/backend implementation teams should be reviewed by security, operations, and data-integrity perspectives.
+- Security-sensitive implementation teams should be reviewed by product/UX, maintainer, and test perspectives.
+- Legacy/refactor implementation teams should be reviewed by maintainer, regression-test, and architecture perspectives.
+- Core product engineering implementation teams should be reviewed by security, operations, accessibility, and maintainability perspectives.
+
 Run a structured brainstorm — one question at a time, get explicit approval after each section:
 
 1. **Architecture** — where does new code live, what existing patterns does it follow.
@@ -270,6 +312,8 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > - **Goal** — 1 sentence outcome.
 > - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
+> - **Team personality** — copy the spec's selected team name, roles, and issue-relevant emphasis. If the selected spec lacks this section, infer it from the request, past specs, repository labels, and memory; if confidence is low, stop and ask the operator to choose from the five starter combinations in Phase 2 before filing issues.
+> - **Review counter-team** — copy the spec's counter-team name, roles, and issue-relevant blind spots to challenge. If the selected spec lacks this section, derive a different review emphasis from the Team personality and issue risk before filing.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
@@ -332,8 +376,7 @@ labels and patches each body with a `## Model fit` block.
 > `type:tracker` label). For each:
 >
 > 1. **Stage context.** Read `gh issue view <N> --repo {repo} --json title,body,labels`. The
->    body should already contain `## Files to read first` and
->    `## Implementation scope`. If either is missing, add label
+>    body should already contain `## Files to read first`, `## Implementation scope`, `## Team personality`, and `## Review counter-team`. If any is missing, add label
 >    `needs-autospec-template` (idempotent `gh label create --force` once at run
 >    start) and skip — do not classify or patch.
 >
@@ -701,6 +744,17 @@ Pass the following prompt verbatim to each background subagent:
 > <BODY>
 > ===END===
 >
+> ## Team personality as execution lens
+>
+> Read the issue body's **Team personality** section before choosing an
+> approach. Let that team shape what you emphasize: a reliability/backend team
+> should scrutinize operational safety and data boundaries, a frontend/product
+> team should scrutinize user workflow and accessibility, a security-sensitive
+> team should scrutinize trust boundaries and abuse cases, and so on. Do not
+> invent extra scope; use the team personality to decide which risks deserve
+> extra attention while still satisfying the issue's concrete acceptance
+> criteria.
+>
 > Keep a progress heartbeat so the monitor can prove forward movement:
 > - Create/update `~/.autospec/process-heartbeats/<ISSUE>.json` at each major step:
 >   - `claimed`, `worktree_ready`, `tests_started`, `tests_passed`, `pr_created`, `smoke_retry`, `reviewed`, `merged`, `failed`
@@ -745,10 +799,13 @@ Pass the following prompt verbatim to each background subagent:
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
 >      _pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
->      trap 'rm -f "$_pr_diff_file"' EXIT
+>      _body_file=$(mktemp -t autospec-issue-body-XXXXXX.md)
+>      trap 'rm -f "$_pr_diff_file" "$_body_file"' EXIT
 >      gh pr diff <PR> > "$_pr_diff_file"
+>      gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
 >      combined_reviewer_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-reviewer-prompt.sh" \
 >        --pr-diff "$_pr_diff_file" \
+>        --issue-body "$_body_file" \
 >        --prev-findings "/tmp/guardian-<PR>.md" \
 >        --issue-labels "<ISSUE_LABELS>" \
 >        --repo "<REPO>")
@@ -757,6 +814,14 @@ Pass the following prompt verbatim to each background subagent:
 >
 >      Dispatch ONE **foreground subagent** with this brief:
 >        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
+>        >
+>        > ## Review counter-team as review lens
+>        >
+>        > Read the issue body's **Review counter-team** section before reviewing.
+>        > Review from that independent team's perspective and challenge likely blind spots
+>        > from the implementation team's **Team personality**. Stay inside the issue
+>        > scope: do not request unrelated rewrites, but do raise findings when the PR
+>        > misses risks the counter-team was selected to notice.
 >        >
 >        > **Part 1 — Guardian (contract compliance)** — skip if `AUTOSPEC_NO_GUARDIAN=1`:
 >        > 1. Read AGENTS.md `## Implementation-quality contract` for the RULE_ID table and directive map.

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -228,6 +228,48 @@ For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Pha
 
 > **Spec quality is the bottleneck.** Phase 2's output drives every downstream cycle's cost; if you care about spec quality, invoke this skill with your top-tier model (Claude Code: `claude-code --model opus`; Codex: top GPT). Phase 2 itself runs in the orchestrator (no subagent dispatch) — your invocation model IS the spec model. Subagents in Phases 1, 3, 3.5 follow this lead by selecting Tier A; Phase 4 implementation work uses Tier B. See AGENTS.md.
 
+## Team personality selection
+
+Before the Architecture question, decide what kind of team should solve this
+request. Infer the team personality from the user's request, Phase 1 evidence,
+repository labels, relevant memory files, and past specs under `docs/specs/`.
+The goal is to shape the design as a fitting team would reason about it, not to
+treat every request as a generic "fix this bug" task.
+
+Write a **Team personality** section into the design spec with:
+- the selected team name,
+- 3-6 roles,
+- why this team fits the request,
+- the risks this team is expected to notice,
+- any team emphasis that should carry into child issues.
+
+Also write a **Review counter-team** subsection. It must be a different
+emphasis from the implementation team and should challenge likely blind spots,
+not duplicate the same perspective. Include:
+- the counter-team name,
+- 2-5 roles,
+- which assumptions or failure modes this team should challenge,
+- how review should stay inside the issue scope while applying that lens.
+
+If confidence is low, ask the user explicitly: `What kind of team should solve this problem?`
+Offer exactly these five starter combinations:
+1. **Core product engineering** — product manager, architect, backend developer, frontend developer, test engineer.
+2. **Reliability/backend** — backend developer, platform engineer, sysadmin/SRE, database engineer, security advisor.
+3. **Frontend/product** — frontend developer, UX designer, accessibility reviewer, API/backend developer, QA engineer.
+4. **Security-sensitive** — security advisor, architect, backend developer, platform engineer, test engineer.
+5. **Legacy/refactor** — architect, maintainer, backend/frontend developer as needed, test engineer, documentation owner.
+
+If one option is clearly best, proceed without asking and record the confidence
+and evidence in the spec. If two or more options are plausible and would change
+the architecture, tests, or decomposition, ask before continuing.
+
+Derive the Review counter-team after choosing the implementation team:
+- Frontend/product implementation teams should be reviewed by accessibility, API contract, and QA perspectives.
+- Reliability/backend implementation teams should be reviewed by security, operations, and data-integrity perspectives.
+- Security-sensitive implementation teams should be reviewed by product/UX, maintainer, and test perspectives.
+- Legacy/refactor implementation teams should be reviewed by maintainer, regression-test, and architecture perspectives.
+- Core product engineering implementation teams should be reviewed by security, operations, accessibility, and maintainability perspectives.
+
 Run a structured brainstorm — one question at a time, get explicit approval after each section:
 
 1. **Architecture** — where does new code live, what existing patterns does it follow.
@@ -264,6 +306,8 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > - **Goal** — 1 sentence outcome.
 > - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
+> - **Team personality** — copy the spec's selected team name, roles, and issue-relevant emphasis. If the selected spec lacks this section, infer it from the request, past specs, repository labels, and memory; if confidence is low, stop and ask the operator to choose from the five starter combinations in Phase 2 before filing issues.
+> - **Review counter-team** — copy the spec's counter-team name, roles, and issue-relevant blind spots to challenge. If the selected spec lacks this section, derive a different review emphasis from the Team personality and issue risk before filing.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
@@ -326,8 +370,7 @@ labels and patches each body with a `## Model fit` block.
 > `type:tracker` label). For each:
 >
 > 1. **Stage context.** Read `gh issue view <N> --repo {repo} --json title,body,labels`. The
->    body should already contain `## Files to read first` and
->    `## Implementation scope`. If either is missing, add label
+>    body should already contain `## Files to read first`, `## Implementation scope`, `## Team personality`, and `## Review counter-team`. If any is missing, add label
 >    `needs-autospec-template` (idempotent `gh label create --force` once at run
 >    start) and skip — do not classify or patch.
 >
@@ -695,6 +738,17 @@ Pass the following prompt verbatim to each background subagent:
 > <BODY>
 > ===END===
 >
+> ## Team personality as execution lens
+>
+> Read the issue body's **Team personality** section before choosing an
+> approach. Let that team shape what you emphasize: a reliability/backend team
+> should scrutinize operational safety and data boundaries, a frontend/product
+> team should scrutinize user workflow and accessibility, a security-sensitive
+> team should scrutinize trust boundaries and abuse cases, and so on. Do not
+> invent extra scope; use the team personality to decide which risks deserve
+> extra attention while still satisfying the issue's concrete acceptance
+> criteria.
+>
 > Keep a progress heartbeat so the monitor can prove forward movement:
 > - Create/update `~/.autospec/process-heartbeats/<ISSUE>.json` at each major step:
 >   - `claimed`, `worktree_ready`, `tests_started`, `tests_passed`, `pr_created`, `smoke_retry`, `reviewed`, `merged`, `failed`
@@ -739,10 +793,13 @@ Pass the following prompt verbatim to each background subagent:
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
 >      _pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
->      trap 'rm -f "$_pr_diff_file"' EXIT
+>      _body_file=$(mktemp -t autospec-issue-body-XXXXXX.md)
+>      trap 'rm -f "$_pr_diff_file" "$_body_file"' EXIT
 >      gh pr diff <PR> > "$_pr_diff_file"
+>      gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
 >      combined_reviewer_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-reviewer-prompt.sh" \
 >        --pr-diff "$_pr_diff_file" \
+>        --issue-body "$_body_file" \
 >        --prev-findings "/tmp/guardian-<PR>.md" \
 >        --issue-labels "<ISSUE_LABELS>" \
 >        --repo "<REPO>")
@@ -751,6 +808,14 @@ Pass the following prompt verbatim to each background subagent:
 >
 >      Dispatch ONE **foreground subagent** with this brief:
 >        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
+>        >
+>        > ## Review counter-team as review lens
+>        >
+>        > Read the issue body's **Review counter-team** section before reviewing.
+>        > Review from that independent team's perspective and challenge likely blind spots
+>        > from the implementation team's **Team personality**. Stay inside the issue
+>        > scope: do not request unrelated rewrites, but do raise findings when the PR
+>        > misses risks the counter-team was selected to notice.
 >        >
 >        > **Part 1 — Guardian (contract compliance)** — skip if `AUTOSPEC_NO_GUARDIAN=1`:
 >        > 1. Read AGENTS.md `## Implementation-quality contract` for the RULE_ID table and directive map.

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -232,6 +232,48 @@ For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Pha
 
 > **Spec quality is the bottleneck.** Phase 2's output drives every downstream cycle's cost; if you care about spec quality, invoke this skill with your top-tier model (Claude Code: `claude-code --model opus`; Codex: top GPT). Phase 2 itself runs in the orchestrator (no subagent dispatch) — your invocation model IS the spec model. Subagents in Phases 1, 3, 3.5 follow this lead by selecting Tier A; Phase 4 implementation work uses Tier B. See AGENTS.md.
 
+## Team personality selection
+
+Before the Architecture question, decide what kind of team should solve this
+request. Infer the team personality from the user's request, Phase 1 evidence,
+repository labels, relevant memory files, and past specs under `docs/specs/`.
+The goal is to shape the design as a fitting team would reason about it, not to
+treat every request as a generic "fix this bug" task.
+
+Write a **Team personality** section into the design spec with:
+- the selected team name,
+- 3-6 roles,
+- why this team fits the request,
+- the risks this team is expected to notice,
+- any team emphasis that should carry into child issues.
+
+Also write a **Review counter-team** subsection. It must be a different
+emphasis from the implementation team and should challenge likely blind spots,
+not duplicate the same perspective. Include:
+- the counter-team name,
+- 2-5 roles,
+- which assumptions or failure modes this team should challenge,
+- how review should stay inside the issue scope while applying that lens.
+
+If confidence is low, ask the user explicitly: `What kind of team should solve this problem?`
+Offer exactly these five starter combinations:
+1. **Core product engineering** — product manager, architect, backend developer, frontend developer, test engineer.
+2. **Reliability/backend** — backend developer, platform engineer, sysadmin/SRE, database engineer, security advisor.
+3. **Frontend/product** — frontend developer, UX designer, accessibility reviewer, API/backend developer, QA engineer.
+4. **Security-sensitive** — security advisor, architect, backend developer, platform engineer, test engineer.
+5. **Legacy/refactor** — architect, maintainer, backend/frontend developer as needed, test engineer, documentation owner.
+
+If one option is clearly best, proceed without asking and record the confidence
+and evidence in the spec. If two or more options are plausible and would change
+the architecture, tests, or decomposition, ask before continuing.
+
+Derive the Review counter-team after choosing the implementation team:
+- Frontend/product implementation teams should be reviewed by accessibility, API contract, and QA perspectives.
+- Reliability/backend implementation teams should be reviewed by security, operations, and data-integrity perspectives.
+- Security-sensitive implementation teams should be reviewed by product/UX, maintainer, and test perspectives.
+- Legacy/refactor implementation teams should be reviewed by maintainer, regression-test, and architecture perspectives.
+- Core product engineering implementation teams should be reviewed by security, operations, accessibility, and maintainability perspectives.
+
 Run a structured brainstorm — one question at a time, get explicit approval after each section:
 
 1. **Architecture** — where does new code live, what existing patterns does it follow.
@@ -268,6 +310,8 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > - **Goal** — 1 sentence outcome.
 > - **Source spec** — `<spec-path>` + `<spec-github-url>` of the design doc this issue derives from.
+> - **Team personality** — copy the spec's selected team name, roles, and issue-relevant emphasis. If the selected spec lacks this section, infer it from the request, past specs, repository labels, and memory; if confidence is low, stop and ask the operator to choose from the five starter combinations in Phase 2 before filing issues.
+> - **Review counter-team** — copy the spec's counter-team name, roles, and issue-relevant blind spots to challenge. If the selected spec lacks this section, derive a different review emphasis from the Team personality and issue risk before filing.
 > - **Files to read first** — 3–7 entries. Each entry is one of: a path with **section anchors** (do not say "read the whole spec"), the closest existing-file analogue to mirror, the test file or fixture pattern to follow, or a dependency issue with a one-line summary so the LLM doesn't fetch its body. Bias toward sectional anchors over full files.
 > - **Local-LLM execution notes** — one-line context-window recommendation (`32k routine`, `64k stretch`, or `split into N subagents along <criterion>` for issues exceeding ~30k tokens of staged context) and whether single-pass or subagent-split is recommended.
 > - **Implementation scope** and **Out of scope** as separate subsections (replaces the prior single "Scope" section).
@@ -330,8 +374,7 @@ labels and patches each body with a `## Model fit` block.
 > `type:tracker` label). For each:
 >
 > 1. **Stage context.** Read `gh issue view <N> --repo {repo} --json title,body,labels`. The
->    body should already contain `## Files to read first` and
->    `## Implementation scope`. If either is missing, add label
+>    body should already contain `## Files to read first`, `## Implementation scope`, `## Team personality`, and `## Review counter-team`. If any is missing, add label
 >    `needs-autospec-template` (idempotent `gh label create --force` once at run
 >    start) and skip — do not classify or patch.
 >
@@ -699,6 +742,17 @@ Pass the following prompt verbatim to each background subagent:
 > <BODY>
 > ===END===
 >
+> ## Team personality as execution lens
+>
+> Read the issue body's **Team personality** section before choosing an
+> approach. Let that team shape what you emphasize: a reliability/backend team
+> should scrutinize operational safety and data boundaries, a frontend/product
+> team should scrutinize user workflow and accessibility, a security-sensitive
+> team should scrutinize trust boundaries and abuse cases, and so on. Do not
+> invent extra scope; use the team personality to decide which risks deserve
+> extra attention while still satisfying the issue's concrete acceptance
+> criteria.
+>
 > Keep a progress heartbeat so the monitor can prove forward movement:
 > - Create/update `~/.autospec/process-heartbeats/<ISSUE>.json` at each major step:
 >   - `claimed`, `worktree_ready`, `tests_started`, `tests_passed`, `pr_created`, `smoke_retry`, `reviewed`, `merged`, `failed`
@@ -743,10 +797,13 @@ Pass the following prompt verbatim to each background subagent:
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
 >      _pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
->      trap 'rm -f "$_pr_diff_file"' EXIT
+>      _body_file=$(mktemp -t autospec-issue-body-XXXXXX.md)
+>      trap 'rm -f "$_pr_diff_file" "$_body_file"' EXIT
 >      gh pr diff <PR> > "$_pr_diff_file"
+>      gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
 >      combined_reviewer_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-reviewer-prompt.sh" \
 >        --pr-diff "$_pr_diff_file" \
+>        --issue-body "$_body_file" \
 >        --prev-findings "/tmp/guardian-<PR>.md" \
 >        --issue-labels "<ISSUE_LABELS>" \
 >        --repo "<REPO>")
@@ -755,6 +812,14 @@ Pass the following prompt verbatim to each background subagent:
 >
 >      Dispatch ONE **foreground subagent** with this brief:
 >        > You are the implementation reviewer for PR #<PR> on {repo}, closing issue #<ISSUE>.
+>        >
+>        > ## Review counter-team as review lens
+>        >
+>        > Read the issue body's **Review counter-team** section before reviewing.
+>        > Review from that independent team's perspective and challenge likely blind spots
+>        > from the implementation team's **Team personality**. Stay inside the issue
+>        > scope: do not request unrelated rewrites, but do raise findings when the PR
+>        > misses risks the counter-team was selected to notice.
 >        >
 >        > **Part 1 — Guardian (contract compliance)** — skip if `AUTOSPEC_NO_GUARDIAN=1`:
 >        > 1. Read AGENTS.md `## Implementation-quality contract` for the RULE_ID table and directive map.

--- a/tests/fixtures/gen-issue-skeleton/expected-minimal.md
+++ b/tests/fixtures/gen-issue-skeleton/expected-minimal.md
@@ -1,10 +1,20 @@
 ## Goal
 
-Add scripts/gen-issue-skeleton.sh to render structured YAML input into an 11-section issue body.
+Add scripts/gen-issue-skeleton.sh to render structured YAML input into a team-lensed issue body.
 
 ## Source spec section anchor
 
 `docs/specs/2026-05-22-autospec-tooling-optimization-design.md` — https://github.com/berlinguyinca/autospec/blob/main/docs/specs/2026-05-22-autospec-tooling-optimization-design.md
+
+## Team personality
+
+- Tooling maintainers: architect, shell developer, test engineer
+- Emphasis: deterministic issue rendering and lock-step validation compatibility
+
+## Review counter-team
+
+- Reliability review: release engineer, docs-drift reviewer, regression tester
+- Challenge: generated issues must preserve all prompt-governance sections
 
 ## Files to read first
 
@@ -26,7 +36,7 @@ Pure implementation; keep files within 200 lines so a 60-120k context window hol
 
 1. Add scripts/gen-issue-skeleton.sh with --input flag
 2. Parse required YAML keys from input
-3. Substitute into 11-section markdown template
+3. Substitute into team-lensed markdown template
 4. Pipe output through scripts/lint-issue.sh
 
 ## Tests required
@@ -35,7 +45,7 @@ Pure implementation; keep files within 200 lines so a 60-120k context window hol
 
 ## Acceptance criteria
 
-- [ ] scripts/gen-issue-skeleton.sh --input minimal.yaml emits 11-section body
+- [ ] scripts/gen-issue-skeleton.sh --input minimal.yaml emits a team-lensed issue body
 
 ## Verification
 

--- a/tests/fixtures/gen-issue-skeleton/minimal.yaml
+++ b/tests/fixtures/gen-issue-skeleton/minimal.yaml
@@ -1,7 +1,13 @@
 issue_id: test-issue-001
 spec_path: docs/specs/2026-05-22-autospec-tooling-optimization-design.md
 spec_url: https://github.com/berlinguyinca/autospec/blob/main/docs/specs/2026-05-22-autospec-tooling-optimization-design.md
-goal_sentence: "Add scripts/gen-issue-skeleton.sh to render structured YAML input into an 11-section issue body."
+goal_sentence: "Add scripts/gen-issue-skeleton.sh to render structured YAML input into a team-lensed issue body."
+team_personality:
+  - "Tooling maintainers: architect, shell developer, test engineer"
+  - "Emphasis: deterministic issue rendering and lock-step validation compatibility"
+review_counter_team:
+  - "Reliability review: release engineer, docs-drift reviewer, regression tester"
+  - "Challenge: generated issues must preserve all prompt-governance sections"
 files_to_read:
   - docs/specs/2026-05-22-autospec-tooling-optimization-design.md
   - scripts/lint-issue.sh
@@ -12,12 +18,12 @@ out_of_scope:
 implementation_outline_lines:
   - "Add scripts/gen-issue-skeleton.sh with --input flag"
   - "Parse required YAML keys from input"
-  - "Substitute into 11-section markdown template"
+  - "Substitute into team-lensed markdown template"
   - "Pipe output through scripts/lint-issue.sh"
 tests_required:
   - "bats tests/gen-issue-skeleton.bats with 3 fixtures"
 acceptance_criteria:
-  - "scripts/gen-issue-skeleton.sh --input minimal.yaml emits 11-section body"
+  - "scripts/gen-issue-skeleton.sh --input minimal.yaml emits a team-lensed issue body"
   - "Output passes scripts/lint-issue.sh with exit 0"
   - "Missing required YAML field exits non-zero with MISSING_FIELD:<name> on stderr"
 verification:

--- a/tests/fixtures/gen-issue-skeleton/vague-goal.yaml
+++ b/tests/fixtures/gen-issue-skeleton/vague-goal.yaml
@@ -2,6 +2,10 @@ issue_id: test-issue-002
 spec_path: docs/specs/2026-05-22-autospec-tooling-optimization-design.md
 spec_url: https://github.com/berlinguyinca/autospec/blob/main/docs/specs/2026-05-22-autospec-tooling-optimization-design.md
 goal_sentence: "Improve the system."
+team_personality:
+  - "Tooling maintainers: architect, shell developer, test engineer"
+review_counter_team:
+  - "Reliability review: release engineer, docs-drift reviewer, regression tester"
 files_to_read:
   - scripts/lint-issue.sh
 implementation_scope:

--- a/tests/gen-issue-skeleton.bats
+++ b/tests/gen-issue-skeleton.bats
@@ -7,12 +7,13 @@ MINIMAL_YAML="$REPO_ROOT/tests/fixtures/gen-issue-skeleton/minimal.yaml"
 VAGUE_YAML="$REPO_ROOT/tests/fixtures/gen-issue-skeleton/vague-goal.yaml"
 LINT_BIN="$REPO_ROOT/scripts/lint-issue.sh"
 
-@test "minimal-valid: --input emits 11-section body that passes lint-issue.sh" {
+@test "minimal-valid: --input emits issue body with team lenses that passes lint-issue.sh" {
   run bash "$GEN_BIN" --input "$MINIMAL_YAML"
   [ "$status" -eq 0 ]
-  # Must contain all 11 required section headings
   echo "$output" | grep -q "^## Goal"
   echo "$output" | grep -q "^## Source spec"
+  echo "$output" | grep -q "^## Team personality"
+  echo "$output" | grep -q "^## Review counter-team"
   echo "$output" | grep -q "^## Files to read first"
   echo "$output" | grep -q "^## Local-LLM notes"
   echo "$output" | grep -q "^## Implementation scope"
@@ -37,6 +38,10 @@ LINT_BIN="$REPO_ROOT/scripts/lint-issue.sh"
 issue_id: missing-goal
 spec_path: docs/specs/foo.md
 spec_url: https://example.com
+team_personality:
+  - "Core product engineering: product manager, architect, backend developer, test engineer"
+review_counter_team:
+  - "Security and reliability review: security advisor, SRE, regression tester"
 files_to_read:
   - scripts/lint-issue.sh
 implementation_scope:
@@ -64,4 +69,9 @@ YAML
   run bash "$GEN_BIN" --input "$VAGUE_YAML"
   # Should fail because lint-issue.sh will reject the vague goal
   [ "$status" -ne 0 ]
+}
+
+@test "operator-full-pipe: generated body can be linted via /dev/stdin" {
+  run bash -c "bash '$GEN_BIN' --input '$MINIMAL_YAML' | bash '$LINT_BIN' /dev/stdin"
+  [ "$status" -eq 0 ]
 }

--- a/tests/gen-reviewer-prompt.bats
+++ b/tests/gen-reviewer-prompt.bats
@@ -73,7 +73,34 @@ for i in range(8100):
   echo "$output" | grep -q "DUPLICATE_CODE"
 }
 
-# Case 9: flat-install resolution — script finds bundle-static-context.sh as a
+# Case 9: issue body appears in output when provided so review lenses are available
+@test "dynamic-suffix: issue body with review counter-team appears in output" {
+  issue_body="$(mktemp)"
+  cat > "$issue_body" <<'BODY'
+## Team personality
+
+- Tooling maintainers: shell developer, test engineer
+
+## Review counter-team
+
+- Reliability review: release engineer, docs-drift reviewer
+
+## Implementation scope
+
+- `scripts/example.sh`
+BODY
+  run bash "$BIN" \
+    --pr-diff "$FIX/pr-303.diff" \
+    --prev-findings "$FIX/findings-empty.json" \
+    --issue-body "$issue_body"
+  rm -f "$issue_body"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "### Issue body"
+  echo "$output" | grep -q "## Review counter-team"
+  echo "$output" | grep -q "Reliability review"
+}
+
+# Case 10: flat-install resolution — script finds bundle-static-context.sh as a
 # sibling in the same dir when AUTOSPEC_SCRIPTS_DIR is unset and no repo layout exists
 @test "flat-install: resolves sibling bundle-static-context.sh with no repo layout" {
   flatdir="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- Carry Team personality and Review counter-team through autospec specs, split issues, skeleton generation, Phase 3.5 validation, and Phase 4 review prompts.
- Add issue-body support to gen-reviewer-prompt.sh so reviewer lenses are available during fused guardian/LGTM review.
- Document the new schema and prompt inputs, and add validation/tests for the contract.

## Review
- Self-review found stale API reference usage for gen-reviewer-prompt.sh; fixed in a follow-up commit before opening this PR.
- No remaining blocking findings from local review.

## Test Plan
- [x] bats tests/gen-reviewer-prompt.bats
- [x] bats tests/gen-issue-skeleton.bats
- [x] git diff --check origin/main...HEAD
- [x] bash scripts/validate.sh

Constraint: Branch-per-issue rule forbids direct pushes to main.
Confidence: high
Scope-risk: moderate
Tested: bats tests/gen-reviewer-prompt.bats
Tested: bats tests/gen-issue-skeleton.bats
Tested: git diff --check origin/main...HEAD
Tested: bash scripts/validate.sh
Not-tested: Live autospec monitor processing a real GitHub issue end-to-end
Co-authored-by: OmX <omx@oh-my-codex.dev>