### PR TITLE
feat: add autospec sweep configuration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ selected model and harness to execute reliably.
 | Skill | Use it when | Result |
 | --- | --- | --- |
 | [`autospec`](skills/autospec/README.md) | You want the full path from feature request to merged PRs. | Bootstraps if needed, investigates, writes a spec, creates issues, classifies them, runs implementation, and reports completion. |
+| [`autospec-sweep`](skills/autospec-sweep/README.md) | You want first-run configuration or continuous improvement across specs, docs, tests, and code. | Creates `.autospec/autospec.yml`, runs a configured sweep, writes `.autospec/sweep/latest.json`, and routes recurring gaps back through specs, issues, and `/autospec-run`. |
 | [`autospec-define`](skills/autospec-define/README.md) | You want planning only before implementation starts. | Produces a design spec plus classified `auto-implement` issues, then hands off to `/autospec-run`. |
 | [`autospec-split`](skills/autospec-split/README.md) | You already have a tracked `docs/specs/*.md` design spec. | Turns the existing spec into an EPIC plus linked child issues, then stops after classification. |
 | [`autospec-run`](skills/autospec-run/README.md) | You already have an `auto-implement` queue. | Runs the implementation monitor, opens PRs, reviews, validates, and merges. |
@@ -167,6 +168,7 @@ Or invoke any installed skill with `update`:
 /autospec-listen update
 /autospec-story update
 /autospec-stop update
+/autospec-sweep update
 ```
 
 ## Model Fit and Profiles

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -9,6 +9,14 @@
 - Status: 7-phase workflow (bootstrap → investigate → design → decompose → background monitor → status updates → final report) with admin-squash-merge of `auto-implement`-labeled PRs.
 - Turbo integration (since 2026-05-17): `install.sh` bootstraps [tobihagemann/turbo](https://github.com/tobihagemann/turbo) as a peer skill family and `--update` keeps both stacks current. Issues filed by `/autospec-define` carry the `autospec:v2-flow` label, which routes the Phase 4 implementer to a prompt at `skills/autospec-run/prompts/phase4-implementer.md` that absorbs turbo's expand → implement → finalize → peer-review → evaluate-findings discipline inline. Peer-review uses Codex CLI; gracefully skips when absent. See [`docs/superpowers/specs/2026-05-17-turbo-autospec-integration-design.md`](docs/superpowers/specs/2026-05-17-turbo-autospec-integration-design.md).
 
+## autospec-sweep
+
+- Path: [`skills/autospec-sweep`](skills/autospec-sweep)
+- Trigger: use when a project needs first-run autospec configuration, recurring spec-vs-reality sweeps, or continuous improvement across docs, tests, and code health.
+- Activation keywords: `autospec-sweep`, `sweep`, `configure autospec`, `first-run config`, `continuous improvement`, `spec sync`, `docs tests code sweep`
+- Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
+- Status: tracked config mode. Creates `.autospec/autospec.yml`, asks project-specific setup questions from repo findings, keeps specs synchronized with implementation reality, and routes improvement gaps through `autospec-review`, issues, and `/autospec-run`.
+
 ## autospec-listen
 
 - Path: [`skills/autospec-listen`](skills/autospec-listen)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -543,6 +543,13 @@ Exit: 0 = all checks pass, non-zero = first failure with diagnostic.
 - Remediation mode section present across the autospec-review trio (`check_review_remediation_section`)
 - Phase 4 guardian block lockstep
 - Phase 4 adaptive-retry loop
+- autospec-sweep config contract and first-run `/autospec-sweep init` preflight
+- autospec-sweep executable runner: `autospec-sweep-run.sh`
+- autospec-sweep deterministic review wrapper: `autospec-sweep-review.sh`
+- autospec config schema: `schemas/autospec-config.schema.json`
+- autospec-sweep execution contract: every run executes configured tests, deploys
+  first when E2E/integration tests need a live app, and records test/deployment
+  status in `.autospec/sweep/latest.json`
 - Docs presence: `docs/USER_MANUAL.md`, `llms.txt`, `docs/.llm-manifest.json`
 - autospec-test structural lint (per-skill validate.sh)
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -73,6 +73,32 @@ shipped during this run, emits surviving gaps as JSON (`emit-gaps.sh`), and file
 `auto-implement,gap-remediation,priority:high` issues (`gap-remediation-loop.sh`), capped at
 `AUTOSPEC_GAP_MAX_ROUNDS` rounds (default 2) to bound the feedback loop.
 
+### `/autospec-sweep`
+
+<!-- autospec-doc-scope:
+  src: ["skills/autospec-sweep/SKILL.md", "skills/autospec-sweep/scripts/wizard.sh"]
+  reason: "User-facing invocation docs for autospec-sweep"
+  generated: true
+-->
+
+First-run and recurring configuration mode. It creates `.autospec/autospec.yml`
+as tracked project source, asks a small set of setup questions with project-specific
+follow-ups from repo findings, then runs `autospec-sweep-run.sh` plus the bundled
+`autospec-sweep-review.sh` to write `.autospec/sweep/latest.json` and feed docs,
+test, and code gaps back through specs, issues, and `/autospec-run`.
+
+Every `run` executes the configured full test command. If E2E or integration
+tests require a deployed or started app, autospec-sweep runs
+`project.findings.commands.deploy` first and fails the sweep on deploy or test
+failure.
+
+**Triggers:** `autospec-sweep`, `configure autospec`, `first-run config`, `continuous improvement`
+
+**Modes:**
+- `init`: create `.autospec/autospec.yml` with all autospec steps enabled by default.
+- `configure`: update only relevant config sections and matching specs when repo reality changes.
+- `run`: sweep spec sync, docs drift, test gaps, and code health, then file bounded fix issues.
+
 ### `/autospec-test`
 
 <!-- autospec-doc-scope:

--- a/docs/specs/2026-05-26-autospec-sweep-config-design.md
+++ b/docs/specs/2026-05-26-autospec-sweep-config-design.md
@@ -1,0 +1,78 @@
+# Autospec Sweep Configuration Design
+
+Date: 2026-05-26
+
+## Goal
+
+Add `/autospec-sweep` as the project-level configuration and continuous-improvement surface for autospec.
+
+## Problem
+
+Autospec has strong individual skills for defining, running, reviewing, testing,
+and clone-based validation, but first-time users still have to discover how those
+pieces fit together. Project-specific retest or sweep workflows become bespoke
+prompts instead of reusable configuration. That makes onboarding slow and makes
+it easy for specs, docs, tests, and code reality to drift apart.
+
+## Design
+
+`/autospec-sweep init` creates `.autospec/autospec.yml` as tracked project source.
+The file is the single user-facing configuration surface for autospec defaults:
+enabled steps, safety posture, team personality, sweep profile, continuous
+improvement checks, and project-specific questions discovered from repo files.
+
+The first-run wizard asks only a small default set:
+
+- sweep profile, default `full`
+- environment safety, default `strict_isolation`
+- team personality, default `auto`
+- competitor research, default `false`
+
+The wizard supplements those answers with repo findings such as package
+manifests, test scripts, Playwright config, and missing base URLs. It refuses to
+write over an existing config without `--force` and refuses if git ignore rules
+hide `.autospec/autospec.yml`.
+
+`/autospec` runs a configuration preflight before normal phases. If the config is
+missing in an existing repo, it routes through the same first-run wizard. If the
+repo is being bootstrapped, it writes the config after the initial scaffold and
+before investigation.
+
+`/autospec-sweep run` starts with `autospec-sweep-run.sh run`. The runner loads
+and validates the config, executes the bundled deterministic
+`autospec-sweep-review.sh` by default, writes `.autospec/sweep/latest.json`,
+accepts emitted gap JSON through `--gaps`, and can execute a configured richer
+review command through `AUTOSPEC_SWEEP_REVIEW_CMD`. When gaps exist, it hands
+them to the existing gap-remediation loop unless `--no-file` is set.
+
+Every run executes the configured full test command. If E2E or integration tests
+are configured and the project requires running software first, the runner
+executes `project.findings.commands.deploy` before those tests. Deploy, unit,
+integration, or E2E failures fail the sweep and are recorded in
+`.autospec/sweep/latest.json`.
+
+## Continuous Improvement Defaults
+
+The default sweep enables improvement areas for:
+
+- documentation: docs drift, user manual, API reference, runbooks
+- tests: coverage gaps, E2E surface gaps, regression gaps
+- code: complexity, duplication, dead code, security-sensitive shortcuts
+
+The sweep does not silently make broad refactors. It updates or creates specs
+first when reality and specs disagree, then files bounded issues and routes code
+fixes through `/autospec-run`.
+
+## Safety
+
+The config stores secret references, never secret values. Production-like sweeps
+default to strict isolation. Scoped production access remains opt-in and must use
+existing backup/restore and autospec-test rails.
+
+## Verification
+
+- `bats tests/unit/test_autospec_sweep_config.bats tests/unit/test_autospec_sweep_skill.bats`
+- `bats tests/unit/test_autospec_sweep_run.bats`
+- `bats tests/smoke/test_install_all_skills.bats`
+- `bash tests/install/test_gitignore_offer.sh`
+- `bash scripts/validate.sh`

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
 #   ./install.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | all
+#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -38,7 +38,7 @@ TURBO_REPO_DIR="${TURBO_REPO_DIR:-$HOME/.turbo/repo}"
 TURBO_REMOTE="https://github.com/tobihagemann/turbo.git"
 CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
 
-ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop"
+ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -65,37 +65,40 @@ run_or_report() {
 }
 
 offer_gitignore() {
-    # Offer to add `.autospec/` to the current repo's .gitignore so the integration
-    # scratch directory does not pollute git status. No-op outside a git repo.
+    # Offer to ignore autospec runtime scratch files while keeping the tracked
+    # project config `.autospec/autospec.yml` visible to git.
     git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
     repo_root="$(git rev-parse --show-toplevel)"
     gitignore="$repo_root/.gitignore"
-    entry=".autospec/"
+    entry=".autospec/*"
+    config_exception="!.autospec/autospec.yml"
 
-    if [ -f "$gitignore" ] && grep -qxF "$entry" "$gitignore"; then
+    if [ -f "$gitignore" ] && grep -qxF "$entry" "$gitignore" && grep -qxF "$config_exception" "$gitignore"; then
         return 0
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then
-        info "[dry-run] offer_gitignore: would add $entry to $gitignore"
+        info "[dry-run] offer_gitignore: would add $entry and $config_exception to $gitignore"
         return 0
     fi
 
     if [ "${AUTOSPEC_AUTO_YES:-0}" = "1" ]; then
         ensure_line_in_file "$gitignore" "$entry"
-        info "offer_gitignore: added $entry to $gitignore"
+        ensure_line_in_file "$gitignore" "$config_exception"
+        info "offer_gitignore: added $entry and $config_exception to $gitignore"
         return 0
     fi
 
     # Only prompt on real interactive TTYs; otherwise skip silently.
     [ -t 0 ] && [ -t 1 ] || return 0
 
-    printf "offer_gitignore: add '%s' to %s? [y/N] " "$entry" "$gitignore"
+    printf "offer_gitignore: ignore autospec runtime files but track .autospec/autospec.yml in %s? [y/N] " "$gitignore"
     read -r reply || return 0
     case "$reply" in
         y|Y|yes|YES|Yes)
             ensure_line_in_file "$gitignore" "$entry"
-            info "offer_gitignore: added $entry to $gitignore"
+            ensure_line_in_file "$gitignore" "$config_exception"
+            info "offer_gitignore: added $entry and $config_exception to $gitignore"
             ;;
         *)
             info "offer_gitignore: skipped"
@@ -267,10 +270,10 @@ done
 
 # Validate --skill
 case "$SKILL_ARG" in
-    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop) ;;
+    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
-        err "must be one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | all"
+        err "must be one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | all"
         exit 2
         ;;
 esac

--- a/schemas/autospec-config.schema.json
+++ b/schemas/autospec-config.schema.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autospec.local/schemas/autospec-config.schema.json",
+  "title": "Autospec project configuration",
+  "type": "object",
+  "required": ["version", "generated_by", "config_path", "git", "project", "steps", "sweep", "continuous_improvement", "execution", "safety"],
+  "additionalProperties": true,
+  "properties": {
+    "version": {
+      "const": 1
+    },
+    "generated_by": {
+      "type": "string"
+    },
+    "config_path": {
+      "const": ".autospec/autospec.yml"
+    },
+    "git": {
+      "type": "object",
+      "required": ["tracked", "commit_required"],
+      "properties": {
+        "tracked": { "const": true },
+        "commit_required": { "const": true }
+      }
+    },
+    "project": {
+      "type": "object",
+      "required": ["profile", "team_personality", "findings", "questions"],
+      "properties": {
+        "profile": { "type": "string", "minLength": 1 },
+        "team_personality": { "type": "string", "minLength": 1 },
+        "findings": {
+          "type": "object",
+          "required": ["stack", "commands"],
+          "properties": {
+            "stack": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "minItems": 1
+            },
+            "commands": {
+              "type": "object",
+              "required": ["test", "e2e", "deploy"],
+              "properties": {
+                "test": { "type": "string", "minLength": 1 },
+                "e2e": { "type": "string", "minLength": 1 },
+                "deploy": { "type": "string", "minLength": 1 }
+              }
+            }
+          }
+        },
+        "questions": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "steps": {
+      "type": "object",
+      "required": ["define", "classify", "run", "review", "test", "clone", "sweep"],
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "sweep": {
+      "type": "object",
+      "required": ["cadence", "spec_sync", "competitor_research", "improvement_budget"],
+      "properties": {
+        "cadence": { "type": "string", "minLength": 1 },
+        "spec_sync": {
+          "type": "object",
+          "required": ["enabled", "update_specs_before_code", "create_gap_issues"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "update_specs_before_code": { "type": "boolean" },
+            "create_gap_issues": { "type": "boolean" }
+          }
+        },
+        "competitor_research": {
+          "type": "object",
+          "required": ["enabled", "sources"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "sources": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        },
+        "improvement_budget": {
+          "type": "object",
+          "required": ["max_issues_per_sweep", "prefer_small_reviewable_changes"],
+          "properties": {
+            "max_issues_per_sweep": { "type": "integer", "minimum": 1 },
+            "prefer_small_reviewable_changes": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "continuous_improvement": {
+      "type": "object",
+      "required": ["docs", "tests", "code", "loop"],
+      "properties": {
+        "docs": { "$ref": "#/$defs/improvement_area" },
+        "tests": { "$ref": "#/$defs/improvement_area" },
+        "code": { "$ref": "#/$defs/improvement_area" },
+        "loop": {
+          "type": "object",
+          "required": ["create_or_update_specs", "file_issues", "route_fixes_via_autospec_run"],
+          "properties": {
+            "create_or_update_specs": { "type": "boolean" },
+            "file_issues": { "type": "boolean" },
+            "route_fixes_via_autospec_run": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "required": ["tests", "deployment"],
+      "properties": {
+        "tests": {
+          "type": "object",
+          "required": ["run_all_every_sweep", "fail_sweep_on_test_failure"],
+          "properties": {
+            "run_all_every_sweep": { "const": true },
+            "fail_sweep_on_test_failure": { "const": true }
+          }
+        },
+        "deployment": {
+          "type": "object",
+          "required": ["deploy_if_tests_require", "required_for"],
+          "properties": {
+            "deploy_if_tests_require": { "const": true },
+            "required_for": {
+              "type": "array",
+              "contains": { "const": "e2e" },
+              "items": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "required": ["production_access", "secrets_policy", "never_clone_raw_secrets"],
+      "properties": {
+        "production_access": {
+          "enum": ["strict_isolation", "scoped_production"]
+        },
+        "secrets_policy": {
+          "const": "references_only"
+        },
+        "never_clone_raw_secrets": {
+          "const": true
+        }
+      }
+    }
+  },
+  "$defs": {
+    "improvement_area": {
+      "type": "object",
+      "required": ["enabled", "checks"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "checks": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -203,7 +203,7 @@ check_startup_preflight() {
     }
     canonical=$(extract_block skills/autospec/SKILL.md)
     [ -n "$canonical" ] || fail "autospec SKILL.md missing ## Startup self-update section"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep; do
         for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
             body=$(extract_block "$f")
             [ -n "$body" ] || fail "$f missing ## Startup self-update section"
@@ -220,7 +220,7 @@ check_startup_preflight() {
 # prompts/ path AND the new skills/ slash-command registry path.
 check_codex_skills_install() {
     info "codex skills-dir install: all skills"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep; do
         f="skills/$s/install.sh"
         grep -q 'skills/\$SKILL_NAME/SKILL\.md' "$f" \
             || fail "$f missing Codex skills-dir install (skills/\$SKILL_NAME/SKILL.md)"
@@ -235,7 +235,7 @@ check_codex_skills_install() {
 check_shared_script_install() {
     info "shared helper install: all skills"
     helpers="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep; do
         f="skills/$s/install.sh"
         grep -q 'install_shared_scripts' "$f" \
             || fail "$f missing install_shared_scripts function/call"
@@ -327,6 +327,29 @@ check_phase1_bounded_context_contract() {
             || fail "$f missing compact-overflow fallback directive"
         grep -q 'bounded local read-only `rg`/file-read investigation' "$f" \
             || fail "$f missing bounded local fallback directive"
+    done
+}
+
+check_autospec_sweep_config_contract() {
+    info "autospec-sweep config contract"
+    local skill_dir="skills/autospec-sweep"
+    [ -d "$skill_dir" ] || fail "$skill_dir: directory missing"
+    [ -f "$skill_dir/scripts/wizard.sh" ] || fail "$skill_dir/scripts/wizard.sh: required file missing"
+    [ -f "$skill_dir/scripts/run.sh" ] || fail "$skill_dir/scripts/run.sh: required file missing"
+    [ -f "$skill_dir/scripts/review.sh" ] || fail "$skill_dir/scripts/review.sh: required file missing"
+    [ -f "schemas/autospec-config.schema.json" ] || fail "schemas/autospec-config.schema.json: required file missing"
+    bash -n "$skill_dir/scripts/wizard.sh" || fail "$skill_dir/scripts/wizard.sh: bash syntax error"
+    bash -n "$skill_dir/scripts/run.sh" || fail "$skill_dir/scripts/run.sh: bash syntax error"
+    bash -n "$skill_dir/scripts/review.sh" || fail "$skill_dir/scripts/review.sh: bash syntax error"
+    grep -q '.autospec/autospec.yml' "$skill_dir/SKILL.md" \
+        || fail "$skill_dir/SKILL.md missing .autospec/autospec.yml contract"
+    grep -q 'continuous improvement' "$skill_dir/SKILL.md" \
+        || fail "$skill_dir/SKILL.md missing continuous improvement contract"
+    for f in skills/autospec/SKILL.md skills/autospec/codex/prompt.md skills/autospec/opencode/agent.md; do
+        grep -q '.autospec/autospec.yml' "$f" \
+            || fail "$f missing autospec.yml first-run preflight"
+        grep -q '/autospec-sweep init' "$f" \
+            || fail "$f missing /autospec-sweep init first-run route"
     done
 }
 
@@ -791,6 +814,7 @@ main() {
     check_phase4_issue_start_summary
     check_phase4_immediate_next_issue_pickup
     check_phase4_adaptive_retry
+    check_autospec_sweep_config_contract
     check_team_personality_contract
     check_autospec_run_priority_sort_lockstep
     check_autospec_run_regression_review_lockstep

--- a/skills/autospec-sweep/README.md
+++ b/skills/autospec-sweep/README.md
@@ -1,0 +1,38 @@
+# autospec-sweep
+
+First-run configuration and continuous-improvement sweep mode for autospec.
+
+`autospec-sweep` creates the tracked project config at `.autospec/autospec.yml`
+and uses it to keep specs, docs, tests, and code health improving over time.
+
+## Usage
+
+```bash
+/autospec-sweep init
+/autospec-sweep configure
+/autospec-sweep run
+```
+
+The default config enables all autospec steps and strict isolation. It records
+repo findings and follow-up questions so project-specific onboarding stays small.
+
+The installed runner is available at:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-sweep-run.sh" run --dry-run
+```
+
+It validates `.autospec/autospec.yml`, runs the bundled
+`autospec-sweep-review.sh`, writes `.autospec/sweep/latest.json`, and can hand
+emitted gap JSON to the existing gap-remediation loop.
+
+Every sweep run executes the configured full test command. When E2E or
+integration tests are configured and the project requires running software first,
+the runner executes `project.findings.commands.deploy` before those tests. Any
+deploy or test failure fails the sweep.
+
+## Install
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-sweep/install.sh) --harness all
+```

--- a/skills/autospec-sweep/SKILL.md
+++ b/skills/autospec-sweep/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: autospec-sweep
+description: Use when a project needs first-run autospec configuration, recurring spec-vs-reality sweeps, or continuous improvement across docs, tests, and code health.
+---
+
+# autospec-sweep (harness-neutral)
+
+Create and maintain the tracked project-level autospec configuration at
+`.autospec/autospec.yml`, then use it to run recurring sweeps that keep specs,
+documentation, tests, and code aligned with reality.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-sweep   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument is exactly `update` after trimming whitespace and
+lowercasing, enter self-update mode and do not run a sweep:
+
+1. Detect the installed harness path for `autospec-sweep`.
+2. Run the canonical installer with `--update` for each detected harness:
+   `bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-sweep/install.sh) --harness <detected> --update`
+3. Show a short before/after summary and stop.
+
+## Invocation
+
+```bash
+/autospec-sweep init
+/autospec-sweep configure
+/autospec-sweep run
+```
+
+- `init` creates `.autospec/autospec.yml` on first use.
+- `configure` reads current repo findings and edits the tracked config.
+- `run` executes the configured sweep and feeds resulting fixes back through
+  `autospec-review`, specs, issues, and `autospec-run`.
+
+## Harness detection
+
+Resolve model tiers once at skill start:
+
+1. Claude Code: `TIER_A` = Opus + maximum thinking; `TIER_B` = Sonnet + medium.
+2. OpenCode: `TIER_A` = top task model + high reasoning; `TIER_B` = smaller task model + medium.
+3. Codex CLI: `TIER_A` = current top GPT + high reasoning; `TIER_B` = current spark/cost-optimized Codex + medium.
+
+If `TIER_B` is unavailable, silently retry the same delegated work with
+`TIER_A` while preserving the task handoff.
+
+## Required capabilities & harness adapter
+
+| Capability | Claude Code | OpenCode | Codex CLI | Fallback if missing |
+|---|---|---|---|---|
+| Repo inspection | `Agent` Explore | read-only `task` | `rg`, `git`, `gh` | Inspect locally with bounded reads |
+| Foreground delegation | `Agent` | `task` | native subagent/CLI | Do the synthesis in-thread |
+| Ask questions | `AskUserQuestion` | inline prompt | inline prompt | Ask one concise question |
+| Subagent model tier | Tier A/B per harness detection | Tier A/B per harness detection | Tier A/B per harness detection | Fall back UP, never down |
+
+## First-run config
+
+Before any sweep work, check for `.autospec/autospec.yml`.
+
+If it is missing:
+
+1. Run:
+   `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-sweep-wizard.sh" init`
+2. Ask only the wizard's small starter set unless repo findings require a
+   project-specific question:
+   - sweep profile, default `full`
+   - environment safety, default `strict_isolation`
+   - team personality, default `auto`
+   - competitor research, default `false`
+3. Commit `.autospec/autospec.yml` with the next autospec spec/config commit.
+   It is project source, not local runtime state.
+
+If the config exists, read it first and treat it as the source of truth. Existing
+`.autospec/test.yml` or `.autospec/clone.yml` files are compatibility inputs only;
+do not make them the new source of truth.
+
+## Configure mode
+
+Use this mode when the user wants to modify sweep behavior or when the repo has
+changed enough that the config is stale.
+
+1. Inspect tracked specs, `AGENTS.md`, package manifests, test commands, E2E
+   config, deployment docs, and existing `.autospec/*` compatibility files.
+2. Compare findings with `.autospec/autospec.yml`.
+3. Ask the minimum project-specific questions needed to resolve missing values.
+4. Edit only the relevant config sections.
+5. If a config change contradicts a tracked spec, update the spec in the same
+   autospec design/spec PR before any implementation issue is filed.
+
+## Sweep execution
+
+> **Model tier:** TIER_A for sweep synthesis and gap classification. Any fix
+> implementation created by downstream `autospec-run` uses that skill's Phase 4
+> Tier B/Tier A routing.
+
+Start with the executable runner:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-sweep-run.sh" run
+```
+
+The runner validates `.autospec/autospec.yml`, writes
+`.autospec/sweep/latest.json`, accepts `--gaps <json>` for already-emitted gap
+contracts, and executes the bundled `autospec-sweep-review.sh` by default. Set
+`AUTOSPEC_SWEEP_REVIEW_CMD="<command>"` to replace the deterministic wrapper with
+a harness-specific or richer review command.
+
+Run the sweep from current reality back to source artifacts:
+
+1. Read `.autospec/autospec.yml`.
+2. Run the enabled review surfaces: spec coverage, docs drift, test gaps, code
+   health, security footguns, clone/test readiness, and implementation status.
+3. Emit concrete gaps with file paths, commands, and expected behavior.
+4. Update or create specs before creating code-fix issues when reality and specs
+   disagree.
+5. File bounded `auto-implement` issues for accepted gaps and hand them to
+   `autospec-run`.
+
+## Continuous improvement
+
+The default sweep is not a one-time bug hunt. It continuously improves:
+
+- Documentation: keep user docs, API docs, runbooks, and generated docs in sync
+  with implemented behavior.
+- Tests: add missing regression, unit, integration, E2E, invariant, and negative
+  path coverage where the sweep finds weak confidence.
+- Code: reduce duplication, dead code, complexity, brittle boundaries, and
+  security-sensitive shortcuts in small reviewable issues.
+
+Every sweep run must execute the configured full test commands. Do not treat
+review-only sweeps as sufficient. If E2E or integration tests require the
+software to be deployed or started first, run `project.findings.commands.deploy`
+before those tests. A failing deploy, unit, integration, or E2E command fails the
+sweep and must be fixed before filing success claims.
+
+Prefer small, reversible changes. File specs and issues for improvement work; do
+not silently refactor broad surfaces inside the sweep itself.
+
+## Spec sync
+
+Specs must stay synchronized with reality:
+
+- If code behavior is correct and the spec is stale, update the spec first.
+- If the spec is correct and code behavior is stale, file implementation issues.
+- If both are ambiguous, ask one project-specific question and record the answer
+  in the config or spec before proceeding.
+
+## Safety
+
+Never clone raw secrets or API keys. The config may store secret references,
+environment variable names, and allowlisted settings, but not secret values.
+Production-like sweeps default to strict isolation. Scoped production access
+requires explicit config, backup/restore, and the existing autospec-test safety
+rails.
+
+## Verification
+
+After changing config or sweep behavior, verify:
+
+```bash
+bash scripts/validate.sh
+bats tests/unit/test_autospec_sweep_config.bats
+bats tests/unit/test_autospec_sweep_run.bats
+ajv compile -s schemas/autospec-config.schema.json --spec=draft2020
+```
+
+Report changed config sections, generated questions, and any remaining unknowns.

--- a/skills/autospec-sweep/codex/prompt.md
+++ b/skills/autospec-sweep/codex/prompt.md
@@ -1,0 +1,206 @@
+
+# autospec-sweep (harness-neutral)
+
+Create and maintain the tracked project-level autospec configuration at
+`.autospec/autospec.yml`, then use it to run recurring sweeps that keep specs,
+documentation, tests, and code aligned with reality.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-sweep   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument is exactly `update` after trimming whitespace and
+lowercasing, enter self-update mode and do not run a sweep:
+
+1. Detect the installed harness path for `autospec-sweep`.
+2. Run the canonical installer with `--update` for each detected harness:
+   `bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-sweep/install.sh) --harness <detected> --update`
+3. Show a short before/after summary and stop.
+
+## Invocation
+
+```bash
+/autospec-sweep init
+/autospec-sweep configure
+/autospec-sweep run
+```
+
+- `init` creates `.autospec/autospec.yml` on first use.
+- `configure` reads current repo findings and edits the tracked config.
+- `run` executes the configured sweep and feeds resulting fixes back through
+  `autospec-review`, specs, issues, and `autospec-run`.
+
+## Harness detection
+
+Resolve model tiers once at skill start:
+
+1. Claude Code: `TIER_A` = Opus + maximum thinking; `TIER_B` = Sonnet + medium.
+2. OpenCode: `TIER_A` = top task model + high reasoning; `TIER_B` = smaller task model + medium.
+3. Codex CLI: `TIER_A` = current top GPT + high reasoning; `TIER_B` = current spark/cost-optimized Codex + medium.
+
+If `TIER_B` is unavailable, silently retry the same delegated work with
+`TIER_A` while preserving the task handoff.
+
+## Required capabilities & harness adapter
+
+| Capability | Claude Code | OpenCode | Codex CLI | Fallback if missing |
+|---|---|---|---|---|
+| Repo inspection | `Agent` Explore | read-only `task` | `rg`, `git`, `gh` | Inspect locally with bounded reads |
+| Foreground delegation | `Agent` | `task` | native subagent/CLI | Do the synthesis in-thread |
+| Ask questions | `AskUserQuestion` | inline prompt | inline prompt | Ask one concise question |
+| Subagent model tier | Tier A/B per harness detection | Tier A/B per harness detection | Tier A/B per harness detection | Fall back UP, never down |
+
+## First-run config
+
+Before any sweep work, check for `.autospec/autospec.yml`.
+
+If it is missing:
+
+1. Run:
+   `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-sweep-wizard.sh" init`
+2. Ask only the wizard's small starter set unless repo findings require a
+   project-specific question:
+   - sweep profile, default `full`
+   - environment safety, default `strict_isolation`
+   - team personality, default `auto`
+   - competitor research, default `false`
+3. Commit `.autospec/autospec.yml` with the next autospec spec/config commit.
+   It is project source, not local runtime state.
+
+If the config exists, read it first and treat it as the source of truth. Existing
+`.autospec/test.yml` or `.autospec/clone.yml` files are compatibility inputs only;
+do not make them the new source of truth.
+
+## Configure mode
+
+Use this mode when the user wants to modify sweep behavior or when the repo has
+changed enough that the config is stale.
+
+1. Inspect tracked specs, `AGENTS.md`, package manifests, test commands, E2E
+   config, deployment docs, and existing `.autospec/*` compatibility files.
+2. Compare findings with `.autospec/autospec.yml`.
+3. Ask the minimum project-specific questions needed to resolve missing values.
+4. Edit only the relevant config sections.
+5. If a config change contradicts a tracked spec, update the spec in the same
+   autospec design/spec PR before any implementation issue is filed.
+
+## Sweep execution
+
+> **Model tier:** TIER_A for sweep synthesis and gap classification. Any fix
+> implementation created by downstream `autospec-run` uses that skill's Phase 4
+> Tier B/Tier A routing.
+
+Start with the executable runner:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-sweep-run.sh" run
+```
+
+The runner validates `.autospec/autospec.yml`, writes
+`.autospec/sweep/latest.json`, accepts `--gaps <json>` for already-emitted gap
+contracts, and executes the bundled `autospec-sweep-review.sh` by default. Set
+`AUTOSPEC_SWEEP_REVIEW_CMD="<command>"` to replace the deterministic wrapper with
+a harness-specific or richer review command.
+
+Run the sweep from current reality back to source artifacts:
+
+1. Read `.autospec/autospec.yml`.
+2. Run the enabled review surfaces: spec coverage, docs drift, test gaps, code
+   health, security footguns, clone/test readiness, and implementation status.
+3. Emit concrete gaps with file paths, commands, and expected behavior.
+4. Update or create specs before creating code-fix issues when reality and specs
+   disagree.
+5. File bounded `auto-implement` issues for accepted gaps and hand them to
+   `autospec-run`.
+
+## Continuous improvement
+
+The default sweep is not a one-time bug hunt. It continuously improves:
+
+- Documentation: keep user docs, API docs, runbooks, and generated docs in sync
+  with implemented behavior.
+- Tests: add missing regression, unit, integration, E2E, invariant, and negative
+  path coverage where the sweep finds weak confidence.
+- Code: reduce duplication, dead code, complexity, brittle boundaries, and
+  security-sensitive shortcuts in small reviewable issues.
+
+Every sweep run must execute the configured full test commands. Do not treat
+review-only sweeps as sufficient. If E2E or integration tests require the
+software to be deployed or started first, run `project.findings.commands.deploy`
+before those tests. A failing deploy, unit, integration, or E2E command fails the
+sweep and must be fixed before filing success claims.
+
+Prefer small, reversible changes. File specs and issues for improvement work; do
+not silently refactor broad surfaces inside the sweep itself.
+
+## Spec sync
+
+Specs must stay synchronized with reality:
+
+- If code behavior is correct and the spec is stale, update the spec first.
+- If the spec is correct and code behavior is stale, file implementation issues.
+- If both are ambiguous, ask one project-specific question and record the answer
+  in the config or spec before proceeding.
+
+## Safety
+
+Never clone raw secrets or API keys. The config may store secret references,
+environment variable names, and allowlisted settings, but not secret values.
+Production-like sweeps default to strict isolation. Scoped production access
+requires explicit config, backup/restore, and the existing autospec-test safety
+rails.
+
+## Verification
+
+After changing config or sweep behavior, verify:
+
+```bash
+bash scripts/validate.sh
+bats tests/unit/test_autospec_sweep_config.bats
+bats tests/unit/test_autospec_sweep_run.bats
+ajv compile -s schemas/autospec-config.schema.json --spec=draft2020
+```
+
+Report changed config sections, generated questions, and any remaining unknowns.

--- a/skills/autospec-sweep/install.sh
+++ b/skills/autospec-sweep/install.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec-sweep skill into one or more harnesses.
+
+set -eu
+
+SKILL_NAME="autospec-sweep"
+SKILL_RAW_BASE="${AUTOSPEC_SWEEP_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_SWEEP_REF:-main}/skills/autospec-sweep}"
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+UPDATE_MODE=0
+TMP_FETCH_DIR=""
+
+err() { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
+
+Installs the ${SKILL_NAME} skill and its first-run wizard.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    command -v curl >/dev/null 2>&1 || { err "curl is required when running from stdin"; exit 1; }
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts" "$TMP_FETCH_DIR/shared-scripts"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md scripts/wizard.sh scripts/run.sh scripts/review.sh; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/$rel"
+            exit 1
+        fi
+    done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/shared-scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/shared-scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/shared-scripts"
+    else
+        printf ''
+    fi
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    [ -f "$src" ] || { err "missing source file: $src"; return 1; }
+    run "mkdir -p \"$(dirname "$dest")\""
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    [ -n "$src_dir" ] || { err "missing shared scripts directory"; return 1; }
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;; esac
+    done
+}
+
+install_sweep_scripts() {
+    install_one "$SKILL_DIR/scripts/wizard.sh" "$HOME/.autospec/scripts/autospec-sweep-wizard.sh"
+    run "chmod +x \"$HOME/.autospec/scripts/autospec-sweep-wizard.sh\""
+    install_one "$SKILL_DIR/scripts/run.sh" "$HOME/.autospec/scripts/autospec-sweep-run.sh"
+    run "chmod +x \"$HOME/.autospec/scripts/autospec-sweep-run.sh\""
+    install_one "$SKILL_DIR/scripts/review.sh" "$HOME/.autospec/scripts/autospec-sweep-review.sh"
+    run "chmod +x \"$HOME/.autospec/scripts/autospec-sweep-review.sh\""
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness) shift; HARNESS="${1:-}" ;;
+        --harness=*) HARNESS="${1#--harness=}" ;;
+        --symlink) USE_SYMLINK=1 ;;
+        --dry-run) DRY_RUN=1 ;;
+        --update) UPDATE_MODE=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) err "unknown arg: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+
+if [ "$need_fetch" -eq 1 ]; then
+    [ "$USE_SYMLINK" -eq 0 ] || { err "--symlink requires a local checkout"; exit 2; }
+    fetch_source_files
+fi
+
+for dep in git gh jq yq; do
+    command -v "$dep" >/dev/null 2>&1 || warn "$dep not found on PATH"
+done
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+CODEX_SKILLS_DEST="$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+
+install_shared_scripts
+install_sweep_scripts
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Claude Code:"
+    install_one "$SKILL_DIR/SKILL.md" "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "OpenCode:"
+    install_one "$SKILL_DIR/opencode/agent.md" "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Codex CLI:"
+    install_one "$SKILL_DIR/codex/prompt.md" "$CODEX_DEST"
+    install_one "$SKILL_DIR/SKILL.md" "$CODEX_SKILLS_DEST"
+fi
+
+[ "$UPDATE_MODE" -eq 0 ] || info "Update mode complete."
+info "Done. Run /autospec-sweep init to create .autospec/autospec.yml."

--- a/skills/autospec-sweep/opencode/agent.md
+++ b/skills/autospec-sweep/opencode/agent.md
@@ -1,0 +1,210 @@
+---
+name: autospec-sweep
+description: Use when a project needs first-run autospec configuration, recurring spec-vs-reality sweeps, or continuous improvement across docs, tests, and code health.
+---
+
+# autospec-sweep (harness-neutral)
+
+Create and maintain the tracked project-level autospec configuration at
+`.autospec/autospec.yml`, then use it to run recurring sweeps that keep specs,
+documentation, tests, and code aligned with reality.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-sweep   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument is exactly `update` after trimming whitespace and
+lowercasing, enter self-update mode and do not run a sweep:
+
+1. Detect the installed harness path for `autospec-sweep`.
+2. Run the canonical installer with `--update` for each detected harness:
+   `bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-sweep/install.sh) --harness <detected> --update`
+3. Show a short before/after summary and stop.
+
+## Invocation
+
+```bash
+/autospec-sweep init
+/autospec-sweep configure
+/autospec-sweep run
+```
+
+- `init` creates `.autospec/autospec.yml` on first use.
+- `configure` reads current repo findings and edits the tracked config.
+- `run` executes the configured sweep and feeds resulting fixes back through
+  `autospec-review`, specs, issues, and `autospec-run`.
+
+## Harness detection
+
+Resolve model tiers once at skill start:
+
+1. Claude Code: `TIER_A` = Opus + maximum thinking; `TIER_B` = Sonnet + medium.
+2. OpenCode: `TIER_A` = top task model + high reasoning; `TIER_B` = smaller task model + medium.
+3. Codex CLI: `TIER_A` = current top GPT + high reasoning; `TIER_B` = current spark/cost-optimized Codex + medium.
+
+If `TIER_B` is unavailable, silently retry the same delegated work with
+`TIER_A` while preserving the task handoff.
+
+## Required capabilities & harness adapter
+
+| Capability | Claude Code | OpenCode | Codex CLI | Fallback if missing |
+|---|---|---|---|---|
+| Repo inspection | `Agent` Explore | read-only `task` | `rg`, `git`, `gh` | Inspect locally with bounded reads |
+| Foreground delegation | `Agent` | `task` | native subagent/CLI | Do the synthesis in-thread |
+| Ask questions | `AskUserQuestion` | inline prompt | inline prompt | Ask one concise question |
+| Subagent model tier | Tier A/B per harness detection | Tier A/B per harness detection | Tier A/B per harness detection | Fall back UP, never down |
+
+## First-run config
+
+Before any sweep work, check for `.autospec/autospec.yml`.
+
+If it is missing:
+
+1. Run:
+   `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-sweep-wizard.sh" init`
+2. Ask only the wizard's small starter set unless repo findings require a
+   project-specific question:
+   - sweep profile, default `full`
+   - environment safety, default `strict_isolation`
+   - team personality, default `auto`
+   - competitor research, default `false`
+3. Commit `.autospec/autospec.yml` with the next autospec spec/config commit.
+   It is project source, not local runtime state.
+
+If the config exists, read it first and treat it as the source of truth. Existing
+`.autospec/test.yml` or `.autospec/clone.yml` files are compatibility inputs only;
+do not make them the new source of truth.
+
+## Configure mode
+
+Use this mode when the user wants to modify sweep behavior or when the repo has
+changed enough that the config is stale.
+
+1. Inspect tracked specs, `AGENTS.md`, package manifests, test commands, E2E
+   config, deployment docs, and existing `.autospec/*` compatibility files.
+2. Compare findings with `.autospec/autospec.yml`.
+3. Ask the minimum project-specific questions needed to resolve missing values.
+4. Edit only the relevant config sections.
+5. If a config change contradicts a tracked spec, update the spec in the same
+   autospec design/spec PR before any implementation issue is filed.
+
+## Sweep execution
+
+> **Model tier:** TIER_A for sweep synthesis and gap classification. Any fix
+> implementation created by downstream `autospec-run` uses that skill's Phase 4
+> Tier B/Tier A routing.
+
+Start with the executable runner:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-sweep-run.sh" run
+```
+
+The runner validates `.autospec/autospec.yml`, writes
+`.autospec/sweep/latest.json`, accepts `--gaps <json>` for already-emitted gap
+contracts, and executes the bundled `autospec-sweep-review.sh` by default. Set
+`AUTOSPEC_SWEEP_REVIEW_CMD="<command>"` to replace the deterministic wrapper with
+a harness-specific or richer review command.
+
+Run the sweep from current reality back to source artifacts:
+
+1. Read `.autospec/autospec.yml`.
+2. Run the enabled review surfaces: spec coverage, docs drift, test gaps, code
+   health, security footguns, clone/test readiness, and implementation status.
+3. Emit concrete gaps with file paths, commands, and expected behavior.
+4. Update or create specs before creating code-fix issues when reality and specs
+   disagree.
+5. File bounded `auto-implement` issues for accepted gaps and hand them to
+   `autospec-run`.
+
+## Continuous improvement
+
+The default sweep is not a one-time bug hunt. It continuously improves:
+
+- Documentation: keep user docs, API docs, runbooks, and generated docs in sync
+  with implemented behavior.
+- Tests: add missing regression, unit, integration, E2E, invariant, and negative
+  path coverage where the sweep finds weak confidence.
+- Code: reduce duplication, dead code, complexity, brittle boundaries, and
+  security-sensitive shortcuts in small reviewable issues.
+
+Every sweep run must execute the configured full test commands. Do not treat
+review-only sweeps as sufficient. If E2E or integration tests require the
+software to be deployed or started first, run `project.findings.commands.deploy`
+before those tests. A failing deploy, unit, integration, or E2E command fails the
+sweep and must be fixed before filing success claims.
+
+Prefer small, reversible changes. File specs and issues for improvement work; do
+not silently refactor broad surfaces inside the sweep itself.
+
+## Spec sync
+
+Specs must stay synchronized with reality:
+
+- If code behavior is correct and the spec is stale, update the spec first.
+- If the spec is correct and code behavior is stale, file implementation issues.
+- If both are ambiguous, ask one project-specific question and record the answer
+  in the config or spec before proceeding.
+
+## Safety
+
+Never clone raw secrets or API keys. The config may store secret references,
+environment variable names, and allowlisted settings, but not secret values.
+Production-like sweeps default to strict isolation. Scoped production access
+requires explicit config, backup/restore, and the existing autospec-test safety
+rails.
+
+## Verification
+
+After changing config or sweep behavior, verify:
+
+```bash
+bash scripts/validate.sh
+bats tests/unit/test_autospec_sweep_config.bats
+bats tests/unit/test_autospec_sweep_run.bats
+ajv compile -s schemas/autospec-config.schema.json --spec=draft2020
+```
+
+Report changed config sections, generated questions, and any remaining unknowns.

--- a/skills/autospec-sweep/scripts/review.sh
+++ b/skills/autospec-sweep/scripts/review.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# review.sh — deterministic autospec-sweep review wrapper.
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage:
+  review.sh --repo-root DIR --emit-gaps FILE [--since DATE]
+
+Emits gap JSON for autospec-sweep without requiring a slash-command harness.
+EOF
+}
+
+fail() {
+  printf 'autospec-sweep review: %s\n' "$*" >&2
+  exit 1
+}
+
+json_escape() {
+  jq -Rn --arg v "$1" '$v'
+}
+
+add_gap() {
+  dimension="$1"
+  severity="$2"
+  file="$3"
+  line="$4"
+  title="$5"
+  body="$6"
+  dedupe_key="$7"
+
+  tmp_gap="$(mktemp -t autospec-sweep-gap.XXXXXX)"
+  jq -n \
+    --arg dimension "$dimension" \
+    --arg severity "$severity" \
+    --arg file "$file" \
+    --argjson line "$line" \
+    --arg title "$title" \
+    --arg body "$body" \
+    --arg dedupe_key "$dedupe_key" \
+    '{
+      dimension: $dimension,
+      severity: $severity,
+      file: $file,
+      line: $line,
+      title: $title,
+      body: $body,
+      dedupe_key: $dedupe_key
+    }' > "$tmp_gap"
+  jq -s '.[0] + [.[1]]' "$GAPS_TMP" "$tmp_gap" > "$GAPS_TMP.next"
+  mv "$GAPS_TMP.next" "$GAPS_TMP"
+  rm -f "$tmp_gap"
+}
+
+REPO_ROOT="$PWD"
+OUT=""
+SINCE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-root)
+      REPO_ROOT="${2:-}"
+      shift 2
+      ;;
+    --emit-gaps)
+      OUT="${2:-}"
+      shift 2
+      ;;
+    --since)
+      SINCE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+[ -n "$OUT" ] || fail "--emit-gaps is required"
+[ -d "$REPO_ROOT" ] || fail "repo root does not exist: $REPO_ROOT"
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
+CONFIG="$REPO_ROOT/.autospec/autospec.yml"
+[ -f "$CONFIG" ] || fail "missing .autospec/autospec.yml"
+
+command -v jq >/dev/null 2>&1 || fail "jq not found on PATH"
+command -v yq >/dev/null 2>&1 || fail "yq not found on PATH"
+
+mkdir -p "$(dirname "$OUT")"
+GAPS_TMP="$(mktemp -t autospec-sweep-review.XXXXXX)"
+trap 'rm -f "$GAPS_TMP"' EXIT
+printf '[]\n' > "$GAPS_TMP"
+
+test_cmd="$(yq -r '.project.findings.commands.test // ""' "$CONFIG")"
+e2e_cmd="$(yq -r '.project.findings.commands.e2e // ""' "$CONFIG")"
+deploy_cmd="$(yq -r '.project.findings.commands.deploy // ""' "$CONFIG")"
+spec_sync_enabled="$(yq -r '.sweep.spec_sync.enabled // true' "$CONFIG")"
+docs_enabled="$(yq -r '.continuous_improvement.docs.enabled // true' "$CONFIG")"
+tests_enabled="$(yq -r '.continuous_improvement.tests.enabled // true' "$CONFIG")"
+code_enabled="$(yq -r '.continuous_improvement.code.enabled // true' "$CONFIG")"
+deploy_if_tests_require="$(yq -r '.execution.deployment.deploy_if_tests_require // true' "$CONFIG")"
+
+if [ "$tests_enabled" = "true" ]; then
+  case "$test_cmd" in
+    ""|TODO:*)
+      add_gap \
+        "tests" \
+        "high" \
+        ".autospec/autospec.yml" \
+        1 \
+        "Configure autospec inner-loop test command" \
+        "Set project.findings.commands.test to the fast command autospec should run before filing or merging fixes." \
+        "autospec-config-test-command"
+      ;;
+  esac
+
+  case "$e2e_cmd" in
+    ""|TODO:*)
+      add_gap \
+        "tests" \
+        "medium" \
+        ".autospec/autospec.yml" \
+        1 \
+        "Configure autospec E2E command" \
+        "Set project.findings.commands.e2e or disable the E2E sweep for projects without browser or workflow coverage." \
+        "autospec-config-e2e-command"
+      ;;
+  esac
+
+  case "$e2e_cmd" in
+    ""|TODO:*) ;;
+    *)
+      if [ "$deploy_if_tests_require" = "true" ]; then
+        case "$deploy_cmd" in
+          ""|TODO:*)
+            add_gap \
+              "tests" \
+              "high" \
+              ".autospec/autospec.yml" \
+              1 \
+              "Configure deploy command before E2E tests" \
+              "Set project.findings.commands.deploy so autospec can deploy or start the software before E2E/integration tests run." \
+              "autospec-config-deploy-command"
+            ;;
+        esac
+      fi
+      ;;
+  esac
+fi
+
+if [ "$spec_sync_enabled" = "true" ] && [ ! -d "$REPO_ROOT/docs/specs" ]; then
+  add_gap \
+    "spec_sync" \
+    "medium" \
+    "docs/specs" \
+    0 \
+    "Create tracked specs directory" \
+    "Add docs/specs/ with at least one current design spec so sweep results can reconcile implementation reality against source artifacts." \
+    "autospec-specs-directory"
+fi
+
+if [ "$docs_enabled" = "true" ] && [ ! -f "$REPO_ROOT/README.md" ]; then
+  add_gap \
+    "docs" \
+    "medium" \
+    "README.md" \
+    0 \
+    "Add project README" \
+    "Create README.md so autospec-sweep has a user-facing documentation surface to keep synchronized with implemented behavior." \
+    "autospec-readme-missing"
+fi
+
+if [ "$code_enabled" = "true" ] && command -v rg >/dev/null 2>&1; then
+  todo_count="$(rg -n '\b(TODO|FIXME|XXX)\b' "$REPO_ROOT" -g '!artifacts/**' -g '!node_modules/**' -g '!.git/**' 2>/dev/null | wc -l | tr -d ' ')"
+  if [ "${todo_count:-0}" -gt 0 ]; then
+    add_gap \
+      "code" \
+      "low" \
+      "." \
+      0 \
+      "Resolve lingering TODO markers" \
+      "Found ${todo_count} TODO/FIXME/XXX markers; convert each real deferred behavior into tracked specs or issues and remove stale markers." \
+      "autospec-code-todo-markers"
+  fi
+fi
+
+jq -c '[to_entries[] | .value + {gap_id: ("G" + ((.key + 1) | tostring))}]' "$GAPS_TMP" > "$OUT"
+printf 'autospec-sweep review: wrote %s\n' "$OUT" >&2

--- a/skills/autospec-sweep/scripts/run.sh
+++ b/skills/autospec-sweep/scripts/run.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# run.sh — executable autospec-sweep runner.
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage:
+  run.sh run [--repo-root DIR] [--dry-run] [--gaps FILE] [--since DATE] [--no-file]
+
+Loads .autospec/autospec.yml, writes .autospec/sweep/latest.json, and, when
+possible, hands emitted gaps to gap-remediation-loop.sh for issue filing.
+
+Environment:
+  AUTOSPEC_SWEEP_REVIEW_CMD  command to run with --emit-gaps <path>
+  AUTOSPEC_SCRIPTS_DIR       installed helper script directory
+EOF
+}
+
+fail() {
+  printf 'autospec-sweep run: %s\n' "$*" >&2
+  exit 1
+}
+
+refuse() {
+  printf 'autospec-sweep run: %s\n' "$*" >&2
+  exit 2
+}
+
+json_string() {
+  jq -Rn --arg v "$1" '$v'
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 not found on PATH"
+}
+
+is_missing_command() {
+  case "$1" in
+    ""|TODO:*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+run_sweep_command() {
+  label="$1"
+  command_text="$2"
+  log_file="$3"
+
+  printf 'autospec-sweep run: running %s: %s\n' "$label" "$command_text"
+  {
+    printf '\n[%s] %s\n' "$label" "$command_text"
+    cd "$REPO_ROOT" && bash -lc "$command_text"
+  } >> "$log_file" 2>&1
+}
+
+SUBCOMMAND="${1:-}"
+if [ "$SUBCOMMAND" != "run" ]; then
+  usage
+  exit 2
+fi
+shift
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$PWD"
+DRY_RUN=0
+NO_FILE=0
+SINCE=""
+INPUT_GAPS=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-root)
+      REPO_ROOT="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --no-file)
+      NO_FILE=1
+      shift
+      ;;
+    --since)
+      SINCE="${2:-}"
+      shift 2
+      ;;
+    --gaps)
+      INPUT_GAPS="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      refuse "unknown flag: $1"
+      ;;
+  esac
+done
+
+[ -d "$REPO_ROOT" ] || fail "repo root does not exist: $REPO_ROOT"
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
+CONFIG="$REPO_ROOT/.autospec/autospec.yml"
+STATE_DIR="$REPO_ROOT/.autospec/sweep"
+LATEST="$STATE_DIR/latest.json"
+GAPS_OUT="$STATE_DIR/gaps.json"
+
+require_tool jq
+require_tool yq
+
+[ -f "$CONFIG" ] || refuse "missing .autospec/autospec.yml; run /autospec-sweep init first"
+
+if ! yq '.' "$CONFIG" >/dev/null 2>&1; then
+  fail "failed to parse .autospec/autospec.yml"
+fi
+
+if command -v ajv >/dev/null 2>&1 && [ -f "$REPO_ROOT/schemas/autospec-config.schema.json" ]; then
+  tmp_json="$(mktemp -t autospec-sweep-config.XXXXXX)"
+  trap 'rm -f "$tmp_json"' EXIT
+  yq -o=json '.' "$CONFIG" > "$tmp_json"
+  ajv validate -s "$REPO_ROOT/schemas/autospec-config.schema.json" --spec=draft2020 -d "$tmp_json" >/dev/null \
+    || fail ".autospec/autospec.yml does not match schemas/autospec-config.schema.json"
+fi
+
+review_enabled="$(yq -r '.steps.review.enabled // true' "$CONFIG")"
+run_enabled="$(yq -r '.steps.run.enabled // true' "$CONFIG")"
+spec_sync_enabled="$(yq -r '.sweep.spec_sync.enabled // true' "$CONFIG")"
+file_issues="$(yq -r '.continuous_improvement.loop.file_issues // true' "$CONFIG")"
+route_run="$(yq -r '.continuous_improvement.loop.route_fixes_via_autospec_run // true' "$CONFIG")"
+max_issues="$(yq -r '.sweep.improvement_budget.max_issues_per_sweep // 5' "$CONFIG")"
+tests_enabled="$(yq -r '.continuous_improvement.tests.enabled // true' "$CONFIG")"
+run_all_tests="$(yq -r '.execution.tests.run_all_every_sweep // true' "$CONFIG")"
+deploy_if_tests_require="$(yq -r '.execution.deployment.deploy_if_tests_require // true' "$CONFIG")"
+test_cmd="$(yq -r '.project.findings.commands.test // ""' "$CONFIG")"
+e2e_cmd="$(yq -r '.project.findings.commands.e2e // ""' "$CONFIG")"
+deploy_cmd="$(yq -r '.project.findings.commands.deploy // ""' "$CONFIG")"
+
+helper_dir="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}"
+if [ -n "${AUTOSPEC_SWEEP_REVIEW_CMD:-}" ]; then
+  review_cmd="$AUTOSPEC_SWEEP_REVIEW_CMD"
+elif [ -x "$helper_dir/autospec-sweep-review.sh" ]; then
+  review_cmd="$helper_dir/autospec-sweep-review.sh"
+elif [ -x "$SCRIPT_DIR/review.sh" ]; then
+  review_cmd="$SCRIPT_DIR/review.sh"
+else
+  review_cmd="autospec-review"
+fi
+review_args="--repo-root $REPO_ROOT --emit-gaps $GAPS_OUT"
+[ -z "$SINCE" ] || review_args="--repo-root $REPO_ROOT --since $SINCE --emit-gaps $GAPS_OUT"
+remediation_cmd="\${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gap-remediation-loop.sh --gaps $GAPS_OUT --file"
+run_cmd="autospec-run"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  jq -n \
+    --arg config ".autospec/autospec.yml" \
+    --arg review "$review_cmd $review_args" \
+    --arg remediation "$remediation_cmd" \
+    --arg run "$run_cmd" \
+    --arg test "$test_cmd" \
+    --arg e2e "$e2e_cmd" \
+    --arg deploy "$deploy_cmd" \
+    --argjson review_enabled "$review_enabled" \
+    --argjson run_enabled "$run_enabled" \
+    --argjson spec_sync_enabled "$spec_sync_enabled" \
+    --argjson tests_enabled "$tests_enabled" \
+    --argjson run_all_tests "$run_all_tests" \
+    --argjson deploy_if_tests_require "$deploy_if_tests_require" \
+    --argjson max_issues "$max_issues" \
+    '{
+      mode: "dry-run",
+      config: $config,
+      enabled: {
+        review: $review_enabled,
+        run: $run_enabled,
+        spec_sync: $spec_sync_enabled,
+        tests: $tests_enabled
+      },
+      execution: {
+        run_all_tests_every_sweep: $run_all_tests,
+        deploy_if_tests_require: $deploy_if_tests_require
+      },
+      improvement_budget: {max_issues_per_sweep: $max_issues},
+      commands: {
+        deploy: $deploy,
+        test: $test,
+        e2e: $e2e,
+        review: $review,
+        remediation: $remediation,
+        run: $run
+      }
+    }'
+  exit 0
+fi
+
+mkdir -p "$STATE_DIR"
+COMMAND_LOG="$STATE_DIR/commands.log"
+: > "$COMMAND_LOG"
+printf '[]\n' > "$GAPS_OUT"
+
+tests_status="skipped"
+deployment_status="skipped"
+
+if [ "$tests_enabled" = "true" ] && [ "$run_all_tests" = "true" ]; then
+  tests_status="pass"
+
+  if ! is_missing_command "$e2e_cmd" && [ "$deploy_if_tests_require" = "true" ]; then
+    if is_missing_command "$deploy_cmd"; then
+      refuse "E2E/integration tests are configured but project.findings.commands.deploy is missing"
+    fi
+    if run_sweep_command "deploy" "$deploy_cmd" "$COMMAND_LOG"; then
+      deployment_status="pass"
+    else
+      deployment_status="fail"
+      fail "deployment command failed; see .autospec/sweep/commands.log"
+    fi
+  fi
+
+  if ! is_missing_command "$test_cmd"; then
+    run_sweep_command "test" "$test_cmd" "$COMMAND_LOG" \
+      || { tests_status="fail"; fail "test command failed; see .autospec/sweep/commands.log"; }
+  fi
+
+  if ! is_missing_command "$e2e_cmd"; then
+    run_sweep_command "e2e" "$e2e_cmd" "$COMMAND_LOG" \
+      || { tests_status="fail"; fail "e2e command failed; see .autospec/sweep/commands.log"; }
+  fi
+fi
+
+if [ -n "$INPUT_GAPS" ]; then
+  [ -f "$INPUT_GAPS" ] || refuse "gaps file not found: $INPUT_GAPS"
+  jq -e 'type=="array"' "$INPUT_GAPS" >/dev/null 2>&1 || fail "gaps file must be a JSON array"
+  cp "$INPUT_GAPS" "$GAPS_OUT"
+elif [ "$review_enabled" = "true" ]; then
+  if command -v "$review_cmd" >/dev/null 2>&1; then
+    "$review_cmd" $review_args || printf 'autospec-sweep run: WARN review command failed; continuing with empty gaps\n' >&2
+  elif [ -x "$review_cmd" ]; then
+    "$review_cmd" $review_args || printf 'autospec-sweep run: WARN review command failed; continuing with empty gaps\n' >&2
+  else
+    printf 'autospec-sweep run: WARN review command not found: %s; wrote empty gaps\n' "$review_cmd" >&2
+  fi
+fi
+
+if ! jq -e 'type=="array"' "$GAPS_OUT" >/dev/null 2>&1; then
+  printf 'autospec-sweep run: WARN review output was not a JSON array; replacing with empty gaps\n' >&2
+  printf '[]\n' > "$GAPS_OUT"
+fi
+
+gap_count="$(jq 'length' "$GAPS_OUT")"
+file_status="skipped"
+loop_helper="$helper_dir/gap-remediation-loop.sh"
+
+if [ "$gap_count" -gt 0 ] && [ "$NO_FILE" -eq 0 ] && [ "$file_issues" = "true" ]; then
+  if [ -x "$loop_helper" ]; then
+    AUTOSPEC_GAP_MAX_ROUNDS="${AUTOSPEC_GAP_MAX_ROUNDS:-$max_issues}" "$loop_helper" --gaps "$GAPS_OUT" --file
+    file_status="filed"
+  elif [ -x "$SCRIPT_DIR/../../autospec-shared/scripts/gap-remediation-loop.sh" ]; then
+    AUTOSPEC_GAP_MAX_ROUNDS="${AUTOSPEC_GAP_MAX_ROUNDS:-$max_issues}" "$SCRIPT_DIR/../../autospec-shared/scripts/gap-remediation-loop.sh" --gaps "$GAPS_OUT" --file
+    file_status="filed"
+  else
+    printf 'autospec-sweep run: WARN gap-remediation-loop.sh not found; gaps written but not filed\n' >&2
+    file_status="helper_missing"
+  fi
+fi
+
+generated_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+jq -n \
+  --arg generated_at "$generated_at" \
+  --arg repo_root "$REPO_ROOT" \
+  --arg config ".autospec/autospec.yml" \
+  --arg gaps ".autospec/sweep/gaps.json" \
+  --arg file_status "$file_status" \
+  --arg tests_status "$tests_status" \
+  --arg deployment_status "$deployment_status" \
+  --argjson gap_count "$gap_count" \
+  --argjson review_enabled "$review_enabled" \
+  --argjson run_enabled "$run_enabled" \
+  --argjson route_run "$route_run" \
+  '{
+    generated_at: $generated_at,
+    repo_root: $repo_root,
+    config: $config,
+    gaps: {
+      path: $gaps,
+      count: $gap_count,
+      file_status: $file_status
+    },
+    enabled: {
+      review: $review_enabled,
+      run: $run_enabled,
+      route_fixes_via_autospec_run: $route_run
+    },
+    tests: {
+      status: $tests_status,
+      log: ".autospec/sweep/commands.log"
+    },
+    deployment: {
+      status: $deployment_status,
+      log: ".autospec/sweep/commands.log"
+    }
+  }' > "$LATEST"
+
+printf 'autospec-sweep run: wrote %s\n' "$LATEST"
+printf 'autospec-sweep run: gaps=%s file_status=%s\n' "$gap_count" "$file_status"
+if [ "$gap_count" -gt 0 ] && [ "$route_run" = "true" ] && [ "$run_enabled" = "true" ]; then
+  printf 'autospec-sweep run: next step: /autospec-run\n'
+fi

--- a/skills/autospec-sweep/scripts/wizard.sh
+++ b/skills/autospec-sweep/scripts/wizard.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# wizard.sh — autospec-sweep first-run configuration wizard.
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage:
+  wizard.sh init [--repo-root DIR] [--answers FILE] [--dry-run] [--force]
+
+Writes .autospec/autospec.yml with safe defaults for all autospec phases.
+EOF
+}
+
+fail() {
+  printf 'autospec-sweep wizard: %s\n' "$*" >&2
+  exit 1
+}
+
+refuse() {
+  printf 'autospec-sweep wizard: %s\n' "$*" >&2
+  exit 2
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 not found on PATH"
+}
+
+yaml_string() {
+  printf '%s' "$1" | sed "s/'/''/g; s/^/'/; s/$/'/"
+}
+
+answer() {
+  key="$1"
+  default="$2"
+  if [ -n "$ANSWERS" ] && [ -f "$ANSWERS" ]; then
+    value="$(yq -r ".$key // \"\"" "$ANSWERS")"
+    if [ -n "$value" ] && [ "$value" != "null" ]; then
+      printf '%s\n' "$value"
+      return 0
+    fi
+  fi
+  printf '%s\n' "$default"
+}
+
+prompt_default() {
+  label="$1"
+  default="$2"
+  if [ -t 0 ] && [ -t 1 ]; then
+    printf '%s [%s]: ' "$label" "$default" >/dev/tty
+    read -r value </dev/tty || value=""
+    printf '%s\n' "${value:-$default}"
+  else
+    printf '%s\n' "$default"
+  fi
+}
+
+append_unique() {
+  value="$1"
+  case " $STACK " in
+    *" $value "*) ;;
+    *) STACK="${STACK}${STACK:+ }${value}" ;;
+  esac
+}
+
+SUBCOMMAND="${1:-}"
+if [ "$SUBCOMMAND" != "init" ]; then
+  usage
+  exit 2
+fi
+shift
+
+REPO_ROOT="$PWD"
+ANSWERS=""
+DRY_RUN=0
+FORCE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-root)
+      REPO_ROOT="${2:-}"
+      shift 2
+      ;;
+    --answers)
+      ANSWERS="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      refuse "unknown flag: $1"
+      ;;
+  esac
+done
+
+[ -d "$REPO_ROOT" ] || fail "repo root does not exist: $REPO_ROOT"
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
+
+require_tool yq
+require_tool jq
+
+CONFIG_DIR="$REPO_ROOT/.autospec"
+CONFIG_PATH="$CONFIG_DIR/autospec.yml"
+
+if [ -e "$CONFIG_PATH" ] && [ "$FORCE" -ne 1 ]; then
+  refuse "$CONFIG_PATH already exists; rerun with --force to replace it"
+fi
+
+PROFILE="$(answer profile full)"
+SAFETY="$(answer safety strict_isolation)"
+TEAM="$(answer team auto)"
+ALLOW_COMPETITOR_RESEARCH="$(answer allow_competitor_research false)"
+
+if [ -z "$ANSWERS" ]; then
+  printf 'autospec-sweep first-run setup\n'
+  printf 'Press return to accept defaults. You can edit .autospec/autospec.yml later.\n\n'
+  PROFILE="$(prompt_default 'Sweep profile (full|docs-tests-code|docs-only)' "$PROFILE")"
+  SAFETY="$(prompt_default 'Environment safety (strict_isolation|scoped_production)' "$SAFETY")"
+  TEAM="$(prompt_default 'Team personality (auto or short team name)' "$TEAM")"
+  ALLOW_COMPETITOR_RESEARCH="$(prompt_default 'Allow competitor research when useful (false|true)' "$ALLOW_COMPETITOR_RESEARCH")"
+fi
+
+case "$SAFETY" in
+  strict_isolation|scoped_production) ;;
+  *) refuse "safety must be strict_isolation or scoped_production" ;;
+esac
+
+case "$ALLOW_COMPETITOR_RESEARCH" in
+  true|false) ;;
+  *) refuse "allow_competitor_research must be true or false" ;;
+esac
+
+if git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  if git -C "$REPO_ROOT" check-ignore -q ".autospec/autospec.yml" 2>/dev/null; then
+    refuse ".autospec/autospec.yml is ignored by git; unignore it before running autospec-sweep init"
+  fi
+fi
+
+STACK=""
+TEST_COMMAND=""
+E2E_COMMAND=""
+DEPLOY_COMMAND=""
+QUESTIONS=""
+
+if [ -f "$REPO_ROOT/package.json" ]; then
+  append_unique node
+  TEST_COMMAND="$(jq -r '.scripts.test // empty' "$REPO_ROOT/package.json" 2>/dev/null || true)"
+  E2E_COMMAND="$(jq -r '.scripts.e2e // .scripts["test:e2e"] // empty' "$REPO_ROOT/package.json" 2>/dev/null || true)"
+  DEPLOY_COMMAND="$(jq -r '.scripts.deploy // .scripts.start // .scripts.dev // empty' "$REPO_ROOT/package.json" 2>/dev/null || true)"
+fi
+
+if ls "$REPO_ROOT"/playwright.config.* >/dev/null 2>&1; then
+  append_unique playwright
+  QUESTIONS="${QUESTIONS}${QUESTIONS:+
+}What is the canonical local or staging base URL for browser E2E sweeps?"
+  if [ -z "$DEPLOY_COMMAND" ]; then
+    QUESTIONS="${QUESTIONS}${QUESTIONS:+
+}Which deploy/start command should autospec run before E2E tests?"
+  fi
+fi
+
+if [ -f "$REPO_ROOT/pyproject.toml" ] || [ -f "$REPO_ROOT/requirements.txt" ]; then
+  append_unique python
+  [ -n "$TEST_COMMAND" ] || TEST_COMMAND="pytest"
+fi
+
+if [ -f "$REPO_ROOT/go.mod" ]; then
+  append_unique go
+  [ -n "$TEST_COMMAND" ] || TEST_COMMAND="go test ./..."
+fi
+
+if [ -f "$REPO_ROOT/Cargo.toml" ]; then
+  append_unique rust
+  [ -n "$TEST_COMMAND" ] || TEST_COMMAND="cargo test"
+fi
+
+if [ -f "$REPO_ROOT/pom.xml" ]; then
+  append_unique jvm
+  [ -n "$TEST_COMMAND" ] || TEST_COMMAND="mvn test"
+fi
+
+if [ -z "$TEST_COMMAND" ]; then
+  QUESTIONS="${QUESTIONS}${QUESTIONS:+
+}Which fast test command should autospec use for the inner-loop smoke test?"
+fi
+
+[ -n "$STACK" ] || STACK="unknown"
+[ -n "$TEST_COMMAND" ] || TEST_COMMAND="TODO: set project test command"
+[ -n "$E2E_COMMAND" ] || E2E_COMMAND="TODO: set project E2E command"
+[ -n "$DEPLOY_COMMAND" ] || DEPLOY_COMMAND="TODO: set deploy/start command for E2E tests"
+
+TMP_CONFIG="$(mktemp -t autospec-sweep-config.XXXXXX)"
+trap 'rm -f "$TMP_CONFIG"' EXIT
+
+{
+  printf 'version: 1\n'
+  printf 'generated_by: autospec-sweep\n'
+  printf 'config_path: .autospec/autospec.yml\n'
+  printf 'git:\n'
+  printf '  tracked: true\n'
+  printf '  commit_required: true\n'
+  printf 'project:\n'
+  printf '  profile: %s\n' "$(yaml_string "$PROFILE")"
+  printf '  team_personality: %s\n' "$(yaml_string "$TEAM")"
+  printf '  findings:\n'
+  printf '    stack:\n'
+  for item in $STACK; do
+    printf '      - %s\n' "$(yaml_string "$item")"
+  done
+  printf '    commands:\n'
+  printf '      test: %s\n' "$(yaml_string "$TEST_COMMAND")"
+  printf '      e2e: %s\n' "$(yaml_string "$E2E_COMMAND")"
+  printf '      deploy: %s\n' "$(yaml_string "$DEPLOY_COMMAND")"
+  printf '  questions:\n'
+  if [ -n "$QUESTIONS" ]; then
+    printf '%s\n' "$QUESTIONS" | while IFS= read -r question; do
+      [ -n "$question" ] || continue
+      printf '    - %s\n' "$(yaml_string "$question")"
+    done
+  else
+    printf '    - %s\n' "$(yaml_string "Which product surfaces are most important for the first sweep?")"
+  fi
+  printf 'steps:\n'
+  for step in define classify run review test clone sweep; do
+    printf '  %s:\n' "$step"
+    printf '    enabled: true\n'
+  done
+  printf 'sweep:\n'
+  printf '  cadence: end_of_run\n'
+  printf '  profile: %s\n' "$(yaml_string "$PROFILE")"
+  printf '  spec_sync:\n'
+  printf '    enabled: true\n'
+  printf '    mode: reality_check\n'
+  printf '    update_specs_before_code: true\n'
+  printf '    create_gap_issues: true\n'
+  printf '  competitor_research:\n'
+  printf '    enabled: %s\n' "$ALLOW_COMPETITOR_RESEARCH"
+  printf '    sources: []\n'
+  printf '  improvement_budget:\n'
+  printf '    max_issues_per_sweep: 5\n'
+  printf '    prefer_small_reviewable_changes: true\n'
+  printf 'continuous_improvement:\n'
+  printf '  docs:\n'
+  printf '    enabled: true\n'
+  printf '    checks: [doc_drift, user_manual, api_reference, runbooks]\n'
+  printf '  tests:\n'
+  printf '    enabled: true\n'
+  printf '    checks: [coverage_gaps, e2e_surface_gaps, regression_gaps]\n'
+  printf '  code:\n'
+  printf '    enabled: true\n'
+  printf '    checks: [complexity, duplication, dead_code, security_footguns]\n'
+  printf '  loop:\n'
+  printf '    create_or_update_specs: true\n'
+  printf '    file_issues: true\n'
+  printf '    route_fixes_via_autospec_run: true\n'
+  printf 'execution:\n'
+  printf '  tests:\n'
+  printf '    run_all_every_sweep: true\n'
+  printf '    fail_sweep_on_test_failure: true\n'
+  printf '  deployment:\n'
+  printf '    deploy_if_tests_require: true\n'
+  printf '    required_for: [e2e]\n'
+  printf 'safety:\n'
+  printf '  production_access: %s\n' "$(yaml_string "$SAFETY")"
+  printf '  secrets_policy: references_only\n'
+  printf '  never_clone_raw_secrets: true\n'
+  printf 'compatibility:\n'
+  printf '  legacy_skill_contracts: read_if_present\n'
+  printf '  source_of_truth: .autospec/autospec.yml\n'
+} > "$TMP_CONFIG"
+
+if ! yq '.' "$TMP_CONFIG" >/dev/null; then
+  fail "generated config is not valid YAML"
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  cat "$TMP_CONFIG"
+  exit 0
+fi
+
+mkdir -p "$CONFIG_DIR"
+cp "$TMP_CONFIG" "$CONFIG_PATH"
+printf 'autospec-sweep wizard: wrote %s\n' "$CONFIG_PATH"
+printf 'autospec-sweep wizard: commit .autospec/autospec.yml so every agent uses the same workflow defaults.\n'

--- a/skills/autospec-sweep/uninstall.sh
+++ b/skills/autospec-sweep/uninstall.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec-sweep skill from one or more harnesses.
+
+set -eu
+
+SKILL_NAME="autospec-sweep"
+HARNESS=""
+DRY_RUN=0
+
+err() { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+    else
+        info "  not installed: $target"
+    fi
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness) shift; HARNESS="${1:-}" ;;
+        --harness=*) HARNESS="${1#--harness=}" ;;
+        --dry-run) DRY_RUN=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) err "unknown arg: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Claude Code:"
+    remove_one "$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "OpenCode:"
+    remove_one "$OPENCODE_DIR/agent/$SKILL_NAME.md"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Codex CLI:"
+    remove_one "$CODEX_DIR/prompts/$SKILL_NAME.md"
+    remove_one "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+
+remove_one "$HOME/.autospec/scripts/autospec-sweep-wizard.sh"
+remove_one "$HOME/.autospec/scripts/autospec-sweep-run.sh"
+remove_one "$HOME/.autospec/scripts/autospec-sweep-review.sh"
+info "Done."

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -183,6 +183,27 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Project configuration preflight
+
+Before Phase 0, look for `.autospec/autospec.yml` at the repository root.
+
+If the file is missing and the current directory is already inside a git repo,
+run `/autospec-sweep init` behavior first:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-sweep-wizard.sh" init
+```
+
+Accept the wizard defaults unless repo findings require a project-specific
+answer. The generated `.autospec/autospec.yml` is tracked project source and
+must be committed with the next autospec spec/config change. After it exists,
+read it before deciding which autospec phases are enabled.
+
+If the file is missing because Phase 0 must bootstrap a brand-new repo, create
+it immediately after the initial repo scaffold and before Phase 1. Use all
+steps enabled by default, strict isolation, `team_personality: auto`, and
+continuous improvement enabled for docs, tests, and code.
+
 ## Phase 0 — Bootstrap repo (if missing)
 
 Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -177,6 +177,27 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Project configuration preflight
+
+Before Phase 0, look for `.autospec/autospec.yml` at the repository root.
+
+If the file is missing and the current directory is already inside a git repo,
+run `/autospec-sweep init` behavior first:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-sweep-wizard.sh" init
+```
+
+Accept the wizard defaults unless repo findings require a project-specific
+answer. The generated `.autospec/autospec.yml` is tracked project source and
+must be committed with the next autospec spec/config change. After it exists,
+read it before deciding which autospec phases are enabled.
+
+If the file is missing because Phase 0 must bootstrap a brand-new repo, create
+it immediately after the initial repo scaffold and before Phase 1. Use all
+steps enabled by default, strict isolation, `team_personality: auto`, and
+continuous improvement enabled for docs, tests, and code.
+
 ## Phase 0 — Bootstrap repo (if missing)
 
 Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -181,6 +181,27 @@ Detect your harness by checking available tools before any phase:
 
 Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
 
+## Project configuration preflight
+
+Before Phase 0, look for `.autospec/autospec.yml` at the repository root.
+
+If the file is missing and the current directory is already inside a git repo,
+run `/autospec-sweep init` behavior first:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-sweep-wizard.sh" init
+```
+
+Accept the wizard defaults unless repo findings require a project-specific
+answer. The generated `.autospec/autospec.yml` is tracked project source and
+must be committed with the next autospec spec/config change. After it exists,
+read it before deciding which autospec phases are enabled.
+
+If the file is missing because Phase 0 must bootstrap a brand-new repo, create
+it immediately after the initial repo scaffold and before Phase 1. Use all
+steps enabled by default, strict isolation, `team_personality: auto`, and
+continuous improvement enabled for docs, tests, and code.
+
 ## Phase 0 — Bootstrap repo (if missing)
 
 Verify `gh auth status` is authenticated. If not, ask the user to run `gh auth login` and stop until they confirm.

--- a/tests/fixtures/autospec-sweep/minimal-answers.yml
+++ b/tests/fixtures/autospec-sweep/minimal-answers.yml
@@ -1,0 +1,4 @@
+profile: full
+safety: strict_isolation
+team: auto
+allow_competitor_research: false

--- a/tests/install/test_gitignore_offer.sh
+++ b/tests/install/test_gitignore_offer.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verifies offer_gitignore: dry-run announces, AUTOSPEC_AUTO_YES adds the entry,
+# Verifies offer_gitignore: dry-run announces, AUTOSPEC_AUTO_YES adds entries,
 # re-run is idempotent, no-op outside a git repo.
 set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -14,10 +14,10 @@ git -C "$tmp_repo" -c user.email=t@t -c user.name=t commit -q -m init
 
 output=$(cd "$tmp_repo" && bash "$SCRIPT_DIR/install.sh" --dry-run --skill autospec --harness claude 2>&1 || true)
 case "$output" in
-    *"offer_gitignore"*".autospec/"*) ;;
-    *) echo "FAIL: dry-run did not announce .autospec/ gitignore offer"; echo "$output"; exit 1 ;;
+    *"offer_gitignore"*".autospec/*"*"!.autospec/autospec.yml"*) ;;
+    *) echo "FAIL: dry-run did not announce autospec runtime gitignore offer"; echo "$output"; exit 1 ;;
 esac
-if grep -qxF ".autospec/" "$tmp_repo/.gitignore"; then
+if grep -qxF ".autospec/*" "$tmp_repo/.gitignore"; then
     echo "FAIL: dry-run modified .gitignore"
     exit 1
 fi
@@ -37,17 +37,26 @@ git -C "$fake_home/.turbo/repo" -c user.email=t@t -c user.name=t commit -q --all
 HOME="$fake_home" AUTOSPEC_AUTO_YES=1 AUTOSPEC_NO_STAR_PROMPT=1 \
     bash -c "cd '$tmp_repo' && bash '$SCRIPT_DIR/install.sh' --skill autospec --harness claude" >/dev/null 2>&1 || true
 
-if ! grep -qxF ".autospec/" "$tmp_repo/.gitignore"; then
-    echo "FAIL: AUTOSPEC_AUTO_YES run did not add .autospec/"
+if ! grep -qxF ".autospec/*" "$tmp_repo/.gitignore"; then
+    echo "FAIL: AUTOSPEC_AUTO_YES run did not add .autospec/*"
+    exit 1
+fi
+if ! grep -qxF "!.autospec/autospec.yml" "$tmp_repo/.gitignore"; then
+    echo "FAIL: AUTOSPEC_AUTO_YES run did not unignore .autospec/autospec.yml"
     exit 1
 fi
 
 # Idempotency
 HOME="$fake_home" AUTOSPEC_AUTO_YES=1 AUTOSPEC_NO_STAR_PROMPT=1 \
     bash -c "cd '$tmp_repo' && bash '$SCRIPT_DIR/install.sh' --skill autospec --harness claude" >/dev/null 2>&1 || true
-count=$(grep -cxF ".autospec/" "$tmp_repo/.gitignore")
+count=$(grep -cxF ".autospec/*" "$tmp_repo/.gitignore")
 if [ "$count" -ne 1 ]; then
-    echo "FAIL: .autospec/ duplicated (count=$count)"
+    echo "FAIL: .autospec/* duplicated (count=$count)"
+    exit 1
+fi
+exception_count=$(grep -cxF "!.autospec/autospec.yml" "$tmp_repo/.gitignore")
+if [ "$exception_count" -ne 1 ]; then
+    echo "FAIL: .autospec/autospec.yml exception duplicated (count=$exception_count)"
     exit 1
 fi
 

--- a/tests/smoke/test_install_all_skills.bats
+++ b/tests/smoke/test_install_all_skills.bats
@@ -17,8 +17,8 @@ setup() {
     export OPENCODE_CONFIG_DIR="$FAKE_HOME/.config/opencode"
     export CODEX_HOME="$FAKE_HOME/.codex"
 
-    SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-story autospec-stop"
-    HELPERS="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
+    SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep"
+    HELPERS="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh autospec-sweep-wizard.sh autospec-sweep-run.sh autospec-sweep-review.sh"
 }
 
 teardown() {

--- a/tests/unit/test_autospec_sweep_config.bats
+++ b/tests/unit/test_autospec_sweep_config.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_sweep_config.bats — first-run autospec config wizard.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  WIZARD="$REPO_ROOT/skills/autospec-sweep/scripts/wizard.sh"
+  SCHEMA="$REPO_ROOT/schemas/autospec-config.schema.json"
+  TEST_TMPDIR="$(mktemp -d /tmp/autospec-sweep-config-XXXXXX)"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+@test "autospec-sweep init writes a tracked top-level config with all steps enabled by default" {
+  mkdir -p "$TEST_TMPDIR/repo"
+
+  run bash "$WIZARD" init --repo-root "$TEST_TMPDIR/repo" --answers "$REPO_ROOT/tests/fixtures/autospec-sweep/minimal-answers.yml"
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMPDIR/repo/.autospec/autospec.yml" ]
+
+  run yq -r '.version' "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+  [ "$output" = "1" ]
+
+  run yq -r '.steps.define.enabled' "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+  [ "$output" = "true" ]
+
+  run yq -r '.steps.run.enabled' "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+  [ "$output" = "true" ]
+
+  run yq -r '.steps.sweep.enabled' "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+  [ "$output" = "true" ]
+
+  run yq -r '.sweep.spec_sync.enabled' "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+  [ "$output" = "true" ]
+
+  run yq -r '.continuous_improvement.docs.enabled' "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+  [ "$output" = "true" ]
+
+  run yq -r '.continuous_improvement.tests.enabled' "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+  [ "$output" = "true" ]
+
+  run yq -r '.continuous_improvement.code.enabled' "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+  [ "$output" = "true" ]
+
+  run yq -r '.execution.tests.run_all_every_sweep' "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+  [ "$output" = "true" ]
+
+  run yq -r '.execution.deployment.deploy_if_tests_require' "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+  [ "$output" = "true" ]
+}
+
+@test "autospec config schema compiles and accepts generated defaults" {
+  mkdir -p "$TEST_TMPDIR/repo"
+  bash "$WIZARD" init --repo-root "$TEST_TMPDIR/repo" --answers "$REPO_ROOT/tests/fixtures/autospec-sweep/minimal-answers.yml"
+
+  run ajv compile -s "$SCHEMA" --spec=draft2020
+  [ "$status" -eq 0 ]
+
+  yq -o=json '.' "$TEST_TMPDIR/repo/.autospec/autospec.yml" > "$TEST_TMPDIR/config.json"
+  run ajv validate -s "$SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/config.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "autospec-sweep init refuses to overwrite an existing config without --force" {
+  mkdir -p "$TEST_TMPDIR/repo/.autospec"
+  printf 'version: 1\n' > "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+
+  run bash "$WIZARD" init --repo-root "$TEST_TMPDIR/repo" --answers "$REPO_ROOT/tests/fixtures/autospec-sweep/minimal-answers.yml"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"already exists"* ]]
+  run yq -r '.steps.define.enabled // "missing"' "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+  [ "$output" = "missing" ]
+}
+
+@test "autospec-sweep init refuses when tracked config path is gitignored" {
+  mkdir -p "$TEST_TMPDIR/repo"
+  git -C "$TEST_TMPDIR/repo" init -q
+  printf '.autospec/\n' > "$TEST_TMPDIR/repo/.gitignore"
+
+  run bash "$WIZARD" init --repo-root "$TEST_TMPDIR/repo" --answers "$REPO_ROOT/tests/fixtures/autospec-sweep/minimal-answers.yml"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"ignored by git"* ]]
+}
+
+@test "autospec-sweep init validates boolean and safety answers" {
+  mkdir -p "$TEST_TMPDIR/repo"
+  cat > "$TEST_TMPDIR/bad-answers.yml" <<'YAML'
+profile: full
+safety: unsafe_prod
+team: auto
+allow_competitor_research: maybe
+YAML
+
+  run bash "$WIZARD" init --repo-root "$TEST_TMPDIR/repo" --answers "$TEST_TMPDIR/bad-answers.yml"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"safety must be"* ]]
+}
+
+@test "autospec-sweep init records project-specific findings and follow-up questions" {
+  mkdir -p "$TEST_TMPDIR/repo"
+  printf '{"scripts":{"test":"vitest","e2e":"playwright test"}}\n' > "$TEST_TMPDIR/repo/package.json"
+  printf 'export default { use: { baseURL: "http://localhost:3000" } };\n' > "$TEST_TMPDIR/repo/playwright.config.ts"
+
+  run bash "$WIZARD" init --repo-root "$TEST_TMPDIR/repo" --answers "$REPO_ROOT/tests/fixtures/autospec-sweep/minimal-answers.yml"
+
+  [ "$status" -eq 0 ]
+  run yq -r '.project.findings.stack[]' "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+  [[ "$output" == *"node"* ]]
+  [[ "$output" == *"playwright"* ]]
+
+  run yq -r '.project.questions[]' "$TEST_TMPDIR/repo/.autospec/autospec.yml"
+  [[ "$output" == *"base URL"* ]]
+}

--- a/tests/unit/test_autospec_sweep_run.bats
+++ b/tests/unit/test_autospec_sweep_run.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_sweep_run.bats — executable autospec-sweep runner.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  WIZARD="$REPO_ROOT/skills/autospec-sweep/scripts/wizard.sh"
+  RUNNER="$REPO_ROOT/skills/autospec-sweep/scripts/run.sh"
+  TEST_TMPDIR="$(mktemp -d /tmp/autospec-sweep-run-XXXXXX)"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+make_configured_repo() {
+  mkdir -p "$TEST_TMPDIR/repo"
+  bash "$WIZARD" init --repo-root "$TEST_TMPDIR/repo" --answers "$REPO_ROOT/tests/fixtures/autospec-sweep/minimal-answers.yml" >/dev/null
+  printf '%s\n' "$TEST_TMPDIR/repo"
+}
+
+@test "autospec-sweep run refuses when config is missing" {
+  mkdir -p "$TEST_TMPDIR/repo"
+
+  run bash "$RUNNER" run --repo-root "$TEST_TMPDIR/repo"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *".autospec/autospec.yml"* ]]
+}
+
+@test "autospec-sweep run --dry-run emits a machine-readable command plan" {
+  repo="$(make_configured_repo)"
+
+  run bash "$RUNNER" run --repo-root "$repo" --dry-run
+
+  [ "$status" -eq 0 ]
+  run bash -c "printf '%s' '$output' | jq -e '.mode == \"dry-run\" and .config == \".autospec/autospec.yml\" and .commands.review != null'"
+  [ "$status" -eq 0 ]
+}
+
+@test "autospec-sweep run writes state and copies provided gaps without filing in --no-file mode" {
+  repo="$(make_configured_repo)"
+  gaps="$TEST_TMPDIR/gaps.json"
+  cat > "$gaps" <<'JSON'
+[
+  {
+    "gap_id": "G1",
+    "dimension": "docs",
+    "severity": "medium",
+    "file": "README.md",
+    "line": 1,
+    "title": "Document sweep",
+    "body": "README.md needs the sweep command.",
+    "dedupe_key": "docs-readme-sweep"
+  }
+]
+JSON
+
+  run bash "$RUNNER" run --repo-root "$repo" --gaps "$gaps" --no-file
+
+  [ "$status" -eq 0 ]
+  [ -f "$repo/.autospec/sweep/latest.json" ]
+  run yq -r '.gaps.count' "$repo/.autospec/sweep/latest.json"
+  [ "$output" = "1" ]
+}
+
+@test "autospec-sweep run can execute a configured review command that emits gaps" {
+  repo="$(make_configured_repo)"
+  stub="$TEST_TMPDIR/review-stub.sh"
+  cat > "$stub" <<'SH'
+#!/usr/bin/env bash
+set -eu
+out=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --emit-gaps) out="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+cat > "$out" <<'JSON'
+[{"dimension":"tests","severity":"high","file":"tests/example.bats","line":7,"title":"Add regression test","body":"Missing regression coverage.","dedupe_key":"tests-regression"}]
+JSON
+SH
+  chmod +x "$stub"
+
+  run env AUTOSPEC_SWEEP_REVIEW_CMD="$stub" bash "$RUNNER" run --repo-root "$repo" --no-file
+
+  [ "$status" -eq 0 ]
+  run yq -r '.gaps.count' "$repo/.autospec/sweep/latest.json"
+  [ "$output" = "1" ]
+}
+
+@test "autospec-sweep run uses bundled executable review wrapper by default" {
+  repo="$(make_configured_repo)"
+
+  run bash "$RUNNER" run --repo-root "$repo" --no-file
+
+  [ "$status" -eq 0 ]
+  [ -f "$repo/.autospec/sweep/gaps.json" ]
+  run jq -r '.[].dedupe_key' "$repo/.autospec/sweep/gaps.json"
+  [[ "$output" == *"autospec-config-test-command"* ]]
+}
+
+@test "autospec-sweep run executes configured all-test command every time" {
+  repo="$(make_configured_repo)"
+  cat > "$repo/all-tests.sh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+printf 'all-tests\n' >> sweep-command.log
+SH
+  chmod +x "$repo/all-tests.sh"
+  yq -i '.project.findings.commands.test = "./all-tests.sh"' "$repo/.autospec/autospec.yml"
+
+  run bash "$RUNNER" run --repo-root "$repo" --no-file
+  [ "$status" -eq 0 ]
+  run bash "$RUNNER" run --repo-root "$repo" --no-file
+  [ "$status" -eq 0 ]
+
+  run bash -c "grep -c '^all-tests$' '$repo/sweep-command.log'"
+  [ "$output" = "2" ]
+  run yq -r '.tests.status' "$repo/.autospec/sweep/latest.json"
+  [ "$output" = "pass" ]
+}
+
+@test "autospec-sweep run deploys before e2e command when tests require software" {
+  repo="$(make_configured_repo)"
+  cat > "$repo/deploy.sh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+printf 'deploy\n' >> sweep-command.log
+SH
+  cat > "$repo/e2e.sh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+printf 'e2e\n' >> sweep-command.log
+SH
+  chmod +x "$repo/deploy.sh" "$repo/e2e.sh"
+  yq -i '.project.findings.commands.test = "true"' "$repo/.autospec/autospec.yml"
+  yq -i '.project.findings.commands.e2e = "./e2e.sh"' "$repo/.autospec/autospec.yml"
+  yq -i '.project.findings.commands.deploy = "./deploy.sh"' "$repo/.autospec/autospec.yml"
+
+  run bash "$RUNNER" run --repo-root "$repo" --no-file
+
+  [ "$status" -eq 0 ]
+  run bash -c "tr '\n' ' ' < '$repo/sweep-command.log'"
+  [ "$output" = "deploy e2e " ]
+  run yq -r '.deployment.status' "$repo/.autospec/sweep/latest.json"
+  [ "$output" = "pass" ]
+}

--- a/tests/unit/test_autospec_sweep_skill.bats
+++ b/tests/unit/test_autospec_sweep_skill.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_sweep_skill.bats — skill and autospec integration contract.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "autospec-sweep ships as a lock-step multi-harness skill" {
+  for f in \
+    "$REPO_ROOT/skills/autospec-sweep/SKILL.md" \
+    "$REPO_ROOT/skills/autospec-sweep/opencode/agent.md" \
+    "$REPO_ROOT/skills/autospec-sweep/codex/prompt.md" \
+    "$REPO_ROOT/skills/autospec-sweep/README.md" \
+    "$REPO_ROOT/skills/autospec-sweep/install.sh" \
+    "$REPO_ROOT/skills/autospec-sweep/uninstall.sh"
+  do
+    [ -f "$f" ]
+  done
+}
+
+@test "autospec first-run preflight routes missing config through autospec-sweep" {
+  for f in \
+    "$REPO_ROOT/skills/autospec/SKILL.md" \
+    "$REPO_ROOT/skills/autospec/opencode/agent.md" \
+    "$REPO_ROOT/skills/autospec/codex/prompt.md"
+  do
+    grep -q '.autospec/autospec.yml' "$f"
+    grep -q '/autospec-sweep init' "$f"
+  done
+}
+
+@test "validate.sh includes autospec-sweep in generated-skill invariants" {
+  grep -q 'autospec-sweep' "$REPO_ROOT/scripts/validate.sh"
+  grep -q 'check_autospec_sweep_config_contract' "$REPO_ROOT/scripts/validate.sh"
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,7 +12,7 @@
 #   ./uninstall.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | all
+#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -24,7 +24,7 @@
 
 set -eu
 
-ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop"
+ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -67,7 +67,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$SKILL_ARG" in
-    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop) ;;
+    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
         exit 2


### PR DESCRIPTION
## Summary

Adds the `autospec-sweep` workflow for first-run project configuration and recurring spec-vs-reality sweeps.

## Changes

- Adds tracked `.autospec/autospec.yml` schema support and a first-run wizard.
- Adds deterministic `autospec-sweep-run.sh` and `autospec-sweep-review.sh` surfaces.
- Wires `/autospec` first-run preflight to route missing config through autospec-sweep.
- Enforces that every sweep run executes configured full tests, and deploys/starts the app before E2E or integration tests when required.
- Documents the sweep workflow in user/API/skill docs and validates install/uninstall coverage.

## Validation

- `bash -n skills/autospec-sweep/scripts/run.sh skills/autospec-sweep/scripts/wizard.sh skills/autospec-sweep/scripts/review.sh skills/autospec-sweep/install.sh skills/autospec-sweep/uninstall.sh`
- `bats tests/unit/test_autospec_sweep_config.bats tests/unit/test_autospec_sweep_skill.bats tests/unit/test_autospec_sweep_run.bats tests/smoke/test_install_all_skills.bats`
- `bash tests/install/test_gitignore_offer.sh`
- `bash scripts/validate.sh`
- `git diff --cached --check`

## Review Notes

Local review found no blocking issues in the staged sweep/config/docs scope. `scripts/lint-implementation.sh --pre-commit --staged` was attempted as an extra verifier but hung while reading its temporary staged diff and produced no findings; canonical repository validation passed.
