### PR TITLE
feat: enforce qa verify-first discipline via post-cluster finding filter: closes #647

### DIFF
--- a/scripts/qa-finding-filter.sh
+++ b/scripts/qa-finding-filter.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# qa-finding-filter.sh — post-cluster finding filter for autospec-qa
+# (issue #647).
+#
+# Enforces verify-first discipline AFTER the QA orchestrator merges cluster
+# output into .autospec/qa-verdict.json. Partitions findings into:
+#   verified[]   — verified_at == current HEAD; fresh probe → keep
+#   stale[]      — verified_at present but != HEAD; re-probe per category
+#   unverified[] — verified_at missing entirely
+#
+# Strict mode (default in CI; controlled via AUTOSPEC_QA_STRICT=1) fails the
+# run when any finding is unverified. Non-strict mode moves unverified
+# findings into unverified_warnings[] and exits 0 so the operator can triage.
+#
+# Stale findings are re-probed via qa-verify-finding.sh against the recorded
+# verify_category + verify_args (if any). Probe exit 1 ("resolved") drops the
+# finding into verified_dropped[]; probe exit 0 ("still reproduces") refreshes
+# verified_at to current HEAD and keeps the finding.
+#
+# Output is rewritten atomically via a sibling tmp file + mv.
+#
+# Exit codes:
+#   0  — filter completed (verdict file may have been rewritten)
+#   1  — strict mode violation: at least one unverified finding present
+#   2  — usage / bad arguments
+
+set -u
+
+usage() {
+    cat <<'EOF'
+Usage: qa-finding-filter.sh --verdict <path>
+
+Reads --verdict path, partitions findings, atomically rewrites the file.
+
+Env:
+  AUTOSPEC_QA_STRICT       1 (default) → fail on unverified findings;
+                           0           → move them to unverified_warnings[]
+  AUTOSPEC_SCRIPTS_DIR     directory containing qa-verify-finding.sh
+                           (defaults to the directory of this script)
+
+Exit 0: filter ran (verdict possibly rewritten).
+Exit 1: strict mode found unverified findings; verdict left unchanged.
+Exit 2: bad usage.
+EOF
+}
+
+VERDICT=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --verdict) VERDICT="$2"; shift 2 ;;
+        -h|--help) usage; exit 2 ;;
+        *) echo "qa-finding-filter: unknown arg: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [ -z "$VERDICT" ]; then
+    echo "qa-finding-filter: --verdict required" >&2
+    usage
+    exit 2
+fi
+
+if [ ! -f "$VERDICT" ]; then
+    echo "qa-finding-filter: verdict file not found: $VERDICT" >&2
+    exit 2
+fi
+
+STRICT="${AUTOSPEC_QA_STRICT:-1}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VERIFY_SH="${AUTOSPEC_SCRIPTS_DIR:-$SCRIPT_DIR}/qa-verify-finding.sh"
+if [ ! -x "$VERIFY_SH" ] && [ -x "$SCRIPT_DIR/qa-verify-finding.sh" ]; then
+    VERIFY_SH="$SCRIPT_DIR/qa-verify-finding.sh"
+fi
+
+REPO_TOP="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+if [ -z "$REPO_TOP" ]; then
+    echo "qa-finding-filter: not inside a git repo (cannot compute HEAD)" >&2
+    exit 2
+fi
+# Resolve verdict to absolute path before chdir so the rewrite finds it.
+case "$VERDICT" in
+    /*) ;;
+    *)  VERDICT="$(cd "$(dirname "$VERDICT")" && pwd)/$(basename "$VERDICT")" ;;
+esac
+TMP_OUT="${VERDICT}.tmp"
+cd "$REPO_TOP"
+HEAD_SHA="$(git rev-parse HEAD)"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "qa-finding-filter: python3 required for JSON manipulation" >&2
+    exit 2
+fi
+
+# Hand off to python3 for JSON-safe partitioning + re-probe orchestration.
+VERDICT="$VERDICT" \
+TMP_OUT="$TMP_OUT" \
+HEAD_SHA="$HEAD_SHA" \
+STRICT="$STRICT" \
+VERIFY_SH="$VERIFY_SH" \
+python3 - <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+verdict_path = os.environ["VERDICT"]
+tmp_out      = os.environ["TMP_OUT"]
+head_sha     = os.environ["HEAD_SHA"]
+strict       = os.environ.get("STRICT", "1") == "1"
+verify_sh    = os.environ["VERIFY_SH"]
+
+with open(verdict_path, "r") as f:
+    try:
+        verdict = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"qa-finding-filter: verdict is not valid JSON: {e}", file=sys.stderr)
+        sys.exit(2)
+
+findings = verdict.get("findings", []) or []
+
+verified            = []
+verified_dropped    = list(verdict.get("verified_dropped", []) or [])
+unverified_warnings = list(verdict.get("unverified_warnings", []) or [])
+unverified_strict   = []
+
+def reprobe(finding):
+    """Run qa-verify-finding.sh against finding's recorded category + args.
+    Returns probe exit code (0 keep, 1 drop, 2 bad args)."""
+    cat = finding.get("verify_category") or finding.get("category")
+    if not cat:
+        return 2
+    args = ["bash", verify_sh, "--category", cat]
+    va = finding.get("verify_args") or {}
+    for k, v in va.items():
+        args.extend([f"--{k}", str(v)])
+    try:
+        rc = subprocess.run(args, stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL).returncode
+    except Exception:
+        rc = 2
+    return rc
+
+for f in findings:
+    va = f.get("verified_at")
+    if not va:
+        if strict:
+            unverified_strict.append(f)
+        else:
+            unverified_warnings.append(f)
+        continue
+    if va == head_sha:
+        verified.append(f)
+        continue
+    # Stale: re-probe.
+    rc = reprobe(f)
+    if rc == 1:
+        # Resolved — drop.
+        dropped = dict(f)
+        dropped["dropped_reason"] = "stale_reprobe_resolved"
+        verified_dropped.append(dropped)
+    elif rc == 0:
+        # Still reproduces — refresh verified_at.
+        refreshed = dict(f)
+        refreshed["verified_at"] = head_sha
+        refreshed["verified_by"] = "qa-finding-filter.sh"
+        verified.append(refreshed)
+    else:
+        # Probe couldn't run — treat as unverified per strict policy.
+        if strict:
+            unverified_strict.append(f)
+        else:
+            warn = dict(f)
+            warn["unverified_reason"] = "reprobe_indeterminate"
+            unverified_warnings.append(warn)
+
+if strict and unverified_strict:
+    print("qa-finding-filter: strict mode violation — "
+          "code_health:verify_first_violation", file=sys.stderr)
+    for f in unverified_strict:
+        summary = f.get("summary", "<no summary>")
+        cat     = f.get("category", "<no category>")
+        print(f"  unverified[{cat}]: {summary}", file=sys.stderr)
+    # Leave verdict file untouched; operator must re-run cluster with probe.
+    sys.exit(1)
+
+verdict["findings"]            = verified
+verdict["verified_dropped"]    = verified_dropped
+verdict["unverified_warnings"] = unverified_warnings
+
+with open(tmp_out, "w") as out:
+    json.dump(verdict, out, indent=2)
+    out.write("\n")
+os.replace(tmp_out, verdict_path)
+PY
+
+rc=$?
+exit "$rc"

--- a/scripts/qa-verify-finding.sh
+++ b/scripts/qa-verify-finding.sh
@@ -47,19 +47,25 @@ CLAIM=""
 COMMIT=""
 LINE=""
 SYMPTOM=""
+EMIT_RECORD=""
+SUMMARY=""
+EVIDENCE=""
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        --category) CATEGORY="$2"; shift 2 ;;
-        --symbol)   SYMBOL="$2";   shift 2 ;;
-        --file)     FILE="$2";     shift 2 ;;
-        --test-cmd) TEST_CMD="$2"; shift 2 ;;
-        --spec)     SPEC="$2";     shift 2 ;;
-        --impl)     IMPL="$2";     shift 2 ;;
-        --claim)    CLAIM="$2";    shift 2 ;;
-        --commit)   COMMIT="$2";   shift 2 ;;
-        --line)     LINE="$2";     shift 2 ;;
-        --symptom)  SYMPTOM="$2";  shift 2 ;;
+        --category)     CATEGORY="$2";    shift 2 ;;
+        --symbol)       SYMBOL="$2";      shift 2 ;;
+        --file)         FILE="$2";        shift 2 ;;
+        --test-cmd)     TEST_CMD="$2";    shift 2 ;;
+        --spec)         SPEC="$2";        shift 2 ;;
+        --impl)         IMPL="$2";        shift 2 ;;
+        --claim)        CLAIM="$2";       shift 2 ;;
+        --commit)       COMMIT="$2";      shift 2 ;;
+        --line)         LINE="$2";        shift 2 ;;
+        --symptom)      SYMPTOM="$2";     shift 2 ;;
+        --emit-record)  EMIT_RECORD="$2"; shift 2 ;;
+        --summary)      SUMMARY="$2";     shift 2 ;;
+        --evidence)     EVIDENCE="$2";    shift 2 ;;
         *) echo "qa-verify-finding: unknown arg: $1" >&2; usage; exit 2 ;;
     esac
 done
@@ -68,6 +74,79 @@ if [ -z "$CATEGORY" ]; then
     echo "qa-verify-finding: --category is required" >&2
     usage
     exit 2
+fi
+
+# --emit-record mode (issue #647): run the per-category probe and, on KEEP,
+# write a properly-formatted finding JSON to the target file containing
+# verified_at, verified_by, verify_category, verify_args, summary, evidence.
+# Exits with the same 0/1/2 contract as the bare probe so callers can branch.
+if [ -n "$EMIT_RECORD" ]; then
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "qa-verify-finding: python3 required for --emit-record" >&2
+        exit 2
+    fi
+    HEAD_SHA="$(git rev-parse HEAD 2>/dev/null || true)"
+    if [ -z "$HEAD_SHA" ]; then
+        echo "qa-verify-finding: --emit-record requires a git repo" >&2
+        exit 2
+    fi
+    # Capture probe verdict by re-invoking ourselves without --emit-record.
+    self="$0"
+    probe_args=(--category "$CATEGORY")
+    [ -n "$SYMBOL" ]   && probe_args+=(--symbol   "$SYMBOL")
+    [ -n "$FILE" ]     && probe_args+=(--file     "$FILE")
+    [ -n "$TEST_CMD" ] && probe_args+=(--test-cmd "$TEST_CMD")
+    [ -n "$SPEC" ]     && probe_args+=(--spec     "$SPEC")
+    [ -n "$IMPL" ]     && probe_args+=(--impl     "$IMPL")
+    [ -n "$CLAIM" ]    && probe_args+=(--claim    "$CLAIM")
+    [ -n "$COMMIT" ]   && probe_args+=(--commit   "$COMMIT")
+    set +e
+    bash "$self" "${probe_args[@]}" >/dev/null 2>&1
+    probe_rc=$?
+    set -e 2>/dev/null || true
+    if [ "$probe_rc" -ne 0 ] && [ "$probe_rc" -ne 1 ]; then
+        echo "qa-verify-finding: probe failed (rc=$probe_rc)" >&2
+        exit 2
+    fi
+    HEAD="$HEAD_SHA" \
+    CAT="$CATEGORY" \
+    OUT="$EMIT_RECORD" \
+    SUMMARY="$SUMMARY" \
+    EVIDENCE="$EVIDENCE" \
+    SYMBOL="$SYMBOL" \
+    FILE="$FILE" \
+    TEST_CMD="$TEST_CMD" \
+    SPEC="$SPEC" \
+    IMPL="$IMPL" \
+    CLAIM="$CLAIM" \
+    COMMIT="$COMMIT" \
+    PROBE_RC="$probe_rc" \
+    python3 - <<'PY'
+import json, os
+verify_args = {}
+for k_env, k_out in [("SYMBOL","symbol"),("FILE","file"),("TEST_CMD","test-cmd"),
+                     ("SPEC","spec"),("IMPL","impl"),("CLAIM","claim"),
+                     ("COMMIT","commit")]:
+    v = os.environ.get(k_env, "")
+    if v:
+        verify_args[k_out] = v
+record = {
+    "category":         os.environ["CAT"],
+    "release_blocking": True,
+    "status":           "fail" if os.environ["PROBE_RC"] == "0" else "resolved",
+    "summary":          os.environ.get("SUMMARY", "") or "<no summary>",
+    "evidence":         os.environ.get("EVIDENCE", "") or "<no evidence>",
+    "verified_at":      os.environ["HEAD"],
+    "verified_by":      "qa-verify-finding.sh",
+    "verify_category":  os.environ["CAT"],
+    "verify_args":      verify_args,
+}
+with open(os.environ["OUT"], "w") as f:
+    json.dump(record, f, indent=2)
+    f.write("\n")
+PY
+    # Forward the probe verdict to the caller (0 keep, 1 drop).
+    exit "$probe_rc"
 fi
 
 case "$CATEGORY" in

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1110,10 +1110,11 @@ check_dogfood_detectors() {
 # fixture suite is run as part of the gate.
 check_qa_verify_first_discipline() {
     info "qa verify-first discipline: scripts + adapter lockstep"
-    for s in scripts/qa-verify-finding.sh scripts/qa-cluster-coverage.sh; do
-        [ -f "$s" ] || fail "$s: file missing (issue #643)"
-        [ -x "$s" ] || fail "$s: file not executable (issue #643)"
-        bash -n "$s" || fail "$s: bash syntax error (issue #643)"
+    for s in scripts/qa-verify-finding.sh scripts/qa-cluster-coverage.sh \
+             scripts/qa-finding-filter.sh; do
+        [ -f "$s" ] || fail "$s: file missing (issue #643/#647)"
+        [ -x "$s" ] || fail "$s: file not executable (issue #643/#647)"
+        bash -n "$s" || fail "$s: bash syntax error (issue #643/#647)"
     done
     for trio in skills/autospec-qa/SKILL.md skills/autospec-qa/codex/prompt.md skills/autospec-qa/opencode/agent.md; do
         grep -q '^## Verify-first discipline' "$trio" \
@@ -1124,11 +1125,20 @@ check_qa_verify_first_discipline() {
             || fail "$trio missing reference to qa-verify-finding.sh (issue #643)"
         grep -q 'qa-cluster-coverage\.sh' "$trio" \
             || fail "$trio missing reference to qa-cluster-coverage.sh (issue #643)"
+        grep -q 'qa-finding-filter\.sh' "$trio" \
+            || fail "$trio missing reference to qa-finding-filter.sh (issue #647)"
+        grep -q 'AUTOSPEC_QA_STRICT=1' "$trio" \
+            || fail "$trio missing AUTOSPEC_QA_STRICT=1 rule (issue #647)"
     done
     if command -v bats >/dev/null 2>&1 && [ -f tests/qa/test_verify_first.bats ]; then
         info "  running: tests/qa/test_verify_first.bats"
         bats tests/qa/test_verify_first.bats >/tmp/validate-verify-first.log 2>&1 \
             || { cat /tmp/validate-verify-first.log >&2; fail "tests/qa/test_verify_first.bats: failed"; }
+    fi
+    if command -v bats >/dev/null 2>&1 && [ -f tests/qa/test_finding_filter.bats ]; then
+        info "  running: tests/qa/test_finding_filter.bats"
+        bats tests/qa/test_finding_filter.bats >/tmp/validate-finding-filter.log 2>&1 \
+            || { cat /tmp/validate-finding-filter.log >&2; fail "tests/qa/test_finding_filter.bats: failed"; }
     fi
 }
 

--- a/skills/autospec-qa/SKILL.md
+++ b/skills/autospec-qa/SKILL.md
@@ -841,6 +841,20 @@ The final QA report MUST surface four explicit count fields so the operator
 can see what the discipline filtered: `findings_emitted`, `verified_dropped`,
 `stale_dropped`, `cluster_skip_dedup`.
 
+After cluster fan-out completes, the QA orchestrator MUST run
+`scripts/qa-finding-filter.sh` against the merged
+`.autospec/qa-verdict.json` before any release-skill (e.g.,
+`/autospec-release`) consumes it. The filter partitions findings into
+verified, stale (re-probed and either refreshed or dropped to
+`verified_dropped[]`), and unverified. Under `AUTOSPEC_QA_STRICT=1`
+(the CI default), any finding lacking `verified_at` causes the QA run
+to FAIL with status `code_health:verify_first_violation`; under
+`AUTOSPEC_QA_STRICT=0` unverified findings are routed to
+`unverified_warnings[]` for operator triage. Cluster agents MUST emit
+findings via `qa-verify-finding.sh --emit-record <path>` so the
+required `verified_at`, `verified_by`, and `verify_category` fields are
+populated by the probe rather than hand-constructed.
+
 ## Cluster sizing
 
 The QA orchestrator's cluster fan-out is a knob, not a constant. When the

--- a/skills/autospec-qa/codex/prompt.md
+++ b/skills/autospec-qa/codex/prompt.md
@@ -837,6 +837,20 @@ The final QA report MUST surface four explicit count fields so the operator
 can see what the discipline filtered: `findings_emitted`, `verified_dropped`,
 `stale_dropped`, `cluster_skip_dedup`.
 
+After cluster fan-out completes, the QA orchestrator MUST run
+`scripts/qa-finding-filter.sh` against the merged
+`.autospec/qa-verdict.json` before any release-skill (e.g.,
+`/autospec-release`) consumes it. The filter partitions findings into
+verified, stale (re-probed and either refreshed or dropped to
+`verified_dropped[]`), and unverified. Under `AUTOSPEC_QA_STRICT=1`
+(the CI default), any finding lacking `verified_at` causes the QA run
+to FAIL with status `code_health:verify_first_violation`; under
+`AUTOSPEC_QA_STRICT=0` unverified findings are routed to
+`unverified_warnings[]` for operator triage. Cluster agents MUST emit
+findings via `qa-verify-finding.sh --emit-record <path>` so the
+required `verified_at`, `verified_by`, and `verify_category` fields are
+populated by the probe rather than hand-constructed.
+
 ## Cluster sizing
 
 The QA orchestrator's cluster fan-out is a knob, not a constant. When the

--- a/skills/autospec-qa/opencode/agent.md
+++ b/skills/autospec-qa/opencode/agent.md
@@ -841,6 +841,20 @@ The final QA report MUST surface four explicit count fields so the operator
 can see what the discipline filtered: `findings_emitted`, `verified_dropped`,
 `stale_dropped`, `cluster_skip_dedup`.
 
+After cluster fan-out completes, the QA orchestrator MUST run
+`scripts/qa-finding-filter.sh` against the merged
+`.autospec/qa-verdict.json` before any release-skill (e.g.,
+`/autospec-release`) consumes it. The filter partitions findings into
+verified, stale (re-probed and either refreshed or dropped to
+`verified_dropped[]`), and unverified. Under `AUTOSPEC_QA_STRICT=1`
+(the CI default), any finding lacking `verified_at` causes the QA run
+to FAIL with status `code_health:verify_first_violation`; under
+`AUTOSPEC_QA_STRICT=0` unverified findings are routed to
+`unverified_warnings[]` for operator triage. Cluster agents MUST emit
+findings via `qa-verify-finding.sh --emit-record <path>` so the
+required `verified_at`, `verified_by`, and `verify_category` fields are
+populated by the probe rather than hand-constructed.
+
 ## Cluster sizing
 
 The QA orchestrator's cluster fan-out is a knob, not a constant. When the

--- a/tests/qa/test_finding_filter.bats
+++ b/tests/qa/test_finding_filter.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+# tests/qa/test_finding_filter.bats
+#
+# Coverage for the post-cluster finding filter (issue #647):
+#   1. Verdict with all-fresh `verified_at` → filter passes; output unchanged.
+#   2. Verdict with stale `verified_at` and probe-resolved finding → finding
+#      dropped, listed in verified_dropped[].
+#   3. Verdict with missing `verified_at` + AUTOSPEC_QA_STRICT=1 → filter
+#      exits non-zero, prints offender.
+#   4. Verdict with missing `verified_at` + AUTOSPEC_QA_STRICT=0 → finding
+#      moved to unverified_warnings[], exit 0.
+#   5. qa-verify-finding.sh --emit-record produces a finding with the three
+#      required fields (verified_at, verified_by, verify_category).
+#
+# Discipline: real fixtures, no helper-script mocking. The filter is
+# exercised against fixture JSON files written to a tmpdir; HEAD is taken
+# from this repo so verified_at is a real SHA.
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../../scripts/qa-finding-filter.sh"
+    VERIFY="$BATS_TEST_DIRNAME/../../scripts/qa-verify-finding.sh"
+    [ -x "$SCRIPT" ] || skip "qa-finding-filter.sh not yet installed"
+    [ -x "$VERIFY" ] || skip "qa-verify-finding.sh not yet installed"
+    TMPDIR_T="$(mktemp -d)"
+    HEAD_SHA="$(git -C "$BATS_TEST_DIRNAME/../.." rev-parse HEAD)"
+}
+
+teardown() {
+    if [ -n "${TMPDIR_T:-}" ]; then
+        rm -rf "$TMPDIR_T"
+    fi
+    return 0
+}
+
+write_verdict() {
+    # $1 = path, $2 = json body
+    printf '%s\n' "$2" > "$1"
+}
+
+@test "filter passes verdict with all-fresh verified_at unchanged" {
+    verdict="$TMPDIR_T/qa-verdict.json"
+    write_verdict "$verdict" "$(cat <<EOF
+{
+  "findings": [
+    {
+      "category": "missing_function",
+      "release_blocking": true,
+      "status": "fail",
+      "summary": "foo missing",
+      "evidence": "git grep foo",
+      "verified_at": "$HEAD_SHA",
+      "verified_by": "qa-verify-finding.sh",
+      "verify_category": "missing_function"
+    }
+  ]
+}
+EOF
+)"
+    run env AUTOSPEC_QA_STRICT=1 bash "$SCRIPT" --verdict "$verdict"
+    [ "$status" -eq 0 ]
+    # Verdict file should still contain the finding
+    grep -q '"summary": "foo missing"' "$verdict"
+}
+
+@test "filter strict mode rejects findings missing verified_at" {
+    verdict="$TMPDIR_T/qa-verdict.json"
+    write_verdict "$verdict" '{
+      "findings": [
+        {
+          "category": "missing_function",
+          "release_blocking": true,
+          "status": "fail",
+          "summary": "unverified finding",
+          "evidence": "blind"
+        }
+      ]
+    }'
+    run env AUTOSPEC_QA_STRICT=1 bash "$SCRIPT" --verdict "$verdict"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unverified finding"* ]] || [[ "$output" == *"verify_first_violation"* ]]
+}
+
+@test "filter non-strict mode moves unverified to unverified_warnings" {
+    verdict="$TMPDIR_T/qa-verdict.json"
+    write_verdict "$verdict" '{
+      "findings": [
+        {
+          "category": "missing_function",
+          "release_blocking": true,
+          "status": "fail",
+          "summary": "blind blob",
+          "evidence": "no probe"
+        }
+      ]
+    }'
+    run env AUTOSPEC_QA_STRICT=0 bash "$SCRIPT" --verdict "$verdict"
+    [ "$status" -eq 0 ]
+    grep -q '"unverified_warnings"' "$verdict"
+    grep -q '"blind blob"' "$verdict"
+}
+
+@test "filter stale verified_at triggers re-probe and drops resolved" {
+    verdict="$TMPDIR_T/qa-verdict.json"
+    # Use a symbol guaranteed present in tracked files at HEAD — the bash
+    # function `qa-verify-finding` is referenced literally in the verify
+    # script's own header, which has been tracked since #643.
+    write_verdict "$verdict" '{
+      "findings": [
+        {
+          "category": "missing_function",
+          "release_blocking": true,
+          "status": "fail",
+          "summary": "stale finding for present symbol",
+          "evidence": "old probe",
+          "verified_at": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "verified_by": "qa-verify-finding.sh",
+          "verify_category": "missing_function",
+          "verify_args": {"symbol": "qa-verify-finding"}
+        }
+      ]
+    }'
+    run env AUTOSPEC_QA_STRICT=1 bash "$SCRIPT" --verdict "$verdict"
+    [ "$status" -eq 0 ]
+    grep -q '"verified_dropped"' "$verdict"
+    # The finding should be moved into verified_dropped[] (not findings[]).
+    python3 -c "
+import json,sys
+d=json.load(open('$verdict'))
+assert not any(f.get('summary')=='stale finding for present symbol' for f in d.get('findings',[])), 'still in findings'
+assert any(f.get('summary')=='stale finding for present symbol' for f in d.get('verified_dropped',[])), 'not in verified_dropped'
+"
+}
+
+@test "qa-verify-finding.sh --emit-record writes required fields" {
+    out="$TMPDIR_T/finding.json"
+    run bash "$VERIFY" --emit-record "$out" \
+        --category missing_function \
+        --symbol some_definitely_absent_token_xyz_$RANDOM \
+        --summary "absent token" \
+        --evidence "git grep returned 0 hits"
+    [ "$status" -eq 0 ]
+    [ -f "$out" ]
+    grep -q '"verified_at"' "$out"
+    grep -q '"verified_by"' "$out"
+    grep -q '"verify_category": "missing_function"' "$out"
+}


### PR DESCRIPTION
Closes #647

## Summary

Adds `scripts/qa-finding-filter.sh` — a post-cluster finding filter that
enforces the verify-first discipline shipped in #643. The filter partitions
findings in `.autospec/qa-verdict.json` into verified, stale (re-probed),
and unverified buckets and atomically rewrites the verdict.

- `AUTOSPEC_QA_STRICT=1` (CI default): unverified findings fail the QA
  run with status `code_health:verify_first_violation`.
- `AUTOSPEC_QA_STRICT=0`: unverified findings move to
  `unverified_warnings[]` for operator triage.

Extends `scripts/qa-verify-finding.sh` with a `--emit-record <path>`
mode so cluster agents call into the probe to produce findings with
`verified_at`, `verified_by`, and `verify_category` already filled —
the schema is guaranteed by the helper, not hand-constructed JSON.

All 3 `autospec-qa` adapter files (SKILL.md + codex/prompt.md +
opencode/agent.md) updated in lockstep with the new filter step and
the `AUTOSPEC_QA_STRICT=1` rule. `validate.sh::check_qa_verify_first_discipline`
extended to enforce both the new script invariants and the new prose.

## Tests

`tests/qa/test_finding_filter.bats` — 5 cases:

1. Verdict with all-fresh `verified_at` → filter passes, output unchanged.
2. Strict mode rejects findings missing `verified_at`.
3. Non-strict mode moves unverified findings to `unverified_warnings[]`.
4. Stale `verified_at` triggers re-probe; resolved findings drop into `verified_dropped[]`.
5. `qa-verify-finding.sh --emit-record` produces a finding JSON with the three required fields.

All 5 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)