### PR TITLE
feat: add autospec-fleet status and stop commands

### DIFF
--- a/skills/autospec-fleet/scripts/fleet-status.sh
+++ b/skills/autospec-fleet/scripts/fleet-status.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Summarize autospec-fleet repository queue state.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+source "$script_dir/fleet-lib.sh"
+
+config="autospec-fleet.yml"
+json_output=0
+list_ready_bin="${AUTOSPEC_FLEET_LIST_READY:-}"
+
+usage() {
+    cat <<'EOF'
+Usage: fleet-status.sh [--config PATH] [--json] [--list-ready-bin PATH]
+EOF
+}
+
+fail() {
+    printf 'fleet-status: %s\n' "$*" >&2
+    exit 2
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --config) shift; [ $# -gt 0 ] || fail "--config requires a path"; config="$1" ;;
+        --config=*) config="${1#--config=}" ;;
+        --json) json_output=1 ;;
+        --list-ready-bin) shift; [ $# -gt 0 ] || fail "--list-ready-bin requires a path"; list_ready_bin="$1" ;;
+        --list-ready-bin=*) list_ready_bin="${1#--list-ready-bin=}" ;;
+        -h|--help) usage; exit 0 ;;
+        *) fail "unknown argument: $1" ;;
+    esac
+    shift
+done
+
+[ -f "$config" ] || fail "config not found: $config"
+if [ -z "$list_ready_bin" ]; then
+    list_ready_bin="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/list-ready-issues.sh"
+fi
+[ -x "$list_ready_bin" ] || list_ready_bin="$repo_root/skills/autospec-run/scripts/list-ready-issues.sh"
+[ -x "$list_ready_bin" ] || fail "list-ready-issues.sh not found or not executable"
+
+bash "$script_dir/fleet-config-lint.sh" --config "$config" >/dev/null
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v yq >/dev/null 2>&1 || fail "yq is required"
+
+workspace="$(yq -r '.workspace' "$config")"
+repos_json="[]"
+repo_count="$(yq -r '.repos | length' "$config")"
+idx=0
+while [ "$idx" -lt "$repo_count" ]; do
+    enabled="$(yq -r ".repos[$idx].enabled // true" "$config")"
+    repo_url="$(yq -r ".repos[$idx].url" "$config")"
+    normalized="$(normalize_repo_url "$repo_url")"
+    checkout_path="$(repo_checkout_path "$workspace" "$normalized")"
+    if [ "$enabled" = "true" ]; then
+        probe_json="$("$list_ready_bin" --repo "$normalized" --batch-size 1)"
+    else
+        probe_json='{"ready":[],"blocked":[],"claimed":[],"conflicts":[],"batch":[]}'
+    fi
+    repo_obj="$(printf '%s\n' "$probe_json" | jq \
+        --arg repo "$normalized" \
+        --arg path "$checkout_path" \
+        --argjson enabled "$enabled" \
+        '{repo:$repo,path:$path,enabled:$enabled,ready:(.ready|length),blocked:(.blocked|length),claimed:(.claimed|length),conflicts:(.conflicts|length),batch:(.batch|length)}')"
+    repos_json="$(jq --argjson repo "$repo_obj" '. + [$repo]' <<<"$repos_json")"
+    idx=$((idx + 1))
+done
+
+if [ "$json_output" -eq 1 ]; then
+    jq -n --argjson repos "$repos_json" '{repos:$repos}'
+else
+    jq -r '.[] | "fleet: \(.repo) ready=\(.ready) blocked=\(.blocked) claimed=\(.claimed)"' <<<"$repos_json"
+fi

--- a/skills/autospec-fleet/scripts/fleet-stop.sh
+++ b/skills/autospec-fleet/scripts/fleet-stop.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Forward autospec-stop to active autospec-fleet repository checkouts.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+source "$script_dir/fleet-lib.sh"
+
+config="autospec-fleet.yml"
+mode="--graceful"
+stop_bin="${AUTOSPEC_FLEET_STOP_BIN:-}"
+
+usage() {
+    cat <<'EOF'
+Usage: fleet-stop.sh [--config PATH] [--graceful|--immediate] [--stop-bin PATH]
+EOF
+}
+
+fail() {
+    printf 'fleet-stop: %s\n' "$*" >&2
+    exit 2
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --config) shift; [ $# -gt 0 ] || fail "--config requires a path"; config="$1" ;;
+        --config=*) config="${1#--config=}" ;;
+        --graceful) mode="--graceful" ;;
+        --immediate) mode="--immediate" ;;
+        --stop-bin) shift; [ $# -gt 0 ] || fail "--stop-bin requires a path"; stop_bin="$1" ;;
+        --stop-bin=*) stop_bin="${1#--stop-bin=}" ;;
+        -h|--help) usage; exit 0 ;;
+        *) fail "unknown argument: $1" ;;
+    esac
+    shift
+done
+
+[ -f "$config" ] || fail "config not found: $config"
+if [ -z "$stop_bin" ]; then
+    stop_bin="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh"
+fi
+[ -x "$stop_bin" ] || stop_bin="$repo_root/scripts/autospec-stop.sh"
+[ -x "$stop_bin" ] || fail "autospec-stop.sh not found or not executable"
+
+bash "$script_dir/fleet-config-lint.sh" --config "$config" >/dev/null
+command -v yq >/dev/null 2>&1 || fail "yq is required"
+
+workspace="$(yq -r '.workspace' "$config")"
+stopped=0
+repo_count="$(yq -r '.repos | length' "$config")"
+idx=0
+while [ "$idx" -lt "$repo_count" ]; do
+    enabled="$(yq -r ".repos[$idx].enabled // true" "$config")"
+    if [ "$enabled" != "true" ]; then idx=$((idx + 1)); continue; fi
+    repo_url="$(yq -r ".repos[$idx].url" "$config")"
+    normalized="$(normalize_repo_url "$repo_url")"
+    checkout_path="$(repo_checkout_path "$workspace" "$normalized")"
+    if [ -d "$checkout_path" ]; then
+        ( cd "$checkout_path" && bash "$stop_bin" "$mode" )
+        printf 'fleet-stop: %s %s\n' "$normalized" "$mode"
+        stopped=$((stopped + 1))
+    fi
+    idx=$((idx + 1))
+done
+printf 'fleet-stop: stopped=%s\n' "$stopped"

--- a/tests/unit/test_autospec_fleet_status_stop.bats
+++ b/tests/unit/test_autospec_fleet_status_stop.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_fleet_status_stop.bats - fleet status and stop.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    FLEET_STATUS="$REPO_ROOT/skills/autospec-fleet/scripts/fleet-status.sh"
+    FLEET_STOP="$REPO_ROOT/skills/autospec-fleet/scripts/fleet-stop.sh"
+    TEST_TMPDIR="$(mktemp -d /tmp/autospec-fleet-status-XXXXXX)"
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+write_config() {
+    cat > "$TEST_TMPDIR/fleet.yml" <<YAML
+version: 1
+workspace: $TEST_TMPDIR/repos
+default_profile: qwen3-32b-laptop
+parallel_repos: 2
+repos:
+  - url: https://github.com/org/repo-a.git
+    profile: qwen3-32b-laptop
+    enabled: true
+  - url: git@github.com:org/repo-b.git
+    profile: claude-sonnet-cloud
+    enabled: true
+YAML
+}
+
+write_mock_probe() {
+    cat > "$TEST_TMPDIR/list-ready-issues.sh" <<'EOF'
+#!/usr/bin/env bash
+repo=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) repo="$2"; shift 2 ;;
+    --batch-size) shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$repo" in
+  org/repo-a)
+    printf '{"ready":[{"number":1}],"blocked":[],"claimed":[],"conflicts":[],"batch":[{"number":1}]}\n'
+    ;;
+  org/repo-b)
+    printf '{"ready":[],"blocked":[{"number":2}],"claimed":[{"number":3}],"conflicts":[],"batch":[]}\n'
+    ;;
+esac
+EOF
+    chmod +x "$TEST_TMPDIR/list-ready-issues.sh"
+}
+
+write_mock_stop() {
+    cat > "$TEST_TMPDIR/autospec-stop.sh" <<EOF
+#!/usr/bin/env bash
+printf '%s|%s\n' "\$(pwd)" "\$*" >> "$TEST_TMPDIR/stop.log"
+EOF
+    chmod +x "$TEST_TMPDIR/autospec-stop.sh"
+}
+
+@test "fleet-status --json emits repos as a JSON array" {
+    write_config
+    write_mock_probe
+
+    run bash "$FLEET_STATUS" --json \
+        --config "$TEST_TMPDIR/fleet.yml" \
+        --list-ready-bin "$TEST_TMPDIR/list-ready-issues.sh"
+
+    [ "$status" -eq 0 ]
+    json="$output"
+    run bash -c 'printf "%s\n" "$1" | jq -e ".repos | type == \"array\" and length == 2"' _ "$json"
+    [ "$status" -eq 0 ]
+    run bash -c 'printf "%s\n" "$1" | jq -e ".repos[] | select(.repo == \"org/repo-a\" and .ready == 1 and .batch == 1)"' _ "$json"
+    [ "$status" -eq 0 ]
+}
+
+@test "fleet-stop --graceful calls autospec-stop once per active repo" {
+    write_config
+    write_mock_stop
+    mkdir -p "$TEST_TMPDIR/repos/org__repo-a"
+
+    run bash "$FLEET_STOP" --graceful \
+        --config "$TEST_TMPDIR/fleet.yml" \
+        --stop-bin "$TEST_TMPDIR/autospec-stop.sh"
+
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_TMPDIR/stop.log" ]
+    [ "$(wc -l < "$TEST_TMPDIR/stop.log" | tr -d ' ')" = "1" ]
+    grep -q "$TEST_TMPDIR/repos/org__repo-a|--graceful" "$TEST_TMPDIR/stop.log"
+}


### PR DESCRIPTION
Closes #619.

## Summary
- Add `fleet-status.sh` with JSON and text aggregate queue summaries per configured repo.
- Add `fleet-stop.sh` to forward `--graceful` / `--immediate` to active managed checkouts through the existing stop helper.
- Add mocked Bats coverage for JSON status shape and one-stop-call-per-active-repo behavior.

## Verification
- `bats tests/unit/test_autospec_fleet_status_stop.bats`
- `bash scripts/validate.sh`