### PR TITLE
fix: bound autospec phase1 research handoff context

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -307,6 +307,29 @@ check_subagent_model_tier() {
     fi
 }
 
+check_phase1_bounded_context_contract() {
+    info "phase1 bounded-context contract: autospec + autospec-define"
+    for f in \
+        skills/autospec/SKILL.md \
+        skills/autospec/codex/prompt.md \
+        skills/autospec/opencode/agent.md \
+        skills/autospec-define/SKILL.md \
+        skills/autospec-define/codex/prompt.md \
+        skills/autospec-define/opencode/agent.md
+    do
+        grep -q 'Phase 1 bounded-context rule' "$f" \
+            || fail "$f missing Phase 1 bounded-context rule"
+        grep -q 'Do NOT fork, inherit, or compact the full parent conversation' "$f" \
+            || fail "$f allows inherited parent conversation in Phase 1"
+        grep -q 'fork_context=false' "$f" \
+            || fail "$f missing Codex fresh-context directive"
+        grep -q 'context window or remote compact failure' "$f" \
+            || fail "$f missing compact-overflow fallback directive"
+        grep -q 'bounded local read-only `rg`/file-read investigation' "$f" \
+            || fail "$f missing bounded local fallback directive"
+    done
+}
+
 # Harness detection block validation.
 # If a SKILL.md contains a "## Harness detection" heading, verify that the
 # section body includes TIER_A, TIER_B, and a "silently" fallback reference.
@@ -764,6 +787,7 @@ main() {
     check_lint_issue_helpers
     check_lint_implementation_helpers
     check_phase4_guardian_block_lockstep
+    check_phase1_bounded_context_contract
     check_phase4_issue_start_summary
     check_phase4_immediate_next_issue_pickup
     check_phase4_adaptive_retry

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -216,6 +216,16 @@ Spawn a **read-only research subagent** to map relevant files, schema, services.
 
 > **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
 
+> **Phase 1 bounded-context rule.** Launch the research subagent with a fresh,
+> bounded handoff. Do NOT fork, inherit, or compact the full parent conversation into Phase 1. The handoff may contain only: the feature request,
+> repo slug/root, a short git status summary, relevant memory-injection output,
+> explicit user-mentioned paths/surfaces, and these Phase 1 instructions. For
+> Codex native subagents, set `fork_context=false`; for Claude/OpenCode, use the
+> equivalent fresh/no-history task mode when available. If the harness cannot
+> start a fresh subagent, or returns a context window or remote compact failure,
+> do not retry with inherited context. Fall back to bounded local read-only `rg`/file-read investigation, label the result as `Phase 1 fallback`, and
+> continue to Phase 2 with the best evidence gathered.
+
 If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
 
 For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -210,6 +210,16 @@ Spawn a **read-only research subagent** to map relevant files, schema, services.
 
 > **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
 
+> **Phase 1 bounded-context rule.** Launch the research subagent with a fresh,
+> bounded handoff. Do NOT fork, inherit, or compact the full parent conversation into Phase 1. The handoff may contain only: the feature request,
+> repo slug/root, a short git status summary, relevant memory-injection output,
+> explicit user-mentioned paths/surfaces, and these Phase 1 instructions. For
+> Codex native subagents, set `fork_context=false`; for Claude/OpenCode, use the
+> equivalent fresh/no-history task mode when available. If the harness cannot
+> start a fresh subagent, or returns a context window or remote compact failure,
+> do not retry with inherited context. Fall back to bounded local read-only `rg`/file-read investigation, label the result as `Phase 1 fallback`, and
+> continue to Phase 2 with the best evidence gathered.
+
 If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
 
 For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -214,6 +214,16 @@ Spawn a **read-only research subagent** to map relevant files, schema, services.
 
 > **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
 
+> **Phase 1 bounded-context rule.** Launch the research subagent with a fresh,
+> bounded handoff. Do NOT fork, inherit, or compact the full parent conversation into Phase 1. The handoff may contain only: the feature request,
+> repo slug/root, a short git status summary, relevant memory-injection output,
+> explicit user-mentioned paths/surfaces, and these Phase 1 instructions. For
+> Codex native subagents, set `fork_context=false`; for Claude/OpenCode, use the
+> equivalent fresh/no-history task mode when available. If the harness cannot
+> start a fresh subagent, or returns a context window or remote compact failure,
+> do not retry with inherited context. Fall back to bounded local read-only `rg`/file-read investigation, label the result as `Phase 1 fallback`, and
+> continue to Phase 2 with the best evidence gathered.
+
 If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.
 
 For a freshly-bootstrapped empty repo, Phase 1 may be a no-op — proceed to Phase 2.

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -224,6 +224,16 @@ Spawn a **read-only research subagent** to map relevant files, schema, services.
 
 > **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
 
+> **Phase 1 bounded-context rule.** Launch the research subagent with a fresh,
+> bounded handoff. Do NOT fork, inherit, or compact the full parent conversation into Phase 1. The handoff may contain only: the feature request,
+> repo slug/root, a short git status summary, relevant memory-injection output,
+> explicit user-mentioned paths/surfaces, and these Phase 1 instructions. For
+> Codex native subagents, set `fork_context=false`; for Claude/OpenCode, use the
+> equivalent fresh/no-history task mode when available. If the harness cannot
+> start a fresh subagent, or returns a context window or remote compact failure,
+> do not retry with inherited context. Fall back to bounded local read-only `rg`/file-read investigation, label the result as `Phase 1 fallback`, and
+> continue to Phase 2 with the best evidence gathered.
+
 > **Hard limits.** Max 25 tool calls. If 3 consecutive read/grep calls return nothing useful, stop and write your best-effort summary even if incomplete. Do not retry the same query verbatim. No wall-clock cap.
 
 If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -218,6 +218,16 @@ Spawn a **read-only research subagent** to map relevant files, schema, services.
 
 > **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
 
+> **Phase 1 bounded-context rule.** Launch the research subagent with a fresh,
+> bounded handoff. Do NOT fork, inherit, or compact the full parent conversation into Phase 1. The handoff may contain only: the feature request,
+> repo slug/root, a short git status summary, relevant memory-injection output,
+> explicit user-mentioned paths/surfaces, and these Phase 1 instructions. For
+> Codex native subagents, set `fork_context=false`; for Claude/OpenCode, use the
+> equivalent fresh/no-history task mode when available. If the harness cannot
+> start a fresh subagent, or returns a context window or remote compact failure,
+> do not retry with inherited context. Fall back to bounded local read-only `rg`/file-read investigation, label the result as `Phase 1 fallback`, and
+> continue to Phase 2 with the best evidence gathered.
+
 > **Hard limits.** Max 25 tool calls. If 3 consecutive read/grep calls return nothing useful, stop and write your best-effort summary even if incomplete. Do not retry the same query verbatim. No wall-clock cap.
 
 If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -222,6 +222,16 @@ Spawn a **read-only research subagent** to map relevant files, schema, services.
 
 > **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
 
+> **Phase 1 bounded-context rule.** Launch the research subagent with a fresh,
+> bounded handoff. Do NOT fork, inherit, or compact the full parent conversation into Phase 1. The handoff may contain only: the feature request,
+> repo slug/root, a short git status summary, relevant memory-injection output,
+> explicit user-mentioned paths/surfaces, and these Phase 1 instructions. For
+> Codex native subagents, set `fork_context=false`; for Claude/OpenCode, use the
+> equivalent fresh/no-history task mode when available. If the harness cannot
+> start a fresh subagent, or returns a context window or remote compact failure,
+> do not retry with inherited context. Fall back to bounded local read-only `rg`/file-read investigation, label the result as `Phase 1 fallback`, and
+> continue to Phase 2 with the best evidence gathered.
+
 > **Hard limits.** Max 25 tool calls. If 3 consecutive read/grep calls return nothing useful, stop and write your best-effort summary even if incomplete. Do not retry the same query verbatim. No wall-clock cap.
 
 If the feature touches a remote system (DB, server, S3), run a real query against the actual data to confirm the problem statement before designing. Surface the concrete numbers in the design.

--- a/tests/unit/test_phase1_bounded_context.bats
+++ b/tests/unit/test_phase1_bounded_context.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+# tests/unit/test_phase1_bounded_context.bats — Phase 1 research must not
+# inherit long parent conversations into a subagent compact task.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  export REPO_ROOT
+}
+
+@test "autospec Phase 1 requires a bounded fresh-context research handoff" {
+  for f in \
+    "$REPO_ROOT/skills/autospec/SKILL.md" \
+    "$REPO_ROOT/skills/autospec/codex/prompt.md" \
+    "$REPO_ROOT/skills/autospec/opencode/agent.md" \
+    "$REPO_ROOT/skills/autospec-define/SKILL.md" \
+    "$REPO_ROOT/skills/autospec-define/codex/prompt.md" \
+    "$REPO_ROOT/skills/autospec-define/opencode/agent.md"
+  do
+    grep -q 'Phase 1 bounded-context rule' "$f"
+    grep -q 'Do NOT fork, inherit, or compact the full parent conversation' "$f"
+    grep -q 'fork_context=false' "$f"
+    grep -q 'context window or remote compact failure' "$f"
+    grep -q 'bounded local read-only `rg`/file-read investigation' "$f"
+  done
+}
+
+@test "validate.sh enforces the Phase 1 bounded context contract" {
+  grep -q '^check_phase1_bounded_context_contract()' "$REPO_ROOT/scripts/validate.sh"
+  grep -q 'check_phase1_bounded_context_contract' "$REPO_ROOT/scripts/validate.sh"
+}

--- a/tests/unit/test_phase1_bounded_context.bats
+++ b/tests/unit/test_phase1_bounded_context.bats
@@ -26,5 +26,6 @@ setup() {
 
 @test "validate.sh enforces the Phase 1 bounded context contract" {
   grep -q '^check_phase1_bounded_context_contract()' "$REPO_ROOT/scripts/validate.sh"
-  grep -q 'check_phase1_bounded_context_contract' "$REPO_ROOT/scripts/validate.sh"
+  count="$(grep -c 'check_phase1_bounded_context_contract' "$REPO_ROOT/scripts/validate.sh")"
+  [ "$count" -ge 2 ]
 }


### PR DESCRIPTION
## Summary
- Require Phase 1 research subagents to start from a fresh bounded handoff instead of inheriting/compacting the full parent conversation.
- Define fallback behavior for context-window or remote compact failures: bounded local read-only `rg`/file reads labeled as Phase 1 fallback.
- Add validate.sh coverage and a Bats regression test across autospec/autospec-define lock-step prompt surfaces.

## Root Cause
Phase 1 said to spawn a read-only research subagent, but did not forbid full parent-context inheritance. In long sessions, Codex can fail while compacting the inherited transcript before the explorer does any work.

## Review
- Local review focused on prompt lock-step, fallback behavior, and validation drift.
- No blocking findings before PR creation.

## Test Plan
- [x] bats tests/unit/test_phase1_bounded_context.bats
- [x] git diff --check
- [x] bash scripts/validate.sh

Constraint: Branch-per-issue rule forbids direct pushes to main.
Confidence: high
Scope-risk: narrow
Tested: bats tests/unit/test_phase1_bounded_context.bats
Tested: git diff --check
Tested: bash scripts/validate.sh
Not-tested: Live autospec invocation in a deliberately overfull parent conversation
Co-authored-by: OmX <omx@oh-my-codex.dev>