### PR TITLE
fix: pin dogfood doc-drift adapter to stable baseline SHA (closes #651)

### DIFF
--- a/.autospec/dogfood.yml
+++ b/.autospec/dogfood.yml
@@ -21,8 +21,16 @@
 #   tests/dogfood/allowlist/dogfood-adapter-doc-drift.json
 #   tests/dogfood/allowlist/dogfood-adapter-lint.json
 
+# Doc-drift uses `baseline_sha` to pin the diff window against a stable
+# commit instead of HEAD~1 (whose contents shift after every merge,
+# silently invalidating the allowlist — issue #651). Bump the baseline
+# only via explicit PR; re-seed the doc-drift allowlist against the new
+# baseline at the same time.
+
 adapters:
   - detector: skills/autospec-shared/scripts/check-doc-drift.sh
     adapter:  scripts/dogfood-adapter-doc-drift.sh
+    args:
+      baseline_sha: 0e0cd124076af1875eb227e3a138efd12081ab3a
   - detector: scripts/lint-implementation.sh
     adapter:  scripts/dogfood-adapter-lint.sh

--- a/scripts/dogfood-adapter-doc-drift.sh
+++ b/scripts/dogfood-adapter-doc-drift.sh
@@ -38,10 +38,26 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 
 GATE_JSON="$WORK_DIR/gate.json"
 
-if git -C "$REPO_DIR" rev-parse HEAD~1 >/dev/null 2>&1; then
-    git -C "$REPO_DIR" diff HEAD~1 HEAD > "$WORK_DIR/diff.txt" 2>/dev/null || true
+# Read baseline_sha from .autospec/dogfood.yml so the diff window is
+# pinned to an explicit commit instead of sliding with HEAD~1 (issue #651).
+BASELINE_SHA=""
+if [ -f "$REPO_DIR/.autospec/dogfood.yml" ]; then
+    BASELINE_SHA=$(awk '
+        /^[[:space:]]*adapter:[[:space:]]+scripts\/dogfood-adapter-doc-drift\.sh/ { in_block=1; next }
+        in_block && /^[[:space:]]*-[[:space:]]/ { in_block=0 }
+        in_block && /^[[:space:]]+baseline_sha:/ {
+            sub(/^[[:space:]]+baseline_sha:[[:space:]]*/,""); print; exit
+        }
+    ' "$REPO_DIR/.autospec/dogfood.yml")
+fi
+
+if [ -n "$BASELINE_SHA" ] && git -C "$REPO_DIR" rev-parse "$BASELINE_SHA" >/dev/null 2>&1; then
+    git -C "$REPO_DIR" diff "$BASELINE_SHA" HEAD > "$WORK_DIR/diff.txt" 2>/dev/null || true
     bash "$DETECTOR" --diff "$WORK_DIR/diff.txt" > "$GATE_JSON" 2>/dev/null || true
 else
+    # No baseline pinned, or baseline unreachable (e.g. shallow clone) —
+    # fall back to working-tree mode so the gate degrades cleanly instead
+    # of silently scanning a sliding window.
     bash "$DETECTOR" --working-tree > "$GATE_JSON" 2>/dev/null || true
 fi
 

--- a/tests/dogfood/allowlist/dogfood-adapter-doc-drift.json
+++ b/tests/dogfood/allowlist/dogfood-adapter-doc-drift.json
@@ -1,9 +1,1 @@
-[
-  {"file":"docs/API_REFERENCE.md","function":"# API Reference","rule_id":"DOC_DRIFT_WARN","justification":"pre-existing drift on main at adapter introduction (issue #646)"},
-  {"file":"docs/API_REFERENCE.md","function":"## Validation (`scripts/validate.sh`)","rule_id":"DOC_DRIFT_WARN","justification":"pre-existing drift on main at adapter introduction (issue #646)"},
-  {"file":"docs/superpowers/plans/2026-05-22-autospec-docs-amendment.md","function":"### Tasks","rule_id":"DOC_DRIFT_WARN","justification":"pre-existing drift on main at adapter introduction (issue #646)"},
-  {"file":"skills/autospec-release/SKILL.md","function":"-","rule_id":"DOC_DRIFT_MISSING_SCOPE","justification":"release skill prose not yet scoped in docs (issue #646)"},
-  {"file":"skills/autospec-release/codex/prompt.md","function":"-","rule_id":"DOC_DRIFT_MISSING_SCOPE","justification":"release skill prose not yet scoped in docs (issue #646)"},
-  {"file":"skills/autospec-release/opencode/agent.md","function":"-","rule_id":"DOC_DRIFT_MISSING_SCOPE","justification":"release skill prose not yet scoped in docs (issue #646)"},
-  {"file":"tests/compute-release-verdict.bats","function":"-","rule_id":"DOC_DRIFT_MISSING_SCOPE","justification":"bats fixture not in docs scope (issue #646)"}
-]
+[]

--- a/tests/dogfood/allowlist/dogfood-adapter-lint.json
+++ b/tests/dogfood/allowlist/dogfood-adapter-lint.json
@@ -1,1 +1,14 @@
-[]
+[
+  {
+    "file": "scripts/qa-finding-filter.sh",
+    "function": "-",
+    "rule_id": "COMPLEXITY",
+    "justification": "Multi-bucket finding partition (verified/stale/unverified) — extract would add indirection without simplification (issue #651)"
+  },
+  {
+    "file": "scripts/qa-verify-finding.sh",
+    "function": "-",
+    "rule_id": "COMPLEXITY",
+    "justification": "Per-category probe dispatcher (missing_function/failing_test/spec_mismatch/regression) — each branch is a different external tool, not extractable into a table (issue #651)"
+  }
+]


### PR DESCRIPTION
## Summary
- doc-drift adapter reads `args.baseline_sha` from `.autospec/dogfood.yml` instead of sliding `HEAD~1..HEAD`; allowlist stays valid until the baseline is explicitly bumped.
- Doc-drift allowlist reset to `[]`; baseline pinned to current main → HEAD vs HEAD = no findings.
- Lint allowlist gains 2 entries for the multi-bucket dispatchers in `qa-finding-filter.sh` and `qa-verify-finding.sh` (shipped by PR #650) with explicit justifications.

## Test plan
- [x] `bash scripts/dogfood-detectors.sh` → all 3 detectors PASS
- [x] `bash scripts/validate.sh` → all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)