### PR TITLE
feat(autospec-design): document migrate handoff flow

### DIFF
--- a/skills/autospec-design/SKILL.md
+++ b/skills/autospec-design/SKILL.md
@@ -265,16 +265,76 @@ printf 'autospec-design apply: wrote %s (%s bytes) on branch %s.\n' \
 printf 'Next: open a PR, or run /autospec-design migrate %s.\n' "$vendor"
 ```
 
-## Subcommand: migrate (placeholder)
+## Migrate
 
 > **Model tier:** `TIER_B` (implementation work) — emits a structured spec and
 > hands off to `/autospec-define`.
 
-Scaffold-only placeholder. Real prose lands in issue #580. Until then, the
-migrate subcommand prints:
+`migrate <vendor> [--branch <name>]` turns an applied vendor `DESIGN.md` into a
+tracked migration spec and then hands that spec to `/autospec-define` for normal
+autospec issue decomposition. It assumes `/autospec-design apply <vendor>` has
+already written the repo-root `DESIGN.md`.
 
-```
-/autospec-design migrate: full implementation lands in issue #580.
+Preconditions and flow:
+
+1. Verify `<repo-root>/DESIGN.md` exists and its first heading or first 20 lines
+   mention `<vendor>` (case-insensitive, with suffixes like `.app` ignored).
+   Otherwise print `Run /autospec-design apply <vendor> first.` and exit
+   non-zero.
+2. Run `scan-ui-sources.sh <repo-root>`; if no UI files are found, surface the
+   helper's no-UI-files message and exit non-zero.
+3. Run `gen-migration-spec.sh <vendor> <repo-root>` to write
+   `docs/specs/<YYYY-MM-DD>-design-migration-<vendor>.md`.
+4. Commit the spec on the current feature branch (or create/switch to
+   `--branch <name>` first when provided).
+5. Hand off to `/autospec-define <spec-path>`. If that handoff fails, do not
+   swallow the error: leave the committed spec on disk and report the exact
+   command for manual recovery.
+
+The deterministic flow below is the canonical shell portion for steps 1-4. The
+actual harness handoff is the final printed `/autospec-define <spec-path>` line;
+invoke that skill through the harness after this script succeeds.
+
+```bash
+# autospec-design-migrate-flow
+set -u
+vendor="${DESIGN_VENDOR:?vendor required: /autospec-design migrate <vendor>}"
+repo_root="${DESIGN_REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+branch="${DESIGN_BRANCH:-}"
+scan="${DESIGN_SCAN:-skills/autospec-design/scripts/scan-ui-sources.sh}"
+generate="${DESIGN_GENERATE:-skills/autospec-design/scripts/gen-migration-spec.sh}"
+target="$repo_root/DESIGN.md"
+vendor_key="$(printf '%s' "$vendor" | sed -E 's/[.](app|ai|com|io)$//' | tr '[:upper:]' '[:lower:]')"
+
+if [ ! -f "$target" ] || ! head -20 "$target" | tr '[:upper:]' '[:lower:]' | grep -qF "$vendor_key"; then
+    printf 'Run /autospec-design apply %s first.\n' "$vendor" >&2
+    exit 1
+fi
+
+if [ -n "$branch" ]; then
+    git -C "$repo_root" checkout -B "$branch" >/dev/null 2>&1 || {
+        printf 'autospec-design migrate: could not create branch %s\n' "$branch" >&2
+        exit 1
+    }
+fi
+
+# Prove the UI inventory is non-empty before generating the spec.
+inventory="$(bash "$scan" "$repo_root")" || exit $?
+if printf '%s' "$inventory" | grep -q '"files":\[\]'; then
+    printf 'gen-migration-spec: no UI files found in %s; nothing to migrate.\n' "$repo_root" >&2
+    exit 2
+fi
+
+spec_path="$(bash "$generate" "$vendor" "$repo_root")" || exit $?
+git -C "$repo_root" add "$spec_path"
+if git -C "$repo_root" diff --cached --quiet -- "$spec_path"; then
+    printf 'autospec-design migrate: migration spec already committed: %s\n' "$spec_path"
+else
+    git -C "$repo_root" commit -q -m "docs(design): add $vendor migration spec"
+fi
+
+printf 'autospec-design migrate: wrote %s.\n' "$spec_path"
+printf '/autospec-define %s\n' "$spec_path"
 ```
 
 ## Hard rules

--- a/skills/autospec-design/codex/prompt.md
+++ b/skills/autospec-design/codex/prompt.md
@@ -261,16 +261,76 @@ printf 'autospec-design apply: wrote %s (%s bytes) on branch %s.\n' \
 printf 'Next: open a PR, or run /autospec-design migrate %s.\n' "$vendor"
 ```
 
-## Subcommand: migrate (placeholder)
+## Migrate
 
 > **Model tier:** `TIER_B` (implementation work) — emits a structured spec and
 > hands off to `/autospec-define`.
 
-Scaffold-only placeholder. Real prose lands in issue #580. Until then, the
-migrate subcommand prints:
+`migrate <vendor> [--branch <name>]` turns an applied vendor `DESIGN.md` into a
+tracked migration spec and then hands that spec to `/autospec-define` for normal
+autospec issue decomposition. It assumes `/autospec-design apply <vendor>` has
+already written the repo-root `DESIGN.md`.
 
-```
-/autospec-design migrate: full implementation lands in issue #580.
+Preconditions and flow:
+
+1. Verify `<repo-root>/DESIGN.md` exists and its first heading or first 20 lines
+   mention `<vendor>` (case-insensitive, with suffixes like `.app` ignored).
+   Otherwise print `Run /autospec-design apply <vendor> first.` and exit
+   non-zero.
+2. Run `scan-ui-sources.sh <repo-root>`; if no UI files are found, surface the
+   helper's no-UI-files message and exit non-zero.
+3. Run `gen-migration-spec.sh <vendor> <repo-root>` to write
+   `docs/specs/<YYYY-MM-DD>-design-migration-<vendor>.md`.
+4. Commit the spec on the current feature branch (or create/switch to
+   `--branch <name>` first when provided).
+5. Hand off to `/autospec-define <spec-path>`. If that handoff fails, do not
+   swallow the error: leave the committed spec on disk and report the exact
+   command for manual recovery.
+
+The deterministic flow below is the canonical shell portion for steps 1-4. The
+actual harness handoff is the final printed `/autospec-define <spec-path>` line;
+invoke that skill through the harness after this script succeeds.
+
+```bash
+# autospec-design-migrate-flow
+set -u
+vendor="${DESIGN_VENDOR:?vendor required: /autospec-design migrate <vendor>}"
+repo_root="${DESIGN_REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+branch="${DESIGN_BRANCH:-}"
+scan="${DESIGN_SCAN:-skills/autospec-design/scripts/scan-ui-sources.sh}"
+generate="${DESIGN_GENERATE:-skills/autospec-design/scripts/gen-migration-spec.sh}"
+target="$repo_root/DESIGN.md"
+vendor_key="$(printf '%s' "$vendor" | sed -E 's/[.](app|ai|com|io)$//' | tr '[:upper:]' '[:lower:]')"
+
+if [ ! -f "$target" ] || ! head -20 "$target" | tr '[:upper:]' '[:lower:]' | grep -qF "$vendor_key"; then
+    printf 'Run /autospec-design apply %s first.\n' "$vendor" >&2
+    exit 1
+fi
+
+if [ -n "$branch" ]; then
+    git -C "$repo_root" checkout -B "$branch" >/dev/null 2>&1 || {
+        printf 'autospec-design migrate: could not create branch %s\n' "$branch" >&2
+        exit 1
+    }
+fi
+
+# Prove the UI inventory is non-empty before generating the spec.
+inventory="$(bash "$scan" "$repo_root")" || exit $?
+if printf '%s' "$inventory" | grep -q '"files":\[\]'; then
+    printf 'gen-migration-spec: no UI files found in %s; nothing to migrate.\n' "$repo_root" >&2
+    exit 2
+fi
+
+spec_path="$(bash "$generate" "$vendor" "$repo_root")" || exit $?
+git -C "$repo_root" add "$spec_path"
+if git -C "$repo_root" diff --cached --quiet -- "$spec_path"; then
+    printf 'autospec-design migrate: migration spec already committed: %s\n' "$spec_path"
+else
+    git -C "$repo_root" commit -q -m "docs(design): add $vendor migration spec"
+fi
+
+printf 'autospec-design migrate: wrote %s.\n' "$spec_path"
+printf '/autospec-define %s\n' "$spec_path"
 ```
 
 ## Hard rules

--- a/skills/autospec-design/opencode/agent.md
+++ b/skills/autospec-design/opencode/agent.md
@@ -265,16 +265,76 @@ printf 'autospec-design apply: wrote %s (%s bytes) on branch %s.\n' \
 printf 'Next: open a PR, or run /autospec-design migrate %s.\n' "$vendor"
 ```
 
-## Subcommand: migrate (placeholder)
+## Migrate
 
 > **Model tier:** `TIER_B` (implementation work) — emits a structured spec and
 > hands off to `/autospec-define`.
 
-Scaffold-only placeholder. Real prose lands in issue #580. Until then, the
-migrate subcommand prints:
+`migrate <vendor> [--branch <name>]` turns an applied vendor `DESIGN.md` into a
+tracked migration spec and then hands that spec to `/autospec-define` for normal
+autospec issue decomposition. It assumes `/autospec-design apply <vendor>` has
+already written the repo-root `DESIGN.md`.
 
-```
-/autospec-design migrate: full implementation lands in issue #580.
+Preconditions and flow:
+
+1. Verify `<repo-root>/DESIGN.md` exists and its first heading or first 20 lines
+   mention `<vendor>` (case-insensitive, with suffixes like `.app` ignored).
+   Otherwise print `Run /autospec-design apply <vendor> first.` and exit
+   non-zero.
+2. Run `scan-ui-sources.sh <repo-root>`; if no UI files are found, surface the
+   helper's no-UI-files message and exit non-zero.
+3. Run `gen-migration-spec.sh <vendor> <repo-root>` to write
+   `docs/specs/<YYYY-MM-DD>-design-migration-<vendor>.md`.
+4. Commit the spec on the current feature branch (or create/switch to
+   `--branch <name>` first when provided).
+5. Hand off to `/autospec-define <spec-path>`. If that handoff fails, do not
+   swallow the error: leave the committed spec on disk and report the exact
+   command for manual recovery.
+
+The deterministic flow below is the canonical shell portion for steps 1-4. The
+actual harness handoff is the final printed `/autospec-define <spec-path>` line;
+invoke that skill through the harness after this script succeeds.
+
+```bash
+# autospec-design-migrate-flow
+set -u
+vendor="${DESIGN_VENDOR:?vendor required: /autospec-design migrate <vendor>}"
+repo_root="${DESIGN_REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+branch="${DESIGN_BRANCH:-}"
+scan="${DESIGN_SCAN:-skills/autospec-design/scripts/scan-ui-sources.sh}"
+generate="${DESIGN_GENERATE:-skills/autospec-design/scripts/gen-migration-spec.sh}"
+target="$repo_root/DESIGN.md"
+vendor_key="$(printf '%s' "$vendor" | sed -E 's/[.](app|ai|com|io)$//' | tr '[:upper:]' '[:lower:]')"
+
+if [ ! -f "$target" ] || ! head -20 "$target" | tr '[:upper:]' '[:lower:]' | grep -qF "$vendor_key"; then
+    printf 'Run /autospec-design apply %s first.\n' "$vendor" >&2
+    exit 1
+fi
+
+if [ -n "$branch" ]; then
+    git -C "$repo_root" checkout -B "$branch" >/dev/null 2>&1 || {
+        printf 'autospec-design migrate: could not create branch %s\n' "$branch" >&2
+        exit 1
+    }
+fi
+
+# Prove the UI inventory is non-empty before generating the spec.
+inventory="$(bash "$scan" "$repo_root")" || exit $?
+if printf '%s' "$inventory" | grep -q '"files":\[\]'; then
+    printf 'gen-migration-spec: no UI files found in %s; nothing to migrate.\n' "$repo_root" >&2
+    exit 2
+fi
+
+spec_path="$(bash "$generate" "$vendor" "$repo_root")" || exit $?
+git -C "$repo_root" add "$spec_path"
+if git -C "$repo_root" diff --cached --quiet -- "$spec_path"; then
+    printf 'autospec-design migrate: migration spec already committed: %s\n' "$spec_path"
+else
+    git -C "$repo_root" commit -q -m "docs(design): add $vendor migration spec"
+fi
+
+printf 'autospec-design migrate: wrote %s.\n' "$spec_path"
+printf '/autospec-define %s\n' "$spec_path"
 ```
 
 ## Hard rules

--- a/tests/unit/test_autospec_design.bats
+++ b/tests/unit/test_autospec_design.bats
@@ -617,3 +617,104 @@ EOF
     [ "$status" -ne 0 ]
     echo "$output" | grep -qi 'no UI files'
 }
+
+# ---- migrate-section trio prose + runnable flow (issue #580) --------------
+
+extract_migrate_flow() {
+    awk '
+        /# autospec-design-migrate-flow/ { capture=1 }
+        capture && /^```[[:space:]]*$/ { exit }
+        capture { print }
+    ' "$SKILL_DIR/SKILL.md" > "$1"
+}
+
+setup_migrate_flow() {
+    MIGRATE_REPO="$BATS_TEST_TMPDIR/migrate-flow-repo"
+    mkdir -p "$MIGRATE_REPO/app"
+    git -C "$MIGRATE_REPO" init -q
+    git -C "$MIGRATE_REPO" config user.email "test@example.com"
+    git -C "$MIGRATE_REPO" config user.name "Test User"
+    cat > "$MIGRATE_REPO/package.json" <<'EOF'
+{"dependencies":{"next":"14.0.0","react":"18.2.0"}}
+EOF
+    cat > "$MIGRATE_REPO/next.config.js" <<'EOF'
+module.exports = {};
+EOF
+    cat > "$MIGRATE_REPO/app/page.tsx" <<'EOF'
+export default function Page() { return <main>Hello</main>; }
+EOF
+    git -C "$MIGRATE_REPO" add .
+    git -C "$MIGRATE_REPO" commit -q -m "init"
+
+    export AUTOSPEC_DESIGN_CACHE_DIR="$FAKE_HOME/.autospec/design-cache"
+    export AUTOSPEC_DESIGN_CACHE_TTL=86400
+    mkdir -p "$AUTOSPEC_DESIGN_CACHE_DIR/linear"
+    printf '# Linear design language\n\nUse crisp product UI.\n' \
+        > "$AUTOSPEC_DESIGN_CACHE_DIR/linear/DESIGN.md"
+}
+
+@test "migrate: trio files each have exactly one '## Migrate' heading" {
+    run grep -c '^## Migrate' "$SKILL_DIR/SKILL.md"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 1 ]
+    run grep -c '^## Migrate' "$SKILL_DIR/opencode/agent.md"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 1 ]
+    run grep -c '^## Migrate' "$SKILL_DIR/codex/prompt.md"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 1 ]
+}
+
+@test "migrate: SKILL.md embeds a runnable migrate flow block" {
+    flow="$BATS_TEST_TMPDIR/migrate-flow.sh"
+    extract_migrate_flow "$flow"
+    [ -s "$flow" ]
+    run bash -n "$flow"
+    [ "$status" -eq 0 ]
+}
+
+@test "migrate: runnable flow requires DESIGN.md from apply first" {
+    setup_migrate_flow
+    flow="$BATS_TEST_TMPDIR/migrate-flow.sh"
+    extract_migrate_flow "$flow"
+    run env DESIGN_VENDOR="linear" \
+        DESIGN_REPO_ROOT="$MIGRATE_REPO" \
+        DESIGN_SCAN="$SKILL_DIR/scripts/scan-ui-sources.sh" \
+        DESIGN_GENERATE="$SKILL_DIR/scripts/gen-migration-spec.sh" \
+        bash "$flow"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q 'Run /autospec-design apply linear first'
+}
+
+@test "migrate: runnable flow writes and commits migration spec" {
+    setup_migrate_flow
+    printf '# Linear design language\n\nUse crisp product UI.\n' > "$MIGRATE_REPO/DESIGN.md"
+    git -C "$MIGRATE_REPO" add DESIGN.md
+    git -C "$MIGRATE_REPO" commit -q -m "feat(design): adopt linear design language"
+    flow="$BATS_TEST_TMPDIR/migrate-flow.sh"
+    extract_migrate_flow "$flow"
+    run env DESIGN_VENDOR="linear" \
+        DESIGN_REPO_ROOT="$MIGRATE_REPO" \
+        DESIGN_SCAN="$SKILL_DIR/scripts/scan-ui-sources.sh" \
+        DESIGN_GENERATE="$SKILL_DIR/scripts/gen-migration-spec.sh" \
+        bash "$flow"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q '/autospec-define '
+    spec_path="$(printf '%s\n' "$output" | sed -n 's#^autospec-design migrate: wrote \(.*\)\.$#\1#p')"
+    [ -f "$spec_path" ]
+    grep -q '^## Per-component outline' "$spec_path"
+    msg="$(git -C "$MIGRATE_REPO" log -1 --pretty=%s)"
+    [ "$msg" = "docs(design): add linear migration spec" ]
+}
+
+@test "migrate: lockstep holds after prose addition (SKILL == codex)" {
+    run diff <(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/SKILL.md") \
+        "$SKILL_DIR/codex/prompt.md"
+    [ "$status" -eq 0 ]
+}
+
+@test "migrate: lockstep holds after prose addition (SKILL == opencode)" {
+    run diff <(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/SKILL.md") \
+        <(awk '/^---$/{c++; next} c>=2' "$SKILL_DIR/opencode/agent.md")
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #580.

## Summary
- Replaces the `/autospec-design migrate` placeholder with lockstep trio prose.
- Embeds a canonical migrate flow that guards for applied `DESIGN.md`, scans UI inventory, generates the migration spec, commits it, and prints the `/autospec-define <spec>` handoff.
- Extends `tests/unit/test_autospec_design.bats` with runnable-flow tests for missing-DESIGN guard and successful spec commit.

## Issue body amendment
Extended #580 implementation scope/outline to include `tests/unit/test_autospec_design.bats`, because the issue required migrate guard/flow tests while the original path list named only trio files.

## Validation
- `bats tests/unit/test_autospec_design.bats`
- `bash scripts/validate.sh`
- `bash scripts/lint-implementation.sh --diff-file /tmp/issue580.diff`