### PR TITLE
feat: make spec-to-app QA a first-class autospec workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,14 @@ selected model and harness to execute reliably.
 | [`autospec-define`](skills/autospec-define/README.md) | You want planning only before implementation starts. | Produces a design spec plus classified `auto-implement` issues, then hands off to `/autospec-run`. |
 | [`autospec-split`](skills/autospec-split/README.md) | You already have a tracked `docs/specs/*.md` design spec. | Turns the existing spec into an EPIC plus linked child issues, then stops after classification. |
 | [`autospec-run`](skills/autospec-run/README.md) | You already have an `auto-implement` queue. | Runs the implementation monitor, opens PRs, reviews, validates, and merges. |
-| [`autospec-fleet`](skills/autospec-fleet/README.md) | You want to run autospec across multiple GitHub repositories from one workspace. | `/autospec-fleet init` records repo URLs, fleet scripts validate config, and fleet run/status/stop coordinate per-repo `/autospec-run` workers. |
+| [`autospec-fleet`](skills/autospec-fleet/README.md) | You want to prepare multi-repo autospec supervision. | Provides config schemas/linting, URL path planning, dry-run `/autospec-run` command generation, JSON status, stop forwarding, and smoke tests. |
 | [`autospec-classify`](skills/autospec-classify/README.md) | Existing issues need model-fit labels. | Adds `ctx:*` and `reasoning:*` labels, inserts a `## Model fit` block, and promotes `needs-classify` issues. |
 | [`autospec-listen`](skills/autospec-listen/README.md) | You want chat phrases like "file an issue" to become tracked work. | Drafts issues for approval or routes spec requests into `/autospec-define`. |
 | [`autospec-story`](skills/autospec-story/README.md) | You need a repo-level product and implementation-state overview. | Produces a cited Markdown story from local specs, docs, issues, PRs, and git history. |
 | [`autospec-stop`](skills/autospec-stop/README.md) | You need to halt or resume an active monitor. | Writes the shared stop sentinel, pauses issues safely, reports status, or resumes paused work. |
 | [`autospec-review`](skills/autospec-review/README.md) | You want to close the spec-vs-code feedback loop. | Audits specs against issues, finds gaps, files `[REGRESSION]` issues with `priority:high`. |
 | [`autospec-test`](skills/autospec-test/README.md) | You want every Phase 4 PR gated on unit + E2E coverage with auto-heal. | Runs a two-stage coverage gate, auto-heals gaps within a 60-min budget, and blocks assertion-loosening rewrites before auto-merge. |
+| [`autospec-qa`](skills/autospec-qa/README.md) | You want to revalidate a running app against its spec and regenerate weak tests. | Builds a spec traceability matrix, exercises UI/API/accessibility/validation flows, and turns gaps into stronger tests or follow-up issues. |
 | [`autospec-design`](skills/autospec-design/README.md) | You want the repo's UI anchored to a known vendor design language (Apple, Linear, Stripe, etc.). | Fetches a `DESIGN.md` from the `berlinguyinca/awesome-design-md` catalog via `suggest`, `apply`, and `migrate` subcommands, writes `DESIGN.md` to the project root on a feature branch, and optionally hands off a per-component migration spec to `/autospec-define`. |
 
 See [`SKILLS.md`](SKILLS.md) for activation keywords and per-skill routing
@@ -303,15 +304,19 @@ Full end-to-end workflow:
 /autospec "add OIDC support behind a feature flag"
 ```
 
-Fleet workflow:
+Fleet helper workflow:
 
 ```text
-mkdir fleet-workspace
-cd fleet-workspace
-/autospec-fleet init https://github.com/org/repo-a https://github.com/org/repo-b
-/autospec-fleet run --profile claude-sonnet-cloud --dry-run
-/autospec-fleet status
+bash skills/autospec-fleet/scripts/fleet-init.sh --dry-run --workspace .autospec-fleet/repos \
+  https://github.com/org/repo-a https://github.com/org/repo-b
+bash skills/autospec-fleet/scripts/fleet-config-lint.sh --config path/to/autospec-fleet.yml
+bash skills/autospec-fleet/scripts/fleet-run.sh --config path/to/autospec-fleet.yml --dry-run --once
+bash skills/autospec-fleet/scripts/fleet-status.sh --config path/to/autospec-fleet.yml --json
 ```
+
+`autospec-fleet` currently exposes helper scripts for planning and dry-run
+coordination. Live repository clone/sync and worker launch are not implemented
+yet.
 
 The monitor:
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -23,7 +23,7 @@
 - Trigger: use when an operator wants to supervise autospec-run across multiple GitHub repositories from an empty workspace.
 - Activation keywords: `autospec-fleet`, `fleet init`, `fleet run`, `fleet status`, `fleet stop`, `run autospec across repos`
 - Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
-- Status: workspace-level fleet supervisor. `init` records GitHub repo URLs, config schemas validate `autospec-fleet.yml` and `~/.autospec/fleet-node.yml`, `run --dry-run` builds per-repo `/autospec-run --profile ... --worker-id fleet:<node>:<repo>` commands, `status --json` summarizes queues, and `stop --graceful|--immediate` forwards existing stop behavior to active managed checkouts.
+- Status: helper-script surface for preparing multi-repo supervision. Config schemas validate `autospec-fleet.yml` and `~/.autospec/fleet-node.yml`; `fleet-init.sh --dry-run` plans checkout paths; `fleet-run.sh --dry-run` builds per-repo `/autospec-run` commands; `fleet-status.sh --json` summarizes queues; and `fleet-stop.sh` forwards stop behavior to configured local checkouts. Live clone/sync and worker launch are still planned.
 
 ## autospec-listen
 
@@ -64,6 +64,14 @@
 - Activation keywords: `autospec-test`, `coverage gate`, `e2e gate`, `unit coverage`, `test gate`, `auto-heal tests`, `enforce test coverage`, `coverage enforcement`
 - Harnesses: Claude Code (`SKILL.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
 - Status: inline Phase 4 gate (runs after build + lint, before auto-merge) plus standalone `/autospec-test [PR#]` invocation. Two-stage: unit coverage → E2E coverage. Self-heal loop up to 5 iterations / 60 min coding time. Assertion-shift guardrail blocks LOOSENING rewrites. Mode II (scoped production) opt-in with mandatory backup/restore.
+
+## autospec-qa
+
+- Path: [`skills/autospec-qa`](skills/autospec-qa)
+- Trigger: use when a running app must be revalidated against a spec, UI controls and validation must be audited, or weak/missing tests should be regenerated from spec behavior.
+- Activation keywords: `autospec-qa`, `qa revalidate`, `revalidate app`, `spec compliance audit`, `regenerate tests`, `test every control`, `validate dropdowns`, `validation audit`
+- Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
+- Status: explicit spec-to-running-app QA workflow. Produces a traceability matrix, exercises UI/API/accessibility/validation/negative paths, and turns gaps into stronger automated tests or follow-up issues.
 
 ## autospec-design
 

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
 #   ./install.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | all
+#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | autospec-qa | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -49,7 +49,7 @@ OH_MY_CODEX_PACKAGE="${OH_MY_CODEX_PACKAGE:-oh-my-codex}"
 OH_MY_OPENCODE_PACKAGE="${OH_MY_OPENCODE_PACKAGE:-oh-my-opencode}"
 OH_MY_CLAUDE_PACKAGE="${OH_MY_CLAUDE_PACKAGE:-oh-my-claude-sisyphus}"
 
-ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet"
+ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -480,10 +480,10 @@ done
 
 # Validate --skill
 case "$SKILL_ARG" in
-    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design|autospec-fleet) ;;
+    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design|autospec-fleet|autospec-qa) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
-        err "must be one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | all"
+        err "must be one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | autospec-qa | all"
         exit 2
         ;;
 esac

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -211,7 +211,7 @@ check_startup_preflight() {
         || printf '%s\n' "$canonical" | grep -F 'raw.githubusercontent.com/berlinguyinca/autospec/main/skills/' >/dev/null; then
         fail "startup preflight must not call a raw installer directly"
     fi
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa; do
         for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
             body=$(extract_block "$f")
             [ -n "$body" ] || fail "$f missing ## Startup self-update section"
@@ -228,7 +228,7 @@ check_startup_preflight() {
 # prompts/ path AND the new skills/ slash-command registry path.
 check_codex_skills_install() {
     info "codex skills-dir install: all skills"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa; do
         f="skills/$s/install.sh"
         grep -q 'skills/\$SKILL_NAME/SKILL\.md' "$f" \
             || fail "$f missing Codex skills-dir install (skills/\$SKILL_NAME/SKILL.md)"
@@ -243,7 +243,7 @@ check_codex_skills_install() {
 check_shared_script_install() {
     info "shared helper install: all skills"
     helpers="autospec-stop.sh autospec-usage-limit.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet; do
+    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa; do
         f="skills/$s/install.sh"
         grep -q 'install_shared_scripts' "$f" \
             || fail "$f missing install_shared_scripts function/call"
@@ -632,6 +632,8 @@ check_team_personality_selection_contract() {
             || fail "$f missing Review counter-team issue/spec section"
         grep -q 'challenge likely blind spots' "$f" \
             || fail "$f missing counter-team blind-spot directive"
+        grep -q 'Critical improvement\|critical improvement' "$f" \
+            || fail "$f missing critical improvement self-question checkpoint"
     done
 }
 
@@ -652,6 +654,8 @@ check_team_personality_phase4_and_docs_contract() {
             || fail "$f missing Phase 4 team personality execution lens"
         grep -q '## Review counter-team as review lens' "$f" \
             || fail "$f missing Phase 4 review counter-team lens"
+        grep -q 'Critical self-question before LGTM' "$f" \
+            || fail "$f missing Phase 4 critical self-question before LGTM"
     done
     grep -q 'team_personality' scripts/gen-issue-skeleton.sh \
         || fail "scripts/gen-issue-skeleton.sh missing team_personality input"

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -290,6 +290,7 @@ Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`, then run a
 2. **Internal consistency** — re-read each section in order. Do any two sections contradict each other? Does the architecture match the feature descriptions? Fix inline.
 3. **Ambiguity** — could any requirement be interpreted two different ways? Pick one and make it explicit in the spec text.
 4. **Scope** — is this focused enough for a single multi-issue pipeline, or does it span independent subsystems that each need their own `/autospec-define` run? If the latter, stop and ask the operator to decompose before proceeding.
+5. **Critical improvement** — ask: "What else could fail even if this spec and its obvious tests pass, and how could this be better?" Add the highest-risk answer to Testing, Acceptance Criteria, or Review counter-team. For app/UI work, explicitly consider mocked-vs-deployed behavior, backend fallbacks, user-visible outcomes, and no-mock smoke coverage.
 
 The spec must be implementable end-to-end by an agent reading only the spec.
 

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -284,6 +284,7 @@ Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`, then run a
 2. **Internal consistency** — re-read each section in order. Do any two sections contradict each other? Does the architecture match the feature descriptions? Fix inline.
 3. **Ambiguity** — could any requirement be interpreted two different ways? Pick one and make it explicit in the spec text.
 4. **Scope** — is this focused enough for a single multi-issue pipeline, or does it span independent subsystems that each need their own `/autospec-define` run? If the latter, stop and ask the operator to decompose before proceeding.
+5. **Critical improvement** — ask: "What else could fail even if this spec and its obvious tests pass, and how could this be better?" Add the highest-risk answer to Testing, Acceptance Criteria, or Review counter-team. For app/UI work, explicitly consider mocked-vs-deployed behavior, backend fallbacks, user-visible outcomes, and no-mock smoke coverage.
 
 The spec must be implementable end-to-end by an agent reading only the spec.
 

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -288,6 +288,7 @@ Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`, then run a
 2. **Internal consistency** — re-read each section in order. Do any two sections contradict each other? Does the architecture match the feature descriptions? Fix inline.
 3. **Ambiguity** — could any requirement be interpreted two different ways? Pick one and make it explicit in the spec text.
 4. **Scope** — is this focused enough for a single multi-issue pipeline, or does it span independent subsystems that each need their own `/autospec-define` run? If the latter, stop and ask the operator to decompose before proceeding.
+5. **Critical improvement** — ask: "What else could fail even if this spec and its obvious tests pass, and how could this be better?" Add the highest-risk answer to Testing, Acceptance Criteria, or Review counter-team. For app/UI work, explicitly consider mocked-vs-deployed behavior, backend fallbacks, user-visible outcomes, and no-mock smoke coverage.
 
 The spec must be implementable end-to-end by an agent reading only the spec.
 

--- a/skills/autospec-fleet/README.md
+++ b/skills/autospec-fleet/README.md
@@ -1,13 +1,12 @@
 # autospec-fleet
 
-Workspace-level supervisor for running autospec across multiple GitHub
-repositories.
+Workspace-level helper surface for preparing autospec supervision across
+multiple GitHub repositories.
 
-`autospec-fleet` starts from an empty directory, records a fleet config, clones
-or syncs target repositories, and launches `/autospec-run` inside each eligible
-checkout. It is intentionally above `/autospec-run`: fleet schedules
-repositories, while `/autospec-run` still owns issue claims, PRs, review, CI,
-and merge behavior.
+`autospec-fleet` currently provides installable skill docs plus shell helpers for
+config validation, GitHub URL/path planning, dry-run `/autospec-run` command
+generation, JSON status summaries, stop forwarding, and mocked smoke coverage.
+Live repository clone/sync and live worker launch are not implemented yet.
 
 ## Quick install
 
@@ -28,20 +27,32 @@ Or via the top-level suite installer:
 ./install.sh --skill autospec-fleet --harness all
 ```
 
-## Invocation
+## Working commands
 
 ```text
-/autospec-fleet init <repo-url>...
-/autospec-fleet sync [--config-repo <url>]
-/autospec-fleet run [--profile <name>] [--parallel <N>] [--once]
-/autospec-fleet status
-/autospec-fleet stop --graceful
-/autospec-fleet stop --immediate
+bash skills/autospec-fleet/scripts/fleet-init.sh --dry-run --workspace .autospec-fleet/repos <repo-url>...
+bash skills/autospec-fleet/scripts/fleet-config-lint.sh --config path/to/autospec-fleet.yml
+bash skills/autospec-fleet/scripts/fleet-run.sh --config path/to/autospec-fleet.yml --dry-run --once
+bash skills/autospec-fleet/scripts/fleet-status.sh --config path/to/autospec-fleet.yml --json
+bash skills/autospec-fleet/scripts/fleet-stop.sh --config path/to/autospec-fleet.yml --graceful
 ```
 
-The scaffold and install surface are present first. Follow-up issues implement
-the schemas, URL normalization, config linting, scheduler, status/stop commands,
-docs, and dry-run smoke tests.
+Implemented surface:
+
+- Install and uninstall scripts for the skill.
+- Fleet and node config schemas.
+- Config linting.
+- GitHub URL normalization and workspace path planning.
+- Dry-run scheduler output for `/autospec-run` commands.
+- JSON status summaries from configured repositories.
+- Stop forwarding for configured local checkout paths.
+- Mocked dry-run smoke tests.
+
+Not implemented yet:
+
+- Live clone/sync of repositories.
+- Live `/autospec-run` worker launch.
+- A single `/autospec-fleet` command dispatcher for the helper scripts.
 
 ## Configuration
 
@@ -73,10 +84,9 @@ profiles:
 | Skill | Purpose |
 | --- | --- |
 | [`autospec-run`](../autospec-run/README.md) | Per-repo implementation monitor that owns issue claims and PR flow. |
-| [`autospec-stop`](../autospec-stop/README.md) | Shared stop/resume sentinel used by fleet workers. |
+| [`autospec-stop`](../autospec-stop/README.md) | Shared stop/resume sentinel used by fleet stop forwarding. |
 | [`autospec`](../autospec/README.md) | Full single-repo path from feature request to merged PRs. |
 
 ## License
 
 MIT - see the repository [LICENSE](../../LICENSE) file.
-

--- a/skills/autospec-qa/README.md
+++ b/skills/autospec-qa/README.md
@@ -1,0 +1,36 @@
+# autospec-qa
+
+Spec-to-running-app QA revalidation for autospec projects.
+
+Use `autospec-qa` when an implementation is believed to be complete but needs a
+broad proof pass against the source spec. The skill audits every requirement,
+UI control, validation rule, state transition, API effect, accessibility path,
+and cross-feature workflow, then regenerates missing or weak automated tests.
+
+## Invocation
+
+```text
+/autospec-qa --spec docs/specs/<feature>.md --url http://localhost:3000
+/autospec-qa --spec docs/specs/<feature>.md --run "npm run dev"
+/autospec-qa revalidate latest spec
+```
+
+## Result
+
+- A spec traceability matrix with PASS/FAIL/PARTIAL/NOT TESTED status.
+- UI control and validation coverage findings.
+- Accessibility, responsive, API, and negative-path findings.
+- Regenerated or strengthened tests where the repo has an existing harness.
+- Follow-up issue drafts for remaining implementation gaps.
+
+## Related skills
+
+| Skill | Purpose |
+| --- | --- |
+| [`autospec-test`](../autospec-test/README.md) | Deterministic Phase 4 unit/E2E coverage gate. |
+| [`autospec-review`](../autospec-review/README.md) | Spec-vs-issues audit and regression issue filing. |
+| [`autospec-run`](../autospec-run/README.md) | Implementation loop that produces PRs. |
+
+## License
+
+MIT - see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autospec-qa/SKILL.md
+++ b/skills/autospec-qa/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: autospec-qa
+description: Use when the user wants to revalidate a running app against a spec, regenerate missing or weak tests, audit UI controls/forms/validation/dropdowns/API behavior/accessibility, or prove implemented features actually work after autospec-run.
+---
+
+# autospec-qa workflow
+
+Run a spec-to-running-app QA audit, then regenerate missing or weak tests until
+the application behavior is covered by executable evidence. This skill is the
+explicit revalidation companion to `autospec-test`: `autospec-test` gates PRs
+with deterministic coverage and E2E checks; `autospec-qa` performs a broad
+human-style audit from the spec and turns gaps into stronger tests or follow-up
+issues.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-qa   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches `update` after trimming and lowercasing,
+re-install the full autospec suite from `main`, show the before/after diff if the
+harness exposes it, then stop. Do not run the QA audit.
+
+## Required capabilities & harness adapter
+
+| Capability | Claude Code | OpenCode | Codex CLI | Fallback if missing |
+| --- | --- | --- | --- | --- |
+| Subagent model tier | Tier A: `opus` + ultrathink | Tier A: top-tier `task` + max reasoning | Tier A: current top GPT + `reasoning_effort=high` | Run inline, but keep the same report contract |
+| Browser/E2E execution | Playwright/browser tool or shell | Playwright/browser task | shell + browser when available | Mark UI-only checks NOT TESTED with blocker |
+| Shell execution | Bash tool | shell tool | shell/apply_patch | Required for regeneration |
+
+**Model tier:** TIER_A for the spec audit and test-regeneration plan because
+false PASS results are more expensive than extra review tokens.
+
+## Harness detection
+
+Detect the harness once at skill start:
+
+1. Claude Code: `Agent` with `subagent_type` is available.
+   - `TIER_A` = `opus` + ultrathink.
+   - `TIER_B` = `sonnet`.
+2. OpenCode: `task` tool is available.
+   - `TIER_A` = top-tier task model + high reasoning.
+   - `TIER_B` = smaller-tier task model + medium reasoning.
+3. Codex CLI: `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT + `reasoning_effort=high`.
+   - `TIER_B` = current cost-optimized Codex model + `reasoning_effort=medium`.
+
+Prefer a Tier A reviewer/QA subagent for the first traceability audit when the
+harness supports it. If `TIER_A` is unavailable, silently fall back to the next
+available top-tier model. If delegation is unavailable, run the audit inline.
+
+## When to use
+
+- After `/autospec-run` finishes and the operator wants proof that the app
+  actually satisfies the source spec.
+- When a UI-heavy feature needs text boxes, validation, selects, dropdowns,
+  buttons, navigation, modals, keyboard behavior, accessibility, and API effects
+  verified from multiple directions.
+- When existing tests pass but the spec may still be under-tested.
+- When the user asks to regenerate tests from a spec or strengthen weak tests.
+
+## When not to use
+
+- Do not use against production unless the target repo's `autospec-test`
+  contract explicitly allows scoped production and backup/restore is verified.
+- Do not mark a feature PASS from code inspection alone.
+- Do not loosen assertions to make regenerated tests pass.
+- Do not treat mocked API tests as proof that a deployed workflow works.
+
+## No-mock deployed smoke rule
+
+For every user workflow button or dropdown-backed action, QA must cover both the
+contract and the deployed user-visible result:
+
+1. Verify the control is enabled and changing it changes the actual request
+   payload, query, route, or command parameters.
+2. Run a mocked happy-path test for deterministic UI state coverage.
+3. Run a no-mock smoke test against the configured deployed/dev URL using a
+   representative input from the spec or domain fixtures.
+4. Assert that no generic live-failure banner appears.
+5. Assert that the result panel contains a real domain result, not only that a
+   request was sent.
+6. Include regression coverage for known fragile backend responses, such as
+   `502` bridge/proxy failures, and require either a working fallback route or a
+   clear actionable user state.
+7. Re-check the endpoint mental model against the app and production behavior:
+   if a mocked route differs from the route that actually supports the workflow,
+   tests must follow the user-visible workflow and document the stable backend
+   contract they prove.
+
+## Critical self-questioning checkpoint
+
+Before finalizing the QA report or accepting regenerated tests, stop and answer
+these questions in the working notes:
+
+1. What could still pass in the current mocked tests while failing for a real
+   user on the deployed/dev environment?
+2. Which user-visible outcome proves the feature worked, independent of DOM
+   wiring or request dispatch?
+3. Which backend route, service, queue, bridge, cache, or external dependency am
+   I assuming is healthy?
+4. If that dependency fails, is there a tested fallback route or a clear
+   actionable user state?
+5. Which button, dropdown, select, text box, validation rule, or error state did
+   I not touch because it was inconvenient, slow, or required setup?
+6. Does the test prove the intended domain result, or only that a generic panel
+   changed?
+7. What is the single highest-risk missing test I can add now?
+
+If any answer identifies a material gap, add the narrowest test for it or file a
+follow-up issue with reproduction steps. Do not silently leave it as an
+unstated risk.
+
+## Inputs
+
+Collect or infer:
+
+- Spec path or URL.
+- App URL or local run command.
+- Repository path.
+- Test credentials and seed data, if needed.
+- Relevant PR/issue numbers.
+
+If the app cannot be run and no URL is available, continue with static/test
+audit only, but mark all runtime UI checks `NOT TESTED` with the exact blocker.
+
+## QA prompt
+
+Use this prompt as the audit driver:
+
+```text
+You are a senior QA engineer, product tester, and spec-compliance auditor.
+
+Your job is to test this application completely from every meaningful scope and
+direction, and to verify that every feature specified in the spec actually works
+in the running app.
+
+Inputs:
+- Spec: <paste or link the product/spec document>
+- App URL or local run command: <URL or command>
+- Repository path, if available: <path>
+- Test credentials/data, if available: <credentials/data>
+
+Mission:
+Create and execute a complete verification pass that proves whether the
+implemented app matches the spec. Do not only inspect code. Run the app and
+interact with it like a real user. Treat the spec as the source of truth.
+
+Required testing scope:
+
+1. Spec Traceability
+- Extract every feature, requirement, acceptance criterion, user flow,
+  validation rule, permission rule, and edge case from the spec.
+- Build a traceability matrix with requirement, expected behavior, test
+  performed, PASS/FAIL/PARTIAL/NOT TESTED result, evidence, and notes.
+
+2. Functional Testing
+Test every user-facing feature end to end: buttons, links, text inputs,
+textareas, checkboxes, radio buttons, selects, dropdowns, multi-selects, search
+fields, filters, sorting, pagination, tabs, modals, forms, uploads/downloads,
+navigation, save/edit/delete flows, auth/login/logout, and empty/loading/
+success/error/disabled states.
+
+For every workflow button or dropdown-backed action, do not stop at clickability
+or request dispatch. Verify the selected values change the real request
+payload/query, run a mocked happy path, run a no-mock deployed/dev smoke path
+with representative input, assert no live-failure banner appears, and assert a
+real domain result is visible.
+
+3. Form and Validation Testing
+For every form/input test valid input, empty input, invalid input, boundary
+values, very long text, special characters, whitespace-only values, duplicates,
+required-field behavior, error-message clarity, recovery after correction,
+keyboard submission, disabled submit behavior, and server-side validation.
+
+4. UI and UX Behavior
+Verify text readability, labels, discoverability, visible state changes,
+loading/error/success states, desktop/tablet/mobile layouts, and absence of
+overlapping or clipped content.
+
+5. Accessibility
+Check keyboard-only navigation, focus order, visible focus indicators, input
+labels, ARIA where needed, screen-reader names for icon buttons, color contrast,
+Escape behavior, and Enter/Space behavior.
+
+6. Data and State Testing
+Verify persistence after refresh, unsaved-change handling, optimistic update
+reconciliation, delete/edit propagation, filter/search/sort state, browser
+back/forward behavior, and deep links.
+
+7. Negative and Edge Cases
+Test API failure, slow responses, empty datasets, large datasets, unauthorized
+access, expired sessions, invalid routes, concurrent edits, repeated rapid
+clicks, and refresh during in-progress actions.
+
+8. Backend/API Integration
+When a backend exists, verify frontend requests match API contracts, API errors
+are handled correctly, storage reflects create/update/delete behavior, and
+permissions/validation are enforced server-side.
+
+Include regression coverage for deployed backend failures such as `502` bridge,
+proxy, queue, or cache misses. If a backend route is known fragile, the UI must
+either recover through a documented fallback route or show a clear actionable
+state. Mocked endpoint success is not sufficient evidence.
+
+9. Regression and Cross-Feature Testing
+Combine flows: create then search/filter/sort, edit then verify list/detail
+views, delete then verify navigation/empty states, change settings then verify
+dependent screens, and complete full user journeys.
+
+10. Automated Test Recommendations
+Identify missing unit, integration, component, E2E, accessibility, and API
+contract tests. For each missing test, state exactly what it should assert.
+
+Execution rules:
+- Do not assume a feature works because code appears to exist.
+- Do not mark PASS without concrete evidence.
+- Mark untestable items NOT TESTED and explain the blocker.
+- Mark spec mismatches FAIL even if the implementation seems reasonable.
+- Mark ambiguous spec items AMBIGUOUS and propose expected behavior.
+- Capture screenshots, logs, console errors, network failures, or command output
+  where useful.
+- Continue until every spec item has a status.
+
+Final report:
+# QA Verification Report
+## Summary
+- Overall result: PASS / FAIL / PARTIAL
+- App/version/commit tested:
+- Environment:
+- Main risks:
+## Spec Traceability Matrix
+| Requirement | Expected Behavior | Test Performed | Result | Evidence | Notes |
+|---|---|---|---|---|---|
+## Bugs and Gaps
+For each issue include severity, area, spec reference, steps to reproduce,
+expected, actual, evidence, and suggested fix.
+## UI Control Coverage
+List every tested text input, select/dropdown, button, form, navigation element,
+modal, table/list, and other control.
+## Validation Coverage
+List every validation rule tested, including valid, invalid, boundary, and
+recovery behavior.
+## Accessibility Findings
+Include keyboard, focus, labels, contrast, ARIA, and screen-reader concerns.
+## Cross-Browser / Responsive Findings
+Include desktop, tablet, and mobile behavior if applicable.
+## Automated Test Gaps
+List exact tests to add before the app is fully protected.
+## Final Verdict
+State whether the app satisfies the spec and the minimum fixes required before
+release.
+```
+
+## Regeneration loop
+
+After the audit:
+
+1. Convert every `FAIL`, `PARTIAL`, `NOT TESTED`, and high-risk `AMBIGUOUS`
+   traceability row into one of:
+   - a product bug fix,
+   - a regenerated/strengthened automated test,
+   - a follow-up GitHub issue when implementation scope is too large.
+2. Regenerate tests in the narrowest existing harness:
+   - unit tests for pure functions and validation rules,
+   - integration/API tests for server-side validation and persistence,
+   - component tests for isolated UI states,
+   - E2E/Playwright tests for user journeys, controls, accessibility, and
+     cross-feature behavior.
+3. Preserve or strengthen assertions. Never replace a specific assertion with a
+   weaker smoke assertion.
+4. Run the relevant test commands and the repo's validation command.
+5. Repeat until the traceability matrix has no unexplained gaps or the remaining
+   gaps are filed as issues with reproduction steps and evidence.
+
+## Output contract
+
+Return:
+
+- QA report path or inline report.
+- Tests added/changed.
+- Product bugs fixed, if any.
+- Follow-up issues filed or drafted.
+- Commands run and results.
+- Remaining risks.
+
+## Stop mode
+
+If the request is exactly `stop` or `stop` plus `--<word>` flags after
+normalization, dispatch to:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>
+```
+
+Print the helper output and stop. Do not run the QA audit.

--- a/skills/autospec-qa/codex/prompt.md
+++ b/skills/autospec-qa/codex/prompt.md
@@ -1,0 +1,334 @@
+
+# autospec-qa workflow
+
+Run a spec-to-running-app QA audit, then regenerate missing or weak tests until
+the application behavior is covered by executable evidence. This skill is the
+explicit revalidation companion to `autospec-test`: `autospec-test` gates PRs
+with deterministic coverage and E2E checks; `autospec-qa` performs a broad
+human-style audit from the spec and turns gaps into stronger tests or follow-up
+issues.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-qa   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches `update` after trimming and lowercasing,
+re-install the full autospec suite from `main`, show the before/after diff if the
+harness exposes it, then stop. Do not run the QA audit.
+
+## Required capabilities & harness adapter
+
+| Capability | Claude Code | OpenCode | Codex CLI | Fallback if missing |
+| --- | --- | --- | --- | --- |
+| Subagent model tier | Tier A: `opus` + ultrathink | Tier A: top-tier `task` + max reasoning | Tier A: current top GPT + `reasoning_effort=high` | Run inline, but keep the same report contract |
+| Browser/E2E execution | Playwright/browser tool or shell | Playwright/browser task | shell + browser when available | Mark UI-only checks NOT TESTED with blocker |
+| Shell execution | Bash tool | shell tool | shell/apply_patch | Required for regeneration |
+
+**Model tier:** TIER_A for the spec audit and test-regeneration plan because
+false PASS results are more expensive than extra review tokens.
+
+## Harness detection
+
+Detect the harness once at skill start:
+
+1. Claude Code: `Agent` with `subagent_type` is available.
+   - `TIER_A` = `opus` + ultrathink.
+   - `TIER_B` = `sonnet`.
+2. OpenCode: `task` tool is available.
+   - `TIER_A` = top-tier task model + high reasoning.
+   - `TIER_B` = smaller-tier task model + medium reasoning.
+3. Codex CLI: `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT + `reasoning_effort=high`.
+   - `TIER_B` = current cost-optimized Codex model + `reasoning_effort=medium`.
+
+Prefer a Tier A reviewer/QA subagent for the first traceability audit when the
+harness supports it. If `TIER_A` is unavailable, silently fall back to the next
+available top-tier model. If delegation is unavailable, run the audit inline.
+
+## When to use
+
+- After `/autospec-run` finishes and the operator wants proof that the app
+  actually satisfies the source spec.
+- When a UI-heavy feature needs text boxes, validation, selects, dropdowns,
+  buttons, navigation, modals, keyboard behavior, accessibility, and API effects
+  verified from multiple directions.
+- When existing tests pass but the spec may still be under-tested.
+- When the user asks to regenerate tests from a spec or strengthen weak tests.
+
+## When not to use
+
+- Do not use against production unless the target repo's `autospec-test`
+  contract explicitly allows scoped production and backup/restore is verified.
+- Do not mark a feature PASS from code inspection alone.
+- Do not loosen assertions to make regenerated tests pass.
+- Do not treat mocked API tests as proof that a deployed workflow works.
+
+## No-mock deployed smoke rule
+
+For every user workflow button or dropdown-backed action, QA must cover both the
+contract and the deployed user-visible result:
+
+1. Verify the control is enabled and changing it changes the actual request
+   payload, query, route, or command parameters.
+2. Run a mocked happy-path test for deterministic UI state coverage.
+3. Run a no-mock smoke test against the configured deployed/dev URL using a
+   representative input from the spec or domain fixtures.
+4. Assert that no generic live-failure banner appears.
+5. Assert that the result panel contains a real domain result, not only that a
+   request was sent.
+6. Include regression coverage for known fragile backend responses, such as
+   `502` bridge/proxy failures, and require either a working fallback route or a
+   clear actionable user state.
+7. Re-check the endpoint mental model against the app and production behavior:
+   if a mocked route differs from the route that actually supports the workflow,
+   tests must follow the user-visible workflow and document the stable backend
+   contract they prove.
+
+## Critical self-questioning checkpoint
+
+Before finalizing the QA report or accepting regenerated tests, stop and answer
+these questions in the working notes:
+
+1. What could still pass in the current mocked tests while failing for a real
+   user on the deployed/dev environment?
+2. Which user-visible outcome proves the feature worked, independent of DOM
+   wiring or request dispatch?
+3. Which backend route, service, queue, bridge, cache, or external dependency am
+   I assuming is healthy?
+4. If that dependency fails, is there a tested fallback route or a clear
+   actionable user state?
+5. Which button, dropdown, select, text box, validation rule, or error state did
+   I not touch because it was inconvenient, slow, or required setup?
+6. Does the test prove the intended domain result, or only that a generic panel
+   changed?
+7. What is the single highest-risk missing test I can add now?
+
+If any answer identifies a material gap, add the narrowest test for it or file a
+follow-up issue with reproduction steps. Do not silently leave it as an
+unstated risk.
+
+## Inputs
+
+Collect or infer:
+
+- Spec path or URL.
+- App URL or local run command.
+- Repository path.
+- Test credentials and seed data, if needed.
+- Relevant PR/issue numbers.
+
+If the app cannot be run and no URL is available, continue with static/test
+audit only, but mark all runtime UI checks `NOT TESTED` with the exact blocker.
+
+## QA prompt
+
+Use this prompt as the audit driver:
+
+```text
+You are a senior QA engineer, product tester, and spec-compliance auditor.
+
+Your job is to test this application completely from every meaningful scope and
+direction, and to verify that every feature specified in the spec actually works
+in the running app.
+
+Inputs:
+- Spec: <paste or link the product/spec document>
+- App URL or local run command: <URL or command>
+- Repository path, if available: <path>
+- Test credentials/data, if available: <credentials/data>
+
+Mission:
+Create and execute a complete verification pass that proves whether the
+implemented app matches the spec. Do not only inspect code. Run the app and
+interact with it like a real user. Treat the spec as the source of truth.
+
+Required testing scope:
+
+1. Spec Traceability
+- Extract every feature, requirement, acceptance criterion, user flow,
+  validation rule, permission rule, and edge case from the spec.
+- Build a traceability matrix with requirement, expected behavior, test
+  performed, PASS/FAIL/PARTIAL/NOT TESTED result, evidence, and notes.
+
+2. Functional Testing
+Test every user-facing feature end to end: buttons, links, text inputs,
+textareas, checkboxes, radio buttons, selects, dropdowns, multi-selects, search
+fields, filters, sorting, pagination, tabs, modals, forms, uploads/downloads,
+navigation, save/edit/delete flows, auth/login/logout, and empty/loading/
+success/error/disabled states.
+
+For every workflow button or dropdown-backed action, do not stop at clickability
+or request dispatch. Verify the selected values change the real request
+payload/query, run a mocked happy path, run a no-mock deployed/dev smoke path
+with representative input, assert no live-failure banner appears, and assert a
+real domain result is visible.
+
+3. Form and Validation Testing
+For every form/input test valid input, empty input, invalid input, boundary
+values, very long text, special characters, whitespace-only values, duplicates,
+required-field behavior, error-message clarity, recovery after correction,
+keyboard submission, disabled submit behavior, and server-side validation.
+
+4. UI and UX Behavior
+Verify text readability, labels, discoverability, visible state changes,
+loading/error/success states, desktop/tablet/mobile layouts, and absence of
+overlapping or clipped content.
+
+5. Accessibility
+Check keyboard-only navigation, focus order, visible focus indicators, input
+labels, ARIA where needed, screen-reader names for icon buttons, color contrast,
+Escape behavior, and Enter/Space behavior.
+
+6. Data and State Testing
+Verify persistence after refresh, unsaved-change handling, optimistic update
+reconciliation, delete/edit propagation, filter/search/sort state, browser
+back/forward behavior, and deep links.
+
+7. Negative and Edge Cases
+Test API failure, slow responses, empty datasets, large datasets, unauthorized
+access, expired sessions, invalid routes, concurrent edits, repeated rapid
+clicks, and refresh during in-progress actions.
+
+8. Backend/API Integration
+When a backend exists, verify frontend requests match API contracts, API errors
+are handled correctly, storage reflects create/update/delete behavior, and
+permissions/validation are enforced server-side.
+
+Include regression coverage for deployed backend failures such as `502` bridge,
+proxy, queue, or cache misses. If a backend route is known fragile, the UI must
+either recover through a documented fallback route or show a clear actionable
+state. Mocked endpoint success is not sufficient evidence.
+
+9. Regression and Cross-Feature Testing
+Combine flows: create then search/filter/sort, edit then verify list/detail
+views, delete then verify navigation/empty states, change settings then verify
+dependent screens, and complete full user journeys.
+
+10. Automated Test Recommendations
+Identify missing unit, integration, component, E2E, accessibility, and API
+contract tests. For each missing test, state exactly what it should assert.
+
+Execution rules:
+- Do not assume a feature works because code appears to exist.
+- Do not mark PASS without concrete evidence.
+- Mark untestable items NOT TESTED and explain the blocker.
+- Mark spec mismatches FAIL even if the implementation seems reasonable.
+- Mark ambiguous spec items AMBIGUOUS and propose expected behavior.
+- Capture screenshots, logs, console errors, network failures, or command output
+  where useful.
+- Continue until every spec item has a status.
+
+Final report:
+# QA Verification Report
+## Summary
+- Overall result: PASS / FAIL / PARTIAL
+- App/version/commit tested:
+- Environment:
+- Main risks:
+## Spec Traceability Matrix
+| Requirement | Expected Behavior | Test Performed | Result | Evidence | Notes |
+|---|---|---|---|---|---|
+## Bugs and Gaps
+For each issue include severity, area, spec reference, steps to reproduce,
+expected, actual, evidence, and suggested fix.
+## UI Control Coverage
+List every tested text input, select/dropdown, button, form, navigation element,
+modal, table/list, and other control.
+## Validation Coverage
+List every validation rule tested, including valid, invalid, boundary, and
+recovery behavior.
+## Accessibility Findings
+Include keyboard, focus, labels, contrast, ARIA, and screen-reader concerns.
+## Cross-Browser / Responsive Findings
+Include desktop, tablet, and mobile behavior if applicable.
+## Automated Test Gaps
+List exact tests to add before the app is fully protected.
+## Final Verdict
+State whether the app satisfies the spec and the minimum fixes required before
+release.
+```
+
+## Regeneration loop
+
+After the audit:
+
+1. Convert every `FAIL`, `PARTIAL`, `NOT TESTED`, and high-risk `AMBIGUOUS`
+   traceability row into one of:
+   - a product bug fix,
+   - a regenerated/strengthened automated test,
+   - a follow-up GitHub issue when implementation scope is too large.
+2. Regenerate tests in the narrowest existing harness:
+   - unit tests for pure functions and validation rules,
+   - integration/API tests for server-side validation and persistence,
+   - component tests for isolated UI states,
+   - E2E/Playwright tests for user journeys, controls, accessibility, and
+     cross-feature behavior.
+3. Preserve or strengthen assertions. Never replace a specific assertion with a
+   weaker smoke assertion.
+4. Run the relevant test commands and the repo's validation command.
+5. Repeat until the traceability matrix has no unexplained gaps or the remaining
+   gaps are filed as issues with reproduction steps and evidence.
+
+## Output contract
+
+Return:
+
+- QA report path or inline report.
+- Tests added/changed.
+- Product bugs fixed, if any.
+- Follow-up issues filed or drafted.
+- Commands run and results.
+- Remaining risks.
+
+## Stop mode
+
+If the request is exactly `stop` or `stop` plus `--<word>` flags after
+normalization, dispatch to:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>
+```
+
+Print the helper output and stop. Do not run the QA audit.

--- a/skills/autospec-qa/install.sh
+++ b/skills/autospec-qa/install.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env sh
+# install.sh - install the autospec-qa skill into one or more harnesses.
+
+set -eu
+
+SKILL_NAME="autospec-qa"
+SKILL_RAW_BASE="${AUTOSPEC_QA_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_QA_REF:-main}/skills/autospec-qa}"
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+UPDATE_MODE=0
+TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
+
+Installs the ${SKILL_NAME} skill into the chosen harness.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    command -v curl >/dev/null 2>&1 || { err "curl is required when running from stdin"; exit 1; }
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel" || { err "failed to download $rel"; exit 1; }
+    done
+    for rel in $SHARED_SCRIPT_FILES; do
+        curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel" || { err "failed to download $rel"; exit 1; }
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    [ -f "$src" ] || { err "missing source file: $src"; return 1; }
+    run "mkdir -p \"$(dirname "$dest")\""
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    [ -n "$src_dir" ] || { err "missing shared scripts directory"; return 1; }
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;; esac
+    done
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness) shift; HARNESS="${1:-}" ;;
+        --harness=*) HARNESS="${1#--harness=}" ;;
+        --symlink) USE_SYMLINK=1 ;;
+        --dry-run) DRY_RUN=1 ;;
+        --update) UPDATE_MODE=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) err "unknown arg: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+
+[ -n "$HARNESS" ] || HARNESS=all
+case "$HARNESS" in claude|opencode|codex|all) ;; *) err "invalid --harness: $HARNESS"; exit 2 ;; esac
+
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+if [ "$need_fetch" -eq 1 ]; then
+    [ "$USE_SYMLINK" -eq 0 ] || { err "--symlink requires a local checkout"; exit 2; }
+    fetch_source_files
+fi
+
+for dep in git gh jq; do
+    command -v "$dep" >/dev/null 2>&1 || warn "$dep not found on PATH"
+done
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Claude Code:"
+    install_one "$SKILL_DIR/SKILL.md" "$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "OpenCode:"
+    install_one "$SKILL_DIR/opencode/agent.md" "$OPENCODE_DIR/agent/$SKILL_NAME.md"
+fi
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Codex CLI:"
+    install_one "$SKILL_DIR/codex/prompt.md" "$CODEX_DIR/prompts/$SKILL_NAME.md"
+    install_one "$SKILL_DIR/SKILL.md" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+elif [ "$UPDATE_MODE" -eq 1 ]; then
+    info "Updated $SKILL_NAME."
+else
+    info "Installed $SKILL_NAME."
+fi

--- a/skills/autospec-qa/opencode/agent.md
+++ b/skills/autospec-qa/opencode/agent.md
@@ -1,0 +1,338 @@
+---
+name: autospec-qa
+description: Use when the user wants to revalidate a running app against a spec, regenerate missing or weak tests, audit UI controls/forms/validation/dropdowns/API behavior/accessibility, or prove implemented features actually work after autospec-run.
+---
+
+# autospec-qa workflow
+
+Run a spec-to-running-app QA audit, then regenerate missing or weak tests until
+the application behavior is covered by executable evidence. This skill is the
+explicit revalidation companion to `autospec-test`: `autospec-test` gates PRs
+with deterministic coverage and E2E checks; `autospec-qa` performs a broad
+human-style audit from the spec and turns gaps into stronger tests or follow-up
+issues.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-qa   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches `update` after trimming and lowercasing,
+re-install the full autospec suite from `main`, show the before/after diff if the
+harness exposes it, then stop. Do not run the QA audit.
+
+## Required capabilities & harness adapter
+
+| Capability | Claude Code | OpenCode | Codex CLI | Fallback if missing |
+| --- | --- | --- | --- | --- |
+| Subagent model tier | Tier A: `opus` + ultrathink | Tier A: top-tier `task` + max reasoning | Tier A: current top GPT + `reasoning_effort=high` | Run inline, but keep the same report contract |
+| Browser/E2E execution | Playwright/browser tool or shell | Playwright/browser task | shell + browser when available | Mark UI-only checks NOT TESTED with blocker |
+| Shell execution | Bash tool | shell tool | shell/apply_patch | Required for regeneration |
+
+**Model tier:** TIER_A for the spec audit and test-regeneration plan because
+false PASS results are more expensive than extra review tokens.
+
+## Harness detection
+
+Detect the harness once at skill start:
+
+1. Claude Code: `Agent` with `subagent_type` is available.
+   - `TIER_A` = `opus` + ultrathink.
+   - `TIER_B` = `sonnet`.
+2. OpenCode: `task` tool is available.
+   - `TIER_A` = top-tier task model + high reasoning.
+   - `TIER_B` = smaller-tier task model + medium reasoning.
+3. Codex CLI: `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT + `reasoning_effort=high`.
+   - `TIER_B` = current cost-optimized Codex model + `reasoning_effort=medium`.
+
+Prefer a Tier A reviewer/QA subagent for the first traceability audit when the
+harness supports it. If `TIER_A` is unavailable, silently fall back to the next
+available top-tier model. If delegation is unavailable, run the audit inline.
+
+## When to use
+
+- After `/autospec-run` finishes and the operator wants proof that the app
+  actually satisfies the source spec.
+- When a UI-heavy feature needs text boxes, validation, selects, dropdowns,
+  buttons, navigation, modals, keyboard behavior, accessibility, and API effects
+  verified from multiple directions.
+- When existing tests pass but the spec may still be under-tested.
+- When the user asks to regenerate tests from a spec or strengthen weak tests.
+
+## When not to use
+
+- Do not use against production unless the target repo's `autospec-test`
+  contract explicitly allows scoped production and backup/restore is verified.
+- Do not mark a feature PASS from code inspection alone.
+- Do not loosen assertions to make regenerated tests pass.
+- Do not treat mocked API tests as proof that a deployed workflow works.
+
+## No-mock deployed smoke rule
+
+For every user workflow button or dropdown-backed action, QA must cover both the
+contract and the deployed user-visible result:
+
+1. Verify the control is enabled and changing it changes the actual request
+   payload, query, route, or command parameters.
+2. Run a mocked happy-path test for deterministic UI state coverage.
+3. Run a no-mock smoke test against the configured deployed/dev URL using a
+   representative input from the spec or domain fixtures.
+4. Assert that no generic live-failure banner appears.
+5. Assert that the result panel contains a real domain result, not only that a
+   request was sent.
+6. Include regression coverage for known fragile backend responses, such as
+   `502` bridge/proxy failures, and require either a working fallback route or a
+   clear actionable user state.
+7. Re-check the endpoint mental model against the app and production behavior:
+   if a mocked route differs from the route that actually supports the workflow,
+   tests must follow the user-visible workflow and document the stable backend
+   contract they prove.
+
+## Critical self-questioning checkpoint
+
+Before finalizing the QA report or accepting regenerated tests, stop and answer
+these questions in the working notes:
+
+1. What could still pass in the current mocked tests while failing for a real
+   user on the deployed/dev environment?
+2. Which user-visible outcome proves the feature worked, independent of DOM
+   wiring or request dispatch?
+3. Which backend route, service, queue, bridge, cache, or external dependency am
+   I assuming is healthy?
+4. If that dependency fails, is there a tested fallback route or a clear
+   actionable user state?
+5. Which button, dropdown, select, text box, validation rule, or error state did
+   I not touch because it was inconvenient, slow, or required setup?
+6. Does the test prove the intended domain result, or only that a generic panel
+   changed?
+7. What is the single highest-risk missing test I can add now?
+
+If any answer identifies a material gap, add the narrowest test for it or file a
+follow-up issue with reproduction steps. Do not silently leave it as an
+unstated risk.
+
+## Inputs
+
+Collect or infer:
+
+- Spec path or URL.
+- App URL or local run command.
+- Repository path.
+- Test credentials and seed data, if needed.
+- Relevant PR/issue numbers.
+
+If the app cannot be run and no URL is available, continue with static/test
+audit only, but mark all runtime UI checks `NOT TESTED` with the exact blocker.
+
+## QA prompt
+
+Use this prompt as the audit driver:
+
+```text
+You are a senior QA engineer, product tester, and spec-compliance auditor.
+
+Your job is to test this application completely from every meaningful scope and
+direction, and to verify that every feature specified in the spec actually works
+in the running app.
+
+Inputs:
+- Spec: <paste or link the product/spec document>
+- App URL or local run command: <URL or command>
+- Repository path, if available: <path>
+- Test credentials/data, if available: <credentials/data>
+
+Mission:
+Create and execute a complete verification pass that proves whether the
+implemented app matches the spec. Do not only inspect code. Run the app and
+interact with it like a real user. Treat the spec as the source of truth.
+
+Required testing scope:
+
+1. Spec Traceability
+- Extract every feature, requirement, acceptance criterion, user flow,
+  validation rule, permission rule, and edge case from the spec.
+- Build a traceability matrix with requirement, expected behavior, test
+  performed, PASS/FAIL/PARTIAL/NOT TESTED result, evidence, and notes.
+
+2. Functional Testing
+Test every user-facing feature end to end: buttons, links, text inputs,
+textareas, checkboxes, radio buttons, selects, dropdowns, multi-selects, search
+fields, filters, sorting, pagination, tabs, modals, forms, uploads/downloads,
+navigation, save/edit/delete flows, auth/login/logout, and empty/loading/
+success/error/disabled states.
+
+For every workflow button or dropdown-backed action, do not stop at clickability
+or request dispatch. Verify the selected values change the real request
+payload/query, run a mocked happy path, run a no-mock deployed/dev smoke path
+with representative input, assert no live-failure banner appears, and assert a
+real domain result is visible.
+
+3. Form and Validation Testing
+For every form/input test valid input, empty input, invalid input, boundary
+values, very long text, special characters, whitespace-only values, duplicates,
+required-field behavior, error-message clarity, recovery after correction,
+keyboard submission, disabled submit behavior, and server-side validation.
+
+4. UI and UX Behavior
+Verify text readability, labels, discoverability, visible state changes,
+loading/error/success states, desktop/tablet/mobile layouts, and absence of
+overlapping or clipped content.
+
+5. Accessibility
+Check keyboard-only navigation, focus order, visible focus indicators, input
+labels, ARIA where needed, screen-reader names for icon buttons, color contrast,
+Escape behavior, and Enter/Space behavior.
+
+6. Data and State Testing
+Verify persistence after refresh, unsaved-change handling, optimistic update
+reconciliation, delete/edit propagation, filter/search/sort state, browser
+back/forward behavior, and deep links.
+
+7. Negative and Edge Cases
+Test API failure, slow responses, empty datasets, large datasets, unauthorized
+access, expired sessions, invalid routes, concurrent edits, repeated rapid
+clicks, and refresh during in-progress actions.
+
+8. Backend/API Integration
+When a backend exists, verify frontend requests match API contracts, API errors
+are handled correctly, storage reflects create/update/delete behavior, and
+permissions/validation are enforced server-side.
+
+Include regression coverage for deployed backend failures such as `502` bridge,
+proxy, queue, or cache misses. If a backend route is known fragile, the UI must
+either recover through a documented fallback route or show a clear actionable
+state. Mocked endpoint success is not sufficient evidence.
+
+9. Regression and Cross-Feature Testing
+Combine flows: create then search/filter/sort, edit then verify list/detail
+views, delete then verify navigation/empty states, change settings then verify
+dependent screens, and complete full user journeys.
+
+10. Automated Test Recommendations
+Identify missing unit, integration, component, E2E, accessibility, and API
+contract tests. For each missing test, state exactly what it should assert.
+
+Execution rules:
+- Do not assume a feature works because code appears to exist.
+- Do not mark PASS without concrete evidence.
+- Mark untestable items NOT TESTED and explain the blocker.
+- Mark spec mismatches FAIL even if the implementation seems reasonable.
+- Mark ambiguous spec items AMBIGUOUS and propose expected behavior.
+- Capture screenshots, logs, console errors, network failures, or command output
+  where useful.
+- Continue until every spec item has a status.
+
+Final report:
+# QA Verification Report
+## Summary
+- Overall result: PASS / FAIL / PARTIAL
+- App/version/commit tested:
+- Environment:
+- Main risks:
+## Spec Traceability Matrix
+| Requirement | Expected Behavior | Test Performed | Result | Evidence | Notes |
+|---|---|---|---|---|---|
+## Bugs and Gaps
+For each issue include severity, area, spec reference, steps to reproduce,
+expected, actual, evidence, and suggested fix.
+## UI Control Coverage
+List every tested text input, select/dropdown, button, form, navigation element,
+modal, table/list, and other control.
+## Validation Coverage
+List every validation rule tested, including valid, invalid, boundary, and
+recovery behavior.
+## Accessibility Findings
+Include keyboard, focus, labels, contrast, ARIA, and screen-reader concerns.
+## Cross-Browser / Responsive Findings
+Include desktop, tablet, and mobile behavior if applicable.
+## Automated Test Gaps
+List exact tests to add before the app is fully protected.
+## Final Verdict
+State whether the app satisfies the spec and the minimum fixes required before
+release.
+```
+
+## Regeneration loop
+
+After the audit:
+
+1. Convert every `FAIL`, `PARTIAL`, `NOT TESTED`, and high-risk `AMBIGUOUS`
+   traceability row into one of:
+   - a product bug fix,
+   - a regenerated/strengthened automated test,
+   - a follow-up GitHub issue when implementation scope is too large.
+2. Regenerate tests in the narrowest existing harness:
+   - unit tests for pure functions and validation rules,
+   - integration/API tests for server-side validation and persistence,
+   - component tests for isolated UI states,
+   - E2E/Playwright tests for user journeys, controls, accessibility, and
+     cross-feature behavior.
+3. Preserve or strengthen assertions. Never replace a specific assertion with a
+   weaker smoke assertion.
+4. Run the relevant test commands and the repo's validation command.
+5. Repeat until the traceability matrix has no unexplained gaps or the remaining
+   gaps are filed as issues with reproduction steps and evidence.
+
+## Output contract
+
+Return:
+
+- QA report path or inline report.
+- Tests added/changed.
+- Product bugs fixed, if any.
+- Follow-up issues filed or drafted.
+- Commands run and results.
+- Remaining risks.
+
+## Stop mode
+
+If the request is exactly `stop` or `stop` plus `--<word>` flags after
+normalization, dispatch to:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>
+```
+
+Print the helper output and stop. Do not run the QA audit.

--- a/skills/autospec-qa/uninstall.sh
+++ b/skills/autospec-qa/uninstall.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env sh
+# uninstall.sh - remove the autospec-qa skill from one or more harnesses.
+
+set -eu
+
+SKILL_NAME="autospec-qa"
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness) shift; HARNESS="${1:-}" ;;
+        --harness=*) HARNESS="${1#--harness=}" ;;
+        --dry-run) DRY_RUN=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) err "unknown arg: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+
+[ -n "$HARNESS" ] || HARNESS=all
+case "$HARNESS" in claude|opencode|codex|all) ;; *) err "invalid --harness: $HARNESS"; exit 2 ;; esac
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Claude Code:"
+    remove_one "$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "OpenCode:"
+    remove_one "$OPENCODE_DIR/agent/$SKILL_NAME.md"
+fi
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Codex CLI:"
+    remove_one "$CODEX_DIR/prompts/$SKILL_NAME.md"
+    remove_one "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+
+info ""
+[ "$DRY_RUN" -eq 1 ] && info "Dry run complete. No files were removed." || info "Done."

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -791,6 +791,7 @@ inline label-swap path below.
 >        > **Part 2 — LGTM (correctness review):** Using the same diff and issue body already in context:
 >        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits).
 >        > 7. Collect findings as a numbered list.
+>        > 8. Critical self-question before LGTM: "What else could still pass here while the real user workflow fails, and how could this be better?" Check especially mocked-vs-deployed behavior, external service assumptions, fallback paths, user-visible outcomes, and missing no-mock smoke coverage. If the answer is actionable inside the issue scope, emit it as a finding or required test.
 >        >
 >        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
 >        >

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -786,6 +786,7 @@ inline label-swap path below.
 >        > **Part 2 — LGTM (correctness review):** Using the same diff and issue body already in context:
 >        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits).
 >        > 7. Collect findings as a numbered list.
+>        > 8. Critical self-question before LGTM: "What else could still pass here while the real user workflow fails, and how could this be better?" Check especially mocked-vs-deployed behavior, external service assumptions, fallback paths, user-visible outcomes, and missing no-mock smoke coverage. If the answer is actionable inside the issue scope, emit it as a finding or required test.
 >        >
 >        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
 >        >

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -790,6 +790,7 @@ inline label-swap path below.
 >        > **Part 2 — LGTM (correctness review):** Using the same diff and issue body already in context:
 >        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits).
 >        > 7. Collect findings as a numbered list.
+>        > 8. Critical self-question before LGTM: "What else could still pass here while the real user workflow fails, and how could this be better?" Check especially mocked-vs-deployed behavior, external service assumptions, fallback paths, user-visible outcomes, and missing no-mock smoke coverage. If the answer is actionable inside the issue scope, emit it as a finding or required test.
 >        >
 >        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
 >        >

--- a/skills/autospec-test/README.md
+++ b/skills/autospec-test/README.md
@@ -1,0 +1,30 @@
+# autospec-test
+
+Phase 4 unit and E2E coverage gate for autospec implementation PRs.
+
+`autospec-test` runs after build/lint and before auto-merge. It checks unit
+coverage, E2E coverage, UI element coverage, behavior taxonomy coverage, and
+assertion-shift safety. Its self-heal loop can strengthen tests or fix product
+bugs within the configured budget.
+
+## Invocation
+
+```text
+/autospec-test [PR#]
+/autospec-test --init
+```
+
+## Result
+
+- Unit and E2E gate status.
+- Coverage and behavior-taxonomy findings.
+- Assertion-shift blocking for loosened tests.
+- Optional self-heal commits within the configured loop budget.
+
+Use [`autospec-qa`](../autospec-qa/README.md) when you need a broader
+spec-to-running-app revalidation pass and regenerated tests from user-visible
+behavior.
+
+## License
+
+MIT - see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autospec-test/SKILL.md
+++ b/skills/autospec-test/SKILL.md
@@ -74,9 +74,48 @@ Auto-merge or block
 
 **Stage 2 — E2E:** Three metrics: code coverage from E2E run (Metric A, thresholds 90/85/90), UI element coverage (Metric B — every reachable `button/a/input/select/textarea/[contenteditable]` touched by Playwright), and behavior taxonomy (Metric D — at least one passing test per declared category: sort, scroll, upload, download, filter, paginate, bulk_select, keyboard_nav, drag_drop).
 
+**Spec-compliance QA audit:** For UI/product features, Stage 2 must also use
+the `autospec-qa` prompt shape when generating or healing E2E coverage: extract
+the spec into a traceability matrix, interact with the running app like a user,
+cover text boxes, textareas, selects, dropdowns, checkboxes, radio buttons,
+buttons, links, forms, validation, state changes, API effects, accessibility,
+responsive layouts, negative paths, and cross-feature flows, then regenerate
+tests for every missing or weak behavior. Do not mark a spec requirement PASS
+from code inspection alone.
+
+**No-mock deployed smoke:** Mocked API tests are necessary but insufficient for
+workflow buttons and dropdowns. For each workflow action, Stage 2 should include
+a deterministic mocked happy path plus a no-mock smoke path against the
+configured deployed/dev URL when the target contract permits it. The smoke path
+must assert no live-failure banner, a visible domain result, request
+payload/query changes from selected values, and recovery or actionable UI for
+known backend failure signatures such as `502` bridge/proxy outages.
+
 **Self-heal loop:** Up to 5 iterations, 60 minutes of coding time (paused while tests run). Each iteration classifies failures (missing_unit_test, missing_test, failing_unit_test, failing_test, flaky_test, selector_brittle, product_bug) and picks the highest-priority cluster that fits remaining budget. Loop state persisted in `.autospec/test-loop-state.json` in the worktree so monitor relaunches resume rather than reset.
 
 **Assertion-shift guardrail:** AST + regex pass over all modified test files. LOOSENING changes block auto-merge (adds `needs-human-review` + `e2e:assertion-loosening`). SHIFTING is conditionally allowed if the same commit also modifies a non-test source file and includes `JUSTIFICATION:` in the commit message. STRENGTHENING always allowed.
+
+## Spec-compliance QA prompt
+
+`autospec-qa` is the canonical full prompt for spec-to-running-app QA. Do not
+duplicate that full prompt here. When Stage 2 or the self-heal loop generates
+UI/product E2E tests, import its intent and preserve these minimum anchors:
+
+- **Spec traceability:** every spec requirement maps to expected behavior,
+  evidence, and PASS/FAIL/PARTIAL/NOT TESTED status.
+- **UI controls:** text inputs, textareas, selects, dropdowns, checkboxes,
+  radio buttons, buttons, links, forms, validation, state changes, responsive
+  layouts, and accessibility are exercised as user-visible behavior.
+- **No-mock deployed smoke:** mocked happy paths are paired with no-mock
+  deployed/dev smoke paths whenever the target contract permits it.
+- **Outcome assertions:** tests prove visible domain results and absence of
+  live-failure banners, not just clickability or request dispatch.
+- **Backend fragility:** `502` bridge/proxy/cache failures require regression
+  coverage plus either a documented fallback route or a clear actionable user
+  state; mocked endpoint success is not proof of deployed workflow success.
+- **Critical self-question:** before accepting green tests, ask: "What could
+  still pass here while a real user workflow fails?" Add one test or issue for
+  the highest-risk answer.
 
 ## Contract file
 

--- a/skills/autospec-test/codex/prompt.md
+++ b/skills/autospec-test/codex/prompt.md
@@ -70,9 +70,48 @@ Auto-merge or block
 
 **Stage 2 — E2E:** Three metrics: code coverage from E2E run (Metric A, thresholds 90/85/90), UI element coverage (Metric B — every reachable `button/a/input/select/textarea/[contenteditable]` touched by Playwright), and behavior taxonomy (Metric D — at least one passing test per declared category: sort, scroll, upload, download, filter, paginate, bulk_select, keyboard_nav, drag_drop).
 
+**Spec-compliance QA audit:** For UI/product features, Stage 2 must also use
+the `autospec-qa` prompt shape when generating or healing E2E coverage: extract
+the spec into a traceability matrix, interact with the running app like a user,
+cover text boxes, textareas, selects, dropdowns, checkboxes, radio buttons,
+buttons, links, forms, validation, state changes, API effects, accessibility,
+responsive layouts, negative paths, and cross-feature flows, then regenerate
+tests for every missing or weak behavior. Do not mark a spec requirement PASS
+from code inspection alone.
+
+**No-mock deployed smoke:** Mocked API tests are necessary but insufficient for
+workflow buttons and dropdowns. For each workflow action, Stage 2 should include
+a deterministic mocked happy path plus a no-mock smoke path against the
+configured deployed/dev URL when the target contract permits it. The smoke path
+must assert no live-failure banner, a visible domain result, request
+payload/query changes from selected values, and recovery or actionable UI for
+known backend failure signatures such as `502` bridge/proxy outages.
+
 **Self-heal loop:** Up to 5 iterations, 60 minutes of coding time (paused while tests run). Each iteration classifies failures (missing_unit_test, missing_test, failing_unit_test, failing_test, flaky_test, selector_brittle, product_bug) and picks the highest-priority cluster that fits remaining budget. Loop state persisted in `.autospec/test-loop-state.json` in the worktree so monitor relaunches resume rather than reset.
 
 **Assertion-shift guardrail:** AST + regex pass over all modified test files. LOOSENING changes block auto-merge (adds `needs-human-review` + `e2e:assertion-loosening`). SHIFTING is conditionally allowed if the same commit also modifies a non-test source file and includes `JUSTIFICATION:` in the commit message. STRENGTHENING always allowed.
+
+## Spec-compliance QA prompt
+
+`autospec-qa` is the canonical full prompt for spec-to-running-app QA. Do not
+duplicate that full prompt here. When Stage 2 or the self-heal loop generates
+UI/product E2E tests, import its intent and preserve these minimum anchors:
+
+- **Spec traceability:** every spec requirement maps to expected behavior,
+  evidence, and PASS/FAIL/PARTIAL/NOT TESTED status.
+- **UI controls:** text inputs, textareas, selects, dropdowns, checkboxes,
+  radio buttons, buttons, links, forms, validation, state changes, responsive
+  layouts, and accessibility are exercised as user-visible behavior.
+- **No-mock deployed smoke:** mocked happy paths are paired with no-mock
+  deployed/dev smoke paths whenever the target contract permits it.
+- **Outcome assertions:** tests prove visible domain results and absence of
+  live-failure banners, not just clickability or request dispatch.
+- **Backend fragility:** `502` bridge/proxy/cache failures require regression
+  coverage plus either a documented fallback route or a clear actionable user
+  state; mocked endpoint success is not proof of deployed workflow success.
+- **Critical self-question:** before accepting green tests, ask: "What could
+  still pass here while a real user workflow fails?" Add one test or issue for
+  the highest-risk answer.
 
 ## Contract file
 

--- a/skills/autospec-test/tests/unit/validate-skill-structure.bats
+++ b/skills/autospec-test/tests/unit/validate-skill-structure.bats
@@ -69,6 +69,20 @@ teardown() {
     grep -q '^## Contract file' "$SKILL_MD"
 }
 
+@test "SKILL.md contains ## Spec-compliance QA prompt section" {
+    grep -q '^## Spec-compliance QA prompt' "$SKILL_MD"
+}
+
+@test "SKILL.md QA prompt covers spec traceability and UI controls" {
+    grep -q 'Spec traceability' "$SKILL_MD"
+    grep -q 'selects, dropdowns' "$SKILL_MD"
+}
+
+@test "SKILL.md QA prompt requires no-mock deployed smoke coverage" {
+    grep -q 'No-mock deployed smoke' "$SKILL_MD"
+    grep -q 'mocked endpoint success' "$SKILL_MD"
+}
+
 @test "SKILL.md contains ## Modes I and II section" {
     grep -q '^## Modes I and II' "$SKILL_MD"
 }

--- a/skills/autospec-test/validate.sh
+++ b/skills/autospec-test/validate.sh
@@ -8,6 +8,7 @@
 #   4. codex/prompt.md starts with a leading blank line (byte-precise).
 #   5. SKILL.md contains a forbidden_url_patterns example block (adapter row).
 #   6. SKILL.md Model tier declares reasoning:standard and ctx:120k.
+#   7. SKILL.md contains the spec-compliance QA prompt anchors.
 #
 # Usage:
 #   bash skills/autospec-test/validate.sh [--skill-dir <path>]
@@ -133,5 +134,18 @@ grep -q 'edge_case_seeds:' "$SKILL_MD" \
 info "checking v2 adapter row in SKILL.md"
 grep -q 'Stage 2\.5' "$SKILL_MD" \
     || fail "SKILL.md missing Stage 2.5 adapter row (required v2 lockstep check)"
+
+# ── 11. SKILL.md: spec-compliance QA prompt anchors ─────────────────────────
+info "checking spec-compliance QA prompt anchors in SKILL.md"
+grep -q '^## Spec-compliance QA prompt' "$SKILL_MD" \
+    || fail "SKILL.md missing '## Spec-compliance QA prompt' section"
+grep -q 'Spec traceability' "$SKILL_MD" \
+    || fail "SKILL.md missing spec traceability QA prompt anchor"
+grep -q 'selects, dropdowns' "$SKILL_MD" \
+    || fail "SKILL.md missing UI control QA prompt anchor"
+grep -q 'No-mock deployed smoke' "$SKILL_MD" \
+    || fail "SKILL.md missing no-mock deployed smoke QA prompt anchor"
+grep -q 'mocked endpoint success' "$SKILL_MD" \
+    || fail "SKILL.md missing mocked endpoint success warning"
 
 info "OK — all autospec-test structural checks passed."

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -359,9 +359,9 @@ Run a structured brainstorm — one question at a time, get explicit approval af
 2. **Interactivity / API shape** — how does the user/caller drive it; commands, keys, endpoints, fields.
 3. **Data model** — types, columns, persistence boundary.
 4. **Error handling** — failure modes, recovery, user-visible signals.
-5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services).
+5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services). For app/UI work, include an `autospec-qa` revalidation plan that maps each spec requirement to running-app checks for text inputs, validation, selects/dropdowns, buttons, forms, API effects, accessibility, responsive behavior, negative paths, and regenerated automated tests.
 
-Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, scope. The spec must be implementable end-to-end by an agent reading only the spec.
+Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, and scope. Then run a critical improvement check: ask "What else could fail even if this spec and its obvious tests pass, and how could this be better?" Add the highest-risk answer to Testing, Acceptance Criteria, or Review counter-team. For app/UI work, explicitly consider mocked-vs-deployed behavior, backend fallbacks, user-visible outcomes, and no-mock smoke coverage. The spec must be implementable end-to-end by an agent reading only the spec.
 
 If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
 
@@ -910,6 +910,7 @@ Pass the following prompt verbatim to each background subagent:
 >        > **Part 2 — LGTM (correctness review):** Using the same diff and issue body already in context:
 >        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits).
 >        > 7. Collect findings as a numbered list.
+>        > 8. Critical self-question before LGTM: "What else could still pass here while the real user workflow fails, and how could this be better?" Check especially mocked-vs-deployed behavior, external service assumptions, fallback paths, user-visible outcomes, and missing no-mock smoke coverage. If the answer is actionable inside the issue scope, emit it as a finding or required test.
 >        >
 >        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
 >        >

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -353,9 +353,9 @@ Run a structured brainstorm — one question at a time, get explicit approval af
 2. **Interactivity / API shape** — how does the user/caller drive it; commands, keys, endpoints, fields.
 3. **Data model** — types, columns, persistence boundary.
 4. **Error handling** — failure modes, recovery, user-visible signals.
-5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services).
+5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services). For app/UI work, include an `autospec-qa` revalidation plan that maps each spec requirement to running-app checks for text inputs, validation, selects/dropdowns, buttons, forms, API effects, accessibility, responsive behavior, negative paths, and regenerated automated tests.
 
-Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, scope. The spec must be implementable end-to-end by an agent reading only the spec.
+Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, and scope. Then run a critical improvement check: ask "What else could fail even if this spec and its obvious tests pass, and how could this be better?" Add the highest-risk answer to Testing, Acceptance Criteria, or Review counter-team. For app/UI work, explicitly consider mocked-vs-deployed behavior, backend fallbacks, user-visible outcomes, and no-mock smoke coverage. The spec must be implementable end-to-end by an agent reading only the spec.
 
 If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
 
@@ -904,6 +904,7 @@ Pass the following prompt verbatim to each background subagent:
 >        > **Part 2 — LGTM (correctness review):** Using the same diff and issue body already in context:
 >        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits).
 >        > 7. Collect findings as a numbered list.
+>        > 8. Critical self-question before LGTM: "What else could still pass here while the real user workflow fails, and how could this be better?" Check especially mocked-vs-deployed behavior, external service assumptions, fallback paths, user-visible outcomes, and missing no-mock smoke coverage. If the answer is actionable inside the issue scope, emit it as a finding or required test.
 >        >
 >        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
 >        >

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -357,9 +357,9 @@ Run a structured brainstorm — one question at a time, get explicit approval af
 2. **Interactivity / API shape** — how does the user/caller drive it; commands, keys, endpoints, fields.
 3. **Data model** — types, columns, persistence boundary.
 4. **Error handling** — failure modes, recovery, user-visible signals.
-5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services).
+5. **Testing** — unit / integration / e2e split, real services vs anything else (rule per AGENTS.md: real services). For app/UI work, include an `autospec-qa` revalidation plan that maps each spec requirement to running-app checks for text inputs, validation, selects/dropdowns, buttons, forms, API effects, accessibility, responsive behavior, negative paths, and regenerated automated tests.
 
-Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, scope. The spec must be implementable end-to-end by an agent reading only the spec.
+Write the agreed design to `docs/specs/YYYY-MM-DD-<topic>-design.md`. Self-review for placeholders, contradictions, ambiguity, and scope. Then run a critical improvement check: ask "What else could fail even if this spec and its obvious tests pass, and how could this be better?" Add the highest-risk answer to Testing, Acceptance Criteria, or Review counter-team. For app/UI work, explicitly consider mocked-vs-deployed behavior, backend fallbacks, user-visible outcomes, and no-mock smoke coverage. The spec must be implementable end-to-end by an agent reading only the spec.
 
 If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
 
@@ -908,6 +908,7 @@ Pass the following prompt verbatim to each background subagent:
 >        > **Part 2 — LGTM (correctness review):** Using the same diff and issue body already in context:
 >        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits).
 >        > 7. Collect findings as a numbered list.
+>        > 8. Critical self-question before LGTM: "What else could still pass here while the real user workflow fails, and how could this be better?" Check especially mocked-vs-deployed behavior, external service assumptions, fallback paths, user-visible outcomes, and missing no-mock smoke coverage. If the answer is actionable inside the issue scope, emit it as a finding or required test.
 >        >
 >        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
 >        >

--- a/tests/smoke/test_install_all_skills.bats
+++ b/tests/smoke/test_install_all_skills.bats
@@ -17,7 +17,7 @@ setup() {
     export OPENCODE_CONFIG_DIR="$FAKE_HOME/.config/opencode"
     export CODEX_HOME="$FAKE_HOME/.codex"
 
-    SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design"
+    SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa"
     HELPERS="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh autospec-sweep-wizard.sh autospec-sweep-run.sh autospec-sweep-review.sh run-state.sh list-ready-issues.sh claim-issue.sh release-issue.sh"
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,7 +12,7 @@
 #   ./uninstall.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | all
+#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | autospec-qa | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -24,7 +24,7 @@
 
 set -eu
 
-ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet"
+ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -67,7 +67,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$SKILL_ARG" in
-    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design|autospec-fleet) ;;
+    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design|autospec-fleet|autospec-qa) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
         exit 2


### PR DESCRIPTION
## Summary
- add autospec-qa as a first-class spec-to-running-app QA workflow
- wire autospec-qa into installer, uninstaller, README, and SKILLS index
- embed no-mock deployed smoke and critical self-question checkpoints into autospec-test/autospec/autospec-define/autospec-run
- add autospec-test README and keep fleet README limited to working helper-script features

## Review
- Reviewed the diff before commit and fixed one issue: root README linked to skills/autospec-test/README.md, but that README did not exist.

## Validation
- bash skills/autospec-test/validate.sh
- bash scripts/validate.sh
- git diff --check
- README skill links OK