### PR TITLE
feat(install): single-line curl-pipe bootstrap installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,49 @@ details.
 
 ## Install
 
-Install the full suite into every supported harness:
+One-line install for the full suite into every supported harness:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash
+```
+
+The bootstrap clones (or fast-forwards) autospec into `~/.autospec/repo` and then runs `./install.sh --skill all --harness all`. Re-run any time to update.
+
+Forward flags to the underlying installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh \
+  | bash -s -- --skill autospec --harness claude
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh \
+  | bash -s -- --skill all --harness opencode
+```
+
+The bootstrap honors:
+
+| Variable | Purpose |
+| --- | --- |
+| `AUTOSPEC_HOME` | Base dir for the autospec checkout + state (default: `~/.autospec`). |
+| `AUTOSPEC_REF` | Git ref (branch, tag, or sha) to install (default: `main`). |
+| `AUTOSPEC_REPO_URL` | Override the remote URL — useful for forks or mirrors. |
+
+The installer also honors:
+
+| Variable | Purpose |
+| --- | --- |
+| `CLAUDE_CONFIG_DIR` | Override Claude Code install root. |
+| `OPENCODE_CONFIG_DIR` | Override OpenCode install root. |
+| `CODEX_HOME` | Override Codex install root. |
+| `AUTOSPEC_NO_STAR_PROMPT=1` | Skip the optional adoption star prompt. |
+
+After a successful interactive suite install, the top-level installer asks
+whether you want to star `berlinguyinca/autospec` to support adoption. It is
+skipped for non-interactive installs (including `curl | bash`), `--update`,
+CI, missing `gh`, or `AUTOSPEC_NO_STAR_PROMPT=1`.
+
+### Manual install (from a checkout)
+
+If you'd rather manage the checkout yourself — e.g. for development on
+autospec itself — clone and run the installer directly:
 
 ```bash
 git clone https://github.com/berlinguyinca/autospec.git
@@ -94,26 +136,20 @@ Uninstall symmetrically:
 ./uninstall.sh --skill all --harness all
 ```
 
-The installer honors:
+### Single-skill curl install (advanced)
 
-| Variable | Purpose |
-| --- | --- |
-| `CLAUDE_CONFIG_DIR` | Override Claude Code install root. |
-| `OPENCODE_CONFIG_DIR` | Override OpenCode install root. |
-| `CODEX_HOME` | Override Codex install root. |
-| `AUTOSPEC_NO_STAR_PROMPT=1` | Skip the optional adoption star prompt. |
-
-After a successful interactive suite install, the top-level installer asks
-whether you want to star `berlinguyinca/autospec` to support adoption. It is
-skipped for non-interactive installs, `--update`, CI, missing `gh`, or
-`AUTOSPEC_NO_STAR_PROMPT=1`.
-
-Each per-skill installer is also standalone-callable:
+Each per-skill installer is also callable standalone over curl:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec/install.sh \
   | sh -s -- --harness all
 ```
+
+This installs only that skill's files and the small shared-script set listed
+inside its installer. It does **not** fetch `skills/autospec-shared/scripts/**`,
+so skills that depend on shared helpers (gap remediation, doc-drift scanning,
+etc.) may fail at runtime. Prefer the one-line `bootstrap.sh` install above
+unless you specifically want a single-skill, no-checkout footprint.
 
 ### Target repo setup
 
@@ -149,7 +185,13 @@ Disable startup self-update:
 AUTOSPEC_NO_SELF_UPDATE=1
 ```
 
-Force an in-place suite update:
+Force an in-place suite update — for a bootstrap install, re-run the one-liner:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --update
+```
+
+Or, from a manual checkout:
 
 ```bash
 ./install.sh --skill all --harness all --update

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# bootstrap.sh — single-line curl-pipe installer for the autospec suite.
+#
+# Designed to be run via:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash
+#
+# Or with forwarded flags:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh \
+#     | bash -s -- --skill autospec --harness claude
+#
+# What it does:
+#   1. Pre-flights git + bash.
+#   2. Clones (or fast-forwards) the repo to $AUTOSPEC_HOME/repo at $AUTOSPEC_REF.
+#   3. cd into the checkout and runs ./install.sh, forwarding any extra args.
+#   4. Exits with the installer's exit code.
+#
+# Honors:
+#   AUTOSPEC_HOME       (default: $HOME/.autospec)  — base dir for repo + state
+#   AUTOSPEC_REF        (default: main)             — git ref to install
+#   AUTOSPEC_REPO_URL   (default: official remote)  — override for forks/mirrors
+#   plus every variable install.sh already honors (AUTOSPEC_NO_STAR_PROMPT, etc.)
+
+set -eu
+
+AUTOSPEC_HOME="${AUTOSPEC_HOME:-$HOME/.autospec}"
+AUTOSPEC_REF="${AUTOSPEC_REF:-main}"
+AUTOSPEC_REPO_URL="${AUTOSPEC_REPO_URL:-https://github.com/berlinguyinca/autospec.git}"
+REPO_DIR="$AUTOSPEC_HOME/repo"
+
+err()  { printf 'bootstrap: error: %s\n' "$*" >&2; }
+info() { printf 'bootstrap: %s\n' "$*"; }
+
+require() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        err "$1 is required but not on PATH. Install it and re-run."
+        exit 1
+    fi
+}
+
+require git
+require bash
+
+mkdir -p "$AUTOSPEC_HOME"
+
+if [ -d "$REPO_DIR/.git" ]; then
+    info "updating existing checkout at $REPO_DIR (ref: $AUTOSPEC_REF)"
+    git -C "$REPO_DIR" fetch --quiet origin "$AUTOSPEC_REF" || {
+        err "git fetch failed for $AUTOSPEC_REPO_URL ($AUTOSPEC_REF)"
+        exit 1
+    }
+    git -C "$REPO_DIR" checkout --quiet "$AUTOSPEC_REF"
+    # Fast-forward only — preserve any uncommitted local edits with a clear error.
+    if ! git -C "$REPO_DIR" merge --ff-only --quiet "origin/$AUTOSPEC_REF" 2>/dev/null; then
+        # Detached HEAD on a tag/sha is fine; only warn if a fast-forward was expected.
+        if git -C "$REPO_DIR" symbolic-ref --quiet HEAD >/dev/null 2>&1; then
+            err "could not fast-forward $REPO_DIR to origin/$AUTOSPEC_REF. Resolve local changes and re-run."
+            exit 1
+        fi
+    fi
+elif [ -e "$REPO_DIR" ]; then
+    err "$REPO_DIR exists but is not a git checkout. Remove it or set AUTOSPEC_HOME and re-run."
+    exit 1
+else
+    info "cloning $AUTOSPEC_REPO_URL to $REPO_DIR (ref: $AUTOSPEC_REF)"
+    git clone --quiet --branch "$AUTOSPEC_REF" --depth 1 "$AUTOSPEC_REPO_URL" "$REPO_DIR" 2>/dev/null \
+        || git clone --quiet "$AUTOSPEC_REPO_URL" "$REPO_DIR"
+    git -C "$REPO_DIR" checkout --quiet "$AUTOSPEC_REF"
+fi
+
+info "running $REPO_DIR/install.sh $*"
+cd "$REPO_DIR"
+exec bash ./install.sh "$@"


### PR DESCRIPTION
Closes #566.

## Summary
- Adds `bootstrap.sh` at the repo root — a true one-liner installer designed for `curl -fsSL .../bootstrap.sh | bash`. Clones (or fast-forwards) the repo to `$AUTOSPEC_HOME/repo` at `$AUTOSPEC_REF`, then runs `./install.sh` forwarding any extra args.
- Rewrites the README **Install** section to lead with the curl one-liner. Demotes git-clone to a **Manual install (from a checkout)** subsection. Annotates the per-skill curl example with a caveat that it does not fetch `skills/autospec-shared/scripts/**` and so may break at runtime for skills that depend on shared helpers.
- Adds an `--update` one-liner to the Update section for bootstrap-installed users.

## Why
The README's documented `curl ... | sh -s` only installs a single skill (`autospec`) and only the small static `SHARED_SCRIPT_FILES` list — it omits `skills/autospec-shared/scripts/**`, which the runtime now depends on (e.g. `run-batch-start.sh`, `gap-remediation-loop.sh`, `scan-doc-scope.mjs`). Users who tried `curl | sh` got a partially-installed skill that fails at runtime.

A clone+install bootstrap sidesteps the file-by-file fetch problem entirely.

## Env vars (new)
| Variable | Purpose |
| --- | --- |
| `AUTOSPEC_HOME` | Base dir for the checkout + state (default: `~/.autospec`). |
| `AUTOSPEC_REF` | Git ref to install (default: `main`). |
| `AUTOSPEC_REPO_URL` | Override remote URL — for forks/mirrors. |

## Verification
- `bash -n bootstrap.sh` clean.
- `bash scripts/validate.sh` — all checks pass.
- `bats tests/smoke/test_install_all_skills.bats` — 4/4 pass.
- Sandbox end-to-end against `file://` remote:
  - Fresh clone → `install.sh --dry-run --skill autospec --harness claude` → 1/1 OK, exit 0.
  - Re-run (update path) → fast-forwards, install runs, exit 0.
  - Stdin-pipe simulation (`cat bootstrap.sh | bash -s -- ...`) → clone + install + exit 0.
  - Error path (existing non-git dir) → clear error, exit 1.

## Known unrelated test failure
`tests/install/test_codex_check.sh` fails on the branch but **also fails on plain `main`** (verified). Pre-existing, out of scope for this PR.

## Out of scope
- Refactoring the per-skill standalone curl install to also fetch `autospec-shared/scripts/**` (kept as documented caveat for now).
- Homebrew tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)