### PR TITLE
feat: add autospec coordination queue planner

### DIFF
--- a/skills/autospec-run/scripts/list-ready-issues.sh
+++ b/skills/autospec-run/scripts/list-ready-issues.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# list-ready-issues.sh — compute safe autospec-run distributed queue candidates.
+
+set -eu
+
+usage() {
+    cat <<'EOF'
+Usage: list-ready-issues.sh [--repo owner/repo] [--batch-size N]
+
+Outputs JSON with ready, blocked, claimed, conflicts, and batch arrays.
+EOF
+}
+
+die() {
+    printf 'list-ready-issues: %s\n' "$1" >&2
+    exit 1
+}
+
+repo=""
+batch_size=3
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --repo) repo="${2:-}"; shift 2 ;;
+        --batch-size) batch_size="${2:-}"; shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        *) die "unknown option: $1" ;;
+    esac
+done
+
+case "$batch_size" in *[!0-9]*|'') die "--batch-size must be an integer" ;; esac
+[ "$batch_size" -gt 0 ] || batch_size=3
+
+if [ -z "$repo" ]; then
+    repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+fi
+[ -n "$repo" ] || die "--repo is required when gh cannot infer it"
+
+issue_list() {
+    label="$1"
+    gh issue list \
+        --repo "$repo" \
+        --state open \
+        --label "$label" \
+        --limit 200 \
+        --json number,title,body,labels
+}
+
+AUTO_FILE="$(mktemp -t autospec-auto-issues.XXXXXX)"
+ACTIVE_FILE="$(mktemp -t autospec-active-issues.XXXXXX)"
+READY_FILE="$(mktemp -t autospec-ready.XXXXXX)"
+BLOCKED_FILE="$(mktemp -t autospec-blocked.XXXXXX)"
+CONFLICTS_FILE="$(mktemp -t autospec-conflicts.XXXXXX)"
+trap 'rm -f "$AUTO_FILE" "$ACTIVE_FILE" "$READY_FILE" "$BLOCKED_FILE" "$CONFLICTS_FILE"' EXIT
+
+issue_list auto-implement > "$AUTO_FILE"
+issue_list in-progress-by-bot > "$ACTIVE_FILE"
+printf '[]\n' > "$READY_FILE"
+printf '[]\n' > "$BLOCKED_FILE"
+printf '[]\n' > "$CONFLICTS_FILE"
+
+extract_paths() {
+    jq -r '.body // ""' | awk '
+      /^## Implementation outline[[:space:]]*$/ { in_outline=1; next }
+      /^## / && in_outline { exit }
+      in_outline { print }
+    ' | grep -Eo '`[^`]+`' | tr -d '`' | grep -E '[/][^[:space:]]+|^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+' || true
+}
+
+extract_deps() {
+    jq -r '.body // ""' | grep -Eo 'Depends on (#|issue )[0-9]+' | grep -Eo '[0-9]+' || true
+}
+
+issue_state() {
+    gh issue view "$1" --repo "$repo" --json state --jq .state 2>/dev/null || printf 'OPEN\n'
+}
+
+json_append() {
+    file="$1"
+    object="$2"
+    jq --argjson object "$object" '. + [$object]' "$file" > "$file.tmp"
+    mv "$file.tmp" "$file"
+}
+
+active_paths_for_issue() {
+    active_issue="$1"
+    jq -c --argjson issue "$active_issue" '.[] | select(.number == $issue)' "$ACTIVE_FILE" | extract_paths
+}
+
+candidate_numbers="$(jq -r 'sort_by(.number) | .[].number' "$AUTO_FILE")"
+for number in $candidate_numbers; do
+    issue_json="$(jq -c --argjson number "$number" '.[] | select(.number == $number)' "$AUTO_FILE")"
+    deps="$(printf '%s\n' "$issue_json" | extract_deps | sort -n | uniq)"
+    unmet=""
+    for dep in $deps; do
+        state="$(issue_state "$dep")"
+        if [ "$state" != "CLOSED" ]; then
+            unmet="${unmet}${unmet:+ }${dep}"
+        fi
+    done
+    if [ -n "$unmet" ]; then
+        object="$(printf '%s\n' "$issue_json" | jq --arg unmet "$unmet" '. + {reason:"blocked_dependencies", unmet_dependencies:($unmet | split(" ") | map(tonumber))}')"
+        json_append "$BLOCKED_FILE" "$object"
+        continue
+    fi
+
+    candidate_paths="$(printf '%s\n' "$issue_json" | extract_paths | sort -u)"
+    conflict_issue=""
+    conflict_path=""
+    active_numbers="$(jq -r 'sort_by(.number) | .[].number' "$ACTIVE_FILE")"
+    for active in $active_numbers; do
+        active_paths="$(active_paths_for_issue "$active" | sort -u)"
+        for path in $candidate_paths; do
+            if printf '%s\n' "$active_paths" | grep -Fx "$path" >/dev/null 2>&1; then
+                conflict_issue="$active"
+                conflict_path="$path"
+                break 2
+            fi
+        done
+    done
+
+    if [ -n "$conflict_issue" ]; then
+        object="$(printf '%s\n' "$issue_json" | jq --argjson conflicts_with "$conflict_issue" --arg path "$conflict_path" '. + {reason:"path_conflict", conflicts_with:$conflicts_with, path:$path}')"
+        json_append "$CONFLICTS_FILE" "$object"
+        continue
+    fi
+
+    object="$(printf '%s\n' "$issue_json" | jq --argjson paths "$(printf '%s\n' "$candidate_paths" | jq -R . | jq -s .)" '. + {paths:$paths}')"
+    json_append "$READY_FILE" "$object"
+done
+
+jq -n \
+    --slurpfile ready "$READY_FILE" \
+    --slurpfile blocked "$BLOCKED_FILE" \
+    --slurpfile conflicts "$CONFLICTS_FILE" \
+    --slurpfile claimed "$ACTIVE_FILE" \
+    --argjson batch_size "$batch_size" \
+    '{
+      ready: ($ready[0] | sort_by(.number)),
+      blocked: ($blocked[0] | sort_by(.number)),
+      claimed: ($claimed[0] | sort_by(.number)),
+      conflicts: ($conflicts[0] | sort_by(.number)),
+      batch: ($ready[0] | sort_by(.number) | .[:$batch_size])
+    }'

--- a/tests/unit/test_autospec_coordination_queue.bats
+++ b/tests/unit/test_autospec_coordination_queue.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_coordination_queue.bats — distributed queue planner.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/skills/autospec-run/scripts/list-ready-issues.sh"
+    TEST_TMP="$(mktemp -d)"
+    AUTO_JSON="$TEST_TMP/auto.json"
+    ACTIVE_JSON="$TEST_TMP/active.json"
+    STATES_JSON="$TEST_TMP/states.json"
+
+    mkdir -p "$TEST_TMP/bin"
+    cat > "$TEST_TMP/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  printf 'testorg/testrepo\n'
+  exit 0
+fi
+
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  label=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --label) label="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  case "$label" in
+    auto-implement) cat "${AUTOSPEC_TEST_AUTO_JSON:?}" ;;
+    in-progress-by-bot) cat "${AUTOSPEC_TEST_ACTIVE_JSON:?}" ;;
+    *) printf '[]\n' ;;
+  esac
+  exit 0
+fi
+
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  issue="$3"
+  jq -r --arg issue "$issue" '.[$issue] // "OPEN"' "${AUTOSPEC_TEST_STATES_JSON:?}"
+  exit 0
+fi
+
+exit 1
+SH
+    chmod +x "$TEST_TMP/bin/gh"
+    export PATH="$TEST_TMP/bin:$PATH"
+    export AUTOSPEC_TEST_AUTO_JSON="$AUTO_JSON"
+    export AUTOSPEC_TEST_ACTIVE_JSON="$ACTIVE_JSON"
+    export AUTOSPEC_TEST_STATES_JSON="$STATES_JSON"
+    printf '[]\n' > "$ACTIVE_JSON"
+    printf '{}\n' > "$STATES_JSON"
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+body_with_path() {
+    local path="$1"
+    cat <<EOF
+## Goal
+Implement fixture.
+
+## Implementation outline
+- \`$path\`: update fixture path.
+
+## Dependencies
+None
+EOF
+}
+
+@test "Depends on #1 blocks issue 2" {
+    body2="$(cat <<'EOF'
+## Goal
+Implement dependent fixture.
+
+## Implementation outline
+- `skills/bar.sh`: update fixture path.
+
+## Dependencies
+Depends on #1
+EOF
+)"
+    jq -n --arg body "$body2" '[{number:2,title:"dependent",body:$body,labels:[{name:"auto-implement"}]}]' > "$AUTO_JSON"
+    printf '{"1":"OPEN"}\n' > "$STATES_JSON"
+
+    run bash "$SCRIPT" --repo testorg/testrepo
+
+    [ "$status" -eq 0 ]
+    planner_output="$output"
+    run bash -c "printf '%s' '$planner_output' | jq -r '.blocked[0].number'"
+    [ "$output" = "2" ]
+    run bash -c "printf '%s' '$planner_output' | jq -r '.ready | length'"
+    [ "$output" = "0" ]
+}
+
+@test "planner groups 4 independent issues in one batch" {
+    jq -n \
+      --arg b1 "$(body_with_path skills/a.sh)" \
+      --arg b2 "$(body_with_path skills/b.sh)" \
+      --arg b3 "$(body_with_path docs/c.md)" \
+      --arg b4 "$(body_with_path tests/d.bats)" \
+      '[
+        {number:10,title:"a",body:$b1,labels:[{name:"auto-implement"}]},
+        {number:11,title:"b",body:$b2,labels:[{name:"auto-implement"}]},
+        {number:12,title:"c",body:$b3,labels:[{name:"auto-implement"}]},
+        {number:13,title:"d",body:$b4,labels:[{name:"auto-implement"}]}
+      ]' > "$AUTO_JSON"
+
+    run bash "$SCRIPT" --repo testorg/testrepo --batch-size 4
+
+    [ "$status" -eq 0 ]
+    run bash -c "printf '%s' '$output' | jq -r '.batch | map(.number) | join(\",\")'"
+    [ "$output" = "10,11,12,13" ]
+}
+
+@test "planner excludes overlapping path skills/foo.sh" {
+    jq -n --arg body "$(body_with_path skills/foo.sh)" \
+      '[{number:20,title:"candidate",body:$body,labels:[{name:"auto-implement"}]}]' > "$AUTO_JSON"
+    jq -n --arg body "$(body_with_path skills/foo.sh)" \
+      '[{number:19,title:"active",body:$body,labels:[{name:"in-progress-by-bot"}]}]' > "$ACTIVE_JSON"
+
+    run bash "$SCRIPT" --repo testorg/testrepo
+
+    [ "$status" -eq 0 ]
+    planner_output="$output"
+    run bash -c "printf '%s' '$planner_output' | jq -r '.conflicts[0].number'"
+    [ "$output" = "20" ]
+    run bash -c "printf '%s' '$planner_output' | jq -r '.conflicts[0].conflicts_with'"
+    [ "$output" = "19" ]
+}


### PR DESCRIPTION
Closes #591

## Summary

Adds a deterministic distributed queue planner for autospec-run.

## Changes

- Adds `skills/autospec-run/scripts/list-ready-issues.sh`.
- Outputs `ready`, `blocked`, `claimed`, `conflicts`, and `batch` arrays as JSON.
- Blocks issues with unmet `Depends on #N` edges.
- Excludes candidates whose implementation outline paths overlap active `in-progress-by-bot` issues.
- Adds fixture-driven Bats coverage with a stubbed `gh` CLI.

## Validation

- `bats tests/unit/test_autospec_coordination_queue.bats`
- `bash -n skills/autospec-run/scripts/list-ready-issues.sh`
- `bash scripts/validate.sh`
