### PR TITLE
feat: autospec-qa verify-first discipline + cluster cross-talk dedup (closes #643)

### DIFF
--- a/scripts/qa-cluster-coverage.sh
+++ b/scripts/qa-cluster-coverage.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# qa-cluster-coverage.sh — cross-cluster coverage ledger for autospec-qa.
+#
+# Atomic append-and-read of .autospec/qa-cluster-coverage.json so parallel
+# QA cluster agents do not re-emit findings on the same
+# (file, spec_section, rule_id) tuple. The first cluster to claim a tuple
+# wins; subsequent claims fail and the caller logs `cluster_skip_dedup`.
+#
+# Commands:
+#   claim --cluster <id> --file <path> --section <section> --rule <rule_id>
+#       Try to claim the tuple. Exit 0 on success, 1 if already claimed.
+#   list
+#       Print every claimed tuple as JSON Lines.
+#   clear
+#       Truncate the ledger.
+#
+# Env:
+#   AUTOSPEC_QA_COVERAGE_FILE — override ledger path (default
+#                              .autospec/qa-cluster-coverage.json).
+
+set -u
+
+LEDGER="${AUTOSPEC_QA_COVERAGE_FILE:-.autospec/qa-cluster-coverage.json}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  qa-cluster-coverage.sh claim --cluster <id> --file <path> --section <section> --rule <rule_id>
+  qa-cluster-coverage.sh list
+  qa-cluster-coverage.sh clear
+
+Env:
+  AUTOSPEC_QA_COVERAGE_FILE  override ledger path
+EOF
+}
+
+with_lock() {
+    # Atomic critical section. Prefer flock when available; fall back to
+    # mkdir-as-lock so this works on macOS where flock is not standard.
+    local cmd_fn="$1"
+    mkdir -p "$(dirname "$LEDGER")"
+    if command -v flock >/dev/null 2>&1; then
+        local lockfile="$LEDGER.lock"
+        : > "$lockfile" 2>/dev/null || true
+        ( flock 9; "$cmd_fn" ) 9>>"$lockfile"
+        return $?
+    fi
+    local lockdir="$LEDGER.lockd"
+    local tries=0
+    while ! mkdir "$lockdir" 2>/dev/null; do
+        tries=$((tries + 1))
+        if [ "$tries" -gt 200 ]; then
+            echo "qa-cluster-coverage: lock timeout on $lockdir" >&2
+            return 2
+        fi
+        sleep 0.05
+    done
+    trap 'rmdir "$lockdir" 2>/dev/null' EXIT
+    "$cmd_fn"
+    local rc=$?
+    rmdir "$lockdir" 2>/dev/null
+    trap - EXIT
+    return $rc
+}
+
+_do_claim() {
+    [ -f "$LEDGER" ] || : > "$LEDGER"
+    # Look for existing matching tuple.
+    if grep -F -q "\"file\":\"$FILE\",\"section\":\"$SECTION\",\"rule\":\"$RULE\"" "$LEDGER" 2>/dev/null; then
+        return 1
+    fi
+    printf '{"cluster":"%s","file":"%s","section":"%s","rule":"%s"}\n' \
+        "$CLUSTER" "$FILE" "$SECTION" "$RULE" >> "$LEDGER"
+    return 0
+}
+
+_do_list() {
+    if [ -f "$LEDGER" ]; then
+        cat "$LEDGER"
+    fi
+    return 0
+}
+
+_do_clear() {
+    : > "$LEDGER"
+    return 0
+}
+
+CMD="${1:-}"
+if [ -z "$CMD" ] || [ "$CMD" = "--help" ] || [ "$CMD" = "-h" ]; then
+    usage
+    exit 2
+fi
+shift || true
+
+case "$CMD" in
+    claim)
+        CLUSTER=""; FILE=""; SECTION=""; RULE=""
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                --cluster) CLUSTER="$2"; shift 2 ;;
+                --file)    FILE="$2";    shift 2 ;;
+                --section) SECTION="$2"; shift 2 ;;
+                --rule)    RULE="$2";    shift 2 ;;
+                *) echo "qa-cluster-coverage: unknown arg: $1" >&2; usage; exit 2 ;;
+            esac
+        done
+        if [ -z "$CLUSTER" ] || [ -z "$FILE" ] || [ -z "$SECTION" ] || [ -z "$RULE" ]; then
+            echo "qa-cluster-coverage: claim requires --cluster --file --section --rule" >&2
+            exit 2
+        fi
+        export CLUSTER FILE SECTION RULE
+        with_lock _do_claim
+        exit $?
+        ;;
+    list)
+        with_lock _do_list
+        exit $?
+        ;;
+    clear)
+        with_lock _do_clear
+        exit $?
+        ;;
+    *)
+        echo "qa-cluster-coverage: unknown command: $CMD" >&2
+        usage
+        exit 2
+        ;;
+esac

--- a/scripts/qa-verify-finding.sh
+++ b/scripts/qa-verify-finding.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# qa-verify-finding.sh — verify a QA cluster finding still reproduces at
+# current HEAD before letting the cluster emit it.
+#
+# Per-category cheap probes:
+#   missing_function / missing_import → git grep for the symbol; symbol absent → KEEP
+#   failing_test                       → run the test once; failing → KEEP
+#   spec_mismatch                      → re-read both files at HEAD; claim still holds → KEEP
+#   regression                         → newer commits touched the area → likely DROP
+#
+# Exit codes:
+#   0 — finding still reproduces, KEEP it
+#   1 — symptom no longer reproduces, DROP it
+#   2 — usage / bad arguments
+
+set -u
+
+usage() {
+    cat <<'EOF'
+Usage: qa-verify-finding.sh --category <cat> [args...]
+
+Categories and args:
+  --category missing_function --symbol <name> [--file <path>]
+  --category missing_import   --symbol <name> [--file <path>]
+  --category failing_test     --test-cmd <cmd>
+  --category spec_mismatch    --spec <spec-path> --impl <impl-path> --claim <text>
+  --category regression       --commit <sha> [--file <path>]
+
+Exit 0: finding still reproduces (KEEP).
+Exit 1: symptom resolved (DROP).
+Exit 2: bad usage.
+EOF
+}
+
+if [ "$#" -eq 0 ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    usage
+    exit 2
+fi
+
+CATEGORY=""
+SYMBOL=""
+FILE=""
+TEST_CMD=""
+SPEC=""
+IMPL=""
+CLAIM=""
+COMMIT=""
+LINE=""
+SYMPTOM=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --category) CATEGORY="$2"; shift 2 ;;
+        --symbol)   SYMBOL="$2";   shift 2 ;;
+        --file)     FILE="$2";     shift 2 ;;
+        --test-cmd) TEST_CMD="$2"; shift 2 ;;
+        --spec)     SPEC="$2";     shift 2 ;;
+        --impl)     IMPL="$2";     shift 2 ;;
+        --claim)    CLAIM="$2";    shift 2 ;;
+        --commit)   COMMIT="$2";   shift 2 ;;
+        --line)     LINE="$2";     shift 2 ;;
+        --symptom)  SYMPTOM="$2";  shift 2 ;;
+        *) echo "qa-verify-finding: unknown arg: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [ -z "$CATEGORY" ]; then
+    echo "qa-verify-finding: --category is required" >&2
+    usage
+    exit 2
+fi
+
+case "$CATEGORY" in
+    missing_function|missing_import)
+        if [ -z "$SYMBOL" ]; then
+            echo "qa-verify-finding: --symbol required for $CATEGORY" >&2
+            exit 2
+        fi
+        if [ -n "$FILE" ] && [ -f "$FILE" ]; then
+            if git grep -nE "$SYMBOL" -- "$FILE" >/dev/null 2>&1; then
+                exit 1  # symbol present in file → resolved
+            fi
+            exit 0  # symbol still missing in file → keep finding
+        fi
+        if git grep -nE "$SYMBOL" >/dev/null 2>&1; then
+            exit 1  # found anywhere → resolved
+        fi
+        exit 0
+        ;;
+    failing_test)
+        if [ -z "$TEST_CMD" ]; then
+            echo "qa-verify-finding: --test-cmd required for failing_test" >&2
+            exit 2
+        fi
+        # Run the test once; if it still fails, finding reproduces.
+        if bash -c "$TEST_CMD" >/dev/null 2>&1; then
+            exit 1  # test passes → resolved
+        fi
+        exit 0  # test still fails → keep finding
+        ;;
+    spec_mismatch)
+        if [ -z "$SPEC" ] || [ -z "$IMPL" ] || [ -z "$CLAIM" ]; then
+            echo "qa-verify-finding: --spec, --impl, --claim required for spec_mismatch" >&2
+            exit 2
+        fi
+        # Claim holds if spec contains the claim text but impl does NOT.
+        if [ ! -f "$SPEC" ] || [ ! -f "$IMPL" ]; then
+            exit 0  # missing file → can't refute, keep
+        fi
+        if grep -qF "$CLAIM" "$SPEC" && ! grep -qF "$CLAIM" "$IMPL"; then
+            exit 0  # still mismatched
+        fi
+        exit 1  # claim now reflected in impl (or absent from spec) → resolved
+        ;;
+    regression)
+        if [ -z "$COMMIT" ]; then
+            echo "qa-verify-finding: --commit required for regression" >&2
+            exit 2
+        fi
+        # If newer commits on HEAD touched the area, likely resolved.
+        local_range_files=()
+        if [ -n "$FILE" ]; then
+            local_range_files=(-- "$FILE")
+        fi
+        if ! git cat-file -e "$COMMIT" 2>/dev/null; then
+            exit 0  # named commit no longer exists in history → keep
+        fi
+        newer=$(git log --oneline "$COMMIT"..HEAD "${local_range_files[@]}" 2>/dev/null | wc -l | tr -d ' ')
+        if [ "${newer:-0}" -gt 0 ]; then
+            exit 1  # newer commits touched the area → likely resolved
+        fi
+        exit 0
+        ;;
+    *)
+        echo "qa-verify-finding: unknown category: $CATEGORY" >&2
+        usage
+        exit 2
+        ;;
+esac

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1036,6 +1036,34 @@ check_dogfood_detectors() {
     fi
 }
 
+# Verify-first discipline gate (issue #643): both helper scripts must exist,
+# be executable, pass bash -n, and all 3 autospec-qa adapter files must
+# reference the two new section headings + both script paths. The bats
+# fixture suite is run as part of the gate.
+check_qa_verify_first_discipline() {
+    info "qa verify-first discipline: scripts + adapter lockstep"
+    for s in scripts/qa-verify-finding.sh scripts/qa-cluster-coverage.sh; do
+        [ -f "$s" ] || fail "$s: file missing (issue #643)"
+        [ -x "$s" ] || fail "$s: file not executable (issue #643)"
+        bash -n "$s" || fail "$s: bash syntax error (issue #643)"
+    done
+    for trio in skills/autospec-qa/SKILL.md skills/autospec-qa/codex/prompt.md skills/autospec-qa/opencode/agent.md; do
+        grep -q '^## Verify-first discipline' "$trio" \
+            || fail "$trio missing '## Verify-first discipline' section (issue #643)"
+        grep -q '^## Cluster sizing' "$trio" \
+            || fail "$trio missing '## Cluster sizing' section (issue #643)"
+        grep -q 'qa-verify-finding\.sh' "$trio" \
+            || fail "$trio missing reference to qa-verify-finding.sh (issue #643)"
+        grep -q 'qa-cluster-coverage\.sh' "$trio" \
+            || fail "$trio missing reference to qa-cluster-coverage.sh (issue #643)"
+    done
+    if command -v bats >/dev/null 2>&1 && [ -f tests/qa/test_verify_first.bats ]; then
+        info "  running: tests/qa/test_verify_first.bats"
+        bats tests/qa/test_verify_first.bats >/tmp/validate-verify-first.log 2>&1 \
+            || { cat /tmp/validate-verify-first.log >&2; fail "tests/qa/test_verify_first.bats: failed"; }
+    fi
+}
+
 check_install_tests() {
     info "install tests: tests/install/*.sh"
     if [ -d tests/install ]; then
@@ -1108,6 +1136,7 @@ main() {
     check_autospec_qa_contract
     check_brute_force_rule_ids
     check_dogfood_detectors
+    check_qa_verify_first_discipline
     check_autospec_release_contract
     check_docs_amendment_presence
     check_install_tests

--- a/skills/autospec-qa/SKILL.md
+++ b/skills/autospec-qa/SKILL.md
@@ -806,6 +806,52 @@ continue. End-to-end regression: after the QA-filed rewrite issues run
 through `/autospec-run`, the offending files no longer trip either
 RULE_ID in the PR-time guardian.
 
+## Verify-first discipline
+
+Before any cluster emits a finding to `.autospec/qa-verdict.json`, the cluster
+MUST verify that the symptom still reproduces at current HEAD. This eliminates
+the dominant false-positive class observed in production: clusters re-flagging
+gaps that landed in a recent PR. Run the shared probe per candidate finding:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/qa-verify-finding.sh" \
+    --category <missing_function|missing_import|failing_test|spec_mismatch|regression> \
+    [--symbol <name>] [--file <path>] [--test-cmd <cmd>] \
+    [--spec <path>] [--impl <path>] [--claim <text>] [--commit <sha>]
+```
+
+Exit 0 means the finding still reproduces (KEEP and emit). Exit 1 means the
+symptom no longer reproduces (DROP and append to `verified_dropped[]` in the
+QA report). When ingesting prior-cycle findings from a previous
+`.autospec/qa-verdict.json`, run the same probe; drops go into
+`stale_dropped[]` rather than `verified_dropped[]`.
+
+Cluster cross-talk dedup: the QA orchestrator maintains
+`.autospec/qa-cluster-coverage.json` via the shared coverage helper. Each
+cluster MUST attempt to claim the `(file, spec_section, rule_id)` tuple it is
+about to scan; a second cluster racing on the same tuple receives exit 1
+("already claimed") and logs the skip as `cluster_skip_dedup`:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/qa-cluster-coverage.sh" \
+    claim --cluster <id> --file <path> --section <section> --rule <rule_id>
+```
+
+The final QA report MUST surface four explicit count fields so the operator
+can see what the discipline filtered: `findings_emitted`, `verified_dropped`,
+`stale_dropped`, `cluster_skip_dedup`.
+
+## Cluster sizing
+
+The QA orchestrator's cluster fan-out is a knob, not a constant. When the
+prior QA run dropped ≥30% of candidate findings on verification, prefer **3
+verify-first clusters** over **7 blind clusters** for the next run. A drop
+rate >50% means clusters are re-litigating the same closed gaps rather than
+exploring new surface; shrink the fan-out and let each cluster do deeper
+verification work. This is prose guidance to the orchestrator — no enforcement
+script — but the rule is non-negotiable for runs whose prior-cycle drop rate
+exceeded the threshold.
+
 ## Dogfood detectors driver
 
 When QA runs against the autospec repo itself, use `scripts/dogfood-detectors.sh` as the authoritative aggregated sweep rather than invoking individual `scripts/qa-*-sweep.sh` directly. The driver enforces an allowlist of intentional findings and fails on regression.

--- a/skills/autospec-qa/codex/prompt.md
+++ b/skills/autospec-qa/codex/prompt.md
@@ -802,6 +802,52 @@ continue. End-to-end regression: after the QA-filed rewrite issues run
 through `/autospec-run`, the offending files no longer trip either
 RULE_ID in the PR-time guardian.
 
+## Verify-first discipline
+
+Before any cluster emits a finding to `.autospec/qa-verdict.json`, the cluster
+MUST verify that the symptom still reproduces at current HEAD. This eliminates
+the dominant false-positive class observed in production: clusters re-flagging
+gaps that landed in a recent PR. Run the shared probe per candidate finding:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/qa-verify-finding.sh" \
+    --category <missing_function|missing_import|failing_test|spec_mismatch|regression> \
+    [--symbol <name>] [--file <path>] [--test-cmd <cmd>] \
+    [--spec <path>] [--impl <path>] [--claim <text>] [--commit <sha>]
+```
+
+Exit 0 means the finding still reproduces (KEEP and emit). Exit 1 means the
+symptom no longer reproduces (DROP and append to `verified_dropped[]` in the
+QA report). When ingesting prior-cycle findings from a previous
+`.autospec/qa-verdict.json`, run the same probe; drops go into
+`stale_dropped[]` rather than `verified_dropped[]`.
+
+Cluster cross-talk dedup: the QA orchestrator maintains
+`.autospec/qa-cluster-coverage.json` via the shared coverage helper. Each
+cluster MUST attempt to claim the `(file, spec_section, rule_id)` tuple it is
+about to scan; a second cluster racing on the same tuple receives exit 1
+("already claimed") and logs the skip as `cluster_skip_dedup`:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/qa-cluster-coverage.sh" \
+    claim --cluster <id> --file <path> --section <section> --rule <rule_id>
+```
+
+The final QA report MUST surface four explicit count fields so the operator
+can see what the discipline filtered: `findings_emitted`, `verified_dropped`,
+`stale_dropped`, `cluster_skip_dedup`.
+
+## Cluster sizing
+
+The QA orchestrator's cluster fan-out is a knob, not a constant. When the
+prior QA run dropped ≥30% of candidate findings on verification, prefer **3
+verify-first clusters** over **7 blind clusters** for the next run. A drop
+rate >50% means clusters are re-litigating the same closed gaps rather than
+exploring new surface; shrink the fan-out and let each cluster do deeper
+verification work. This is prose guidance to the orchestrator — no enforcement
+script — but the rule is non-negotiable for runs whose prior-cycle drop rate
+exceeded the threshold.
+
 ## Dogfood detectors driver
 
 When QA runs against the autospec repo itself, use `scripts/dogfood-detectors.sh` as the authoritative aggregated sweep rather than invoking individual `scripts/qa-*-sweep.sh` directly. The driver enforces an allowlist of intentional findings and fails on regression.

--- a/skills/autospec-qa/opencode/agent.md
+++ b/skills/autospec-qa/opencode/agent.md
@@ -806,6 +806,52 @@ continue. End-to-end regression: after the QA-filed rewrite issues run
 through `/autospec-run`, the offending files no longer trip either
 RULE_ID in the PR-time guardian.
 
+## Verify-first discipline
+
+Before any cluster emits a finding to `.autospec/qa-verdict.json`, the cluster
+MUST verify that the symptom still reproduces at current HEAD. This eliminates
+the dominant false-positive class observed in production: clusters re-flagging
+gaps that landed in a recent PR. Run the shared probe per candidate finding:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/qa-verify-finding.sh" \
+    --category <missing_function|missing_import|failing_test|spec_mismatch|regression> \
+    [--symbol <name>] [--file <path>] [--test-cmd <cmd>] \
+    [--spec <path>] [--impl <path>] [--claim <text>] [--commit <sha>]
+```
+
+Exit 0 means the finding still reproduces (KEEP and emit). Exit 1 means the
+symptom no longer reproduces (DROP and append to `verified_dropped[]` in the
+QA report). When ingesting prior-cycle findings from a previous
+`.autospec/qa-verdict.json`, run the same probe; drops go into
+`stale_dropped[]` rather than `verified_dropped[]`.
+
+Cluster cross-talk dedup: the QA orchestrator maintains
+`.autospec/qa-cluster-coverage.json` via the shared coverage helper. Each
+cluster MUST attempt to claim the `(file, spec_section, rule_id)` tuple it is
+about to scan; a second cluster racing on the same tuple receives exit 1
+("already claimed") and logs the skip as `cluster_skip_dedup`:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/qa-cluster-coverage.sh" \
+    claim --cluster <id> --file <path> --section <section> --rule <rule_id>
+```
+
+The final QA report MUST surface four explicit count fields so the operator
+can see what the discipline filtered: `findings_emitted`, `verified_dropped`,
+`stale_dropped`, `cluster_skip_dedup`.
+
+## Cluster sizing
+
+The QA orchestrator's cluster fan-out is a knob, not a constant. When the
+prior QA run dropped ≥30% of candidate findings on verification, prefer **3
+verify-first clusters** over **7 blind clusters** for the next run. A drop
+rate >50% means clusters are re-litigating the same closed gaps rather than
+exploring new surface; shrink the fan-out and let each cluster do deeper
+verification work. This is prose guidance to the orchestrator — no enforcement
+script — but the rule is non-negotiable for runs whose prior-cycle drop rate
+exceeded the threshold.
+
 ## Dogfood detectors driver
 
 When QA runs against the autospec repo itself, use `scripts/dogfood-detectors.sh` as the authoritative aggregated sweep rather than invoking individual `scripts/qa-*-sweep.sh` directly. The driver enforces an allowlist of intentional findings and fails on regression.

--- a/tests/qa/test_verify_first.bats
+++ b/tests/qa/test_verify_first.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+# tests/qa/test_verify_first.bats
+#
+# Coverage for verify-first discipline (issue #643):
+#   1. Finding whose symptom no longer reproduces at HEAD must be DROPped.
+#   2. Finding that still reproduces must KEEP (probe exit 0).
+#   3. Stale prior-cycle finding ingested from a previous QA verdict is
+#      probed again; resolved → dropped to stale_dropped[].
+#   4. Two clusters racing on the same tuple — the second cluster's claim
+#      must fail (cluster_skip_dedup).
+#   5. A simulated QA report includes the four count fields:
+#      findings_emitted, verified_dropped, stale_dropped, cluster_skip_dedup.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+VERIFY="$REPO_ROOT/scripts/qa-verify-finding.sh"
+COVERAGE="$REPO_ROOT/scripts/qa-cluster-coverage.sh"
+
+setup() {
+    TMPDIR_TEST="$(mktemp -d -t qa-verify-first.XXXXXX)"
+    cd "$TMPDIR_TEST"
+    git init -q .
+    git config user.email "test@example.com"
+    git config user.name "test"
+    git commit -q --allow-empty -m "init"
+    export AUTOSPEC_QA_COVERAGE_FILE="$TMPDIR_TEST/.autospec/qa-cluster-coverage.json"
+    mkdir -p "$TMPDIR_TEST/.autospec"
+}
+
+teardown() {
+    cd /
+    rm -rf "$TMPDIR_TEST"
+}
+
+@test "verify-first: missing_function symbol now present → DROP (exit 1)" {
+    mkdir -p src
+    cat > src/foo.py <<'PY'
+def already_implemented():
+    return 42
+PY
+    git add . && git commit -q -m "add already_implemented"
+    run bash "$VERIFY" --category missing_function --symbol already_implemented --file src/foo.py
+    [ "$status" -eq 1 ]
+}
+
+@test "verify-first: missing_function symbol still absent → KEEP (exit 0)" {
+    mkdir -p src
+    printf 'x = 1\n' > src/foo.py
+    git add . && git commit -q -m "stub"
+    run bash "$VERIFY" --category missing_function --symbol not_yet_implemented --file src/foo.py
+    [ "$status" -eq 0 ]
+}
+
+@test "verify-first: failing_test now passes → DROP (stale prior-cycle finding)" {
+    # Simulate prior-cycle ingested finding: previously the test failed.
+    # At current HEAD the test passes, so the finding must be dropped.
+    run bash "$VERIFY" --category failing_test --test-cmd "true"
+    [ "$status" -eq 1 ]
+}
+
+@test "verify-first: failing_test still fails → KEEP" {
+    run bash "$VERIFY" --category failing_test --test-cmd "false"
+    [ "$status" -eq 0 ]
+}
+
+@test "verify-first: spec_mismatch still mismatched → KEEP" {
+    echo "must call foobar()" > spec.md
+    echo "no such symbol here" > impl.py
+    git add . && git commit -q -m "spec mismatch fixture"
+    run bash "$VERIFY" --category spec_mismatch --spec spec.md --impl impl.py --claim "foobar()"
+    [ "$status" -eq 0 ]
+}
+
+@test "verify-first: spec_mismatch resolved → DROP" {
+    echo "must call foobar()" > spec.md
+    echo "result = foobar()" > impl.py
+    git add . && git commit -q -m "spec match"
+    run bash "$VERIFY" --category spec_mismatch --spec spec.md --impl impl.py --claim "foobar()"
+    [ "$status" -eq 1 ]
+}
+
+@test "cluster-coverage: first claim wins, second on same tuple is skipped" {
+    run bash "$COVERAGE" claim --cluster c1 --file src/a.py --section auth --rule MISSING_FUNCTION
+    [ "$status" -eq 0 ]
+    run bash "$COVERAGE" claim --cluster c2 --file src/a.py --section auth --rule MISSING_FUNCTION
+    [ "$status" -eq 1 ]
+}
+
+@test "cluster-coverage: different tuple coexists" {
+    run bash "$COVERAGE" claim --cluster c1 --file src/a.py --section auth --rule MISSING_FUNCTION
+    [ "$status" -eq 0 ]
+    run bash "$COVERAGE" claim --cluster c2 --file src/b.py --section auth --rule MISSING_FUNCTION
+    [ "$status" -eq 0 ]
+    run bash "$COVERAGE" list
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"src/a.py"* ]]
+    [[ "$output" == *"src/b.py"* ]]
+}
+
+@test "qa report carries findings_emitted/verified_dropped/stale_dropped/cluster_skip_dedup counts" {
+    # Simulate the QA orchestrator assembling a verdict file.
+    #
+    # Walk a tiny set of synthetic findings, run the verify probe per
+    # category, attempt to claim coverage, and tally the four count fields
+    # the spec requires.
+    mkdir -p src
+    cat > src/foo.py <<'PY'
+def already_implemented():
+    return 1
+PY
+    git add . && git commit -q -m "fixture"
+
+    findings_emitted=0
+    verified_dropped=0
+    stale_dropped=0
+    cluster_skip_dedup=0
+
+    # Current-cycle finding #1: still reproduces → KEEP, claim wins → emit.
+    if bash "$VERIFY" --category missing_function --symbol absent_symbol --file src/foo.py; then
+        if bash "$COVERAGE" claim --cluster c1 --file src/foo.py --section x --rule R1; then
+            findings_emitted=$((findings_emitted + 1))
+        else
+            cluster_skip_dedup=$((cluster_skip_dedup + 1))
+        fi
+    else
+        verified_dropped=$((verified_dropped + 1))
+    fi
+
+    # Current-cycle finding #2: resolved → DROP into verified_dropped.
+    if bash "$VERIFY" --category missing_function --symbol already_implemented --file src/foo.py; then
+        if bash "$COVERAGE" claim --cluster c1 --file src/foo.py --section y --rule R2; then
+            findings_emitted=$((findings_emitted + 1))
+        else
+            cluster_skip_dedup=$((cluster_skip_dedup + 1))
+        fi
+    else
+        verified_dropped=$((verified_dropped + 1))
+    fi
+
+    # Prior-cycle stale finding: re-probed at HEAD, now resolved → stale_dropped.
+    # verify exits 0 = KEEP, exit 1 = DROP. For a resolved stale finding the
+    # probe exits 1, so the else branch is the drop path.
+    if bash "$VERIFY" --category failing_test --test-cmd "true"; then
+        findings_emitted=$((findings_emitted + 1))
+    else
+        stale_dropped=$((stale_dropped + 1))
+    fi
+
+    # Second cluster races on the same tuple as finding #1 → skip_dedup.
+    if bash "$COVERAGE" claim --cluster c2 --file src/foo.py --section x --rule R1; then
+        findings_emitted=$((findings_emitted + 1))
+    else
+        cluster_skip_dedup=$((cluster_skip_dedup + 1))
+    fi
+
+    cat > .autospec/qa-verdict.json <<EOF
+{
+  "verdict": "PARTIAL",
+  "findings_emitted": $findings_emitted,
+  "verified_dropped": $verified_dropped,
+  "stale_dropped": $stale_dropped,
+  "cluster_skip_dedup": $cluster_skip_dedup
+}
+EOF
+    grep -q '"findings_emitted": 1'   .autospec/qa-verdict.json
+    grep -q '"verified_dropped": 1'   .autospec/qa-verdict.json
+    grep -q '"stale_dropped": 1'      .autospec/qa-verdict.json
+    grep -q '"cluster_skip_dedup": 1' .autospec/qa-verdict.json
+}


### PR DESCRIPTION
Closes #643

## Summary

Eliminates the ~58% false-positive rate observed in production where autospec-qa cluster fan-out re-emits findings that were already fixed in recent PRs.

- `scripts/qa-verify-finding.sh` — per-category cheap probe: exit 0 = symptom still reproduces (KEEP), exit 1 = resolved (DROP). Covers `missing_function`, `missing_import`, `failing_test`, `spec_mismatch`, `regression`.
- `scripts/qa-cluster-coverage.sh` — atomic claim ledger at `.autospec/qa-cluster-coverage.json` (flock when available, mkdir-as-lock fallback for macOS) so parallel clusters racing the same `(file, spec_section, rule_id)` tuple cleanly skip on the loser side.
- autospec-qa adapter trio (SKILL.md / codex/prompt.md / opencode/agent.md) — adds `## Verify-first discipline` + `## Cluster sizing` sections in byte-for-byte lockstep, inserted just before the existing `## Dogfood detectors driver` section so the trio's section ordering stays consistent.
- `scripts/validate.sh` — new `check_qa_verify_first_discipline` gate enforces script presence/executable/syntax, adapter lockstep references to both scripts and section headings, and runs the bats fixture suite.
- QA report contract — orchestrators MUST surface `findings_emitted`, `verified_dropped`, `stale_dropped`, `cluster_skip_dedup` counts.

## Test plan

- [x] `bash scripts/validate.sh` end-to-end — passes
- [x] `bats tests/qa/test_verify_first.bats` — 9/9 fixtures pass (KEEP/DROP per category, prior-cycle stale handling, cluster race, four count fields)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)