### PR TITLE
docs: document autospec-fleet operator workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ selected model and harness to execute reliably.
 | [`autospec-define`](skills/autospec-define/README.md) | You want planning only before implementation starts. | Produces a design spec plus classified `auto-implement` issues, then hands off to `/autospec-run`. |
 | [`autospec-split`](skills/autospec-split/README.md) | You already have a tracked `docs/specs/*.md` design spec. | Turns the existing spec into an EPIC plus linked child issues, then stops after classification. |
 | [`autospec-run`](skills/autospec-run/README.md) | You already have an `auto-implement` queue. | Runs the implementation monitor, opens PRs, reviews, validates, and merges. |
+| [`autospec-fleet`](skills/autospec-fleet/README.md) | You want to run autospec across multiple GitHub repositories from one workspace. | `/autospec-fleet init` records repo URLs, fleet scripts validate config, and fleet run/status/stop coordinate per-repo `/autospec-run` workers. |
 | [`autospec-classify`](skills/autospec-classify/README.md) | Existing issues need model-fit labels. | Adds `ctx:*` and `reasoning:*` labels, inserts a `## Model fit` block, and promotes `needs-classify` issues. |
 | [`autospec-listen`](skills/autospec-listen/README.md) | You want chat phrases like "file an issue" to become tracked work. | Drafts issues for approval or routes spec requests into `/autospec-define`. |
 | [`autospec-story`](skills/autospec-story/README.md) | You need a repo-level product and implementation-state overview. | Produces a cited Markdown story from local specs, docs, issues, PRs, and git history. |
@@ -300,6 +301,16 @@ Full end-to-end workflow:
 
 ```text
 /autospec "add OIDC support behind a feature flag"
+```
+
+Fleet workflow:
+
+```text
+mkdir fleet-workspace
+cd fleet-workspace
+/autospec-fleet init https://github.com/org/repo-a https://github.com/org/repo-b
+/autospec-fleet run --profile claude-sonnet-cloud --dry-run
+/autospec-fleet status
 ```
 
 The monitor:

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -17,6 +17,14 @@
 - Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
 - Status: tracked config mode. Creates `.autospec/autospec.yml`, asks project-specific setup questions from repo findings, keeps specs synchronized with implementation reality, and routes improvement gaps through `autospec-review`, issues, and `/autospec-run`.
 
+## autospec-fleet
+
+- Path: [`skills/autospec-fleet`](skills/autospec-fleet)
+- Trigger: use when an operator wants to supervise autospec-run across multiple GitHub repositories from an empty workspace.
+- Activation keywords: `autospec-fleet`, `fleet init`, `fleet run`, `fleet status`, `fleet stop`, `run autospec across repos`
+- Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
+- Status: workspace-level fleet supervisor. `init` records GitHub repo URLs, config schemas validate `autospec-fleet.yml` and `~/.autospec/fleet-node.yml`, `run --dry-run` builds per-repo `/autospec-run --profile ... --worker-id fleet:<node>:<repo>` commands, `status --json` summarizes queues, and `stop --graceful|--immediate` forwards existing stop behavior to active managed checkouts.
+
 ## autospec-listen
 
 - Path: [`skills/autospec-listen`](skills/autospec-listen)

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -87,6 +87,50 @@ shipped during this run, emits surviving gaps as JSON (`emit-gaps.sh`), and file
 `auto-implement,gap-remediation,priority:high` issues (`gap-remediation-loop.sh`), capped at
 `AUTOSPEC_GAP_MAX_ROUNDS` rounds (default 2) to bound the feedback loop.
 
+### `/autospec-fleet`
+
+<!-- autospec-doc-scope:
+  src: ["skills/autospec-fleet/SKILL.md", "skills/autospec-fleet/README.md", "skills/autospec-fleet/scripts/fleet-run.sh", "skills/autospec-fleet/scripts/fleet-status.sh", "skills/autospec-fleet/scripts/fleet-stop.sh"]
+  reason: "User-facing invocation docs for autospec-fleet"
+  generated: true
+-->
+
+Workspace supervisor for running autospec across multiple GitHub repositories.
+Fleet schedules repositories; `/autospec-run` still owns issue claims, PRs,
+review, CI, and merge behavior inside each checkout.
+
+**Triggers:** `autospec-fleet`, `fleet init`, `fleet run`, `fleet status`, `fleet stop`
+
+**Operator flow:**
+
+```text
+mkdir fleet-workspace
+cd fleet-workspace
+/autospec-fleet init https://github.com/org/repo-a https://github.com/org/repo-b
+/autospec-fleet run --profile claude-sonnet-cloud --dry-run
+/autospec-fleet status
+/autospec-fleet stop --graceful
+```
+
+**Configuration distribution:** shared desired state lives in a versioned
+`autospec-fleet.yml`, preferably in a small Git control repository reviewed by
+PR. Nodes fetch that repo with `sync` or before each scheduler tick, so Git
+provides audit history, rollback, and access control without a separate control
+plane.
+
+**Node-local capacity:** private machine settings live in
+`~/.autospec/fleet-node.yml` and are never committed. This file declares
+`node_id`, local workspace override, `max_parallel_repos`, and runnable model
+profiles. Fleet combines `autospec-fleet.yml` and `fleet-node.yml` with the
+lower parallel cap, then emits worker IDs such as
+`fleet:mac-mini-01:org__repo-a`.
+
+**Commands:**
+- `init <repo-url>...`: record target GitHub repositories and planned checkout paths.
+- `run --dry-run`: validate config, probe each repo queue, and print per-repo `/autospec-run --profile` commands.
+- `status --json`: return a `repos` array with ready, blocked, claimed, conflict, and batch counts.
+- `stop --graceful|--immediate`: forward the existing autospec stop helper to active managed checkouts.
+
 ### `/autospec-sweep`
 
 <!-- autospec-doc-scope:


### PR DESCRIPTION
Closes #620.

## Summary
- Add `autospec-fleet` to the README skill table and implementation workflow examples.
- Add a single `## autospec-fleet` heading to `SKILLS.md` with activation and status details.
- Add user-manual guidance for `autospec-fleet.yml`, node-local `fleet-node.yml`, run/status/stop workflows, and config distribution.

## Verification
- `rg -n "autospec-fleet|autospec-fleet.yml" README.md SKILLS.md docs/USER_MANUAL.md`
- `bash scripts/validate.sh`