### PR TITLE
feat(autospec-design): wire validate.sh skill enumerations (4 hardcoded lists)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -203,7 +203,7 @@ check_startup_preflight() {
     }
     canonical=$(extract_block skills/autospec/SKILL.md)
     [ -n "$canonical" ] || fail "autospec SKILL.md missing ## Startup self-update section"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design; do
         for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
             body=$(extract_block "$f")
             [ -n "$body" ] || fail "$f missing ## Startup self-update section"
@@ -220,7 +220,7 @@ check_startup_preflight() {
 # prompts/ path AND the new skills/ slash-command registry path.
 check_codex_skills_install() {
     info "codex skills-dir install: all skills"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design; do
         f="skills/$s/install.sh"
         grep -q 'skills/\$SKILL_NAME/SKILL\.md' "$f" \
             || fail "$f missing Codex skills-dir install (skills/\$SKILL_NAME/SKILL.md)"
@@ -235,7 +235,7 @@ check_codex_skills_install() {
 check_shared_script_install() {
     info "shared helper install: all skills"
     helpers="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design; do
         f="skills/$s/install.sh"
         grep -q 'install_shared_scripts' "$f" \
             || fail "$f missing install_shared_scripts function/call"
@@ -296,6 +296,8 @@ check_subagent_model_tier() {
             expected_a=1; expected_b=0 ;;
         autospec-story)
             expected_a=1; expected_b=0 ;;
+        autospec-design)
+            expected_a=2; expected_b=0 ;;
         *)
             expected_a=""; expected_b="" ;;
     esac

--- a/tests/unit/test_autospec_design.bats
+++ b/tests/unit/test_autospec_design.bats
@@ -152,3 +152,40 @@ teardown() {
     run sh "$UNINSTALL" --harness all
     [ "$status" -eq 0 ]
 }
+
+# ---- validate.sh wiring (issue #573) -------------------------------------
+
+@test "validate.sh: check_startup_preflight enumerates autospec-design" {
+    sed -n '/^check_startup_preflight()/,/^}/p' "$REPO_ROOT/scripts/validate.sh" \
+        | grep -q 'autospec-design'
+}
+
+@test "validate.sh: check_codex_skills_install enumerates autospec-design" {
+    sed -n '/^check_codex_skills_install()/,/^}/p' "$REPO_ROOT/scripts/validate.sh" \
+        | grep -q 'autospec-design'
+}
+
+@test "validate.sh: check_shared_script_install enumerates autospec-design" {
+    sed -n '/^check_shared_script_install()/,/^}/p' "$REPO_ROOT/scripts/validate.sh" \
+        | grep -q 'autospec-design'
+}
+
+@test "validate.sh: check_subagent_model_tier has autospec-design case branch with expected_a=2 expected_b=0" {
+    block="$(sed -n '/^check_subagent_model_tier()/,/^}/p' "$REPO_ROOT/scripts/validate.sh")"
+    # Capture from "autospec-design)" up to and including the ";;" terminator.
+    case_body="$(printf '%s\n' "$block" \
+        | awk '/autospec-design)/{f=1} f{print; if (/;;/) exit}')"
+    [ -n "$case_body" ]
+    printf '%s\n' "$case_body" | grep -q 'expected_a=2'
+    printf '%s\n' "$case_body" | grep -q 'expected_b=0'
+}
+
+@test "validate.sh: autospec-design appears in at least 4 hardcoded skill enumerations" {
+    count="$(grep -c 'autospec-design' "$REPO_ROOT/scripts/validate.sh")"
+    [ "$count" -ge 4 ]
+}
+
+@test "validate.sh: bash scripts/validate.sh exits 0 against current tree" {
+    run bash "$REPO_ROOT/scripts/validate.sh"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #573

Adds `autospec-design` to the 4 hardcoded skill enumerations in `scripts/validate.sh`:

- `check_startup_preflight` (line 206) — startup preflight lockstep check
- `check_codex_skills_install` (line 223) — Codex skills-dir install check
- `check_shared_script_install` (line 238) — shared helper install check
- `check_subagent_model_tier` case branch — `expected_a=2; expected_b=0` per spec (count check is skipped because the SKILL.md uses the new `TIER_A`/`TIER_B` reference format, but the branch is added for forward-compat with the legacy verbose format)

Extends `tests/unit/test_autospec_design.bats` with 6 new assertions covering the enumerations and the case-branch values plus an end-to-end `bash scripts/validate.sh` exit-0 gate. TDD: tests added first (5 red), wiring then made them green.