### PR TITLE
feat(autospec-design): implement /autospec-design suggest (rubric scorer + trio prose)

### DIFF
--- a/skills/autospec-design/SKILL.md
+++ b/skills/autospec-design/SKILL.md
@@ -148,16 +148,41 @@ AUTOSPEC_DESIGN_CATALOG_REF="${AUTOSPEC_DESIGN_CATALOG_REF:-main}"
 
 Per-vendor DESIGN.md is fetched via `gh api repos/${owner}/${repo}/contents/design-md/${vendor}/DESIGN.md?ref=${ref} --jq '.content' | base64 -d`, with a fallback to `curl -fsSL https://raw.githubusercontent.com/...`. Cache lands under `~/.autospec/design-cache/<vendor>/DESIGN.md` with a 24h freshness window. The catalog fetcher script lands in issue #576 (`fetch-design-md.sh`).
 
-## Subcommand: suggest (placeholder)
+## Suggest
 
-> **Model tier:** `TIER_B` (implementation work) — scoring is mechanical; rubric is a fixed table.
+> **Model tier:** `TIER_B` (implementation work) — scoring is mechanical; the
+> rubric is a fixed table and the helper is deterministic.
 
-Scaffold-only placeholder. Real prose lands in issue #577. Until then, the
-suggest subcommand prints:
+`suggest` scans the current repo, scores every catalog vendor against a fixed
+rubric, and presents the top 3 candidates with a one-line rationale each. It is
+**read-only** — it never modifies any file in the target repo.
 
+Run the deterministic scorer (it prints tab-separated `<score>\t<vendor>\t<rationale>`
+lines, highest score first):
+
+```bash
+bash skills/autospec-design/scripts/score-suggestion.sh <repo-root>
 ```
-/autospec-design suggest: full implementation lands in issue #577.
-```
+
+The scorer:
+
+1. Fetches the catalog vendor list once (via `gh api .../contents/design-md`,
+   `curl` fallback). When you have already fetched it, pass it in via
+   `AUTOSPEC_DESIGN_VENDORS` to avoid a second round-trip.
+2. Detects repo signals: framework (`package.json`, `next.config.*`,
+   `vite.config.*`, `angular.json`, `svelte.config.*`, Tailwind config), brand
+   keywords (README + `package.json` `name`/`description`), and product-domain
+   keywords (README).
+3. Scores each vendor on the rubric below (cap 6):
+   - **Framework match (+2)** — repo uses a web/JS UI framework AND the vendor
+     is a developer / SaaS / web-product brand (e.g. Linear, Vercel, Stripe).
+   - **Brand match (+1)** — the vendor's normalized name appears in the repo's
+     README or `package.json`.
+   - **Domain match (+1)** — a vendor-name token overlaps the repo README.
+
+Present the top 3 to the user with their rationales and let them pick. Then run
+`/autospec-design apply <vendor>` with the chosen vendor. Do **not** apply
+automatically — `suggest` only recommends.
 
 ## Subcommand: apply (placeholder)
 

--- a/skills/autospec-design/codex/prompt.md
+++ b/skills/autospec-design/codex/prompt.md
@@ -144,16 +144,41 @@ AUTOSPEC_DESIGN_CATALOG_REF="${AUTOSPEC_DESIGN_CATALOG_REF:-main}"
 
 Per-vendor DESIGN.md is fetched via `gh api repos/${owner}/${repo}/contents/design-md/${vendor}/DESIGN.md?ref=${ref} --jq '.content' | base64 -d`, with a fallback to `curl -fsSL https://raw.githubusercontent.com/...`. Cache lands under `~/.autospec/design-cache/<vendor>/DESIGN.md` with a 24h freshness window. The catalog fetcher script lands in issue #576 (`fetch-design-md.sh`).
 
-## Subcommand: suggest (placeholder)
+## Suggest
 
-> **Model tier:** `TIER_B` (implementation work) — scoring is mechanical; rubric is a fixed table.
+> **Model tier:** `TIER_B` (implementation work) — scoring is mechanical; the
+> rubric is a fixed table and the helper is deterministic.
 
-Scaffold-only placeholder. Real prose lands in issue #577. Until then, the
-suggest subcommand prints:
+`suggest` scans the current repo, scores every catalog vendor against a fixed
+rubric, and presents the top 3 candidates with a one-line rationale each. It is
+**read-only** — it never modifies any file in the target repo.
 
+Run the deterministic scorer (it prints tab-separated `<score>\t<vendor>\t<rationale>`
+lines, highest score first):
+
+```bash
+bash skills/autospec-design/scripts/score-suggestion.sh <repo-root>
 ```
-/autospec-design suggest: full implementation lands in issue #577.
-```
+
+The scorer:
+
+1. Fetches the catalog vendor list once (via `gh api .../contents/design-md`,
+   `curl` fallback). When you have already fetched it, pass it in via
+   `AUTOSPEC_DESIGN_VENDORS` to avoid a second round-trip.
+2. Detects repo signals: framework (`package.json`, `next.config.*`,
+   `vite.config.*`, `angular.json`, `svelte.config.*`, Tailwind config), brand
+   keywords (README + `package.json` `name`/`description`), and product-domain
+   keywords (README).
+3. Scores each vendor on the rubric below (cap 6):
+   - **Framework match (+2)** — repo uses a web/JS UI framework AND the vendor
+     is a developer / SaaS / web-product brand (e.g. Linear, Vercel, Stripe).
+   - **Brand match (+1)** — the vendor's normalized name appears in the repo's
+     README or `package.json`.
+   - **Domain match (+1)** — a vendor-name token overlaps the repo README.
+
+Present the top 3 to the user with their rationales and let them pick. Then run
+`/autospec-design apply <vendor>` with the chosen vendor. Do **not** apply
+automatically — `suggest` only recommends.
 
 ## Subcommand: apply (placeholder)
 

--- a/skills/autospec-design/opencode/agent.md
+++ b/skills/autospec-design/opencode/agent.md
@@ -148,16 +148,41 @@ AUTOSPEC_DESIGN_CATALOG_REF="${AUTOSPEC_DESIGN_CATALOG_REF:-main}"
 
 Per-vendor DESIGN.md is fetched via `gh api repos/${owner}/${repo}/contents/design-md/${vendor}/DESIGN.md?ref=${ref} --jq '.content' | base64 -d`, with a fallback to `curl -fsSL https://raw.githubusercontent.com/...`. Cache lands under `~/.autospec/design-cache/<vendor>/DESIGN.md` with a 24h freshness window. The catalog fetcher script lands in issue #576 (`fetch-design-md.sh`).
 
-## Subcommand: suggest (placeholder)
+## Suggest
 
-> **Model tier:** `TIER_B` (implementation work) — scoring is mechanical; rubric is a fixed table.
+> **Model tier:** `TIER_B` (implementation work) — scoring is mechanical; the
+> rubric is a fixed table and the helper is deterministic.
 
-Scaffold-only placeholder. Real prose lands in issue #577. Until then, the
-suggest subcommand prints:
+`suggest` scans the current repo, scores every catalog vendor against a fixed
+rubric, and presents the top 3 candidates with a one-line rationale each. It is
+**read-only** — it never modifies any file in the target repo.
 
+Run the deterministic scorer (it prints tab-separated `<score>\t<vendor>\t<rationale>`
+lines, highest score first):
+
+```bash
+bash skills/autospec-design/scripts/score-suggestion.sh <repo-root>
 ```
-/autospec-design suggest: full implementation lands in issue #577.
-```
+
+The scorer:
+
+1. Fetches the catalog vendor list once (via `gh api .../contents/design-md`,
+   `curl` fallback). When you have already fetched it, pass it in via
+   `AUTOSPEC_DESIGN_VENDORS` to avoid a second round-trip.
+2. Detects repo signals: framework (`package.json`, `next.config.*`,
+   `vite.config.*`, `angular.json`, `svelte.config.*`, Tailwind config), brand
+   keywords (README + `package.json` `name`/`description`), and product-domain
+   keywords (README).
+3. Scores each vendor on the rubric below (cap 6):
+   - **Framework match (+2)** — repo uses a web/JS UI framework AND the vendor
+     is a developer / SaaS / web-product brand (e.g. Linear, Vercel, Stripe).
+   - **Brand match (+1)** — the vendor's normalized name appears in the repo's
+     README or `package.json`.
+   - **Domain match (+1)** — a vendor-name token overlaps the repo README.
+
+Present the top 3 to the user with their rationales and let them pick. Then run
+`/autospec-design apply <vendor>` with the chosen vendor. Do **not** apply
+automatically — `suggest` only recommends.
 
 ## Subcommand: apply (placeholder)
 

--- a/skills/autospec-design/scripts/score-suggestion.sh
+++ b/skills/autospec-design/scripts/score-suggestion.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# score-suggestion.sh — deterministic rubric scorer for /autospec-design suggest.
+#
+# Spec: docs/specs/2026-05-26-autospec-design-skill.md § API shape → suggest.
+#
+# Scans a repo for framework / brand / domain signals, scores every catalog
+# vendor against the repo using a fixed rubric, and prints the top 3 with a
+# one-line rationale. Read-only — never modifies any file in the target repo.
+#
+# Usage:
+#   score-suggestion.sh <repo-root>
+#
+# Rubric (cap 6 per vendor):
+#   +2  framework match  — repo uses a web/JS UI framework AND the vendor is a
+#                          developer / SaaS / web-product brand.
+#   +1  brand match      — vendor's normalized name appears in the repo's
+#                          README or package.json.
+#   +1  domain match     — keyword overlap between the vendor name tokens and
+#                          the repo README.
+#
+# Output: tab-separated "<score>\t<vendor>\t<rationale>" lines, top 3 by score
+# (descending), highest first. Vendors scoring 0 are still eligible if fewer
+# than 3 vendors score above 0.
+#
+# Environment:
+#   AUTOSPEC_DESIGN_VENDORS  — space/newline-separated vendor list. When set,
+#                              used instead of fetching the catalog directory
+#                              (keeps the helper testable offline and lets the
+#                              suggest flow pass a pre-fetched list).
+#   AUTOSPEC_DESIGN_CATALOG_OWNER / _REPO / _REF — catalog coordinates when
+#                              fetching the vendor list (see fetch-design-md.sh).
+#
+# Exit codes:
+#   0  Success.
+#   1  Usage error / repo root missing.
+#   4  Catalog vendor list unavailable (no AUTOSPEC_DESIGN_VENDORS and no
+#      gh/curl reachable).
+
+set -u
+
+OWNER="${AUTOSPEC_DESIGN_CATALOG_OWNER:-berlinguyinca}"
+REPO="${AUTOSPEC_DESIGN_CATALOG_REPO:-awesome-design-md}"
+REF="${AUTOSPEC_DESIGN_CATALOG_REF:-main}"
+
+REPO_ROOT="${1:-}"
+if [ -z "$REPO_ROOT" ]; then
+    printf 'usage: score-suggestion.sh <repo-root>\n' >&2
+    exit 1
+fi
+if [ ! -d "$REPO_ROOT" ]; then
+    printf 'score-suggestion: repo root not found: %s\n' "$REPO_ROOT" >&2
+    exit 1
+fi
+
+# Developer / SaaS / web-product brands in the catalog. A repo built on a
+# web/JS UI framework aligns with these design languages (per spec: "Linear" +
+# "developer tool" maps well to a Next.js repo).
+WEB_PRODUCT_VENDORS=" linear vercel stripe notion figma cursor supabase \
+    sentry posthog framer raycast warp resend sanity mintlify intercom \
+    slack shopify airtable cal claude cohere replicate together mistral \
+    minimax elevenlabs opencode lovable miro zapier wise revolut x.ai \
+    composio clay clickhouse mongodb webflow superhuman expo voltagent "
+
+# ── Repo signal detection ────────────────────────────────────────────────────
+
+# detect_framework — print "web" when a JS/TS UI framework is present, else "".
+detect_framework() {
+    local root="$1"
+    # Config-file signatures.
+    if ls "$root"/next.config.* "$root"/vite.config.* "$root"/angular.json \
+        "$root"/svelte.config.* "$root"/tailwind.config.* > /dev/null 2>&1; then
+        printf 'web'
+        return
+    fi
+    # package.json dependency signatures.
+    if [ -f "$root/package.json" ]; then
+        if grep -qE '"(next|react|vue|svelte|@angular/core|vite|tailwindcss)"' \
+            "$root/package.json" 2> /dev/null; then
+            printf 'web'
+            return
+        fi
+    fi
+    printf ''
+}
+
+# repo_text — concatenated lower-cased README + package.json text for keyword
+# matching. Printed once and reused.
+repo_text() {
+    local root="$1"
+    {
+        [ -f "$root/README.md" ] && cat "$root/README.md"
+        [ -f "$root/readme.md" ] && cat "$root/readme.md"
+        [ -f "$root/package.json" ] && cat "$root/package.json"
+    } 2> /dev/null | tr '[:upper:]' '[:lower:]'
+}
+
+# normalize_vendor — strip common TLD-style suffixes so "linear.app" → "linear".
+normalize_vendor() {
+    local v="$1"
+    v="${v%.app}"
+    v="${v%.ai}"
+    v="${v%.com}"
+    v="${v%.io}"
+    printf '%s' "$v"
+}
+
+# ── Scoring ──────────────────────────────────────────────────────────────────
+
+FRAMEWORK="$(detect_framework "$REPO_ROOT")"
+TEXT="$(repo_text "$REPO_ROOT" | tr '[:lower:]' '[:lower:]')"
+
+# score_vendor VENDOR — print "<score>\t<vendor>\t<rationale>".
+score_vendor() {
+    local vendor="$1"
+    local norm
+    norm="$(normalize_vendor "$vendor" | tr '[:upper:]' '[:lower:]')"
+    local score=0
+    local parts=""
+
+    # Framework match (+2): web framework present AND vendor is a web product.
+    if [ -n "$FRAMEWORK" ]; then
+        case "$WEB_PRODUCT_VENDORS" in
+            *" $norm "*)
+                score=$((score + 2))
+                parts="${parts}framework(+2) "
+                ;;
+        esac
+    fi
+
+    # Brand match (+1): normalized vendor name appears in repo text.
+    if [ -n "$norm" ] && printf '%s' "$TEXT" | grep -qF "$norm"; then
+        score=$((score + 1))
+        parts="${parts}brand(+1) "
+    fi
+
+    # Domain match (+1): any vendor-name token (len >= 4) overlaps repo text,
+    # distinct from a full brand hit (covers multi-word / partial overlap).
+    local token matched_domain=0
+    for token in $(printf '%s' "$norm" | tr -c 'a-z0-9' ' '); do
+        [ "${#token}" -ge 4 ] || continue
+        if printf '%s' "$TEXT" | grep -qF "$token"; then
+            matched_domain=1
+            break
+        fi
+    done
+    if [ "$matched_domain" -eq 1 ]; then
+        # Only add domain credit when it is not already counted as a brand hit.
+        case "$parts" in
+            *"brand(+1)"*) : ;;
+            *)
+                score=$((score + 1))
+                parts="${parts}domain(+1) "
+                ;;
+        esac
+    fi
+
+    # Cap at 6.
+    [ "$score" -gt 6 ] && score=6
+
+    [ -z "$parts" ] && parts="default(+0)"
+    printf '%s\t%s\t%s\n' "$score" "$vendor" "${parts% }"
+}
+
+# ── Vendor list source ───────────────────────────────────────────────────────
+
+vendor_list() {
+    if [ -n "${AUTOSPEC_DESIGN_VENDORS:-}" ]; then
+        printf '%s\n' $AUTOSPEC_DESIGN_VENDORS
+        return 0
+    fi
+    if command -v gh > /dev/null 2>&1; then
+        gh api "repos/$OWNER/$REPO/contents/design-md?ref=$REF" \
+            --jq '.[] | select(.type=="dir") | .name' 2> /dev/null && return 0
+    fi
+    if command -v curl > /dev/null 2>&1; then
+        curl -fsSL \
+            "https://api.github.com/repos/$OWNER/$REPO/contents/design-md?ref=$REF" \
+            2> /dev/null \
+            | grep -oE '"name":[[:space:]]*"[^"]+"' \
+            | sed -E 's/.*"name":[[:space:]]*"([^"]+)".*/\1/' && return 0
+    fi
+    return 4
+}
+
+VENDORS="$(vendor_list)"
+if [ -z "$VENDORS" ]; then
+    printf 'score-suggestion: catalog vendor list unavailable.\n' >&2
+    printf 'score-suggestion: set AUTOSPEC_DESIGN_VENDORS or install gh/curl.\n' >&2
+    exit 4
+fi
+
+# Score every vendor, sort by score DESC (stable on ties via vendor name), top 3.
+{
+    while IFS= read -r v; do
+        [ -z "$v" ] && continue
+        score_vendor "$v"
+    done <<EOF
+$VENDORS
+EOF
+} | sort -t "$(printf '\t')" -k1,1nr -k2,2 | head -3

--- a/tests/unit/test_autospec_design.bats
+++ b/tests/unit/test_autospec_design.bats
@@ -291,3 +291,116 @@ setup_fetch() {
     [ "$status" -ne 0 ]
     echo "$output" | grep -qiE 'install|gh|curl'
 }
+
+# ---- score-suggestion: rubric scorer (issue #577) ------------------------
+# Tests build throwaway fixture repos under $BATS_TEST_TMPDIR and inject the
+# catalog vendor list via $AUTOSPEC_DESIGN_VENDORS so the scorer runs
+# hermetically without hitting the real catalog. The vendor list mirrors a
+# representative slice of berlinguyinca/awesome-design-md.
+
+SCORE_VENDORS="linear.app vercel stripe apple tesla notion figma cursor supabase nike"
+
+setup_score() {
+    SCORE="$SKILL_DIR/scripts/score-suggestion.sh"
+    NEXT_REPO="$BATS_TEST_TMPDIR/nextjs-app"
+    HTML_REPO="$BATS_TEST_TMPDIR/vanilla-html"
+
+    mkdir -p "$NEXT_REPO"
+    cat > "$NEXT_REPO/package.json" <<'EOF'
+{
+  "name": "linear-style-dashboard",
+  "description": "A developer-tool dashboard inspired by Linear's design language.",
+  "dependencies": { "next": "14.0.0", "react": "18.2.0" }
+}
+EOF
+    cat > "$NEXT_REPO/next.config.js" <<'EOF'
+module.exports = {};
+EOF
+    cat > "$NEXT_REPO/README.md" <<'EOF'
+# Linear-style developer dashboard
+
+A Next.js app for engineering teams, modeled after Linear.
+EOF
+
+    mkdir -p "$HTML_REPO"
+    cat > "$HTML_REPO/index.html" <<'EOF'
+<!doctype html>
+<html><head><title>Tesla showroom</title></head>
+<body><h1>Electric vehicles by Tesla</h1></body></html>
+EOF
+    cat > "$HTML_REPO/README.md" <<'EOF'
+# Tesla electric vehicle marketing site
+
+A static HTML brochure site for Tesla cars.
+EOF
+}
+
+@test "score-suggestion: script exists and is executable" {
+    setup_score
+    [ -f "$SCORE" ]
+    [ -x "$SCORE" ]
+}
+
+@test "score-suggestion: no repo arg exits non-zero with usage" {
+    setup_score
+    run bash "$SCORE"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -qi 'usage'
+}
+
+@test "score-suggestion: Next.js fixture scores linear at least 3" {
+    setup_score
+    run env AUTOSPEC_DESIGN_VENDORS="$SCORE_VENDORS" bash "$SCORE" "$NEXT_REPO"
+    [ "$status" -eq 0 ]
+    # Output lines look like: "<score>\t<vendor>\t<rationale>". Find linear's score.
+    linear_line="$(echo "$output" | grep -iE 'linear' | head -1)"
+    [ -n "$linear_line" ]
+    linear_score="$(echo "$linear_line" | grep -oE '^[0-9]+' | head -1)"
+    [ -n "$linear_score" ]
+    [ "$linear_score" -ge 3 ]
+}
+
+@test "score-suggestion: prints at most 3 vendors" {
+    setup_score
+    run env AUTOSPEC_DESIGN_VENDORS="$SCORE_VENDORS" bash "$SCORE" "$NEXT_REPO"
+    [ "$status" -eq 0 ]
+    # Count vendor result lines (those beginning with a score integer).
+    n="$(echo "$output" | grep -cE '^[0-9]+')"
+    [ "$n" -le 3 ]
+    [ "$n" -ge 1 ]
+}
+
+@test "score-suggestion: vanilla HTML top-1 differs from Next.js top-1" {
+    setup_score
+    run env AUTOSPEC_DESIGN_VENDORS="$SCORE_VENDORS" bash "$SCORE" "$NEXT_REPO"
+    [ "$status" -eq 0 ]
+    next_top="$(echo "$output" | grep -E '^[0-9]+' | head -1 | cut -f2)"
+
+    run env AUTOSPEC_DESIGN_VENDORS="$SCORE_VENDORS" bash "$SCORE" "$HTML_REPO"
+    [ "$status" -eq 0 ]
+    html_top="$(echo "$output" | grep -E '^[0-9]+' | head -1 | cut -f2)"
+
+    [ -n "$next_top" ]
+    [ -n "$html_top" ]
+    [ "$next_top" != "$html_top" ]
+}
+
+# ---- suggest-section trio prose + lockstep (issue #577) ------------------
+
+@test "suggest: SKILL.md has a '## Suggest' heading" {
+    run grep -c '^## Suggest' "$SKILL_DIR/SKILL.md"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 1 ]
+}
+
+@test "suggest: lockstep holds after prose addition (SKILL == codex)" {
+    skill_body="$(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/SKILL.md")"
+    codex_body="$(cat "$SKILL_DIR/codex/prompt.md")"
+    [ "$skill_body" = "$codex_body" ]
+}
+
+@test "suggest: lockstep holds after prose addition (SKILL == opencode)" {
+    skill_body="$(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/SKILL.md")"
+    opencode_body="$(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/opencode/agent.md")"
+    [ "$skill_body" = "$opencode_body" ]
+}


### PR DESCRIPTION
Closes #577.

## Summary
- Adds `skills/autospec-design/scripts/score-suggestion.sh` — deterministic, read-only rubric scorer. Detects repo framework / brand / domain signals and scores every catalog vendor (framework +2, brand +1, domain +1; cap 6), printing the top 3 with a one-line rationale.
- Vendor list comes from `$AUTOSPEC_DESIGN_VENDORS` when set (offline-testable, reuses a pre-fetched list) else `gh api` with curl fallback.
- Replaces the placeholder `suggest` section in the SKILL.md / opencode / codex trio with real prose under a `## Suggest` heading; lockstep bodies stay byte-identical.
- Adds 8 bats cases (scorer presence/usage, Next.js → linear >= 3, top-3 cap, Next.js vs vanilla-HTML top-1 divergence, `## Suggest` heading, lockstep equality).

## Issue body amendment
Extended `## Implementation scope` to enumerate the 5 files touched (scorer + trio + bats test) for the OUT_OF_SCOPE guardian.

## Smoke / verification
- `bats tests/unit/test_autospec_design.bats` → 39/39 pass.
- `bash scripts/validate.sh` → OK.
- Scorer output on fixtures:
  - Next.js fixture: `3  linear.app  framework(+2) brand(+1)` (top-1).
  - Vanilla HTML fixture: `1  tesla  brand(+1)` (top-1) — differs from Next.js top-1.