### PR TITLE
feat(autospec-design): wire top-level install.sh (ALL_SKILLS + --skill case)

### DIFF
--- a/docs/specs/2026-05-26-autospec-design-skill.md
+++ b/docs/specs/2026-05-26-autospec-design-skill.md
@@ -261,7 +261,9 @@ curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstr
 
 Once `autospec-design` is in `ALL_SKILLS`, it gets picked up automatically.
 The per-skill curl one-liner also works once `skills/autospec-design/install.sh`
-exists.
+exists. The top-level `install.sh --skill autospec-design` flag value is
+accepted by the `--skill` validation case (wired in issue #574) and delegates
+to the per-skill installer.
 
 ## Migration path (rollout)
 

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
 #   ./install.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | all
+#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -38,7 +38,7 @@ TURBO_REPO_DIR="${TURBO_REPO_DIR:-$HOME/.turbo/repo}"
 TURBO_REMOTE="https://github.com/tobihagemann/turbo.git"
 CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
 
-ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep"
+ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -270,10 +270,10 @@ done
 
 # Validate --skill
 case "$SKILL_ARG" in
-    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep) ;;
+    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
-        err "must be one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | all"
+        err "must be one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | all"
         exit 2
         ;;
 esac

--- a/skills/autospec-design/README.md
+++ b/skills/autospec-design/README.md
@@ -30,6 +30,13 @@ cd skills/autospec-design
 ./install.sh --harness all
 ```
 
+Or via the top-level orchestrator (`install.sh` at the repo root) which
+delegates to this per-skill installer:
+
+```bash
+./install.sh --skill autospec-design --harness all
+```
+
 ## Invocation
 
 ```

--- a/tests/unit/test_autospec_design.bats
+++ b/tests/unit/test_autospec_design.bats
@@ -189,3 +189,28 @@ teardown() {
     run bash "$REPO_ROOT/scripts/validate.sh"
     [ "$status" -eq 0 ]
 }
+
+# ---- top-level install.sh wiring (issue #574) ----------------------------
+
+@test "top-level install.sh: ALL_SKILLS contains autospec-design" {
+    grep -E '^ALL_SKILLS=' "$REPO_ROOT/install.sh" | grep -q 'autospec-design'
+}
+
+@test "top-level install.sh: --skill validation case accepts autospec-design" {
+    # Find the validation case-statement and confirm autospec-design is listed.
+    block="$(awk '/^case "\$SKILL_ARG" in/{f=1} f{print; if (/^esac/) exit}' "$REPO_ROOT/install.sh")"
+    [ -n "$block" ]
+    printf '%s\n' "$block" | grep -q 'autospec-design'
+}
+
+@test "install.sh --skill autospec-design --harness all --dry-run exits 0" {
+    run env AUTOSPEC_NO_STAR_PROMPT=1 AUTOSPEC_NO_SELF_UPDATE=1 \
+        bash "$REPO_ROOT/install.sh" --skill autospec-design --harness all --dry-run
+    [ "$status" -eq 0 ]
+}
+
+@test "install.sh --skill bogus-skill --dry-run exits non-zero (regression guard)" {
+    run env AUTOSPEC_NO_STAR_PROMPT=1 AUTOSPEC_NO_SELF_UPDATE=1 \
+        bash "$REPO_ROOT/install.sh" --skill bogus-skill --dry-run
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Closes #574

Wires `autospec-design` into the top-level `install.sh` so the standalone-installer one-liner works:

- `ALL_SKILLS` declaration — appended `autospec-design`.
- `--skill` validation case statement — appended `|autospec-design)`.
- Help-text and error-message enumerations updated to match.

Extends `tests/unit/test_autospec_design.bats` with 4 new assertions (ALL_SKILLS contains the skill, validation case accepts it, dry-run exits 0, bogus-skill rejection is preserved as regression guard). TDD: tests added first (3 red), wiring made them green. 26 tests pass; `bash scripts/validate.sh` green.