### PR TITLE
feat: release/QA handoff via qa-verdict.json + iteration loop

### DIFF
--- a/skills/autospec-qa/SKILL.md
+++ b/skills/autospec-qa/SKILL.md
@@ -1047,12 +1047,14 @@ Rules:
   against a booted app whose commit matches `head_sha`. Otherwise `false`.
 - `release_blocking` defaults TRUE for:
   - `benchmark_overfit` with failure mode 6 (training-on-test leak),
-  - `no_mock_smoke` with `status: NOT_TESTED` on a required path,
+  - `no_mock_smoke` on a required path with any non-PASS status,
   - `live_backend_blocker` unresolved,
   - `mutation_proof_missing` on a critical workflow,
   - `spec_contradiction` unresolved,
   - `legacy_residue` referenced by current user-facing docs.
-  Other categories default FALSE and can be promoted by the QA author.
+  Other categories default FALSE; promote to TRUE only when the finding
+  documents a user-visible regression, data loss, security exposure, or
+  violated spec requirement.
 - Write atomically: `.autospec/qa-verdict.json.tmp` then `mv` to the final
   path. Chmod 644. Always overwrite — staleness is checked by `head_sha`,
   not mtime.

--- a/skills/autospec-qa/SKILL.md
+++ b/skills/autospec-qa/SKILL.md
@@ -527,6 +527,48 @@ Required outcome:
 - Record the result in `.autospec/mutation-proof.json` or the QA report.
 ```
 
+## Benchmark leak and overfit gate
+
+For every test that consumes a public dataset, benchmark, leaderboard, or
+externally-curated answer key (e.g., ClassyFire, ChEMBL, MassBank, MNIST,
+GLUE, SuperGLUE, ImageNet, BIG-bench, HELM, GSM8K, MMLU, fixtures derived
+from a named corpus), audit for benchmark leak and overfit-shaped assertions:
+
+```text
+For each test fixture and assertion derived from a public benchmark or
+externally-curated dataset:
+
+1. Identifier hard-coding — does the test pin specific benchmark IDs
+   (InChIKeys, accession numbers, row hashes, sample indices, image filenames,
+   prompt IDs) and assert exact downstream values?
+2. First-N slice — is the fixture the first N rows / top-N records / a fixed
+   prefix of a known benchmark, rather than a randomized or rotated sample?
+3. Answer-key shape — do the assertions match the benchmark's published
+   answer key (labels, class names, expected outputs) such that the system
+   under test could pass by memorizing those rows?
+4. Distributional sibling — is there a randomized or property-based test
+   covering the same code path on a fresh draw from the source distribution?
+5. Refresh path — can the fixture be regenerated on demand from the upstream
+   source (API, query, seeded sampler), or is it frozen indefinitely?
+6. Training-on-test — is the same fixture also used to train, tune, select,
+   or prompt-engineer the code under test? If yes, the fixture is leaked.
+
+Required outcome:
+- Replace fixed slices with a seeded random sample drawn from the upstream
+  source per run (or per release), and rotate the seed at a defined cadence.
+- Replace exact-value assertions on benchmark identifiers with property-based
+  or invariant assertions that hold for any valid draw from the distribution.
+- Keep at most one tiny "shape smoke" test with hard-coded IDs, clearly named
+  as a smoke test, never as the primary correctness signal.
+- A test that asserts exact benchmark answers without a randomized sibling is
+  a PARTIAL finding. If the same fixture is also used as the training or
+  selection signal for the code under test, it is FAIL (training-on-test
+  leak).
+- Record each finding in the QA report under "Benchmark Overfit and Test
+  Leak" with the test path, the leaked dataset, the failure mode (1-6
+  above), and the required remediation.
+```
+
 ## Post-merge deployed canary prompt
 
 When a deployed/dev URL exists, define the post-merge canary before release:
@@ -904,6 +946,12 @@ alternatives or follow-up fixes.
 ## Mutation and Breakage Proof
 List critical workflow tests, the simulated break or mutation, expected failing
 assertion, observed result, and strengthening performed if the test stayed green.
+## Benchmark Overfit and Test Leak
+List tests whose fixtures hard-code public benchmark identifiers, use a fixed
+first-N slice, assert exact benchmark answer-key values, lack a randomized or
+property-based sibling, or reuse the same fixture as training/selection signal.
+For each: test path, leaked dataset, failure mode (1-6 from the gate), and
+required remediation.
 ## Post-Merge Deployed Canary
 List required canary workflows, representative input, deployed/dev URL, expected
 domain result, result, and regression issue/action for failures.
@@ -963,6 +1011,54 @@ After the audit:
 4. Run the relevant test commands and the repo's validation command.
 5. Repeat until the traceability matrix has no unexplained gaps or the remaining
    gaps are filed as issues with reproduction steps and evidence.
+
+## QA verdict artifact
+
+At the end of every audit run (including aborted runs), write
+`.autospec/qa-verdict.json` as the machine-readable result. Downstream
+skills — notably `/autospec-release` — read this file as the authoritative
+gate signal instead of re-parsing the prose report.
+
+Schema:
+
+```json
+{
+  "verdict": "PASS|PARTIAL|FAIL",
+  "head_sha": "<git rev-parse HEAD at run start>",
+  "generated_at": "<ISO-8601 UTC>",
+  "live_app_proof": true,
+  "artifacts": ["path/to/screenshot.png", "path/to/network-trace.har"],
+  "findings": [
+    {
+      "category": "benchmark_overfit|no_mock_smoke|live_backend_blocker|mutation_proof_missing|spec_contradiction|duplicate_code|presentational_misclassified|legacy_residue|new_code_intent|accessibility|cross_browser|automated_test_gap|other",
+      "release_blocking": true,
+      "status": "PASS|PARTIAL|FAIL|NOT_TESTED",
+      "summary": "<one-line description>",
+      "evidence": "<path or pointer to artifact, report section, or issue>"
+    }
+  ]
+}
+```
+
+Rules:
+
+- `live_app_proof` is `true` ONLY if at least one interaction artifact
+  (screenshot, DOM snapshot, network trace, recorded session) was captured
+  against a booted app whose commit matches `head_sha`. Otherwise `false`.
+- `release_blocking` defaults TRUE for:
+  - `benchmark_overfit` with failure mode 6 (training-on-test leak),
+  - `no_mock_smoke` with `status: NOT_TESTED` on a required path,
+  - `live_backend_blocker` unresolved,
+  - `mutation_proof_missing` on a critical workflow,
+  - `spec_contradiction` unresolved,
+  - `legacy_residue` referenced by current user-facing docs.
+  Other categories default FALSE and can be promoted by the QA author.
+- Write atomically: `.autospec/qa-verdict.json.tmp` then `mv` to the final
+  path. Chmod 644. Always overwrite — staleness is checked by `head_sha`,
+  not mtime.
+- If the audit aborts before completion, still write the file with
+  `verdict: "FAIL"` and one finding describing the abort reason. Never
+  leave a stale prior verdict in place to be misread as the current run.
 
 ## Output contract
 

--- a/skills/autospec-qa/codex/prompt.md
+++ b/skills/autospec-qa/codex/prompt.md
@@ -1043,12 +1043,14 @@ Rules:
   against a booted app whose commit matches `head_sha`. Otherwise `false`.
 - `release_blocking` defaults TRUE for:
   - `benchmark_overfit` with failure mode 6 (training-on-test leak),
-  - `no_mock_smoke` with `status: NOT_TESTED` on a required path,
+  - `no_mock_smoke` on a required path with any non-PASS status,
   - `live_backend_blocker` unresolved,
   - `mutation_proof_missing` on a critical workflow,
   - `spec_contradiction` unresolved,
   - `legacy_residue` referenced by current user-facing docs.
-  Other categories default FALSE and can be promoted by the QA author.
+  Other categories default FALSE; promote to TRUE only when the finding
+  documents a user-visible regression, data loss, security exposure, or
+  violated spec requirement.
 - Write atomically: `.autospec/qa-verdict.json.tmp` then `mv` to the final
   path. Chmod 644. Always overwrite — staleness is checked by `head_sha`,
   not mtime.

--- a/skills/autospec-qa/codex/prompt.md
+++ b/skills/autospec-qa/codex/prompt.md
@@ -523,6 +523,48 @@ Required outcome:
 - Record the result in `.autospec/mutation-proof.json` or the QA report.
 ```
 
+## Benchmark leak and overfit gate
+
+For every test that consumes a public dataset, benchmark, leaderboard, or
+externally-curated answer key (e.g., ClassyFire, ChEMBL, MassBank, MNIST,
+GLUE, SuperGLUE, ImageNet, BIG-bench, HELM, GSM8K, MMLU, fixtures derived
+from a named corpus), audit for benchmark leak and overfit-shaped assertions:
+
+```text
+For each test fixture and assertion derived from a public benchmark or
+externally-curated dataset:
+
+1. Identifier hard-coding — does the test pin specific benchmark IDs
+   (InChIKeys, accession numbers, row hashes, sample indices, image filenames,
+   prompt IDs) and assert exact downstream values?
+2. First-N slice — is the fixture the first N rows / top-N records / a fixed
+   prefix of a known benchmark, rather than a randomized or rotated sample?
+3. Answer-key shape — do the assertions match the benchmark's published
+   answer key (labels, class names, expected outputs) such that the system
+   under test could pass by memorizing those rows?
+4. Distributional sibling — is there a randomized or property-based test
+   covering the same code path on a fresh draw from the source distribution?
+5. Refresh path — can the fixture be regenerated on demand from the upstream
+   source (API, query, seeded sampler), or is it frozen indefinitely?
+6. Training-on-test — is the same fixture also used to train, tune, select,
+   or prompt-engineer the code under test? If yes, the fixture is leaked.
+
+Required outcome:
+- Replace fixed slices with a seeded random sample drawn from the upstream
+  source per run (or per release), and rotate the seed at a defined cadence.
+- Replace exact-value assertions on benchmark identifiers with property-based
+  or invariant assertions that hold for any valid draw from the distribution.
+- Keep at most one tiny "shape smoke" test with hard-coded IDs, clearly named
+  as a smoke test, never as the primary correctness signal.
+- A test that asserts exact benchmark answers without a randomized sibling is
+  a PARTIAL finding. If the same fixture is also used as the training or
+  selection signal for the code under test, it is FAIL (training-on-test
+  leak).
+- Record each finding in the QA report under "Benchmark Overfit and Test
+  Leak" with the test path, the leaked dataset, the failure mode (1-6
+  above), and the required remediation.
+```
+
 ## Post-merge deployed canary prompt
 
 When a deployed/dev URL exists, define the post-merge canary before release:
@@ -900,6 +942,12 @@ alternatives or follow-up fixes.
 ## Mutation and Breakage Proof
 List critical workflow tests, the simulated break or mutation, expected failing
 assertion, observed result, and strengthening performed if the test stayed green.
+## Benchmark Overfit and Test Leak
+List tests whose fixtures hard-code public benchmark identifiers, use a fixed
+first-N slice, assert exact benchmark answer-key values, lack a randomized or
+property-based sibling, or reuse the same fixture as training/selection signal.
+For each: test path, leaked dataset, failure mode (1-6 from the gate), and
+required remediation.
 ## Post-Merge Deployed Canary
 List required canary workflows, representative input, deployed/dev URL, expected
 domain result, result, and regression issue/action for failures.
@@ -959,6 +1007,54 @@ After the audit:
 4. Run the relevant test commands and the repo's validation command.
 5. Repeat until the traceability matrix has no unexplained gaps or the remaining
    gaps are filed as issues with reproduction steps and evidence.
+
+## QA verdict artifact
+
+At the end of every audit run (including aborted runs), write
+`.autospec/qa-verdict.json` as the machine-readable result. Downstream
+skills — notably `/autospec-release` — read this file as the authoritative
+gate signal instead of re-parsing the prose report.
+
+Schema:
+
+```json
+{
+  "verdict": "PASS|PARTIAL|FAIL",
+  "head_sha": "<git rev-parse HEAD at run start>",
+  "generated_at": "<ISO-8601 UTC>",
+  "live_app_proof": true,
+  "artifacts": ["path/to/screenshot.png", "path/to/network-trace.har"],
+  "findings": [
+    {
+      "category": "benchmark_overfit|no_mock_smoke|live_backend_blocker|mutation_proof_missing|spec_contradiction|duplicate_code|presentational_misclassified|legacy_residue|new_code_intent|accessibility|cross_browser|automated_test_gap|other",
+      "release_blocking": true,
+      "status": "PASS|PARTIAL|FAIL|NOT_TESTED",
+      "summary": "<one-line description>",
+      "evidence": "<path or pointer to artifact, report section, or issue>"
+    }
+  ]
+}
+```
+
+Rules:
+
+- `live_app_proof` is `true` ONLY if at least one interaction artifact
+  (screenshot, DOM snapshot, network trace, recorded session) was captured
+  against a booted app whose commit matches `head_sha`. Otherwise `false`.
+- `release_blocking` defaults TRUE for:
+  - `benchmark_overfit` with failure mode 6 (training-on-test leak),
+  - `no_mock_smoke` with `status: NOT_TESTED` on a required path,
+  - `live_backend_blocker` unresolved,
+  - `mutation_proof_missing` on a critical workflow,
+  - `spec_contradiction` unresolved,
+  - `legacy_residue` referenced by current user-facing docs.
+  Other categories default FALSE and can be promoted by the QA author.
+- Write atomically: `.autospec/qa-verdict.json.tmp` then `mv` to the final
+  path. Chmod 644. Always overwrite — staleness is checked by `head_sha`,
+  not mtime.
+- If the audit aborts before completion, still write the file with
+  `verdict: "FAIL"` and one finding describing the abort reason. Never
+  leave a stale prior verdict in place to be misread as the current run.
 
 ## Output contract
 

--- a/skills/autospec-qa/opencode/agent.md
+++ b/skills/autospec-qa/opencode/agent.md
@@ -1047,12 +1047,14 @@ Rules:
   against a booted app whose commit matches `head_sha`. Otherwise `false`.
 - `release_blocking` defaults TRUE for:
   - `benchmark_overfit` with failure mode 6 (training-on-test leak),
-  - `no_mock_smoke` with `status: NOT_TESTED` on a required path,
+  - `no_mock_smoke` on a required path with any non-PASS status,
   - `live_backend_blocker` unresolved,
   - `mutation_proof_missing` on a critical workflow,
   - `spec_contradiction` unresolved,
   - `legacy_residue` referenced by current user-facing docs.
-  Other categories default FALSE and can be promoted by the QA author.
+  Other categories default FALSE; promote to TRUE only when the finding
+  documents a user-visible regression, data loss, security exposure, or
+  violated spec requirement.
 - Write atomically: `.autospec/qa-verdict.json.tmp` then `mv` to the final
   path. Chmod 644. Always overwrite — staleness is checked by `head_sha`,
   not mtime.

--- a/skills/autospec-qa/opencode/agent.md
+++ b/skills/autospec-qa/opencode/agent.md
@@ -527,6 +527,48 @@ Required outcome:
 - Record the result in `.autospec/mutation-proof.json` or the QA report.
 ```
 
+## Benchmark leak and overfit gate
+
+For every test that consumes a public dataset, benchmark, leaderboard, or
+externally-curated answer key (e.g., ClassyFire, ChEMBL, MassBank, MNIST,
+GLUE, SuperGLUE, ImageNet, BIG-bench, HELM, GSM8K, MMLU, fixtures derived
+from a named corpus), audit for benchmark leak and overfit-shaped assertions:
+
+```text
+For each test fixture and assertion derived from a public benchmark or
+externally-curated dataset:
+
+1. Identifier hard-coding — does the test pin specific benchmark IDs
+   (InChIKeys, accession numbers, row hashes, sample indices, image filenames,
+   prompt IDs) and assert exact downstream values?
+2. First-N slice — is the fixture the first N rows / top-N records / a fixed
+   prefix of a known benchmark, rather than a randomized or rotated sample?
+3. Answer-key shape — do the assertions match the benchmark's published
+   answer key (labels, class names, expected outputs) such that the system
+   under test could pass by memorizing those rows?
+4. Distributional sibling — is there a randomized or property-based test
+   covering the same code path on a fresh draw from the source distribution?
+5. Refresh path — can the fixture be regenerated on demand from the upstream
+   source (API, query, seeded sampler), or is it frozen indefinitely?
+6. Training-on-test — is the same fixture also used to train, tune, select,
+   or prompt-engineer the code under test? If yes, the fixture is leaked.
+
+Required outcome:
+- Replace fixed slices with a seeded random sample drawn from the upstream
+  source per run (or per release), and rotate the seed at a defined cadence.
+- Replace exact-value assertions on benchmark identifiers with property-based
+  or invariant assertions that hold for any valid draw from the distribution.
+- Keep at most one tiny "shape smoke" test with hard-coded IDs, clearly named
+  as a smoke test, never as the primary correctness signal.
+- A test that asserts exact benchmark answers without a randomized sibling is
+  a PARTIAL finding. If the same fixture is also used as the training or
+  selection signal for the code under test, it is FAIL (training-on-test
+  leak).
+- Record each finding in the QA report under "Benchmark Overfit and Test
+  Leak" with the test path, the leaked dataset, the failure mode (1-6
+  above), and the required remediation.
+```
+
 ## Post-merge deployed canary prompt
 
 When a deployed/dev URL exists, define the post-merge canary before release:
@@ -904,6 +946,12 @@ alternatives or follow-up fixes.
 ## Mutation and Breakage Proof
 List critical workflow tests, the simulated break or mutation, expected failing
 assertion, observed result, and strengthening performed if the test stayed green.
+## Benchmark Overfit and Test Leak
+List tests whose fixtures hard-code public benchmark identifiers, use a fixed
+first-N slice, assert exact benchmark answer-key values, lack a randomized or
+property-based sibling, or reuse the same fixture as training/selection signal.
+For each: test path, leaked dataset, failure mode (1-6 from the gate), and
+required remediation.
 ## Post-Merge Deployed Canary
 List required canary workflows, representative input, deployed/dev URL, expected
 domain result, result, and regression issue/action for failures.
@@ -963,6 +1011,54 @@ After the audit:
 4. Run the relevant test commands and the repo's validation command.
 5. Repeat until the traceability matrix has no unexplained gaps or the remaining
    gaps are filed as issues with reproduction steps and evidence.
+
+## QA verdict artifact
+
+At the end of every audit run (including aborted runs), write
+`.autospec/qa-verdict.json` as the machine-readable result. Downstream
+skills — notably `/autospec-release` — read this file as the authoritative
+gate signal instead of re-parsing the prose report.
+
+Schema:
+
+```json
+{
+  "verdict": "PASS|PARTIAL|FAIL",
+  "head_sha": "<git rev-parse HEAD at run start>",
+  "generated_at": "<ISO-8601 UTC>",
+  "live_app_proof": true,
+  "artifacts": ["path/to/screenshot.png", "path/to/network-trace.har"],
+  "findings": [
+    {
+      "category": "benchmark_overfit|no_mock_smoke|live_backend_blocker|mutation_proof_missing|spec_contradiction|duplicate_code|presentational_misclassified|legacy_residue|new_code_intent|accessibility|cross_browser|automated_test_gap|other",
+      "release_blocking": true,
+      "status": "PASS|PARTIAL|FAIL|NOT_TESTED",
+      "summary": "<one-line description>",
+      "evidence": "<path or pointer to artifact, report section, or issue>"
+    }
+  ]
+}
+```
+
+Rules:
+
+- `live_app_proof` is `true` ONLY if at least one interaction artifact
+  (screenshot, DOM snapshot, network trace, recorded session) was captured
+  against a booted app whose commit matches `head_sha`. Otherwise `false`.
+- `release_blocking` defaults TRUE for:
+  - `benchmark_overfit` with failure mode 6 (training-on-test leak),
+  - `no_mock_smoke` with `status: NOT_TESTED` on a required path,
+  - `live_backend_blocker` unresolved,
+  - `mutation_proof_missing` on a critical workflow,
+  - `spec_contradiction` unresolved,
+  - `legacy_residue` referenced by current user-facing docs.
+  Other categories default FALSE and can be promoted by the QA author.
+- Write atomically: `.autospec/qa-verdict.json.tmp` then `mv` to the final
+  path. Chmod 644. Always overwrite — staleness is checked by `head_sha`,
+  not mtime.
+- If the audit aborts before completion, still write the file with
+  `verdict: "FAIL"` and one finding describing the abort reason. Never
+  leave a stale prior verdict in place to be misread as the current run.
 
 ## Output contract
 

--- a/skills/autospec-release/SKILL.md
+++ b/skills/autospec-release/SKILL.md
@@ -158,13 +158,26 @@ the explicit skill invocation was unavailable.
    - Failed tests are work, not report decoration: fix them or create a
      release-blocking issue with exact reproduction.
 
-7. QA proof
-   - Run `/autospec-qa` against the configured local or deployed app.
+7. QA proof (MANDATORY — required for PASS)
+   - Run `/autospec-qa` against a live booted app. Either:
+     (a) boot the app locally (dev or prod build) and exercise it, or
+     (b) point QA at an already-deployed environment whose commit SHA matches
+         HEAD (or is explicitly recorded as the SHA under test).
+   - Mocked unit/integration tests do NOT satisfy this gate. Stage 7 must
+     produce browser- or app-level interaction artifacts (screenshots, DOM
+     snapshots, network traces, or recorded sessions) covering the user-
+     facing surfaces in the release range.
    - Require control-level proof for text boxes, selects, dropdowns, buttons,
      validation, API effects, failure banners, fallback behavior, accessibility,
      and no-mock smoke paths where the repo contract requires them.
    - Validate QA artifacts with
      `skills/autospec-shared/scripts/validate-qa-artifacts.sh` when available.
+   - Do not skip silently. If the app cannot be booted or reached, record the
+     reason, mark Stage 7 as `NOT EXECUTED`, and apply the Stage 9 verdict cap.
+   - After `/autospec-qa` completes, confirm `.autospec/qa-verdict.json`
+     exists with `head_sha` matching current HEAD and `live_app_proof: true`.
+     If absent, stale, or `live_app_proof: false`, the QA gate has not been
+     satisfied for this commit — treat as `NOT EXECUTED` for Stage 9.
 
 8. Legacy cleanup gate
    - Search code, specs, docs, tests, fixtures, config, infra, and examples for
@@ -174,14 +187,64 @@ the explicit skill invocation was unavailable.
    - If a legacy path cannot be removed yet, create a deprecation issue that
      names the owner, replacement path, and removal trigger.
 
-9. Final release verdict
-   - `PASS`: all release gates pass, no release-blocking issues remain, no
-     untested required no-mock path remains, docs match behavior, and legacy
-     cleanup is either complete or explicitly tracked.
-   - `PARTIAL`: useful progress landed, but at least one required gate is not
-     tested or externally blocked.
-   - `FAIL`: a release-blocking test, QA path, review finding, docs mismatch,
-     or legacy conflict remains.
+9. Verdict computation and release iteration loop
+
+   Compute the verdict deterministically from `.autospec/qa-verdict.json`:
+
+   - If the file is missing → verdict is `FAIL` with a synthetic finding
+     "qa-verdict.json not produced by Stage 7".
+   - If `head_sha` does not match `git rev-parse HEAD` → cap at `PARTIAL`
+     ("QA verdict is stale relative to current commit"). Re-run Stage 7
+     before accepting any further progress.
+   - If `live_app_proof: false` → cap at `PARTIAL` regardless of findings.
+   - For each finding with `release_blocking: true`:
+     - `status: FAIL` → verdict is at least `FAIL` for that finding.
+     - `status: PARTIAL` or `NOT_TESTED` → cap at `PARTIAL`.
+   - Otherwise → verdict is `PASS`.
+
+   Hard caps that override the file contents:
+   - "No merged PR in this range requires it" is NOT a valid reason to skip
+     live-app QA or any release-blocking finding. This gate evaluates the
+     cumulative shippable state of the repo, not the diff of the most
+     recent PRs.
+
+   Iteration loop:
+   - If verdict is `PASS`, emit the release report and stop.
+   - Otherwise, do NOT emit a final report yet. Pick the smallest
+     remediation that converts the highest-priority `release_blocking`
+     finding into evidence:
+     - `benchmark_overfit` / `mutation_proof_missing` /
+       `automated_test_gap` → re-enter `/autospec-qa`'s regeneration loop
+       to rewrite the offending tests.
+     - `no_mock_smoke` / `live_backend_blocker` → boot the app or unblock
+       the live backend, then re-run Stage 7.
+     - `spec_contradiction` / `legacy_residue` → fix docs/specs/code in one
+       commit, then re-run Stages 3-4.
+     - Untriaged `auto-implement` issue or queued blocker → run
+       `/autospec-run` on it, then re-run Stages 4-7.
+     After the remediation lands and is committed, re-enter at Stage 2
+     (sweep) and recompute.
+
+   Termination conditions (any one ends the loop):
+   - Verdict reached `PASS`.
+   - Iteration cap hit. Default: 5 iterations. Override:
+     `AUTOSPEC_RELEASE_MAX_ITERATIONS=<n>`. On cap, emit `PARTIAL` with the
+     unresolved findings and the exact next remediation command.
+   - `~/.autospec/stop.flag` is present (operator halt). Emit `PARTIAL`
+     with the current state.
+   - No-progress detector: two consecutive iterations produced an identical
+     set of `release_blocking` findings (by category + summary). Emit
+     `FAIL` with the stuck findings and an escalation note.
+
+   Verdict values:
+   - `PASS`: all gates green; verdict file confirms live-app proof; no
+     blocking findings remain.
+   - `PARTIAL`: useful progress landed but the iteration cap or operator
+     halt ended the loop with at least one non-FAIL blocking finding
+     still open.
+   - `FAIL`: at least one `release_blocking` finding has `status: FAIL`
+     after the loop terminated, or the no-progress detector tripped, or
+     the loop aborted on infrastructure failure.
 
 ## Legacy cleanup prompt
 

--- a/skills/autospec-release/SKILL.md
+++ b/skills/autospec-release/SKILL.md
@@ -193,9 +193,10 @@ the explicit skill invocation was unavailable.
 
    - If the file is missing → verdict is `FAIL` with a synthetic finding
      "qa-verdict.json not produced by Stage 7".
-   - If `head_sha` does not match `git rev-parse HEAD` → cap at `PARTIAL`
-     ("QA verdict is stale relative to current commit"). Re-run Stage 7
-     before accepting any further progress.
+   - If `head_sha` does not match `git rev-parse HEAD` → treat as missing.
+     Synthesize a FAIL finding "QA verdict stale relative to HEAD" and
+     require Stage 7 to re-run in the same iteration before recomputing
+     the verdict.
    - If `live_app_proof: false` → cap at `PARTIAL` regardless of findings.
    - For each finding with `release_blocking: true`:
      - `status: FAIL` → verdict is at least `FAIL` for that finding.
@@ -222,8 +223,15 @@ the explicit skill invocation was unavailable.
        commit, then re-run Stages 3-4.
      - Untriaged `auto-implement` issue or queued blocker → run
        `/autospec-run` on it, then re-run Stages 4-7.
+     - Any other `release_blocking` finding (e.g. `accessibility`,
+       `cross_browser`, `duplicate_code`, `new_code_intent`,
+       `presentational_misclassified`, `other`) → file a tracked GitHub
+       issue with reproduction steps, link it from the release report,
+       then re-run Stage 7.
      After the remediation lands and is committed, re-enter at Stage 2
-     (sweep) and recompute.
+     (sweep) and recompute. Each iteration MUST re-run Stage 7 before
+     recomputing the verdict — a verdict file whose `head_sha` does not
+     match the iteration's current HEAD is treated as missing.
 
    Termination conditions (any one ends the loop):
    - Verdict reached `PASS`.

--- a/skills/autospec-release/codex/prompt.md
+++ b/skills/autospec-release/codex/prompt.md
@@ -154,13 +154,26 @@ the explicit skill invocation was unavailable.
    - Failed tests are work, not report decoration: fix them or create a
      release-blocking issue with exact reproduction.
 
-7. QA proof
-   - Run `/autospec-qa` against the configured local or deployed app.
+7. QA proof (MANDATORY — required for PASS)
+   - Run `/autospec-qa` against a live booted app. Either:
+     (a) boot the app locally (dev or prod build) and exercise it, or
+     (b) point QA at an already-deployed environment whose commit SHA matches
+         HEAD (or is explicitly recorded as the SHA under test).
+   - Mocked unit/integration tests do NOT satisfy this gate. Stage 7 must
+     produce browser- or app-level interaction artifacts (screenshots, DOM
+     snapshots, network traces, or recorded sessions) covering the user-
+     facing surfaces in the release range.
    - Require control-level proof for text boxes, selects, dropdowns, buttons,
      validation, API effects, failure banners, fallback behavior, accessibility,
      and no-mock smoke paths where the repo contract requires them.
    - Validate QA artifacts with
      `skills/autospec-shared/scripts/validate-qa-artifacts.sh` when available.
+   - Do not skip silently. If the app cannot be booted or reached, record the
+     reason, mark Stage 7 as `NOT EXECUTED`, and apply the Stage 9 verdict cap.
+   - After `/autospec-qa` completes, confirm `.autospec/qa-verdict.json`
+     exists with `head_sha` matching current HEAD and `live_app_proof: true`.
+     If absent, stale, or `live_app_proof: false`, the QA gate has not been
+     satisfied for this commit — treat as `NOT EXECUTED` for Stage 9.
 
 8. Legacy cleanup gate
    - Search code, specs, docs, tests, fixtures, config, infra, and examples for
@@ -170,14 +183,64 @@ the explicit skill invocation was unavailable.
    - If a legacy path cannot be removed yet, create a deprecation issue that
      names the owner, replacement path, and removal trigger.
 
-9. Final release verdict
-   - `PASS`: all release gates pass, no release-blocking issues remain, no
-     untested required no-mock path remains, docs match behavior, and legacy
-     cleanup is either complete or explicitly tracked.
-   - `PARTIAL`: useful progress landed, but at least one required gate is not
-     tested or externally blocked.
-   - `FAIL`: a release-blocking test, QA path, review finding, docs mismatch,
-     or legacy conflict remains.
+9. Verdict computation and release iteration loop
+
+   Compute the verdict deterministically from `.autospec/qa-verdict.json`:
+
+   - If the file is missing → verdict is `FAIL` with a synthetic finding
+     "qa-verdict.json not produced by Stage 7".
+   - If `head_sha` does not match `git rev-parse HEAD` → cap at `PARTIAL`
+     ("QA verdict is stale relative to current commit"). Re-run Stage 7
+     before accepting any further progress.
+   - If `live_app_proof: false` → cap at `PARTIAL` regardless of findings.
+   - For each finding with `release_blocking: true`:
+     - `status: FAIL` → verdict is at least `FAIL` for that finding.
+     - `status: PARTIAL` or `NOT_TESTED` → cap at `PARTIAL`.
+   - Otherwise → verdict is `PASS`.
+
+   Hard caps that override the file contents:
+   - "No merged PR in this range requires it" is NOT a valid reason to skip
+     live-app QA or any release-blocking finding. This gate evaluates the
+     cumulative shippable state of the repo, not the diff of the most
+     recent PRs.
+
+   Iteration loop:
+   - If verdict is `PASS`, emit the release report and stop.
+   - Otherwise, do NOT emit a final report yet. Pick the smallest
+     remediation that converts the highest-priority `release_blocking`
+     finding into evidence:
+     - `benchmark_overfit` / `mutation_proof_missing` /
+       `automated_test_gap` → re-enter `/autospec-qa`'s regeneration loop
+       to rewrite the offending tests.
+     - `no_mock_smoke` / `live_backend_blocker` → boot the app or unblock
+       the live backend, then re-run Stage 7.
+     - `spec_contradiction` / `legacy_residue` → fix docs/specs/code in one
+       commit, then re-run Stages 3-4.
+     - Untriaged `auto-implement` issue or queued blocker → run
+       `/autospec-run` on it, then re-run Stages 4-7.
+     After the remediation lands and is committed, re-enter at Stage 2
+     (sweep) and recompute.
+
+   Termination conditions (any one ends the loop):
+   - Verdict reached `PASS`.
+   - Iteration cap hit. Default: 5 iterations. Override:
+     `AUTOSPEC_RELEASE_MAX_ITERATIONS=<n>`. On cap, emit `PARTIAL` with the
+     unresolved findings and the exact next remediation command.
+   - `~/.autospec/stop.flag` is present (operator halt). Emit `PARTIAL`
+     with the current state.
+   - No-progress detector: two consecutive iterations produced an identical
+     set of `release_blocking` findings (by category + summary). Emit
+     `FAIL` with the stuck findings and an escalation note.
+
+   Verdict values:
+   - `PASS`: all gates green; verdict file confirms live-app proof; no
+     blocking findings remain.
+   - `PARTIAL`: useful progress landed but the iteration cap or operator
+     halt ended the loop with at least one non-FAIL blocking finding
+     still open.
+   - `FAIL`: at least one `release_blocking` finding has `status: FAIL`
+     after the loop terminated, or the no-progress detector tripped, or
+     the loop aborted on infrastructure failure.
 
 ## Legacy cleanup prompt
 

--- a/skills/autospec-release/codex/prompt.md
+++ b/skills/autospec-release/codex/prompt.md
@@ -189,9 +189,10 @@ the explicit skill invocation was unavailable.
 
    - If the file is missing → verdict is `FAIL` with a synthetic finding
      "qa-verdict.json not produced by Stage 7".
-   - If `head_sha` does not match `git rev-parse HEAD` → cap at `PARTIAL`
-     ("QA verdict is stale relative to current commit"). Re-run Stage 7
-     before accepting any further progress.
+   - If `head_sha` does not match `git rev-parse HEAD` → treat as missing.
+     Synthesize a FAIL finding "QA verdict stale relative to HEAD" and
+     require Stage 7 to re-run in the same iteration before recomputing
+     the verdict.
    - If `live_app_proof: false` → cap at `PARTIAL` regardless of findings.
    - For each finding with `release_blocking: true`:
      - `status: FAIL` → verdict is at least `FAIL` for that finding.
@@ -218,8 +219,15 @@ the explicit skill invocation was unavailable.
        commit, then re-run Stages 3-4.
      - Untriaged `auto-implement` issue or queued blocker → run
        `/autospec-run` on it, then re-run Stages 4-7.
+     - Any other `release_blocking` finding (e.g. `accessibility`,
+       `cross_browser`, `duplicate_code`, `new_code_intent`,
+       `presentational_misclassified`, `other`) → file a tracked GitHub
+       issue with reproduction steps, link it from the release report,
+       then re-run Stage 7.
      After the remediation lands and is committed, re-enter at Stage 2
-     (sweep) and recompute.
+     (sweep) and recompute. Each iteration MUST re-run Stage 7 before
+     recomputing the verdict — a verdict file whose `head_sha` does not
+     match the iteration's current HEAD is treated as missing.
 
    Termination conditions (any one ends the loop):
    - Verdict reached `PASS`.

--- a/skills/autospec-release/opencode/agent.md
+++ b/skills/autospec-release/opencode/agent.md
@@ -158,13 +158,26 @@ the explicit skill invocation was unavailable.
    - Failed tests are work, not report decoration: fix them or create a
      release-blocking issue with exact reproduction.
 
-7. QA proof
-   - Run `/autospec-qa` against the configured local or deployed app.
+7. QA proof (MANDATORY — required for PASS)
+   - Run `/autospec-qa` against a live booted app. Either:
+     (a) boot the app locally (dev or prod build) and exercise it, or
+     (b) point QA at an already-deployed environment whose commit SHA matches
+         HEAD (or is explicitly recorded as the SHA under test).
+   - Mocked unit/integration tests do NOT satisfy this gate. Stage 7 must
+     produce browser- or app-level interaction artifacts (screenshots, DOM
+     snapshots, network traces, or recorded sessions) covering the user-
+     facing surfaces in the release range.
    - Require control-level proof for text boxes, selects, dropdowns, buttons,
      validation, API effects, failure banners, fallback behavior, accessibility,
      and no-mock smoke paths where the repo contract requires them.
    - Validate QA artifacts with
      `skills/autospec-shared/scripts/validate-qa-artifacts.sh` when available.
+   - Do not skip silently. If the app cannot be booted or reached, record the
+     reason, mark Stage 7 as `NOT EXECUTED`, and apply the Stage 9 verdict cap.
+   - After `/autospec-qa` completes, confirm `.autospec/qa-verdict.json`
+     exists with `head_sha` matching current HEAD and `live_app_proof: true`.
+     If absent, stale, or `live_app_proof: false`, the QA gate has not been
+     satisfied for this commit — treat as `NOT EXECUTED` for Stage 9.
 
 8. Legacy cleanup gate
    - Search code, specs, docs, tests, fixtures, config, infra, and examples for
@@ -174,14 +187,64 @@ the explicit skill invocation was unavailable.
    - If a legacy path cannot be removed yet, create a deprecation issue that
      names the owner, replacement path, and removal trigger.
 
-9. Final release verdict
-   - `PASS`: all release gates pass, no release-blocking issues remain, no
-     untested required no-mock path remains, docs match behavior, and legacy
-     cleanup is either complete or explicitly tracked.
-   - `PARTIAL`: useful progress landed, but at least one required gate is not
-     tested or externally blocked.
-   - `FAIL`: a release-blocking test, QA path, review finding, docs mismatch,
-     or legacy conflict remains.
+9. Verdict computation and release iteration loop
+
+   Compute the verdict deterministically from `.autospec/qa-verdict.json`:
+
+   - If the file is missing → verdict is `FAIL` with a synthetic finding
+     "qa-verdict.json not produced by Stage 7".
+   - If `head_sha` does not match `git rev-parse HEAD` → cap at `PARTIAL`
+     ("QA verdict is stale relative to current commit"). Re-run Stage 7
+     before accepting any further progress.
+   - If `live_app_proof: false` → cap at `PARTIAL` regardless of findings.
+   - For each finding with `release_blocking: true`:
+     - `status: FAIL` → verdict is at least `FAIL` for that finding.
+     - `status: PARTIAL` or `NOT_TESTED` → cap at `PARTIAL`.
+   - Otherwise → verdict is `PASS`.
+
+   Hard caps that override the file contents:
+   - "No merged PR in this range requires it" is NOT a valid reason to skip
+     live-app QA or any release-blocking finding. This gate evaluates the
+     cumulative shippable state of the repo, not the diff of the most
+     recent PRs.
+
+   Iteration loop:
+   - If verdict is `PASS`, emit the release report and stop.
+   - Otherwise, do NOT emit a final report yet. Pick the smallest
+     remediation that converts the highest-priority `release_blocking`
+     finding into evidence:
+     - `benchmark_overfit` / `mutation_proof_missing` /
+       `automated_test_gap` → re-enter `/autospec-qa`'s regeneration loop
+       to rewrite the offending tests.
+     - `no_mock_smoke` / `live_backend_blocker` → boot the app or unblock
+       the live backend, then re-run Stage 7.
+     - `spec_contradiction` / `legacy_residue` → fix docs/specs/code in one
+       commit, then re-run Stages 3-4.
+     - Untriaged `auto-implement` issue or queued blocker → run
+       `/autospec-run` on it, then re-run Stages 4-7.
+     After the remediation lands and is committed, re-enter at Stage 2
+     (sweep) and recompute.
+
+   Termination conditions (any one ends the loop):
+   - Verdict reached `PASS`.
+   - Iteration cap hit. Default: 5 iterations. Override:
+     `AUTOSPEC_RELEASE_MAX_ITERATIONS=<n>`. On cap, emit `PARTIAL` with the
+     unresolved findings and the exact next remediation command.
+   - `~/.autospec/stop.flag` is present (operator halt). Emit `PARTIAL`
+     with the current state.
+   - No-progress detector: two consecutive iterations produced an identical
+     set of `release_blocking` findings (by category + summary). Emit
+     `FAIL` with the stuck findings and an escalation note.
+
+   Verdict values:
+   - `PASS`: all gates green; verdict file confirms live-app proof; no
+     blocking findings remain.
+   - `PARTIAL`: useful progress landed but the iteration cap or operator
+     halt ended the loop with at least one non-FAIL blocking finding
+     still open.
+   - `FAIL`: at least one `release_blocking` finding has `status: FAIL`
+     after the loop terminated, or the no-progress detector tripped, or
+     the loop aborted on infrastructure failure.
 
 ## Legacy cleanup prompt
 

--- a/skills/autospec-release/opencode/agent.md
+++ b/skills/autospec-release/opencode/agent.md
@@ -193,9 +193,10 @@ the explicit skill invocation was unavailable.
 
    - If the file is missing → verdict is `FAIL` with a synthetic finding
      "qa-verdict.json not produced by Stage 7".
-   - If `head_sha` does not match `git rev-parse HEAD` → cap at `PARTIAL`
-     ("QA verdict is stale relative to current commit"). Re-run Stage 7
-     before accepting any further progress.
+   - If `head_sha` does not match `git rev-parse HEAD` → treat as missing.
+     Synthesize a FAIL finding "QA verdict stale relative to HEAD" and
+     require Stage 7 to re-run in the same iteration before recomputing
+     the verdict.
    - If `live_app_proof: false` → cap at `PARTIAL` regardless of findings.
    - For each finding with `release_blocking: true`:
      - `status: FAIL` → verdict is at least `FAIL` for that finding.
@@ -222,8 +223,15 @@ the explicit skill invocation was unavailable.
        commit, then re-run Stages 3-4.
      - Untriaged `auto-implement` issue or queued blocker → run
        `/autospec-run` on it, then re-run Stages 4-7.
+     - Any other `release_blocking` finding (e.g. `accessibility`,
+       `cross_browser`, `duplicate_code`, `new_code_intent`,
+       `presentational_misclassified`, `other`) → file a tracked GitHub
+       issue with reproduction steps, link it from the release report,
+       then re-run Stage 7.
      After the remediation lands and is committed, re-enter at Stage 2
-     (sweep) and recompute.
+     (sweep) and recompute. Each iteration MUST re-run Stage 7 before
+     recomputing the verdict — a verdict file whose `head_sha` does not
+     match the iteration's current HEAD is treated as missing.
 
    Termination conditions (any one ends the loop):
    - Verdict reached `PASS`.


### PR DESCRIPTION
## Summary

Closes the false-PASS path in `/autospec-release` where it would emit PASS while marking "Live e2e:prod smoke" and "Browser-level interactive verification" as NOT TESTED.

- `/autospec-qa` now writes `.autospec/qa-verdict.json` at end of every run (incl. aborts). Schema: `verdict`, `head_sha`, `generated_at`, `live_app_proof`, `artifacts[]`, `findings[]` with `category` + `release_blocking` + `status`.
- New finding category: `benchmark_overfit` — flags tests that hard-code public-benchmark answer keys (ClassyFire InChIKeys, first-N slices, training-on-test fixtures) so QA regenerates them with property-based or seeded-random alternatives.
- `/autospec-release` Stage 7 requires the verdict file with matching `head_sha` and `live_app_proof: true`, else `NOT EXECUTED`.
- Stage 9 is now a deterministic compute + iteration loop. On PARTIAL/FAIL it picks the smallest remediation, re-enters at Stage 2, and recomputes. Terminates on PASS, iteration cap (default 5, `AUTOSPEC_RELEASE_MAX_ITERATIONS`), `~/.autospec/stop.flag`, or a no-progress detector.

## Test plan

- [x] `scripts/validate.sh` green (lockstep + structural lint)
- [ ] Dogfood: run `/autospec-release` on a repo with known-broken live path; confirm it can no longer emit PASS without a fresh verdict file
- [ ] Confirm iteration loop terminates on operator stop.flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)