### PR TITLE
feat: add autospec coordination claim helpers

### DIFF
--- a/skills/autospec-run/scripts/claim-issue.sh
+++ b/skills/autospec-run/scripts/claim-issue.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# claim-issue.sh — atomically claim an autospec auto-implement issue.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+RUN_STATE="$SCRIPT_DIR/run-state.sh"
+
+usage() {
+    cat <<'EOF'
+Usage: claim-issue.sh --issue <N> [--repo owner/repo] [--worker-id <id>] [--branch <branch>]
+
+Exit codes:
+  0  issue claimed
+  2  issue was already claimed or is not auto-implement-ready
+EOF
+}
+
+die() {
+    printf 'claim-issue: %s\n' "$1" >&2
+    exit 1
+}
+
+issue=""
+repo=""
+worker_id="${AUTOSPEC_WORKER_ID:-}"
+branch=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --issue) issue="${2:-}"; shift 2 ;;
+        --repo) repo="${2:-}"; shift 2 ;;
+        --worker-id) worker_id="${2:-}"; shift 2 ;;
+        --branch) branch="${2:-}"; shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        *) die "unknown option: $1" ;;
+    esac
+done
+
+[ -n "$issue" ] || die "--issue is required"
+case "$issue" in *[!0-9]*|'') die "--issue must be an integer" ;; esac
+
+if [ -z "$repo" ]; then
+    repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+fi
+[ -n "$repo" ] || die "--repo is required when gh cannot infer it"
+
+if [ -z "$worker_id" ]; then
+    host="$(hostname 2>/dev/null || printf 'unknown-host')"
+    user="${USER:-unknown-user}"
+    worker_id="${host}:${user}:shell:$$:$(date -u +%s)"
+fi
+
+labels="$(gh issue view "$issue" --repo "$repo" --json labels --jq '.labels[].name' 2>/dev/null || true)"
+if ! printf '%s\n' "$labels" | grep -Fx auto-implement >/dev/null 2>&1; then
+    jq -n --argjson issue "$issue" --arg repo "$repo" --arg reason "not_auto_implement" \
+        '{claimed:false, issue:$issue, repo:$repo, reason:$reason}'
+    exit 2
+fi
+
+gh label create in-progress-by-bot --repo "$repo" --color ededed --force >/dev/null 2>&1 || true
+if ! gh issue edit "$issue" --repo "$repo" --remove-label auto-implement --add-label in-progress-by-bot >/dev/null; then
+    jq -n --argjson issue "$issue" --arg repo "$repo" --arg reason "label_mutation_failed" \
+        '{claimed:false, issue:$issue, repo:$repo, reason:$reason}'
+    exit 2
+fi
+
+"$RUN_STATE" upsert \
+    --issue "$issue" \
+    --repo "$repo" \
+    --worker-id "$worker_id" \
+    --state claimed \
+    --step claimed \
+    --branch "$branch" >/dev/null
+
+jq -n \
+    --argjson issue "$issue" \
+    --arg repo "$repo" \
+    --arg worker_id "$worker_id" \
+    --arg branch "$branch" \
+    '{claimed:true, issue:$issue, repo:$repo, worker_id:$worker_id, branch:$branch}'

--- a/skills/autospec-run/scripts/release-issue.sh
+++ b/skills/autospec-run/scripts/release-issue.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# release-issue.sh — release or fail an autospec distributed issue claim.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+RUN_STATE="$SCRIPT_DIR/run-state.sh"
+
+usage() {
+    cat <<'EOF'
+Usage: release-issue.sh --issue <N> [--repo owner/repo] [--worker-id <id>] [--state released|failed] [--branch <branch>] [--pr <PR>]
+EOF
+}
+
+die() {
+    printf 'release-issue: %s\n' "$1" >&2
+    exit 1
+}
+
+issue=""
+repo=""
+worker_id="${AUTOSPEC_WORKER_ID:-}"
+state="released"
+branch=""
+pr=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --issue) issue="${2:-}"; shift 2 ;;
+        --repo) repo="${2:-}"; shift 2 ;;
+        --worker-id) worker_id="${2:-}"; shift 2 ;;
+        --state) state="${2:-}"; shift 2 ;;
+        --branch) branch="${2:-}"; shift 2 ;;
+        --pr) pr="${2:-}"; shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        *) die "unknown option: $1" ;;
+    esac
+done
+
+[ -n "$issue" ] || die "--issue is required"
+case "$issue" in *[!0-9]*|'') die "--issue must be an integer" ;; esac
+case "$state" in released|failed) ;; *) die "--state must be released or failed" ;; esac
+
+if [ -z "$repo" ]; then
+    repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+fi
+[ -n "$repo" ] || die "--repo is required when gh cannot infer it"
+
+if [ -z "$worker_id" ]; then
+    host="$(hostname 2>/dev/null || printf 'unknown-host')"
+    user="${USER:-unknown-user}"
+    worker_id="${host}:${user}:shell:$$:$(date -u +%s)"
+fi
+
+gh issue edit "$issue" --repo "$repo" --remove-label in-progress-by-bot --add-label auto-implement >/dev/null 2>&1 || true
+
+"$RUN_STATE" upsert \
+    --issue "$issue" \
+    --repo "$repo" \
+    --worker-id "$worker_id" \
+    --state "$state" \
+    --step "$state" \
+    --branch "$branch" \
+    --pr "$pr" >/dev/null
+
+jq -n \
+    --argjson issue "$issue" \
+    --arg repo "$repo" \
+    --arg worker_id "$worker_id" \
+    --arg state "$state" \
+    '{released:true, issue:$issue, repo:$repo, worker_id:$worker_id, state:$state}'

--- a/tests/unit/test_autospec_coordination_claim.bats
+++ b/tests/unit/test_autospec_coordination_claim.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_coordination_claim.bats — claim/release helpers.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    CLAIM="$REPO_ROOT/skills/autospec-run/scripts/claim-issue.sh"
+    RELEASE="$REPO_ROOT/skills/autospec-run/scripts/release-issue.sh"
+    TEST_TMP="$(mktemp -d)"
+    LABELS="$TEST_TMP/labels.txt"
+    COMMENTS="$TEST_TMP/comments.json"
+    CALLS="$TEST_TMP/calls.log"
+    printf 'auto-implement\nctx:32k\n' > "$LABELS"
+    printf '[]\n' > "$COMMENTS"
+
+    mkdir -p "$TEST_TMP/bin"
+    cat > "$TEST_TMP/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+
+labels="${AUTOSPEC_TEST_LABELS:?}"
+comments="${AUTOSPEC_TEST_COMMENTS:?}"
+calls="${AUTOSPEC_TEST_CALLS:?}"
+printf '%s\n' "$*" >> "$calls"
+
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  printf 'testorg/testrepo\n'
+  exit 0
+fi
+
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  if printf '%s\n' "$*" | grep -q -- '--json comments'; then
+    cat "$comments"
+  else
+    cat "$labels"
+  fi
+  exit 0
+fi
+
+if [ "$1" = "issue" ] && [ "$2" = "edit" ]; then
+  shift 2
+  add=""
+  remove=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --add-label) add="$2"; shift 2 ;;
+      --remove-label) remove="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [ -n "$remove" ]; then
+    tr ',' '\n' <<<"$remove" | while IFS= read -r label; do
+      [ -n "$label" ] || continue
+      grep -Fxv "$label" "$labels" > "$labels.tmp" && mv "$labels.tmp" "$labels"
+    done
+  fi
+  if [ -n "$add" ]; then
+    tr ',' '\n' <<<"$add" | while IFS= read -r label; do
+      [ -n "$label" ] || continue
+      grep -Fx "$label" "$labels" >/dev/null 2>&1 || printf '%s\n' "$label" >> "$labels"
+    done
+  fi
+  exit 0
+fi
+
+if [ "$1" = "issue" ] && [ "$2" = "comment" ]; then
+  body_file=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --body-file) body_file="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  jq --arg body "$(cat "$body_file")" '. + [{id: 1, body: $body}]' "$comments" > "$comments.tmp"
+  mv "$comments.tmp" "$comments"
+  exit 0
+fi
+
+if [ "$1" = "api" ]; then
+  method=""
+  body_file=""
+  url="$2"
+  shift 2
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -X) method="$2"; shift 2 ;;
+      -F) case "$2" in body=@*) body_file="${2#body=@}" ;; esac; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  id="${url##*/}"
+  if [ "$method" = "PATCH" ]; then
+    jq --argjson id "$id" --arg body "$(cat "$body_file")" \
+      'map(if .id == $id then .body = $body else . end)' "$comments" > "$comments.tmp"
+    mv "$comments.tmp" "$comments"
+  fi
+  exit 0
+fi
+
+exit 1
+SH
+    chmod +x "$TEST_TMP/bin/gh"
+    export PATH="$TEST_TMP/bin:$PATH"
+    export AUTOSPEC_TEST_LABELS="$LABELS"
+    export AUTOSPEC_TEST_COMMENTS="$COMMENTS"
+    export AUTOSPEC_TEST_CALLS="$CALLS"
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+@test "only 1 of 2 workers claims issue 42" {
+    run bash "$CLAIM" --issue 42 --repo testorg/testrepo --worker-id worker-a
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"claimed": true'* ]]
+
+    run bash "$CLAIM" --issue 42 --repo testorg/testrepo --worker-id worker-b
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'"claimed": false'* ]]
+
+    run bash -c "grep -c '^in-progress-by-bot$' '$LABELS'"
+    [ "$output" = "1" ]
+}
+
+@test "release restores auto-implement" {
+    bash "$CLAIM" --issue 42 --repo testorg/testrepo --worker-id worker-a >/dev/null
+
+    run bash "$RELEASE" --issue 42 --repo testorg/testrepo --worker-id worker-a
+
+    [ "$status" -eq 0 ]
+    grep -Fx auto-implement "$LABELS"
+    ! grep -Fx in-progress-by-bot "$LABELS"
+    run jq -r '.[0].body | contains("\"state\": \"released\"")' "$COMMENTS"
+    [ "$output" = "true" ]
+}
+
+@test "claim-issue.sh exits 0 for claimed and 2 for already claimed" {
+    run bash "$CLAIM" --issue 42 --repo testorg/testrepo --worker-id worker-a
+    [ "$status" -eq 0 ]
+
+    run bash "$CLAIM" --issue 42 --repo testorg/testrepo --worker-id worker-b
+    [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
Closes #592

## Summary

Adds distributed autospec-run claim and release helpers.

## Changes

- Adds `claim-issue.sh` to verify `auto-implement`, swap to `in-progress-by-bot`, and upsert `claimed` run-state.
- Adds `release-issue.sh` to restore `auto-implement`, remove active claim label, and mark run-state `released` or `failed`.
- Adds Bats coverage for two-worker claim races, release restore behavior, and exit code `2` for already claimed issues.

## Validation

- `bats tests/unit/test_autospec_coordination_claim.bats`
- `bash -n skills/autospec-run/scripts/claim-issue.sh skills/autospec-run/scripts/release-issue.sh`
- `bash scripts/validate.sh`
