### PR TITLE
test: add autospec-fleet dry-run smoke coverage

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -929,6 +929,11 @@ check_phase4_tests() {
                 || { cat /tmp/validate-docs.log >&2; fail "$t: failed"; }
         done
     fi
+    if [ -f tests/e2e/test_autospec_fleet_dry_run.bats ] && [ -d tests/fixtures/fleet ]; then
+        info "e2e tests: tests/e2e/test_autospec_fleet_dry_run.bats"
+        AUTOSPEC_FLEET_LIVE_E2E=0 bats tests/e2e/test_autospec_fleet_dry_run.bats >/tmp/validate-fleet-e2e.log 2>&1 \
+            || { cat /tmp/validate-fleet-e2e.log >&2; fail "tests/e2e/test_autospec_fleet_dry_run.bats: failed"; }
+    fi
 }
 
 main "$@"

--- a/tests/e2e/test_autospec_fleet_dry_run.bats
+++ b/tests/e2e/test_autospec_fleet_dry_run.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# tests/e2e/test_autospec_fleet_dry_run.bats - mocked fleet dry-run smoke.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    FLEET_RUN="$REPO_ROOT/skills/autospec-fleet/scripts/fleet-run.sh"
+    FIXTURES="$REPO_ROOT/tests/fixtures/fleet"
+    TEST_TMPDIR="$(mktemp -d /tmp/autospec-fleet-e2e-XXXXXX)"
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+write_configs() {
+    cat > "$TEST_TMPDIR/fleet.yml" <<YAML
+version: 1
+workspace: $TEST_TMPDIR/repos
+default_profile: qwen3-32b-laptop
+parallel_repos: 2
+repos:
+  - url: https://github.com/org/repo-a.git
+    profile: qwen3-32b-laptop
+    enabled: true
+  - url: git@github.com:org/repo-b.git
+    profile: qwen3-32b-laptop
+    enabled: true
+YAML
+    cat > "$TEST_TMPDIR/fleet-node.yml" <<'YAML'
+node_id: smoke-node
+max_parallel_repos: 2
+profiles:
+  - qwen3-32b-laptop
+YAML
+}
+
+@test "mocked fleet dry-run discovers two repos with distinct worker IDs" {
+    write_configs
+
+    run bash "$FLEET_RUN" --dry-run --once \
+        --config "$TEST_TMPDIR/fleet.yml" \
+        --node-config "$TEST_TMPDIR/fleet-node.yml" \
+        --list-ready-bin "$FIXTURES/mock-list-ready.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"fleet:smoke-node:org__repo-a"* ]]
+    [[ "$output" == *"fleet:smoke-node:org__repo-b"* ]]
+    worker_count="$(printf '%s\n' "$output" | grep -o 'fleet:smoke-node:org__[A-Za-z0-9._-]*' | sort -u | wc -l | tr -d ' ')"
+    [ "$worker_count" = "2" ]
+}
+
+@test "live fleet E2E remains opt-in behind AUTOSPEC_FLEET_LIVE_E2E" {
+    [ "${AUTOSPEC_FLEET_LIVE_E2E:-0}" != "1" ]
+}

--- a/tests/fixtures/fleet/mock-list-ready.sh
+++ b/tests/fixtures/fleet/mock-list-ready.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Mock list-ready-issues.sh for autospec-fleet dry-run E2E.
+
+set -euo pipefail
+
+fixture_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo) repo="${2:-}"; shift 2 ;;
+        --batch-size) shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+case "$repo" in
+    org/repo-a) cat "$fixture_dir/queue-org-repo-a.json" ;;
+    org/repo-b) cat "$fixture_dir/queue-org-repo-b.json" ;;
+    *) printf '{"ready":[],"blocked":[],"claimed":[],"conflicts":[],"batch":[]}\n' ;;
+esac

--- a/tests/fixtures/fleet/queue-org-repo-a.json
+++ b/tests/fixtures/fleet/queue-org-repo-a.json
@@ -1,0 +1,11 @@
+{
+  "ready": [
+    { "number": 101, "title": "Repo A ready issue" }
+  ],
+  "blocked": [],
+  "claimed": [],
+  "conflicts": [],
+  "batch": [
+    { "number": 101, "title": "Repo A ready issue" }
+  ]
+}

--- a/tests/fixtures/fleet/queue-org-repo-b.json
+++ b/tests/fixtures/fleet/queue-org-repo-b.json
@@ -1,0 +1,11 @@
+{
+  "ready": [
+    { "number": 202, "title": "Repo B ready issue" }
+  ],
+  "blocked": [],
+  "claimed": [],
+  "conflicts": [],
+  "batch": [
+    { "number": 202, "title": "Repo B ready issue" }
+  ]
+}


### PR DESCRIPTION
Closes #621.

## Summary
- Add mocked fleet queue fixtures and a mock ready-issue probe.
- Add `tests/e2e/test_autospec_fleet_dry_run.bats` proving two repos get distinct `fleet:` worker IDs.
- Wire the non-live smoke into `scripts/validate.sh` with `AUTOSPEC_FLEET_LIVE_E2E=0`.

## Verification
- `AUTOSPEC_FLEET_LIVE_E2E=0 bats tests/e2e/test_autospec_fleet_dry_run.bats`
- `bash scripts/validate.sh`