### PR TITLE
feat: add autospec-fleet URL planning helpers

### DIFF
--- a/skills/autospec-fleet/scripts/fleet-init.sh
+++ b/skills/autospec-fleet/scripts/fleet-init.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Plan autospec-fleet checkout paths for repository URLs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/fleet-lib.sh"
+
+workspace=".autospec-fleet/repos"
+dry_run=0
+
+usage() {
+    cat <<'EOF'
+Usage: fleet-init.sh [--workspace PATH] [--dry-run] <repo-url>...
+
+Plans deterministic autospec-fleet checkout paths. In dry-run mode, no
+directories are created and no repositories are cloned.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --workspace)
+            shift
+            [ $# -gt 0 ] || { printf 'fleet: --workspace requires a path\n' >&2; exit 2; }
+            workspace="$1"
+            ;;
+        --workspace=*)
+            workspace="${1#--workspace=}"
+            ;;
+        --dry-run)
+            dry_run=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --*)
+            printf 'fleet: unknown option: %s\n' "$1" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            break
+            ;;
+    esac
+    shift
+done
+
+[ $# -gt 0 ] || { printf 'fleet: at least one repo URL is required\n' >&2; usage >&2; exit 2; }
+
+if [ "$dry_run" -eq 0 ]; then
+    mkdir -p "$workspace"
+fi
+
+for repo_url in "$@"; do
+    normalized="$(normalize_repo_url "$repo_url")"
+    checkout_path="$(repo_checkout_path "$workspace" "$normalized")"
+    if [ "$dry_run" -eq 1 ]; then
+        printf 'fleet: plan clone %s -> %s\n' "$normalized" "$checkout_path"
+    else
+        printf 'fleet: planned %s at %s\n' "$normalized" "$checkout_path"
+    fi
+done

--- a/skills/autospec-fleet/scripts/fleet-lib.sh
+++ b/skills/autospec-fleet/scripts/fleet-lib.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Shared helpers for autospec-fleet shell commands.
+
+if [ -z "${BASH_VERSION:-}" ]; then
+    printf 'fleet-lib.sh must be sourced by bash\n' >&2
+    return 2 2>/dev/null || exit 2
+fi
+
+normalize_repo_url() {
+    local input="${1:-}"
+    local path=""
+    local owner=""
+    local repo=""
+
+    case "$input" in
+        https://github.com/*/*)
+            path="${input#https://github.com/}"
+            ;;
+        git@github.com:*/*)
+            path="${input#git@github.com:}"
+            ;;
+        *)
+            printf 'fleet: unsupported repo URL: %s\n' "$input" >&2
+            return 2
+            ;;
+    esac
+
+    path="${path%.git}"
+    if [[ "$path" =~ ^([^/]+)/([^/]+)$ ]]; then
+        owner="${BASH_REMATCH[1]}"
+        repo="${BASH_REMATCH[2]}"
+    else
+        printf 'fleet: unsupported repo URL: %s\n' "$input" >&2
+        return 2
+    fi
+
+    if [ -z "$owner" ] || [ -z "$repo" ]; then
+        printf 'fleet: unsupported repo URL: %s\n' "$input" >&2
+        return 2
+    fi
+
+    printf '%s/%s\n' "$owner" "$repo"
+}
+
+repo_slug() {
+    local normalized="${1:-}"
+
+    case "$normalized" in
+        */*) ;;
+        *)
+            printf 'fleet: repo slug requires owner/repo, got: %s\n' "$normalized" >&2
+            return 2
+            ;;
+    esac
+
+    printf '%s\n' "${normalized//\//__}"
+}
+
+repo_checkout_path() {
+    local workspace="${1:-}"
+    local normalized="${2:-}"
+    local slug
+
+    if [ -z "$workspace" ]; then
+        printf 'fleet: workspace is required\n' >&2
+        return 2
+    fi
+
+    slug="$(repo_slug "$normalized")" || return 2
+    printf '%s/%s\n' "${workspace%/}" "$slug"
+}

--- a/tests/unit/test_autospec_fleet_url.bats
+++ b/tests/unit/test_autospec_fleet_url.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_fleet_url.bats - autospec-fleet URL normalization.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    FLEET_LIB="$REPO_ROOT/skills/autospec-fleet/scripts/fleet-lib.sh"
+    FLEET_INIT="$REPO_ROOT/skills/autospec-fleet/scripts/fleet-init.sh"
+    TEST_TMPDIR="$(mktemp -d /tmp/autospec-fleet-url-XXXXXX)"
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+@test "normalize_repo_url accepts HTTPS without .git suffix" {
+    run bash -c 'source "$1"; normalize_repo_url "https://github.com/org/repo"' _ "$FLEET_LIB"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "org/repo" ]
+}
+
+@test "normalize_repo_url accepts HTTPS with .git suffix" {
+    run bash -c 'source "$1"; normalize_repo_url "https://github.com/org/repo.git"' _ "$FLEET_LIB"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "org/repo" ]
+}
+
+@test "normalize_repo_url accepts SSH with .git suffix" {
+    run bash -c 'source "$1"; normalize_repo_url "git@github.com:org/repo.git"' _ "$FLEET_LIB"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "org/repo" ]
+}
+
+@test "repo_slug maps owner/repo to owner__repo" {
+    run bash -c 'source "$1"; repo_slug "org/repo"' _ "$FLEET_LIB"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "org__repo" ]
+}
+
+@test "fleet-init dry-run prints deterministic checkout paths without cloning" {
+    workspace="$TEST_TMPDIR/repos"
+
+    run bash "$FLEET_INIT" --dry-run --workspace "$workspace" \
+        "https://github.com/org/repo-a.git" \
+        "git@github.com:org/repo-b.git"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"fleet: plan clone org/repo-a -> $workspace/org__repo-a"* ]]
+    [[ "$output" == *"fleet: plan clone org/repo-b -> $workspace/org__repo-b"* ]]
+    [ ! -e "$workspace" ]
+}


### PR DESCRIPTION
Closes #616.

## Summary
- Add `fleet-lib.sh` with `normalize_repo_url`, `repo_slug`, and checkout path helpers.
- Add `fleet-init.sh` dry-run planning for deterministic checkout paths.
- Add Bats coverage for HTTPS, HTTPS `.git`, SSH `.git`, slug mapping, and no-side-effect dry-run output.

## Verification
- `bats tests/unit/test_autospec_fleet_url.bats`
- `bash scripts/validate.sh`