### PR TITLE
feat: keep autospec updates and quota resumes autonomous

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ build/
 *.log
 *.tmp
 *.bak
+artifacts/
+batch-done.json
+batch-donel.json
 
 # Agent-state artifacts (codesight, omc, claude session state)
 .codesight/

--- a/README.md
+++ b/README.md
@@ -176,9 +176,11 @@ Turbo bootstrap failures are non-fatal: offline or no-remote setups continue usi
 ## Update
 
 Each installed suite skill runs a startup self-update check at most once every
-24 hours. It reinstalls from `main` when a newer commit is available. The check
-is fail-open: network or install errors log a `WARN:` line and the installed
-skill continues to run.
+24 hours. It reinstalls from `main` when a newer commit is available by running
+the curl-safe bootstrap with `--skill all --harness all --update`, so newly added
+autospec skills are picked up during ordinary self-update. The check is
+fail-open: network or install errors log a `WARN:` line and the installed skill
+continues to run.
 
 Disable startup self-update:
 
@@ -313,6 +315,24 @@ Check or resume:
 
 Stop state is stored in `~/.autospec/stop.flag`. Immediate stops preserve resume
 context on the issue and mark it with `paused-by-user`.
+
+## Usage-Limit Recovery
+
+Autospec-run can hand off quota pauses to a shell supervisor before the harness
+runs out of usable LLM turns. Set `AUTOSPEC_RESUME_COMMAND` to the exact command
+that relaunches the same run, then arm the helper with the reset time or wait
+duration:
+
+```bash
+"${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-usage-limit.sh" \
+  arm --harness codex --repo-dir "$PWD" \
+  --command "$AUTOSPEC_RESUME_COMMAND" --wait-seconds 1800
+```
+
+The supervisor stores state in `~/.autospec/usage-limits/`, polls every five
+minutes, and relaunches after the reset time. `/autospec-run` uses the same
+helper when a harness exposes `AUTOSPEC_USAGE_LIMIT_RESUME_AT` or
+`AUTOSPEC_USAGE_LIMIT_WAIT_SECONDS`.
 
 ## Repo Story Mode
 

--- a/docs/memory/MEMORY.md
+++ b/docs/memory/MEMORY.md
@@ -23,6 +23,7 @@
 - [Autospec mutation testing — queued](project_autospec_mutation_testing.md) — test-of-tests layer: mutation testing gate + assertion-density floor + negative-path-pair lint; tracker #420
 - [Cross-tool memory — SHIPPED](project_cross_tool_memory_brainstorm.md) — M1-M5 all merged PRs #503-#507; CC↔Codex↔OpenCode share docs/memory/ via symlink+AGENTS.md inventory; mempalace MCP indexes (2026-05-23)
 - [Session close 2026-05-22→23](project_2026_05_22_23_session_close.md) — ~105 PRs shipped across 11 feature families; queue drained; CI disabled; cross-tool memory live
+- [Gap-remediation + keyword-routing SHIPPED](project_gap_remediation_keyword_routing.md) — 2026-05-24: end-of-run gap-remediation loop (Phase 5.5) + autospec-listen keyword auto-routing; built via parallel-wave opus single-issue monitors on disjoint files (watchdog off, no shared batch-done)
 
 <!-- Archived entries (shipped work; kept in dir for git history but not indexed):
 - project_autospec_review_status.md (autospec-review shipped 2026-05-07)

--- a/docs/memory/feedback_mempalace_integration_boundary.md
+++ b/docs/memory/feedback_mempalace_integration_boundary.md
@@ -1,0 +1,22 @@
+---
+name: feedback-mempalace-integration-boundary
+description: "Autospec ships the shared-memory FLOOR natively; mempalace stays an optional external CLI/MCP plugin — clarify scope when discussing \"integration\""
+metadata:
+  node_type: memory
+  type: feedback
+  wing: synthesis
+  drawer_class: lesson
+  originSessionId: 2e9dc40b-7a14-4cff-8d65-1043d1718ed0
+---
+
+User asked 2026-05-23: "so memplace is no external plugn anymore and completely integrated?" — revealing the assumption that "integration" meant "autospec vendors mempalace." It does not.
+
+**The boundary:**
+- **Native in autospec:** `docs/memory/` filesystem floor, `auto-init-memory.sh` (symlink + AGENTS.md inventory), `mempalace-mine.sh` (frontmatter mining for `wing:` + `drawer_class:`), the AGENTS.md `## Memory inventory` block.
+- **External (optional):** mempalace CLI (`/Users/wohlgemuth/.local/bin/mempalace`), mempalace MCP server (search/KG/traverse/diary). Best-effort: miner calls `mempalace kg-rebuild` if CLI present, silent skip otherwise.
+
+**Why this matters:** the shared-memory contract works without mempalace. Files have mempalace-compatible frontmatter so *any* future indexer can use them, but the rich-query layer is opt-in. Don't conflate "speaks mempalace schema" with "bundles mempalace."
+
+**How to apply:** when describing autospec memory features, distinguish (1) the native floor (always works) from (2) the mempalace overlay (requires external install). When user says "integrated" — clarify they're asking about scope, not assume completion.
+
+**Update 2026-05-23 (PR #509):** user followed up with *"no i want you to completely iplement mempalaca here so its not an external dependency"* — when offered 4 scopes (vendor submodule / bundle source / slim bash reimpl / auto-install), picked **auto-install on first run**. Decision: keep mempalace external (9.1K LOC Python, MIT, chromadb dep) but make `auto-init-memory.sh` `pipx install mempalace` on first migration (with pipx → uv → pip3 → pip fallback chain, opt-out via `AUTOSPEC_SKIP_MEMPALACE_INSTALL=1`). Avoids vendoring a large Python project into a bash-first repo while making mempalace effectively zero-config for end users.

--- a/docs/memory/project_gap_remediation_keyword_routing.md
+++ b/docs/memory/project_gap_remediation_keyword_routing.md
@@ -1,0 +1,19 @@
+---
+name: project-gap-remediation-keyword-routing
+description: Two autospec features shipped 2026-05-24 (end-of-run gap remediation + keyword auto-routing) and the parallel-wave pipeline execution pattern that built them
+metadata:
+  node_type: memory
+  type: project
+  originSessionId: 720b91a2-3664-4f6b-a9ba-ebc4f439de76
+---
+
+Shipped 2026-05-24 in one session, driven end-to-end through autospec's own pipeline per the user directive "use autospec as much as possible / keep it moving":
+
+1. **End-of-run gap remediation loop** — after a run drains, `/autospec-review --remediation --emit-gaps` does a broad review (spec-coverage + correctness + test-quality + integration-wiring + docs) with a false-positive filter, then `gap-remediation-loop.sh` files surviving gaps as `auto-implement,gap-remediation,priority:high` issues, re-looped up to `AUTOSPEC_GAP_MAX_ROUNDS` (default 2). New `## Phase 5.5` section in the autospec-run trio replaced the report-only post-batch audit. Scripts: `run-batch-start.sh`, `gap-json-lib.sh`, `emit-gaps.sh`, `gap-remediation-loop.sh`. Spec `docs/specs/2026-05-24-autospec-end-of-run-gap-remediation-design.md` + plan in `docs/superpowers/plans/`. Issues #530-536, PRs #542/#543/#545/#546/#548/#549/#550, tracker #540 (closed).
+2. **autospec-listen keyword auto-routing** — `listener-match.sh --classify` (verb→skill map + imperative intent gate, biased to false-negatives) + a `## Keyword auto-routing` trio section. Imperative `design`/`new feature`/`spec`→`/autospec-define`, `implement`/`build`/`ship`→`/autospec-run`, `review`→`/autospec-review`, `autospec …`→`/autospec`, with a one-line opt-out. Spec `docs/specs/2026-05-24-autospec-listen-keyword-routing-design.md`. Issues #537-538, PRs #544/#547, tracker #541 (closed).
+
+**Origin:** "review everything for gaps now + always do this at the end" → a deep review found G1/G2/G3 (G1 = a real GNU-vs-BSD grep divergence in `cross-repo-search.sh`), fixed via #525/#526/#527/#528, then institutionalized as feature 1. Keyword-routing from "route common verbs into the autospec loop."
+
+**Parallel-wave execution pattern (the reusable workflow win):** decomposed both specs into 9 dep-linked issues, then drained them as **dependency-ordered waves of parallel opus single-issue monitors** operating on disjoint files. Per monitor: explicit single issue, `run_in_background`, isolated `/tmp/wt-*` worktree off origin/main, primary checkout pinned to `main`, **watchdog reconciliation disabled** (so concurrent siblings don't reclaim each other's claims), and **no shared `~/.autospec/batch-done.json`** (relied on task-completion notifications instead). Concurrent merges were absorbed by the rebase-and-retest gate (BEHIND→rebase→retest). Result: ~zero recovery needed, far faster than sequential. **Opus monitors were 100% reliable across all 16 single-issue runs this session; sonnet truncates** — see [[feedback_monitor_silent_exit]]. Codex peer-review caught 3 real bugs in #532 + a regex-wildcard bug in #535 — keep it in the loop.
+
+**How to apply:** when implementing a decomposed spec via autospec, launch the no-dependency wave as parallel opus single-issue monitors on non-overlapping files, then fire each dependent wave as its deps close. Disable the watchdog and skip the shared batch-done signal for parallel runs. Related: [[project_memory_consumers_epic]] (prior single-monitor run).

--- a/docs/memory/project_memory_consumers_epic.md
+++ b/docs/memory/project_memory_consumers_epic.md
@@ -1,0 +1,32 @@
+---
+name: project-memory-consumers-epic
+description: Epic
+metadata:
+  node_type: memory
+  type: project
+  wing: episodic
+  drawer_class: session-log
+  originSessionId: 2e9dc40b-7a14-4cff-8d65-1043d1718ed0
+---
+
+**STATUS: ALL 7 SHIPPED 2026-05-24** — drained in one `/autospec-run` (PRs #518–524, all admin-squash-merged, 0 failures, 0 deferred). Post-batch `/autospec-review` confirmed full functional coverage + intact lockstep trios; only warn-level docs-drift remained (8 new scripts not yet named in the cross-tool-memory spec; cross-repo/GC still listed "deferred"). User chose to rely on #515's queued `docs:drift` self-heal rather than file/fix. Epic #517 tracker left open/untouched. In practice the issues had NO `Depends-on` declarations (the "needs #512" notes below were design intent, not encoded deps) — all 7 were independent and processed oldest-first.
+
+User reviewed the repo post-M5 merge and said *"ok please do all of these"* after I surfaced 7 follow-up ideas. Picked autospec pipeline mode + all 7 in flight at once.
+
+**Epic #517** (tracker, not auto-implement). Children all carried `auto-implement` + `skill:autospec-run` (now CLOSED):
+
+| # | Issue | What | Dep |
+|---|---|---|---|
+| 1 | #512 | Inject relevant memory into autospec-review / classify / define / monitor prompts | none — KEYSTONE |
+| 2 | #510 | AAAK compression GC via mempalace compress | none |
+| 3 | #511 | Mine PR descriptions + git log into lesson_*.md | none |
+| 4 | #515 | Generalize ensure-tool.sh for bats/jq/gh/mempalace (refactor of #509 helper) | none |
+| 5 | #513 | Diary auto-write on Phase 1→2 + Phase 4 monitor boundaries | needs #512 |
+| 6 | #516 | /autospec-stop --resume driven by feedback_monitor_silent_exit.md | needs #512 |
+| 7 | #514 | Cross-repo memory traversal via ~/.autospec/memory-index/ symlink farm | needs #512 |
+
+**Why this matters:** M1-M5 built the shared-memory FLOOR. Without consumers, the 30 memory files just sit there. #512 is the keystone — once skills actually read memory, the other items have a clear integration target. #515 generalizes the auto-install pattern proved out in PR #509.
+
+**How to apply when resuming:** check `gh issue list --label auto-implement --search "memory in:title"` to see what the monitor has picked up. The pipeline's batch=3 default means 3 in flight at once max (per feedback_autospec_design_prefs.md). If #512 lands first, the dependent children (#513/#514/#516) can proceed without waiting; otherwise the monitor may serialize them. No new labels were created — `skill:autospec-stop` doesn't exist; #516 uses `skill:autospec-run` instead.
+
+Related: [[project-cross-tool-memory-brainstorm]] (M1-M5 SHIPPED), [[feedback-mempalace-integration-boundary]] (auto-install scope decision in PR #509).

--- a/docs/superpowers/specs/2026-05-05-autospec-wednesday-presentation-design.md
+++ b/docs/superpowers/specs/2026-05-05-autospec-wednesday-presentation-design.md
@@ -1,0 +1,350 @@
+# Autospec Wednesday Presentation Design
+
+## Goal
+
+Create a twenty-two-slide light-blue executive presentation that opens with a title slide called "Last 2 Weeks Work", then explains why autospec is needed, shows the request-to-issue-tree workflow, explains autospec's evolution, walks through the local-model hardware search caused by cloud quota exhaustion, explains why LLM context length directly affects local memory and speed, introduces ChemLake/Nexus as the chemistry evidence workspace, closes the LCB-adjacent last-two-weeks delivery section with throughput, and ends by noting that autospec also generates documentation and a rough publication draft.
+
+## Audience
+
+Wednesday meeting attendees who need a fast product-level understanding of autospec without reading the repository.
+
+## Visual Style
+
+Use the global PowerPoint guidelines in `~/.codex/powerpoint-style-guidelines.md`: light background, refined blue system, spacious cards, and simple sketch-style diagrams.
+
+The deck should use one cohesive design language across all slides, matching the older `artifacts/presentations/old.key` visual direction:
+
+- Same header hierarchy on every slide: small blue eyebrow, large navy title, readable gray subtitle, and top-right slide number.
+- Light-blue background, white or pale-blue surfaces, saturated blue emphasis, and subtle sketch-style connector lines.
+- Large airy cards with generous internal padding, soft blue outlines, and small purposeful accent ticks instead of heavy flat blocks.
+- A pale-blue takeaway band near the bottom of each slide.
+- Purposeful accent colors only where they add meaning: warm red for problem state, cyan/green/amber for secondary lanes.
+- Avoid nested dense boxes, tiny pills, duplicated labels, and text that relies on the presenter decoding shorthand.
+- Keep slide 1, slides 4-9, and slides 10-12 visually related while preserving the older deck's stronger "wow" factor.
+
+## Narrative
+
+1. **Title.** Last 2 Weeks Work frames the full update for a mixed audience.
+2. **Why autospec is needed.** AI can generate large volumes of code quickly, but without specs and issue history teams lose the ability to explain why code exists, what it was meant to do, and how it was generated.
+3. **Intent to shipped PRs.** Autospec turns a feature request into a design spec, then a linked 1:n issue tree with epics, tasks, and sub-issues, followed by implementation PRs and merged work.
+4. **Product evolution.** Autospec began as Claude Code skills, was refactored into a tool coordinated through the minion issues browser, and collapsed into one unified multi-harness skill.
+5. **Quota cliff.** Codex and Claude usage ran out during high-throughput autospec work, forcing a local open-source model fallback path.
+6. **Local hardware comparison.** Qwen 3.6 35B-A3B exposed the difference between unified memory and discrete VRAM: a 48GB MacBook could run the experiment while a 22GB-VRAM workstation could not do so comfortably despite 512GB RAM.
+7. **Frontier-model bottleneck.** GLM-5.1 can run with CPU/GPU offload, but the observed ~2 tokens/sec is far below the 20-50 tokens/sec target for productive development; a 256GB Mac Studio is the plausible next test but is expensive and hard to obtain.
+8. **Context window reality.** Context is the LLM's working memory: Claude hides the memory cost in the provider, while local Qwen 3.6 and GLM-5.1 expose long-context cost as VRAM/cache pressure, offload, latency, and lower tokens/sec.
+9. **ChemLake proof point.** The private `metabolomics-us/chemlake` repository shows the pattern in practice: a checked-in ChemSpider spec generated a linked issue tree with an epic, implementation issues, model-fit labels, and PR activity.
+10. **Naming decision.** Claude and Codex both agree that ChemLake is a poor public name; ChemLake remains the internal data-lake codename and Nexus becomes the publication/general-use name.
+11. **Nexus product story.** ChemLake is the internal lake and source-ingestion engine; Nexus is the public workspace that turns source databases into explainable chemistry evidence.
+12. **Nexus architecture.** Hive/Quobyte, Slurm, NATS, and bounded APIs make the internal lake usable without exposing users to raw lake complexity.
+13. **Live Hive coverage.** Real normalized Parquet counts from May 5, 2026 show usable coverage today and concrete source gaps for the next buildout.
+14. **Aspirin lookup showcase.** A single aspirin query demonstrates deterministic cross-source evidence: identity, synonyms, drug evidence, labels, targets, mappings, and query-performance caveat.
+15. **LCB reminder title.** A short section divider makes the final delivery updates read as LCB-relevant operational and scientific guardrails rather than a separate status dump.
+16. **go-modules recovery functionality.** Users can move from "sample is stuck" to bounded recovery actions: retry, repair, inspect logs, or accept a deterministic failed state.
+17. **go-modules operator/runtime surfaces.** Operators can see queues, files, nodes, logs, and audit state while safer worker boundaries keep automation controlled.
+18. **TUI diagnostics.** Sample state and upload events become a traceable timeline for diagnosing lab upload issues.
+19. **WCMC chemical identity and STEAC functionality.** Scientists and operators get safer chemical identity handling, inspectable generated-bin decisions, fewer silent promotions, and clearer failure behavior.
+20. **Shared delivery pattern.** Across projects, the useful pattern is functionality users can understand and operate: recover stuck work, inspect real state, protect scientific decisions, and preserve why each change happened.
+21. **Throughput.** Autospec converted two weeks of work across the discussed repositories into a visible issue graph with 709 created issues, 578 solved issues, and a daily stacked closure plot by project.
+22. **Publication draft example.** Autospec also turns the same evidence trail into generated documentation and a rough Nature Methods-style abstract draft, so teams keep a narrative seed alongside code, issues, and PRs.
+
+## Slide Specification
+
+### Slide 1: Last 2 Weeks Work
+
+- Main message: frame the whole update before the audience sees the details.
+- Use the old blue presentation style: large title, short subtitle, three symmetric agenda cards, and a pale-blue footer.
+- Cards: Autospec delivery, local model reality, and LCB + ChemLake.
+- Keep the slide spacious and executive-readable.
+
+### Slide 2: Make AI-generated code explainable
+
+- Main message: the point is not more code; the point is code with memory.
+- Reference the go-modules cautionary example: the project grew by close to 100k lines of code without a clear historical record of why changes were made or what was added.
+- Show a polished before/after: code volume without a trail versus generated work backed by specs, issues, labels, PRs, and review history.
+- Use the shared three-card system: without a trail, autospec bridge, and with memory.
+
+### Slide 3: Autospec turns intent into shipped work
+
+- Main message: one user request can become a structured delivery pipeline.
+- Use compact step cards for request -> design spec -> 1:n linked issue tree -> PR loop -> merged output, plus three supporting explanation cards.
+- Include supported harnesses: Claude Code, OpenCode, Codex CLI.
+
+### Slide 4: From Claude skills to one autospec skill
+
+- Main message: autospec evolved from prompt collections into a portable operating contract.
+- Show the timeline:
+  - Original Claude Code skill experiments proved the spec-first workflow.
+  - The workflow was refactored into a tool using different specialized agents for research, planning, issue creation, implementation, and review.
+  - The minion issues browser coordinated visibility, ownership, queues, issue trees, and PR progress.
+  - The system collapsed back into one unified skill shared across Claude Code, Codex CLI, and OpenCode.
+- Explain why the collapse matters:
+  - One canonical skill avoids prompt drift across harnesses.
+  - Issue sizing and model-fit labels keep context controlled.
+  - Tiered routing keeps expensive reasoning on spec stages and cheaper loops on implementation.
+  - Subagents are used heavily, but only for bounded parallel work that improves the result.
+- Use the shared card language for the four-stage timeline and two supporting explanation cards.
+
+### Slide 5: Quota limits forced local model experiments
+
+- Main message: Codex and Claude usage exhaustion turned local open-source inference from an optimization into a necessity.
+- Explain the practical problem: autospec, subagents, issue decomposition, review loops, and retries create high token demand.
+- Show the target: not just "can the model run," but "can it run at a development-useful speed."
+- Include the working threshold used in the presentation: around 20-50 tokens/sec is the target range for coding-agent usefulness; around 2 tokens/sec is not interactive enough.
+- Compare two candidate model paths:
+  - Qwen 3.6 35B-A3B: small MoE path that fit the MacBook 48GB experiment.
+  - GLM-5.1: frontier-class agentic coding target with much larger memory pressure.
+
+### Slide 6: Qwen 3.6 exposed the memory architecture gap
+
+- Main message: unified memory can make a smaller MacBook more useful for local LLM testing than a larger workstation when the workstation has insufficient VRAM.
+- Show three comparison cards:
+  - MacBook Pro path: 48GB unified memory, roughly $2.4k, successfully runs the 35B-class MoE experiment.
+  - Workstation path: 512GB system RAM, 22GB VRAM, blocked by discrete-GPU memory limits.
+  - GPU upgrade path: RTX 6000 Ada-class 48GB VRAM upgrade, roughly $6k-$7k, not a sensible near-term purchase.
+- Explain the audience-level distinction: system RAM is not equivalent to VRAM for local inference on a discrete GPU.
+
+### Slide 7: GLM-5.1 runs, but not fast enough yet
+
+- Main message: GLM-5.1 can be made to run by offloading most computation into system memory, but the resulting speed is not usable for development.
+- Show three cards:
+  - Feasible on workstation: hybrid CPU/GPU placement avoids a hard VRAM failure.
+  - Not interactive: observed throughput is about 2 tokens/sec.
+  - Blocked option: a 256GB unified-memory Mac Studio is the likely next experiment but costs around $5k and is hard to find due to high-memory Mac supply constraints.
+- Show a simple speed bar: 2 tok/s current path versus 20-50 tok/s usable target.
+- Web research notes:
+  - Z.ai documents GLM-5.1 as its latest flagship model for long-horizon and agentic coding workflows.
+  - Public GLM-5.1 summaries describe it as a very large open-weight MoE model, so local deployment is primarily a memory-placement problem.
+  - 2026 Mac Studio high-memory configurations have been supply constrained, with top RAM options removed or delayed.
+  - RTX 6000 Ada-class cards provide 48GB VRAM but sit in the multi-thousand-dollar workstation GPU price tier.
+
+### Slide 8: Context is memory, latency, and accuracy budget
+
+- Main message: context length is not just a model-feature number; it consumes memory, slows inference, and can reduce agent usefulness if it forces offload.
+- Explain context for a mixed audience:
+  - Context is the model's working memory: prompt, chat history, tool output, file excerpts, and generated state.
+  - Longer context means more tokens must be attended to and more KV/cache state must be kept during generation.
+  - Cloud models hide local memory pressure; local models expose it directly as VRAM, unified memory, offload, and tokens/sec.
+- Compare the three model paths:
+  - Claude: provider-managed long context, 200K standard with 1M available in eligible deployments; the user pays quota/cost/latency rather than local VRAM.
+  - Qwen 3.6 local MoE: smaller open model path that fit the 48GB unified-memory MacBook experiment.
+  - GLM-5.1: 200K frontier-class long-context target, but much larger MoE weights make local offload the dominant bottleneck.
+- Include a simple horizontal bar plot estimating local context-cache memory pressure for common context sizes: 16k, 64k, 128k, and 200k tokens.
+- Show approximate KV/cache-only values: 1.5GB, 6.0GB, 12.0GB, and 18.8GB, with a 22GB VRAM marker. Label that model weights, runtime overhead, and offloaded layers are additional.
+- Audience takeaway: Claude hides memory pressure in the cloud; local Qwen 3.6 and GLM-5.1 experiments expose it directly as VRAM, offload, and tokens/sec.
+- Source notes:
+  - Anthropic documents Claude context windows as 200K standard, with 1M available for eligible deployments.
+  - Z.ai documents GLM-5.1 as a 200K-context long-horizon model.
+  - Qwen and GLM Hugging Face configs show the architectural fields used to reason about KV/cache size; the plotted values are an explanatory local-estimate, not a measured profiler result.
+
+### Slide 9: ChemLake proof point
+
+- Main message: ChemLake already uses autospec-style decomposition to convert specs into model-sized issue trees and PRs.
+- Include repository data fetched from `metabolomics-us/chemlake` on 2026-05-05:
+  - 1 tracked `docs/specs/*.md` file.
+  - ChemSpider spec generated 9 linked issues: #565 epic plus #566-#572 and #576.
+  - 8 model-fit implementation nodes: 4 `ctx:32k`, 4 `ctx:64k`, all `reasoning:medium`.
+  - Repo-wide activity: 354 issues, 224 PRs, 210 merged PRs, 101 PRs tied to issue-closing/auto branches.
+  - Model/harness evidence: 166 `llm-ready` issues, 142 `batch:small` issues, 99 merged auto/issue-closing PRs, and 75 `codex/*` PR branches.
+- Use shared metric cards and explanation cards showing spec-to-tree, model-fit routing, and PR evidence.
+
+### Slide 10: Naming decision: ChemLake internal, Nexus public
+
+- Main message: ChemLake remains the internal data-lake/repository codename; Nexus is the publication and general-use name.
+- State the naming decision plainly: Claude and Codex both think “ChemLake” is a bad public name.
+- Show a simple rename-boundary diagram:
+  - ChemLake: internal engineering name, Hive data lake, source ingestion, normalized evidence tables.
+  - Nexus: public/product name, user workspace, queries, sharing, and publication-facing chemistry evidence.
+- Bottom chips: internal scope = ChemLake; public scope = Nexus; publication copy = Nexus; code/repo roots = ChemLake.
+- Audience takeaway: ChemLake is what we build and operate internally; Nexus is what users and publications should remember.
+
+### Slide 11: Nexus is a chemistry evidence workspace
+
+- Main message: ChemLake is the internal evidence lake; Nexus is the publication and user-facing workspace.
+- Show a clean left-to-right product story:
+  - Source databases: PubChem, HMDB, DrugBank, DailyMed, GNPS, MoNA, MassBank, SMPDB, and future lanes.
+  - ChemLake internal lake: raw snapshots, normalized identity rows, provenance, work manifests, and release state.
+  - Nexus user surface: compound lookup, saved queries, rerun/diff, sharing, and publication-ready evidence.
+- Keep the data anchors readable: about 11 TB raw lake, 30+ planned source lanes, and a visible shift from database plumbing to workspace outcomes.
+- Bottom takeaway: users should remember Nexus; ChemLake remains the internal engine.
+
+### Slide 12: How the internal lake becomes a usable workspace
+
+- Main message: Hive and Slurm do the heavy lifting inside ChemLake; NATS and bounded APIs turn that work into user-facing Nexus queries.
+- Show the architecture as a simple flow:
+  - Hive/Quobyte: raw snapshots, work manifests, logs, releases, and normalized Parquet close to the data.
+  - Slurm execution: orchestrators recover stale claims, workers process source jobs, and jobs publish releases.
+  - NATS events: worker lifecycle, job progress, cancellation, and request/reply boundaries.
+  - Nexus workspace: saved queries, rerun/diff, sharing, and ChemLake-aware model routing.
+  - Bounded API surface: translation and predefined service queries without exposing raw lake internals.
+- Include a compact metric strip: 11 TB raw lake, 3.9 GB normalized, 329 ChemLake closed, 63 Nexus closed, 76 PubChem closed, and 54 open work.
+- Keep the slide architectural, not a backlog dump.
+
+### Slide 13: Live ChemLake Hive content counts
+
+- Main message: ChemLake now has real normalized chemical identity coverage on Hive, not just planned source lanes.
+- Use live read-only Hive normalized Parquet metadata gathered on May 5, 2026.
+- Show the counts as insight groups rather than a dense table:
+  - PubChem: 247,694,674 identity rows in `snapshot=2026-05-05-overnight-poc`.
+  - DrugBank: 19,858 distinct compound IDs from 3,963,135 identity rows.
+  - HMDB: 217,920 distinct compounds.
+  - MoNA: 851,895 identity rows.
+  - GNPS: 600,328 identity rows.
+  - MassBank: 22,311 identity rows.
+  - DailyMed: 8,071 distinct compounds in full-release labels, plus 68 in daily snapshot.
+  - SMPDB: 53,239 identity rows.
+  - Blood Exposome: 67,150 identity rows.
+- Show missing/discovered compound identity lanes: ChEBI, ChEMBL, KEGG, CAS Common Chemistry, ECHA, FooDB, T3DB, LipidMaps, PubMed, Reactome, Wikidata, MeSH, clinicaltrials, CompTox/DSSTox, and related registered lanes.
+- Do not call PubChem identity rows “distinct compounds” unless the distinct query completes.
+
+### Slide 14: Aspirin lookup showcase
+
+- Main message: one compound lookup becomes an auditable cross-source evidence graph.
+- Use two large panels rather than a dense table:
+  - Resolved identity: formula, InChIKey, SMILES, and compact identifier tags.
+  - Source contributions: PubChem, DrugBank, HMDB, DailyMed, targets, and cross-references.
+- Show aspirin / acetylsalicylic acid identity:
+  - Formula `C9H8O4`.
+  - InChIKey `BSYNRYMUTXBXSQ-UHFFFAOYSA-N`.
+  - SMILES `CC(=O)OC1=CC=CC=C1C(O)=O`.
+  - DrugBank `DB00945`, PubChem CID `2244`, HMDB `HMDB0001879`, CAS `50-78-2`, ChEBI `15365`, ChEMBL `CHEMBL25`, RxCUI `1191`, UNII `R16CO5Y76E`, KEGG `C01405` / `D00109`.
+- Show deterministic local evidence categories:
+  - Synonyms: ASA, acetylsalicylic acid, O-acetylsalicylic acid, Aspirina, Bufferin, Ecotrin, Durlaza, Polopiryna, and multilingual/brand variants.
+  - DrugBank: approved drug indication, proxy strength `0.65`, approved/investigational/veterinary-approved groups, and target evidence including COX-1 and COX-2 inhibitor records.
+  - DailyMed: aspirin product labels including low-dose, Bayer, enteric-coated, delayed-release, and combination products.
+  - PubChem: CID `2244` substance mappings including Tox21, Debye Scientific, and Innovapharm SIDs.
+- Add caveat: this query took about 20 minutes because the backend still uses the large remote databases inefficiently; research is ongoing to make Hive-scale queries remotely usable.
+- Note that no separate exact “asperin” entity was found; useful records resolve under aspirin / acetylsalicylic acid.
+
+### Slide 15: LCB delivery section
+
+- Main message: the final section is not a separate status dump; it shows how autospec-assisted changes landed LCB-relevant operational and scientific guardrails.
+- Use a short section-divider slide before the moved last-two-weeks updates.
+- Show three cards: go-modules, WCMC, and LCB relevance.
+- Explain that the final section contains concrete operational and scientific workflow progress from the last two weeks: fewer stuck jobs, more visible production state, and safer identity automation.
+
+### Slide 16: go-modules recovery and queue control became actionable
+
+- Main message: users can move from stuck samples and queue pressure to bounded recovery paths, controlled retries, and clearer failure causes.
+- Show three symmetric explanation cards: recover failed work, control queue pressure, and explain failure causes.
+- Keep the card grid sparse enough for a mixed audience: one explanatory paragraph plus one result callout per card.
+- Audience takeaway: production failures became recoverable states with controlled retries and clearer operator decisions.
+- Include examples: failed-conversion recovery (#191-#198), missing-result recovery (#229), zombie message repair (#234), backlog relief (#224), transient retry routing (#369), duplicate aggregation guard (#226), explicit aggregation failure reasons (#225), JAR failure state (#237), and segfault recovery (#200/#228).
+
+### Slide 17: go-modules operator surfaces and runtime safety converged
+
+- Main message: production state became visible and automated execution boundaries became safer.
+- Show three symmetric cards: operate from GUI/TUI, audit jobs and files, and run workers safely.
+- Condense the earlier operator-surface and runtime-boundary material into this single slide to reduce end-section density.
+- Audience takeaway: diagnosis and execution moved from ad hoc operations into purpose-built, bounded workflows.
+- Include examples: GUI primitives/pages/live push (#209-#223/#227), job-file audit CLI and docs (#273-#278), audit navigation/native SSH (#310-#317), input hints/footer scoping (#292-#302), canonical Slurm paths (#390), LLM log lookup (#416/#418/#420), and live Slurm node health (#394/#395).
+
+### Slide 18: TUI sample state and upload event tracking
+
+- Main message: add a screenshot-ready slide for the TUI that traces sample state and upload events.
+- Use a large terminal-style screenshot frame on the left, with a placeholder that can be replaced by the real TUI screenshot.
+- The screenshot should show sample ID, state, event, timestamp/location, and enough context to diagnose lab upload issues.
+- Show three explanation cards: diagnose upload timing, trace location, and find lab issues.
+- Audience takeaway: state and event tracking turns lab upload problems into a traceable timeline instead of a late-stage mystery.
+
+### Slide 19: WCMC chemical identity decisions got guardrails
+
+- Main message: STEAC and generated-bin work focused on preventing bad automatic associations and making identity decisions easier to inspect after the fact.
+- Show three larger explanation cards:
+  - Protect identity decisions: assay-version resets, scan-correlation gates, and promotion diagnostics reduce silent promotions of weak identities.
+  - Inspect generated bins: association metadata and profile integration coverage help reviewers trace why an identity exists.
+  - Surface STEAC failures: persistence failures rethrow, fast identity grouping has a concrete direction, and build blockers no longer hide validation.
+- Audience takeaway: chemical identity automation is becoming explainable enough to review and constrained enough to trust.
+- Include examples: assay-version reset (#717), merge gate (#718), promotion diagnostics (#729), generated-bin metadata (#719), STEAC profile integration coverage (#720), local test preservation (#723), persistence failure surfacing (#740/#741), fast identity grouping spec (#746), and build hygiene (#693).
+
+### Slide 20: One delivery pattern across multiple systems
+
+- Main message: the useful pattern is not PR count; it is production problems becoming scoped, reviewed, and delivered as functionality users can operate.
+- Show three user outcomes with short explanations:
+  - Recover stuck work: failures become states with bounded retry, repair, and inspection paths.
+  - Operate real state: queues, files, nodes, logs, and samples are visible through production tools.
+  - Protect decisions: scientific identity handling gets tests, diagnostics, and gates before automation promotes results.
+- Show four autospec principles: specify intended behavior, slice work into bounded changes, verify behavior with checks, and preserve the rationale.
+
+
+### Slide 21: Autospec issue throughput
+
+- Main message: autospec solved 578 issues in the last two weeks and made the closure pattern visible by project.
+- Use GitHub search counts from 2026-04-22 through 2026-05-06 across `berlinguyinca/autospec`, `metabolomics-us/go-modules`, `metabolomics-us/wcmc`, and `metabolomics-us/chemlake`.
+- Show three large number cards:
+  - 709 issues created: autospec 110, go-modules 140, WCMC 47, ChemLake 412.
+  - 578 issues solved/closed: autospec 109, go-modules 83, WCMC 14, ChemLake 372.
+  - 73 workflow-generated issues manually generated by the autospec workflow in the same window.
+- Add a stacked bar plot of closed issues per day, stacked by project:
+  - ChemLake: 372 closed.
+  - autospec: 109 closed.
+  - go-modules: 83 closed.
+  - WCMC: 14 closed.
+- Mark the data as refreshed on May 6, 2026 after the overnight run.
+- Keep this as the final delivery-throughput slide so the audience sees concrete progress before the documentation/publication closer.
+
+### Slide 22: Autospec can draft the Nature Methods abstract too
+
+- Main message: autospec does not stop at issues and PRs; it can also use the ChemLake/Nexus documentation trail to draft publication prose.
+- Use the Nature Methods Article/Resource abstract limit of up to 150 unreferenced words; the draft artifact is 141 words.
+- Show the generated abstract in a large readable card.
+- Show four supporting evidence cards:
+  - Problem: per-compound web searches and heterogeneous identifiers do not scale reproducibly.
+  - ChemLake method: immutable raw snapshots, normalized identities/xrefs/evidence, provenance, DuckDB/Parquet, Hive/Quobyte, Slurm, and NATS-connected workers.
+  - Nexus surface: compound lookups, saved queries, reports, audit trails, and MAP/LCB review flow.
+  - Current scale: 11 TB raw Hive lake plus normalized PubChem, HMDB, DrugBank, DailyMed, MassBank, GNPS, MoNA, and related evidence.
+- Save the complete editable abstract at `artifacts/publications/nexus-nature-methods-abstract.md`.
+- Add a caveat band: the abstract is a human-edit starting point and final claims still need validation before submission.
+- Audience takeaway: autospec preserves enough context to generate docs and a credible publication-draft seed.
+
+## Acceptance Criteria
+
+- Deck has exactly twenty-two slides.
+- Deck uses a consistent light-blue visual style.
+- Each slide contains a sketch-style visual.
+- Slide 1 is a polished opener for the last-two-weeks update with a clear agenda.
+- Slide 2 shows a linked 1:n issue tree rather than a single issue.
+- The deck explains that issues are sized and written for different LLM quality/context tiers.
+- The deck highlights support for multiple models and harnesses.
+- Slide 3 explains the evolution from Claude skills to tool-and-agent orchestration to one unified multi-harness skill.
+- Slides 5-7 explain the local-model fallback story, including Codex/Claude quota exhaustion, Qwen 3.6 versus GLM-5.1, hardware constraints, cost tradeoffs, and the current Mac Studio blocker.
+- Slide 8 explains what LLM context is and shows a horizontal bar plot of estimated context-cache memory pressure at 16k, 64k, 128k, and 200k tokens.
+- Slide 9 includes ChemLake repository counts with the date of retrieval.
+- Slide 10 explains that ChemLake is now the internal name and Nexus is the publication/general-use name.
+- Slide 11 explains Nexus as the public-facing chemistry evidence workspace powered by internal ChemLake source lanes.
+- Slide 12 shows how Hive/Quobyte, Slurm, NATS, and bounded APIs make the internal lake usable from Nexus.
+- Slide 13 shows live ChemLake Hive normalized Parquet content counts from May 5, 2026 without overstating PubChem rows as distinct compounds.
+- Slide 14 shows the deterministic aspirin lookup as readable source-contribution cards and includes the 20-minute query-performance caveat.
+- Slide 15 is an LCB delivery-section transition before the final update slides.
+- Slides 16-17 explain condensed go-modules user-facing functionality delivered from 2026-04-22 to 2026-05-06.
+- Slide 18 provides a screenshot-ready TUI diagnostics slide for sample state and upload event tracking.
+- Slide 19 explains WCMC chemical-identity functionality delivered from 2026-04-22 to 2026-05-06.
+- Slide 20 ties go-modules, WCMC, and ChemLake into one repeated autospec-assisted delivery pattern.
+- Slide 21 shows the refreshed two-week GitHub issue throughput summary, including `berlinguyinca/autospec`, and includes a stacked bar plot of solved issues by project.
+- Slide 22 closes by showing a 141-word Nature Methods-style abstract draft generated from ChemLake/Nexus documentation.
+- A reusable global PowerPoint style guide exists at `~/.codex/powerpoint-style-guidelines.md`.
+
+## Generated Issue Slices
+
+- `PRES-EPIC`: Coordinate the presentation narrative and acceptance criteria.
+- `PRES-1`: Add the opening Last 2 Weeks Work title slide.
+- `PRES-2`: Explain why autospec is needed for documented AI-generated code.
+- `PRES-3`: Create opening narrative and 1:n issue-tree pipeline sketch.
+- `PRES-4`: Explain autospec's evolution from Claude skills to unified multi-harness skill.
+- `PRES-5`: Explain why Codex/Claude quota exhaustion forced local open-source model experiments.
+- `PRES-6`: Compare Qwen 3.6 local inference across MacBook unified memory, workstation VRAM, and RTX 6000 Ada-class GPU upgrade paths.
+- `PRES-7`: Explain the GLM-5.1 offload experiment, speed bottleneck, Mac Studio 256GB blocker, and local frontier-model next step.
+- `PRES-8`: Explain LLM context windows and show estimated local KV/cache memory pressure.
+- `PRES-9`: Add ChemLake proof point using live repository counts.
+- `PRES-10`: Explain the ChemLake-internal / Nexus-public naming decision.
+- `PRES-11`: Explain Nexus as the public chemistry evidence workspace backed by internal ChemLake.
+- `PRES-12`: Explain how Hive/Quobyte, Slurm, NATS, and bounded APIs make the internal lake usable.
+- `PRES-13`: Add live ChemLake Hive normalized Parquet content counts.
+- `PRES-14`: Add deterministic aspirin lookup with query-performance caveat.
+- `PRES-15`: Add the LCB reminder title slide before the final delivery update section.
+- `PRES-16`: Summarize go-modules recovery and queue-control work from the last two weeks.
+- `PRES-17`: Summarize go-modules operator-surface and runtime-boundary work from the last two weeks.
+- `PRES-18`: Add screenshot-ready TUI diagnostics slide for sample state and upload event tracking.
+- `PRES-19`: Summarize WCMC STEAC and chemical-identity safety work from the last two weeks.
+- `PRES-20`: Explain the shared autospec-assisted delivery pattern across go-modules, WCMC, and ChemLake.
+- `PRES-21`: Close with two-week issue throughput across the discussed projects.
+- `PRES-22`: Add the final Nature Methods-style abstract draft slide and markdown artifact.

--- a/scripts/autospec-usage-limit.sh
+++ b/scripts/autospec-usage-limit.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# autospec-usage-limit.sh — deterministic usage-limit pause/resume supervisor.
+#
+# The LLM may be unable to reason after a quota/context limit is reached. This
+# helper records the known reset time and exact resume command before exiting,
+# then a plain shell daemon polls until the reset time and relaunches the command.
+
+set -euo pipefail
+
+DEFAULT_STATE_DIR="${HOME}/.autospec/usage-limits"
+DEFAULT_INTERVAL_SECONDS=300
+
+usage() {
+    cat <<'EOF'
+Usage:
+  autospec-usage-limit.sh arm --harness <claude|codex|opencode> --repo-dir <dir> --command <cmd> (--resume-at <ISO8601>|--wait-seconds <N>) [--run-id <id>] [--interval-seconds <N>] [--state-dir <dir>] [--no-daemon]
+  autospec-usage-limit.sh poll --run-id <id> [--state-dir <dir>] [--foreground]
+  autospec-usage-limit.sh daemon --run-id <id> [--state-dir <dir>]
+  autospec-usage-limit.sh status --run-id <id> [--state-dir <dir>]
+  autospec-usage-limit.sh clear --run-id <id> [--state-dir <dir>]
+
+The daemon polls every 300 seconds by default and launches the recorded command
+after the resume time. Use --foreground in tests to run the command inline.
+EOF
+}
+
+die() {
+    printf 'autospec-usage-limit: %s\n' "$1" >&2
+    exit 1
+}
+
+info() {
+    printf '[autospec-usage-limit] %s\n' "$*"
+}
+
+require_jq() {
+    command -v jq >/dev/null 2>&1 || die "jq is required"
+}
+
+iso_now() {
+    date -u +'%Y-%m-%dT%H:%M:%SZ'
+}
+
+epoch_now() {
+    date -u +%s
+}
+
+iso_to_epoch() {
+    ts="$1"
+    date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$ts" +%s 2>/dev/null \
+        || date -u -d "$ts" +%s 2>/dev/null \
+        || echo 0
+}
+
+epoch_to_iso() {
+    epoch="$1"
+    date -u -r "$epoch" +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+        || date -u -d "@$epoch" +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+        || die "could not format epoch: $epoch"
+}
+
+sanitize_run_id() {
+    printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-'
+}
+
+state_file_for() {
+    state_dir="$1"
+    run_id="$2"
+    printf '%s/%s.json\n' "$state_dir" "$(sanitize_run_id "$run_id")"
+}
+
+write_json_atomic() {
+    target="$1"
+    mkdir -p "$(dirname "$target")"
+    tmp="$(mktemp "${target}.XXXXXX")"
+    cat > "$tmp"
+    mv "$tmp" "$target"
+}
+
+update_state() {
+    file="$1"
+    shift
+    require_jq
+    jq "$@" "$file" | write_json_atomic "$file"
+}
+
+default_run_id() {
+    harness="$1"
+    repo_dir="$2"
+    repo_slug="$(cd "$repo_dir" 2>/dev/null && git remote get-url origin 2>/dev/null \
+        | sed -E 's#^git@[^:]+:##; s#^https?://[^/]+/##; s#\\.git$##; s#[/:]#_#g' \
+        || true)"
+    [ -n "$repo_slug" ] || repo_slug="$(printf '%s' "$repo_dir" | sed 's#[^A-Za-z0-9._-]#_#g')"
+    printf '%s-%s\n' "$harness" "$repo_slug"
+}
+
+command_name="${1:-}"
+[ -n "$command_name" ] || { usage; exit 1; }
+case "$command_name" in --help|-h) usage; exit 0 ;; esac
+shift
+
+STATE_DIR="$DEFAULT_STATE_DIR"
+RUN_ID=""
+HARNESS=""
+REPO_DIR=""
+RESUME_COMMAND=""
+RESUME_AT=""
+WAIT_SECONDS=""
+INTERVAL_SECONDS="$DEFAULT_INTERVAL_SECONDS"
+NO_DAEMON=0
+FOREGROUND=0
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --state-dir) STATE_DIR="${2:-}"; shift 2 ;;
+        --run-id) RUN_ID="${2:-}"; shift 2 ;;
+        --harness) HARNESS="${2:-}"; shift 2 ;;
+        --repo-dir) REPO_DIR="${2:-}"; shift 2 ;;
+        --command) RESUME_COMMAND="${2:-}"; shift 2 ;;
+        --resume-at) RESUME_AT="${2:-}"; shift 2 ;;
+        --wait-seconds) WAIT_SECONDS="${2:-}"; shift 2 ;;
+        --interval-seconds) INTERVAL_SECONDS="${2:-}"; shift 2 ;;
+        --no-daemon) NO_DAEMON=1; shift ;;
+        --foreground) FOREGROUND=1; shift ;;
+        --help|-h) usage; exit 0 ;;
+        *) die "unknown option: $1" ;;
+    esac
+done
+
+case "$INTERVAL_SECONDS" in *[!0-9]*|'') die "--interval-seconds must be an integer" ;; esac
+[ "$INTERVAL_SECONDS" -gt 0 ] || die "--interval-seconds must be > 0"
+
+case "$command_name" in
+    arm)
+        require_jq
+        [ -n "$HARNESS" ] || die "--harness is required"
+        case "$HARNESS" in claude|codex|opencode) ;; *) die "--harness must be claude, codex, or opencode" ;; esac
+        [ -n "$REPO_DIR" ] || die "--repo-dir is required"
+        [ -d "$REPO_DIR" ] || die "--repo-dir does not exist: $REPO_DIR"
+        [ -n "$RESUME_COMMAND" ] || die "--command is required"
+        if [ -n "$RESUME_AT" ] && [ -n "$WAIT_SECONDS" ]; then
+            die "use either --resume-at or --wait-seconds, not both"
+        fi
+        if [ -n "$WAIT_SECONDS" ]; then
+            case "$WAIT_SECONDS" in *[!0-9]*|'') die "--wait-seconds must be an integer" ;; esac
+            RESUME_AT="$(epoch_to_iso "$(( $(epoch_now) + WAIT_SECONDS ))")"
+        fi
+        [ -n "$RESUME_AT" ] || die "--resume-at or --wait-seconds is required"
+        [ "$(iso_to_epoch "$RESUME_AT")" -gt 0 ] || die "--resume-at must be ISO8601 UTC, e.g. 2026-05-27T03:00:00Z"
+        [ -n "$RUN_ID" ] || RUN_ID="$(default_run_id "$HARNESS" "$REPO_DIR")"
+        state_file="$(state_file_for "$STATE_DIR" "$RUN_ID")"
+        log_dir="${HOME}/.autospec/logs"
+        mkdir -p "$STATE_DIR" "$log_dir"
+        run_log="$log_dir/usage-limit-$(sanitize_run_id "$RUN_ID").log"
+        daemon_log="$log_dir/usage-limit-$(sanitize_run_id "$RUN_ID").daemon.log"
+        jq -n \
+            --argjson schema 1 \
+            --arg run_id "$RUN_ID" \
+            --arg harness "$HARNESS" \
+            --arg repo_dir "$REPO_DIR" \
+            --arg command "$RESUME_COMMAND" \
+            --arg resume_at "$RESUME_AT" \
+            --arg created_at "$(iso_now)" \
+            --arg status "waiting" \
+            --arg run_log "$run_log" \
+            --arg daemon_log "$daemon_log" \
+            --arg last_poll_at "" \
+            --arg resumed_at "" \
+            --argjson interval_seconds "$INTERVAL_SECONDS" \
+            --argjson attempts 0 \
+            '{schema:$schema,run_id:$run_id,harness:$harness,repo_dir:$repo_dir,command:$command,resume_at:$resume_at,interval_seconds:$interval_seconds,status:$status,attempts:$attempts,created_at:$created_at,last_poll_at:$last_poll_at,resumed_at:$resumed_at,run_log:$run_log,daemon_log:$daemon_log}' \
+            | write_json_atomic "$state_file"
+        info "armed $RUN_ID; resume_at=$RESUME_AT"
+        if [ "$NO_DAEMON" -eq 0 ]; then
+            nohup bash "$0" daemon --run-id "$RUN_ID" --state-dir "$STATE_DIR" > "$daemon_log" 2>&1 &
+            daemon_pid="$!"
+            update_state "$state_file" --argjson pid "$daemon_pid" '.daemon_pid = $pid'
+            info "daemon pid=$daemon_pid interval=${INTERVAL_SECONDS}s"
+        fi
+        ;;
+    poll)
+        require_jq
+        [ -n "$RUN_ID" ] || die "--run-id is required"
+        state_file="$(state_file_for "$STATE_DIR" "$RUN_ID")"
+        [ -f "$state_file" ] || die "state not found for run-id: $RUN_ID"
+        status="$(jq -r '.status // empty' "$state_file")"
+        case "$status" in
+            succeeded|resumed)
+                cat "$state_file"
+                exit 0
+                ;;
+            failed)
+                cat "$state_file"
+                exit 1
+                ;;
+            waiting) ;;
+            *) die "state is not waiting: ${status:-<empty>}" ;;
+        esac
+        resume_at="$(jq -r '.resume_at' "$state_file")"
+        resume_epoch="$(iso_to_epoch "$resume_at")"
+        [ "$resume_epoch" -gt 0 ] || die "invalid resume_at in state: $resume_at"
+        now_epoch="$(epoch_now)"
+        update_state "$state_file" --arg at "$(iso_now)" '.last_poll_at = $at'
+        if [ "$now_epoch" -lt "$resume_epoch" ]; then
+            info "waiting until $resume_at"
+            exit 2
+        fi
+        repo_dir="$(jq -r '.repo_dir' "$state_file")"
+        resume_command="$(jq -r '.command' "$state_file")"
+        run_log="$(jq -r '.run_log' "$state_file")"
+        mkdir -p "$(dirname "$run_log")"
+        update_state "$state_file" --arg at "$(iso_now)" '.status = "launching" | .attempts += 1 | .resumed_at = $at'
+        if [ "$FOREGROUND" -eq 1 ]; then
+            set +e
+            ( cd "$repo_dir" && bash -lc "$resume_command" )
+            rc="$?"
+            set -e
+            if [ "$rc" -eq 0 ]; then
+                update_state "$state_file" '.status = "succeeded"'
+            else
+                update_state "$state_file" --argjson rc "$rc" '.status = "failed" | .exit_code = $rc'
+            fi
+            exit "$rc"
+        fi
+        (
+            cd "$repo_dir"
+            nohup bash -lc "$resume_command" > "$run_log" 2>&1 &
+            printf '%s\n' "$!" > "${run_log}.pid"
+        )
+        child_pid="$(cat "${run_log}.pid" 2>/dev/null || echo "")"
+        if [ -n "$child_pid" ]; then
+            update_state "$state_file" --argjson pid "$child_pid" '.status = "resumed" | .child_pid = $pid'
+        else
+            update_state "$state_file" '.status = "resumed"'
+        fi
+        info "resumed $RUN_ID pid=${child_pid:-unknown}"
+        ;;
+    daemon)
+        require_jq
+        [ -n "$RUN_ID" ] || die "--run-id is required"
+        state_file="$(state_file_for "$STATE_DIR" "$RUN_ID")"
+        [ -f "$state_file" ] || die "state not found for run-id: $RUN_ID"
+        while :; do
+            if bash "$0" poll --run-id "$RUN_ID" --state-dir "$STATE_DIR"; then
+                exit 0
+            fi
+            rc="$?"
+            [ "$rc" -eq 2 ] || exit "$rc"
+            interval="$(jq -r '.interval_seconds // 300' "$state_file" 2>/dev/null || echo 300)"
+            case "$interval" in *[!0-9]*|'') interval="$DEFAULT_INTERVAL_SECONDS" ;; esac
+            sleep "$interval"
+        done
+        ;;
+    status)
+        require_jq
+        [ -n "$RUN_ID" ] || die "--run-id is required"
+        state_file="$(state_file_for "$STATE_DIR" "$RUN_ID")"
+        [ -f "$state_file" ] || die "state not found for run-id: $RUN_ID"
+        jq . "$state_file"
+        ;;
+    clear)
+        [ -n "$RUN_ID" ] || die "--run-id is required"
+        state_file="$(state_file_for "$STATE_DIR" "$RUN_ID")"
+        rm -f "$state_file"
+        info "cleared $RUN_ID"
+        ;;
+    *)
+        usage >&2
+        exit 1
+        ;;
+esac

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -203,6 +203,14 @@ check_startup_preflight() {
     }
     canonical=$(extract_block skills/autospec/SKILL.md)
     [ -n "$canonical" ] || fail "autospec SKILL.md missing ## Startup self-update section"
+    printf '%s\n' "$canonical" | grep -F 'raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh' >/dev/null \
+        || fail "startup preflight must call the curl-safe suite bootstrap.sh"
+    printf '%s\n' "$canonical" | grep -F -- '--skill all --harness all --update' >/dev/null \
+        || fail "startup preflight must update all skills across all harnesses"
+    if printf '%s\n' "$canonical" | grep -F 'raw.githubusercontent.com/berlinguyinca/autospec/main/install.sh' >/dev/null \
+        || printf '%s\n' "$canonical" | grep -F 'raw.githubusercontent.com/berlinguyinca/autospec/main/skills/' >/dev/null; then
+        fail "startup preflight must not call a raw installer directly"
+    fi
     for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design; do
         for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
             body=$(extract_block "$f")
@@ -234,7 +242,7 @@ check_codex_skills_install() {
 # not contain this repo's scripts/ directory.
 check_shared_script_install() {
     info "shared helper install: all skills"
-    helpers="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
+    helpers="autospec-stop.sh autospec-usage-limit.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
     for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design; do
         f="skills/$s/install.sh"
         grep -q 'install_shared_scripts' "$f" \
@@ -475,6 +483,20 @@ check_lint_implementation_helpers() {
         printf '%s\n' "$help_out" | grep -q "$rule_id" \
             || fail "scripts/lint-implementation.sh --help missing RULE_ID: $rule_id"
     done
+}
+
+# Usage-limit recovery helper invariants: autospec-run's quota recovery path
+# depends on this shell-only supervisor being installed and executable.
+check_usage_limit_helper() {
+    info "usage-limit helper: scripts/autospec-usage-limit.sh"
+    [ -f scripts/autospec-usage-limit.sh ] \
+        || fail "scripts/autospec-usage-limit.sh: file missing"
+    [ -x scripts/autospec-usage-limit.sh ] \
+        || fail "scripts/autospec-usage-limit.sh: file not executable"
+    bash -n scripts/autospec-usage-limit.sh \
+        || fail "scripts/autospec-usage-limit.sh: bash syntax error"
+    bash scripts/autospec-usage-limit.sh --help 2>/dev/null | grep -q '^Usage:' \
+        || fail "scripts/autospec-usage-limit.sh --help did not print a 'Usage:' line"
 }
 
 # Phase 4 guardian block lock-step invariants (introduced by issue #212): the
@@ -836,6 +858,7 @@ main() {
     check_existing_spec_mode
     check_lint_issue_helpers
     check_lint_implementation_helpers
+    check_usage_limit_helper
     check_phase4_guardian_block_lockstep
     check_phase1_bounded_context_contract
     check_phase4_issue_start_summary

--- a/skills/autospec-classify/SKILL.md
+++ b/skills/autospec-classify/SKILL.md
@@ -44,9 +44,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -65,11 +65,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-classify/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-classify.md`
    - Codex CLI:   `~/.codex/prompts/autospec-classify.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-classify/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-classify/codex/prompt.md
+++ b/skills/autospec-classify/codex/prompt.md
@@ -40,9 +40,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -61,11 +61,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-classify/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-classify.md`
    - Codex CLI:   `~/.codex/prompts/autospec-classify.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-classify/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-classify/install.sh
+++ b/skills/autospec-classify/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec-classify/opencode/agent.md
+++ b/skills/autospec-classify/opencode/agent.md
@@ -44,9 +44,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -65,11 +65,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-classify/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-classify.md`
    - Codex CLI:   `~/.codex/prompts/autospec-classify.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-classify/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -46,9 +46,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -67,11 +67,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-define/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-define.md`
    - Codex CLI:   `~/.codex/prompts/autospec-define.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-define/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -42,9 +42,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -63,11 +63,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-define/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-define.md`
    - Codex CLI:   `~/.codex/prompts/autospec-define.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-define/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-define/install.sh
+++ b/skills/autospec-define/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -46,9 +46,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -67,11 +67,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-define/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-define.md`
    - Codex CLI:   `~/.codex/prompts/autospec-define.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-define/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-design/SKILL.md
+++ b/skills/autospec-design/SKILL.md
@@ -49,9 +49,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -70,11 +70,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-design/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-design.md`
    - Codex CLI:   `~/.codex/prompts/autospec-design.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-design/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter any subcommand. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-design/codex/prompt.md
+++ b/skills/autospec-design/codex/prompt.md
@@ -45,9 +45,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -66,11 +66,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-design/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-design.md`
    - Codex CLI:   `~/.codex/prompts/autospec-design.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-design/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter any subcommand. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-design/install.sh
+++ b/skills/autospec-design/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec-design/opencode/agent.md
+++ b/skills/autospec-design/opencode/agent.md
@@ -49,9 +49,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -70,11 +70,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-design/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-design.md`
    - Codex CLI:   `~/.codex/prompts/autospec-design.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-design/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter any subcommand. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-e2e-clone/SKILL.md
+++ b/skills/autospec-e2e-clone/SKILL.md
@@ -23,9 +23,9 @@ normal pipeline.
    - Codex CLI:   `~/.codex/prompts/autospec-e2e-clone.md`
 2. Re-install from `main` by piping the canonical installer:
    ```
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-e2e-clone/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. Show the diff between the prior installed file(s) and the freshly fetched copy.
 4. Stop. Do not enter any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-e2e-clone/codex/prompt.md
+++ b/skills/autospec-e2e-clone/codex/prompt.md
@@ -19,9 +19,9 @@ normal pipeline.
    - Codex CLI:   `~/.codex/prompts/autospec-e2e-clone.md`
 2. Re-install from `main` by piping the canonical installer:
    ```
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-e2e-clone/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. Show the diff between the prior installed file(s) and the freshly fetched copy.
 4. Stop. Do not enter any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-e2e-clone/opencode/agent.md
+++ b/skills/autospec-e2e-clone/opencode/agent.md
@@ -23,9 +23,9 @@ normal pipeline.
    - Codex CLI:   `~/.codex/prompts/autospec-e2e-clone.md`
 2. Re-install from `main` by piping the canonical installer:
    ```
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-e2e-clone/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. Show the diff between the prior installed file(s) and the freshly fetched copy.
 4. Stop. Do not enter any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-listen/SKILL.md
+++ b/skills/autospec-listen/SKILL.md
@@ -41,9 +41,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -62,11 +62,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-listen/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-listen.md`
    - Codex CLI:   `~/.codex/prompts/autospec-listen.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-listen/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter any trigger flow. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-listen/codex/prompt.md
+++ b/skills/autospec-listen/codex/prompt.md
@@ -36,9 +36,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -57,11 +57,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-listen/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-listen.md`
    - Codex CLI:   `~/.codex/prompts/autospec-listen.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-listen/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter any trigger flow. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-listen/install.sh
+++ b/skills/autospec-listen/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec-listen/opencode/agent.md
+++ b/skills/autospec-listen/opencode/agent.md
@@ -40,9 +40,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -61,11 +61,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-listen/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-listen.md`
    - Codex CLI:   `~/.codex/prompts/autospec-listen.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-listen/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter any trigger flow. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-review/SKILL.md
+++ b/skills/autospec-review/SKILL.md
@@ -18,9 +18,9 @@ normal pipeline.
    - Codex CLI:   `~/.codex/prompts/autospec-review.md`
 2. **Re-install from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-review/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
 
 ## Required capabilities & harness adapter

--- a/skills/autospec-review/codex/prompt.md
+++ b/skills/autospec-review/codex/prompt.md
@@ -14,9 +14,9 @@ normal pipeline.
    - Codex CLI:   `~/.codex/prompts/autospec-review.md`
 2. **Re-install from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-review/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
 
 ## Required capabilities & harness adapter

--- a/skills/autospec-review/opencode/agent.md
+++ b/skills/autospec-review/opencode/agent.md
@@ -18,9 +18,9 @@ normal pipeline.
    - Codex CLI:   `~/.codex/prompts/autospec-review.md`
 2. **Re-install from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-review/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
 
 ## Required capabilities & harness adapter

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -43,9 +43,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -71,11 +71,11 @@ normal pipeline.
    - Claude Code: `~/.claude/skills/autospec-run/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-run.md`
    - Codex CLI:   `~/.codex/prompts/autospec-run.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-run/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 
@@ -237,6 +237,25 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
 **Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
+
+**Usage-limit recovery guard.** Before launching the monitor, determine the exact non-interactive command that can relaunch this same `/autospec-run` invocation in the current repo and store it in `AUTOSPEC_RESUME_COMMAND` if the harness has not already set one. This must be a real shell command, for example the same Claude Code, Codex CLI, OpenCode, tmux, or wrapper command the operator used to start the run with the same `--profile` and repo path. Do not ask the user for it during a running monitor.
+
+When a harness reports a deterministic usage-limit/quota/capacity pause with a known reset time or wait duration, do not spend tokens diagnosing the message. Immediately arm the shell supervisor and exit:
+
+```bash
+USAGE_LIMIT="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-usage-limit.sh"
+if [ -n "${AUTOSPEC_USAGE_LIMIT_RESUME_AT:-}" ]; then
+  bash "$USAGE_LIMIT" arm --harness "<claude|codex|opencode>" --repo-dir "$(pwd)" \
+    --command "$AUTOSPEC_RESUME_COMMAND" --resume-at "$AUTOSPEC_USAGE_LIMIT_RESUME_AT"
+  exit 0
+elif [ -n "${AUTOSPEC_USAGE_LIMIT_WAIT_SECONDS:-}" ]; then
+  bash "$USAGE_LIMIT" arm --harness "<claude|codex|opencode>" --repo-dir "$(pwd)" \
+    --command "$AUTOSPEC_RESUME_COMMAND" --wait-seconds "$AUTOSPEC_USAGE_LIMIT_WAIT_SECONDS"
+  exit 0
+fi
+```
+
+The helper writes `~/.autospec/usage-limits/<run-id>.json`, starts a background daemon, polls every 300 seconds by default, and relaunches the recorded command after the reset time. This is intentionally shell-only so recovery does not require an LLM turn after the usage limit has already been hit.
 
 Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -39,9 +39,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -67,11 +67,11 @@ normal pipeline.
    - Claude Code: `~/.claude/skills/autospec-run/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-run.md`
    - Codex CLI:   `~/.codex/prompts/autospec-run.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-run/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 
@@ -232,6 +232,25 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
 **Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
+
+**Usage-limit recovery guard.** Before launching the monitor, determine the exact non-interactive command that can relaunch this same `/autospec-run` invocation in the current repo and store it in `AUTOSPEC_RESUME_COMMAND` if the harness has not already set one. This must be a real shell command, for example the same Claude Code, Codex CLI, OpenCode, tmux, or wrapper command the operator used to start the run with the same `--profile` and repo path. Do not ask the user for it during a running monitor.
+
+When a harness reports a deterministic usage-limit/quota/capacity pause with a known reset time or wait duration, do not spend tokens diagnosing the message. Immediately arm the shell supervisor and exit:
+
+```bash
+USAGE_LIMIT="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-usage-limit.sh"
+if [ -n "${AUTOSPEC_USAGE_LIMIT_RESUME_AT:-}" ]; then
+  bash "$USAGE_LIMIT" arm --harness "<claude|codex|opencode>" --repo-dir "$(pwd)" \
+    --command "$AUTOSPEC_RESUME_COMMAND" --resume-at "$AUTOSPEC_USAGE_LIMIT_RESUME_AT"
+  exit 0
+elif [ -n "${AUTOSPEC_USAGE_LIMIT_WAIT_SECONDS:-}" ]; then
+  bash "$USAGE_LIMIT" arm --harness "<claude|codex|opencode>" --repo-dir "$(pwd)" \
+    --command "$AUTOSPEC_RESUME_COMMAND" --wait-seconds "$AUTOSPEC_USAGE_LIMIT_WAIT_SECONDS"
+  exit 0
+fi
+```
+
+The helper writes `~/.autospec/usage-limits/<run-id>.json`, starts a background daemon, polls every 300 seconds by default, and relaunches the recorded command after the reset time. This is intentionally shell-only so recovery does not require an LLM turn after the usage limit has already been hit.
 
 Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 

--- a/skills/autospec-run/install.sh
+++ b/skills/autospec-run/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -43,9 +43,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -71,11 +71,11 @@ normal pipeline.
    - Claude Code: `~/.claude/skills/autospec-run/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-run.md`
    - Codex CLI:   `~/.codex/prompts/autospec-run.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-run/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 
@@ -236,6 +236,25 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
 
 **Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
+
+**Usage-limit recovery guard.** Before launching the monitor, determine the exact non-interactive command that can relaunch this same `/autospec-run` invocation in the current repo and store it in `AUTOSPEC_RESUME_COMMAND` if the harness has not already set one. This must be a real shell command, for example the same Claude Code, Codex CLI, OpenCode, tmux, or wrapper command the operator used to start the run with the same `--profile` and repo path. Do not ask the user for it during a running monitor.
+
+When a harness reports a deterministic usage-limit/quota/capacity pause with a known reset time or wait duration, do not spend tokens diagnosing the message. Immediately arm the shell supervisor and exit:
+
+```bash
+USAGE_LIMIT="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-usage-limit.sh"
+if [ -n "${AUTOSPEC_USAGE_LIMIT_RESUME_AT:-}" ]; then
+  bash "$USAGE_LIMIT" arm --harness "<claude|codex|opencode>" --repo-dir "$(pwd)" \
+    --command "$AUTOSPEC_RESUME_COMMAND" --resume-at "$AUTOSPEC_USAGE_LIMIT_RESUME_AT"
+  exit 0
+elif [ -n "${AUTOSPEC_USAGE_LIMIT_WAIT_SECONDS:-}" ]; then
+  bash "$USAGE_LIMIT" arm --harness "<claude|codex|opencode>" --repo-dir "$(pwd)" \
+    --command "$AUTOSPEC_RESUME_COMMAND" --wait-seconds "$AUTOSPEC_USAGE_LIMIT_WAIT_SECONDS"
+  exit 0
+fi
+```
+
+The helper writes `~/.autospec/usage-limits/<run-id>.json`, starts a background daemon, polls every 300 seconds by default, and relaunches the recorded command after the reset time. This is intentionally shell-only so recovery does not require an LLM turn after the usage limit has already been hit.
 
 Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 

--- a/skills/autospec-split/SKILL.md
+++ b/skills/autospec-split/SKILL.md
@@ -42,9 +42,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -63,11 +63,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-split/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-split.md`
    - Codex CLI:   `~/.codex/prompts/autospec-split.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-split/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-split/codex/prompt.md
+++ b/skills/autospec-split/codex/prompt.md
@@ -38,9 +38,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -59,11 +59,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-split/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-split.md`
    - Codex CLI:   `~/.codex/prompts/autospec-split.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-split/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-split/install.sh
+++ b/skills/autospec-split/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec-split/opencode/agent.md
+++ b/skills/autospec-split/opencode/agent.md
@@ -42,9 +42,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -63,11 +63,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-split/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-split.md`
    - Codex CLI:   `~/.codex/prompts/autospec-split.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-split/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-stop/SKILL.md
+++ b/skills/autospec-stop/SKILL.md
@@ -41,9 +41,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -62,11 +62,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-stop/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-stop.md`
    - Codex CLI:   `~/.codex/prompts/autospec-stop.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-stop/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
 4. **Stop.** Do not enter any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-stop/codex/prompt.md
+++ b/skills/autospec-stop/codex/prompt.md
@@ -37,9 +37,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -58,11 +58,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-stop/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-stop.md`
    - Codex CLI:   `~/.codex/prompts/autospec-stop.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-stop/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
 4. **Stop.** Do not enter any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-stop/install.sh
+++ b/skills/autospec-stop/install.sh
@@ -37,7 +37,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 # Scripts that live under skills/autospec-shared/scripts/ rather than the
 # repo-root scripts/ dir, but are still required at runtime by this skill.
 # detect-monitor-exit-mode.sh backs the memory-aware `/autospec-stop --resume`.

--- a/skills/autospec-stop/opencode/agent.md
+++ b/skills/autospec-stop/opencode/agent.md
@@ -41,9 +41,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -62,11 +62,11 @@ If the feature-request argument matches the regex `^\s*update\s*$` (case-insensi
    - Claude Code: `~/.claude/skills/autospec-stop/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-stop.md`
    - Codex CLI:   `~/.codex/prompts/autospec-stop.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-stop/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
 4. **Stop.** Do not enter any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-story/SKILL.md
+++ b/skills/autospec-story/SKILL.md
@@ -45,9 +45,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -68,11 +68,11 @@ does not run the normal story workflow:
    - Claude Code: `~/.claude/skills/autospec-story/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-story.md`
    - Codex CLI:   `~/.codex/prompts/autospec-story.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-story/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched
    copy.
 4. **Stop.** Do not gather repo state or write a story report. Print the upgrade

--- a/skills/autospec-story/codex/prompt.md
+++ b/skills/autospec-story/codex/prompt.md
@@ -41,9 +41,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -64,11 +64,11 @@ does not run the normal story workflow:
    - Claude Code: `~/.claude/skills/autospec-story/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-story.md`
    - Codex CLI:   `~/.codex/prompts/autospec-story.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-story/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched
    copy.
 4. **Stop.** Do not gather repo state or write a story report. Print the upgrade

--- a/skills/autospec-story/install.sh
+++ b/skills/autospec-story/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec-story/opencode/agent.md
+++ b/skills/autospec-story/opencode/agent.md
@@ -45,9 +45,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -68,11 +68,11 @@ does not run the normal story workflow:
    - Claude Code: `~/.claude/skills/autospec-story/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec-story.md`
    - Codex CLI:   `~/.codex/prompts/autospec-story.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-story/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched
    copy.
 4. **Stop.** Do not gather repo state or write a story report. Print the upgrade

--- a/skills/autospec-sweep/SKILL.md
+++ b/skills/autospec-sweep/SKILL.md
@@ -40,9 +40,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -58,9 +58,9 @@ echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 If the feature-request argument is exactly `update` after trimming whitespace and
 lowercasing, enter self-update mode and do not run a sweep:
 
-1. Detect the installed harness path for `autospec-sweep`.
-2. Run the canonical installer with `--update` for each detected harness:
-   `bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-sweep/install.sh) --harness <detected> --update`
+1. Detect whether `autospec-sweep` is installed in any harness.
+2. Run the canonical suite installer once with `--update`:
+   `curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update`
 3. Show a short before/after summary and stop.
 
 ## Invocation

--- a/skills/autospec-sweep/codex/prompt.md
+++ b/skills/autospec-sweep/codex/prompt.md
@@ -36,9 +36,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -54,9 +54,9 @@ echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 If the feature-request argument is exactly `update` after trimming whitespace and
 lowercasing, enter self-update mode and do not run a sweep:
 
-1. Detect the installed harness path for `autospec-sweep`.
-2. Run the canonical installer with `--update` for each detected harness:
-   `bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-sweep/install.sh) --harness <detected> --update`
+1. Detect whether `autospec-sweep` is installed in any harness.
+2. Run the canonical suite installer once with `--update`:
+   `curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update`
 3. Show a short before/after summary and stop.
 
 ## Invocation

--- a/skills/autospec-sweep/install.sh
+++ b/skills/autospec-sweep/install.sh
@@ -5,7 +5,7 @@ set -eu
 
 SKILL_NAME="autospec-sweep"
 SKILL_RAW_BASE="${AUTOSPEC_SWEEP_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_SWEEP_REF:-main}/skills/autospec-sweep}"
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 SCRIPT_PATH="${0:-}"
 if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then

--- a/skills/autospec-sweep/opencode/agent.md
+++ b/skills/autospec-sweep/opencode/agent.md
@@ -40,9 +40,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -58,9 +58,9 @@ echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
 If the feature-request argument is exactly `update` after trimming whitespace and
 lowercasing, enter self-update mode and do not run a sweep:
 
-1. Detect the installed harness path for `autospec-sweep`.
-2. Run the canonical installer with `--update` for each detected harness:
-   `bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-sweep/install.sh) --harness <detected> --update`
+1. Detect whether `autospec-sweep` is installed in any harness.
+2. Run the canonical suite installer once with `--update`:
+   `curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update`
 3. Show a short before/after summary and stop.
 
 ## Invocation

--- a/skills/autospec-test/SKILL.md
+++ b/skills/autospec-test/SKILL.md
@@ -23,9 +23,9 @@ normal pipeline.
    - Codex CLI:   `~/.codex/prompts/autospec-test.md`
 2. Re-install from `main` by piping the canonical installer:
    ```
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-test/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. Show the diff between the prior installed file(s) and the freshly fetched copy.
 4. Stop. Do not enter any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec-test/codex/prompt.md
+++ b/skills/autospec-test/codex/prompt.md
@@ -19,9 +19,9 @@ normal pipeline.
    - Codex CLI:   `~/.codex/prompts/autospec-test.md`
 2. Re-install from `main` by piping the canonical installer:
    ```
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-test/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. Show the diff between the prior installed file(s) and the freshly fetched copy.
 4. Stop. Do not enter any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -46,9 +46,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -74,11 +74,11 @@ normal pipeline.
    - Claude Code: `~/.claude/skills/autospec/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec.md`
    - Codex CLI:   `~/.codex/prompts/autospec.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -42,9 +42,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -70,11 +70,11 @@ normal pipeline.
    - Claude Code: `~/.claude/skills/autospec/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec.md`
    - Codex CLI:   `~/.codex/prompts/autospec.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/skills/autospec/install.sh
+++ b/skills/autospec/install.sh
@@ -43,7 +43,7 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
-SHARED_SCRIPT_FILES="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
 
 # ---------- helpers --------------------------------------------------------
 

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -46,9 +46,9 @@ if [ -z "$REMOTE" ]; then
 fi
 LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
 if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
-bash <(curl -fsSL --max-time 30 \
-    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/$SKILL_NAME/install.sh") \
-    --harness all --update >/dev/null 2>&1
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
 RC=$?
 if [ "$RC" -ne 0 ]; then
     echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
@@ -74,11 +74,11 @@ normal pipeline.
    - Claude Code: `~/.claude/skills/autospec/SKILL.md`
    - OpenCode:    `~/.config/opencode/agent/autospec.md`
    - Codex CLI:   `~/.codex/prompts/autospec.md`
-2. **Re-install from `main`** by piping the canonical installer:
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
    ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec/install.sh) --harness <detected> --update
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
    ```
-   If multiple harness paths exist, run the one-liner once per detected harness.
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
 3. **Show the diff** between the prior installed file(s) and the freshly fetched copy (e.g. `diff <(cat <prior>) <(curl -fsSL ...SKILL.md)` or the equivalent recorded by the installer).
 4. **Stop.** Do not enter Phase 0 / Phase 1 / any pipeline phase. Print the upgrade summary and return to the user.
 

--- a/tests/unit/test_autospec_run_install_helpers.bats
+++ b/tests/unit/test_autospec_run_install_helpers.bats
@@ -18,7 +18,7 @@ teardown() {
     run bash "$INSTALLER" --harness codex
 
     [ "$status" -eq 0 ]
-    for helper in run-state.sh list-ready-issues.sh claim-issue.sh release-issue.sh heartbeat-write.sh heartbeat-read.sh; do
+    for helper in run-state.sh list-ready-issues.sh claim-issue.sh release-issue.sh heartbeat-write.sh heartbeat-read.sh autospec-usage-limit.sh; do
         [ -f "$HOME/.autospec/scripts/$helper" ]
         [ -x "$HOME/.autospec/scripts/$helper" ]
     done

--- a/tests/unit/test_autospec_usage_limit.bats
+++ b/tests/unit/test_autospec_usage_limit.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_usage_limit.bats — deterministic usage-limit resume helper.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/autospec-usage-limit.sh"
+    TEST_TMP="$(mktemp -d)"
+    export HOME="$TEST_TMP/home"
+    mkdir -p "$HOME" "$TEST_TMP/repo"
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+@test "arm records a waiting resume state without launching the daemon" {
+    run bash "$SCRIPT" arm \
+        --run-id test-run \
+        --harness codex \
+        --repo-dir "$TEST_TMP/repo" \
+        --command 'printf resumed > resumed.txt' \
+        --wait-seconds 600 \
+        --no-daemon
+
+    [ "$status" -eq 0 ]
+    state="$HOME/.autospec/usage-limits/test-run.json"
+    [ -f "$state" ]
+    jq -e '.status == "waiting" and .harness == "codex" and .interval_seconds == 300' "$state" >/dev/null
+    [ ! -f "$TEST_TMP/repo/resumed.txt" ]
+}
+
+@test "poll before resume time leaves state waiting and exits 2" {
+    bash "$SCRIPT" arm \
+        --run-id test-run \
+        --harness claude \
+        --repo-dir "$TEST_TMP/repo" \
+        --command 'printf resumed > resumed.txt' \
+        --wait-seconds 600 \
+        --no-daemon >/dev/null
+
+    run bash "$SCRIPT" poll --run-id test-run --foreground
+
+    [ "$status" -eq 2 ]
+    jq -e '.status == "waiting" and .last_poll_at != ""' "$HOME/.autospec/usage-limits/test-run.json" >/dev/null
+    [ ! -f "$TEST_TMP/repo/resumed.txt" ]
+}
+
+@test "poll after resume time runs the command once and marks succeeded" {
+    bash "$SCRIPT" arm \
+        --run-id test-run \
+        --harness opencode \
+        --repo-dir "$TEST_TMP/repo" \
+        --command 'printf resumed > resumed.txt' \
+        --wait-seconds 0 \
+        --no-daemon >/dev/null
+
+    run bash "$SCRIPT" poll --run-id test-run --foreground
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_TMP/repo/resumed.txt")" = "resumed" ]
+    jq -e '.status == "succeeded" and .attempts == 1 and .resumed_at != ""' "$HOME/.autospec/usage-limits/test-run.json" >/dev/null
+
+    run bash "$SCRIPT" poll --run-id test-run --foreground
+    [ "$status" -eq 0 ]
+    jq -e '.attempts == 1' "$HOME/.autospec/usage-limits/test-run.json" >/dev/null
+}
+
+@test "clear removes a recorded resume state" {
+    bash "$SCRIPT" arm \
+        --run-id test-run \
+        --harness codex \
+        --repo-dir "$TEST_TMP/repo" \
+        --command 'printf resumed > resumed.txt' \
+        --wait-seconds 600 \
+        --no-daemon >/dev/null
+
+    run bash "$SCRIPT" clear --run-id test-run
+
+    [ "$status" -eq 0 ]
+    [ ! -f "$HOME/.autospec/usage-limits/test-run.json" ]
+}

--- a/tests/unit/test_self_update_preflight.bats
+++ b/tests/unit/test_self_update_preflight.bats
@@ -160,6 +160,54 @@ CURLSHIM
 }
 
 # ---------------------------------------------------------------------------
+# Scenario 6b — Installer target: suite bootstrap refreshes every skill
+# ---------------------------------------------------------------------------
+
+@test "startup self-update invokes suite bootstrap for all skills and harnesses" {
+    mkdir -p "$HOME/.autospec"
+    date -u -v-25H +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+        || date -u -d '25 hours ago' +'%Y-%m-%dT%H:%M:%SZ' \
+        > "$HOME/.autospec/last-update-check"
+    echo "oldsha1" > "$HOME/.autospec/installed-version"
+
+    cat > "$SHIMDIR/curl" << 'CURLSHIM'
+#!/usr/bin/env bash
+for arg in "$@"; do
+    case "$arg" in
+        *commits/main*)
+            printf '{"sha":"newsha99"}\n'
+            exit 0
+            ;;
+        *raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh)
+            printf '%s\n' "$arg" > "$HOME/install-url"
+            printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" > "$HOME/install-args"\nexit 0\n'
+            exit 0
+            ;;
+        *raw.githubusercontent.com/berlinguyinca/autospec/main/install.sh)
+            printf '%s\n' "$arg" > "$HOME/unexpected-raw-installer"
+            printf '#!/usr/bin/env bash\nexit 98\n'
+            exit 0
+            ;;
+        *raw.githubusercontent.com/berlinguyinca/autospec/main/skills/*/install.sh)
+            printf '%s\n' "$arg" > "$HOME/unexpected-skill-installer"
+            printf '#!/usr/bin/env bash\nexit 99\n'
+            exit 0
+            ;;
+    esac
+done
+exit 1
+CURLSHIM
+    chmod +x "$SHIMDIR/curl"
+
+    _run_block_shimmed
+    [ "$status" -eq 0 ]
+    [ "$(cat "$HOME/install-url")" = "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" ]
+    [ "$(cat "$HOME/install-args")" = "--skill all --harness all --update" ]
+    [ ! -f "$HOME/unexpected-raw-installer" ]
+    [ ! -f "$HOME/unexpected-skill-installer" ]
+}
+
+# ---------------------------------------------------------------------------
 # Scenario 7 — Lock contention: lock dir already held → WARN, exit 0
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Switch autospec startup and explicit self-update instructions to the curl-safe bootstrap path with `--skill all --harness all --update`.
- Add `autospec-usage-limit.sh`, a shell supervisor that records quota reset state and relaunches the recorded resume command after the reset.
- Add validation/tests for the bootstrap update path, helper installation, usage-limit supervisor, ignored runtime artifacts, and checked-in docs/memory additions.

## Review
- Local review found one blocker before publishing: raw `main/install.sh` is not curl-pipe safe because it expects a checkout beside it. Fixed by switching to `bootstrap.sh | bash -s -- --skill all --harness all --update`.
- No remaining blocking findings after re-review.

## Validation
- `git diff --check HEAD~1..HEAD`
- `bats tests/unit/test_self_update_preflight.bats tests/unit/test_autospec_usage_limit.bats tests/unit/test_autospec_run_install_helpers.bats`
- `bash scripts/validate.sh`

## Known gaps
- Live Claude/Codex/OpenCode provider quota reset flow was not exercised.