### PR TITLE
fix: harden autospec-run distributed coordination

### DIFF
--- a/skills/autospec-run/README.md
+++ b/skills/autospec-run/README.md
@@ -34,7 +34,7 @@ cd skills/autospec-run
 ## Invocation
 
 ```
-/autospec-run [--profile <name>]
+/autospec-run [--profile <name>] [--worker-id <id>] [--coordination-status] [--max-parallel-safe]
 ```
 
 - `--profile <name>` — filter the candidate queue against
@@ -44,10 +44,36 @@ cd skills/autospec-run
 - (no flag) — run with the file's `default:` profile if present; otherwise prints
   `Profile filter inactive — running all auto-implement issues.` and continues
   without filtering.
+- `--worker-id <id>` — override the distributed worker identity written to the
+  GitHub run-state comment for a claimed issue.
+- `--coordination-status` — print the distributed queue state, including ready,
+  blocked, claimed, conflicting, and next-batch issues, then exit without
+  claiming work.
+- `--max-parallel-safe` — print only the next conflict-free batch from the
+  distributed queue planner, then exit without claiming work.
+- `--claim <issue>` — attempt to claim one issue and exit with status `0` when
+  claimed or `2` when the issue is already claimed or not ready.
+- `--release <issue>` — release a claim during failure, stop, or manual recovery.
 
 The full filter logic, deferred-summary accumulation, and `model-profiles.yml`
 auto-init arrive in PR B2 (issue #15). This skill currently plumbs the flag with
 no filter behaviour yet — runs all auto-implement issues regardless of profile.
+
+## Distributed coordination
+
+Multiple workstations can run `autospec-run` against the same GitHub repository.
+The shared queue is GitHub Issues:
+
+- `auto-implement` is the ready queue.
+- `in-progress-by-bot` is the active claim label.
+- A single marked `autospec-run-state` issue comment records worker identity,
+  step, branch, PR, owned paths, and TTL.
+
+Before selecting work, the monitor uses `list-ready-issues.sh` to exclude issues
+with open dependencies or path conflicts. It then uses `claim-issue.sh` to swap
+labels, write run-state, and verify that the same worker still owns the state
+comment. Lost claims are treated as normal races, not failures. The watchdog
+reclaims stale GitHub run-state in addition to same-host heartbeat files.
 
 ## What it does
 

--- a/skills/autospec-run/install.sh
+++ b/skills/autospec-run/install.sh
@@ -275,7 +275,7 @@ install_shared_scripts
 
 info ""
 info "autospec-run skill helper scripts:"
-SKILL_SCRIPT_FILES="heartbeat-write.sh heartbeat-read.sh"
+SKILL_SCRIPT_FILES="heartbeat-write.sh heartbeat-read.sh run-state.sh list-ready-issues.sh claim-issue.sh release-issue.sh"
 for rel in $SKILL_SCRIPT_FILES; do
     skill_scripts_src=""
     if [ -d "$SKILL_DIR/scripts" ]; then

--- a/skills/autospec-run/scripts/claim-issue.sh
+++ b/skills/autospec-run/scripts/claim-issue.sh
@@ -73,6 +73,20 @@ fi
     --step claimed \
     --branch "$branch" >/dev/null
 
+verified_state_json="$("$RUN_STATE" read --issue "$issue" --repo "$repo" 2>/dev/null || true)"
+verified_owner="$(printf '%s\n' "$verified_state_json" | jq -r '.worker_id // empty' 2>/dev/null || true)"
+verified_state="$(printf '%s\n' "$verified_state_json" | jq -r '.state // empty' 2>/dev/null || true)"
+if [ "$verified_owner" != "$worker_id" ] || [ "$verified_state" != "claimed" ]; then
+    jq -n \
+        --argjson issue "$issue" \
+        --arg repo "$repo" \
+        --arg worker_id "$worker_id" \
+        --arg owner "$verified_owner" \
+        --arg state "$verified_state" \
+        '{claimed:false, issue:$issue, repo:$repo, worker_id:$worker_id, reason:"claim_lost", observed_owner:$owner, observed_state:$state}'
+    exit 2
+fi
+
 jq -n \
     --argjson issue "$issue" \
     --arg repo "$repo" \

--- a/skills/autospec-run/scripts/list-ready-issues.sh
+++ b/skills/autospec-run/scripts/list-ready-issues.sh
@@ -68,7 +68,7 @@ extract_paths() {
 }
 
 extract_deps() {
-    jq -r '.body // ""' | grep -Eo 'Depends on (#|issue )[0-9]+' | grep -Eo '[0-9]+' || true
+    jq -r '.body // ""' | grep -Eoi 'Depends on[[:space:]]+(issue[[:space:]]+)?#?[0-9]+' | grep -Eo '[0-9]+' || true
 }
 
 issue_state() {
@@ -85,6 +85,11 @@ json_append() {
 active_paths_for_issue() {
     active_issue="$1"
     jq -c --argjson issue "$active_issue" '.[] | select(.number == $issue)' "$ACTIVE_FILE" | extract_paths
+}
+
+ready_paths_for_issue() {
+    ready_issue="$1"
+    jq -r --argjson issue "$ready_issue" '.[] | select(.number == $issue) | (.paths // [])[]' "$READY_FILE"
 }
 
 candidate_numbers="$(jq -r 'sort_by(.number) | .[].number' "$AUTO_FILE")"
@@ -121,6 +126,24 @@ for number in $candidate_numbers; do
 
     if [ -n "$conflict_issue" ]; then
         object="$(printf '%s\n' "$issue_json" | jq --argjson conflicts_with "$conflict_issue" --arg path "$conflict_path" '. + {reason:"path_conflict", conflicts_with:$conflicts_with, path:$path}')"
+        json_append "$CONFLICTS_FILE" "$object"
+        continue
+    fi
+
+    ready_numbers="$(jq -r 'sort_by(.number) | .[].number' "$READY_FILE")"
+    for ready in $ready_numbers; do
+        ready_paths="$(ready_paths_for_issue "$ready" | sort -u)"
+        for path in $candidate_paths; do
+            if printf '%s\n' "$ready_paths" | grep -Fx "$path" >/dev/null 2>&1; then
+                conflict_issue="$ready"
+                conflict_path="$path"
+                break 2
+            fi
+        done
+    done
+
+    if [ -n "$conflict_issue" ]; then
+        object="$(printf '%s\n' "$issue_json" | jq --argjson conflicts_with "$conflict_issue" --arg path "$conflict_path" '. + {reason:"batch_path_conflict", conflicts_with:$conflicts_with, path:$path}')"
         json_append "$CONFLICTS_FILE" "$object"
         continue
     fi

--- a/skills/autospec-run/scripts/run-state.sh
+++ b/skills/autospec-run/scripts/run-state.sh
@@ -59,14 +59,37 @@ fi
 [ -n "$repo" ] || die "--repo is required when gh cannot infer it"
 
 comments_json() {
-    gh issue view "$issue" --repo "$repo" --json comments --jq '.comments // []'
+    gh api "repos/$repo/issues/$issue/comments" --jq '. // []'
+}
+
+gh_api_retry() {
+    attempts=0
+    max_attempts="${AUTOSPEC_GH_API_RETRIES:-3}"
+    sleep_seconds="${AUTOSPEC_GH_API_RETRY_SLEEP:-1}"
+    case "$max_attempts" in *[!0-9]*|'') max_attempts=3 ;; esac
+    [ "$max_attempts" -gt 0 ] || max_attempts=1
+
+    while :; do
+        if gh api "$@"; then
+            return 0
+        fi
+        attempts=$((attempts + 1))
+        if [ "$attempts" -ge "$max_attempts" ]; then
+            return 1
+        fi
+        sleep "$sleep_seconds"
+    done
+}
+
+state_comment_ids() {
+    comments_json | jq -r --arg begin "$BEGIN_MARKER" --arg end "$END_MARKER" '
+      map(select((.body // "") | contains($begin) and contains($end))) |
+      .[].id
+    '
 }
 
 state_comment_id() {
-    comments_json | jq -r --arg begin "$BEGIN_MARKER" --arg end "$END_MARKER" '
-      map(select((.body // "") | contains($begin) and contains($end))) |
-      if length == 0 then "" else .[0].id end
-    '
+    state_comment_ids | sed -n '1p'
 }
 
 state_comment_body() {
@@ -142,20 +165,22 @@ case "$command_name" in
             printf '%s\n' "$END_MARKER"
         } > "$body_file"
 
-        comment_id="$(state_comment_id)"
-        if [ -n "$comment_id" ] && [ "$comment_id" != "null" ]; then
-            gh api "repos/$repo/issues/comments/$comment_id" -X PATCH -F "body=@$body_file" >/dev/null
-        else
-            gh issue comment "$issue" --repo "$repo" --body-file "$body_file" >/dev/null
-        fi
-        printf '%s\n' "$state_json" | jq .
-        ;;
-    clear)
-        comment_id="$(state_comment_id)"
-        if [ -n "$comment_id" ] && [ "$comment_id" != "null" ]; then
-            gh api "repos/$repo/issues/comments/$comment_id" -X DELETE >/dev/null
-        fi
-        ;;
+	    comment_id="$(state_comment_id)"
+	    if [ -n "$comment_id" ] && [ "$comment_id" != "null" ]; then
+	        gh_api_retry "repos/$repo/issues/comments/$comment_id" -X PATCH -F "body=@$body_file" >/dev/null
+	    else
+	        gh issue comment "$issue" --repo "$repo" --body-file "$body_file" >/dev/null
+	    fi
+	    for duplicate_id in $(state_comment_ids | sed '1d'); do
+	        gh_api_retry "repos/$repo/issues/comments/$duplicate_id" -X DELETE >/dev/null || true
+	    done
+	    printf '%s\n' "$state_json" | jq .
+	    ;;
+	clear)
+	    for comment_id in $(state_comment_ids); do
+	        gh_api_retry "repos/$repo/issues/comments/$comment_id" -X DELETE >/dev/null
+	    done
+	    ;;
     *)
         usage >&2
         exit 1

--- a/tests/e2e/test_autospec_run_live_coordination.bats
+++ b/tests/e2e/test_autospec_run_live_coordination.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+# tests/e2e/test_autospec_run_live_coordination.bats — opt-in live GitHub
+# coordination test for distributed autospec-run helpers.
+#
+# This test creates a throwaway public GitHub repo, seeds a small autospec-run
+# queue, and validates the real GitHub label/comment path. It is skipped unless
+# AUTOSPEC_RUN_LIVE_COORDINATION_E2E=1 is set.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    LIST_READY="$REPO_ROOT/skills/autospec-run/scripts/list-ready-issues.sh"
+    CLAIM="$REPO_ROOT/skills/autospec-run/scripts/claim-issue.sh"
+    RELEASE="$REPO_ROOT/skills/autospec-run/scripts/release-issue.sh"
+    RUN_STATE="$REPO_ROOT/skills/autospec-run/scripts/run-state.sh"
+
+    if [ "${AUTOSPEC_RUN_LIVE_COORDINATION_E2E:-0}" != "1" ]; then
+        skip "set AUTOSPEC_RUN_LIVE_COORDINATION_E2E=1 to run live GitHub coordination e2e"
+    fi
+    if ! command -v gh >/dev/null 2>&1; then
+        skip "gh CLI not installed"
+    fi
+    if ! gh auth status >/dev/null 2>&1; then
+        skip "gh not authenticated (set GH_TOKEN or run gh auth login)"
+    fi
+    OWNER="$(gh api user --jq .login 2>/dev/null || true)"
+    if [ -z "$OWNER" ]; then
+        skip "could not resolve gh user"
+    fi
+
+    TEST_TMP="$(mktemp -d)"
+    SUFFIX="$(date +%s)-$$"
+    THROWAWAY_REPO="$OWNER/autospec-e2e-coordination-$SUFFIX"
+    export TEST_TMP THROWAWAY_REPO
+
+    if ! gh repo create "$THROWAWAY_REPO" --public --confirm >/dev/null 2>&1; then
+        skip "gh repo create denied or unavailable in this environment"
+    fi
+
+    gh label create auto-implement --repo "$THROWAWAY_REPO" --color 0e8a16 --force >/dev/null
+    gh label create in-progress-by-bot --repo "$THROWAWAY_REPO" --color ededed --force >/dev/null
+}
+
+teardown() {
+    if [ -n "${THROWAWAY_REPO:-}" ]; then
+        gh repo delete "$THROWAWAY_REPO" --yes >/dev/null 2>&1 || true
+    fi
+    if [ -n "${TEST_TMP:-}" ] && [ -d "$TEST_TMP" ]; then
+        rm -rf "$TEST_TMP"
+    fi
+}
+
+issue_body() {
+    path="$1"
+    dep="${2:-}"
+    cat <<EOF
+## Goal
+Exercise live distributed autospec-run coordination for \`$path\`.
+
+## Implementation outline
+- \`$path\`: update fixture path.
+
+## Dependencies
+${dep:-None}
+EOF
+}
+
+create_issue() {
+    title="$1"
+    path="$2"
+    dep="${3:-}"
+    body_file="$TEST_TMP/body-${title// /-}.md"
+    issue_body "$path" "$dep" > "$body_file"
+    url="$(gh issue create --repo "$THROWAWAY_REPO" --title "$title" --body-file "$body_file" --label auto-implement)"
+    printf '%s\n' "${url##*/}"
+}
+
+wait_for_auto_queue() {
+    expected="$1"
+    attempts=0
+    while [ "$attempts" -lt 12 ]; do
+        count="$(gh issue list --repo "$THROWAWAY_REPO" --state open --label auto-implement --limit 20 --json number --jq 'length' 2>/dev/null || printf '0')"
+        if [ "$count" -ge "$expected" ]; then
+            return 0
+        fi
+        attempts=$((attempts + 1))
+        sleep 2
+    done
+    printf 'auto-implement queue did not reach %s issues; last count=%s\n' "$expected" "$count" >&2
+    return 1
+}
+
+wait_for_label() {
+    issue="$1"
+    label="$2"
+    attempts=0
+    while [ "$attempts" -lt 12 ]; do
+        labels="$(gh issue view "$issue" --repo "$THROWAWAY_REPO" --json labels --jq '.labels[].name' 2>/dev/null || true)"
+        if printf '%s\n' "$labels" | grep -Fx "$label" >/dev/null 2>&1; then
+            return 0
+        fi
+        attempts=$((attempts + 1))
+        sleep 1
+    done
+    printf 'issue #%s did not reach label %s\n' "$issue" "$label" >&2
+    return 1
+}
+
+claim_async() {
+    issue="$1"
+    worker="$2"
+    out="$TEST_TMP/claim-${issue}-${worker}.json"
+    status_file="$TEST_TMP/claim-${issue}-${worker}.status"
+    (
+        set +e
+        bash "$CLAIM" --repo "$THROWAWAY_REPO" --issue "$issue" --worker-id "$worker" > "$out" 2>&1
+        printf '%s\n' "$?" > "$status_file"
+    ) &
+}
+
+@test "live coordinator plans safe work and settles concurrent claims" {
+    issue_a="$(create_issue "Coordination A" "skills/shared.sh")"
+    issue_b="$(create_issue "Coordination B blocked" "skills/blocked.sh" "Depends on issue #$issue_a")"
+    issue_c="$(create_issue "Coordination C" "docs/independent.md")"
+    issue_d="$(create_issue "Coordination D overlap" "skills/shared.sh")"
+    wait_for_auto_queue 4
+
+    run bash "$LIST_READY" --repo "$THROWAWAY_REPO" --batch-size 4
+    [ "$status" -eq 0 ]
+    planner="$output"
+    batch="$(printf '%s\n' "$planner" | jq -r '.batch | map(.number) | join(",")')"
+    [ "$batch" = "$issue_a,$issue_c" ]
+    blocked="$(printf '%s\n' "$planner" | jq -r '.blocked[0].number')"
+    [ "$blocked" = "$issue_b" ]
+    conflict="$(printf '%s\n' "$planner" | jq -r '.conflicts[0].number')"
+    [ "$conflict" = "$issue_d" ]
+
+    claim_async "$issue_a" worker-a
+    claim_async "$issue_c" worker-c
+    wait
+    [ "$(cat "$TEST_TMP/claim-${issue_a}-worker-a.status")" = "0" ]
+    [ "$(cat "$TEST_TMP/claim-${issue_c}-worker-c.status")" = "0" ]
+
+    labels_a="$(gh issue view "$issue_a" --repo "$THROWAWAY_REPO" --json labels --jq '.labels[].name')"
+    labels_c="$(gh issue view "$issue_c" --repo "$THROWAWAY_REPO" --json labels --jq '.labels[].name')"
+    echo "$labels_a" | grep -Fx in-progress-by-bot >/dev/null
+    echo "$labels_c" | grep -Fx in-progress-by-bot >/dev/null
+
+    bash "$RELEASE" --repo "$THROWAWAY_REPO" --issue "$issue_a" --worker-id worker-a >/dev/null
+    wait_for_label "$issue_a" auto-implement
+
+    claim_async "$issue_a" race-a
+    claim_async "$issue_a" race-b
+    wait
+    status_a="$(cat "$TEST_TMP/claim-${issue_a}-race-a.status")"
+    status_b="$(cat "$TEST_TMP/claim-${issue_a}-race-b.status")"
+    success_count="$(printf '%s\n%s\n' "$status_a" "$status_b" | grep -c '^0$' || true)"
+    [ "$success_count" = "1" ]
+
+    owner="$(bash "$RUN_STATE" read --repo "$THROWAWAY_REPO" --issue "$issue_a" | jq -r '.worker_id')"
+    case "$owner" in
+        race-a|race-b) ;;
+        *) printf 'unexpected owner: %s\n' "$owner"; return 1 ;;
+    esac
+}

--- a/tests/smoke/test_install_all_skills.bats
+++ b/tests/smoke/test_install_all_skills.bats
@@ -18,7 +18,7 @@ setup() {
     export CODEX_HOME="$FAKE_HOME/.codex"
 
     SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep"
-    HELPERS="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh autospec-sweep-wizard.sh autospec-sweep-run.sh autospec-sweep-review.sh"
+    HELPERS="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh autospec-sweep-wizard.sh autospec-sweep-run.sh autospec-sweep-review.sh run-state.sh list-ready-issues.sh claim-issue.sh release-issue.sh"
 }
 
 teardown() {

--- a/tests/unit/test_autospec_coordination_claim.bats
+++ b/tests/unit/test_autospec_coordination_claim.bats
@@ -70,7 +70,11 @@ if [ "$1" = "issue" ] && [ "$2" = "comment" ]; then
       *) shift ;;
     esac
   done
-  jq --arg body "$(cat "$body_file")" '. + [{id: 1, body: $body}]' "$comments" > "$comments.tmp"
+  body="$(cat "$body_file")"
+  if [ -n "${AUTOSPEC_TEST_FORCE_OWNER:-}" ]; then
+    body="$(printf '%s\n' "$body" | sed "s/\"worker_id\": \"[^\"]*\"/\"worker_id\": \"${AUTOSPEC_TEST_FORCE_OWNER}\"/")"
+  fi
+  jq --arg body "$body" '. + [{id: 1, body: $body}]' "$comments" > "$comments.tmp"
   mv "$comments.tmp" "$comments"
   exit 0
 fi
@@ -88,8 +92,16 @@ if [ "$1" = "api" ]; then
     esac
   done
   id="${url##*/}"
+  if [ "$url" = "repos/testorg/testrepo/issues/42/comments" ]; then
+    cat "$comments"
+    exit 0
+  fi
   if [ "$method" = "PATCH" ]; then
-    jq --argjson id "$id" --arg body "$(cat "$body_file")" \
+    body="$(cat "$body_file")"
+    if [ -n "${AUTOSPEC_TEST_FORCE_OWNER:-}" ]; then
+      body="$(printf '%s\n' "$body" | sed "s/\"worker_id\": \"[^\"]*\"/\"worker_id\": \"${AUTOSPEC_TEST_FORCE_OWNER}\"/")"
+    fi
+    jq --argjson id "$id" --arg body "$body" \
       'map(if .id == $id then .body = $body else . end)' "$comments" > "$comments.tmp"
     mv "$comments.tmp" "$comments"
   fi
@@ -103,6 +115,7 @@ SH
     export AUTOSPEC_TEST_LABELS="$LABELS"
     export AUTOSPEC_TEST_COMMENTS="$COMMENTS"
     export AUTOSPEC_TEST_CALLS="$CALLS"
+    export AUTOSPEC_TEST_FORCE_OWNER=""
 }
 
 teardown() {
@@ -140,4 +153,12 @@ teardown() {
 
     run bash "$CLAIM" --issue 42 --repo testorg/testrepo --worker-id worker-b
     [ "$status" -eq 2 ]
+}
+
+@test "claim-issue.sh exits 2 when run-state ownership is lost" {
+    AUTOSPEC_TEST_FORCE_OWNER=worker-b run bash "$CLAIM" --issue 42 --repo testorg/testrepo --worker-id worker-a
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'"claimed": false'* ]]
+    [[ "$output" == *'"reason": "claim_lost"'* ]]
 }

--- a/tests/unit/test_autospec_coordination_queue.bats
+++ b/tests/unit/test_autospec_coordination_queue.bats
@@ -95,6 +95,31 @@ EOF
     [ "$output" = "0" ]
 }
 
+@test "Depends on issue #1 blocks issue 2" {
+    body2="$(cat <<'EOF'
+## Goal
+Implement dependent fixture.
+
+## Implementation outline
+- `skills/bar.sh`: update fixture path.
+
+## Dependencies
+Depends on issue #1
+EOF
+)"
+    jq -n --arg body "$body2" '[{number:2,title:"dependent",body:$body,labels:[{name:"auto-implement"}]}]' > "$AUTO_JSON"
+    printf '{"1":"OPEN"}\n' > "$STATES_JSON"
+
+    run bash "$SCRIPT" --repo testorg/testrepo
+
+    [ "$status" -eq 0 ]
+    planner_output="$output"
+    run bash -c "printf '%s' '$planner_output' | jq -r '.blocked[0].number'"
+    [ "$output" = "2" ]
+    run bash -c "printf '%s' '$planner_output' | jq -r '.ready | length'"
+    [ "$output" = "0" ]
+}
+
 @test "planner groups 4 independent issues in one batch" {
     jq -n \
       --arg b1 "$(body_with_path skills/a.sh)" \
@@ -129,4 +154,25 @@ EOF
     [ "$output" = "20" ]
     run bash -c "printf '%s' '$planner_output' | jq -r '.conflicts[0].conflicts_with'"
     [ "$output" = "19" ]
+}
+
+@test "planner batch excludes ready issues that overlap each other" {
+    jq -n \
+      --arg b1 "$(body_with_path skills/shared.sh)" \
+      --arg b2 "$(body_with_path skills/shared.sh)" \
+      --arg b3 "$(body_with_path docs/independent.md)" \
+      '[
+        {number:30,title:"shared-a",body:$b1,labels:[{name:"auto-implement"}]},
+        {number:31,title:"shared-b",body:$b2,labels:[{name:"auto-implement"}]},
+        {number:32,title:"independent",body:$b3,labels:[{name:"auto-implement"}]}
+      ]' > "$AUTO_JSON"
+
+    run bash "$SCRIPT" --repo testorg/testrepo --batch-size 3
+
+    [ "$status" -eq 0 ]
+    planner_output="$output"
+    run bash -c "printf '%s' '$planner_output' | jq -r '.batch | map(.number) | join(\",\")'"
+    [ "$output" = "30,32" ]
+    run bash -c "printf '%s' '$planner_output' | jq -r '.conflicts[] | select(.number == 31).conflicts_with'"
+    [ "$output" = "30" ]
 }

--- a/tests/unit/test_autospec_run_install_helpers.bats
+++ b/tests/unit/test_autospec_run_install_helpers.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_run_install_helpers.bats — autospec-run installer helper coverage.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    INSTALLER="$REPO_ROOT/skills/autospec-run/install.sh"
+    TEST_TMP="$(mktemp -d)"
+    export HOME="$TEST_TMP/home"
+    export CODEX_HOME="$TEST_TMP/codex"
+    mkdir -p "$HOME" "$CODEX_HOME"
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+@test "autospec-run installer installs distributed coordinator helpers" {
+    run bash "$INSTALLER" --harness codex
+
+    [ "$status" -eq 0 ]
+    for helper in run-state.sh list-ready-issues.sh claim-issue.sh release-issue.sh heartbeat-write.sh heartbeat-read.sh; do
+        [ -f "$HOME/.autospec/scripts/$helper" ]
+        [ -x "$HOME/.autospec/scripts/$helper" ]
+    done
+}

--- a/tests/unit/test_autospec_run_state.bats
+++ b/tests/unit/test_autospec_run_state.bats
@@ -23,11 +23,6 @@ if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
   exit 0
 fi
 
-if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
-  cat "$comments"
-  exit 0
-fi
-
 if [ "$1" = "issue" ] && [ "$2" = "comment" ]; then
   body_file=""
   while [ "$#" -gt 0 ]; do
@@ -57,8 +52,16 @@ if [ "$1" = "api" ]; then
     esac
   done
   id="${url##*/}"
+  if [ "$url" = "repos/testorg/testrepo/issues/42/comments" ]; then
+    cat "$comments"
+    exit 0
+  fi
   case "$method" in
     PATCH)
+      if [ -n "${AUTOSPEC_TEST_FAIL_PATCH_ONCE:-}" ] && [ ! -f "${AUTOSPEC_TEST_PATCH_FAIL_MARKER:?}" ]; then
+        touch "$AUTOSPEC_TEST_PATCH_FAIL_MARKER"
+        exit 1
+      fi
       jq --argjson id "$id" --arg body "$(cat "$body_file")" \
         'map(if .id == $id then .body = $body else . end)' "$comments" > "$comments.tmp"
       mv "$comments.tmp" "$comments"
@@ -77,6 +80,9 @@ SH
     export PATH="$TEST_TMP/bin:$PATH"
     export AUTOSPEC_TEST_COMMENTS="$COMMENTS"
     export AUTOSPEC_TEST_CALLS="$CALLS"
+    export AUTOSPEC_TEST_FAIL_PATCH_ONCE=""
+    export AUTOSPEC_TEST_PATCH_FAIL_MARKER="$TEST_TMP/patch-failed-once"
+    export AUTOSPEC_GH_API_RETRY_SLEEP=0
 }
 
 teardown() {
@@ -129,4 +135,50 @@ JSON
     [ "$output" = "true" ]
     run jq '[.[].body | select(contains("autospec-run-state:begin"))] | length' "$COMMENTS"
     [ "$output" = "1" ]
+}
+
+@test "run-state.sh ignores state comments for another repo" {
+    bash "$SCRIPT" upsert --issue 42 --repo testorg/testrepo --worker-id worker-a --state claimed --step claimed >/dev/null
+
+    run bash "$SCRIPT" read --issue 42 --repo otherorg/otherrepo
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "upsert collapses duplicate marked state comments" {
+    cat > "$COMMENTS" <<'JSON'
+[
+  {
+    "id": 7,
+    "body": "<!-- autospec-run-state:begin -->\n{\"schema\":1,\"issue\":42,\"repo\":\"testorg/testrepo\",\"worker_id\":\"old-a\",\"state\":\"claimed\",\"claimed_at\":\"2026-01-01T00:00:00Z\"}\n<!-- autospec-run-state:end -->"
+  },
+  {
+    "id": 8,
+    "body": "<!-- autospec-run-state:begin -->\n{\"schema\":1,\"issue\":42,\"repo\":\"testorg/testrepo\",\"worker_id\":\"old-b\",\"state\":\"claimed\",\"claimed_at\":\"2026-01-01T00:00:00Z\"}\n<!-- autospec-run-state:end -->"
+  }
+]
+JSON
+
+    run bash "$SCRIPT" upsert --issue 42 --repo testorg/testrepo --worker-id worker-a --state worktree_ready
+
+    [ "$status" -eq 0 ]
+    run jq '[.[].body | select(contains("autospec-run-state:begin"))] | length' "$COMMENTS"
+    [ "$output" = "1" ]
+    run jq -r '.[0].id' "$COMMENTS"
+    [ "$output" = "7" ]
+    run bash "$SCRIPT" read --issue 42 --repo testorg/testrepo
+    [[ "$output" == *'"worker_id": "worker-a"'* ]]
+}
+
+@test "upsert retries transient REST patch failure" {
+    bash "$SCRIPT" upsert --issue 42 --repo testorg/testrepo --worker-id worker-a --state claimed >/dev/null
+    export AUTOSPEC_TEST_FAIL_PATCH_ONCE=1
+
+    run bash "$SCRIPT" upsert --issue 42 --repo testorg/testrepo --worker-id worker-a --state worktree_ready
+
+    [ "$status" -eq 0 ]
+    [ -f "$AUTOSPEC_TEST_PATCH_FAIL_MARKER" ]
+    run bash "$SCRIPT" read --issue 42 --repo testorg/testrepo
+    [[ "$output" == *'"state": "worktree_ready"'* ]]
 }


### PR DESCRIPTION
## Summary
- harden autospec-run distributed run-state against real GitHub REST comment semantics
- verify claim ownership after label mutation and treat lost claims as normal races
- prevent same-batch path conflicts and parse canonical `Depends on issue #N` dependencies
- install coordinator helpers through autospec-run and top-level install smoke coverage
- add opt-in live GitHub two-worker coordination e2e coverage

## Verification
- `bats tests/unit/test_autospec_run_state.bats tests/unit/test_autospec_coordination_claim.bats tests/unit/test_autospec_coordination_queue.bats tests/unit/test_autospec_run_install_helpers.bats`
- `bats tests/smoke/test_install_all_skills.bats`
- `AUTOSPEC_RUN_LIVE_COORDINATION_E2E=1 bats tests/e2e/test_autospec_run_live_coordination.bats`
- `bats tests/e2e/test_autospec_run_live_coordination.bats`
- `bash -n skills/autospec-run/scripts/run-state.sh skills/autospec-run/scripts/claim-issue.sh skills/autospec-run/scripts/list-ready-issues.sh skills/autospec-run/scripts/release-issue.sh scripts/autospec-watchdog.sh`
- `bash scripts/validate.sh`