### PR TITLE
feat: reclaim stale autospec run-state claims

### DIFF
--- a/scripts/autospec-watchdog.sh
+++ b/scripts/autospec-watchdog.sh
@@ -204,6 +204,13 @@ json_value() {
     jq -r --arg key "$key" '.[$key] // empty' "$file" 2>/dev/null || true
 }
 
+iso_to_epoch() {
+    ts="$1"
+    date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$ts" +%s 2>/dev/null \
+        || date -u -d "$ts" +%s 2>/dev/null \
+        || echo 0
+}
+
 heartbeat_schema_valid() {
     file="$1"
     issue="$2"
@@ -331,6 +338,84 @@ for hb in "$WATCHDOG_DIR"/*.json; do
         skipped=$((skipped + 1))
     fi
 done
+
+run_state_body_for_issue() {
+    issue="$1"
+    # shellcheck disable=SC2086
+    gh issue view "$issue" $REPO_ARGS \
+        --json comments \
+        --jq '[.comments[]? | select((.body // "") | contains("<!-- autospec-run-state:begin -->") and contains("<!-- autospec-run-state:end -->")) | .body][0] // ""' \
+        2>/dev/null || true
+}
+
+extract_run_state_json() {
+    awk '
+      /^<!-- autospec-run-state:begin -->$/ { inside=1; next }
+      /^<!-- autospec-run-state:end -->$/ { inside=0; exit }
+      inside { print }
+    '
+}
+
+pr_is_open() {
+    pr="$1"
+    [ -n "$pr" ] || return 1
+    # shellcheck disable=SC2086
+    state="$(gh pr view "$pr" $REPO_ARGS --json state --jq .state 2>/dev/null || true)"
+    [ "$state" = "OPEN" ]
+}
+
+reconcile_run_state_comments() {
+    # shellcheck disable=SC2086
+    issue_numbers="$(gh issue list $REPO_ARGS \
+        --state open \
+        --label in-progress-by-bot \
+        --limit 200 \
+        --json number \
+        --jq '.[].number' 2>/dev/null || true)"
+    for issue in $issue_numbers; do
+        body="$(run_state_body_for_issue "$issue")"
+        [ -n "$body" ] || continue
+        run_state_json="$(printf '%s\n' "$body" | extract_run_state_json)"
+        if ! printf '%s\n' "$run_state_json" | jq -e --argjson issue "$issue" \
+            '.schema == 1 and .issue == $issue' >/dev/null 2>&1; then
+            invalid_schema=$((invalid_schema + 1))
+            continue
+        fi
+
+        step="$(printf '%s\n' "$run_state_json" | jq -r '.step // .state // empty')"
+        updated_at="$(printf '%s\n' "$run_state_json" | jq -r '.updated_at // empty')"
+        ttl="$(printf '%s\n' "$run_state_json" | jq -r '.ttl_seconds // empty')"
+        pr="$(printf '%s\n' "$run_state_json" | jq -r '.pr // empty')"
+        case "$ttl" in ''|*[!0-9]*) ttl="$WATCHDOG_RECLAIM_SECS" ;; esac
+        [ -n "$updated_at" ] || continue
+
+        updated_epoch="$(iso_to_epoch "$updated_at")"
+        [ "$updated_epoch" -gt 0 ] || continue
+        age=$((now_ts - updated_epoch))
+        [ "$age" -ge 0 ] || age=0
+
+        case "$step" in
+            pr_created|awaiting_ci)
+                if pr_is_open "$pr"; then
+                    continue
+                fi
+                ;;
+        esac
+
+        if [ "$step" = "claimed" ] && [ "$age" -ge "$WATCHDOG_CLAIMED_TIMEOUT_SECS" ]; then
+            reclaim_issue "$issue" "$age"
+            claimed_released=$((claimed_released + 1))
+            continue
+        fi
+
+        if [ "$age" -ge "$ttl" ]; then
+            reclaim_issue "$issue" "$age"
+            reclaimed=$((reclaimed + 1))
+        fi
+    done
+}
+
+reconcile_run_state_comments
 
 save_state
 printf 'service-watch: nudged=%s reclaimed=%s claimed_released=%s garbage_collected=%s invalid_schema=%s skipped=%s\n' \

--- a/tests/unit/test_autospec_watchdog_run_state.bats
+++ b/tests/unit/test_autospec_watchdog_run_state.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_watchdog_run_state.bats — GitHub run-state reclaim.
+
+WATCHDOG="${BATS_TEST_DIRNAME}/../../scripts/autospec-watchdog.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    export AUTOSPEC_WATCHDOG_DIR="$TEST_TMP/heartbeats"
+    export AUTOSPEC_WATCHDOG_REPO="testorg/testrepo"
+    export AUTOSPEC_WATCHDOG_CLAIMED_TIMEOUT_SECS=300
+    export AUTOSPEC_WATCHDOG_RECLAIM_SECS=10800
+    export AUTOSPEC_WATCHDOG_STALE_SECS=1800
+    export LABELS="$TEST_TMP/labels.txt"
+    export COMMENTS="$TEST_TMP/comments.json"
+    export PR_STATE="$TEST_TMP/pr-state.txt"
+    export CALLS="$TEST_TMP/calls.log"
+    mkdir -p "$AUTOSPEC_WATCHDOG_DIR"
+    printf 'OPEN in-progress-by-bot\n' > "$LABELS"
+    printf 'OPEN\n' > "$PR_STATE"
+
+    mkdir -p "$TEST_TMP/bin"
+    cat > "$TEST_TMP/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$*" >> "${CALLS:?}"
+
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  printf 'testorg/testrepo\n'
+  exit 0
+fi
+
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  jq -r '.[].number' "${COMMENTS:?}"
+  exit 0
+fi
+
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  if printf '%s\n' "$*" | grep -q -- '--json comments'; then
+    issue="$3"
+    jq --argjson issue "$issue" \
+      -r '[.[] | select(.number == $issue) | .body][0] // ""' "${COMMENTS:?}"
+  else
+    cat "${LABELS:?}"
+  fi
+  exit 0
+fi
+
+if [ "$1" = "issue" ] && [ "$2" = "edit" ]; then
+  remove=""
+  add=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --remove-label) remove="$2"; shift 2 ;;
+      --add-label) add="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [ "$remove" = "in-progress-by-bot" ] && [ "$add" = "auto-implement" ]; then
+    printf 'OPEN auto-implement\n' > "$LABELS"
+  fi
+  exit 0
+fi
+
+if [ "$1" = "issue" ] && [ "$2" = "comment" ]; then
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  cat "$PR_STATE"
+  exit 0
+fi
+
+exit 0
+SH
+    chmod +x "$TEST_TMP/bin/gh"
+    export PATH="$TEST_TMP/bin:$PATH"
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+write_state_comment() {
+    local issue="$1"
+    local state="$2"
+    local updated_at="$3"
+    local pr="$4"
+    jq -n \
+      --argjson issue "$issue" \
+      --arg state "$state" \
+      --arg updated_at "$updated_at" \
+      --arg pr "$pr" \
+      '[{
+        number: $issue,
+        body: ("<!-- autospec-run-state:begin -->\n" +
+          ({schema:1,repo:"testorg/testrepo",issue:$issue,worker_id:"worker-a",state:$state,branch:"feat/x",pr:$pr,step:$state,paths:[],claimed_at:$updated_at,updated_at:$updated_at,ttl_seconds:300} | tojson) +
+          "\n<!-- autospec-run-state:end -->")
+      }]'
+}
+
+@test "watchdog restores auto-implement for stale claimed state" {
+    stale="$(date -u -v-10M +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '10 minutes ago' +'%Y-%m-%dT%H:%M:%SZ')"
+    write_state_comment 42 claimed "$stale" "" > "$COMMENTS"
+
+    run bash "$WATCHDOG"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"claimed_released=1"* ]]
+    grep -q -- '--remove-label in-progress-by-bot --add-label auto-implement' "$CALLS"
+}
+
+@test "watchdog keeps pr_created state with open PR 7" {
+    stale="$(date -u -v-4H +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '4 hours ago' +'%Y-%m-%dT%H:%M:%SZ')"
+    write_state_comment 42 pr_created "$stale" "7" > "$COMMENTS"
+    printf 'OPEN\n' > "$PR_STATE"
+
+    run bash "$WATCHDOG"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"reclaimed=0"* ]]
+    grep -q 'in-progress-by-bot' "$LABELS"
+}


### PR DESCRIPTION
Closes #593

## Summary

Extends the autospec watchdog to reconcile GitHub-visible `autospec-run-state` comments.

## Changes

- Reads marked run-state comments from open `in-progress-by-bot` issues.
- Restores stale `claimed` state back to `auto-implement`.
- Preserves `pr_created` / `awaiting_ci` states when their PR is still open.
- Adds Bats coverage for stale claim reclaim and active PR preservation.
- Keeps existing heartbeat tests passing.

## Validation

- `bats tests/unit/test_autospec_watchdog_run_state.bats tests/heartbeat.bats`
- `bash -n scripts/autospec-watchdog.sh`
- `bash scripts/validate.sh`
