### PR TITLE
feat: add autospec-fleet config lint command

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -363,6 +363,15 @@ check_autospec_sweep_config_contract() {
     done
 }
 
+check_autospec_fleet_scripts() {
+    info "autospec-fleet scripts"
+    local skill_dir="skills/autospec-fleet"
+    for f in fleet-lib.sh fleet-init.sh fleet-config-lint.sh; do
+        [ -f "$skill_dir/scripts/$f" ] || fail "$skill_dir/scripts/$f: required file missing"
+        bash -n "$skill_dir/scripts/$f" || fail "$skill_dir/scripts/$f: bash syntax error"
+    done
+}
+
 # Harness detection block validation.
 # If a SKILL.md contains a "## Harness detection" heading, verify that the
 # section body includes TIER_A, TIER_B, and a "silently" fallback reference.
@@ -877,6 +886,7 @@ main() {
     check_phase4_immediate_next_issue_pickup
     check_phase4_adaptive_retry
     check_autospec_sweep_config_contract
+    check_autospec_fleet_scripts
     check_team_personality_contract
     check_autospec_run_priority_sort_lockstep
     check_autospec_run_regression_review_lockstep

--- a/skills/autospec-fleet/scripts/fleet-config-lint.sh
+++ b/skills/autospec-fleet/scripts/fleet-config-lint.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Validate autospec-fleet desired-state and optional node-local config.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+
+config="autospec-fleet.yml"
+node_config=""
+profiles_file=""
+tmp_files=""
+
+usage() {
+    cat <<'EOF'
+Usage: fleet-config-lint.sh --config PATH [--node-config PATH] [--profiles PATH]
+
+Validates autospec-fleet.yml and, when supplied, ~/.autospec/fleet-node.yml.
+EOF
+}
+
+cleanup() {
+    [ -z "$tmp_files" ] || rm -f $tmp_files
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+    printf 'fleet-config-lint: %s\n' "$*" >&2
+    exit 2
+}
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+schema_validate() {
+    local schema="$1"
+    local src="$2"
+    local json_file
+    json_file="$(mktemp -t fleet-config.XXXXXX).json"
+    tmp_files="$tmp_files $json_file"
+    yq -o=json '.' "$src" > "$json_file"
+    ajv validate -s "$schema" --spec=draft2020 -d "$json_file" >/dev/null \
+        || fail "$src failed schema validation"
+}
+
+resolve_profiles_file() {
+    if [ -n "$profiles_file" ]; then
+        printf '%s\n' "$profiles_file"
+    elif [ -f "$repo_root/examples/model-profiles.yml" ]; then
+        printf '%s\n' "$repo_root/examples/model-profiles.yml"
+    elif [ -f "$HOME/.autospec/model-profiles.yml" ]; then
+        printf '%s\n' "$HOME/.autospec/model-profiles.yml"
+    fi
+}
+
+profile_names() {
+    local file="$1"
+    if [ "$(yq -r 'has("profiles")' "$file")" = "true" ]; then
+        yq -r '.profiles | keys | .[]' "$file"
+    else
+        yq -r 'keys | .[]' "$file"
+    fi
+}
+
+profile_known() {
+    local file="$1"
+    local profile="$2"
+    profile_names "$file" | grep -Fx -- "$profile" >/dev/null
+}
+
+validate_fleet_profiles() {
+    local file="$1"
+    local known="$2"
+    local profile
+
+    [ -n "$known" ] || return 0
+    while IFS= read -r profile; do
+        [ -z "$profile" ] && continue
+        profile_known "$known" "$profile" \
+            || fail "unknown profile '$profile' in $file"
+    done <<EOF
+$(yq -r '[.default_profile] + (.repos[]?.profile // [] | [.] ) | .[] | select(. != null)' "$file")
+EOF
+}
+
+validate_node_profiles() {
+    local file="$1"
+    local known="$2"
+    local profile
+
+    [ -n "$known" ] || return 0
+    while IFS= read -r profile; do
+        [ -z "$profile" ] && continue
+        profile_known "$known" "$profile" \
+            || fail "unknown profile '$profile' in $file"
+    done <<EOF
+$(yq -r '.profiles[]? | select(. != null)' "$file")
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --config)
+            shift
+            [ $# -gt 0 ] || fail "--config requires a path"
+            config="$1"
+            ;;
+        --config=*)
+            config="${1#--config=}"
+            ;;
+        --node-config)
+            shift
+            [ $# -gt 0 ] || fail "--node-config requires a path"
+            node_config="$1"
+            ;;
+        --node-config=*)
+            node_config="${1#--node-config=}"
+            ;;
+        --profiles)
+            shift
+            [ $# -gt 0 ] || fail "--profiles requires a path"
+            profiles_file="$1"
+            ;;
+        --profiles=*)
+            profiles_file="${1#--profiles=}"
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown argument: $1"
+            ;;
+    esac
+    shift
+done
+
+need_cmd ajv
+need_cmd yq
+
+[ -f "$config" ] || fail "config not found: $config"
+profiles_path="$(resolve_profiles_file)"
+[ -z "$profiles_path" ] || [ -f "$profiles_path" ] || fail "profiles file not found: $profiles_path"
+
+schema_validate "$repo_root/schemas/autospec-fleet.schema.json" "$config"
+validate_fleet_profiles "$config" "$profiles_path"
+
+if [ -n "$node_config" ]; then
+    [ -f "$node_config" ] || fail "node config not found: $node_config"
+    schema_validate "$repo_root/schemas/autospec-fleet-node.schema.json" "$node_config"
+    validate_node_profiles "$node_config" "$profiles_path"
+fi
+
+printf 'fleet-config-lint: OK\n'

--- a/tests/unit/test_autospec_fleet_config.bats
+++ b/tests/unit/test_autospec_fleet_config.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_fleet_config.bats - autospec-fleet config linting.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    LINT="$REPO_ROOT/skills/autospec-fleet/scripts/fleet-config-lint.sh"
+    TEST_TMPDIR="$(mktemp -d /tmp/autospec-fleet-config-XXXXXX)"
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+write_config() {
+    cat > "$1"
+}
+
+@test "fleet-config-lint accepts examples/fleet.yml" {
+    run bash "$LINT" --config "$REPO_ROOT/examples/fleet.yml"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"fleet-config-lint: OK"* ]]
+}
+
+@test "fleet-config-lint accepts node-local capacity config" {
+    node="$TEST_TMPDIR/fleet-node.yml"
+    cat > "$node" <<'YAML'
+node_id: mac-mini-01
+workspace: ~/.autospec/fleet/repos
+max_parallel_repos: 2
+profiles:
+  - qwen3-32b-laptop
+YAML
+
+    run bash "$LINT" --config "$REPO_ROOT/examples/fleet.yml" --node-config "$node"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "fleet-config-lint rejects missing required fields" {
+    config="$TEST_TMPDIR/missing-required.yml"
+    write_config "$config" <<'YAML'
+version: 1
+workspace: .autospec-fleet/repos
+YAML
+
+    run bash "$LINT" --config "$config"
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"failed schema validation"* ]]
+}
+
+@test "fleet-config-lint rejects unsupported repo URLs" {
+    config="$TEST_TMPDIR/bad-url.yml"
+    write_config "$config" <<'YAML'
+version: 1
+workspace: .autospec-fleet/repos
+repos:
+  - url: https://example.com/org/repo.git
+    profile: qwen3-32b-laptop
+YAML
+
+    run bash "$LINT" --config "$config"
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"failed schema validation"* ]]
+}
+
+@test "fleet-config-lint rejects unknown profile references" {
+    config="$TEST_TMPDIR/unknown-profile.yml"
+    write_config "$config" <<'YAML'
+version: 1
+workspace: .autospec-fleet/repos
+default_profile: missing-laptop
+repos:
+  - url: https://github.com/org/repo.git
+    profile: qwen3-32b-laptop
+YAML
+
+    run bash "$LINT" --config "$config"
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"unknown profile 'missing-laptop'"* ]]
+}
+
+@test "fleet-config-lint rejects invalid concurrency fields" {
+    config="$TEST_TMPDIR/bad-concurrency.yml"
+    write_config "$config" <<'YAML'
+version: 1
+workspace: .autospec-fleet/repos
+parallel_repos: 0
+repos:
+  - url: https://github.com/org/repo.git
+YAML
+
+    run bash "$LINT" --config "$config"
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"failed schema validation"* ]]
+}


### PR DESCRIPTION
Closes #617.

## Summary
- Add `fleet-config-lint.sh` for shared fleet config and optional node-local config validation.
- Validate schemas with `ajv`, read YAML with `yq`, and reject unknown profile references.
- Add Bats coverage for valid config plus missing fields, bad URLs, unknown profiles, and invalid concurrency.
- Add `scripts/validate.sh` syntax/presence coverage for fleet scripts.

## Verification
- `bash skills/autospec-fleet/scripts/fleet-config-lint.sh --config examples/fleet.yml`
- `bats tests/unit/test_autospec_fleet_config.bats`
- `bash scripts/validate.sh`