### PR TITLE
feat(autospec-design): add migrate helper scripts

### DIFF
--- a/skills/autospec-design/scripts/gen-migration-spec.sh
+++ b/skills/autospec-design/scripts/gen-migration-spec.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -u
+
+vendor="${1:-}"
+repo_root="${2:-}"
+if [ -z "$vendor" ] || [ -z "$repo_root" ]; then
+    printf 'usage: gen-migration-spec.sh <vendor> <repo-root>\n' >&2
+    exit 1
+fi
+if [ ! -d "$repo_root" ]; then
+    printf 'gen-migration-spec: repo root not found: %s\n' "$repo_root" >&2
+    exit 1
+fi
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+fetch_script="$script_dir/fetch-design-md.sh"
+scan_script="$script_dir/scan-ui-sources.sh"
+
+design_body="$(bash "$fetch_script" "$vendor")" || exit $?
+inventory="$(bash "$scan_script" "$repo_root")" || exit $?
+framework="$(printf '%s' "$inventory" | sed -n 's/^.*"framework":"\([^"]*\)".*$/\1/p')"
+files_csv="$(printf '%s' "$inventory" | sed -n 's/^.*"files":\[\(.*\)\].*$/\1/p')"
+
+files_tmp="$(mktemp)"
+trap 'rm -f "$files_tmp"' EXIT
+printf '%s\n' "$files_csv" \
+    | tr ',' '\n' \
+    | sed 's/^"//; s/"$//; /^$/d' > "$files_tmp"
+
+if [ ! -s "$files_tmp" ]; then
+    printf 'gen-migration-spec: no UI files found in %s; nothing to migrate.\n' "$repo_root" >&2
+    exit 2
+fi
+
+today="$(date -u +%Y-%m-%d)"
+spec_dir="$repo_root/docs/specs"
+spec_path="$spec_dir/${today}-design-migration-${vendor}.md"
+mkdir -p "$spec_dir"
+
+{
+    printf '# %s Design Migration To %s\n\n' "$today" "$vendor"
+    printf '## Source\n\n'
+    printf -- '- Vendor: `%s`\n' "$vendor"
+    printf -- '- Catalog: `berlinguyinca/awesome-design-md/design-md/%s/DESIGN.md`\n' "$vendor"
+    printf -- '- Framework detected: `%s`\n' "${framework:-unknown}"
+    printf -- '- DESIGN.md bytes: `%s`\n\n' "$(printf '%s' "$design_body" | wc -c | tr -d ' ')"
+
+    printf '## Target\n\n'
+    printf 'Migrate the scanned UI surface in `%s` toward `%s` while preserving existing behavior.\n\n' \
+        "$repo_root" "$vendor"
+    printf 'Scanned files:\n'
+    while IFS= read -r file; do
+        printf -- '- `%s`\n' "$file"
+    done < "$files_tmp"
+    printf '\n'
+
+    printf '## Team personality\n\n'
+    printf 'Frontend/product migration team: frontend developer, UX designer, accessibility reviewer, API/backend developer, QA engineer. Emphasize incremental, reviewable UI changes with behavior-preserving tests.\n\n'
+
+    printf '## Counter-team\n\n'
+    printf 'Accessibility + visual regression reviewers: challenge contrast, keyboard flow, layout regressions, and over-broad rewrites. Review must stay scoped to the scanned UI files.\n\n'
+
+    printf '## Per-component outline\n\n'
+    while IFS= read -r file; do
+        printf '### `%s`\n\n' "$file"
+        printf -- '- Compare current structure against `%s` DESIGN.md guidance.\n' "$vendor"
+        printf -- '- Apply the smallest visual-system change that preserves behavior.\n'
+        printf -- '- Add or update focused UI regression coverage for this file.\n\n'
+    done < "$files_tmp"
+
+    printf '## Suggested decomposition\n\n'
+    printf -- '- [ ] Create one child issue per 3-5 related UI files.\n'
+    printf -- '- [ ] Keep accessibility and visual regression checks in every child issue.\n'
+    printf -- '- [ ] Run `/autospec-define %s` to decompose this migration spec.\n' "$spec_path"
+} > "$spec_path"
+
+printf '%s\n' "$spec_path"

--- a/skills/autospec-design/scripts/scan-ui-sources.sh
+++ b/skills/autospec-design/scripts/scan-ui-sources.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -u
+
+repo_root="${1:-}"
+if [ -z "$repo_root" ]; then
+    printf 'usage: scan-ui-sources.sh <repo-root>\n' >&2
+    exit 1
+fi
+if [ ! -d "$repo_root" ]; then
+    printf 'scan-ui-sources: repo root not found: %s\n' "$repo_root" >&2
+    exit 1
+fi
+
+detect_framework() {
+    root="$1"
+    if ls "$root"/next.config.* >/dev/null 2>&1; then printf 'next'; return; fi
+    if ls "$root"/vite.config.* >/dev/null 2>&1; then printf 'vite'; return; fi
+    if [ -f "$root/angular.json" ]; then printf 'angular'; return; fi
+    if ls "$root"/svelte.config.* >/dev/null 2>&1; then printf 'svelte'; return; fi
+    if [ -f "$root/package.json" ]; then
+        if grep -q '"next"' "$root/package.json" 2>/dev/null; then printf 'next'; return; fi
+        if grep -q '"vite"' "$root/package.json" 2>/dev/null; then printf 'vite'; return; fi
+        if grep -q '"@angular/core"' "$root/package.json" 2>/dev/null; then printf 'angular'; return; fi
+        if grep -q '"svelte"' "$root/package.json" 2>/dev/null; then printf 'svelte'; return; fi
+    fi
+    if find "$root" -type f -name '*.html' -print -quit 2>/dev/null | grep -q .; then
+        printf 'vanilla-html'
+        return
+    fi
+    printf 'unknown'
+}
+
+json_escape() {
+    sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+framework="$(detect_framework "$repo_root")"
+
+files="$(
+    cd "$repo_root" || exit 1
+    find . \
+        \( -path './node_modules' -o -path './node_modules/*' \
+           -o -path './dist' -o -path './dist/*' \
+           -o -path './.next' -o -path './.next/*' \
+           -o -path './vendor' -o -path './vendor/*' \) -prune \
+        -o -type f \( \
+            -name '*.tsx' -o -name '*.jsx' -o -name '*.ts' -o -name '*.js' \
+            -o -name '*.vue' -o -name '*.svelte' -o -name '*.html' \
+            -o -name '*.css' -o -name '*.scss' \
+        \) -print \
+        | sed 's#^\./##' \
+        | sort \
+        | head -50
+)"
+
+printf '{"framework":"%s","files":[' "$framework"
+first=1
+while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    if [ "$first" -eq 0 ]; then printf ','; fi
+    first=0
+    escaped="$(printf '%s' "$file" | json_escape)"
+    printf '"%s"' "$escaped"
+done <<EOF
+$files
+EOF
+printf ']}\n'

--- a/tests/unit/test_autospec_design.bats
+++ b/tests/unit/test_autospec_design.bats
@@ -525,3 +525,95 @@ setup_apply() {
         <(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/opencode/agent.md")
     [ "$status" -eq 0 ]
 }
+
+# ---- migrate helpers: scan UI sources + generate migration spec (#579) -----
+
+setup_migrate_helpers() {
+    SCAN="$SKILL_DIR/scripts/scan-ui-sources.sh"
+    GEN_MIGRATION="$SKILL_DIR/scripts/gen-migration-spec.sh"
+    UI_REPO="$BATS_TEST_TMPDIR/ui-repo"
+    EMPTY_REPO="$BATS_TEST_TMPDIR/empty-repo"
+
+    mkdir -p "$UI_REPO/app" "$UI_REPO/components" "$UI_REPO/node_modules/ignored"
+    cat > "$UI_REPO/package.json" <<'EOF'
+{
+  "name": "ui-repo",
+  "dependencies": { "next": "14.0.0", "react": "18.2.0" }
+}
+EOF
+    cat > "$UI_REPO/next.config.js" <<'EOF'
+module.exports = {};
+EOF
+    cat > "$UI_REPO/app/page.tsx" <<'EOF'
+export default function Page() { return <main>Hello</main>; }
+EOF
+    cat > "$UI_REPO/components/Button.tsx" <<'EOF'
+export function Button() { return <button>Go</button>; }
+EOF
+    cat > "$UI_REPO/node_modules/ignored/Skip.tsx" <<'EOF'
+export const Skip = () => null;
+EOF
+
+    mkdir -p "$EMPTY_REPO"
+
+    export AUTOSPEC_DESIGN_CACHE_DIR="$FAKE_HOME/.autospec/design-cache"
+    export AUTOSPEC_DESIGN_CACHE_TTL=86400
+    mkdir -p "$AUTOSPEC_DESIGN_CACHE_DIR/linear"
+    printf '# Linear design language\n\nUse crisp product UI.\n' \
+        > "$AUTOSPEC_DESIGN_CACHE_DIR/linear/DESIGN.md"
+}
+
+@test "migrate helpers: scan-ui-sources.sh exists and is executable" {
+    setup_migrate_helpers
+    [ -x "$SCAN" ]
+}
+
+@test "migrate helpers: gen-migration-spec.sh exists and is executable" {
+    setup_migrate_helpers
+    [ -x "$GEN_MIGRATION" ]
+}
+
+@test "migrate helpers: scan detects Next.js and UI files" {
+    setup_migrate_helpers
+    run bash "$SCAN" "$UI_REPO"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q '"framework":"next"'
+    echo "$output" | grep -q '"app/page.tsx"'
+    echo "$output" | grep -q '"components/Button.tsx"'
+    ! echo "$output" | grep -q 'node_modules'
+}
+
+@test "migrate helpers: scan caps UI inventory at 50 files" {
+    setup_migrate_helpers
+    for i in $(seq 1 60); do
+        printf 'export const C%s = true;\n' "$i" > "$UI_REPO/components/C$i.tsx"
+    done
+    run bash "$SCAN" "$UI_REPO"
+    [ "$status" -eq 0 ]
+    file_count="$(printf '%s\n' "$output" | grep -oE '"[^"]+[.](tsx|jsx|ts|js|vue|svelte|html|css|scss)"' | wc -l | tr -d ' ')"
+    [ "$file_count" -eq 50 ]
+}
+
+@test "migrate helpers: gen-migration-spec writes mandatory sections" {
+    setup_migrate_helpers
+    run bash "$GEN_MIGRATION" linear "$UI_REPO"
+    [ "$status" -eq 0 ]
+    spec_path="$(printf '%s\n' "$output" | tail -1)"
+    [ -f "$spec_path" ]
+    case "$spec_path" in
+        "$UI_REPO"/docs/specs/*-design-migration-linear.md) ;;
+        *) echo "unexpected spec path: $spec_path"; false ;;
+    esac
+    grep -q '^## Source' "$spec_path"
+    grep -q '^## Target' "$spec_path"
+    grep -q '^## Team personality' "$spec_path"
+    grep -q '^## Counter-team' "$spec_path"
+    grep -q '^## Per-component outline' "$spec_path"
+}
+
+@test "migrate helpers: gen-migration-spec exits non-zero for repos with no UI files" {
+    setup_migrate_helpers
+    run bash "$GEN_MIGRATION" linear "$EMPTY_REPO"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -qi 'no UI files'
+}


### PR DESCRIPTION
Closes #579.

## Summary
- Adds `scan-ui-sources.sh` for framework detection and capped UI file inventory.
- Adds `gen-migration-spec.sh` to fetch the vendor DESIGN.md, scan UI sources, and emit a dated migration spec under `docs/specs/`.
- Extends `tests/unit/test_autospec_design.bats` with real fixture coverage for Next.js detection, denylist pruning, 50-file cap, generated spec sections, and empty-repo failure.

## Issue body amendment
Extended #579 implementation scope/outline to include `tests/unit/test_autospec_design.bats`, because the issue required helper tests while the original path list named only the scripts.

## Validation
- `bats tests/unit/test_autospec_design.bats`
- `bash skills/autospec-design/scripts/scan-ui-sources.sh .`
- `bash scripts/validate.sh`
- `bash scripts/lint-implementation.sh --diff-file /tmp/issue579.diff`