### PR TITLE
docs(autospec-design): add README skills row + SKILLS.md section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ selected model and harness to execute reliably.
 | [`autospec-stop`](skills/autospec-stop/README.md) | You need to halt or resume an active monitor. | Writes the shared stop sentinel, pauses issues safely, reports status, or resumes paused work. |
 | [`autospec-review`](skills/autospec-review/README.md) | You want to close the spec-vs-code feedback loop. | Audits specs against issues, finds gaps, files `[REGRESSION]` issues with `priority:high`. |
 | [`autospec-test`](skills/autospec-test/README.md) | You want every Phase 4 PR gated on unit + E2E coverage with auto-heal. | Runs a two-stage coverage gate, auto-heals gaps within a 60-min budget, and blocks assertion-loosening rewrites before auto-merge. |
+| [`autospec-design`](skills/autospec-design/README.md) | You want the repo's UI anchored to a known vendor design language (Apple, Linear, Stripe, etc.). | Fetches a `DESIGN.md` from the `berlinguyinca/awesome-design-md` catalog via `suggest`, `apply`, and `migrate` subcommands, writes `DESIGN.md` to the project root on a feature branch, and optionally hands off a per-component migration spec to `/autospec-define`. |
 
 See [`SKILLS.md`](SKILLS.md) for activation keywords and per-skill routing
 details.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -57,6 +57,16 @@
 - Harnesses: Claude Code (`SKILL.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
 - Status: inline Phase 4 gate (runs after build + lint, before auto-merge) plus standalone `/autospec-test [PR#]` invocation. Two-stage: unit coverage → E2E coverage. Self-heal loop up to 5 iterations / 60 min coding time. Assertion-shift guardrail blocks LOOSENING rewrites. Mode II (scoped production) opt-in with mandatory backup/restore.
 
+## autospec-design
+
+- Path: [`skills/autospec-design`](skills/autospec-design)
+- Trigger: use when a user wants the repo's UI anchored to a vendor design language (Apple, Linear, Notion, Stripe, Tesla, etc.) from the `berlinguyinca/awesome-design-md` catalog — pick a vendor, write `DESIGN.md` at the project root on a feature branch, and optionally migrate existing UI to match via per-component `auto-implement` issues.
+- Activation keywords: `autospec-design`, `adopt design`, `design language`, `DESIGN.md`, `apply design`, `suggest design`, `migrate to design`, `vendor design system`
+- Subcommands: `suggest` (rank catalog vendors against repo signals), `apply <vendor>` (fetch + write `DESIGN.md` to project root on a feature branch), `migrate <vendor>` (decompose existing UI into per-component design-migration spec, hand off to `/autospec-define`).
+- Catalog source: [`berlinguyinca/awesome-design-md`](https://github.com/berlinguyinca/awesome-design-md) (fork of `voltagent/awesome-design-md`, MIT). Fetched at runtime via `gh api` with `curl` fallback, cached for 24h under `~/.autospec/design-cache/<vendor>/DESIGN.md`.
+- Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
+- Status: vendor-design adoption skill. See [`docs/specs/2026-05-26-autospec-design-skill.md`](docs/specs/2026-05-26-autospec-design-skill.md) for the design spec and [`skills/autospec-design/README.md`](skills/autospec-design/README.md) for usage.
+
 ## Docs amendment (Phase 10c)
 
 The autospec docs amendment ships first-class documentation artifacts to every target repo.


### PR DESCRIPTION
Closes #575.

## Summary
- Append `autospec-design` row to the Skills table in `README.md` (after `autospec-test`).
- Add `## autospec-design` section to `SKILLS.md` matching the existing per-skill format (path, trigger, activation keywords, subcommands, catalog source, harnesses, status). Cites the suggest / apply / migrate subcommands and the `berlinguyinca/awesome-design-md` catalog.

## Notes for reviewer
- Both files modified are inside the issue's `## Implementation scope`.
- The literal acceptance grep `grep -c '^| autospec-design ' README.md` returns 0 because every existing row in the Skills table uses the linked form `| [\`name\`](path)` — the new row follows that convention (Rule 11: match codebase conventions). `grep -c '^| \[\`autospec-design\`' README.md` returns 1.
- `bash scripts/validate.sh` exits 0 (governance heading checks for autospec-listen + autospec-story remain intact).

## Smoke
- `bash scripts/validate.sh` → OK.