### PR TITLE
feat(autospec-design): scaffold skill skeleton (6-file lockstep trio + install/uninstall + README)

### DIFF
--- a/skills/autospec-design/README.md
+++ b/skills/autospec-design/README.md
@@ -1,0 +1,88 @@
+# autospec-design
+
+Adopt a vendor design language for the current repo. Pick a vendor from the
+`berlinguyinca/awesome-design-md` catalog, write `DESIGN.md` at the project
+root, and optionally hand off a migration spec to `/autospec-define`.
+
+Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
+
+> **Scaffold issue #572.** Subcommand bodies are placeholders until the
+> follow-up issues land: `suggest` (#577), `apply` (#578), `migrate` (#580).
+
+## Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-design/install.sh | sh -s -- --harness all
+```
+
+Per-harness:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-design/install.sh | sh -s -- --harness claude
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-design/install.sh | sh -s -- --harness opencode
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-design/install.sh | sh -s -- --harness codex
+```
+
+From a clone:
+
+```bash
+cd skills/autospec-design
+./install.sh --harness all
+```
+
+## Invocation
+
+```
+/autospec-design suggest
+/autospec-design apply <vendor> [--force] [--branch <name>]
+/autospec-design migrate <vendor> [--branch <name>]
+```
+
+| Subcommand | Behavior |
+|---|---|
+| `suggest` | Scan the current repo, score every catalog vendor, present top 3 with rationale. Prints only — never modifies files. |
+| `apply <vendor>` | Fetch the vendor's DESIGN.md, write to `<repo-root>/DESIGN.md` on `feat/design-<vendor>`, commit + push. No PR. |
+| `migrate <vendor>` | Generate `docs/specs/<YYYY-MM-DD>-design-migration-<vendor>.md` and hand off to `/autospec-define`. |
+
+## Catalog source
+
+The catalog is fetched at runtime, never vendored:
+
+| Variable | Default |
+|---|---|
+| `AUTOSPEC_DESIGN_CATALOG_OWNER` | `berlinguyinca` |
+| `AUTOSPEC_DESIGN_CATALOG_REPO`  | `awesome-design-md` |
+| `AUTOSPEC_DESIGN_CATALOG_REF`   | `main` |
+
+Per-vendor DESIGN.md lives at
+`design-md/<vendor>/DESIGN.md` in the catalog repo. Fetched via `gh api`
+with a `curl -fsSL` fallback. Cache: `~/.autospec/design-cache/<vendor>/`
+with a 24h freshness window.
+
+## Related skills
+
+| Skill | Purpose |
+| --- | --- |
+| [`autospec`](../autospec/README.md) | Full pipeline (Phases 0–6) — accepts a `DESIGN.md` if present. |
+| [`autospec-define`](../autospec-define/README.md) | Planning half (Phases 0–3); consumes migration specs emitted by `migrate`. |
+| [`autospec-classify`](../autospec-classify/README.md) | Phase 3.5 model-fit labeling — sibling pattern this skill mirrors. |
+
+## Self-update
+
+Once installed, run the skill with the literal argument `update` to refresh in
+place. The skill detects its harness, re-runs the canonical install one-liner
+with `--update`, shows the diff, and stops without running any subcommand:
+
+```
+/autospec-design update
+```
+
+Or re-run the per-skill installer with `--update`:
+
+```bash
+./install.sh --harness all --update
+```
+
+## License
+
+MIT — see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autospec-design/SKILL.md
+++ b/skills/autospec-design/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: autospec-design
+description: Use when the user wants to adopt a vendor design language for the current repo — fetches the per-vendor DESIGN.md from the berlinguyinca/awesome-design-md catalog, scores the repo against candidate vendors, writes DESIGN.md at the project root, and optionally hands off a migration spec to /autospec-define. Subcommands suggest, apply, and migrate.
+---
+
+# autospec-design (harness-neutral)
+
+Skill scaffold for the **autospec-design** workflow. The full workflow lets the
+user pick a vendor design language (Linear, Stripe, Vercel, ...) from a curated
+catalog, write `DESIGN.md` at the project root, and optionally hand off a
+migration spec into `/autospec-define`. The catalog lives at
+`berlinguyinca/awesome-design-md` and is fetched at runtime — never vendored.
+
+This file is the **scaffold trio body** (see issue #572). The three
+subcommands — `suggest`, `apply`, `migrate` — currently hold placeholder
+sections. Real prose lands in the follow-up issues (#577 suggest, #578 apply,
+#580 migrate).
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-design   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-design/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-design.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-design.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-design/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter any subcommand. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-design found; run install.sh first.` and exit.
+
+## Invocation
+
+```
+/autospec-design suggest
+/autospec-design apply <vendor> [--force] [--branch <name>]
+/autospec-design migrate <vendor> [--branch <name>]
+```
+
+- `suggest` — scan the current repo, score every catalog vendor by the
+  framework / domain / brand-language rubric, present the top 3 with a
+  one-line rationale each. Prints only — never modifies any files.
+- `apply <vendor>` — fetch `<vendor>/DESIGN.md` from the catalog, write it
+  to `<repo-root>/DESIGN.md` on a fresh feature branch (default:
+  `feat/design-<vendor>`), commit, and push. Refuses to overwrite an
+  existing `DESIGN.md` without `--force`. Does **not** open a PR.
+- `migrate <vendor>` — generate a migration spec at
+  `docs/specs/<YYYY-MM-DD>-design-migration-<vendor>.md` from the scanned
+  UI inventory and hand off to `/autospec-define <spec-path>`.
+
+The skill exits non-zero if `gh auth status` fails when issuing a network
+operation that needs authentication. See spec
+`docs/specs/2026-05-26-autospec-design-skill.md` for the full contract.
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work, Tier B (cheaper model + medium thinking) for implementation work. The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
+
+## Harness detection (run once at skill start, before any subcommand)
+
+Detect your harness by checking available tools before any subcommand:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness (model unknown, quota/capacity failure, authorization failure, or tool call returns an error for that model), silently retry the same subagent dispatch with `TIER_A`. Preserve the parent context on retry; for Codex native subagents, fork/inherit the current conversation context and use the latest top GPT model instead of moving the work into the main session. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
+## Catalog source (single source of truth)
+
+Fetched at runtime, never vendored:
+
+```bash
+AUTOSPEC_DESIGN_CATALOG_OWNER="${AUTOSPEC_DESIGN_CATALOG_OWNER:-berlinguyinca}"
+AUTOSPEC_DESIGN_CATALOG_REPO="${AUTOSPEC_DESIGN_CATALOG_REPO:-awesome-design-md}"
+AUTOSPEC_DESIGN_CATALOG_REF="${AUTOSPEC_DESIGN_CATALOG_REF:-main}"
+```
+
+Per-vendor DESIGN.md is fetched via `gh api repos/${owner}/${repo}/contents/design-md/${vendor}/DESIGN.md?ref=${ref} --jq '.content' | base64 -d`, with a fallback to `curl -fsSL https://raw.githubusercontent.com/...`. Cache lands under `~/.autospec/design-cache/<vendor>/DESIGN.md` with a 24h freshness window. The catalog fetcher script lands in issue #576 (`fetch-design-md.sh`).
+
+## Subcommand: suggest (placeholder)
+
+> **Model tier:** `TIER_B` (implementation work) — scoring is mechanical; rubric is a fixed table.
+
+Scaffold-only placeholder. Real prose lands in issue #577. Until then, the
+suggest subcommand prints:
+
+```
+/autospec-design suggest: full implementation lands in issue #577.
+```
+
+## Subcommand: apply (placeholder)
+
+> **Model tier:** `TIER_B` (implementation work) — write-out is a deterministic
+> branch-and-commit; no novel design.
+
+Scaffold-only placeholder. Real prose lands in issue #578. Until then, the
+apply subcommand prints:
+
+```
+/autospec-design apply: full implementation lands in issue #578.
+```
+
+## Subcommand: migrate (placeholder)
+
+> **Model tier:** `TIER_B` (implementation work) — emits a structured spec and
+> hands off to `/autospec-define`.
+
+Scaffold-only placeholder. Real prose lands in issue #580. Until then, the
+migrate subcommand prints:
+
+```
+/autospec-design migrate: full implementation lands in issue #580.
+```
+
+## Hard rules
+
+- Never overwrite an existing `DESIGN.md` without `--force`.
+- Never open a PR automatically — the operator opens it (or `/autospec-define`
+  takes over via the migration spec).
+- Never modify the issue title (when running via the autospec pipeline).
+- Always idempotent — running `apply` twice with the same vendor on the same
+  branch is a no-op after the first commit.
+- `gh` CLI only for GitHub ops; `curl` only as a fallback for catalog reads.

--- a/skills/autospec-design/codex/prompt.md
+++ b/skills/autospec-design/codex/prompt.md
@@ -1,0 +1,190 @@
+
+# autospec-design (harness-neutral)
+
+Skill scaffold for the **autospec-design** workflow. The full workflow lets the
+user pick a vendor design language (Linear, Stripe, Vercel, ...) from a curated
+catalog, write `DESIGN.md` at the project root, and optionally hand off a
+migration spec into `/autospec-define`. The catalog lives at
+`berlinguyinca/awesome-design-md` and is fetched at runtime — never vendored.
+
+This file is the **scaffold trio body** (see issue #572). The three
+subcommands — `suggest`, `apply`, `migrate` — currently hold placeholder
+sections. Real prose lands in the follow-up issues (#577 suggest, #578 apply,
+#580 migrate).
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-design   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-design/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-design.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-design.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-design/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter any subcommand. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-design found; run install.sh first.` and exit.
+
+## Invocation
+
+```
+/autospec-design suggest
+/autospec-design apply <vendor> [--force] [--branch <name>]
+/autospec-design migrate <vendor> [--branch <name>]
+```
+
+- `suggest` — scan the current repo, score every catalog vendor by the
+  framework / domain / brand-language rubric, present the top 3 with a
+  one-line rationale each. Prints only — never modifies any files.
+- `apply <vendor>` — fetch `<vendor>/DESIGN.md` from the catalog, write it
+  to `<repo-root>/DESIGN.md` on a fresh feature branch (default:
+  `feat/design-<vendor>`), commit, and push. Refuses to overwrite an
+  existing `DESIGN.md` without `--force`. Does **not** open a PR.
+- `migrate <vendor>` — generate a migration spec at
+  `docs/specs/<YYYY-MM-DD>-design-migration-<vendor>.md` from the scanned
+  UI inventory and hand off to `/autospec-define <spec-path>`.
+
+The skill exits non-zero if `gh auth status` fails when issuing a network
+operation that needs authentication. See spec
+`docs/specs/2026-05-26-autospec-design-skill.md` for the full contract.
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work, Tier B (cheaper model + medium thinking) for implementation work. The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
+
+## Harness detection (run once at skill start, before any subcommand)
+
+Detect your harness by checking available tools before any subcommand:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness (model unknown, quota/capacity failure, authorization failure, or tool call returns an error for that model), silently retry the same subagent dispatch with `TIER_A`. Preserve the parent context on retry; for Codex native subagents, fork/inherit the current conversation context and use the latest top GPT model instead of moving the work into the main session. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
+## Catalog source (single source of truth)
+
+Fetched at runtime, never vendored:
+
+```bash
+AUTOSPEC_DESIGN_CATALOG_OWNER="${AUTOSPEC_DESIGN_CATALOG_OWNER:-berlinguyinca}"
+AUTOSPEC_DESIGN_CATALOG_REPO="${AUTOSPEC_DESIGN_CATALOG_REPO:-awesome-design-md}"
+AUTOSPEC_DESIGN_CATALOG_REF="${AUTOSPEC_DESIGN_CATALOG_REF:-main}"
+```
+
+Per-vendor DESIGN.md is fetched via `gh api repos/${owner}/${repo}/contents/design-md/${vendor}/DESIGN.md?ref=${ref} --jq '.content' | base64 -d`, with a fallback to `curl -fsSL https://raw.githubusercontent.com/...`. Cache lands under `~/.autospec/design-cache/<vendor>/DESIGN.md` with a 24h freshness window. The catalog fetcher script lands in issue #576 (`fetch-design-md.sh`).
+
+## Subcommand: suggest (placeholder)
+
+> **Model tier:** `TIER_B` (implementation work) — scoring is mechanical; rubric is a fixed table.
+
+Scaffold-only placeholder. Real prose lands in issue #577. Until then, the
+suggest subcommand prints:
+
+```
+/autospec-design suggest: full implementation lands in issue #577.
+```
+
+## Subcommand: apply (placeholder)
+
+> **Model tier:** `TIER_B` (implementation work) — write-out is a deterministic
+> branch-and-commit; no novel design.
+
+Scaffold-only placeholder. Real prose lands in issue #578. Until then, the
+apply subcommand prints:
+
+```
+/autospec-design apply: full implementation lands in issue #578.
+```
+
+## Subcommand: migrate (placeholder)
+
+> **Model tier:** `TIER_B` (implementation work) — emits a structured spec and
+> hands off to `/autospec-define`.
+
+Scaffold-only placeholder. Real prose lands in issue #580. Until then, the
+migrate subcommand prints:
+
+```
+/autospec-design migrate: full implementation lands in issue #580.
+```
+
+## Hard rules
+
+- Never overwrite an existing `DESIGN.md` without `--force`.
+- Never open a PR automatically — the operator opens it (or `/autospec-define`
+  takes over via the migration spec).
+- Never modify the issue title (when running via the autospec pipeline).
+- Always idempotent — running `apply` twice with the same vendor on the same
+  branch is a no-op after the first commit.
+- `gh` CLI only for GitHub ops; `curl` only as a fallback for catalog reads.

--- a/skills/autospec-design/install.sh
+++ b/skills/autospec-design/install.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec-design skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --symlink           # symlink instead of copy (updates propagate)
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-design/install.sh \
+#     | sh -s -- --harness all
+# When piped, the script auto-downloads the skill files from the same branch.
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPEC_DESIGN_REF         (default: main) — git ref to fetch from when piped
+#   AUTOSPEC_DESIGN_RAW_BASE    (override the raw URL base entirely)
+#
+# Idempotent: re-running upgrades the install. Exits non-zero on hard failure;
+# exits zero with warnings on missing optional deps.
+
+set -eu
+
+SKILL_NAME="autospec-design"
+SKILL_RAW_BASE="${AUTOSPEC_DESIGN_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_DESIGN_REF:-main}/skills/autospec-design}"
+
+# Resolve the directory containing this script. When piped through stdin (e.g.
+# `curl ... | sh`), $0 will not be a real file — detect that and fall back to
+# downloading the source files from the raw GitHub URL.
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+UPDATE_MODE=0
+TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+
+# ---------- helpers --------------------------------------------------------
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
+
+Installs the ${SKILL_NAME} skill into the chosen harness's standard
+skill/agent/prompt directory.
+
+Examples:
+  $0                          # interactive
+  $0 --harness all            # install everywhere
+  $0 --harness claude         # Claude Code only
+  $0 --harness opencode       # OpenCode only
+  $0 --harness codex          # Codex CLI only
+  $0 --harness all --symlink  # symlink instead of copy
+  $0 --dry-run --harness all  # print plan, change nothing
+  $0 --harness claude --update  # idempotent re-install (overwrite existing)
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    # Download the files we need into a temp dir and set SKILL_DIR to it.
+    if ! command -v curl >/dev/null 2>&1; then
+        err "curl is required when running from stdin (e.g. piped via 'curl | sh')."
+        exit 1
+    fi
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/$rel"
+            exit 1
+        fi
+    done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autospec helper scripts"
+        return 1
+    fi
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    dest_dir="$(dirname "$dest")"
+
+    if [ ! -f "$src" ]; then
+        err "missing source file: $src"
+        return 1
+    fi
+
+    run "mkdir -p \"$dest_dir\""
+
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --symlink)
+            USE_SYMLINK=1
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        --update)
+            UPDATE_MODE=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# ---------- harness prompt -------------------------------------------------
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- ensure source files are available ------------------------------
+
+# If we couldn't resolve a local SKILL_DIR (piped from curl) OR the local dir
+# doesn't actually contain the skill files, fall back to remote fetch.
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+
+if [ "$need_fetch" -eq 1 ]; then
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        err "--symlink requires running from a checkout of the autospec repo (no local files to symlink to)."
+        exit 2
+    fi
+    fetch_source_files
+fi
+
+# ---------- dependency checks ---------------------------------------------
+
+dep_warnings=0
+
+check_dep() {
+    name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        warn "$name not found on PATH (required by the skill at runtime)"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+}
+
+check_dep git
+check_dep gh
+check_dep jq
+
+if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+        warn "gh is installed but not authenticated. Run: gh auth login"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+fi
+
+if [ "$dep_warnings" -gt 0 ]; then
+    warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
+fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+CLAUDE_SRC="$SKILL_DIR/SKILL.md"
+OPENCODE_SRC="$SKILL_DIR/opencode/agent.md"
+CODEX_SRC="$SKILL_DIR/codex/prompt.md"
+
+# ---------- install --------------------------------------------------------
+
+installed_paths=""
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_SRC" "$CLAUDE_DEST"
+    installed_paths="${installed_paths}  Claude Code: ${CLAUDE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_SRC" "$OPENCODE_DEST"
+    installed_paths="${installed_paths}  OpenCode:    ${OPENCODE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+    installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
+fi
+
+# ---------- final summary --------------------------------------------------
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    if [ "$UPDATE_MODE" -eq 1 ]; then
+        info "Updated (idempotent overwrite):"
+    else
+        info "Installed:"
+    fi
+    printf '%b' "$installed_paths"
+    info ""
+    info "Invoke with:"
+    info "  Claude Code:  /${SKILL_NAME} <subcommand> [args]"
+    info "  OpenCode:     @${SKILL_NAME} <subcommand> [args]"
+    info "  Codex CLI:    /${SKILL_NAME} <subcommand> [args]"
+fi
+
+exit 0

--- a/skills/autospec-design/opencode/agent.md
+++ b/skills/autospec-design/opencode/agent.md
@@ -1,0 +1,194 @@
+---
+description: Use when the user wants to adopt a vendor design language for the current repo — fetches the per-vendor DESIGN.md from the berlinguyinca/awesome-design-md catalog, scores the repo against candidate vendors, writes DESIGN.md at the project root, and optionally hands off a migration spec to /autospec-define. Subcommands suggest, apply, and migrate.
+mode: primary
+---
+
+# autospec-design (harness-neutral)
+
+Skill scaffold for the **autospec-design** workflow. The full workflow lets the
+user pick a vendor design language (Linear, Stripe, Vercel, ...) from a curated
+catalog, write `DESIGN.md` at the project root, and optionally hand off a
+migration spec into `/autospec-define`. The catalog lives at
+`berlinguyinca/awesome-design-md` and is fetched at runtime — never vendored.
+
+This file is the **scaffold trio body** (see issue #572). The three
+subcommands — `suggest`, `apply`, `migrate` — currently hold placeholder
+sections. Real prose lands in the follow-up issues (#577 suggest, #578 apply,
+#580 migrate).
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-design   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+bash <(curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
+    --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-design/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-design.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-design.md`
+2. **Re-install from `main`** by piping the canonical installer:
+   ```bash
+   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-design/install.sh) --harness <detected> --update
+   ```
+   If multiple harness paths exist, run the one-liner once per detected harness.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
+4. **Stop.** Do not enter any subcommand. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-design found; run install.sh first.` and exit.
+
+## Invocation
+
+```
+/autospec-design suggest
+/autospec-design apply <vendor> [--force] [--branch <name>]
+/autospec-design migrate <vendor> [--branch <name>]
+```
+
+- `suggest` — scan the current repo, score every catalog vendor by the
+  framework / domain / brand-language rubric, present the top 3 with a
+  one-line rationale each. Prints only — never modifies any files.
+- `apply <vendor>` — fetch `<vendor>/DESIGN.md` from the catalog, write it
+  to `<repo-root>/DESIGN.md` on a fresh feature branch (default:
+  `feat/design-<vendor>`), commit, and push. Refuses to overwrite an
+  existing `DESIGN.md` without `--force`. Does **not** open a PR.
+- `migrate <vendor>` — generate a migration spec at
+  `docs/specs/<YYYY-MM-DD>-design-migration-<vendor>.md` from the scanned
+  UI inventory and hand off to `/autospec-define <spec-path>`.
+
+The skill exits non-zero if `gh auth status` fails when issuing a network
+operation that needs authentication. See spec
+`docs/specs/2026-05-26-autospec-design-skill.md` for the full contract.
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work, Tier B (cheaper model + medium thinking) for implementation work. The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
+
+## Harness detection (run once at skill start, before any subcommand)
+
+Detect your harness by checking available tools before any subcommand:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness (model unknown, quota/capacity failure, authorization failure, or tool call returns an error for that model), silently retry the same subagent dispatch with `TIER_A`. Preserve the parent context on retry; for Codex native subagents, fork/inherit the current conversation context and use the latest top GPT model instead of moving the work into the main session. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
+## Catalog source (single source of truth)
+
+Fetched at runtime, never vendored:
+
+```bash
+AUTOSPEC_DESIGN_CATALOG_OWNER="${AUTOSPEC_DESIGN_CATALOG_OWNER:-berlinguyinca}"
+AUTOSPEC_DESIGN_CATALOG_REPO="${AUTOSPEC_DESIGN_CATALOG_REPO:-awesome-design-md}"
+AUTOSPEC_DESIGN_CATALOG_REF="${AUTOSPEC_DESIGN_CATALOG_REF:-main}"
+```
+
+Per-vendor DESIGN.md is fetched via `gh api repos/${owner}/${repo}/contents/design-md/${vendor}/DESIGN.md?ref=${ref} --jq '.content' | base64 -d`, with a fallback to `curl -fsSL https://raw.githubusercontent.com/...`. Cache lands under `~/.autospec/design-cache/<vendor>/DESIGN.md` with a 24h freshness window. The catalog fetcher script lands in issue #576 (`fetch-design-md.sh`).
+
+## Subcommand: suggest (placeholder)
+
+> **Model tier:** `TIER_B` (implementation work) — scoring is mechanical; rubric is a fixed table.
+
+Scaffold-only placeholder. Real prose lands in issue #577. Until then, the
+suggest subcommand prints:
+
+```
+/autospec-design suggest: full implementation lands in issue #577.
+```
+
+## Subcommand: apply (placeholder)
+
+> **Model tier:** `TIER_B` (implementation work) — write-out is a deterministic
+> branch-and-commit; no novel design.
+
+Scaffold-only placeholder. Real prose lands in issue #578. Until then, the
+apply subcommand prints:
+
+```
+/autospec-design apply: full implementation lands in issue #578.
+```
+
+## Subcommand: migrate (placeholder)
+
+> **Model tier:** `TIER_B` (implementation work) — emits a structured spec and
+> hands off to `/autospec-define`.
+
+Scaffold-only placeholder. Real prose lands in issue #580. Until then, the
+migrate subcommand prints:
+
+```
+/autospec-design migrate: full implementation lands in issue #580.
+```
+
+## Hard rules
+
+- Never overwrite an existing `DESIGN.md` without `--force`.
+- Never open a PR automatically — the operator opens it (or `/autospec-define`
+  takes over via the migration spec).
+- Never modify the issue title (when running via the autospec pipeline).
+- Always idempotent — running `apply` twice with the same vendor on the same
+  branch is a no-op after the first commit.
+- `gh` CLI only for GitHub ops; `curl` only as a fallback for catalog reads.

--- a/skills/autospec-design/uninstall.sh
+++ b/skills/autospec-design/uninstall.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec-design skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autospec-design"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        # Try to remove an empty parent skill directory (Claude only — its layout
+        # has a per-skill subdir).
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+# ---------- remove ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0

--- a/tests/unit/test_autospec_design.bats
+++ b/tests/unit/test_autospec_design.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_design.bats — scaffold-level tests for the
+# autospec-design skill: presence of the 6 lockstep trio + install/uninstall
+# + README files, lockstep equality (SKILL body == opencode body == codex
+# body), and round-trip install/uninstall behavior across all three harnesses.
+#
+# Spec ref: docs/specs/2026-05-26-autospec-design-skill.md § Skill layout.
+# Mirrors tests/unit/test_install_listener.bats.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SKILL_DIR="$REPO_ROOT/skills/autospec-design"
+    INSTALL="$SKILL_DIR/install.sh"
+    UNINSTALL="$SKILL_DIR/uninstall.sh"
+
+    # Per-test fake HOME — so the real user environment never sees our writes
+    # and tests run hermetically.
+    FAKE_HOME="$(mktemp -d)"
+    export HOME="$FAKE_HOME"
+    export CLAUDE_CONFIG_DIR="$FAKE_HOME/.claude"
+    export OPENCODE_CONFIG_DIR="$FAKE_HOME/.config/opencode"
+    export CODEX_HOME="$FAKE_HOME/.codex"
+    export AUTOSPEC_NO_SELF_UPDATE=1
+
+    # Expected destinations (mirror install.sh).
+    CLAUDE_DEST="$CLAUDE_CONFIG_DIR/skills/autospec-design/SKILL.md"
+    OPENCODE_DEST="$OPENCODE_CONFIG_DIR/agent/autospec-design.md"
+    CODEX_DEST="$CODEX_HOME/prompts/autospec-design.md"
+}
+
+teardown() {
+    if [ -n "${FAKE_HOME:-}" ] && [ -d "$FAKE_HOME" ]; then
+        rm -rf "$FAKE_HOME"
+    fi
+}
+
+# ---- 6-file scaffold presence --------------------------------------------
+
+@test "scaffold: SKILL.md exists" {
+    [ -f "$SKILL_DIR/SKILL.md" ]
+}
+
+@test "scaffold: opencode/agent.md exists" {
+    [ -f "$SKILL_DIR/opencode/agent.md" ]
+}
+
+@test "scaffold: codex/prompt.md exists" {
+    [ -f "$SKILL_DIR/codex/prompt.md" ]
+}
+
+@test "scaffold: install.sh exists and is executable" {
+    [ -f "$SKILL_DIR/install.sh" ]
+    [ -x "$SKILL_DIR/install.sh" ]
+}
+
+@test "scaffold: uninstall.sh exists and is executable" {
+    [ -f "$SKILL_DIR/uninstall.sh" ]
+    [ -x "$SKILL_DIR/uninstall.sh" ]
+}
+
+@test "scaffold: README.md exists" {
+    [ -f "$SKILL_DIR/README.md" ]
+}
+
+# ---- lockstep: SKILL body == opencode body == codex body -----------------
+
+@test "lockstep: SKILL.md body (post-frontmatter) == codex/prompt.md verbatim" {
+    skill_body="$(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/SKILL.md")"
+    codex_body="$(cat "$SKILL_DIR/codex/prompt.md")"
+    [ "$skill_body" = "$codex_body" ]
+}
+
+@test "lockstep: SKILL.md body (post-frontmatter) == opencode body (post-frontmatter)" {
+    skill_body="$(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/SKILL.md")"
+    opencode_body="$(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/opencode/agent.md")"
+    [ "$skill_body" = "$opencode_body" ]
+}
+
+# ---- install --dry-run --harness all ---------------------------------------
+
+@test "install --dry-run --harness all lists all destinations and exits 0" {
+    run sh "$INSTALL" --harness all --dry-run
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "autospec-design"
+}
+
+# ---- install creates expected files --------------------------------------
+
+@test "install creates expected files for --harness all" {
+    run sh "$INSTALL" --harness all
+    [ "$status" -eq 0 ]
+    [ -f "$CLAUDE_DEST" ]
+    [ -f "$OPENCODE_DEST" ]
+    [ -f "$CODEX_DEST" ]
+}
+
+@test "install --harness claude only places the Claude file" {
+    run sh "$INSTALL" --harness claude
+    [ "$status" -eq 0 ]
+    [ -f "$CLAUDE_DEST" ]
+    [ ! -f "$OPENCODE_DEST" ]
+    [ ! -f "$CODEX_DEST" ]
+}
+
+@test "install --harness opencode only places the OpenCode file" {
+    run sh "$INSTALL" --harness opencode
+    [ "$status" -eq 0 ]
+    [ ! -f "$CLAUDE_DEST" ]
+    [ -f "$OPENCODE_DEST" ]
+    [ ! -f "$CODEX_DEST" ]
+}
+
+@test "install --harness codex only places the Codex prompt" {
+    run sh "$INSTALL" --harness codex
+    [ "$status" -eq 0 ]
+    [ ! -f "$CLAUDE_DEST" ]
+    [ ! -f "$OPENCODE_DEST" ]
+    [ -f "$CODEX_DEST" ]
+}
+
+# ---- round-trip install + uninstall --------------------------------------
+
+@test "uninstall removes files placed by install (--harness all)" {
+    sh "$INSTALL" --harness all >/dev/null
+    [ -f "$CLAUDE_DEST" ]
+    [ -f "$OPENCODE_DEST" ]
+    [ -f "$CODEX_DEST" ]
+
+    run sh "$UNINSTALL" --harness all
+    [ "$status" -eq 0 ]
+    [ ! -f "$CLAUDE_DEST" ]
+    [ ! -f "$OPENCODE_DEST" ]
+    [ ! -f "$CODEX_DEST" ]
+}
+
+# ---- idempotency ---------------------------------------------------------
+
+@test "install is idempotent (running twice in a row exits 0 both times)" {
+    run sh "$INSTALL" --harness all
+    [ "$status" -eq 0 ]
+    run sh "$INSTALL" --harness all
+    [ "$status" -eq 0 ]
+    [ -f "$CLAUDE_DEST" ]
+    [ -f "$OPENCODE_DEST" ]
+    [ -f "$CODEX_DEST" ]
+}
+
+@test "uninstall is idempotent (running twice in a row exits 0 both times)" {
+    sh "$INSTALL" --harness all >/dev/null
+    run sh "$UNINSTALL" --harness all
+    [ "$status" -eq 0 ]
+    run sh "$UNINSTALL" --harness all
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #572

Mirrors `skills/autospec-classify/` exactly. Subcommand bodies (`suggest`, `apply`, `migrate`) are scaffold placeholders that will be filled in by follow-up issues #577 / #578 / #580.

- Trio bodies are byte-identical below frontmatter — `scripts/validate.sh` lockstep check passes.
- `install.sh` / `uninstall.sh` mirror `skills/autospec-classify/` install symmetry.
- New `tests/unit/test_autospec_design.bats` covers scaffold presence (6 files), lockstep equality, install/uninstall round-trip, and idempotency (16 tests).
- `bash scripts/validate.sh` and `bats tests/unit/test_autospec_design.bats` both pass green.