### PR TITLE
fix: qa-brute-force-sweep.sh per-function scope (closes #640)

### DIFF
--- a/scripts/qa-brute-force-sweep.sh
+++ b/scripts/qa-brute-force-sweep.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 # scripts/qa-brute-force-sweep.sh
 #
-# autospec-qa brute-force string-heuristics sweep (issue #637).
+# autospec-qa brute-force string-heuristics sweep (issue #637, refined #640).
 #
 # Scans REPO_DIR for already-merged code that matches either of the two
 # LLM-tier RULE_IDs:
 #   - STRING_MATCH_DOMAIN_LOGIC      (substring-on-name encoding domain
 #                                     meaning while a proper-rep library
 #                                     is imported in the same file)
-#   - REPEATED_STRUCTURE_AS_CODE     (>=5 branches in one function/method
+#   - REPEATED_STRUCTURE_AS_CODE     (>=5 branches in ONE function/method
 #                                     sharing identical structural shape)
 #
 # Supported languages: Python, JavaScript/TypeScript, Go, Java, Scala, Rust.
+#
+# REPEATED_STRUCTURE_AS_CODE is scoped per-function (issue #640): we parse
+# function boundaries with a cheap per-language regex, count same-shape
+# branches inside each range, and emit one finding per offending function.
 #
 # For each offender we:
 #   1. Append a finding to $VERDICT_FILE (qa-verdict.json) under the
@@ -39,14 +43,8 @@ mkdir -p "$(dirname "$VERDICT_FILE")"
 DIRECTIVE_STRING_MATCH='Replace substring checks with the proper domain primitive (SMARTS/AST/parsed URL/IP/date/schema). Substring-on-name is brittle to synonyms, locants, salt forms, escaping, and case.'
 DIRECTIVE_REPEATED_STRUCTURE='Extract the N branches into a table + single dispatcher loop. In Python use a list of tuples or dict; in Java/Scala use a Map/sealed-trait registry; in Rust use a &[(predicate, value)] slice; in Go use a []struct{...} table. Each new entry should be one row, not a ~10-line block.'
 
-# Per-language ext -> (lang-tag, proper-rep-library-pattern).
-# The lang-tag is what gets written into qa-verdict.json `language` field.
 emit_finding() {
     local file="$1" lang="$2" rule_id="$3" line="$4" func="$5"
-    # Append a compact JSON line; the caller is responsible for wrapping
-    # these into a valid JSON document downstream. We use a leniently
-    # structured append because qa-verdict.json is consumed by `jq` in
-    # autospec-qa with a `if file is not valid JSON, rebuild it` guard.
     printf '{"category":"code_health:brute_force_string_heuristics","rule_id":"%s","language":"%s","file":"%s","function":"%s","line":%s}\n' \
         "$rule_id" "$lang" "$file" "$func" "$line" >> "$VERDICT_FILE"
 }
@@ -81,7 +79,9 @@ has_proper_rep_library() {
     esac
 }
 
-# Heuristic: count substring-style checks in the file.
+# Heuristic: count substring-style checks in the file (used only for
+# STRING_MATCH_DOMAIN_LOGIC which remains a file-scope heuristic — the
+# proper-rep-library import already scopes it).
 count_substring_checks() {
     local file="$1" lang="$2"
     case "$lang" in
@@ -94,60 +94,275 @@ count_substring_checks() {
     esac
 }
 
-# Heuristic: count repeated branch-shaped structures in the file.
-count_repeated_branches() {
-    local file="$1"
-    # if/elif (Python), case (switch arms), match arms — count whichever wins.
-    local a b c
-    a=$(grep -cE '^\s*(if|elif|else if)\b.*:' "$file" || true)
-    b=$(grep -cE '^\s*case\b' "$file" || true)
-    c=$(grep -cE '^\s*if\s+.*\{.*return' "$file" || true)
-    # union (max-ish): pick the largest of the three
-    printf '%s\n' "$a" "$b" "$c" | sort -nr | head -1
-}
-
-# Try to detect the function name an offending block lives in. Best-effort.
-detect_function() {
+# Detect a file-level function name for the STRING_MATCH_DOMAIN_LOGIC
+# finding (file-scoped rule). Best-effort; falls back to <unknown>.
+detect_first_function() {
     local file="$1" lang="$2"
     case "$lang" in
         python)     grep -m1 -oE '^def [A-Za-z_][A-Za-z0-9_]*' "$file" | head -1 | awk '{print $2}' ;;
         javascript) grep -m1 -oE '\bfunction [A-Za-z_][A-Za-z0-9_]*' "$file" | head -1 | awk '{print $2}' ;;
         go)         grep -m1 -oE '^func\s+([A-Za-z_][A-Za-z0-9_]*\s*\)\s*)?[A-Za-z_][A-Za-z0-9_]*' "$file" | head -1 | awk '{print $NF}' ;;
-        java)       grep -m1 -oE '\b(public|private|protected)?\s*[A-Za-z_<>,\s]+\s+[A-Za-z_][A-Za-z0-9_]*\(' "$file" | head -1 ;;
+        java)       grep -m1 -oE '\b(public|private|protected)\s+[A-Za-z_<>,\s\[\]]+\s+[A-Za-z_][A-Za-z0-9_]*\(' "$file" | head -1 | grep -oE '[A-Za-z_][A-Za-z0-9_]*\(' | head -1 | tr -d '(' ;;
         scala)      grep -m1 -oE '\bdef [A-Za-z_][A-Za-z0-9_]*' "$file" | head -1 | awk '{print $2}' ;;
         rust)       grep -m1 -oE '\bfn [A-Za-z_][A-Za-z0-9_]*' "$file" | head -1 | awk '{print $2}' ;;
     esac
 }
 
-scan_file() {
+# ---- per-function range parsing (issue #640) ----
+#
+# Emit "start_line end_line name" rows on stdout, one per function in $file.
+# Cheap regexes — intentional, see header note.
+
+function_ranges_python() {
+    # Python: function range = def line through (last line at deeper indent
+    # before another def at <= same indent OR EOF). We use awk to track
+    # indentation.
+    local file="$1"
+    awk '
+        function flush(   i) {
+            if (start_line) {
+                print start_line, last_line, fname
+            }
+            start_line = 0
+        }
+        /^[[:space:]]*def[[:space:]]+[A-Za-z_][A-Za-z0-9_]*/ {
+            # measure indent of this def
+            match($0, /^[[:space:]]*/)
+            this_indent = RLENGTH
+            if (start_line && this_indent <= def_indent) flush()
+            # extract name
+            line = $0
+            sub(/^[[:space:]]*def[[:space:]]+/, "", line)
+            sub(/[(:].*$/, "", line)
+            fname = line
+            start_line = NR
+            def_indent = this_indent
+            last_line = NR
+            next
+        }
+        {
+            if (start_line && NF > 0) {
+                match($0, /^[[:space:]]*/)
+                if (RLENGTH > def_indent) last_line = NR
+                else if (NF > 0) flush()
+            }
+        }
+        END { flush() }
+    ' "$file"
+}
+
+function_ranges_brace() {
+    # Generic brace-language range parser used by JS/TS, Go, Java, Scala, Rust.
+    # Finds function/method signature lines per language via `awk` keyword
+    # detection (BSD-awk compatible — no ERE capture groups), then walks
+    # `{`/`}` to find the matching close brace.
     local file="$1" lang="$2"
-    [ -r "$file" ] || return 0
 
-    local subs reps
+    awk -v lang="$lang" '
+        function is_sig(s,   r) {
+            if (lang == "javascript") {
+                return (s ~ /(^|[^A-Za-z0-9_])function[[:space:]]+[A-Za-z_]/)
+            } else if (lang == "go") {
+                return (s ~ /^func[[:space:]]/)
+            } else if (lang == "java") {
+                # access modifier + ident + ( ... ) + {  (rough)
+                return (s ~ /(public|private|protected)[[:space:]].*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\(/) \
+                    && (s ~ /\{/ || s !~ /;[[:space:]]*$/)
+            } else if (lang == "scala") {
+                return (s ~ /(^|[^A-Za-z0-9_])def[[:space:]]+[A-Za-z_]/)
+            } else if (lang == "rust") {
+                return (s ~ /(^|[^A-Za-z0-9_])fn[[:space:]]+[A-Za-z_]/)
+            }
+            return 0
+        }
+        function extract_name(s,   t, kw_re) {
+            if (lang == "javascript") kw_re = "function[[:space:]]+"
+            else if (lang == "go")     kw_re = "func[[:space:]]+"
+            else if (lang == "scala")  kw_re = "def[[:space:]]+"
+            else if (lang == "rust")   kw_re = "fn[[:space:]]+"
+            else                        kw_re = ""
+            if (kw_re != "") {
+                if (match(s, kw_re "[A-Za-z_][A-Za-z0-9_]*")) {
+                    t = substr(s, RSTART, RLENGTH)
+                    sub("^" kw_re, "", t)
+                    # for go, strip leading receiver group remnants — rare
+                    return t
+                }
+            } else {
+                # java path — find ident followed by ( after access modifier
+                if (match(s, /[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\(/)) {
+                    t = substr(s, RSTART, RLENGTH)
+                    sub(/[[:space:]]*\(.*/, "", t)
+                    return t
+                }
+            }
+            return "<unknown>"
+        }
+        {
+            line = $0
+            # strip line comments to avoid counting braces in `// {`
+            gsub(/\/\/.*/, "", line)
+            if (!in_fn) {
+                if (is_sig($0)) {
+                    fname = extract_name($0)
+                    start_line = NR
+                    last_line = NR
+                    n_open = gsub(/\{/, "{", line)
+                    n_close = gsub(/\}/, "}", line)
+                    depth = n_open - n_close
+                    if (depth > 0) {
+                        in_fn = 1
+                    } else if (n_open > 0 && depth == 0) {
+                        # single-line function body — emit
+                        print start_line, NR, fname
+                    }
+                    next
+                }
+            } else {
+                last_line = NR
+                n_open = gsub(/\{/, "{", line)
+                n_close = gsub(/\}/, "}", line)
+                depth += n_open - n_close
+                if (depth <= 0) {
+                    print start_line, NR, fname
+                    in_fn = 0
+                }
+            }
+        }
+        END {
+            if (in_fn) print start_line, last_line, fname
+        }
+    ' "$file"
+}
+
+function_ranges() {
+    local file="$1" lang="$2"
+    case "$lang" in
+        python) function_ranges_python "$file" ;;
+        javascript|go|java|scala|rust) function_ranges_brace "$file" "$lang" ;;
+    esac
+}
+
+# Within a function range [start..end], collect branch "shape signatures":
+# first 8 chars after the `if`/`elif`/`case`/`match` keyword. Returns the
+# max count of any single shape repeated within the range, and the line
+# number of the first occurrence of the dominant shape.
+#
+# Output: "<max_count> <first_line>" (or "0 0" if nothing).
+dominant_branch_shape() {
+    local file="$1" lang="$2" start="$3" end="$4"
+    awk -v start="$start" -v end="$end" -v lang="$lang" '
+        NR < start { next }
+        NR > end   { exit }
+        {
+            # strip leading whitespace
+            s = $0
+            sub(/^[[:space:]]+/, "", s)
+            kw = ""
+            rest = ""
+            if (lang == "python") {
+                if (match(s, /^(if|elif)[[:space:]]+/)) {
+                    kw = "if"
+                    rest = substr(s, RLENGTH+1)
+                }
+            } else if (lang == "scala") {
+                if (match(s, /^case[[:space:]]+/)) {
+                    kw = "case"
+                    rest = substr(s, RLENGTH+1)
+                } else if (match(s, /^(if|else if)[[:space:]]*\(/)) {
+                    kw = "if"
+                    rest = substr(s, RLENGTH+1)
+                }
+            } else if (lang == "go") {
+                if (match(s, /^case[[:space:]]+/)) {
+                    kw = "case"
+                    rest = substr(s, RLENGTH+1)
+                } else if (match(s, /^if[[:space:]]+/)) {
+                    kw = "if"
+                    rest = substr(s, RLENGTH+1)
+                }
+            } else {
+                # javascript / java / rust
+                if (match(s, /^(if|else if)[[:space:]]*\(/)) {
+                    kw = "if"
+                    rest = substr(s, RLENGTH+1)
+                } else if (match(s, /^case[[:space:]]+/)) {
+                    kw = "case"
+                    rest = substr(s, RLENGTH+1)
+                } else if (lang == "rust" && match(s, /^if[[:space:]]+/)) {
+                    kw = "if"
+                    rest = substr(s, RLENGTH+1)
+                }
+            }
+            if (kw == "") next
+            # shape = first 8 chars of rest, with string literals + numbers
+            # normalized away so e.g. `"acid" in name` and `"alcohol" in name`
+            # collapse to the same shape (`"" in na`). Spec: issue #640
+            # "same first 8 characters after the if/case/match keyword,
+            # repeated >=5 times" — applied AFTER literal normalization so
+            # ladders that only differ in their string/number arguments
+            # still count as one shape.
+            gsub(/"[^"]*"/, "\"\"", rest)
+            gsub(/'\''[^'\'']*'\''/, "''", rest)
+            gsub(/[0-9]+/, "N", rest)
+            gsub(/[[:space:]]+/, " ", rest)
+            shape = substr(rest, 1, 8)
+            key = kw "|" shape
+            count[key]++
+            if (!(key in firstline)) firstline[key] = NR
+            if (count[key] > maxc) {
+                maxc = count[key]
+                maxline = firstline[key]
+            }
+        }
+        END {
+            if (maxc == "") maxc = 0
+            if (maxline == "") maxline = 0
+            print maxc, maxline
+        }
+    ' "$file"
+}
+
+scan_file_string_match() {
+    local file="$1" lang="$2"
+    local subs func line
     subs=$(count_substring_checks "$file" "$lang")
-    reps=$(count_repeated_branches "$file")
     subs="${subs:-0}"
-    reps="${reps:-0}"
-
-    local func line
-    func=$(detect_function "$file" "$lang")
-    func="${func:-<unknown>}"
-    line=$(grep -nE '\b(contains|includes|in name|in s)\b' "$file" 2>/dev/null | head -1 | cut -d: -f1)
-    line="${line:-1}"
-
-    # STRING_MATCH_DOMAIN_LOGIC requires substring checks AND a proper-rep
-    # library imported in the same file.
     if [ "$subs" -ge 3 ] && has_proper_rep_library "$file" "$lang"; then
+        func=$(detect_first_function "$file" "$lang")
+        func="${func:-<unknown>}"
+        line=$(grep -nE '\b(contains|includes|in name|in s)\b' "$file" 2>/dev/null | head -1 | cut -d: -f1)
+        line="${line:-1}"
         emit_finding "$file" "$lang" "STRING_MATCH_DOMAIN_LOGIC" "$line" "$func"
         file_issue "$file" "$lang" "STRING_MATCH_DOMAIN_LOGIC" "$line" "$func" "$DIRECTIVE_STRING_MATCH"
     fi
+}
 
-    # REPEATED_STRUCTURE_AS_CODE — >=5 branch-shaped lines in one file
-    # (file-level heuristic, refined by LLM at PR time).
-    if [ "$reps" -ge 5 ]; then
-        emit_finding "$file" "$lang" "REPEATED_STRUCTURE_AS_CODE" "$line" "$func"
-        file_issue "$file" "$lang" "REPEATED_STRUCTURE_AS_CODE" "$line" "$func" "$DIRECTIVE_REPEATED_STRUCTURE"
-    fi
+scan_file_repeated_structure() {
+    local file="$1" lang="$2"
+    # For each function range, count dominant branch shape; emit a finding
+    # per function meeting the >=5 threshold.
+    function_ranges "$file" "$lang" | while read -r start end fname; do
+        [ -n "${start:-}" ] || continue
+        [ -n "${end:-}" ] || continue
+        [ -n "${fname:-}" ] || fname="<unknown>"
+        # ranges of <3 lines can't fit 5 branches — skip
+        if [ "$((end - start))" -lt 4 ]; then continue; fi
+        read -r maxc maxline <<<"$(dominant_branch_shape "$file" "$lang" "$start" "$end")"
+        maxc="${maxc:-0}"
+        maxline="${maxline:-0}"
+        if [ "$maxc" -ge 5 ] && [ "$maxline" -gt 0 ]; then
+            emit_finding "$file" "$lang" "REPEATED_STRUCTURE_AS_CODE" "$maxline" "$fname"
+            file_issue "$file" "$lang" "REPEATED_STRUCTURE_AS_CODE" "$maxline" "$fname" "$DIRECTIVE_REPEATED_STRUCTURE"
+        fi
+    done
+}
+
+scan_file() {
+    local file="$1" lang="$2"
+    [ -r "$file" ] || return 0
+    scan_file_string_match "$file" "$lang"
+    scan_file_repeated_structure "$file" "$lang"
 }
 
 scan_lang() {

--- a/scripts/qa-brute-force-sweep.sh
+++ b/scripts/qa-brute-force-sweep.sh
@@ -161,7 +161,19 @@ function_ranges_brace() {
     awk -v lang="$lang" '
         function is_sig(s,   r) {
             if (lang == "javascript") {
-                return (s ~ /(^|[^A-Za-z0-9_])function[[:space:]]+[A-Za-z_]/)
+                # Accept: classic `function name(`, arrow `const name = (...) =>`,
+                # class/object methods `name(...) {`, and `name: function(`.
+                # Method form requires `{` on the same line to avoid matching
+                # bare call sites; arrow form matches `=>` anywhere on the line.
+                # Exclude lines whose leading identifier is a JS control-flow
+                # keyword so `switch (x) {` / `for (...) {` etc. do not get
+                # mistaken for a method signature.
+                if (s ~ /^[[:space:]]*(if|else|for|while|do|switch|case|catch|try|return|throw|with|typeof|new|in|of|delete|void|yield|await|async)[[:space:]]*[\({]/) return 0
+                return (s ~ /(^|[^A-Za-z0-9_])function[[:space:]]+[A-Za-z_]/) \
+                    || (s ~ /(^|[^A-Za-z0-9_])(const|let|var)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*(\([^)]*\)|[A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=>/) \
+                    || (s ~ /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\([^)]*\)[[:space:]]*\{/) \
+                    || (s ~ /[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:[[:space:]]*function[[:space:]]*\(/) \
+                    || (s ~ /[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:[[:space:]]*(\([^)]*\)|[A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=>/)
             } else if (lang == "go") {
                 return (s ~ /^func[[:space:]]/)
             } else if (lang == "java") {
@@ -176,16 +188,37 @@ function_ranges_brace() {
             return 0
         }
         function extract_name(s,   t, kw_re) {
-            if (lang == "javascript") kw_re = "function[[:space:]]+"
-            else if (lang == "go")     kw_re = "func[[:space:]]+"
-            else if (lang == "scala")  kw_re = "def[[:space:]]+"
-            else if (lang == "rust")   kw_re = "fn[[:space:]]+"
-            else                        kw_re = ""
+            if (lang == "javascript") {
+                # classic function
+                if (match(s, /function[[:space:]]+[A-Za-z_][A-Za-z0-9_]*/)) {
+                    t = substr(s, RSTART, RLENGTH)
+                    sub(/^function[[:space:]]+/, "", t)
+                    return t
+                }
+                # arrow: const|let|var NAME =
+                if (match(s, /(const|let|var)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=/)) {
+                    t = substr(s, RSTART, RLENGTH)
+                    sub(/^(const|let|var)[[:space:]]+/, "", t)
+                    sub(/[[:space:]]*=.*/, "", t)
+                    return t
+                }
+                # object/class member: NAME:  or  NAME(
+                if (match(s, /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[(:]/)) {
+                    t = substr(s, RSTART, RLENGTH)
+                    sub(/^[[:space:]]*/, "", t)
+                    sub(/[[:space:]]*[(:].*/, "", t)
+                    return t
+                }
+                return "<unknown>"
+            }
+            if (lang == "go")         kw_re = "func[[:space:]]+"
+            else if (lang == "scala") kw_re = "def[[:space:]]+"
+            else if (lang == "rust")  kw_re = "fn[[:space:]]+"
+            else                       kw_re = ""
             if (kw_re != "") {
                 if (match(s, kw_re "[A-Za-z_][A-Za-z0-9_]*")) {
                     t = substr(s, RSTART, RLENGTH)
                     sub("^" kw_re, "", t)
-                    # for go, strip leading receiver group remnants — rare
                     return t
                 }
             } else {

--- a/tests/qa/test_brute_force_sweep.bats
+++ b/tests/qa/test_brute_force_sweep.bats
@@ -2,18 +2,12 @@
 # tests/qa/test_brute_force_sweep.bats
 #
 # Fixture-driven test for the autospec-qa brute-force string-heuristics sweep
-# introduced in issue #637. We synthesize offender files in each of the six
-# supported languages (Python, JS/TS, Go, Java, Scala, Rust), mock `gh`, and
-# assert that the sweep:
-#   1. Emits a `code_health:brute_force_string_heuristics` finding per
-#      language into `.autospec/qa-verdict.json`.
-#   2. Files one `auto-implement,autospec:v2-flow` GitHub issue per offender
-#      via `gh issue create`, with the file/function/line and the verbatim
-#      RULE_ID directive in the body.
+# introduced in issue #637 and refined in issue #640 (per-function scope).
 #
-# Because the sweep itself is what's under test, mocking `gh` is the right
-# call (per the issue scope). All other fixtures are real source files on
-# disk that the sweep grep/heuristic pass will see.
+# The sweep now scopes REPEATED_STRUCTURE_AS_CODE branch-counting to
+# individual function bodies and emits findings only when 5+ same-shape
+# branches appear within ONE function. Scattering branches across multiple
+# functions must NOT emit a finding.
 
 REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
 SWEEP="${REPO_ROOT}/scripts/qa-brute-force-sweep.sh"
@@ -22,6 +16,8 @@ setup() {
     TMPDIR_FIXT="$(mktemp -d)"
     export TMPDIR_FIXT
     mkdir -p "$TMPDIR_FIXT/.autospec"
+
+    # ----- positive offenders (5+ same-shape branches in ONE function) -----
 
     # synthetic offender — Python with rdkit imported + substring-on-name ladder
     mkdir -p "$TMPDIR_FIXT/src"
@@ -117,6 +113,75 @@ fn classify(name: &str) -> (&str, i32) {
 }
 RUST
 
+    # ----- negative cases (#640): branches scattered across functions -----
+    # 5 unrelated `if` lines across 5 different functions in each language —
+    # must produce ZERO findings for REPEATED_STRUCTURE_AS_CODE.
+
+    mkdir -p "$TMPDIR_FIXT/neg"
+
+    cat >"$TMPDIR_FIXT/neg/scattered.py" <<'PY'
+def a(x):
+    if x > 0:
+        return 1
+def b(x):
+    if x > 0:
+        return 2
+def c(x):
+    if x > 0:
+        return 3
+def d(x):
+    if x > 0:
+        return 4
+def e(x):
+    if x > 0:
+        return 5
+PY
+
+    cat >"$TMPDIR_FIXT/neg/scattered.ts" <<'TS'
+function a(x: number) { if (x > 0) return 1; }
+function b(x: number) { if (x > 0) return 2; }
+function c(x: number) { if (x > 0) return 3; }
+function d(x: number) { if (x > 0) return 4; }
+function e(x: number) { if (x > 0) return 5; }
+TS
+
+    cat >"$TMPDIR_FIXT/neg/scattered.go" <<'GO'
+package main
+func a(x int) int { if x > 0 { return 1 }; return 0 }
+func b(x int) int { if x > 0 { return 2 }; return 0 }
+func c(x int) int { if x > 0 { return 3 }; return 0 }
+func d(x int) int { if x > 0 { return 4 }; return 0 }
+func e(x int) int { if x > 0 { return 5 }; return 0 }
+GO
+
+    cat >"$TMPDIR_FIXT/neg/Scattered.java" <<'JAVA'
+public class Scattered {
+    public int a(int x) { if (x > 0) return 1; return 0; }
+    public int b(int x) { if (x > 0) return 2; return 0; }
+    public int c(int x) { if (x > 0) return 3; return 0; }
+    public int d(int x) { if (x > 0) return 4; return 0; }
+    public int e(int x) { if (x > 0) return 5; return 0; }
+}
+JAVA
+
+    cat >"$TMPDIR_FIXT/neg/Scattered.scala" <<'SCALA'
+object Scattered {
+  def a(x: Int): Int = { if (x > 0) return 1; 0 }
+  def b(x: Int): Int = { if (x > 0) return 2; 0 }
+  def c(x: Int): Int = { if (x > 0) return 3; 0 }
+  def d(x: Int): Int = { if (x > 0) return 4; 0 }
+  def e(x: Int): Int = { if (x > 0) return 5; 0 }
+}
+SCALA
+
+    cat >"$TMPDIR_FIXT/neg/scattered.rs" <<'RUST'
+fn a(x: i32) -> i32 { if x > 0 { return 1; } 0 }
+fn b(x: i32) -> i32 { if x > 0 { return 2; } 0 }
+fn c(x: i32) -> i32 { if x > 0 { return 3; } 0 }
+fn d(x: i32) -> i32 { if x > 0 { return 4; } 0 }
+fn e(x: i32) -> i32 { if x > 0 { return 5; } 0 }
+RUST
+
     # Mock gh — record invocations into a log file
     MOCK_BIN="$TMPDIR_FIXT/bin"
     mkdir -p "$MOCK_BIN"
@@ -142,12 +207,12 @@ teardown() {
 }
 
 @test "sweep emits per-language findings in qa-verdict.json" {
-    run env REPO_DIR="$TMPDIR_FIXT" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
+    run env REPO_DIR="$TMPDIR_FIXT/src" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
         bash "$SWEEP"
     [ "$status" -eq 0 ]
     [ -f "$TMPDIR_FIXT/.autospec/qa-verdict.json" ]
     for lang in python javascript go java scala rust; do
-        run grep -F "$lang" "$TMPDIR_FIXT/.autospec/qa-verdict.json"
+        run grep -F "\"language\":\"$lang\"" "$TMPDIR_FIXT/.autospec/qa-verdict.json"
         [ "$status" -eq 0 ]
     done
     run grep -F 'code_health:brute_force_string_heuristics' "$TMPDIR_FIXT/.autospec/qa-verdict.json"
@@ -155,7 +220,7 @@ teardown() {
 }
 
 @test "sweep files an auto-implement issue per offender via gh" {
-    run env REPO_DIR="$TMPDIR_FIXT" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
+    run env REPO_DIR="$TMPDIR_FIXT/src" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
         bash "$SWEEP"
     [ "$status" -eq 0 ]
     [ -f "$TMPDIR_FIXT/gh-calls.log" ]
@@ -168,10 +233,92 @@ teardown() {
 }
 
 @test "sweep issue bodies cite RULE_ID directive verbatim" {
-    run env REPO_DIR="$TMPDIR_FIXT" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
+    run env REPO_DIR="$TMPDIR_FIXT/src" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
         bash "$SWEEP"
     [ "$status" -eq 0 ]
     # At least one of the two new RULE_IDs must appear in the gh calls.
     run grep -E 'STRING_MATCH_DOMAIN_LOGIC|REPEATED_STRUCTURE_AS_CODE' "$TMPDIR_FIXT/gh-calls.log"
     [ "$status" -eq 0 ]
+}
+
+# ---------- issue #640 per-function-scope regression tests ----------
+
+@test "per-function: positive offender cites the offending function name (python)" {
+    run env REPO_DIR="$TMPDIR_FIXT/src" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
+        bash "$SWEEP"
+    [ "$status" -eq 0 ]
+    # Finding for classify.py must name the `classify` function, not "<unknown>"
+    # and not the file's first def (here there is only one, but the rule still
+    # applies).
+    run grep -E '"file":"[^"]*classify\.py".*"function":"classify"' "$TMPDIR_FIXT/.autospec/qa-verdict.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "per-function: positive offender cites the first branch line inside the function (python)" {
+    run env REPO_DIR="$TMPDIR_FIXT/src" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
+        bash "$SWEEP"
+    [ "$status" -eq 0 ]
+    # First `if "acid" in name:` is on line 4 of the fixture.
+    run grep -E '"rule_id":"REPEATED_STRUCTURE_AS_CODE".*"file":"[^"]*classify\.py".*"line":4' "$TMPDIR_FIXT/.autospec/qa-verdict.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "per-function: scattered branches across 5 functions emit ZERO findings (python)" {
+    run env REPO_DIR="$TMPDIR_FIXT/neg" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
+        bash "$SWEEP"
+    [ "$status" -eq 0 ]
+    if [ -f "$TMPDIR_FIXT/.autospec/qa-verdict.json" ]; then
+        run grep -F 'scattered.py' "$TMPDIR_FIXT/.autospec/qa-verdict.json"
+        [ "$status" -ne 0 ]
+    fi
+}
+
+@test "per-function: scattered branches across 5 functions emit ZERO findings (javascript)" {
+    run env REPO_DIR="$TMPDIR_FIXT/neg" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
+        bash "$SWEEP"
+    [ "$status" -eq 0 ]
+    if [ -f "$TMPDIR_FIXT/.autospec/qa-verdict.json" ]; then
+        run grep -F 'scattered.ts' "$TMPDIR_FIXT/.autospec/qa-verdict.json"
+        [ "$status" -ne 0 ]
+    fi
+}
+
+@test "per-function: scattered branches across 5 functions emit ZERO findings (go)" {
+    run env REPO_DIR="$TMPDIR_FIXT/neg" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
+        bash "$SWEEP"
+    [ "$status" -eq 0 ]
+    if [ -f "$TMPDIR_FIXT/.autospec/qa-verdict.json" ]; then
+        run grep -F 'scattered.go' "$TMPDIR_FIXT/.autospec/qa-verdict.json"
+        [ "$status" -ne 0 ]
+    fi
+}
+
+@test "per-function: scattered branches across 5 functions emit ZERO findings (java)" {
+    run env REPO_DIR="$TMPDIR_FIXT/neg" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
+        bash "$SWEEP"
+    [ "$status" -eq 0 ]
+    if [ -f "$TMPDIR_FIXT/.autospec/qa-verdict.json" ]; then
+        run grep -F 'Scattered.java' "$TMPDIR_FIXT/.autospec/qa-verdict.json"
+        [ "$status" -ne 0 ]
+    fi
+}
+
+@test "per-function: scattered branches across 5 functions emit ZERO findings (scala)" {
+    run env REPO_DIR="$TMPDIR_FIXT/neg" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
+        bash "$SWEEP"
+    [ "$status" -eq 0 ]
+    if [ -f "$TMPDIR_FIXT/.autospec/qa-verdict.json" ]; then
+        run grep -F 'Scattered.scala' "$TMPDIR_FIXT/.autospec/qa-verdict.json"
+        [ "$status" -ne 0 ]
+    fi
+}
+
+@test "per-function: scattered branches across 5 functions emit ZERO findings (rust)" {
+    run env REPO_DIR="$TMPDIR_FIXT/neg" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
+        bash "$SWEEP"
+    [ "$status" -eq 0 ]
+    if [ -f "$TMPDIR_FIXT/.autospec/qa-verdict.json" ]; then
+        run grep -F 'scattered.rs' "$TMPDIR_FIXT/.autospec/qa-verdict.json"
+        [ "$status" -ne 0 ]
+    fi
 }

--- a/tests/qa/test_brute_force_sweep.bats
+++ b/tests/qa/test_brute_force_sweep.bats
@@ -313,6 +313,48 @@ teardown() {
     fi
 }
 
+@test "per-function: detects 5+ same-shape branches inside a JS arrow function" {
+    mkdir -p "$TMPDIR_FIXT/arrow"
+    cat >"$TMPDIR_FIXT/arrow/route.ts" <<'TS'
+const route = (name: string) => {
+    if (name.includes("http")) return ["http", 1];
+    if (name.includes("ftp")) return ["ftp", 2];
+    if (name.includes("ssh")) return ["ssh", 3];
+    if (name.includes("git")) return ["git", 4];
+    if (name.includes("ws")) return ["ws", 5];
+    return ["unknown", 0];
+};
+TS
+    run env REPO_DIR="$TMPDIR_FIXT/arrow" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
+        bash "$SWEEP"
+    [ "$status" -eq 0 ]
+    [ -f "$TMPDIR_FIXT/.autospec/qa-verdict.json" ]
+    run grep -E '"rule_id":"REPEATED_STRUCTURE_AS_CODE".*"file":"[^"]*route\.ts".*"function":"route"' "$TMPDIR_FIXT/.autospec/qa-verdict.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "per-function: detects 5+ same-shape branches inside a JS class method" {
+    mkdir -p "$TMPDIR_FIXT/method"
+    cat >"$TMPDIR_FIXT/method/router.ts" <<'TS'
+class Router {
+    route(name: string) {
+        if (name.includes("http")) return ["http", 1];
+        if (name.includes("ftp")) return ["ftp", 2];
+        if (name.includes("ssh")) return ["ssh", 3];
+        if (name.includes("git")) return ["git", 4];
+        if (name.includes("ws")) return ["ws", 5];
+        return ["unknown", 0];
+    }
+}
+TS
+    run env REPO_DIR="$TMPDIR_FIXT/method" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
+        bash "$SWEEP"
+    [ "$status" -eq 0 ]
+    [ -f "$TMPDIR_FIXT/.autospec/qa-verdict.json" ]
+    run grep -E '"rule_id":"REPEATED_STRUCTURE_AS_CODE".*"file":"[^"]*router\.ts".*"function":"route"' "$TMPDIR_FIXT/.autospec/qa-verdict.json"
+    [ "$status" -eq 0 ]
+}
+
 @test "per-function: scattered branches across 5 functions emit ZERO findings (rust)" {
     run env REPO_DIR="$TMPDIR_FIXT/neg" VERDICT_FILE="$TMPDIR_FIXT/.autospec/qa-verdict.json" \
         bash "$SWEEP"


### PR DESCRIPTION
Closes #640

## Summary

`scripts/qa-brute-force-sweep.sh` shipped in #639 misfired against the autospec repo itself, emitting two false positives (`compute_gap_id`, `getVersion`) because branch-counting for `REPEATED_STRUCTURE_AS_CODE` was file-scope while the RULE_ID is defined per-function.

This PR rewrites the detector to scope per function and confirms zero findings when dogfooded against the autospec repo.

## Changes

- **Per-function range parsing** — cheap awk parsers per language: Python uses indent tracking; JS/TS/Go/Java/Scala/Rust use brace-balance walking off a signature regex.
- **Same-shape guard** — string literals normalized to `""` and numeric constants to `N` before taking the first 8 chars of the branch predicate, so e.g. `if "acid" in name` and `if "alcohol" in name` collapse to the same shape.
- **Drops `detect_function()`** — finding cites the actual offending function name, not the file's first def.
- **Line pointer** = first occurrence of the dominant branch shape inside the offending function; no more `line:1` fallback.
- **Bats fixtures** — scattered-branches negative case per language (5 unrelated `if`s across 5 functions emit ZERO findings) plus positive line-pointer assertion for Python.

## Dogfood verification

```
PATH=/tmp/mock/bin:$PATH REPO_DIR=$autospec VERDICT_FILE=/tmp/v.json \
  bash scripts/qa-brute-force-sweep.sh
# -> no verdict file created = zero findings
```

## Test plan

- [x] `bats tests/qa/test_brute_force_sweep.bats` — all 12 tests pass (6 original + 6 new per-function regressions)
- [x] `bash scripts/validate.sh` — all validation checks pass
- [x] Dogfood sweep against `/Users/wohlgemuth/IdeaProjects/autospec` produces zero findings

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>