### PR TITLE
test(autospec-design): include skill in install-all smoke matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ Uninstall symmetrically:
 ./uninstall.sh --skill all --harness all
 ```
 
+`uninstall.sh --skill all` removes every suite skill listed in the install
+matrix, including `autospec-design`.
+
 ### Single-skill curl install (advanced)
 
 Each per-skill installer is also callable standalone over curl:

--- a/install.sh
+++ b/install.sh
@@ -217,7 +217,7 @@ maybe_prompt_star() {
     command -v gh >/dev/null 2>&1 || return 0
 
     answer=""
-    if exec 3<>/dev/tty 2>/dev/null; then
+    if { exec 3<>/dev/tty; } 2>/dev/null; then
         info ""
         printf 'Would you like to star https://github.com/berlinguyinca/autospec to support adoption? [y/N] ' >&3
         read -r answer <&3 || { exec 3>&-; return 0; }

--- a/tests/smoke/test_install_all_skills.bats
+++ b/tests/smoke/test_install_all_skills.bats
@@ -17,7 +17,7 @@ setup() {
     export OPENCODE_CONFIG_DIR="$FAKE_HOME/.config/opencode"
     export CODEX_HOME="$FAKE_HOME/.codex"
 
-    SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep"
+    SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design"
     HELPERS="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh autospec-sweep-wizard.sh autospec-sweep-run.sh autospec-sweep-review.sh run-state.sh list-ready-issues.sh claim-issue.sh release-issue.sh"
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,7 +12,7 @@
 #   ./uninstall.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | all
+#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -24,7 +24,7 @@
 
 set -eu
 
-ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep"
+ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -67,7 +67,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$SKILL_ARG" in
-    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep) ;;
+    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
         exit 2


### PR DESCRIPTION
Closes #581.

## Summary
- Adds `autospec-design` to `tests/smoke/test_install_all_skills.bats` so install-all/uninstall-all smoke coverage includes it.
- Fixes top-level `uninstall.sh` symmetry so `--skill all` and `--skill autospec-design` remove the installed skill files.
- Documents uninstall-all symmetry in README and quiets the optional star prompt `/dev/tty` probe during headless smoke runs.

## Validation
- `bats tests/unit/test_autospec_design.bats`
- `bats tests/smoke/test_install_all_skills.bats`
- `bash scripts/validate.sh`
- `bash scripts/lint-implementation.sh --diff-file /tmp/issue581.diff`