### PR TITLE
feat: add autospec-fleet config schemas

### DIFF
--- a/examples/fleet.yml
+++ b/examples/fleet.yml
@@ -1,0 +1,14 @@
+version: 1
+workspace: .autospec-fleet/repos
+default_profile: qwen3-32b-laptop
+parallel_repos: 2
+sync:
+  config_repo: git@github.com:org/autospec-fleet-control.git
+  ref: main
+repos:
+  - url: https://github.com/org/repo-a.git
+    profile: qwen3-32b-laptop
+    enabled: true
+  - url: git@github.com:org/repo-b.git
+    profile: claude-sonnet-cloud
+    enabled: true

--- a/schemas/autospec-fleet-node.schema.json
+++ b/schemas/autospec-fleet-node.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-fleet-node.schema.json",
+  "title": "autospec-fleet node-local capacity",
+  "description": "Schema for ~/.autospec/fleet-node.yml, the private per-node capacity file. It declares node identity, local workspace placement, runnable profiles, and concurrency limits.",
+  "type": "object",
+  "required": ["node_id", "max_parallel_repos"],
+  "additionalProperties": false,
+  "properties": {
+    "node_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+      "description": "Stable node identifier used in fleet worker IDs and status files."
+    },
+    "workspace": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Node-local checkout directory. Overrides the shared desired-state workspace on this node."
+    },
+    "max_parallel_repos": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum number of repository workers this node may run concurrently."
+    },
+    "profiles": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "description": "Model profiles this node is allowed to run.",
+      "items": {
+        "$ref": "#/$defs/profile_name"
+      }
+    }
+  },
+  "$defs": {
+    "profile_name": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+    }
+  }
+}

--- a/schemas/autospec-fleet.schema.json
+++ b/schemas/autospec-fleet.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-fleet.schema.json",
+  "title": "autospec-fleet desired state",
+  "description": "Schema for autospec-fleet.yml, the shared fleet desired-state file. It declares managed repositories, workspace placement, profile defaults, and optional config-repo sync metadata.",
+  "type": "object",
+  "required": ["version", "workspace", "repos"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "const": 1,
+      "description": "Fleet config schema version."
+    },
+    "workspace": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Directory where autospec-fleet stores managed repository checkouts."
+    },
+    "default_profile": {
+      "$ref": "#/$defs/profile_name",
+      "description": "Profile used by repos that do not set an explicit profile."
+    },
+    "parallel_repos": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum number of repositories this desired state permits a node to run concurrently."
+    },
+    "sync": {
+      "type": "object",
+      "description": "Optional Git-backed desired-state distribution settings.",
+      "additionalProperties": false,
+      "properties": {
+        "config_repo": {
+          "$ref": "#/$defs/repo_url",
+          "description": "Git repository URL containing the canonical fleet config."
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Branch, tag, or ref to fetch from the config repository."
+        }
+      }
+    },
+    "repos": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Target repositories managed by this fleet.",
+      "items": {
+        "type": "object",
+        "required": ["url"],
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "$ref": "#/$defs/repo_url",
+            "description": "HTTPS or SSH GitHub repository URL."
+          },
+          "profile": {
+            "$ref": "#/$defs/profile_name",
+            "description": "Model profile override for this repository."
+          },
+          "enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "When false, fleet status may report the repo but run scheduling skips it."
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "profile_name": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+    },
+    "repo_url": {
+      "type": "string",
+      "minLength": 1,
+      "anyOf": [
+        {
+          "pattern": "^https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:\\.git)?$"
+        },
+        {
+          "pattern": "^git@github\\.com:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:\\.git)?$"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes #615.

## Summary
- Add `schemas/autospec-fleet.schema.json` for shared fleet desired state.
- Add `schemas/autospec-fleet-node.schema.json` for private node-local capacity.
- Add `examples/fleet.yml` with two repository entries and profile overrides.

## Verification
- `ajv compile -s schemas/autospec-fleet.schema.json --spec=draft2020`
- `ajv compile -s schemas/autospec-fleet-node.schema.json --spec=draft2020`
- `ajv validate -s schemas/autospec-fleet.schema.json -d examples/fleet.yml --spec=draft2020`
- node-local sample validation against `schemas/autospec-fleet-node.schema.json`
- `bash scripts/validate.sh`