### PR TITLE
feat: add autospec-fleet skill scaffold

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
 #   ./install.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | all
+#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -49,7 +49,7 @@ OH_MY_CODEX_PACKAGE="${OH_MY_CODEX_PACKAGE:-oh-my-codex}"
 OH_MY_OPENCODE_PACKAGE="${OH_MY_OPENCODE_PACKAGE:-oh-my-opencode}"
 OH_MY_CLAUDE_PACKAGE="${OH_MY_CLAUDE_PACKAGE:-oh-my-claude-sisyphus}"
 
-ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design"
+ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -480,10 +480,10 @@ done
 
 # Validate --skill
 case "$SKILL_ARG" in
-    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design) ;;
+    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design|autospec-fleet) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
-        err "must be one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | all"
+        err "must be one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | all"
         exit 2
         ;;
 esac

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -211,7 +211,7 @@ check_startup_preflight() {
         || printf '%s\n' "$canonical" | grep -F 'raw.githubusercontent.com/berlinguyinca/autospec/main/skills/' >/dev/null; then
         fail "startup preflight must not call a raw installer directly"
     fi
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet; do
         for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
             body=$(extract_block "$f")
             [ -n "$body" ] || fail "$f missing ## Startup self-update section"
@@ -228,7 +228,7 @@ check_startup_preflight() {
 # prompts/ path AND the new skills/ slash-command registry path.
 check_codex_skills_install() {
     info "codex skills-dir install: all skills"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet; do
         f="skills/$s/install.sh"
         grep -q 'skills/\$SKILL_NAME/SKILL\.md' "$f" \
             || fail "$f missing Codex skills-dir install (skills/\$SKILL_NAME/SKILL.md)"
@@ -243,7 +243,7 @@ check_codex_skills_install() {
 check_shared_script_install() {
     info "shared helper install: all skills"
     helpers="autospec-stop.sh autospec-usage-limit.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet; do
         f="skills/$s/install.sh"
         grep -q 'install_shared_scripts' "$f" \
             || fail "$f missing install_shared_scripts function/call"

--- a/skills/autospec-fleet/README.md
+++ b/skills/autospec-fleet/README.md
@@ -1,0 +1,82 @@
+# autospec-fleet
+
+Workspace-level supervisor for running autospec across multiple GitHub
+repositories.
+
+`autospec-fleet` starts from an empty directory, records a fleet config, clones
+or syncs target repositories, and launches `/autospec-run` inside each eligible
+checkout. It is intentionally above `/autospec-run`: fleet schedules
+repositories, while `/autospec-run` still owns issue claims, PRs, review, CI,
+and merge behavior.
+
+## Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-fleet/install.sh | sh -s -- --harness all
+```
+
+From a clone:
+
+```bash
+cd skills/autospec-fleet
+./install.sh --harness all
+```
+
+Or via the top-level suite installer:
+
+```bash
+./install.sh --skill autospec-fleet --harness all
+```
+
+## Invocation
+
+```text
+/autospec-fleet init <repo-url>...
+/autospec-fleet sync [--config-repo <url>]
+/autospec-fleet run [--profile <name>] [--parallel <N>] [--once]
+/autospec-fleet status
+/autospec-fleet stop --graceful
+/autospec-fleet stop --immediate
+```
+
+The scaffold and install surface are present first. Follow-up issues implement
+the schemas, URL normalization, config linting, scheduler, status/stop commands,
+docs, and dry-run smoke tests.
+
+## Configuration
+
+Fleet desired state belongs in a workspace or Git control repository:
+
+```yaml
+version: 1
+workspace: .autospec-fleet/repos
+default_profile: qwen3-32b-laptop
+parallel_repos: 2
+repos:
+  - url: https://github.com/org/repo-a.git
+    profile: qwen3-32b-laptop
+    enabled: true
+```
+
+Node-local capacity stays private:
+
+```yaml
+node_id: mac-mini-01
+workspace: ~/.autospec/fleet/repos
+max_parallel_repos: 2
+profiles:
+  - qwen3-32b-laptop
+```
+
+## Related skills
+
+| Skill | Purpose |
+| --- | --- |
+| [`autospec-run`](../autospec-run/README.md) | Per-repo implementation monitor that owns issue claims and PR flow. |
+| [`autospec-stop`](../autospec-stop/README.md) | Shared stop/resume sentinel used by fleet workers. |
+| [`autospec`](../autospec/README.md) | Full single-repo path from feature request to merged PRs. |
+
+## License
+
+MIT - see the repository [LICENSE](../../LICENSE) file.
+

--- a/skills/autospec-fleet/SKILL.md
+++ b/skills/autospec-fleet/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: autospec-fleet
+description: Use when the user wants to supervise autospec-run across multiple GitHub repositories from an empty workspace - initializes fleet config, clones or syncs repos, and runs per-repo autospec-run workers.
+---
+
+# autospec-fleet workflow (harness-neutral)
+
+Autospec Fleet is the workspace-level supervisor for a cluster of autospec
+workers. It starts from an empty directory, accepts GitHub repository URLs,
+clones or syncs those repositories into a managed workspace, and launches the
+existing `/autospec-run` monitor inside each eligible checkout.
+
+It does **not** replace `/autospec-run`. Fleet owns repo-level orchestration;
+`/autospec-run` owns issue-level claiming, implementation, review, CI, and
+merge behavior.
+
+Design source:
+`docs/specs/2026-05-28-autospec-fleet-design.md`.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-fleet   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$`
+(case-insensitive, whitespace-padded), this skill enters self-update mode and
+does not run a fleet command:
+
+1. Detect harness by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-fleet/SKILL.md`
+   - OpenCode: `~/.config/opencode/agent/autospec-fleet.md`
+   - Codex CLI: `~/.codex/prompts/autospec-fleet.md`
+2. Re-install the full autospec suite from `main`:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+3. Show the diff between prior installed files and the freshly fetched copy
+   when the harness can expose it.
+4. Stop. Do not enter any subcommand.
+
+If no install path is detected, print
+`Self-update: no installed copy of autospec-fleet found; run install.sh first.`
+and exit.
+
+## Invocation
+
+```text
+/autospec-fleet init <repo-url>...
+/autospec-fleet sync [--config-repo <url>]
+/autospec-fleet run [--profile <name>] [--parallel <N>] [--once]
+/autospec-fleet status
+/autospec-fleet stop --graceful
+/autospec-fleet stop --immediate
+```
+
+- `init` creates `autospec-fleet.yml` in the current directory and prepares the
+  managed workspace for the listed GitHub repository URLs.
+- `sync` updates the local copy of a fleet control repository when configured.
+- `run` loads fleet config plus node-local capacity and launches per-repo
+  `/autospec-run` workers.
+- `status` summarizes queue state, active workers, open PRs, and recent
+  failures across configured repositories.
+- `stop` forwards existing autospec stop semantics to active repo workers.
+
+## Required capabilities & harness adapter
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+
+**Model tier:** `TIER_B` (implementation work) for deterministic fleet shell
+helpers and status/reporting. Future spec/decomposition work stays in
+`/autospec` and `/autospec-define`.
+
+## Harness detection (run once at skill start)
+
+Detect your harness by checking available tools before any subcommand:
+
+1. Claude Code: the `Agent` tool with a `subagent_type` parameter is available.
+2. OpenCode: a `task` tool with model/tier configuration is available.
+3. Codex CLI: neither `Agent` nor configurable `task` is available; `apply_patch`
+   is the primary edit tool.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Silently fall back UP from
+`TIER_B` to `TIER_A` on quota, capacity, model, or authorization failure while
+preserving parent context.
+
+## Configuration
+
+Fleet desired state lives in `autospec-fleet.yml` in the current workspace or a
+Git-backed control repository:
+
+```yaml
+version: 1
+workspace: .autospec-fleet/repos
+default_profile: qwen3-32b-laptop
+parallel_repos: 2
+repos:
+  - url: https://github.com/org/repo-a.git
+    profile: qwen3-32b-laptop
+    enabled: true
+```
+
+Node-local capacity lives outside source control:
+
+```yaml
+node_id: mac-mini-01
+workspace: ~/.autospec/fleet/repos
+max_parallel_repos: 2
+profiles:
+  - qwen3-32b-laptop
+```
+
+Never store tokens or secrets in either file. Use `gh` and git credential
+helpers for authentication.
+
+## Current scaffold status
+
+This scaffold defines the skill surface and install contract. Follow-up issues
+land the schemas, URL/workspace helpers, config linting, scheduler, status,
+stop, docs, and dry-run smoke tests. Until those land, subcommands may report
+that implementation is pending.

--- a/skills/autospec-fleet/codex/prompt.md
+++ b/skills/autospec-fleet/codex/prompt.md
@@ -1,0 +1,164 @@
+
+# autospec-fleet workflow (harness-neutral)
+
+Autospec Fleet is the workspace-level supervisor for a cluster of autospec
+workers. It starts from an empty directory, accepts GitHub repository URLs,
+clones or syncs those repositories into a managed workspace, and launches the
+existing `/autospec-run` monitor inside each eligible checkout.
+
+It does **not** replace `/autospec-run`. Fleet owns repo-level orchestration;
+`/autospec-run` owns issue-level claiming, implementation, review, CI, and
+merge behavior.
+
+Design source:
+`docs/specs/2026-05-28-autospec-fleet-design.md`.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-fleet   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$`
+(case-insensitive, whitespace-padded), this skill enters self-update mode and
+does not run a fleet command:
+
+1. Detect harness by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-fleet/SKILL.md`
+   - OpenCode: `~/.config/opencode/agent/autospec-fleet.md`
+   - Codex CLI: `~/.codex/prompts/autospec-fleet.md`
+2. Re-install the full autospec suite from `main`:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+3. Show the diff between prior installed files and the freshly fetched copy
+   when the harness can expose it.
+4. Stop. Do not enter any subcommand.
+
+If no install path is detected, print
+`Self-update: no installed copy of autospec-fleet found; run install.sh first.`
+and exit.
+
+## Invocation
+
+```text
+/autospec-fleet init <repo-url>...
+/autospec-fleet sync [--config-repo <url>]
+/autospec-fleet run [--profile <name>] [--parallel <N>] [--once]
+/autospec-fleet status
+/autospec-fleet stop --graceful
+/autospec-fleet stop --immediate
+```
+
+- `init` creates `autospec-fleet.yml` in the current directory and prepares the
+  managed workspace for the listed GitHub repository URLs.
+- `sync` updates the local copy of a fleet control repository when configured.
+- `run` loads fleet config plus node-local capacity and launches per-repo
+  `/autospec-run` workers.
+- `status` summarizes queue state, active workers, open PRs, and recent
+  failures across configured repositories.
+- `stop` forwards existing autospec stop semantics to active repo workers.
+
+## Required capabilities & harness adapter
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+
+**Model tier:** `TIER_B` (implementation work) for deterministic fleet shell
+helpers and status/reporting. Future spec/decomposition work stays in
+`/autospec` and `/autospec-define`.
+
+## Harness detection (run once at skill start)
+
+Detect your harness by checking available tools before any subcommand:
+
+1. Claude Code: the `Agent` tool with a `subagent_type` parameter is available.
+2. OpenCode: a `task` tool with model/tier configuration is available.
+3. Codex CLI: neither `Agent` nor configurable `task` is available; `apply_patch`
+   is the primary edit tool.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Silently fall back UP from
+`TIER_B` to `TIER_A` on quota, capacity, model, or authorization failure while
+preserving parent context.
+
+## Configuration
+
+Fleet desired state lives in `autospec-fleet.yml` in the current workspace or a
+Git-backed control repository:
+
+```yaml
+version: 1
+workspace: .autospec-fleet/repos
+default_profile: qwen3-32b-laptop
+parallel_repos: 2
+repos:
+  - url: https://github.com/org/repo-a.git
+    profile: qwen3-32b-laptop
+    enabled: true
+```
+
+Node-local capacity lives outside source control:
+
+```yaml
+node_id: mac-mini-01
+workspace: ~/.autospec/fleet/repos
+max_parallel_repos: 2
+profiles:
+  - qwen3-32b-laptop
+```
+
+Never store tokens or secrets in either file. Use `gh` and git credential
+helpers for authentication.
+
+## Current scaffold status
+
+This scaffold defines the skill surface and install contract. Follow-up issues
+land the schemas, URL/workspace helpers, config linting, scheduler, status,
+stop, docs, and dry-run smoke tests. Until those land, subcommands may report
+that implementation is pending.

--- a/skills/autospec-fleet/install.sh
+++ b/skills/autospec-fleet/install.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env sh
+# install.sh - install the autospec-fleet skill into one or more harnesses.
+
+set -eu
+
+SKILL_NAME="autospec-fleet"
+SKILL_RAW_BASE="${AUTOSPEC_FLEET_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_FLEET_REF:-main}/skills/autospec-fleet}"
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+UPDATE_MODE=0
+TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
+
+Installs the ${SKILL_NAME} skill into the chosen harness.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    command -v curl >/dev/null 2>&1 || { err "curl is required when running from stdin"; exit 1; }
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel" || { err "failed to download $rel"; exit 1; }
+    done
+    for rel in $SHARED_SCRIPT_FILES; do
+        curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel" || { err "failed to download $rel"; exit 1; }
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    [ -f "$src" ] || { err "missing source file: $src"; return 1; }
+    run "mkdir -p \"$(dirname "$dest")\""
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    [ -n "$src_dir" ] || { err "missing shared scripts directory"; return 1; }
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;; esac
+    done
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness) shift; HARNESS="${1:-}" ;;
+        --harness=*) HARNESS="${1#--harness=}" ;;
+        --symlink) USE_SYMLINK=1 ;;
+        --dry-run) DRY_RUN=1 ;;
+        --update) UPDATE_MODE=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) err "unknown arg: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+
+[ -n "$HARNESS" ] || HARNESS=all
+case "$HARNESS" in claude|opencode|codex|all) ;; *) err "invalid --harness: $HARNESS"; exit 2 ;; esac
+
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+if [ "$need_fetch" -eq 1 ]; then
+    [ "$USE_SYMLINK" -eq 0 ] || { err "--symlink requires a local checkout"; exit 2; }
+    fetch_source_files
+fi
+
+for dep in git gh jq; do
+    command -v "$dep" >/dev/null 2>&1 || warn "$dep not found on PATH"
+done
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Claude Code:"
+    install_one "$SKILL_DIR/SKILL.md" "$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "OpenCode:"
+    install_one "$SKILL_DIR/opencode/agent.md" "$OPENCODE_DIR/agent/$SKILL_NAME.md"
+fi
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Codex CLI:"
+    install_one "$SKILL_DIR/codex/prompt.md" "$CODEX_DIR/prompts/$SKILL_NAME.md"
+    install_one "$SKILL_DIR/SKILL.md" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+elif [ "$UPDATE_MODE" -eq 1 ]; then
+    info "Updated $SKILL_NAME."
+else
+    info "Installed $SKILL_NAME."
+fi
+

--- a/skills/autospec-fleet/opencode/agent.md
+++ b/skills/autospec-fleet/opencode/agent.md
@@ -1,0 +1,168 @@
+---
+name: autospec-fleet
+description: Use when the user wants to supervise autospec-run across multiple GitHub repositories from an empty workspace - initializes fleet config, clones or syncs repos, and runs per-repo autospec-run workers.
+---
+
+# autospec-fleet workflow (harness-neutral)
+
+Autospec Fleet is the workspace-level supervisor for a cluster of autospec
+workers. It starts from an empty directory, accepts GitHub repository URLs,
+clones or syncs those repositories into a managed workspace, and launches the
+existing `/autospec-run` monitor inside each eligible checkout.
+
+It does **not** replace `/autospec-run`. Fleet owns repo-level orchestration;
+`/autospec-run` owns issue-level claiming, implementation, review, CI, and
+merge behavior.
+
+Design source:
+`docs/specs/2026-05-28-autospec-fleet-design.md`.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-fleet   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$`
+(case-insensitive, whitespace-padded), this skill enters self-update mode and
+does not run a fleet command:
+
+1. Detect harness by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-fleet/SKILL.md`
+   - OpenCode: `~/.config/opencode/agent/autospec-fleet.md`
+   - Codex CLI: `~/.codex/prompts/autospec-fleet.md`
+2. Re-install the full autospec suite from `main`:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+3. Show the diff between prior installed files and the freshly fetched copy
+   when the harness can expose it.
+4. Stop. Do not enter any subcommand.
+
+If no install path is detected, print
+`Self-update: no installed copy of autospec-fleet found; run install.sh first.`
+and exit.
+
+## Invocation
+
+```text
+/autospec-fleet init <repo-url>...
+/autospec-fleet sync [--config-repo <url>]
+/autospec-fleet run [--profile <name>] [--parallel <N>] [--once]
+/autospec-fleet status
+/autospec-fleet stop --graceful
+/autospec-fleet stop --immediate
+```
+
+- `init` creates `autospec-fleet.yml` in the current directory and prepares the
+  managed workspace for the listed GitHub repository URLs.
+- `sync` updates the local copy of a fleet control repository when configured.
+- `run` loads fleet config plus node-local capacity and launches per-repo
+  `/autospec-run` workers.
+- `status` summarizes queue state, active workers, open PRs, and recent
+  failures across configured repositories.
+- `stop` forwards existing autospec stop semantics to active repo workers.
+
+## Required capabilities & harness adapter
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+
+**Model tier:** `TIER_B` (implementation work) for deterministic fleet shell
+helpers and status/reporting. Future spec/decomposition work stays in
+`/autospec` and `/autospec-define`.
+
+## Harness detection (run once at skill start)
+
+Detect your harness by checking available tools before any subcommand:
+
+1. Claude Code: the `Agent` tool with a `subagent_type` parameter is available.
+2. OpenCode: a `task` tool with model/tier configuration is available.
+3. Codex CLI: neither `Agent` nor configurable `task` is available; `apply_patch`
+   is the primary edit tool.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Silently fall back UP from
+`TIER_B` to `TIER_A` on quota, capacity, model, or authorization failure while
+preserving parent context.
+
+## Configuration
+
+Fleet desired state lives in `autospec-fleet.yml` in the current workspace or a
+Git-backed control repository:
+
+```yaml
+version: 1
+workspace: .autospec-fleet/repos
+default_profile: qwen3-32b-laptop
+parallel_repos: 2
+repos:
+  - url: https://github.com/org/repo-a.git
+    profile: qwen3-32b-laptop
+    enabled: true
+```
+
+Node-local capacity lives outside source control:
+
+```yaml
+node_id: mac-mini-01
+workspace: ~/.autospec/fleet/repos
+max_parallel_repos: 2
+profiles:
+  - qwen3-32b-laptop
+```
+
+Never store tokens or secrets in either file. Use `gh` and git credential
+helpers for authentication.
+
+## Current scaffold status
+
+This scaffold defines the skill surface and install contract. Follow-up issues
+land the schemas, URL/workspace helpers, config linting, scheduler, status,
+stop, docs, and dry-run smoke tests. Until those land, subcommands may report
+that implementation is pending.

--- a/skills/autospec-fleet/uninstall.sh
+++ b/skills/autospec-fleet/uninstall.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env sh
+# uninstall.sh - remove the autospec-fleet skill from one or more harnesses.
+
+set -eu
+
+SKILL_NAME="autospec-fleet"
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness) shift; HARNESS="${1:-}" ;;
+        --harness=*) HARNESS="${1#--harness=}" ;;
+        --dry-run) DRY_RUN=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) err "unknown arg: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+
+[ -n "$HARNESS" ] || HARNESS=all
+case "$HARNESS" in claude|opencode|codex|all) ;; *) err "invalid --harness: $HARNESS"; exit 2 ;; esac
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Claude Code:"
+    remove_one "$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "OpenCode:"
+    remove_one "$OPENCODE_DIR/agent/$SKILL_NAME.md"
+fi
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Codex CLI:"
+    remove_one "$CODEX_DIR/prompts/$SKILL_NAME.md"
+    remove_one "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+
+info ""
+[ "$DRY_RUN" -eq 1 ] && info "Dry run complete. No files were removed." || info "Done."
+

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,7 +12,7 @@
 #   ./uninstall.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | all
+#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -24,7 +24,7 @@
 
 set -eu
 
-ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design"
+ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -67,7 +67,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$SKILL_ARG" in
-    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design) ;;
+    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design|autospec-fleet) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
         exit 2


### PR DESCRIPTION
Closes #614

Adds the multi-harness autospec-fleet scaffold, installer/uninstaller, top-level install matrix wiring, and validation coverage. Runtime fleet subcommands remain split into follow-up issues from the autospec-fleet epic.