### PR TITLE
fix: skip doc-drift gate on repos with no autospec-doc-scope annotations

### DIFF
--- a/skills/autospec-shared/scripts/check-doc-drift.sh
+++ b/skills/autospec-shared/scripts/check-doc-drift.sh
@@ -145,6 +145,20 @@ if [ -n "$PR_BODY" ]; then
     fi
 fi
 
+# ── no-scope-config short-circuit ────────────────────────────────────────────
+# If the repo has zero `<!-- autospec-doc-scope: ... -->` annotations anywhere
+# in DOCS_DIR, the gate is not opted-in: every changed non-docs/ file would
+# otherwise be reported as missing-scope (exit 2), false-blocking every PR that
+# touches source. Treat this like a repo-wide `docs: skip` until annotations
+# are added. The pattern mirrors SCOPE_OPEN_RE in scan-doc-scope.mjs.
+NO_SCOPE_REPO=false
+if [ -d "$DOCS_DIR" ]; then
+    if ! grep -rlE '<!--[[:space:]]*autospec-doc-scope[[:space:]]*:' "$DOCS_DIR" --include='*.md' >/dev/null 2>&1; then
+        NO_SCOPE_REPO=true
+        echo "check-doc-drift: no autospec-doc-scope annotations in ${DOCS_DIR}; gate not opted-in, skipping" >&2
+    fi
+fi
+
 # ── Extract changed files from diff ──────────────────────────────────────────
 
 # Changed source files (not docs/) — one per line in a temp file
@@ -433,12 +447,13 @@ vstale_arr="$(build_json_array "$WORK_DIR/visual_stale_entries.txt")"
 
 # ── Apply docs: skip ──────────────────────────────────────────────────────────
 
-if $DOCS_SKIP; then
+if $DOCS_SKIP || $NO_SCOPE_REPO; then
     passed=true
     exit_code=0
     skipped_val=true
     drift_arr="[]"
     drift_warn_arr="[]"
+    missing_arr="[]"
 else
     drift_count=0
     missing_count=0

--- a/skills/autospec-shared/tests/unit/check-doc-drift.bats
+++ b/skills/autospec-shared/tests/unit/check-doc-drift.bats
@@ -109,7 +109,34 @@ typeof d.skipped==='boolean' ? 'ok' : 'fail'
 
 # ── Missing scope detection ───────────────────────────────────────────────────
 
-@test "changed source with no doc scope → missing_scope + exit 2" {
+@test "scoped repo, changed source not covered by any scope → missing_scope + exit 2" {
+    # valid-scope.md opts the repo into doc-drift (it carries annotations), but
+    # the changed file below is outside every declared src glob, so it is a
+    # genuine missing-scope finding.
+    cp "$FIXTURES_DIR/valid-scope.md" "$TMP_DIR/docs/USER_MANUAL.md"
+
+    DFILE="$(mktemp /tmp/autospec-driftpatch-XXXXXX)"
+    cat > "$DFILE" <<'DIFF'
+diff --git a/src/uncovered.py b/src/uncovered.py
+index abc..def 100644
+--- a/src/uncovered.py
++++ b/src/uncovered.py
+@@ -1,2 +1,3 @@
+ import os
+ # module
++print("new line")
+DIFF
+
+    run bash -c "\"$CHECK_DRIFT\" --diff \"$DFILE\" 2>/dev/null"
+    rm -f "$DFILE"
+    [ "$status" -eq 2 ]
+    mc="$(json_field "$output" "d.missing_scope.length")"
+    [ "$mc" -gt 0 ]
+}
+
+@test "no autospec-doc-scope annotations anywhere → skipped + exit 0" {
+    # Repo has a docs dir but zero annotations: gate is not opted-in, so a
+    # source-only change must pass (skipped) rather than hard-fail exit 2.
     cp "$FIXTURES_DIR/no-scope.md" "$TMP_DIR/docs/USER_MANUAL.md"
 
     DFILE="$(mktemp /tmp/autospec-driftpatch-XXXXXX)"
@@ -126,9 +153,11 @@ DIFF
 
     run bash -c "\"$CHECK_DRIFT\" --diff \"$DFILE\" 2>/dev/null"
     rm -f "$DFILE"
-    [ "$status" -eq 2 ]
+    [ "$status" -eq 0 ]
+    sk="$(json_field "$output" "d.skipped")"
+    [ "$sk" = "true" ]
     mc="$(json_field "$output" "d.missing_scope.length")"
-    [ "$mc" -gt 0 ]
+    [ "$mc" -eq 0 ]
 }
 
 # ── Drift detection ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`check-doc-drift.sh` returned **exit 2 (missing-scope) for every PR touching a non-`docs/` file** in repos that haven't adopted the doc-drift phase. When zero `<!-- autospec-doc-scope: -->` annotations exist, no source path can be "covered", so every changed source file is reported as missing-scope — false-blocking the PR.

This was observed in production: running `/autospec-run` against `metabolomics-us/chemlake` (193 docs files, **zero** annotations) paused every PR that touched `mkdocs.yml`, source, or config on a missing-scope verdict.

## Change

- **`check-doc-drift.sh`**: short-circuit to `passed: true, skipped: true` (exit 0) when `DOCS_DIR` contains no `autospec-doc-scope` annotations. This treats the gate as **opt-in via annotations**, consistent with the existing per-PR `docs: skip` escape hatch. The detection regex mirrors `SCOPE_OPEN_RE` in `scan-doc-scope.mjs` (`<!--\s*autospec-doc-scope\s*:`).
- **`check-doc-drift.bats`**: the former *"changed source with no doc scope → exit 2"* test now asserts the opt-in skip behavior; missing-scope detection is re-covered by a new case using a **scoped** repo (`valid-scope.md`) with a source change outside every declared glob.

## Scope notes

- The short-circuit is gated on the `docs/` dir existing. The "no docs dir at all → exit 2" case (existing test) is intentionally left unchanged to keep this surgical — can be revisited separately if desired.
- 4 pre-existing `*matches golden*` failures in `tests/integration/run-against-target.bats` are **unrelated** to this change (failing on `main` before it) and are left untouched.

## Test plan

- [x] `bats skills/autospec-shared/tests/unit/check-doc-drift.bats` — 19/19 pass
- [x] `bats tests/unit/test_doc_drift_mismatch_action.bats` — 7/7 pass
- [x] `bats skills/autospec-run/tests/integration/phase4-drift-gate.bats` — 7/7 pass
- [x] Verified normal-case behavior preserved: scoped repo + uncovered source → exit 2; scoped repo + stale doc → exit 1; scoped repo + updated doc → exit 0
- [x] Verified against the real chemlake repo: `--working-tree` now returns `passed:true, skipped:true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)