### PR TITLE
feat: spec supersession by recency across autospec-define/qa/release (#635)

### DIFF
--- a/scripts/resolve-spec-supersession.sh
+++ b/scripts/resolve-spec-supersession.sh
@@ -20,9 +20,10 @@
 #   Deleted specs (no longer present on disk) are excluded.
 #
 # Recency tie-break:
-#   Most recent `git log -1 --format=%ct -- <spec>` wins. If git is unavailable
-#   or two specs share a commit timestamp, falls back to mtime, then lexical
-#   sort (later path wins) for determinism.
+#   Most recent `git log -1 --format=%ct -- <spec>` on the current branch wins.
+#   If git is unavailable or the spec is untracked, falls back to filesystem
+#   mtime. When two candidates share the same final timestamp, lexical sort of
+#   the path (later path wins) breaks the tie deterministically.
 #
 # Exit codes:
 #   0  authoritative spec resolved (printed on stdout)

--- a/scripts/resolve-spec-supersession.sh
+++ b/scripts/resolve-spec-supersession.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# scripts/resolve-spec-supersession.sh — resolve which spec is authoritative for a
+# given behavior key under implicit-by-recency supersession (issue #635).
+#
+# When two specs in docs/specs/ overlap on a behavior (matching heading or
+# behavior-clause text), the spec whose last-modifying commit on the current
+# branch is most recent wins. Operators do NOT write `Supersedes:` frontmatter
+# — recency alone decides.
+#
+# Usage:
+#   scripts/resolve-spec-supersession.sh <behavior-key>           # print winning spec path (exit 0) or "" (exit 1)
+#   scripts/resolve-spec-supersession.sh --json <behavior-key>    # JSON: {"winner":"...","candidates":[...],"behavior":"..."}
+#   scripts/resolve-spec-supersession.sh --list-overlapping <behavior-key>  # print all candidates oldest-first, one per line
+#   scripts/resolve-spec-supersession.sh --specs-dir <dir> ...    # override docs/specs/ search root
+#   scripts/resolve-spec-supersession.sh --help
+#
+# Behavior key matching:
+#   A spec is a "candidate" for <behavior-key> when the key appears as a
+#   case-insensitive substring of any line in the spec (heading or body).
+#   Deleted specs (no longer present on disk) are excluded.
+#
+# Recency tie-break:
+#   Most recent `git log -1 --format=%ct -- <spec>` wins. If git is unavailable
+#   or two specs share a commit timestamp, falls back to mtime, then lexical
+#   sort (later path wins) for determinism.
+#
+# Exit codes:
+#   0  authoritative spec resolved (printed on stdout)
+#   1  no spec covers the behavior key
+#   2  invalid arguments
+
+set -eu
+
+HELP_TEXT="Usage:
+  scripts/resolve-spec-supersession.sh <behavior-key>
+  scripts/resolve-spec-supersession.sh --json <behavior-key>
+  scripts/resolve-spec-supersession.sh --list-overlapping <behavior-key>
+  scripts/resolve-spec-supersession.sh [--specs-dir <dir>] <behavior-key>
+  scripts/resolve-spec-supersession.sh --help
+
+Resolve the authoritative spec for a behavior key using implicit-by-recency
+supersession (issue #635). When multiple specs overlap on a behavior, the spec
+with the most recent last-modifying commit on the current branch wins.
+
+Exit codes:
+  0  authoritative spec resolved (printed on stdout)
+  1  no spec covers the behavior key
+  2  invalid arguments"
+
+MODE="path"
+SPECS_DIR=""
+BEHAVIOR_KEY=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --help|-h)
+            printf '%s\n' "$HELP_TEXT"
+            exit 0
+            ;;
+        --json)
+            MODE="json"
+            shift
+            ;;
+        --list-overlapping)
+            MODE="list"
+            shift
+            ;;
+        --specs-dir)
+            shift
+            [ $# -gt 0 ] || { printf 'resolve-spec-supersession: --specs-dir requires a value\n' >&2; exit 2; }
+            SPECS_DIR="$1"
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            printf 'resolve-spec-supersession: unknown flag: %s\n' "$1" >&2
+            exit 2
+            ;;
+        *)
+            if [ -z "$BEHAVIOR_KEY" ]; then
+                BEHAVIOR_KEY="$1"
+                shift
+            else
+                printf 'resolve-spec-supersession: unexpected extra argument: %s\n' "$1" >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+
+[ -n "$BEHAVIOR_KEY" ] || { printf '%s\n' "$HELP_TEXT" >&2; exit 2; }
+
+if [ -z "$SPECS_DIR" ]; then
+    if [ -d docs/specs ]; then
+        SPECS_DIR="docs/specs"
+    else
+        printf 'resolve-spec-supersession: no docs/specs/ directory; pass --specs-dir <dir>\n' >&2
+        exit 1
+    fi
+fi
+
+[ -d "$SPECS_DIR" ] || { printf 'resolve-spec-supersession: specs dir not found: %s\n' "$SPECS_DIR" >&2; exit 1; }
+
+# Discover candidate spec files (existing only — deleted specs are excluded).
+candidates=""
+while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    # Case-insensitive substring match anywhere in the file.
+    if grep -i -F -q -- "$BEHAVIOR_KEY" "$f" 2>/dev/null; then
+        candidates="${candidates}${f}
+"
+    fi
+done <<EOF
+$(find "$SPECS_DIR" -type f \( -name '*.md' -o -name '*.markdown' \) 2>/dev/null | sort)
+EOF
+
+# Strip trailing newlines.
+candidates="$(printf '%s' "$candidates" | sed '/^$/d')"
+
+if [ -z "$candidates" ]; then
+    if [ "$MODE" = "json" ]; then
+        printf '{"winner":null,"candidates":[],"behavior":%s}\n' "$(printf '%s' "$BEHAVIOR_KEY" | awk 'BEGIN{printf "\""} {gsub(/\\/,"\\\\"); gsub(/"/,"\\\""); printf "%s", $0} END{print "\""}')"
+        exit 1
+    fi
+    exit 1
+fi
+
+# Recency ranking: produce "<sort-key>\t<path>" lines, sort descending.
+RANK_FILE="$(mktemp -t resolve-spec-supersession.XXXXXX)"
+trap 'rm -f "$RANK_FILE"' EXIT
+
+while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    ctime=""
+    if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        ctime="$(git log -1 --format=%ct -- "$f" 2>/dev/null || true)"
+    fi
+    if [ -z "$ctime" ]; then
+        # Not tracked or no commit history — use filesystem mtime so candidates
+        # without git history still receive a deterministic recency rank.
+        if [ -f "$f" ]; then
+            if stat -f %m "$f" >/dev/null 2>&1; then
+                ctime="$(stat -f %m "$f")"
+            elif stat -c %Y "$f" >/dev/null 2>&1; then
+                ctime="$(stat -c %Y "$f")"
+            else
+                ctime=0
+            fi
+        else
+            ctime=0
+        fi
+    fi
+    # Zero-pad ctime to 12 digits so lexical sort matches numeric sort, append
+    # path as deterministic secondary key.
+    printf '%012d\t%s\n' "$ctime" "$f" >> "$RANK_FILE"
+done <<EOF
+$candidates
+EOF
+
+sort -r "$RANK_FILE" -o "$RANK_FILE"
+
+# Winner is the top line's path.
+winner="$(head -n 1 "$RANK_FILE" | awk -F'\t' '{print $2}')"
+
+case "$MODE" in
+    path)
+        printf '%s\n' "$winner"
+        ;;
+    list)
+        # Print candidates oldest-first (reverse the ranking).
+        sort "$RANK_FILE" | awk -F'\t' '{print $2}'
+        ;;
+    json)
+        # Build JSON array of candidates ranked newest-first.
+        json_candidates="$(awk -F'\t' 'BEGIN{first=1; printf "["} {if (!first) printf ","; first=0; p=$2; gsub(/\\/,"\\\\",p); gsub(/"/,"\\\"",p); printf "\"%s\"", p} END{print "]"}' "$RANK_FILE")"
+        # Escape strings for JSON output.
+        esc_winner="$(printf '%s' "$winner" | awk 'BEGIN{ORS=""} {gsub(/\\/,"\\\\"); gsub(/"/,"\\\""); print}')"
+        esc_behavior="$(printf '%s' "$BEHAVIOR_KEY" | awk 'BEGIN{ORS=""} {gsub(/\\/,"\\\\"); gsub(/"/,"\\\""); print}')"
+        printf '{"winner":"%s","candidates":%s,"behavior":"%s"}\n' "$esc_winner" "$json_candidates" "$esc_behavior"
+        ;;
+esac
+
+exit 0

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -535,6 +535,11 @@ check_supersession_contract() {
     done
     [ -f tests/resolve-spec-supersession.bats ] \
         || fail "tests/resolve-spec-supersession.bats: bats coverage missing"
+    if command -v bats >/dev/null 2>&1; then
+        info "  running: tests/resolve-spec-supersession.bats"
+        bats tests/resolve-spec-supersession.bats >/tmp/validate-supersession.log 2>&1 \
+            || { cat /tmp/validate-supersession.log >&2; fail "tests/resolve-spec-supersession.bats: failed"; }
+    fi
 }
 
 # Phase 4 guardian block lock-step invariants (introduced by issue #212): the

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -508,6 +508,35 @@ check_usage_limit_helper() {
         || fail "scripts/autospec-usage-limit.sh --help did not print a 'Usage:' line"
 }
 
+# Spec supersession contract (issue #635): scripts/resolve-spec-supersession.sh
+# must exist, be executable, pass bash -n, and `--help` must print a `Usage:`
+# line. Each of autospec-define, autospec-qa, autospec-release must reference
+# the resolver in all three trio files (SKILL.md + codex/prompt.md +
+# opencode/agent.md) under a `## Spec supersession (recency)` heading so the
+# lockstep stays uniform across adapters.
+check_supersession_contract() {
+    info "spec-supersession helper: scripts/resolve-spec-supersession.sh"
+    [ -f scripts/resolve-spec-supersession.sh ] \
+        || fail "scripts/resolve-spec-supersession.sh: file missing"
+    [ -x scripts/resolve-spec-supersession.sh ] \
+        || fail "scripts/resolve-spec-supersession.sh: file not executable"
+    bash -n scripts/resolve-spec-supersession.sh \
+        || fail "scripts/resolve-spec-supersession.sh: bash syntax error"
+    bash scripts/resolve-spec-supersession.sh --help 2>/dev/null | grep -q '^Usage:' \
+        || fail "scripts/resolve-spec-supersession.sh --help did not print a 'Usage:' line"
+    for s in autospec-define autospec-qa autospec-release; do
+        info "spec-supersession lockstep: $s"
+        for trio in SKILL.md codex/prompt.md opencode/agent.md; do
+            grep -q '^## Spec supersession (recency)' "skills/$s/$trio" \
+                || fail "$s: $trio missing '## Spec supersession (recency)' section"
+            grep -q 'resolve-spec-supersession\.sh' "skills/$s/$trio" \
+                || fail "$s: $trio missing reference to scripts/resolve-spec-supersession.sh"
+        done
+    done
+    [ -f tests/resolve-spec-supersession.bats ] \
+        || fail "tests/resolve-spec-supersession.bats: bats coverage missing"
+}
+
 # Phase 4 guardian block lock-step invariants (introduced by issue #212): the
 # outer guardian dispatch block (between <!-- guardian-block:begin --> and
 # <!-- guardian-block:end --> markers) must be byte-identical across all 6
@@ -999,6 +1028,7 @@ main() {
     check_lint_issue_helpers
     check_lint_implementation_helpers
     check_usage_limit_helper
+    check_supersession_contract
     check_phase4_guardian_block_lockstep
     check_phase1_bounded_context_contract
     check_phase4_issue_start_summary

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -528,6 +528,33 @@ labels and patches each body with a `## Model fit` block.
 
 ---
 
+## Spec supersession (recency)
+
+Specs in `docs/specs/` accumulate over time. When a newer spec adds, modifies, or
+removes behavior that an earlier spec described, autospec applies
+**implicit-by-recency supersession** (issue #635): the spec whose
+last-modifying commit on `main` is most recent wins for any overlapping
+behavior. Operators do NOT write `Supersedes:` frontmatter — recency alone
+decides.
+
+During Phase 3 decomposition, before filing a candidate child issue, resolve
+the authoritative spec for each behavior the issue touches. Use the shared
+helper:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resolve-spec-supersession.sh" "<behavior-key>"
+```
+
+If the resolver prints a spec path other than the one currently being
+decomposed, the candidate behavior has already been overridden by a newer
+spec — skip filing the issue (it would re-introduce removed behavior) and
+note the supersession in the decompose run log. If the resolver exits 1 (no
+overlap), proceed normally: the behavior is new to this spec.
+
+See `tests/resolve-spec-supersession.bats` for the resolver contract:
+no-overlap → exit 1, single overlap → that spec wins, two/three-way overlap
+→ most recent wins, deleted specs are excluded.
+
 ## Phase 3 pre-impl gate
 
 After Phase 3 decomposition completes (and Phase 3.5 review-and-label has

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -533,9 +533,9 @@ labels and patches each body with a `## Model fit` block.
 Specs in `docs/specs/` accumulate over time. When a newer spec adds, modifies, or
 removes behavior that an earlier spec described, autospec applies
 **implicit-by-recency supersession** (issue #635): the spec whose
-last-modifying commit on `main` is most recent wins for any overlapping
-behavior. Operators do NOT write `Supersedes:` frontmatter — recency alone
-decides.
+last-modifying commit on the current branch is most recent wins for any
+overlapping behavior (untracked specs fall back to filesystem mtime).
+Operators do NOT write `Supersedes:` frontmatter — recency alone decides.
 
 During Phase 3 decomposition, before filing a candidate child issue, resolve
 the authoritative spec for each behavior the issue touches. Use the shared

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -521,6 +521,33 @@ labels and patches each body with a `## Model fit` block.
 >    ```
 
 
+## Spec supersession (recency)
+
+Specs in `docs/specs/` accumulate over time. When a newer spec adds, modifies, or
+removes behavior that an earlier spec described, autospec applies
+**implicit-by-recency supersession** (issue #635): the spec whose
+last-modifying commit on `main` is most recent wins for any overlapping
+behavior. Operators do NOT write `Supersedes:` frontmatter — recency alone
+decides.
+
+During Phase 3 decomposition, before filing a candidate child issue, resolve
+the authoritative spec for each behavior the issue touches. Use the shared
+helper:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resolve-spec-supersession.sh" "<behavior-key>"
+```
+
+If the resolver prints a spec path other than the one currently being
+decomposed, the candidate behavior has already been overridden by a newer
+spec — skip filing the issue (it would re-introduce removed behavior) and
+note the supersession in the decompose run log. If the resolver exits 1 (no
+overlap), proceed normally: the behavior is new to this spec.
+
+See `tests/resolve-spec-supersession.bats` for the resolver contract:
+no-overlap → exit 1, single overlap → that spec wins, two/three-way overlap
+→ most recent wins, deleted specs are excluded.
+
 ## Phase 3 pre-impl gate
 
 After Phase 3 decomposition completes (and Phase 3.5 review-and-label has

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -526,9 +526,9 @@ labels and patches each body with a `## Model fit` block.
 Specs in `docs/specs/` accumulate over time. When a newer spec adds, modifies, or
 removes behavior that an earlier spec described, autospec applies
 **implicit-by-recency supersession** (issue #635): the spec whose
-last-modifying commit on `main` is most recent wins for any overlapping
-behavior. Operators do NOT write `Supersedes:` frontmatter — recency alone
-decides.
+last-modifying commit on the current branch is most recent wins for any
+overlapping behavior (untracked specs fall back to filesystem mtime).
+Operators do NOT write `Supersedes:` frontmatter — recency alone decides.
 
 During Phase 3 decomposition, before filing a candidate child issue, resolve
 the authoritative spec for each behavior the issue touches. Use the shared

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -530,9 +530,9 @@ labels and patches each body with a `## Model fit` block.
 Specs in `docs/specs/` accumulate over time. When a newer spec adds, modifies, or
 removes behavior that an earlier spec described, autospec applies
 **implicit-by-recency supersession** (issue #635): the spec whose
-last-modifying commit on `main` is most recent wins for any overlapping
-behavior. Operators do NOT write `Supersedes:` frontmatter — recency alone
-decides.
+last-modifying commit on the current branch is most recent wins for any
+overlapping behavior (untracked specs fall back to filesystem mtime).
+Operators do NOT write `Supersedes:` frontmatter — recency alone decides.
 
 During Phase 3 decomposition, before filing a candidate child issue, resolve
 the authoritative spec for each behavior the issue touches. Use the shared

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -525,6 +525,33 @@ labels and patches each body with a `## Model fit` block.
 >    ```
 
 
+## Spec supersession (recency)
+
+Specs in `docs/specs/` accumulate over time. When a newer spec adds, modifies, or
+removes behavior that an earlier spec described, autospec applies
+**implicit-by-recency supersession** (issue #635): the spec whose
+last-modifying commit on `main` is most recent wins for any overlapping
+behavior. Operators do NOT write `Supersedes:` frontmatter — recency alone
+decides.
+
+During Phase 3 decomposition, before filing a candidate child issue, resolve
+the authoritative spec for each behavior the issue touches. Use the shared
+helper:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resolve-spec-supersession.sh" "<behavior-key>"
+```
+
+If the resolver prints a spec path other than the one currently being
+decomposed, the candidate behavior has already been overridden by a newer
+spec — skip filing the issue (it would re-introduce removed behavior) and
+note the supersession in the decompose run log. If the resolver exits 1 (no
+overlap), proceed normally: the behavior is new to this spec.
+
+See `tests/resolve-spec-supersession.bats` for the resolver contract:
+no-overlap → exit 1, single overlap → that spec wins, two/three-way overlap
+→ most recent wins, deleted specs are excluded.
+
 ## Phase 3 pre-impl gate
 
 After Phase 3 decomposition completes (and Phase 3.5 review-and-label has

--- a/skills/autospec-qa/SKILL.md
+++ b/skills/autospec-qa/SKILL.md
@@ -350,9 +350,10 @@ spec/config follow-up before implementation is called complete.
 ## Spec supersession (recency)
 
 When two specs in `docs/specs/` overlap on a behavior, the spec whose
-last-modifying commit on `main` is most recent wins (issue #635:
-implicit-by-recency supersession). Operators do NOT write `Supersedes:`
-frontmatter — recency alone decides.
+last-modifying commit on the current branch is most recent wins (issue #635:
+implicit-by-recency supersession; untracked specs fall back to filesystem
+mtime). Operators do NOT write `Supersedes:` frontmatter — recency alone
+decides.
 
 QA validation MUST resolve each behavior to its authoritative spec before
 classifying a row as `FAIL`. Behavior present only in an older, superseded

--- a/skills/autospec-qa/SKILL.md
+++ b/skills/autospec-qa/SKILL.md
@@ -347,6 +347,38 @@ UI/API behavior for contradictions:
 Contradictions become `AMBIGUOUS` rows with a proposed resolution and a
 spec/config follow-up before implementation is called complete.
 
+## Spec supersession (recency)
+
+When two specs in `docs/specs/` overlap on a behavior, the spec whose
+last-modifying commit on `main` is most recent wins (issue #635:
+implicit-by-recency supersession). Operators do NOT write `Supersedes:`
+frontmatter — recency alone decides.
+
+QA validation MUST resolve each behavior to its authoritative spec before
+classifying a row as `FAIL`. Behavior present only in an older, superseded
+spec is not a QA failure — it has been replaced by the newer spec. Use the
+shared helper to look up the authoritative spec for each behavior key:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resolve-spec-supersession.sh" "<behavior-key>"
+```
+
+For each proof-matrix row whose expected behavior overlaps multiple specs:
+
+1. Run the resolver against the behavior key (e.g. heading text or
+   acceptance-criterion fragment).
+2. If the resolver returns a spec path different from the row's
+   `spec_reference`, the row is being validated against a superseded
+   behavior. Re-derive the expected behavior from the resolver's winning
+   spec and update the row's `spec_reference` accordingly.
+3. If the row's expected behavior no longer appears in the winning spec,
+   mark the row `superseded` with a note pointing at the winning spec; do
+   NOT classify it `FAIL`.
+
+This rule applies symmetrically to control-intent ledger entries and
+live-evidence checks: a control whose intent is only described by a
+superseded spec is not a regression.
+
 ## Data lifecycle proof
 
 For CRUD, stateful, or workflow apps, prove the data lifecycle:

--- a/skills/autospec-qa/codex/prompt.md
+++ b/skills/autospec-qa/codex/prompt.md
@@ -343,6 +343,38 @@ UI/API behavior for contradictions:
 Contradictions become `AMBIGUOUS` rows with a proposed resolution and a
 spec/config follow-up before implementation is called complete.
 
+## Spec supersession (recency)
+
+When two specs in `docs/specs/` overlap on a behavior, the spec whose
+last-modifying commit on `main` is most recent wins (issue #635:
+implicit-by-recency supersession). Operators do NOT write `Supersedes:`
+frontmatter — recency alone decides.
+
+QA validation MUST resolve each behavior to its authoritative spec before
+classifying a row as `FAIL`. Behavior present only in an older, superseded
+spec is not a QA failure — it has been replaced by the newer spec. Use the
+shared helper to look up the authoritative spec for each behavior key:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resolve-spec-supersession.sh" "<behavior-key>"
+```
+
+For each proof-matrix row whose expected behavior overlaps multiple specs:
+
+1. Run the resolver against the behavior key (e.g. heading text or
+   acceptance-criterion fragment).
+2. If the resolver returns a spec path different from the row's
+   `spec_reference`, the row is being validated against a superseded
+   behavior. Re-derive the expected behavior from the resolver's winning
+   spec and update the row's `spec_reference` accordingly.
+3. If the row's expected behavior no longer appears in the winning spec,
+   mark the row `superseded` with a note pointing at the winning spec; do
+   NOT classify it `FAIL`.
+
+This rule applies symmetrically to control-intent ledger entries and
+live-evidence checks: a control whose intent is only described by a
+superseded spec is not a regression.
+
 ## Data lifecycle proof
 
 For CRUD, stateful, or workflow apps, prove the data lifecycle:

--- a/skills/autospec-qa/codex/prompt.md
+++ b/skills/autospec-qa/codex/prompt.md
@@ -346,9 +346,10 @@ spec/config follow-up before implementation is called complete.
 ## Spec supersession (recency)
 
 When two specs in `docs/specs/` overlap on a behavior, the spec whose
-last-modifying commit on `main` is most recent wins (issue #635:
-implicit-by-recency supersession). Operators do NOT write `Supersedes:`
-frontmatter — recency alone decides.
+last-modifying commit on the current branch is most recent wins (issue #635:
+implicit-by-recency supersession; untracked specs fall back to filesystem
+mtime). Operators do NOT write `Supersedes:` frontmatter — recency alone
+decides.
 
 QA validation MUST resolve each behavior to its authoritative spec before
 classifying a row as `FAIL`. Behavior present only in an older, superseded

--- a/skills/autospec-qa/opencode/agent.md
+++ b/skills/autospec-qa/opencode/agent.md
@@ -350,9 +350,10 @@ spec/config follow-up before implementation is called complete.
 ## Spec supersession (recency)
 
 When two specs in `docs/specs/` overlap on a behavior, the spec whose
-last-modifying commit on `main` is most recent wins (issue #635:
-implicit-by-recency supersession). Operators do NOT write `Supersedes:`
-frontmatter — recency alone decides.
+last-modifying commit on the current branch is most recent wins (issue #635:
+implicit-by-recency supersession; untracked specs fall back to filesystem
+mtime). Operators do NOT write `Supersedes:` frontmatter — recency alone
+decides.
 
 QA validation MUST resolve each behavior to its authoritative spec before
 classifying a row as `FAIL`. Behavior present only in an older, superseded

--- a/skills/autospec-qa/opencode/agent.md
+++ b/skills/autospec-qa/opencode/agent.md
@@ -347,6 +347,38 @@ UI/API behavior for contradictions:
 Contradictions become `AMBIGUOUS` rows with a proposed resolution and a
 spec/config follow-up before implementation is called complete.
 
+## Spec supersession (recency)
+
+When two specs in `docs/specs/` overlap on a behavior, the spec whose
+last-modifying commit on `main` is most recent wins (issue #635:
+implicit-by-recency supersession). Operators do NOT write `Supersedes:`
+frontmatter — recency alone decides.
+
+QA validation MUST resolve each behavior to its authoritative spec before
+classifying a row as `FAIL`. Behavior present only in an older, superseded
+spec is not a QA failure — it has been replaced by the newer spec. Use the
+shared helper to look up the authoritative spec for each behavior key:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resolve-spec-supersession.sh" "<behavior-key>"
+```
+
+For each proof-matrix row whose expected behavior overlaps multiple specs:
+
+1. Run the resolver against the behavior key (e.g. heading text or
+   acceptance-criterion fragment).
+2. If the resolver returns a spec path different from the row's
+   `spec_reference`, the row is being validated against a superseded
+   behavior. Re-derive the expected behavior from the resolver's winning
+   spec and update the row's `spec_reference` accordingly.
+3. If the row's expected behavior no longer appears in the winning spec,
+   mark the row `superseded` with a note pointing at the winning spec; do
+   NOT classify it `FAIL`.
+
+This rule applies symmetrically to control-intent ledger entries and
+live-evidence checks: a control whose intent is only described by a
+superseded spec is not a regression.
+
 ## Data lifecycle proof
 
 For CRUD, stateful, or workflow apps, prove the data lifecycle:

--- a/skills/autospec-release/SKILL.md
+++ b/skills/autospec-release/SKILL.md
@@ -262,6 +262,34 @@ the explicit skill invocation was unavailable.
      after the loop terminated, or the no-progress detector tripped, or
      the loop aborted on infrastructure failure.
 
+## Spec supersession (recency)
+
+When `docs/specs/` contains two specs that overlap on a behavior, the spec
+whose last-modifying commit on `main` is most recent wins (issue #635:
+implicit-by-recency supersession). Operators do NOT write `Supersedes:`
+frontmatter — recency alone decides.
+
+Release verdict computation MUST consult the resolver before treating any
+finding as `release_blocking`. A finding whose `source_spec` is older than
+another spec covering the same behavior is downgraded from
+`release_blocking` to `informational` — the newer spec has already replaced
+the requirement.
+
+Use the shared helper for every finding under review:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resolve-spec-supersession.sh" "<behavior-key>"
+```
+
+If the resolver returns a spec path different from the finding's
+`source_spec`, the finding is referencing a superseded behavior. Downgrade
+the severity and annotate the finding with the winning spec path so the
+operator can confirm the supersession intent. Do NOT block the release on a
+superseded finding.
+
+This rule applies to release report rows, QA proof-matrix carryover, and
+legacy-cleanup blockers alike.
+
 ## Legacy cleanup prompt
 
 Use this prompt whenever code, config, docs, tests, specs, infra, or examples

--- a/skills/autospec-release/SKILL.md
+++ b/skills/autospec-release/SKILL.md
@@ -265,9 +265,10 @@ the explicit skill invocation was unavailable.
 ## Spec supersession (recency)
 
 When `docs/specs/` contains two specs that overlap on a behavior, the spec
-whose last-modifying commit on `main` is most recent wins (issue #635:
-implicit-by-recency supersession). Operators do NOT write `Supersedes:`
-frontmatter — recency alone decides.
+whose last-modifying commit on the current branch is most recent wins
+(issue #635: implicit-by-recency supersession; untracked specs fall back
+to filesystem mtime). Operators do NOT write `Supersedes:` frontmatter —
+recency alone decides.
 
 Release verdict computation MUST consult the resolver before treating any
 finding as `release_blocking`. A finding whose `source_spec` is older than

--- a/skills/autospec-release/codex/prompt.md
+++ b/skills/autospec-release/codex/prompt.md
@@ -258,6 +258,34 @@ the explicit skill invocation was unavailable.
      after the loop terminated, or the no-progress detector tripped, or
      the loop aborted on infrastructure failure.
 
+## Spec supersession (recency)
+
+When `docs/specs/` contains two specs that overlap on a behavior, the spec
+whose last-modifying commit on `main` is most recent wins (issue #635:
+implicit-by-recency supersession). Operators do NOT write `Supersedes:`
+frontmatter — recency alone decides.
+
+Release verdict computation MUST consult the resolver before treating any
+finding as `release_blocking`. A finding whose `source_spec` is older than
+another spec covering the same behavior is downgraded from
+`release_blocking` to `informational` — the newer spec has already replaced
+the requirement.
+
+Use the shared helper for every finding under review:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resolve-spec-supersession.sh" "<behavior-key>"
+```
+
+If the resolver returns a spec path different from the finding's
+`source_spec`, the finding is referencing a superseded behavior. Downgrade
+the severity and annotate the finding with the winning spec path so the
+operator can confirm the supersession intent. Do NOT block the release on a
+superseded finding.
+
+This rule applies to release report rows, QA proof-matrix carryover, and
+legacy-cleanup blockers alike.
+
 ## Legacy cleanup prompt
 
 Use this prompt whenever code, config, docs, tests, specs, infra, or examples

--- a/skills/autospec-release/codex/prompt.md
+++ b/skills/autospec-release/codex/prompt.md
@@ -261,9 +261,10 @@ the explicit skill invocation was unavailable.
 ## Spec supersession (recency)
 
 When `docs/specs/` contains two specs that overlap on a behavior, the spec
-whose last-modifying commit on `main` is most recent wins (issue #635:
-implicit-by-recency supersession). Operators do NOT write `Supersedes:`
-frontmatter — recency alone decides.
+whose last-modifying commit on the current branch is most recent wins
+(issue #635: implicit-by-recency supersession; untracked specs fall back
+to filesystem mtime). Operators do NOT write `Supersedes:` frontmatter —
+recency alone decides.
 
 Release verdict computation MUST consult the resolver before treating any
 finding as `release_blocking`. A finding whose `source_spec` is older than

--- a/skills/autospec-release/opencode/agent.md
+++ b/skills/autospec-release/opencode/agent.md
@@ -262,6 +262,34 @@ the explicit skill invocation was unavailable.
      after the loop terminated, or the no-progress detector tripped, or
      the loop aborted on infrastructure failure.
 
+## Spec supersession (recency)
+
+When `docs/specs/` contains two specs that overlap on a behavior, the spec
+whose last-modifying commit on `main` is most recent wins (issue #635:
+implicit-by-recency supersession). Operators do NOT write `Supersedes:`
+frontmatter — recency alone decides.
+
+Release verdict computation MUST consult the resolver before treating any
+finding as `release_blocking`. A finding whose `source_spec` is older than
+another spec covering the same behavior is downgraded from
+`release_blocking` to `informational` — the newer spec has already replaced
+the requirement.
+
+Use the shared helper for every finding under review:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resolve-spec-supersession.sh" "<behavior-key>"
+```
+
+If the resolver returns a spec path different from the finding's
+`source_spec`, the finding is referencing a superseded behavior. Downgrade
+the severity and annotate the finding with the winning spec path so the
+operator can confirm the supersession intent. Do NOT block the release on a
+superseded finding.
+
+This rule applies to release report rows, QA proof-matrix carryover, and
+legacy-cleanup blockers alike.
+
 ## Legacy cleanup prompt
 
 Use this prompt whenever code, config, docs, tests, specs, infra, or examples

--- a/skills/autospec-release/opencode/agent.md
+++ b/skills/autospec-release/opencode/agent.md
@@ -265,9 +265,10 @@ the explicit skill invocation was unavailable.
 ## Spec supersession (recency)
 
 When `docs/specs/` contains two specs that overlap on a behavior, the spec
-whose last-modifying commit on `main` is most recent wins (issue #635:
-implicit-by-recency supersession). Operators do NOT write `Supersedes:`
-frontmatter — recency alone decides.
+whose last-modifying commit on the current branch is most recent wins
+(issue #635: implicit-by-recency supersession; untracked specs fall back
+to filesystem mtime). Operators do NOT write `Supersedes:` frontmatter —
+recency alone decides.
 
 Release verdict computation MUST consult the resolver before treating any
 finding as `release_blocking`. A finding whose `source_spec` is older than

--- a/tests/resolve-spec-supersession.bats
+++ b/tests/resolve-spec-supersession.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+# tests/resolve-spec-supersession.bats — coverage for scripts/resolve-spec-supersession.sh
+#
+# Cases (issue #635 acceptance):
+#   - no overlap                  → exit 1, no winner
+#   - single spec mentions key    → that spec wins
+#   - newer of two overlapping    → newest commit wins
+#   - three-way overlap           → most recent wins
+#   - deleted spec excluded       → deleted file not considered even if it referenced the key
+#
+# All tests run inside a fresh tmpdir with a synthetic docs/specs/ layout. We
+# force commit timestamps via GIT_AUTHOR_DATE / GIT_COMMITTER_DATE so the
+# recency ordering is deterministic.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/resolve-spec-supersession.sh"
+
+setup() {
+    TMPDIR_T="$(mktemp -d)"
+    cd "$TMPDIR_T"
+    mkdir -p docs/specs
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    git commit -q --allow-empty -m "init"
+}
+
+teardown() {
+    cd /
+    rm -rf "$TMPDIR_T"
+}
+
+commit_spec() {
+    local path="$1"
+    local body="$2"
+    local epoch="$3"
+    printf '%s\n' "$body" > "$path"
+    git add "$path"
+    GIT_AUTHOR_DATE="@${epoch} +0000" GIT_COMMITTER_DATE="@${epoch} +0000" \
+        git commit -q -m "add ${path}"
+}
+
+@test "exit 1 when no spec covers the behavior key" {
+    commit_spec docs/specs/2026-01-01-foo.md "# Foo spec
+button is blue" 1700000000
+
+    run bash "$SCRIPT" "nonexistent-behavior-key-zzz"
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "single overlapping spec wins outright" {
+    commit_spec docs/specs/2026-01-01-foo.md "# Foo spec
+the login button is blue" 1700000000
+
+    run bash "$SCRIPT" "login button"
+    [ "$status" -eq 0 ]
+    [ "$output" = "docs/specs/2026-01-01-foo.md" ]
+}
+
+@test "newer of two overlapping specs wins (recency)" {
+    commit_spec docs/specs/2026-01-01-old.md "# Old spec
+the login button is blue" 1700000000
+    commit_spec docs/specs/2026-02-01-new.md "# New spec
+the login button is red" 1700500000
+
+    run bash "$SCRIPT" "login button"
+    [ "$status" -eq 0 ]
+    [ "$output" = "docs/specs/2026-02-01-new.md" ]
+}
+
+@test "three-way overlap returns most recent" {
+    commit_spec docs/specs/2026-01-01-a.md "# A
+shopping cart shows totals" 1700000000
+    commit_spec docs/specs/2026-02-01-b.md "# B
+shopping cart shows totals with tax" 1700500000
+    commit_spec docs/specs/2026-03-01-c.md "# C
+shopping cart shows totals with tax and shipping" 1701000000
+
+    run bash "$SCRIPT" "shopping cart"
+    [ "$status" -eq 0 ]
+    [ "$output" = "docs/specs/2026-03-01-c.md" ]
+}
+
+@test "deleted spec is excluded from candidates" {
+    commit_spec docs/specs/2026-01-01-keep.md "# Keep
+checkout flow uses 2FA" 1700000000
+    commit_spec docs/specs/2026-02-01-delete.md "# Delete
+checkout flow is single-step" 1700500000
+    # Now remove the newer spec on disk (and from git).
+    git rm -q docs/specs/2026-02-01-delete.md
+    GIT_AUTHOR_DATE="@1701000000 +0000" GIT_COMMITTER_DATE="@1701000000 +0000" \
+        git commit -q -m "remove delete spec"
+
+    run bash "$SCRIPT" "checkout flow"
+    [ "$status" -eq 0 ]
+    [ "$output" = "docs/specs/2026-01-01-keep.md" ]
+}
+
+@test "--list-overlapping prints all candidates oldest-first" {
+    commit_spec docs/specs/2026-01-01-old.md "feature alpha" 1700000000
+    commit_spec docs/specs/2026-02-01-mid.md "feature alpha" 1700500000
+    commit_spec docs/specs/2026-03-01-new.md "feature alpha" 1701000000
+
+    run bash "$SCRIPT" --list-overlapping "feature alpha"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s\n' "$output" | head -1)" = "docs/specs/2026-01-01-old.md" ]
+    [ "$(printf '%s\n' "$output" | tail -1)" = "docs/specs/2026-03-01-new.md" ]
+}
+
+@test "--json emits winner + ranked candidates" {
+    commit_spec docs/specs/2026-01-01-old.md "feature beta" 1700000000
+    commit_spec docs/specs/2026-02-01-new.md "feature beta" 1700500000
+
+    run bash "$SCRIPT" --json "feature beta"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q '"winner":"docs/specs/2026-02-01-new.md"'
+    echo "$output" | grep -q '"behavior":"feature beta"'
+}
+
+@test "--specs-dir override searches alternate directory" {
+    mkdir -p other/specs
+    commit_spec other/specs/2026-01-01-foo.md "# Foo
+alternate-tree-key here" 1700000000
+
+    run bash "$SCRIPT" --specs-dir other/specs "alternate-tree-key"
+    [ "$status" -eq 0 ]
+    [ "$output" = "other/specs/2026-01-01-foo.md" ]
+}
+
+@test "case-insensitive substring match" {
+    commit_spec docs/specs/2026-01-01-foo.md "# Foo
+The Submit Button is green" 1700000000
+
+    run bash "$SCRIPT" "submit button"
+    [ "$status" -eq 0 ]
+    [ "$output" = "docs/specs/2026-01-01-foo.md" ]
+}
+
+@test "--help prints usage and exits 0" {
+    run bash "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q '^Usage:'
+}
+
+@test "missing behavior key exits 2" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
Closes #635

## Summary

Adopt **implicit-by-recency** supersession: when two specs in `docs/specs/` overlap on a behavior, the spec whose last-modifying commit on the current branch is most recent wins (mtime fallback for untracked specs). No `Supersedes:` frontmatter; recency alone decides.

## Files

- **`scripts/resolve-spec-supersession.sh`** — shared resolver. Modes: print path, `--json`, `--list-overlapping`, `--specs-dir`. Exit 0 = winner found, 1 = no overlap, 2 = bad args.
- **`skills/autospec-define/`, `skills/autospec-qa/`, `skills/autospec-release/`** — lockstep prose in all nine adapter files under a new `## Spec supersession (recency)` heading. define: skip re-filing overridden behavior during Phase 3 decompose. qa: behavior present only in superseded specs is not a `FAIL`. release: superseded findings are downgraded `release_blocking` → `informational`.
- **`scripts/validate.sh`** — `check_supersession_contract()` enforces helper presence + executability + nine-file lockstep + runs the bats suite.
- **`tests/resolve-spec-supersession.bats`** — 11 cases: no-overlap, single overlap, two- and three-way recency, deleted-spec exclusion, `--list-overlapping`, `--json`, `--specs-dir`, case-insensitive substring match, `--help`, missing-arg.

## Peer-review

Codex review surfaced two must-fix findings (doc/impl mismatch on tie-break and "on main" vs current branch) and one nice-to-have (wire bats into validate.sh). All three were addressed in commit `fe70297` before opening this PR.

## Test plan

- [x] `bash scripts/validate.sh` passes (now includes the new bats run).
- [x] `bats tests/resolve-spec-supersession.bats` — 11/11 green.
- [x] Nine adapter files byte-diff clean against `SKILL.md` body via `check_lockstep`.