### PR TITLE
feat: add release readiness gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,30 @@ repo overview.
 
 Autospec works across **Claude Code**, **OpenCode**, and **Codex CLI**.
 
+## Getting Started
+
+Pick the skill that matches where you are:
+
+| I want to... | Use | What happens |
+| --- | --- | --- |
+| Turn a feature idea into shipped PRs | [`/autospec`](skills/autospec/README.md) | Write the spec, create issues, implement, review, test, and merge. |
+| Plan only, then stop | [`/autospec-define`](skills/autospec-define/README.md) | Create the spec and issue queue without running implementation. |
+| Split an existing spec into issues | [`/autospec-split`](skills/autospec-split/README.md) | Turn `docs/specs/*.md` into classified GitHub issues. |
+| Work through ready issues | [`/autospec-run`](skills/autospec-run/README.md) | Process the `auto-implement` queue and merge passing PRs. |
+| Check whether the repo is ready to ship | [`/autospec-release`](skills/autospec-release/README.md) | Run sweep, review, implementation, tests, QA proof, docs sync, and legacy cleanup gates. |
+| Keep specs, docs, tests, and code aligned over time | [`/autospec-sweep`](skills/autospec-sweep/README.md) | Configure and run recurring repo sweeps. |
+| Prove the running app actually matches the spec | [`/autospec-qa`](skills/autospec-qa/README.md) | Revalidate UI controls, validation, API behavior, accessibility, and no-mock smoke paths. |
+| Stop or resume a long-running monitor | [`/autospec-stop`](skills/autospec-stop/README.md) | Gracefully stop, immediately pause, check status, or resume. |
+| Understand what has been built | [`/autospec-story`](skills/autospec-story/README.md) | Produce a cited repo story from specs, issues, PRs, and docs. |
+
+If you are unsure, start with `/autospec-release` for an existing repo or
+`/autospec` for a new feature.
+
 ## What It Solves
 
-AI-generated code can grow quickly without a clear record of why it exists, what
-spec produced it, which model worked on it, and which parts are actually
-implemented. Autospec makes that process auditable.
+AI-generated code can move fast without leaving a good trail of why it exists,
+what spec produced it, which model worked on it, and which parts actually work.
+Autospec makes that process auditable.
 
 It gives you:
 
@@ -55,6 +74,7 @@ selected model and harness to execute reliably.
 | Skill | Use it when | Result |
 | --- | --- | --- |
 | [`autospec`](skills/autospec/README.md) | You want the full path from feature request to merged PRs. | Bootstraps if needed, investigates, writes a spec, creates issues, classifies them, runs implementation, and reports completion. |
+| [`autospec-release`](skills/autospec-release/README.md) | You want to know whether the current repo is ready to ship. | Runs the release-readiness loop across sweep, review, run, test, QA, docs sync, proof artifacts, and legacy cleanup. |
 | [`autospec-sweep`](skills/autospec-sweep/README.md) | You want first-run configuration or continuous improvement across specs, docs, tests, and code. | Creates `.autospec/autospec.yml`, runs a configured sweep, writes `.autospec/sweep/latest.json`, and routes recurring gaps back through specs, issues, and `/autospec-run`. |
 | [`autospec-define`](skills/autospec-define/README.md) | You want planning only before implementation starts. | Produces a design spec plus classified `auto-implement` issues, then hands off to `/autospec-run`. |
 | [`autospec-split`](skills/autospec-split/README.md) | You already have a tracked `docs/specs/*.md` design spec. | Turns the existing spec into an EPIC plus linked child issues, then stops after classification. |

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -17,6 +17,14 @@
 - Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
 - Status: tracked config mode. Creates `.autospec/autospec.yml`, asks project-specific setup questions from repo findings, keeps specs synchronized with implementation reality, and routes improvement gaps through `autospec-review`, issues, and `/autospec-run`.
 
+## autospec-release
+
+- Path: [`skills/autospec-release`](skills/autospec-release)
+- Trigger: use when an existing repo needs an end-to-end release readiness gate across specs, docs, implementation, tests, QA proof artifacts, legacy cleanup, and merge readiness.
+- Activation keywords: `autospec-release`, `release readiness`, `release sweep`, `make repo releasable`, `full repo QA`, `ship current repo`, `release gate`
+- Harnesses: Claude Code (`SKILL.md`), OpenCode (`opencode/agent.md`), Codex CLI (`codex/prompt.md`). Bundled `install.sh` / `uninstall.sh` handle per-harness placement.
+- Status: wrapper workflow over working autospec skills. Runs preflight, `/autospec-sweep`, docs/spec sync, `/autospec-review`, `/autospec-classify`, `/autospec-run`, `/autospec-test`, `/autospec-qa`, proof validation, and the legacy cleanup gate before returning `PASS`, `PARTIAL`, or `FAIL`.
+
 ## autospec-fleet
 
 - Path: [`skills/autospec-fleet`](skills/autospec-fleet)

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
 #   ./install.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | autospec-qa | all
+#   --skill   one of: autospec | autospec-release | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | autospec-qa | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -49,7 +49,7 @@ OH_MY_CODEX_PACKAGE="${OH_MY_CODEX_PACKAGE:-oh-my-codex}"
 OH_MY_OPENCODE_PACKAGE="${OH_MY_OPENCODE_PACKAGE:-oh-my-opencode}"
 OH_MY_CLAUDE_PACKAGE="${OH_MY_CLAUDE_PACKAGE:-oh-my-claude-sisyphus}"
 
-ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa"
+ALL_SKILLS="autospec autospec-release autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -480,10 +480,10 @@ done
 
 # Validate --skill
 case "$SKILL_ARG" in
-    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design|autospec-fleet|autospec-qa) ;;
+    all|autospec|autospec-release|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design|autospec-fleet|autospec-qa) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
-        err "must be one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | autospec-qa | all"
+        err "must be one of: autospec | autospec-release | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | autospec-qa | all"
         exit 2
         ;;
 esac

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -211,7 +211,7 @@ check_startup_preflight() {
         || printf '%s\n' "$canonical" | grep -F 'raw.githubusercontent.com/berlinguyinca/autospec/main/skills/' >/dev/null; then
         fail "startup preflight must not call a raw installer directly"
     fi
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa; do
+    for s in autospec autospec-release autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa; do
         for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
             body=$(extract_block "$f")
             [ -n "$body" ] || fail "$f missing ## Startup self-update section"
@@ -228,7 +228,7 @@ check_startup_preflight() {
 # prompts/ path AND the new skills/ slash-command registry path.
 check_codex_skills_install() {
     info "codex skills-dir install: all skills"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa; do
+    for s in autospec autospec-release autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa; do
         f="skills/$s/install.sh"
         grep -q 'skills/\$SKILL_NAME/SKILL\.md' "$f" \
             || fail "$f missing Codex skills-dir install (skills/\$SKILL_NAME/SKILL.md)"
@@ -243,7 +243,7 @@ check_codex_skills_install() {
 check_shared_script_install() {
     info "shared helper install: all skills"
     helpers="autospec-stop.sh autospec-usage-limit.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
-    for s in autospec autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa; do
+    for s in autospec autospec-release autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa; do
         f="skills/$s/install.sh"
         grep -q 'install_shared_scripts' "$f" \
             || fail "$f missing install_shared_scripts function/call"
@@ -914,6 +914,36 @@ check_autospec_qa_contract() {
         || fail "schemas/autospec-reliability.schema.json: missing deprecated_surfaces contract"
 }
 
+check_autospec_release_contract() {
+    info "autospec-release contract: release readiness wrapper"
+    local skill_file="skills/autospec-release/SKILL.md"
+    [ -f "$skill_file" ] || fail "$skill_file: required file missing"
+    [ -f "skills/autospec-release/README.md" ] || fail "skills/autospec-release/README.md: required file missing"
+
+    grep -q '^## Release pipeline' "$skill_file" \
+        || fail "$skill_file: missing release pipeline section"
+    grep -q '/autospec-sweep' "$skill_file" \
+        || fail "$skill_file: missing autospec-sweep stage"
+    grep -q '/autospec-review' "$skill_file" \
+        || fail "$skill_file: missing autospec-review stage"
+    grep -q '/autospec-run' "$skill_file" \
+        || fail "$skill_file: missing autospec-run stage"
+    grep -q '/autospec-test' "$skill_file" \
+        || fail "$skill_file: missing autospec-test stage"
+    grep -q '/autospec-qa' "$skill_file" \
+        || fail "$skill_file: missing autospec-qa stage"
+    grep -q 'validate-qa-artifacts.sh' "$skill_file" \
+        || fail "$skill_file: missing QA artifact validation helper"
+    grep -q '^## Legacy cleanup prompt' "$skill_file" \
+        || fail "$skill_file: missing legacy cleanup prompt"
+    grep -q 'PASS`, `PARTIAL`, or `FAIL`' "$skill_file" \
+        || fail "$skill_file: missing explicit release verdict vocabulary"
+    grep -q 'autospec-release' README.md \
+        || fail "README.md: missing autospec-release getting-started entry"
+    grep -q 'Getting Started' README.md \
+        || fail "README.md: missing getting-started skill guide"
+}
+
 check_install_tests() {
     info "install tests: tests/install/*.sh"
     if [ -d tests/install ]; then
@@ -983,6 +1013,7 @@ main() {
     check_autospec_review_tier_a_directives
     check_autospec_test_skill_present
     check_autospec_qa_contract
+    check_autospec_release_contract
     check_docs_amendment_presence
     check_install_tests
     check_phase4_tests

--- a/skills/autospec-release/README.md
+++ b/skills/autospec-release/README.md
@@ -1,0 +1,46 @@
+# autospec-release
+
+Use `autospec-release` when you want one repo-level answer to the question:
+"Is this ready to ship?"
+
+It is a wrapper over the working autospec skills. It runs the release-readiness
+loop across sweep, review, implementation, tests, QA proof artifacts,
+documentation drift, and legacy cleanup.
+
+## Use it when
+
+- You are done with feature work and want a release gate.
+- You want specs, docs, tests, QA, and code reality checked together.
+- You want stale legacy code and stale spec references removed or tracked.
+- You want a clear `PASS`, `PARTIAL`, or `FAIL` verdict.
+
+## What it runs
+
+1. Preflight: branch, dirty files, issues, PRs, and repo state.
+2. `/autospec-sweep`: recurring spec/docs/tests/code drift.
+3. Spec/docs/story sync: stale claims and legacy references.
+4. `/autospec-review`: spec-vs-issue regression gaps.
+5. `/autospec-classify` and `/autospec-run`: remaining implementation queue.
+6. `/autospec-test`: release test gates.
+7. `/autospec-qa`: running-app proof, controls, validation, no-mock smoke.
+8. Legacy cleanup: dead code, stale docs, old config, old infra.
+9. Final verdict: `PASS`, `PARTIAL`, or `FAIL`.
+
+## Install
+
+From this checkout:
+
+```bash
+./skills/autospec-release/install.sh --harness all
+```
+
+Through the top-level installer:
+
+```bash
+./install.sh --skill autospec-release --harness all
+```
+
+## Output
+
+The final report lists what ran, what passed, what changed, and what still
+blocks release. It must separate proven evidence from `NOT TESTED` gaps.

--- a/skills/autospec-release/SKILL.md
+++ b/skills/autospec-release/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: autospec-release
+description: Use when a repo needs an end-to-end release readiness sweep across specs, docs, implementation, tests, QA proof artifacts, legacy cleanup, and merge readiness using existing autospec skills.
+---
+
+# autospec-release workflow
+
+Run the repo-level release readiness loop. This is the "I want to ship the
+current repo" wrapper over the existing autospec surfaces: sweep, review, run,
+test, QA, proof validation, documentation drift checks, and legacy-code cleanup.
+
+Use this when the operator wants one explicit release gate instead of invoking
+each lower-level skill by hand.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-release   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches `update` after trimming and lowercasing,
+re-install the full autospec suite from `main`, show the before/after diff if the
+harness exposes it, then stop. Do not run the release gate.
+
+## Required capabilities & harness adapter
+
+| Capability | Claude Code | OpenCode | Codex CLI | Fallback if missing |
+| --- | --- | --- | --- | --- |
+| Subagent model tier | Tier A: `opus` + ultrathink | Tier A: top-tier `task` + max reasoning | Tier A: current top GPT + `reasoning_effort=high` | Run inline, but keep the same PASS/PARTIAL/FAIL contract |
+| Existing autospec skills | Slash skills | agent prompts | skills/prompts | Run the matching workflow instructions inline |
+| GitHub operations | `gh` through shell | shell | shell | Mark merge/issue steps BLOCKED with exact command |
+| Test and QA execution | Browser/E2E or shell | browser/task or shell | shell/browser when available | Mark app-only checks NOT TESTED with blocker |
+
+**Model tier:** TIER_A for release synthesis and final readiness verdicts
+because a false PASS can ship broken behavior.
+
+## Harness detection
+
+Detect the harness once at skill start:
+
+1. Claude Code: `Agent` with `subagent_type` is available.
+   - `TIER_A` = `opus` + ultrathink.
+   - `TIER_B` = `sonnet`.
+2. OpenCode: `task` tool is available.
+   - `TIER_A` = top-tier task model + high reasoning.
+   - `TIER_B` = smaller-tier task model + medium reasoning.
+3. Codex CLI: `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT + `reasoning_effort=high`.
+   - `TIER_B` = current cost-optimized Codex model + `reasoning_effort=medium`.
+
+Prefer a Tier A reviewer/verifier subagent for the final release verdict when
+the harness supports it. If `TIER_A` is unavailable, silently fall back to the
+next available top-tier model. If delegation is unavailable, run the verdict
+inline.
+
+## When to use
+
+- The repo has existing specs, issues, code, and docs, and the operator asks
+  "can we release this?"
+- A project needs QA, review, testing, documentation drift checks, and legacy
+  cleanup in one coordinated pass.
+- Lower-level autospec skills have been run piecemeal and the operator wants a
+  single release-readiness answer.
+- The team wants a repeatable gate before tagging, deployment, or handoff.
+
+## When not to use
+
+- Do not use this as the first step for a brand-new feature idea. Use
+  `/autospec` or `/autospec-define`.
+- Do not use it as a replacement for `/autospec-stop` while a monitor is active.
+- Do not mark release PASS with mocked tests only when a no-mock smoke path is
+  required by the repo contract.
+- Do not paper over legacy code by leaving stale spec/docs references behind.
+
+## Release pipeline
+
+Run these stages in order. If a lower-level skill is installed and invocable,
+call that skill. If not, follow its documented workflow inline and report that
+the explicit skill invocation was unavailable.
+
+1. Preflight
+   - Record branch, dirty files, remotes, GitHub repo, open PRs, open
+     `auto-implement` and `needs-classify` issues, and installed autospec skill
+     versions if visible.
+   - Do not revert user work. If dirty files exist, treat them as current repo
+     reality and avoid overwriting them.
+
+2. Sweep
+   - Run `/autospec-sweep` or the equivalent sweep workflow.
+   - Ensure `.autospec/autospec.yml` and the latest sweep report exist when the
+     repo is configured for sweeps.
+   - Turn recurring drift into concrete spec, issue, test, or docs work.
+
+3. Spec, docs, and story sync
+   - Compare `docs/specs/**`, README docs, user-facing docs, config docs, and
+     implementation reality.
+   - Remove stale claims for legacy code, legacy storage, deprecated APIs,
+     removed flags, dead routes, and old workflows.
+   - If behavior still exists only for compatibility, document that explicitly
+     as compatibility, not as the preferred path.
+
+4. Review
+   - Run `/autospec-review`.
+   - File or surface high-priority regression issues for spec-vs-code gaps.
+   - Do not proceed to PASS while untriaged release-blocking review findings
+     remain.
+
+5. Implementation queue
+   - Run `/autospec-classify` if `needs-classify` issues exist.
+   - Run `/autospec-run` until there are no ready release-blocking
+     `auto-implement` issues, or until a blocker is documented with the exact
+     issue number and command to resume.
+
+6. Test gate
+   - Run `/autospec-test` where available.
+   - Require lint, typecheck, unit, integration, smoke, E2E, and static checks
+     that the target repo defines as release gates.
+   - Failed tests are work, not report decoration: fix them or create a
+     release-blocking issue with exact reproduction.
+
+7. QA proof
+   - Run `/autospec-qa` against the configured local or deployed app.
+   - Require control-level proof for text boxes, selects, dropdowns, buttons,
+     validation, API effects, failure banners, fallback behavior, accessibility,
+     and no-mock smoke paths where the repo contract requires them.
+   - Validate QA artifacts with
+     `skills/autospec-shared/scripts/validate-qa-artifacts.sh` when available.
+
+8. Legacy cleanup gate
+   - Search code, specs, docs, tests, fixtures, config, infra, and examples for
+     removed or deprecated behavior.
+   - Delete dead code when tests prove it is unreachable.
+   - Remove stale spec/docs references in the same change that removes the code.
+   - If a legacy path cannot be removed yet, create a deprecation issue that
+     names the owner, replacement path, and removal trigger.
+
+9. Final release verdict
+   - `PASS`: all release gates pass, no release-blocking issues remain, no
+     untested required no-mock path remains, docs match behavior, and legacy
+     cleanup is either complete or explicitly tracked.
+   - `PARTIAL`: useful progress landed, but at least one required gate is not
+     tested or externally blocked.
+   - `FAIL`: a release-blocking test, QA path, review finding, docs mismatch,
+     or legacy conflict remains.
+
+## Legacy cleanup prompt
+
+Use this prompt whenever code, config, docs, tests, specs, infra, or examples
+mention a deprecated path:
+
+```text
+Before accepting this release:
+
+1. Is this path still reachable in the product, CLI, API, deployment, tests, or
+   docs?
+2. Is it the preferred path, a compatibility shim, or dead code?
+3. Does the spec still describe it as current behavior?
+4. Does any test fixture, README, runbook, env var, script, or infra module keep
+   it alive accidentally?
+5. What is the replacement path and where is that replacement proven?
+6. Can I delete it now? If not, what exact issue tracks removal and what event
+   will make removal safe?
+
+Required outcome:
+- Preferred path: keep it and prove it.
+- Compatibility path: label and document it as compatibility only.
+- Dead path: delete it and remove matching spec/docs/tests references.
+- Unknown path: mark release PARTIAL and create the smallest investigation or
+  cleanup issue needed to settle it.
+```
+
+## Release report contract
+
+Return a concise report with:
+
+- Verdict: `PASS`, `PARTIAL`, or `FAIL`.
+- Branch and commit range reviewed.
+- Skills/stages run, with command evidence.
+- Changed files and simplifications made, if edits were performed.
+- Test, QA, docs, review, and legacy-cleanup evidence.
+- Remaining blockers with exact issue numbers or next commands.
+- Known `NOT TESTED` areas, separated from tested evidence.
+
+Never say the repo is release-ready unless the evidence above is complete.

--- a/skills/autospec-release/codex/prompt.md
+++ b/skills/autospec-release/codex/prompt.md
@@ -1,0 +1,220 @@
+
+# autospec-release workflow
+
+Run the repo-level release readiness loop. This is the "I want to ship the
+current repo" wrapper over the existing autospec surfaces: sweep, review, run,
+test, QA, proof validation, documentation drift checks, and legacy-code cleanup.
+
+Use this when the operator wants one explicit release gate instead of invoking
+each lower-level skill by hand.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-release   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches `update` after trimming and lowercasing,
+re-install the full autospec suite from `main`, show the before/after diff if the
+harness exposes it, then stop. Do not run the release gate.
+
+## Required capabilities & harness adapter
+
+| Capability | Claude Code | OpenCode | Codex CLI | Fallback if missing |
+| --- | --- | --- | --- | --- |
+| Subagent model tier | Tier A: `opus` + ultrathink | Tier A: top-tier `task` + max reasoning | Tier A: current top GPT + `reasoning_effort=high` | Run inline, but keep the same PASS/PARTIAL/FAIL contract |
+| Existing autospec skills | Slash skills | agent prompts | skills/prompts | Run the matching workflow instructions inline |
+| GitHub operations | `gh` through shell | shell | shell | Mark merge/issue steps BLOCKED with exact command |
+| Test and QA execution | Browser/E2E or shell | browser/task or shell | shell/browser when available | Mark app-only checks NOT TESTED with blocker |
+
+**Model tier:** TIER_A for release synthesis and final readiness verdicts
+because a false PASS can ship broken behavior.
+
+## Harness detection
+
+Detect the harness once at skill start:
+
+1. Claude Code: `Agent` with `subagent_type` is available.
+   - `TIER_A` = `opus` + ultrathink.
+   - `TIER_B` = `sonnet`.
+2. OpenCode: `task` tool is available.
+   - `TIER_A` = top-tier task model + high reasoning.
+   - `TIER_B` = smaller-tier task model + medium reasoning.
+3. Codex CLI: `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT + `reasoning_effort=high`.
+   - `TIER_B` = current cost-optimized Codex model + `reasoning_effort=medium`.
+
+Prefer a Tier A reviewer/verifier subagent for the final release verdict when
+the harness supports it. If `TIER_A` is unavailable, silently fall back to the
+next available top-tier model. If delegation is unavailable, run the verdict
+inline.
+
+## When to use
+
+- The repo has existing specs, issues, code, and docs, and the operator asks
+  "can we release this?"
+- A project needs QA, review, testing, documentation drift checks, and legacy
+  cleanup in one coordinated pass.
+- Lower-level autospec skills have been run piecemeal and the operator wants a
+  single release-readiness answer.
+- The team wants a repeatable gate before tagging, deployment, or handoff.
+
+## When not to use
+
+- Do not use this as the first step for a brand-new feature idea. Use
+  `/autospec` or `/autospec-define`.
+- Do not use it as a replacement for `/autospec-stop` while a monitor is active.
+- Do not mark release PASS with mocked tests only when a no-mock smoke path is
+  required by the repo contract.
+- Do not paper over legacy code by leaving stale spec/docs references behind.
+
+## Release pipeline
+
+Run these stages in order. If a lower-level skill is installed and invocable,
+call that skill. If not, follow its documented workflow inline and report that
+the explicit skill invocation was unavailable.
+
+1. Preflight
+   - Record branch, dirty files, remotes, GitHub repo, open PRs, open
+     `auto-implement` and `needs-classify` issues, and installed autospec skill
+     versions if visible.
+   - Do not revert user work. If dirty files exist, treat them as current repo
+     reality and avoid overwriting them.
+
+2. Sweep
+   - Run `/autospec-sweep` or the equivalent sweep workflow.
+   - Ensure `.autospec/autospec.yml` and the latest sweep report exist when the
+     repo is configured for sweeps.
+   - Turn recurring drift into concrete spec, issue, test, or docs work.
+
+3. Spec, docs, and story sync
+   - Compare `docs/specs/**`, README docs, user-facing docs, config docs, and
+     implementation reality.
+   - Remove stale claims for legacy code, legacy storage, deprecated APIs,
+     removed flags, dead routes, and old workflows.
+   - If behavior still exists only for compatibility, document that explicitly
+     as compatibility, not as the preferred path.
+
+4. Review
+   - Run `/autospec-review`.
+   - File or surface high-priority regression issues for spec-vs-code gaps.
+   - Do not proceed to PASS while untriaged release-blocking review findings
+     remain.
+
+5. Implementation queue
+   - Run `/autospec-classify` if `needs-classify` issues exist.
+   - Run `/autospec-run` until there are no ready release-blocking
+     `auto-implement` issues, or until a blocker is documented with the exact
+     issue number and command to resume.
+
+6. Test gate
+   - Run `/autospec-test` where available.
+   - Require lint, typecheck, unit, integration, smoke, E2E, and static checks
+     that the target repo defines as release gates.
+   - Failed tests are work, not report decoration: fix them or create a
+     release-blocking issue with exact reproduction.
+
+7. QA proof
+   - Run `/autospec-qa` against the configured local or deployed app.
+   - Require control-level proof for text boxes, selects, dropdowns, buttons,
+     validation, API effects, failure banners, fallback behavior, accessibility,
+     and no-mock smoke paths where the repo contract requires them.
+   - Validate QA artifacts with
+     `skills/autospec-shared/scripts/validate-qa-artifacts.sh` when available.
+
+8. Legacy cleanup gate
+   - Search code, specs, docs, tests, fixtures, config, infra, and examples for
+     removed or deprecated behavior.
+   - Delete dead code when tests prove it is unreachable.
+   - Remove stale spec/docs references in the same change that removes the code.
+   - If a legacy path cannot be removed yet, create a deprecation issue that
+     names the owner, replacement path, and removal trigger.
+
+9. Final release verdict
+   - `PASS`: all release gates pass, no release-blocking issues remain, no
+     untested required no-mock path remains, docs match behavior, and legacy
+     cleanup is either complete or explicitly tracked.
+   - `PARTIAL`: useful progress landed, but at least one required gate is not
+     tested or externally blocked.
+   - `FAIL`: a release-blocking test, QA path, review finding, docs mismatch,
+     or legacy conflict remains.
+
+## Legacy cleanup prompt
+
+Use this prompt whenever code, config, docs, tests, specs, infra, or examples
+mention a deprecated path:
+
+```text
+Before accepting this release:
+
+1. Is this path still reachable in the product, CLI, API, deployment, tests, or
+   docs?
+2. Is it the preferred path, a compatibility shim, or dead code?
+3. Does the spec still describe it as current behavior?
+4. Does any test fixture, README, runbook, env var, script, or infra module keep
+   it alive accidentally?
+5. What is the replacement path and where is that replacement proven?
+6. Can I delete it now? If not, what exact issue tracks removal and what event
+   will make removal safe?
+
+Required outcome:
+- Preferred path: keep it and prove it.
+- Compatibility path: label and document it as compatibility only.
+- Dead path: delete it and remove matching spec/docs/tests references.
+- Unknown path: mark release PARTIAL and create the smallest investigation or
+  cleanup issue needed to settle it.
+```
+
+## Release report contract
+
+Return a concise report with:
+
+- Verdict: `PASS`, `PARTIAL`, or `FAIL`.
+- Branch and commit range reviewed.
+- Skills/stages run, with command evidence.
+- Changed files and simplifications made, if edits were performed.
+- Test, QA, docs, review, and legacy-cleanup evidence.
+- Remaining blockers with exact issue numbers or next commands.
+- Known `NOT TESTED` areas, separated from tested evidence.
+
+Never say the repo is release-ready unless the evidence above is complete.

--- a/skills/autospec-release/install.sh
+++ b/skills/autospec-release/install.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env sh
+# install.sh - install the autospec-release skill into one or more harnesses.
+
+set -eu
+
+SKILL_NAME="autospec-release"
+SKILL_RAW_BASE="${AUTOSPEC_RELEASE_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_RELEASE_REF:-main}/skills/autospec-release}"
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+UPDATE_MODE=0
+TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh validate-qa-artifacts.sh"
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
+
+Installs the ${SKILL_NAME} skill into the chosen harness.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    command -v curl >/dev/null 2>&1 || { err "curl is required when running from stdin"; exit 1; }
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel" || { err "failed to download $rel"; exit 1; }
+    done
+    for rel in $SHARED_SCRIPT_FILES; do
+        curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel" || { err "failed to download $rel"; exit 1; }
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    [ -f "$src" ] || { err "missing source file: $src"; return 1; }
+    run "mkdir -p \"$(dirname "$dest")\""
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    [ -n "$src_dir" ] || { err "missing shared scripts directory"; return 1; }
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;; esac
+    done
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness) shift; HARNESS="${1:-}" ;;
+        --harness=*) HARNESS="${1#--harness=}" ;;
+        --symlink) USE_SYMLINK=1 ;;
+        --dry-run) DRY_RUN=1 ;;
+        --update) UPDATE_MODE=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) err "unknown arg: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+
+[ -n "$HARNESS" ] || HARNESS=all
+case "$HARNESS" in claude|opencode|codex|all) ;; *) err "invalid --harness: $HARNESS"; exit 2 ;; esac
+
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+if [ "$need_fetch" -eq 1 ]; then
+    [ "$USE_SYMLINK" -eq 0 ] || { err "--symlink requires a local checkout"; exit 2; }
+    fetch_source_files
+fi
+
+for dep in git gh jq; do
+    command -v "$dep" >/dev/null 2>&1 || warn "$dep not found on PATH"
+done
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Claude Code:"
+    install_one "$SKILL_DIR/SKILL.md" "$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "OpenCode:"
+    install_one "$SKILL_DIR/opencode/agent.md" "$OPENCODE_DIR/agent/$SKILL_NAME.md"
+fi
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Codex CLI:"
+    install_one "$SKILL_DIR/codex/prompt.md" "$CODEX_DIR/prompts/$SKILL_NAME.md"
+    install_one "$SKILL_DIR/SKILL.md" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+elif [ "$UPDATE_MODE" -eq 1 ]; then
+    info "Updated $SKILL_NAME."
+else
+    info "Installed $SKILL_NAME."
+fi

--- a/skills/autospec-release/opencode/agent.md
+++ b/skills/autospec-release/opencode/agent.md
@@ -1,0 +1,224 @@
+---
+name: autospec-release
+description: Use when a repo needs an end-to-end release readiness sweep across specs, docs, implementation, tests, QA proof artifacts, legacy cleanup, and merge readiness using existing autospec skills.
+---
+
+# autospec-release workflow
+
+Run the repo-level release readiness loop. This is the "I want to ship the
+current repo" wrapper over the existing autospec surfaces: sweep, review, run,
+test, QA, proof validation, documentation drift checks, and legacy-code cleanup.
+
+Use this when the operator wants one explicit release gate instead of invoking
+each lower-level skill by hand.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-release   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches `update` after trimming and lowercasing,
+re-install the full autospec suite from `main`, show the before/after diff if the
+harness exposes it, then stop. Do not run the release gate.
+
+## Required capabilities & harness adapter
+
+| Capability | Claude Code | OpenCode | Codex CLI | Fallback if missing |
+| --- | --- | --- | --- | --- |
+| Subagent model tier | Tier A: `opus` + ultrathink | Tier A: top-tier `task` + max reasoning | Tier A: current top GPT + `reasoning_effort=high` | Run inline, but keep the same PASS/PARTIAL/FAIL contract |
+| Existing autospec skills | Slash skills | agent prompts | skills/prompts | Run the matching workflow instructions inline |
+| GitHub operations | `gh` through shell | shell | shell | Mark merge/issue steps BLOCKED with exact command |
+| Test and QA execution | Browser/E2E or shell | browser/task or shell | shell/browser when available | Mark app-only checks NOT TESTED with blocker |
+
+**Model tier:** TIER_A for release synthesis and final readiness verdicts
+because a false PASS can ship broken behavior.
+
+## Harness detection
+
+Detect the harness once at skill start:
+
+1. Claude Code: `Agent` with `subagent_type` is available.
+   - `TIER_A` = `opus` + ultrathink.
+   - `TIER_B` = `sonnet`.
+2. OpenCode: `task` tool is available.
+   - `TIER_A` = top-tier task model + high reasoning.
+   - `TIER_B` = smaller-tier task model + medium reasoning.
+3. Codex CLI: `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT + `reasoning_effort=high`.
+   - `TIER_B` = current cost-optimized Codex model + `reasoning_effort=medium`.
+
+Prefer a Tier A reviewer/verifier subagent for the final release verdict when
+the harness supports it. If `TIER_A` is unavailable, silently fall back to the
+next available top-tier model. If delegation is unavailable, run the verdict
+inline.
+
+## When to use
+
+- The repo has existing specs, issues, code, and docs, and the operator asks
+  "can we release this?"
+- A project needs QA, review, testing, documentation drift checks, and legacy
+  cleanup in one coordinated pass.
+- Lower-level autospec skills have been run piecemeal and the operator wants a
+  single release-readiness answer.
+- The team wants a repeatable gate before tagging, deployment, or handoff.
+
+## When not to use
+
+- Do not use this as the first step for a brand-new feature idea. Use
+  `/autospec` or `/autospec-define`.
+- Do not use it as a replacement for `/autospec-stop` while a monitor is active.
+- Do not mark release PASS with mocked tests only when a no-mock smoke path is
+  required by the repo contract.
+- Do not paper over legacy code by leaving stale spec/docs references behind.
+
+## Release pipeline
+
+Run these stages in order. If a lower-level skill is installed and invocable,
+call that skill. If not, follow its documented workflow inline and report that
+the explicit skill invocation was unavailable.
+
+1. Preflight
+   - Record branch, dirty files, remotes, GitHub repo, open PRs, open
+     `auto-implement` and `needs-classify` issues, and installed autospec skill
+     versions if visible.
+   - Do not revert user work. If dirty files exist, treat them as current repo
+     reality and avoid overwriting them.
+
+2. Sweep
+   - Run `/autospec-sweep` or the equivalent sweep workflow.
+   - Ensure `.autospec/autospec.yml` and the latest sweep report exist when the
+     repo is configured for sweeps.
+   - Turn recurring drift into concrete spec, issue, test, or docs work.
+
+3. Spec, docs, and story sync
+   - Compare `docs/specs/**`, README docs, user-facing docs, config docs, and
+     implementation reality.
+   - Remove stale claims for legacy code, legacy storage, deprecated APIs,
+     removed flags, dead routes, and old workflows.
+   - If behavior still exists only for compatibility, document that explicitly
+     as compatibility, not as the preferred path.
+
+4. Review
+   - Run `/autospec-review`.
+   - File or surface high-priority regression issues for spec-vs-code gaps.
+   - Do not proceed to PASS while untriaged release-blocking review findings
+     remain.
+
+5. Implementation queue
+   - Run `/autospec-classify` if `needs-classify` issues exist.
+   - Run `/autospec-run` until there are no ready release-blocking
+     `auto-implement` issues, or until a blocker is documented with the exact
+     issue number and command to resume.
+
+6. Test gate
+   - Run `/autospec-test` where available.
+   - Require lint, typecheck, unit, integration, smoke, E2E, and static checks
+     that the target repo defines as release gates.
+   - Failed tests are work, not report decoration: fix them or create a
+     release-blocking issue with exact reproduction.
+
+7. QA proof
+   - Run `/autospec-qa` against the configured local or deployed app.
+   - Require control-level proof for text boxes, selects, dropdowns, buttons,
+     validation, API effects, failure banners, fallback behavior, accessibility,
+     and no-mock smoke paths where the repo contract requires them.
+   - Validate QA artifacts with
+     `skills/autospec-shared/scripts/validate-qa-artifacts.sh` when available.
+
+8. Legacy cleanup gate
+   - Search code, specs, docs, tests, fixtures, config, infra, and examples for
+     removed or deprecated behavior.
+   - Delete dead code when tests prove it is unreachable.
+   - Remove stale spec/docs references in the same change that removes the code.
+   - If a legacy path cannot be removed yet, create a deprecation issue that
+     names the owner, replacement path, and removal trigger.
+
+9. Final release verdict
+   - `PASS`: all release gates pass, no release-blocking issues remain, no
+     untested required no-mock path remains, docs match behavior, and legacy
+     cleanup is either complete or explicitly tracked.
+   - `PARTIAL`: useful progress landed, but at least one required gate is not
+     tested or externally blocked.
+   - `FAIL`: a release-blocking test, QA path, review finding, docs mismatch,
+     or legacy conflict remains.
+
+## Legacy cleanup prompt
+
+Use this prompt whenever code, config, docs, tests, specs, infra, or examples
+mention a deprecated path:
+
+```text
+Before accepting this release:
+
+1. Is this path still reachable in the product, CLI, API, deployment, tests, or
+   docs?
+2. Is it the preferred path, a compatibility shim, or dead code?
+3. Does the spec still describe it as current behavior?
+4. Does any test fixture, README, runbook, env var, script, or infra module keep
+   it alive accidentally?
+5. What is the replacement path and where is that replacement proven?
+6. Can I delete it now? If not, what exact issue tracks removal and what event
+   will make removal safe?
+
+Required outcome:
+- Preferred path: keep it and prove it.
+- Compatibility path: label and document it as compatibility only.
+- Dead path: delete it and remove matching spec/docs/tests references.
+- Unknown path: mark release PARTIAL and create the smallest investigation or
+  cleanup issue needed to settle it.
+```
+
+## Release report contract
+
+Return a concise report with:
+
+- Verdict: `PASS`, `PARTIAL`, or `FAIL`.
+- Branch and commit range reviewed.
+- Skills/stages run, with command evidence.
+- Changed files and simplifications made, if edits were performed.
+- Test, QA, docs, review, and legacy-cleanup evidence.
+- Remaining blockers with exact issue numbers or next commands.
+- Known `NOT TESTED` areas, separated from tested evidence.
+
+Never say the repo is release-ready unless the evidence above is complete.

--- a/skills/autospec-release/uninstall.sh
+++ b/skills/autospec-release/uninstall.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env sh
+# uninstall.sh - remove the autospec-release skill from one or more harnesses.
+
+set -eu
+
+SKILL_NAME="autospec-release"
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness) shift; HARNESS="${1:-}" ;;
+        --harness=*) HARNESS="${1#--harness=}" ;;
+        --dry-run) DRY_RUN=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) err "unknown arg: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+
+[ -n "$HARNESS" ] || HARNESS=all
+case "$HARNESS" in claude|opencode|codex|all) ;; *) err "invalid --harness: $HARNESS"; exit 2 ;; esac
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Claude Code:"
+    remove_one "$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "OpenCode:"
+    remove_one "$OPENCODE_DIR/agent/$SKILL_NAME.md"
+fi
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""; info "Codex CLI:"
+    remove_one "$CODEX_DIR/prompts/$SKILL_NAME.md"
+    remove_one "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+fi
+
+info ""
+[ "$DRY_RUN" -eq 1 ] && info "Dry run complete. No files were removed." || info "Done."

--- a/tests/smoke/test_install_all_skills.bats
+++ b/tests/smoke/test_install_all_skills.bats
@@ -17,7 +17,7 @@ setup() {
     export OPENCODE_CONFIG_DIR="$FAKE_HOME/.config/opencode"
     export CODEX_HOME="$FAKE_HOME/.codex"
 
-    SKILLS="autospec autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa"
+    SKILLS="autospec autospec-release autospec-split autospec-define autospec-run autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa"
     HELPERS="autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh autospec-sweep-wizard.sh autospec-sweep-run.sh autospec-sweep-review.sh run-state.sh list-ready-issues.sh claim-issue.sh release-issue.sh"
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,7 +12,7 @@
 #   ./uninstall.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | autospec-qa | all
+#   --skill   one of: autospec | autospec-release | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | autospec-qa | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)
@@ -24,7 +24,7 @@
 
 set -eu
 
-ALL_SKILLS="autospec autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa"
+ALL_SKILLS="autospec autospec-release autospec-split autospec-define autospec-run autospec-review autospec-classify autospec-listen autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa"
 ALL_HARNESSES="claude opencode codex"
 
 SKILL_ARG="all"
@@ -67,7 +67,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$SKILL_ARG" in
-    all|autospec|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design|autospec-fleet|autospec-qa) ;;
+    all|autospec|autospec-release|autospec-split|autospec-define|autospec-run|autospec-review|autospec-classify|autospec-listen|autospec-story|autospec-stop|autospec-sweep|autospec-design|autospec-fleet|autospec-qa) ;;
     *)
         err "invalid --skill: $SKILL_ARG"
         exit 2


### PR DESCRIPTION
## Summary
- add `autospec-release` as a multi-harness release readiness wrapper skill
- document when to use each skill in a new README getting-started table
- wire release skill install/uninstall, validation, and smoke install coverage

## Validation
- `bash scripts/validate.sh`
- `bats tests/smoke/test_install_all_skills.bats`
- `./install.sh --skill autospec-release --harness all --dry-run`
- `git diff --check`

## Notes
`autospec-release` is intentionally a release-gate workflow contract over existing working skills, not a new long-running daemon.
