### PR TITLE
feat: bootstrap recommended agent ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ One-line install for the full suite into every supported harness:
 curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash
 ```
 
+Windows PowerShell can use the native bootstrap, which installs Git/Bash through
+`winget`, `choco`, or `scoop` when available:
+
+```powershell
+irm https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.ps1 | iex
+```
+
 The bootstrap clones (or fast-forwards) autospec into `~/.autospec/repo` and then runs `./install.sh --skill all --harness all`. Re-run any time to update.
 
 Forward flags to the underlying installer:
@@ -105,6 +112,12 @@ The installer also honors:
 | `OPENCODE_CONFIG_DIR` | Override OpenCode install root. |
 | `CODEX_HOME` | Override Codex install root. |
 | `AUTOSPEC_NO_STAR_PROMPT=1` | Skip the optional adoption star prompt. |
+| `AUTOSPEC_SKIP_SYSTEM_TOOLS=1` | Skip best-effort installation of required/recommended CLIs. |
+| `AUTOSPEC_SKIP_ECOSYSTEM_BOOTSTRAP=1` | Skip peer ecosystem bootstrap. |
+| `AUTOSPEC_SKIP_SUPERPOWERS=1` | Skip Superpowers clone/link/OpenCode plugin setup. |
+| `AUTOSPEC_SKIP_OH_MY_CODEX=1` | Skip `oh-my-codex` npm install/setup. |
+| `AUTOSPEC_SKIP_OH_MY_OPENCODE=1` | Skip `oh-my-opencode` npm install/setup. |
+| `AUTOSPEC_SKIP_OH_MY_CLAUDE=1` | Skip `oh-my-claude`/OMC npm install/setup. |
 
 After a successful interactive suite install, the top-level installer asks
 whether you want to star `berlinguyinca/autospec` to support adoption. It is
@@ -168,14 +181,19 @@ cross-session CI rot.
 
 ### Turbo integration
 
-`install.sh` also bootstraps [tobihagemann/turbo](https://github.com/tobihagemann/turbo) as a peer skill family:
+`install.sh` also bootstraps the recommended peer ecosystem on macOS, Linux, and
+Windows hosts:
 
+- Ensures common system tools best-effort: `git`, `bash`, `curl`, `jq`, `yq`, `gh`, `node`, `npm`, `bun`, `bats`, `codex`, `claude`, `opencode`, `omx`, `omc`, `oh-my-opencode`, `mempalace`, and `ajv`.
+- Uses platform package managers when present: Homebrew, apt/dnf/yum/pacman/apk, winget, Chocolatey, Scoop, npm, pipx, uv, and pip.
+- Installs/updates `oh-my-codex`, `oh-my-opencode`, and OMC (`oh-my-claude-sisyphus`) through npm, runs idempotent setup for OMX/OMC, and initializes `oh-my-opencode` only when its config is missing.
+- Clones (or fast-forward pulls) [obra/superpowers](https://github.com/obra/superpowers), exposes its Codex skills at `~/.agents/skills/superpowers`, and adds the OpenCode plugin entry `superpowers@git+https://github.com/obra/superpowers.git`.
 - Clones (or fast-forward pulls) `~/.turbo/repo` and symlinks turbo skills into `~/.claude/skills/`.
 - Checks for the [Codex CLI](https://github.com/openai/codex). When present, autospec's Phase 4 implementer (issues labelled `autospec:v2-flow`) runs an inline peer-review pass on each diff before opening a PR. When absent, peer-review skips gracefully and the implementer continues.
 - Idempotently merges an `<!-- autospec-block -->` section into `~/.claude/CLAUDE.md` documenting both stacks' entrypoints.
 - Inside a git repo, offers to add `.autospec/` to `.gitignore` (auto-accept via `AUTOSPEC_AUTO_YES=1`).
 
-Turbo bootstrap failures are non-fatal: offline or no-remote setups continue using the cached turbo checkout.
+Peer ecosystem bootstrap failures are non-fatal: offline or locked-down hosts continue with cached tools or the autospec install itself.
 
 ## Update
 
@@ -204,7 +222,7 @@ Or, from a manual checkout:
 ./install.sh --skill all --harness all --update
 ```
 
-`--update` also fast-forwards the autospec checkout itself and pulls `~/.turbo/repo`, so a single command keeps both autospec and turbo current.
+`--update` also fast-forwards the autospec checkout itself and refreshes the peer ecosystem (`superpowers`, `oh-my-*`, and `~/.turbo/repo`), so a single command keeps the whole autospec toolchain current.
 
 Or invoke any installed skill with `update`:
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -78,6 +78,24 @@ function Find-Bash {
     return $null
 }
 
+function Find-Git {
+    $cmd = Get-Command git -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+
+    $candidates = @(
+        "$env:ProgramFiles\Git\cmd\git.exe",
+        "$env:ProgramFiles\Git\bin\git.exe",
+        "${env:ProgramFiles(x86)}\Git\cmd\git.exe",
+        "${env:ProgramFiles(x86)}\Git\bin\git.exe",
+        "$env:LOCALAPPDATA\Programs\Git\cmd\git.exe",
+        "$env:LOCALAPPDATA\Programs\Git\bin\git.exe"
+    )
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path $candidate)) { return $candidate }
+    }
+    return $null
+}
+
 $autospecHome = [Environment]::GetEnvironmentVariable("AUTOSPEC_HOME")
 if ([string]::IsNullOrWhiteSpace($autospecHome)) {
     $autospecHome = Join-Path $HOME ".autospec"
@@ -95,7 +113,8 @@ $repoDir = Join-Path $autospecHome "repo"
 Install-CommandBestEffort "git" "Git.Git" "git" "git"
 Install-CommandBestEffort "bash" "Git.Git" "git" "git"
 
-if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+$git = Find-Git
+if ([string]::IsNullOrWhiteSpace($git)) {
     throw "git is required but was not found after best-effort installation."
 }
 $bash = Find-Bash
@@ -107,11 +126,11 @@ New-Item -ItemType Directory -Force -Path $autospecHome | Out-Null
 
 if (Test-Path (Join-Path $repoDir ".git")) {
     Write-Info "updating existing checkout at $repoDir (ref: $autospecRef)"
-    Invoke-Checked -CommandName "git" -CommandArgs @("-C", $repoDir, "fetch", "--quiet", "origin", $autospecRef) -ErrorMessage "git fetch failed for $repoUrl ($autospecRef)"
-    Invoke-Checked -CommandName "git" -CommandArgs @("-C", $repoDir, "checkout", "--quiet", $autospecRef) -ErrorMessage "git checkout failed for $autospecRef"
-    & git -C $repoDir merge --ff-only --quiet "origin/$autospecRef"
+    Invoke-Checked -CommandName $git -CommandArgs @("-C", $repoDir, "fetch", "--quiet", "origin", $autospecRef) -ErrorMessage "git fetch failed for $repoUrl ($autospecRef)"
+    Invoke-Checked -CommandName $git -CommandArgs @("-C", $repoDir, "checkout", "--quiet", $autospecRef) -ErrorMessage "git checkout failed for $autospecRef"
+    & $git -C $repoDir merge --ff-only --quiet "origin/$autospecRef"
     if ($LASTEXITCODE -ne 0) {
-        & git -C $repoDir symbolic-ref --quiet HEAD | Out-Null
+        & $git -C $repoDir symbolic-ref --quiet HEAD | Out-Null
         if ($LASTEXITCODE -eq 0) {
             throw "could not fast-forward $repoDir to origin/$autospecRef. Resolve local changes and re-run."
         }
@@ -120,11 +139,11 @@ if (Test-Path (Join-Path $repoDir ".git")) {
     throw "$repoDir exists but is not a git checkout. Remove it or set AUTOSPEC_HOME and re-run."
 } else {
     Write-Info "cloning $repoUrl to $repoDir (ref: $autospecRef)"
-    & git clone --quiet --branch $autospecRef --depth 1 $repoUrl $repoDir
+    & $git clone --quiet --branch $autospecRef --depth 1 $repoUrl $repoDir
     if ($LASTEXITCODE -ne 0) {
         Write-Warn "shallow branch clone failed; retrying full clone"
-        Invoke-Checked -CommandName "git" -CommandArgs @("clone", "--quiet", $repoUrl, $repoDir) -ErrorMessage "git clone failed for $repoUrl"
-        Invoke-Checked -CommandName "git" -CommandArgs @("-C", $repoDir, "checkout", "--quiet", $autospecRef) -ErrorMessage "git checkout failed for $autospecRef"
+        Invoke-Checked -CommandName $git -CommandArgs @("clone", "--quiet", $repoUrl, $repoDir) -ErrorMessage "git clone failed for $repoUrl"
+        Invoke-Checked -CommandName $git -CommandArgs @("-C", $repoDir, "checkout", "--quiet", $autospecRef) -ErrorMessage "git checkout failed for $autospecRef"
     }
 }
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,0 +1,138 @@
+# bootstrap.ps1 - Windows-friendly bootstrap for the autospec suite.
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.ps1 | iex
+#   ./bootstrap.ps1 --skill autospec --harness codex --update
+#
+# Honors:
+#   AUTOSPEC_HOME       (default: $HOME\.autospec)
+#   AUTOSPEC_REF        (default: main)
+#   AUTOSPEC_REPO_URL   (default: official remote)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Info {
+    param([string]$Message)
+    Write-Output "bootstrap: $Message"
+}
+
+function Write-Warn {
+    param([string]$Message)
+    Write-Warning "bootstrap: $Message"
+}
+
+function Invoke-Checked {
+    param(
+        [string]$CommandName,
+        [string[]]$CommandArgs,
+        [string]$ErrorMessage
+    )
+    & $CommandName @CommandArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw $ErrorMessage
+    }
+}
+
+function Install-CommandBestEffort {
+    param(
+        [string]$CommandName,
+        [string]$WingetId,
+        [string]$ChocoPackage,
+        [string]$ScoopPackage
+    )
+
+    if (Get-Command $CommandName -ErrorAction SilentlyContinue) {
+        return
+    }
+
+    if ((Get-Command winget -ErrorAction SilentlyContinue) -and -not [string]::IsNullOrWhiteSpace($WingetId)) {
+        Write-Info "installing $CommandName via winget"
+        & winget install --id $WingetId -e --accept-package-agreements --accept-source-agreements | Out-Null
+        if (Get-Command $CommandName -ErrorAction SilentlyContinue) { return }
+    }
+
+    if ((Get-Command choco -ErrorAction SilentlyContinue) -and -not [string]::IsNullOrWhiteSpace($ChocoPackage)) {
+        Write-Info "installing $CommandName via choco"
+        & choco install -y $ChocoPackage | Out-Null
+        if (Get-Command $CommandName -ErrorAction SilentlyContinue) { return }
+    }
+
+    if ((Get-Command scoop -ErrorAction SilentlyContinue) -and -not [string]::IsNullOrWhiteSpace($ScoopPackage)) {
+        Write-Info "installing $CommandName via scoop"
+        & scoop install $ScoopPackage | Out-Null
+    }
+}
+
+function Find-Bash {
+    $cmd = Get-Command bash -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+
+    $candidates = @(
+        "$env:ProgramFiles\Git\bin\bash.exe",
+        "${env:ProgramFiles(x86)}\Git\bin\bash.exe",
+        "$env:LOCALAPPDATA\Programs\Git\bin\bash.exe"
+    )
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path $candidate)) { return $candidate }
+    }
+    return $null
+}
+
+$autospecHome = [Environment]::GetEnvironmentVariable("AUTOSPEC_HOME")
+if ([string]::IsNullOrWhiteSpace($autospecHome)) {
+    $autospecHome = Join-Path $HOME ".autospec"
+}
+$autospecRef = [Environment]::GetEnvironmentVariable("AUTOSPEC_REF")
+if ([string]::IsNullOrWhiteSpace($autospecRef)) {
+    $autospecRef = "main"
+}
+$repoUrl = [Environment]::GetEnvironmentVariable("AUTOSPEC_REPO_URL")
+if ([string]::IsNullOrWhiteSpace($repoUrl)) {
+    $repoUrl = "https://github.com/berlinguyinca/autospec.git"
+}
+$repoDir = Join-Path $autospecHome "repo"
+
+Install-CommandBestEffort "git" "Git.Git" "git" "git"
+Install-CommandBestEffort "bash" "Git.Git" "git" "git"
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    throw "git is required but was not found after best-effort installation."
+}
+$bash = Find-Bash
+if ([string]::IsNullOrWhiteSpace($bash)) {
+    throw "bash is required but was not found after best-effort Git installation."
+}
+
+New-Item -ItemType Directory -Force -Path $autospecHome | Out-Null
+
+if (Test-Path (Join-Path $repoDir ".git")) {
+    Write-Info "updating existing checkout at $repoDir (ref: $autospecRef)"
+    Invoke-Checked -CommandName "git" -CommandArgs @("-C", $repoDir, "fetch", "--quiet", "origin", $autospecRef) -ErrorMessage "git fetch failed for $repoUrl ($autospecRef)"
+    Invoke-Checked -CommandName "git" -CommandArgs @("-C", $repoDir, "checkout", "--quiet", $autospecRef) -ErrorMessage "git checkout failed for $autospecRef"
+    & git -C $repoDir merge --ff-only --quiet "origin/$autospecRef"
+    if ($LASTEXITCODE -ne 0) {
+        & git -C $repoDir symbolic-ref --quiet HEAD | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            throw "could not fast-forward $repoDir to origin/$autospecRef. Resolve local changes and re-run."
+        }
+    }
+} elseif (Test-Path $repoDir) {
+    throw "$repoDir exists but is not a git checkout. Remove it or set AUTOSPEC_HOME and re-run."
+} else {
+    Write-Info "cloning $repoUrl to $repoDir (ref: $autospecRef)"
+    & git clone --quiet --branch $autospecRef --depth 1 $repoUrl $repoDir
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warn "shallow branch clone failed; retrying full clone"
+        Invoke-Checked -CommandName "git" -CommandArgs @("clone", "--quiet", $repoUrl, $repoDir) -ErrorMessage "git clone failed for $repoUrl"
+        Invoke-Checked -CommandName "git" -CommandArgs @("-C", $repoDir, "checkout", "--quiet", $autospecRef) -ErrorMessage "git checkout failed for $autospecRef"
+    }
+}
+
+Write-Info "running $repoDir/install.sh $args"
+Push-Location $repoDir
+try {
+    & $bash ./install.sh @args
+    exit $LASTEXITCODE
+} finally {
+    Pop-Location
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -4,7 +4,7 @@
 > *Per-symbol reference for all public CLI surfaces and shared scripts.*
 
 <!-- autospec-doc-scope:
-  src: ["scripts/**/*.sh", "scripts/**/*.mjs", "scripts/**/*.ps1", "skills/autospec-shared/scripts/**/*.mjs", "skills/autospec-shared/scripts/**/*.sh", "install.sh", "skills/*/install.sh", "tests/ship-completeness.bats"]
+  src: ["bootstrap.ps1", "scripts/**/*.sh", "scripts/**/*.mjs", "scripts/**/*.ps1", "skills/autospec-shared/scripts/**/*.mjs", "skills/autospec-shared/scripts/**/*.sh", "install.sh", "skills/*/install.sh", "tests/ship-completeness.bats"]
   reason: "API reference for all autospec shared scripts, their shipping path, and the ship-completeness guard"
   mismatch_action: warn
   generated: true
@@ -357,8 +357,12 @@ Exit: always 0 (best-effort; never blocks the caller).
 
 ### `ensure-tool.sh`
 
-Best-effort idempotent installer for autospec's optional CLI deps via a platform fallback chain
-(brew / apt-get / npm / pipx / uv / pip). Baked-in tool table: `bats`, `jq`, `gh`, `mempalace`.
+Best-effort idempotent installer for autospec's required and recommended CLI
+deps via a platform fallback chain (brew / apt/dnf/yum/pacman/apk /
+winget/choco/scoop / npm / pipx / uv / pip). Baked-in tool table: `ajv`,
+`bash`, `bats`, `bun`, `claude`, `codex`, `curl`, `gh`, `git`, `jq`,
+`mempalace`, `node`, `npm`, `omc`, `omx`, `oh-my-opencode`, `opencode`,
+`pipx`, `python3`, `uv`, `yq`.
 
 ```
 Usage: bash ensure-tool.sh <tool>
@@ -367,6 +371,20 @@ Env:   AUTOSPEC_SKIP_ENSURE_TOOL=1          disable ALL auto-installs
 ```
 
 Exit: always 0 (best-effort by design; unknown tools are a silent no-op).
+
+### `bootstrap.ps1`
+
+Windows-friendly suite bootstrap. Ensures Git/Bash through `winget`, `choco`,
+or `scoop` when available, clones or updates autospec in
+`$HOME\.autospec\repo`, then invokes `install.sh` through Bash and forwards all
+arguments.
+
+```
+Usage: ./bootstrap.ps1 [install.sh args...]
+Env:   AUTOSPEC_HOME       override checkout/state directory
+       AUTOSPEC_REF        git ref to install (default: main)
+       AUTOSPEC_REPO_URL   override remote URL
+```
 
 ### `cross-repo-index.sh`
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -21,14 +21,28 @@ requests with validation, review, and merge control.
 ## Installation
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/install.sh)
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.ps1 | iex
 ```
 
 To update an existing install:
 
 ```bash
-bash install.sh --update
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --update
 ```
+
+The suite installer also bootstraps required and recommended local tools on a
+best-effort basis across macOS, Linux, and Windows: system CLIs (`git`, `bash`,
+`curl`, `jq`, `yq`, `gh`, `node`, `npm`, `bun`, `bats`), agent CLIs (`codex`,
+`claude`, `opencode`), and companion ecosystems (`superpowers`,
+`oh-my-codex`/OMX, `oh-my-opencode`, OMC/oh-my-claude, and turbo). Locked-down
+or offline hosts continue with warnings; use `AUTOSPEC_SKIP_SYSTEM_TOOLS=1` or
+`AUTOSPEC_SKIP_ECOSYSTEM_BOOTSTRAP=1` to opt out.
 
 ## Skills
 

--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,8 @@
 #
 # Honors:
 #   AUTOSPEC_NO_STAR_PROMPT=1  skip the optional GitHub star prompt.
+#   AUTOSPEC_SKIP_SYSTEM_TOOLS=1  skip best-effort CLI dependency installs.
+#   AUTOSPEC_SKIP_ECOSYSTEM_BOOTSTRAP=1  skip peer ecosystem bootstrap.
 #
 # Exits non-zero on any sub-installer failure; reports per-pair status.
 
@@ -37,6 +39,15 @@ SKILLS_DIR="$REPO_ROOT/skills"
 TURBO_REPO_DIR="${TURBO_REPO_DIR:-$HOME/.turbo/repo}"
 TURBO_REMOTE="https://github.com/tobihagemann/turbo.git"
 CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
+SUPERPOWERS_REPO_DIR="${SUPERPOWERS_REPO_DIR:-$HOME/.codex/superpowers}"
+SUPERPOWERS_REMOTE="${SUPERPOWERS_REMOTE:-https://github.com/obra/superpowers.git}"
+SUPERPOWERS_CODEX_SKILLS_DIR="${SUPERPOWERS_CODEX_SKILLS_DIR:-$HOME/.agents/skills}"
+SUPERPOWERS_OPENCODE_PLUGIN="${SUPERPOWERS_OPENCODE_PLUGIN:-superpowers@git+https://github.com/obra/superpowers.git}"
+OPENCODE_CONFIG_ROOT="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+AUTOSPEC_SYSTEM_TOOLS="${AUTOSPEC_SYSTEM_TOOLS:-git bash curl jq yq gh node npm bun bats codex claude opencode omx omc oh-my-opencode mempalace ajv}"
+OH_MY_CODEX_PACKAGE="${OH_MY_CODEX_PACKAGE:-oh-my-codex}"
+OH_MY_OPENCODE_PACKAGE="${OH_MY_OPENCODE_PACKAGE:-oh-my-opencode}"
+OH_MY_CLAUDE_PACKAGE="${OH_MY_CLAUDE_PACKAGE:-oh-my-claude-sisyphus}"
 
 ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design"
 ALL_HARNESSES="claude opencode codex"
@@ -134,6 +145,195 @@ check_codex() {
     info "  Phase 4 peer-review will skip gracefully until codex is installed."
     info "  Install: see https://github.com/openai/codex (or your package manager)."
     return 0
+}
+
+ensure_system_tools() {
+    if [ "${AUTOSPEC_SKIP_SYSTEM_TOOLS:-0}" = "1" ]; then
+        info "ensure_system_tools: skipped by AUTOSPEC_SKIP_SYSTEM_TOOLS=1"
+        return 0
+    fi
+    ensure_tool="$REPO_ROOT/skills/autospec-shared/scripts/ensure-tool.sh"
+    if [ ! -f "$ensure_tool" ]; then
+        warn "ensure_system_tools: $ensure_tool missing; skipping"
+        return 0
+    fi
+    for tool in $AUTOSPEC_SYSTEM_TOOLS; do
+        if [ "$DRY_RUN" -eq 1 ]; then
+            info "[dry-run] ensure_system_tools: would ensure $tool"
+        else
+            bash "$ensure_tool" "$tool" || true
+        fi
+    done
+}
+
+install_npm_ecosystem_package() {
+    label="$1"
+    package_name="$2"
+    command_name="$3"
+    skip_var="$4"
+
+    eval "skip_val=\${${skip_var}:-0}"
+    if [ "$skip_val" = "1" ]; then
+        info "$label: skipped by $skip_var=1"
+        return 0
+    fi
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        info "[dry-run] $label: would npm install -g $package_name when $command_name is missing or --update is set"
+        return 0
+    fi
+
+    if command_present "$command_name" && [ "$UPDATE" -eq 0 ]; then
+        info "$label: $command_name present ($(command -v "$command_name"))"
+        return 0
+    fi
+
+    if ! command_present npm; then
+        warn "$label: npm not found; install Node.js/npm or rerun after ensure_system_tools succeeds"
+        return 0
+    fi
+
+    npm install -g "$package_name" >/dev/null 2>&1 \
+        && info "$label: installed/updated $package_name" \
+        || warn "$label: npm install -g $package_name failed; continuing"
+}
+
+bootstrap_superpowers_codex_link() {
+    src="$SUPERPOWERS_REPO_DIR/skills"
+    target="$SUPERPOWERS_CODEX_SKILLS_DIR/superpowers"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        info "[dry-run] bootstrap_superpowers: would expose $src at $target"
+        return 0
+    fi
+
+    [ -d "$src" ] || { warn "bootstrap_superpowers: $src missing; cannot expose Codex skills"; return 0; }
+    mkdir -p "$SUPERPOWERS_CODEX_SKILLS_DIR"
+
+    if [ -L "$target" ]; then
+        ln -sfn "$src" "$target" \
+            && info "bootstrap_superpowers: refreshed Codex skills symlink at $target" \
+            || warn "bootstrap_superpowers: could not refresh $target"
+    elif [ ! -e "$target" ]; then
+        ln -s "$src" "$target" 2>/dev/null \
+            && info "bootstrap_superpowers: linked Codex skills at $target" \
+            || { cp -R "$src" "$target" 2>/dev/null \
+                && info "bootstrap_superpowers: copied Codex skills to $target (symlink unavailable)" \
+                || warn "bootstrap_superpowers: could not link or copy Codex skills to $target"; }
+    else
+        info "bootstrap_superpowers: existing $target left untouched"
+    fi
+}
+
+bootstrap_superpowers_opencode_plugin() {
+    config_file="$OPENCODE_CONFIG_ROOT/opencode.json"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        info "[dry-run] bootstrap_superpowers: would ensure OpenCode plugin $SUPERPOWERS_OPENCODE_PLUGIN in $config_file"
+        return 0
+    fi
+
+    if ! command_present node; then
+        warn "bootstrap_superpowers: node not found; cannot update $config_file"
+        return 0
+    fi
+
+    mkdir -p "$OPENCODE_CONFIG_ROOT"
+    if node - "$config_file" "$SUPERPOWERS_OPENCODE_PLUGIN" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const file = process.argv[2];
+const plugin = process.argv[3];
+let config = {};
+if (fs.existsSync(file)) {
+  try {
+    config = JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    console.error(`invalid JSON in ${file}: ${error.message}`);
+    process.exit(2);
+  }
+}
+const plugins = Array.isArray(config.plugin)
+  ? config.plugin
+  : (typeof config.plugin === 'string' ? [config.plugin] : []);
+if (!plugins.includes(plugin)) {
+  plugins.push(plugin);
+}
+config.plugin = plugins;
+fs.mkdirSync(path.dirname(file), { recursive: true });
+fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`);
+NODE
+    then
+        info "bootstrap_superpowers: ensured OpenCode plugin in $config_file"
+    else
+        warn "bootstrap_superpowers: could not update $config_file"
+    fi
+}
+
+bootstrap_superpowers() {
+    if [ "${AUTOSPEC_SKIP_SUPERPOWERS:-0}" = "1" ]; then
+        info "bootstrap_superpowers: skipped by AUTOSPEC_SKIP_SUPERPOWERS=1"
+        return 0
+    fi
+
+    if [ -d "$SUPERPOWERS_REPO_DIR/.git" ]; then
+        info "bootstrap_superpowers: pulling obra/superpowers at $SUPERPOWERS_REPO_DIR"
+        if [ "$DRY_RUN" -eq 0 ]; then
+            git -C "$SUPERPOWERS_REPO_DIR" pull --ff-only 2>/dev/null \
+                || warn "bootstrap_superpowers: pull failed (offline or local changes); using cached superpowers"
+        fi
+    else
+        info "bootstrap_superpowers: cloning obra/superpowers to $SUPERPOWERS_REPO_DIR"
+        if [ "$DRY_RUN" -eq 0 ]; then
+            git clone --depth 1 "$SUPERPOWERS_REMOTE" "$SUPERPOWERS_REPO_DIR" 2>/dev/null \
+                || { warn "bootstrap_superpowers: clone failed; superpowers will not be installed"; return 0; }
+        fi
+    fi
+
+    bootstrap_superpowers_codex_link
+    bootstrap_superpowers_opencode_plugin
+}
+
+run_peer_setup_commands() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        info "[dry-run] bootstrap_oh_my_codex: would run omx setup --scope user --skill-target codex-home"
+        info "[dry-run] bootstrap_oh_my_opencode: would initialize oh-my-opencode only when config is missing"
+        info "[dry-run] bootstrap_oh_my_claude: would run omc setup --quiet"
+        return 0
+    fi
+
+    if command_present omx; then
+        omx setup --scope user --skill-target codex-home >/dev/null 2>&1 \
+            && info "bootstrap_oh_my_codex: refreshed OMX setup" \
+            || warn "bootstrap_oh_my_codex: omx setup failed; continuing"
+    fi
+    if command_present oh-my-opencode; then
+        if [ -f "$OPENCODE_CONFIG_ROOT/oh-my-openagent.json" ]; then
+            info "bootstrap_oh_my_opencode: existing config left untouched"
+        else
+            oh-my-opencode install --no-tui --claude=no --openai=no --gemini=no --copilot=no --skip-auth >/dev/null 2>&1 \
+                && info "bootstrap_oh_my_opencode: initialized OpenCode setup" \
+                || warn "bootstrap_oh_my_opencode: non-interactive setup failed; package install still completed"
+        fi
+    fi
+    if command_present omc; then
+        omc setup --quiet >/dev/null 2>&1 \
+            && info "bootstrap_oh_my_claude: refreshed OMC setup" \
+            || warn "bootstrap_oh_my_claude: omc setup failed; continuing"
+    fi
+}
+
+bootstrap_peer_ecosystems() {
+    if [ "${AUTOSPEC_SKIP_ECOSYSTEM_BOOTSTRAP:-0}" = "1" ]; then
+        info "bootstrap_peer_ecosystems: skipped by AUTOSPEC_SKIP_ECOSYSTEM_BOOTSTRAP=1"
+        return 0
+    fi
+
+    bootstrap_superpowers
+    install_npm_ecosystem_package "bootstrap_oh_my_codex" "$OH_MY_CODEX_PACKAGE" "omx" "AUTOSPEC_SKIP_OH_MY_CODEX"
+    install_npm_ecosystem_package "bootstrap_oh_my_opencode" "$OH_MY_OPENCODE_PACKAGE" "oh-my-opencode" "AUTOSPEC_SKIP_OH_MY_OPENCODE"
+    install_npm_ecosystem_package "bootstrap_oh_my_claude" "$OH_MY_CLAUDE_PACKAGE" "omc" "AUTOSPEC_SKIP_OH_MY_CLAUDE"
+    run_peer_setup_commands
 }
 
 bootstrap_turbo() {
@@ -398,6 +598,8 @@ copy_repo_scripts() {
 pull_autospec
 copy_shared_scripts
 copy_repo_scripts
+ensure_system_tools
+bootstrap_peer_ecosystems
 bootstrap_turbo
 check_codex
 merge_claude_md

--- a/skills/autospec-shared/scripts/ensure-tool.sh
+++ b/skills/autospec-shared/scripts/ensure-tool.sh
@@ -3,13 +3,16 @@
 #
 # Generalizes the _ensure_mempalace_installed helper (PR #509) into a reusable
 # tool-installer with a baked-in tool table and a platform-appropriate fallback
-# chain (brew / apt-get / npm / pipx / uv / pip). Every install is a silent
-# best-effort: a missing or failed installer never blocks the caller.
+# chain (brew / apt/dnf/yum/pacman/apk / winget/choco/scoop / npm / pipx / uv /
+# pip). Every install is a silent best-effort: a missing or failed installer
+# never blocks the caller.
 #
 # Usage:
 #   ensure-tool.sh <tool>          # ensure <tool> is on PATH; install if absent
 #
-# Supported tools (baked-in table): bats, jq, gh, mempalace
+# Supported tools (baked-in table): ajv, bash, bats, bun, claude, codex, curl,
+# gh, git, jq, mempalace, node, npm, omc, omx, oh-my-opencode, opencode, pipx,
+# python3, uv, yq
 # Unknown tools are a silent no-op (exit 0).
 #
 # Exit codes:
@@ -52,22 +55,82 @@ fi
 # the caller's chain can short-circuit; returns 1 if its installer is absent or
 # the install failed.
 
-_try_brew() {  # _try_brew <pkg>
+_sudo_cmd() {
+  if [ "$(id -u 2>/dev/null || echo 1)" != "0" ] && command -v sudo > /dev/null 2>&1; then
+    printf 'sudo'
+  fi
+}
+
+_try_brew() {  # _try_brew <pkg...>
   command -v brew > /dev/null 2>&1 || return 1
-  brew install "$1" > /dev/null 2>&1 \
+  brew install "$@" > /dev/null 2>&1 \
     && { echo "ensure-tool: installed $TOOL via brew" >&2; return 0; }
   return 1
 }
 
-_try_apt() {  # _try_apt <pkg>
+_try_apt() {  # _try_apt <pkg...>
   command -v apt-get > /dev/null 2>&1 || return 1
-  # -y non-interactive; sudo only if not already root and available.
-  local sudo=""
-  if [ "$(id -u 2>/dev/null || echo 1)" != "0" ] && command -v sudo > /dev/null 2>&1; then
-    sudo="sudo"
-  fi
-  $sudo apt-get install -y "$1" > /dev/null 2>&1 \
+  local sudo
+  sudo="$(_sudo_cmd)"
+  $sudo apt-get install -y "$@" > /dev/null 2>&1 \
     && { echo "ensure-tool: installed $TOOL via apt-get" >&2; return 0; }
+  return 1
+}
+
+_try_dnf() {  # _try_dnf <pkg...>
+  command -v dnf > /dev/null 2>&1 || return 1
+  local sudo
+  sudo="$(_sudo_cmd)"
+  $sudo dnf install -y "$@" > /dev/null 2>&1 \
+    && { echo "ensure-tool: installed $TOOL via dnf" >&2; return 0; }
+  return 1
+}
+
+_try_yum() {  # _try_yum <pkg...>
+  command -v yum > /dev/null 2>&1 || return 1
+  local sudo
+  sudo="$(_sudo_cmd)"
+  $sudo yum install -y "$@" > /dev/null 2>&1 \
+    && { echo "ensure-tool: installed $TOOL via yum" >&2; return 0; }
+  return 1
+}
+
+_try_pacman() {  # _try_pacman <pkg...>
+  command -v pacman > /dev/null 2>&1 || return 1
+  local sudo
+  sudo="$(_sudo_cmd)"
+  $sudo pacman -Sy --noconfirm "$@" > /dev/null 2>&1 \
+    && { echo "ensure-tool: installed $TOOL via pacman" >&2; return 0; }
+  return 1
+}
+
+_try_apk() {  # _try_apk <pkg...>
+  command -v apk > /dev/null 2>&1 || return 1
+  local sudo
+  sudo="$(_sudo_cmd)"
+  $sudo apk add --no-cache "$@" > /dev/null 2>&1 \
+    && { echo "ensure-tool: installed $TOOL via apk" >&2; return 0; }
+  return 1
+}
+
+_try_winget() {  # _try_winget <id>
+  command -v winget > /dev/null 2>&1 || return 1
+  winget install --id "$1" -e --accept-package-agreements --accept-source-agreements > /dev/null 2>&1 \
+    && { echo "ensure-tool: installed $TOOL via winget" >&2; return 0; }
+  return 1
+}
+
+_try_choco() {  # _try_choco <pkg>
+  command -v choco > /dev/null 2>&1 || return 1
+  choco install -y "$1" > /dev/null 2>&1 \
+    && { echo "ensure-tool: installed $TOOL via choco" >&2; return 0; }
+  return 1
+}
+
+_try_scoop() {  # _try_scoop <pkg>
+  command -v scoop > /dev/null 2>&1 || return 1
+  scoop install "$1" > /dev/null 2>&1 \
+    && { echo "ensure-tool: installed $TOOL via scoop" >&2; return 0; }
   return 1
 }
 
@@ -107,18 +170,77 @@ _try_pip() {  # _try_pip <pkg>
 # Each case tries installers in preference order; first success wins. Package
 # name may differ from the command name (kept explicit per installer).
 case "$TOOL" in
+  ajv)
+    _try_npm ajv-cli || true
+    ;;
+  bash)
+    _try_brew bash || _try_apt bash || _try_dnf bash || _try_yum bash || _try_pacman bash || _try_apk bash \
+      || _try_winget Git.Git || _try_choco git || _try_scoop git || true
+    ;;
   bats)
-    _try_brew bats-core || _try_apt bats || _try_npm bats || true
+    _try_brew bats-core || _try_apt bats || _try_dnf bats || _try_yum bats || _try_pacman bats || _try_apk bats \
+      || _try_choco bats || _try_scoop bats || _try_npm bats || true
+    ;;
+  bun)
+    _try_brew bun || _try_winget Oven-sh.Bun || _try_choco bun || _try_scoop bun || true
+    ;;
+  claude)
+    _try_npm @anthropic-ai/claude-code || true
+    ;;
+  codex)
+    _try_npm @openai/codex || true
+    ;;
+  curl)
+    _try_brew curl || _try_apt curl || _try_dnf curl || _try_yum curl || _try_pacman curl || _try_apk curl \
+      || _try_winget cURL.cURL || _try_choco curl || _try_scoop curl || true
     ;;
   jq)
-    _try_brew jq || _try_apt jq || true
+    _try_brew jq || _try_apt jq || _try_dnf jq || _try_yum jq || _try_pacman jq || _try_apk jq \
+      || _try_winget jqlang.jq || _try_choco jq || _try_scoop jq || true
     ;;
   gh)
-    _try_brew gh || _try_apt gh || true
+    _try_brew gh || _try_apt gh || _try_dnf gh || _try_yum gh || _try_pacman github-cli || _try_apk github-cli \
+      || _try_winget GitHub.cli || _try_choco gh || _try_scoop gh || true
+    ;;
+  git)
+    _try_brew git || _try_apt git || _try_dnf git || _try_yum git || _try_pacman git || _try_apk git \
+      || _try_winget Git.Git || _try_choco git || _try_scoop git || true
     ;;
   mempalace)
     # Python tool: pipx (isolated venv) → uv → pip --user. Mirrors PR #509.
     _try_pipx mempalace || _try_uv mempalace || _try_pip mempalace || true
+    ;;
+  node|npm)
+    _try_brew node || _try_apt nodejs npm || _try_dnf nodejs npm || _try_yum nodejs npm || _try_pacman nodejs npm \
+      || _try_apk nodejs npm || _try_winget OpenJS.NodeJS.LTS || _try_choco nodejs-lts || _try_scoop nodejs-lts || true
+    ;;
+  oh-my-opencode)
+    _try_npm oh-my-opencode || true
+    ;;
+  omc)
+    _try_npm oh-my-claude-sisyphus || true
+    ;;
+  omx)
+    _try_npm oh-my-codex || true
+    ;;
+  opencode)
+    _try_npm opencode-ai || true
+    ;;
+  pipx)
+    _try_brew pipx || _try_apt pipx || _try_dnf pipx || _try_yum pipx || _try_pacman python-pipx || _try_apk pipx \
+      || _try_choco pipx || _try_scoop pipx || true
+    ;;
+  python3)
+    _try_brew python || _try_apt python3 python3-pip || _try_dnf python3 python3-pip || _try_yum python3 python3-pip \
+      || _try_pacman python python-pip || _try_apk python3 py3-pip || _try_winget Python.Python.3.12 \
+      || _try_choco python || _try_scoop python || true
+    ;;
+  uv)
+    _try_brew uv || _try_pipx uv || _try_pip uv || _try_choco uv || _try_scoop uv || true
+    ;;
+  yq)
+    _try_brew yq || _try_apt yq || _try_dnf yq || _try_yum yq || _try_pacman yq || _try_apk yq \
+      || _try_winget MikeFarah.yq || _try_choco yq || _try_scoop yq || true
     ;;
   *)
     # Unknown tool: no table entry. Best-effort silent no-op.

--- a/skills/autospec-shared/tests/unit/ensure-tool.bats
+++ b/skills/autospec-shared/tests/unit/ensure-tool.bats
@@ -5,7 +5,7 @@
 #
 # Strategy: each test builds an isolated fake PATH containing only the stub
 # binaries it wants the script to "see" (command -v resolves against PATH).
-# Installer stubs (brew/apt-get/pipx/uv/pip3/npm) log their invocation to a
+# Installer stubs (brew/apt-get/winget/choco/scoop/pipx/uv/pip3/npm) log their invocation to a
 # file so we can assert which installer branch fired. No real installs happen.
 
 SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/ensure-tool.sh"
@@ -142,6 +142,62 @@ run_ensure_isolated() {
   run_ensure_isolated bats
   [ "$status" -eq 0 ]
   grep -q "apt-get .*bats" "$LOG"
+}
+
+@test "yq absent + brew available → installs via brew" {
+  mk_installer brew
+  run_ensure_isolated yq
+  [ "$status" -eq 0 ]
+  grep -q "brew .*yq" "$LOG"
+}
+
+@test "node absent + winget available → installs Node.js LTS via winget" {
+  mk_installer winget
+  run_ensure_isolated node
+  [ "$status" -eq 0 ]
+  grep -q "winget .*OpenJS.NodeJS.LTS" "$LOG"
+}
+
+@test "codex absent + npm available → installs OpenAI Codex CLI via npm" {
+  mk_installer npm
+  run_ensure_isolated codex
+  [ "$status" -eq 0 ]
+  grep -q "npm .*@openai/codex" "$LOG"
+}
+
+@test "claude absent + npm available → installs Claude Code via npm" {
+  mk_installer npm
+  run_ensure_isolated claude
+  [ "$status" -eq 0 ]
+  grep -q "npm .*@anthropic-ai/claude-code" "$LOG"
+}
+
+@test "opencode absent + npm available → installs OpenCode via npm" {
+  mk_installer npm
+  run_ensure_isolated opencode
+  [ "$status" -eq 0 ]
+  grep -q "npm .*opencode-ai" "$LOG"
+}
+
+@test "omx absent + npm available → installs oh-my-codex via npm" {
+  mk_installer npm
+  run_ensure_isolated omx
+  [ "$status" -eq 0 ]
+  grep -q "npm .*oh-my-codex" "$LOG"
+}
+
+@test "omc absent + npm available → installs oh-my-claude via npm" {
+  mk_installer npm
+  run_ensure_isolated omc
+  [ "$status" -eq 0 ]
+  grep -q "npm .*oh-my-claude-sisyphus" "$LOG"
+}
+
+@test "oh-my-opencode absent + npm available → installs oh-my-opencode via npm" {
+  mk_installer npm
+  run_ensure_isolated oh-my-opencode
+  [ "$status" -eq 0 ]
+  grep -q "npm .*oh-my-opencode" "$LOG"
 }
 
 # ── mempalace pip fallback chain ─────────────────────────────────────────────

--- a/tests/install/test_ecosystem_bootstrap_dry_run.sh
+++ b/tests/install/test_ecosystem_bootstrap_dry_run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+output=$(bash "$SCRIPT_DIR/install.sh" --dry-run --skill autospec --harness claude 2>&1 || true)
+
+for expected in \
+    "ensure_system_tools" \
+    "bootstrap_superpowers" \
+    "bootstrap_oh_my_codex" \
+    "bootstrap_oh_my_opencode" \
+    "bootstrap_oh_my_claude"
+do
+    case "$output" in
+        *"$expected"*) ;;
+        *) echo "FAIL: $expected step not reported in dry-run output"; echo "----"; echo "$output"; exit 1 ;;
+    esac
+done
+
+case "$output" in
+    *"obra/superpowers"*) ;;
+    *) echo "FAIL: superpowers repo not mentioned in dry-run output"; exit 1 ;;
+esac
+
+echo "PASS"

--- a/tests/install/test_star_prompt.sh
+++ b/tests/install/test_star_prompt.sh
@@ -9,6 +9,10 @@ if ! command -v script >/dev/null 2>&1; then
     echo "SKIP: script(1) not found"
     exit 0
 fi
+if ! script -qfec true /dev/null >/dev/null 2>&1; then
+    echo "SKIP: script(1) does not support GNU -qfec pseudo-TTY mode"
+    exit 0
+fi
 
 tmp_root="$(mktemp -d)"
 trap 'rm -rf "$tmp_root"' EXIT


### PR DESCRIPTION
## Summary
- add best-effort system tool installation across macOS, Linux, and Windows package managers
- bootstrap Superpowers plus oh-my-codex, oh-my-opencode, OMC/oh-my-claude, and existing Turbo integration from install.sh
- add a Windows PowerShell bootstrap path and document the new opt-outs

## Verification
- bash scripts/validate.sh
- bats skills/autospec-shared/tests/unit/ensure-tool.bats
- bash tests/install/test_ecosystem_bootstrap_dry_run.sh

Not-tested: native Windows execution of bootstrap.ps1; reviewed and documented, but this host is macOS.