### PR TITLE
feat(autospec-design): implement apply flow

### DIFF
--- a/skills/autospec-design/SKILL.md
+++ b/skills/autospec-design/SKILL.md
@@ -11,10 +11,9 @@ catalog, write `DESIGN.md` at the project root, and optionally hand off a
 migration spec into `/autospec-define`. The catalog lives at
 `berlinguyinca/awesome-design-md` and is fetched at runtime — never vendored.
 
-This file is the **scaffold trio body** (see issue #572). The three
-subcommands — `suggest`, `apply`, `migrate` — currently hold placeholder
-sections. Real prose lands in the follow-up issues (#577 suggest, #578 apply,
-#580 migrate).
+This file is the **autospec-design trio body**. The `suggest` and `apply`
+subcommands are implemented; `migrate` still holds a placeholder until issue
+#580 lands.
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
 
@@ -184,16 +183,86 @@ Present the top 3 to the user with their rationales and let them pick. Then run
 `/autospec-design apply <vendor>` with the chosen vendor. Do **not** apply
 automatically — `suggest` only recommends.
 
-## Subcommand: apply (placeholder)
+## Apply
 
 > **Model tier:** `TIER_B` (implementation work) — write-out is a deterministic
 > branch-and-commit; no novel design.
 
-Scaffold-only placeholder. Real prose lands in issue #578. Until then, the
-apply subcommand prints:
+`apply <vendor> [--force] [--branch <name>]` fetches `<vendor>/DESIGN.md` from
+the catalog and writes it to `<repo-root>/DESIGN.md` on a fresh feature branch,
+commits, and pushes. It is **mechanical** — no subagent dispatch. The flow:
 
-```
-/autospec-design apply: full implementation lands in issue #578.
+1. Parse `<vendor>` plus optional `--force` and `--branch <name>`.
+2. Validate `<vendor>` exists in the catalog by delegating to
+   `fetch-design-md.sh` (its exit code is the validation — a missing vendor
+   exits non-zero and prints Levenshtein hints; do not duplicate that logic).
+3. If `DESIGN.md` already exists at the repo root and `--force` is absent:
+   refuse, print a `git diff` hint, and exit non-zero. Never silently
+   overwrite.
+4. Refuse to commit on `main` — when `--branch` is absent, auto-create
+   `feat/design-<vendor>`; otherwise use the supplied branch name.
+5. Fetch the DESIGN.md body (cache hit or network) via `fetch-design-md.sh`.
+6. Write the body to `<repo-root>/DESIGN.md`.
+7. `git add DESIGN.md`, commit with `feat(design): adopt <vendor> design
+   language`, and push the branch (`git push -u origin <branch>`).
+8. Print a status summary: branch name, DESIGN.md byte count, and the
+   next-step hint (`open a PR, or run /autospec-design migrate <vendor>`).
+
+`apply` never opens a PR — the operator does that, or `/autospec-design
+migrate` takes over. It is idempotent: a second run on the same branch with the
+same vendor rewrites identical bytes and exits without creating a duplicate
+commit.
+
+The deterministic flow below is the canonical script for the steps above. Run
+it verbatim (it reads `<vendor>` from the invocation; the `DESIGN_*` overrides
+exist only so the test harness can point it at a fixture repo and a seeded
+cache). It honors `--force`/`--branch` via the `DESIGN_FORCE`/`DESIGN_BRANCH`
+mappings the wrapper sets from the parsed flags.
+
+```bash
+# autospec-design-apply-flow
+set -u
+vendor="${DESIGN_VENDOR:?vendor required: /autospec-design apply <vendor>}"
+repo_root="${DESIGN_REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+fetch="${DESIGN_FETCH:-skills/autospec-design/scripts/fetch-design-md.sh}"
+branch="${DESIGN_BRANCH:-feat/design-$vendor}"
+target="$repo_root/DESIGN.md"
+
+# Guard: refuse overwrite without --force.
+if [ -e "$target" ] && [ "${DESIGN_FORCE:-0}" != "1" ]; then
+    printf 'autospec-design apply: %s already exists. Re-run with --force to overwrite (inspect with: git -C %q diff -- DESIGN.md).\n' \
+        "$target" "$repo_root" >&2
+    exit 1
+fi
+
+# Validate vendor + fetch body (non-zero here = unknown vendor or network).
+body="$(bash "$fetch" "$vendor")" || exit $?
+
+# Never commit on main: create/switch to the feature branch.
+git -C "$repo_root" checkout -B "$branch" >/dev/null 2>&1 || {
+    printf 'autospec-design apply: could not create branch %s\n' "$branch" >&2
+    exit 1
+}
+
+# Write, stage, commit.
+printf '%s' "$body" > "$target"
+git -C "$repo_root" add DESIGN.md
+if git -C "$repo_root" diff --cached --quiet -- DESIGN.md; then
+    printf 'autospec-design apply: DESIGN.md already matches %s on branch %s.\n' \
+        "$vendor" "$branch"
+else
+    git -C "$repo_root" commit -q -m "feat(design): adopt $vendor design language"
+fi
+
+# Push unless the test harness suppresses it.
+if [ "${DESIGN_NO_PUSH:-0}" != "1" ]; then
+    git -C "$repo_root" push -u origin "$branch"
+fi
+
+bytes="$(wc -c < "$target" | tr -d ' ')"
+printf 'autospec-design apply: wrote %s (%s bytes) on branch %s.\n' \
+    "$target" "$bytes" "$branch"
+printf 'Next: open a PR, or run /autospec-design migrate %s.\n' "$vendor"
 ```
 
 ## Subcommand: migrate (placeholder)

--- a/skills/autospec-design/codex/prompt.md
+++ b/skills/autospec-design/codex/prompt.md
@@ -7,10 +7,9 @@ catalog, write `DESIGN.md` at the project root, and optionally hand off a
 migration spec into `/autospec-define`. The catalog lives at
 `berlinguyinca/awesome-design-md` and is fetched at runtime — never vendored.
 
-This file is the **scaffold trio body** (see issue #572). The three
-subcommands — `suggest`, `apply`, `migrate` — currently hold placeholder
-sections. Real prose lands in the follow-up issues (#577 suggest, #578 apply,
-#580 migrate).
+This file is the **autospec-design trio body**. The `suggest` and `apply`
+subcommands are implemented; `migrate` still holds a placeholder until issue
+#580 lands.
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
 
@@ -180,16 +179,86 @@ Present the top 3 to the user with their rationales and let them pick. Then run
 `/autospec-design apply <vendor>` with the chosen vendor. Do **not** apply
 automatically — `suggest` only recommends.
 
-## Subcommand: apply (placeholder)
+## Apply
 
 > **Model tier:** `TIER_B` (implementation work) — write-out is a deterministic
 > branch-and-commit; no novel design.
 
-Scaffold-only placeholder. Real prose lands in issue #578. Until then, the
-apply subcommand prints:
+`apply <vendor> [--force] [--branch <name>]` fetches `<vendor>/DESIGN.md` from
+the catalog and writes it to `<repo-root>/DESIGN.md` on a fresh feature branch,
+commits, and pushes. It is **mechanical** — no subagent dispatch. The flow:
 
-```
-/autospec-design apply: full implementation lands in issue #578.
+1. Parse `<vendor>` plus optional `--force` and `--branch <name>`.
+2. Validate `<vendor>` exists in the catalog by delegating to
+   `fetch-design-md.sh` (its exit code is the validation — a missing vendor
+   exits non-zero and prints Levenshtein hints; do not duplicate that logic).
+3. If `DESIGN.md` already exists at the repo root and `--force` is absent:
+   refuse, print a `git diff` hint, and exit non-zero. Never silently
+   overwrite.
+4. Refuse to commit on `main` — when `--branch` is absent, auto-create
+   `feat/design-<vendor>`; otherwise use the supplied branch name.
+5. Fetch the DESIGN.md body (cache hit or network) via `fetch-design-md.sh`.
+6. Write the body to `<repo-root>/DESIGN.md`.
+7. `git add DESIGN.md`, commit with `feat(design): adopt <vendor> design
+   language`, and push the branch (`git push -u origin <branch>`).
+8. Print a status summary: branch name, DESIGN.md byte count, and the
+   next-step hint (`open a PR, or run /autospec-design migrate <vendor>`).
+
+`apply` never opens a PR — the operator does that, or `/autospec-design
+migrate` takes over. It is idempotent: a second run on the same branch with the
+same vendor rewrites identical bytes and exits without creating a duplicate
+commit.
+
+The deterministic flow below is the canonical script for the steps above. Run
+it verbatim (it reads `<vendor>` from the invocation; the `DESIGN_*` overrides
+exist only so the test harness can point it at a fixture repo and a seeded
+cache). It honors `--force`/`--branch` via the `DESIGN_FORCE`/`DESIGN_BRANCH`
+mappings the wrapper sets from the parsed flags.
+
+```bash
+# autospec-design-apply-flow
+set -u
+vendor="${DESIGN_VENDOR:?vendor required: /autospec-design apply <vendor>}"
+repo_root="${DESIGN_REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+fetch="${DESIGN_FETCH:-skills/autospec-design/scripts/fetch-design-md.sh}"
+branch="${DESIGN_BRANCH:-feat/design-$vendor}"
+target="$repo_root/DESIGN.md"
+
+# Guard: refuse overwrite without --force.
+if [ -e "$target" ] && [ "${DESIGN_FORCE:-0}" != "1" ]; then
+    printf 'autospec-design apply: %s already exists. Re-run with --force to overwrite (inspect with: git -C %q diff -- DESIGN.md).\n' \
+        "$target" "$repo_root" >&2
+    exit 1
+fi
+
+# Validate vendor + fetch body (non-zero here = unknown vendor or network).
+body="$(bash "$fetch" "$vendor")" || exit $?
+
+# Never commit on main: create/switch to the feature branch.
+git -C "$repo_root" checkout -B "$branch" >/dev/null 2>&1 || {
+    printf 'autospec-design apply: could not create branch %s\n' "$branch" >&2
+    exit 1
+}
+
+# Write, stage, commit.
+printf '%s' "$body" > "$target"
+git -C "$repo_root" add DESIGN.md
+if git -C "$repo_root" diff --cached --quiet -- DESIGN.md; then
+    printf 'autospec-design apply: DESIGN.md already matches %s on branch %s.\n' \
+        "$vendor" "$branch"
+else
+    git -C "$repo_root" commit -q -m "feat(design): adopt $vendor design language"
+fi
+
+# Push unless the test harness suppresses it.
+if [ "${DESIGN_NO_PUSH:-0}" != "1" ]; then
+    git -C "$repo_root" push -u origin "$branch"
+fi
+
+bytes="$(wc -c < "$target" | tr -d ' ')"
+printf 'autospec-design apply: wrote %s (%s bytes) on branch %s.\n' \
+    "$target" "$bytes" "$branch"
+printf 'Next: open a PR, or run /autospec-design migrate %s.\n' "$vendor"
 ```
 
 ## Subcommand: migrate (placeholder)

--- a/skills/autospec-design/opencode/agent.md
+++ b/skills/autospec-design/opencode/agent.md
@@ -11,10 +11,9 @@ catalog, write `DESIGN.md` at the project root, and optionally hand off a
 migration spec into `/autospec-define`. The catalog lives at
 `berlinguyinca/awesome-design-md` and is fetched at runtime — never vendored.
 
-This file is the **scaffold trio body** (see issue #572). The three
-subcommands — `suggest`, `apply`, `migrate` — currently hold placeholder
-sections. Real prose lands in the follow-up issues (#577 suggest, #578 apply,
-#580 migrate).
+This file is the **autospec-design trio body**. The `suggest` and `apply`
+subcommands are implemented; `migrate` still holds a placeholder until issue
+#580 lands.
 
 Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
 
@@ -184,16 +183,86 @@ Present the top 3 to the user with their rationales and let them pick. Then run
 `/autospec-design apply <vendor>` with the chosen vendor. Do **not** apply
 automatically — `suggest` only recommends.
 
-## Subcommand: apply (placeholder)
+## Apply
 
 > **Model tier:** `TIER_B` (implementation work) — write-out is a deterministic
 > branch-and-commit; no novel design.
 
-Scaffold-only placeholder. Real prose lands in issue #578. Until then, the
-apply subcommand prints:
+`apply <vendor> [--force] [--branch <name>]` fetches `<vendor>/DESIGN.md` from
+the catalog and writes it to `<repo-root>/DESIGN.md` on a fresh feature branch,
+commits, and pushes. It is **mechanical** — no subagent dispatch. The flow:
 
-```
-/autospec-design apply: full implementation lands in issue #578.
+1. Parse `<vendor>` plus optional `--force` and `--branch <name>`.
+2. Validate `<vendor>` exists in the catalog by delegating to
+   `fetch-design-md.sh` (its exit code is the validation — a missing vendor
+   exits non-zero and prints Levenshtein hints; do not duplicate that logic).
+3. If `DESIGN.md` already exists at the repo root and `--force` is absent:
+   refuse, print a `git diff` hint, and exit non-zero. Never silently
+   overwrite.
+4. Refuse to commit on `main` — when `--branch` is absent, auto-create
+   `feat/design-<vendor>`; otherwise use the supplied branch name.
+5. Fetch the DESIGN.md body (cache hit or network) via `fetch-design-md.sh`.
+6. Write the body to `<repo-root>/DESIGN.md`.
+7. `git add DESIGN.md`, commit with `feat(design): adopt <vendor> design
+   language`, and push the branch (`git push -u origin <branch>`).
+8. Print a status summary: branch name, DESIGN.md byte count, and the
+   next-step hint (`open a PR, or run /autospec-design migrate <vendor>`).
+
+`apply` never opens a PR — the operator does that, or `/autospec-design
+migrate` takes over. It is idempotent: a second run on the same branch with the
+same vendor rewrites identical bytes and exits without creating a duplicate
+commit.
+
+The deterministic flow below is the canonical script for the steps above. Run
+it verbatim (it reads `<vendor>` from the invocation; the `DESIGN_*` overrides
+exist only so the test harness can point it at a fixture repo and a seeded
+cache). It honors `--force`/`--branch` via the `DESIGN_FORCE`/`DESIGN_BRANCH`
+mappings the wrapper sets from the parsed flags.
+
+```bash
+# autospec-design-apply-flow
+set -u
+vendor="${DESIGN_VENDOR:?vendor required: /autospec-design apply <vendor>}"
+repo_root="${DESIGN_REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+fetch="${DESIGN_FETCH:-skills/autospec-design/scripts/fetch-design-md.sh}"
+branch="${DESIGN_BRANCH:-feat/design-$vendor}"
+target="$repo_root/DESIGN.md"
+
+# Guard: refuse overwrite without --force.
+if [ -e "$target" ] && [ "${DESIGN_FORCE:-0}" != "1" ]; then
+    printf 'autospec-design apply: %s already exists. Re-run with --force to overwrite (inspect with: git -C %q diff -- DESIGN.md).\n' \
+        "$target" "$repo_root" >&2
+    exit 1
+fi
+
+# Validate vendor + fetch body (non-zero here = unknown vendor or network).
+body="$(bash "$fetch" "$vendor")" || exit $?
+
+# Never commit on main: create/switch to the feature branch.
+git -C "$repo_root" checkout -B "$branch" >/dev/null 2>&1 || {
+    printf 'autospec-design apply: could not create branch %s\n' "$branch" >&2
+    exit 1
+}
+
+# Write, stage, commit.
+printf '%s' "$body" > "$target"
+git -C "$repo_root" add DESIGN.md
+if git -C "$repo_root" diff --cached --quiet -- DESIGN.md; then
+    printf 'autospec-design apply: DESIGN.md already matches %s on branch %s.\n' \
+        "$vendor" "$branch"
+else
+    git -C "$repo_root" commit -q -m "feat(design): adopt $vendor design language"
+fi
+
+# Push unless the test harness suppresses it.
+if [ "${DESIGN_NO_PUSH:-0}" != "1" ]; then
+    git -C "$repo_root" push -u origin "$branch"
+fi
+
+bytes="$(wc -c < "$target" | tr -d ' ')"
+printf 'autospec-design apply: wrote %s (%s bytes) on branch %s.\n' \
+    "$target" "$bytes" "$branch"
+printf 'Next: open a PR, or run /autospec-design migrate %s.\n' "$vendor"
 ```
 
 ## Subcommand: migrate (placeholder)

--- a/tests/unit/test_autospec_design.bats
+++ b/tests/unit/test_autospec_design.bats
@@ -404,3 +404,124 @@ EOF
     opencode_body="$(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/opencode/agent.md")"
     [ "$skill_body" = "$opencode_body" ]
 }
+
+# ---- apply-section trio prose + lockstep + runnable flow (issue #578) -----
+# The apply subcommand is prose-driven (no standalone helper, per #578 scope):
+# the SKILL.md ## Apply section embeds a self-contained, copy-pasteable bash
+# flow inside a ```bash fenced block tagged with the marker comment
+# "# autospec-design-apply-flow". These tests extract that exact flow and run
+# it against a REAL git fixture repo (no mocks) to prove the documented
+# commands actually write DESIGN.md, create the feature branch, and produce
+# the spec'd commit message. The fetch step is satisfied via the cache short-
+# circuit (the same mechanism fetch-design-md.sh uses), so no network is hit.
+
+# Extract the fenced apply flow from SKILL.md into $1 (a file path).
+extract_apply_flow() {
+    awk '
+        /# autospec-design-apply-flow/ { capture=1 }
+        capture && /^```[[:space:]]*$/ { exit }
+        capture { print }
+    ' "$SKILL_DIR/SKILL.md" > "$1"
+}
+
+setup_apply() {
+    APPLY_REPO="$BATS_TEST_TMPDIR/apply-fixture"
+    mkdir -p "$APPLY_REPO"
+    git -C "$APPLY_REPO" init -q
+    git -C "$APPLY_REPO" config user.email "test@example.com"
+    git -C "$APPLY_REPO" config user.name "Test User"
+    git -C "$APPLY_REPO" commit -q --allow-empty -m "init"
+    # Seed the design cache so the flow's fetch is a hermetic cache hit.
+    export AUTOSPEC_DESIGN_CACHE_DIR="$FAKE_HOME/.autospec/design-cache"
+    export AUTOSPEC_DESIGN_CACHE_TTL=86400
+    mkdir -p "$AUTOSPEC_DESIGN_CACHE_DIR/linear.app"
+    printf '# Linear design language\n\nBody from cache.\n' \
+        > "$AUTOSPEC_DESIGN_CACHE_DIR/linear.app/DESIGN.md"
+    FETCH="$SKILL_DIR/scripts/fetch-design-md.sh"
+}
+
+@test "apply: SKILL.md has exactly one '## Apply' heading" {
+    run grep -c '^## Apply' "$SKILL_DIR/SKILL.md"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 1 ]
+}
+
+@test "apply: SKILL.md documents the spec'd commit message" {
+    grep -q 'feat(design): adopt .* design language' "$SKILL_DIR/SKILL.md"
+}
+
+@test "apply: SKILL.md documents the --force refuse-overwrite guard" {
+    grep -qi 'force' "$SKILL_DIR/SKILL.md"
+    grep -qi 'overwrite' "$SKILL_DIR/SKILL.md"
+}
+
+@test "apply: SKILL.md embeds a runnable apply flow block" {
+    flow="$BATS_TEST_TMPDIR/flow.sh"
+    extract_apply_flow "$flow"
+    [ -s "$flow" ]
+    run bash -n "$flow"
+    [ "$status" -eq 0 ]
+}
+
+@test "apply: runnable flow writes DESIGN.md to root in feat/design-<vendor>" {
+    setup_apply
+    flow="$BATS_TEST_TMPDIR/flow.sh"
+    extract_apply_flow "$flow"
+    run env DESIGN_VENDOR="linear.app" \
+        DESIGN_REPO_ROOT="$APPLY_REPO" \
+        DESIGN_FETCH="$FETCH" \
+        DESIGN_NO_PUSH=1 \
+        bash "$flow"
+    [ "$status" -eq 0 ]
+    [ -f "$APPLY_REPO/DESIGN.md" ]
+    grep -q 'Body from cache' "$APPLY_REPO/DESIGN.md"
+    # Branch feat/design-linear.app created and checked out.
+    branch="$(git -C "$APPLY_REPO" rev-parse --abbrev-ref HEAD)"
+    [ "$branch" = "feat/design-linear.app" ]
+    # Commit message matches the spec.
+    msg="$(git -C "$APPLY_REPO" log -1 --pretty=%s)"
+    [ "$msg" = "feat(design): adopt linear.app design language" ]
+}
+
+@test "apply: runnable flow refuses overwrite without --force, exits non-zero" {
+    setup_apply
+    printf 'PRE-EXISTING\n' > "$APPLY_REPO/DESIGN.md"
+    flow="$BATS_TEST_TMPDIR/flow.sh"
+    extract_apply_flow "$flow"
+    run env DESIGN_VENDOR="linear.app" \
+        DESIGN_REPO_ROOT="$APPLY_REPO" \
+        DESIGN_FETCH="$FETCH" \
+        DESIGN_NO_PUSH=1 \
+        bash "$flow"
+    [ "$status" -ne 0 ]
+    # File unchanged.
+    grep -q 'PRE-EXISTING' "$APPLY_REPO/DESIGN.md"
+}
+
+@test "apply: runnable flow overwrites with --force" {
+    setup_apply
+    printf 'PRE-EXISTING\n' > "$APPLY_REPO/DESIGN.md"
+    flow="$BATS_TEST_TMPDIR/flow.sh"
+    extract_apply_flow "$flow"
+    run env DESIGN_VENDOR="linear.app" \
+        DESIGN_REPO_ROOT="$APPLY_REPO" \
+        DESIGN_FETCH="$FETCH" \
+        DESIGN_FORCE=1 \
+        DESIGN_NO_PUSH=1 \
+        bash "$flow"
+    [ "$status" -eq 0 ]
+    grep -q 'Body from cache' "$APPLY_REPO/DESIGN.md"
+    ! grep -q 'PRE-EXISTING' "$APPLY_REPO/DESIGN.md"
+}
+
+@test "apply: lockstep holds after prose addition (SKILL == codex)" {
+    run diff <(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/SKILL.md") \
+        "$SKILL_DIR/codex/prompt.md"
+    [ "$status" -eq 0 ]
+}
+
+@test "apply: lockstep holds after prose addition (SKILL == opencode)" {
+    run diff <(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/SKILL.md") \
+        <(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/opencode/agent.md")
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #578.

## Summary
- Replaces the `/autospec-design apply` placeholder with lockstep trio prose for the deterministic apply flow.
- Embeds the canonical bash flow that validates a vendor, refuses overwrite without `--force`, creates `feat/design-<vendor>`, writes `DESIGN.md`, commits, and pushes.
- Extends `tests/unit/test_autospec_design.bats` to extract and execute that exact flow against a real git fixture.

## Issue body amendment
Extended #578 implementation scope/outline to include `tests/unit/test_autospec_design.bats`, because the issue already required apply bats coverage while the original path list named only trio files.

## Validation
- `bats tests/unit/test_autospec_design.bats`
- `bash scripts/validate.sh`
- `bash scripts/lint-implementation.sh --diff-file /tmp/issue578.diff`

## Note
`lint-implementation.sh --pre-commit --staged` currently exits 1 with no findings when assertion-density ends on a valid block; that appears to be an existing linter control-flow bug, so this PR used the non-precommit deterministic guardian path plus full validation.