### PR TITLE
feat: prompt installers to star autospec

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ The installer also honors:
 
 After a successful interactive suite install, the top-level installer asks
 whether you want to star `berlinguyinca/autospec` to support adoption. It is
-skipped for non-interactive installs (including `curl | bash`), `--update`,
-CI, missing `gh`, or `AUTOSPEC_NO_STAR_PROMPT=1`.
+prompted through `/dev/tty`, so one-line `curl | bash` installs can still ask
+when a terminal is available. The prompt is skipped for headless installs,
+`--update`, CI, missing `gh`, or `AUTOSPEC_NO_STAR_PROMPT=1`.
 
 ### Manual install (from a checkout)
 

--- a/install.sh
+++ b/install.sh
@@ -209,16 +209,26 @@ bootstrap_turbo() {
 }
 
 maybe_prompt_star() {
-    # Keep scripted installs quiet: no prompt during updates, CI, pipes, or when opted out.
+    # Keep scripted installs quiet: no prompt during updates, CI, or when opted out.
     [ "$UPDATE" -eq 0 ] || return 0
+    [ "$DRY_RUN" -eq 0 ] || return 0
     [ "${AUTOSPEC_NO_STAR_PROMPT:-0}" != "1" ] || return 0
     [ "${CI:-}" = "" ] || return 0
-    [ -t 0 ] && [ -t 1 ] || return 0
     command -v gh >/dev/null 2>&1 || return 0
 
-    info ""
-    printf 'Would you like to star https://github.com/berlinguyinca/autospec to support adoption? [y/N] '
-    read -r answer || return 0
+    answer=""
+    if exec 3<>/dev/tty 2>/dev/null; then
+        info ""
+        printf 'Would you like to star https://github.com/berlinguyinca/autospec to support adoption? [y/N] ' >&3
+        read -r answer <&3 || { exec 3>&-; return 0; }
+        exec 3>&-
+    else
+        [ -t 0 ] && [ -t 1 ] || return 0
+        info ""
+        printf 'Would you like to star https://github.com/berlinguyinca/autospec to support adoption? [y/N] '
+        read -r answer || return 0
+    fi
+
     case "$answer" in
         y|Y|yes|YES|Yes)
             if gh api -X PUT /user/starred/berlinguyinca/autospec >/dev/null 2>&1; then

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -816,6 +816,18 @@ check_autospec_test_skill_present() {
         || { bash "$validate_sh" >&2; fail "$validate_sh: structural lint failed"; }
 }
 
+check_install_tests() {
+    info "install tests: tests/install/*.sh"
+    if [ -d tests/install ]; then
+        for t in tests/install/*.sh; do
+            [ -f "$t" ] || continue
+            info "  running: $t"
+            bash "$t" >/tmp/validate-install.log 2>&1 \
+                || { cat /tmp/validate-install.log >&2; fail "$t: failed"; }
+        done
+    fi
+}
+
 main() {
     info "scanning multi-harness skills under skills/ ..."
     skills="$(discover_skills)"
@@ -872,6 +884,7 @@ main() {
     check_autospec_review_tier_a_directives
     check_autospec_test_skill_present
     check_docs_amendment_presence
+    check_install_tests
     check_phase4_tests
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax

--- a/tests/install/test_star_prompt.sh
+++ b/tests/install/test_star_prompt.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Verifies the optional install-time GitHub star prompt without touching a real
+# GitHub account. Uses script(1) to provide a pseudo-TTY, matching curl|bash.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+if ! command -v script >/dev/null 2>&1; then
+    echo "SKIP: script(1) not found"
+    exit 0
+fi
+
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+setup_fake_home() {
+    fake_home="$(mktemp -d "$tmp_root/home.XXXXXX")"
+    mkdir -p "$fake_home/.turbo/repo/claude/skills"
+    git -C "$fake_home/.turbo/repo" init -q
+    git -C "$fake_home/.turbo/repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+    printf '%s\n' "$fake_home"
+}
+
+setup_fake_gh() {
+    log_file="$1"
+    fake_bin="$(mktemp -d "$tmp_root/bin.XXXXXX")"
+    cat > "$fake_bin/gh" <<'EOS'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+exit 0
+EOS
+    chmod +x "$fake_bin/gh"
+    printf '%s\n' "$fake_bin"
+}
+
+run_install_with_reply() {
+    reply="$1"
+    output_file="$2"
+    log_file="$3"
+    fake_home="$(setup_fake_home)"
+    fake_bin="$(setup_fake_gh "$log_file")"
+    : > "$log_file"
+
+    cmd="cd '$SCRIPT_DIR' && HOME='$fake_home' GH_LOG='$log_file' PATH='$fake_bin':\$PATH bash '$SCRIPT_DIR/install.sh' --skill autospec --harness claude"
+    printf '%s\n' "$reply" | script -qfec "$cmd" "$output_file" >/dev/null
+}
+
+yes_output="$tmp_root/yes.out"
+yes_log="$tmp_root/yes-gh.log"
+run_install_with_reply "y" "$yes_output" "$yes_log"
+grep -q "Would you like to star https://github.com/berlinguyinca/autospec" "$yes_output" \
+    || { echo "FAIL: TTY install did not show star prompt"; cat "$yes_output"; exit 1; }
+grep -qF "api -X PUT /user/starred/berlinguyinca/autospec" "$yes_log" \
+    || { echo "FAIL: yes answer did not call GitHub star API"; cat "$yes_log"; exit 1; }
+
+no_output="$tmp_root/no.out"
+no_log="$tmp_root/no-gh.log"
+run_install_with_reply "n" "$no_output" "$no_log"
+if grep -qF "api -X PUT /user/starred/berlinguyinca/autospec" "$no_log"; then
+    echo "FAIL: no answer called GitHub star API"
+    cat "$no_log"
+    exit 1
+fi
+
+non_tty_home="$(setup_fake_home)"
+non_tty_log="$tmp_root/non-tty-gh.log"
+non_tty_bin="$(setup_fake_gh "$non_tty_log")"
+: > "$non_tty_log"
+non_tty_output="$tmp_root/non-tty.out"
+printf 'y\n' | HOME="$non_tty_home" GH_LOG="$non_tty_log" PATH="$non_tty_bin:$PATH" \
+    bash "$SCRIPT_DIR/install.sh" --skill autospec --harness claude >"$non_tty_output" 2>&1
+if grep -q "Would you like to star" "$non_tty_output"; then
+    echo "FAIL: non-TTY install prompted"
+    cat "$non_tty_output"
+    exit 1
+fi
+if grep -qF "api -X PUT /user/starred/berlinguyinca/autospec" "$non_tty_log"; then
+    echo "FAIL: non-TTY install called GitHub star API"
+    cat "$non_tty_log"
+    exit 1
+fi
+
+echo "PASS"


### PR DESCRIPTION
## Summary
- prompt through `/dev/tty` so interactive `curl | bash` installs can opt into starring autospec
- keep `--update`, `--dry-run`, CI, missing `gh`, and headless installs quiet
- add a fake-`gh` pseudo-TTY install regression test and run it from `scripts/validate.sh`

Closes #603.

## Validation
- `bash tests/install/test_star_prompt.sh`
- `bash scripts/validate.sh`