### PR TITLE
feat: add autospec run-state helper

### DIFF
--- a/skills/autospec-run/scripts/run-state.sh
+++ b/skills/autospec-run/scripts/run-state.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# run-state.sh — read/upsert/clear autospec-run GitHub issue state comments.
+
+set -eu
+
+BEGIN_MARKER="<!-- autospec-run-state:begin -->"
+END_MARKER="<!-- autospec-run-state:end -->"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  run-state.sh read   --issue <N> [--repo owner/repo]
+  run-state.sh upsert --issue <N> [--repo owner/repo] --worker-id <id> --state <state> [--step <step>] [--branch <b>] [--pr <p>] [--paths <json-or-csv>] [--ttl-seconds <N>]
+  run-state.sh clear  --issue <N> [--repo owner/repo]
+EOF
+}
+
+die() {
+    printf 'run-state: %s\n' "$1" >&2
+    exit 1
+}
+
+command_name="${1:-}"
+[ -n "$command_name" ] || { usage; exit 1; }
+shift
+
+issue=""
+repo=""
+worker_id=""
+state=""
+step=""
+branch=""
+pr=""
+paths="[]"
+ttl_seconds="10800"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --issue) issue="${2:-}"; shift 2 ;;
+        --repo) repo="${2:-}"; shift 2 ;;
+        --worker-id) worker_id="${2:-}"; shift 2 ;;
+        --state) state="${2:-}"; shift 2 ;;
+        --step) step="${2:-}"; shift 2 ;;
+        --branch) branch="${2:-}"; shift 2 ;;
+        --pr) pr="${2:-}"; shift 2 ;;
+        --paths) paths="${2:-}"; shift 2 ;;
+        --ttl-seconds) ttl_seconds="${2:-}"; shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        *) die "unknown option: $1" ;;
+    esac
+done
+
+[ -n "$issue" ] || die "--issue is required"
+case "$issue" in *[!0-9]*|'') die "--issue must be an integer" ;; esac
+
+if [ -z "$repo" ]; then
+    repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+fi
+[ -n "$repo" ] || die "--repo is required when gh cannot infer it"
+
+comments_json() {
+    gh issue view "$issue" --repo "$repo" --json comments --jq '.comments // []'
+}
+
+state_comment_id() {
+    comments_json | jq -r --arg begin "$BEGIN_MARKER" --arg end "$END_MARKER" '
+      map(select((.body // "") | contains($begin) and contains($end))) |
+      if length == 0 then "" else .[0].id end
+    '
+}
+
+state_comment_body() {
+    comments_json | jq -r --arg begin "$BEGIN_MARKER" --arg end "$END_MARKER" '
+      map(select((.body // "") | contains($begin) and contains($end))) |
+      if length == 0 then "" else .[0].body end
+    '
+}
+
+extract_state_json() {
+    awk -v begin="$BEGIN_MARKER" -v end="$END_MARKER" '
+      $0 == begin { inside=1; next }
+      $0 == end { inside=0; exit }
+      inside { print }
+    '
+}
+
+normalize_paths() {
+    raw="$1"
+    if printf '%s' "$raw" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        printf '%s' "$raw"
+    elif [ -z "$raw" ]; then
+        printf '[]'
+    else
+        printf '%s' "$raw" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))'
+    fi
+}
+
+case "$command_name" in
+    read)
+        body="$(state_comment_body)"
+        [ -n "$body" ] || exit 0
+        json="$(printf '%s\n' "$body" | extract_state_json)"
+        if printf '%s\n' "$json" | jq -e --arg issue "$issue" --arg repo "$repo" \
+            '.schema == 1 and (.issue|tostring) == $issue and .repo == $repo' >/dev/null 2>&1; then
+            printf '%s\n' "$json" | jq .
+        fi
+        ;;
+    upsert)
+        [ -n "$worker_id" ] || die "--worker-id is required for upsert"
+        [ -n "$state" ] || die "--state is required for upsert"
+        [ -n "$step" ] || step="$state"
+        case "$ttl_seconds" in *[!0-9]*|'') die "--ttl-seconds must be an integer" ;; esac
+
+        now_iso="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+        path_json="$(normalize_paths "$paths")"
+        existing="$(state_comment_body)"
+        claimed_at="$now_iso"
+        if [ -n "$existing" ]; then
+            existing_json="$(printf '%s\n' "$existing" | extract_state_json)"
+            claimed_at="$(printf '%s\n' "$existing_json" | jq -r '.claimed_at // empty' 2>/dev/null || true)"
+            [ -n "$claimed_at" ] || claimed_at="$now_iso"
+        fi
+
+        state_json="$(jq -n \
+            --arg repo "$repo" \
+            --arg issue "$issue" \
+            --arg worker_id "$worker_id" \
+            --arg state "$state" \
+            --arg branch "$branch" \
+            --arg pr "$pr" \
+            --arg step "$step" \
+            --argjson paths "$path_json" \
+            --arg claimed_at "$claimed_at" \
+            --arg updated_at "$now_iso" \
+            --argjson ttl_seconds "$ttl_seconds" \
+            '{schema:1, repo:$repo, issue:($issue|tonumber), worker_id:$worker_id, state:$state, branch:$branch, pr:$pr, step:$step, paths:$paths, claimed_at:$claimed_at, updated_at:$updated_at, ttl_seconds:$ttl_seconds}')"
+        body_file="$(mktemp -t autospec-run-state.XXXXXX)"
+        trap 'rm -f "$body_file"' EXIT
+        {
+            printf '%s\n' "$BEGIN_MARKER"
+            printf '%s\n' "$state_json"
+            printf '%s\n' "$END_MARKER"
+        } > "$body_file"
+
+        comment_id="$(state_comment_id)"
+        if [ -n "$comment_id" ] && [ "$comment_id" != "null" ]; then
+            gh api "repos/$repo/issues/comments/$comment_id" -X PATCH -F "body=@$body_file" >/dev/null
+        else
+            gh issue comment "$issue" --repo "$repo" --body-file "$body_file" >/dev/null
+        fi
+        printf '%s\n' "$state_json" | jq .
+        ;;
+    clear)
+        comment_id="$(state_comment_id)"
+        if [ -n "$comment_id" ] && [ "$comment_id" != "null" ]; then
+            gh api "repos/$repo/issues/comments/$comment_id" -X DELETE >/dev/null
+        fi
+        ;;
+    *)
+        usage >&2
+        exit 1
+        ;;
+esac

--- a/tests/unit/test_autospec_run_state.bats
+++ b/tests/unit/test_autospec_run_state.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_run_state.bats — GitHub run-state comment helper.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/skills/autospec-run/scripts/run-state.sh"
+    TEST_TMP="$(mktemp -d)"
+    COMMENTS="$TEST_TMP/comments.json"
+    CALLS="$TEST_TMP/calls.log"
+    printf '[]\n' > "$COMMENTS"
+
+    mkdir -p "$TEST_TMP/bin"
+    cat > "$TEST_TMP/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+
+comments="${AUTOSPEC_TEST_COMMENTS:?}"
+calls="${AUTOSPEC_TEST_CALLS:?}"
+printf '%s\n' "$*" >> "$calls"
+
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  printf 'testorg/testrepo\n'
+  exit 0
+fi
+
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  cat "$comments"
+  exit 0
+fi
+
+if [ "$1" = "issue" ] && [ "$2" = "comment" ]; then
+  body_file=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --body-file) body_file="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  jq --arg body "$(cat "$body_file")" '. + [{id: 1, body: $body}]' "$comments" > "$comments.tmp"
+  mv "$comments.tmp" "$comments"
+  exit 0
+fi
+
+if [ "$1" = "api" ]; then
+  method=""
+  body_file=""
+  url="$2"
+  shift 2
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -X) method="$2"; shift 2 ;;
+      -F)
+        case "$2" in body=@*) body_file="${2#body=@}" ;; esac
+        shift 2
+        ;;
+      *) shift ;;
+    esac
+  done
+  id="${url##*/}"
+  case "$method" in
+    PATCH)
+      jq --argjson id "$id" --arg body "$(cat "$body_file")" \
+        'map(if .id == $id then .body = $body else . end)' "$comments" > "$comments.tmp"
+      mv "$comments.tmp" "$comments"
+      ;;
+    DELETE)
+      jq --argjson id "$id" 'map(select(.id != $id))' "$comments" > "$comments.tmp"
+      mv "$comments.tmp" "$comments"
+      ;;
+  esac
+  exit 0
+fi
+
+exit 1
+SH
+    chmod +x "$TEST_TMP/bin/gh"
+    export PATH="$TEST_TMP/bin:$PATH"
+    export AUTOSPEC_TEST_COMMENTS="$COMMENTS"
+    export AUTOSPEC_TEST_CALLS="$CALLS"
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+@test "run-state.sh supports read, upsert, and clear commands" {
+    run bash "$SCRIPT" upsert --issue 42 --repo testorg/testrepo --worker-id worker-a --state claimed --step claimed
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"state": "claimed"'* ]]
+
+    run bash "$SCRIPT" read --issue 42 --repo testorg/testrepo
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"worker_id": "worker-a"'* ]]
+
+    run bash "$SCRIPT" clear --issue 42 --repo testorg/testrepo
+    [ "$status" -eq 0 ]
+    run bash "$SCRIPT" read --issue 42 --repo testorg/testrepo
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "repeated upsert keeps 1 marked state comment" {
+    bash "$SCRIPT" upsert --issue 42 --repo testorg/testrepo --worker-id worker-a --state claimed --step claimed >/dev/null
+    bash "$SCRIPT" upsert --issue 42 --repo testorg/testrepo --worker-id worker-a --state worktree_ready --step worktree_ready >/dev/null
+
+    run jq '[.[].body | select(contains("autospec-run-state:begin"))] | length' "$COMMENTS"
+    [ "$status" -eq 0 ]
+    [ "$output" = "1" ]
+    run bash "$SCRIPT" read --issue 42 --repo testorg/testrepo
+    [[ "$output" == *'"state": "worktree_ready"'* ]]
+}
+
+@test "invalid schema 0 is replaced" {
+    cat > "$COMMENTS" <<'JSON'
+[
+  {
+    "id": 7,
+    "body": "<!-- autospec-run-state:begin -->\n{\"schema\":0,\"issue\":42,\"repo\":\"testorg/testrepo\"}\n<!-- autospec-run-state:end -->"
+  }
+]
+JSON
+
+    run bash "$SCRIPT" upsert --issue 42 --repo testorg/testrepo --worker-id worker-a --state claimed --step claimed
+    [ "$status" -eq 0 ]
+
+    run jq -r '.[0].id' "$COMMENTS"
+    [ "$output" = "7" ]
+    run jq -r '.[0].body | contains("\"schema\": 1")' "$COMMENTS"
+    [ "$output" = "true" ]
+    run jq '[.[].body | select(contains("autospec-run-state:begin"))] | length' "$COMMENTS"
+    [ "$output" = "1" ]
+}


### PR DESCRIPTION
Closes #590

## Summary

Adds `skills/autospec-run/scripts/run-state.sh`, a GitHub issue comment helper for distributed autospec-run coordination.

## Changes

- Supports `read`, `upsert`, and `clear` commands.
- Stores one marked `autospec-run-state` JSON block per issue.
- Replaces invalid schema `0` state and keeps repeated upserts from stacking comments.
- Adds Bats coverage with a stubbed `gh` CLI and no network calls.

## Validation

- `bats tests/unit/test_autospec_run_state.bats`
- `bash -n skills/autospec-run/scripts/run-state.sh`
- `bash scripts/validate.sh`
