### PR TITLE
feat: rewrite autospec-run Phase 4 as single-agent absorbed-discipline: closes #648

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -655,6 +655,13 @@ check_phase4_single_agent_discipline() {
         || fail "$impl missing 'single-agent' assumption in prompt body"
     grep -F 'Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool' "$impl" >/dev/null \
         || fail "$impl missing canonical subagent-Agent-inheritance constraint sentence"
+    bats_file="tests/phase4/test_single_agent_discipline.bats"
+    [ -f "$bats_file" ] || fail "$bats_file: bats coverage missing"
+    if command -v bats >/dev/null 2>&1; then
+        info "  running: $bats_file"
+        bats "$bats_file" >/tmp/validate-single-agent-discipline.log 2>&1 \
+            || { cat /tmp/validate-single-agent-discipline.log >&2; fail "$bats_file: failed"; }
+    fi
 }
 
 # Phase 4 adaptive-retry loop: the implementer prompt block must contain the

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -619,6 +619,44 @@ check_phase4_immediate_next_issue_pickup() {
     done
 }
 
+# Phase 4 single-agent absorbed-discipline (issue #648): the autospec-run trio
+# must (1) carry the canonical constraint sentence stating that subagents spawned
+# by background `Agent` calls do NOT inherit the `Agent` tool, (2) reference the
+# single-agent absorbed-discipline rewrite, (3) document that Phase 4 implementers
+# must be top-level agents launched directly by the main session orchestrator,
+# and (4) NOT contain the legacy "process(ISSUE)   # foreground subagent" or
+# "dispatches a **foreground subagent**" patterns that previously misled
+# operators into nested-dispatch. The phase4-implementer.md prompt must also
+# state the single-agent assumption explicitly.
+check_phase4_single_agent_discipline() {
+    info "phase4 single-agent absorbed-discipline: autospec-run trio"
+    for f in \
+        skills/autospec-run/SKILL.md \
+        skills/autospec-run/codex/prompt.md \
+        skills/autospec-run/opencode/agent.md
+    do
+        [ -f "$f" ] || fail "$f: required file missing"
+        grep -F 'Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool' "$f" >/dev/null \
+            || fail "$f missing canonical subagent-Agent-inheritance constraint sentence"
+        grep -F 'single-agent absorbed-discipline' "$f" >/dev/null \
+            || fail "$f missing 'single-agent absorbed-discipline' reference"
+        grep -F 'top-level agents launched directly by the main session orchestrator' "$f" >/dev/null \
+            || fail "$f missing 'top-level agents launched directly by the main session orchestrator' sentence"
+        if grep -F 'process(ISSUE)   # foreground subagent' "$f" >/dev/null 2>&1; then
+            fail "$f still contains legacy 'process(ISSUE)   # foreground subagent' nested-dispatch pattern"
+        fi
+        if grep -F 'dispatches a **foreground subagent**' "$f" >/dev/null 2>&1; then
+            fail "$f still contains legacy 'dispatches a **foreground subagent**' nested-dispatch pattern"
+        fi
+    done
+    impl="skills/autospec-run/prompts/phase4-implementer.md"
+    [ -f "$impl" ] || fail "$impl: required file missing"
+    grep -F 'single-agent' "$impl" >/dev/null \
+        || fail "$impl missing 'single-agent' assumption in prompt body"
+    grep -F 'Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool' "$impl" >/dev/null \
+        || fail "$impl missing canonical subagent-Agent-inheritance constraint sentence"
+}
+
 # Phase 4 adaptive-retry loop: the implementer prompt block must contain the
 # MAX_IMPL_RETRIES while-loop with directive_context accumulation and an
 # exhaustion branch that posts a manual-intervention comment. All three trio
@@ -1202,6 +1240,7 @@ main() {
     check_phase1_bounded_context_contract
     check_phase4_issue_start_summary
     check_phase4_immediate_next_issue_pickup
+    check_phase4_single_agent_discipline
     check_phase4_adaptive_retry
     check_autospec_sweep_config_contract
     check_autospec_fleet_scripts

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -232,6 +232,8 @@ This writes the UTC ISO 8601 timestamp to `~/.autospec/.run-batch-start` (idempo
 
 ## Phase 4 — Background autonomous monitor
 
+**Single-agent absorbed-discipline (canonical Phase 4 path).** The monitor agent IS the implementer for the issue it claims — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — all in one agent's context. The main session orchestrator relaunches the monitor between issues so each one gets a fresh top-level `Agent` call with full tool access. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch its own inner implementer. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "the monitor agent now does the implementation work itself in this same context", NOT a nested subagent dispatch. `AUTOSPEC_BATCH_SIZE` semantics are preserved: a single agent can still process up to N issues sequentially within its 40-tool-call budget, exiting with `BATCH_COMPLETE` when the budget is approaching or after N issues, whichever comes first.
+
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
@@ -520,7 +522,7 @@ inline label-swap path below.
 >   echo "[monitor] goal: ${ISSUE_GOAL:-<not provided>}"
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
->   process(ISSUE)   # foreground subagent — see template below
+>   process(ISSUE)   # single-agent absorbed-discipline — the monitor IS the implementer; see template below
 >   batch_issue_count=$((batch_issue_count + 1))
 >   if [ "$batch_issue_count" -ge "${effective_batch_size:-$BATCH_SIZE}" ]; then
 >     bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/diary-write.sh" \
@@ -551,7 +553,7 @@ inline label-swap path below.
 >
 > Both paths share the same outer monitor loop (queue scan, lock-step compliance, label-based locking, heartbeat updates, post-process pickup). The selection only changes the inner subagent prompt body.
 >
-> `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
+> `process(ISSUE)` is single-agent absorbed-discipline: the monitor agent performs the implementation work itself, in-context, using the prompt below as its working brief. There is NO nested subagent dispatch here — subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so the monitor must own the work directly:
 >
 > **Prompt construction (cache-prefix + dynamic suffix):**
 > Before dispatch, the orchestrator builds the subagent prompt. Two options:

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -227,6 +227,8 @@ This writes the UTC ISO 8601 timestamp to `~/.autospec/.run-batch-start` (idempo
 
 ## Phase 4 — Background autonomous monitor
 
+**Single-agent absorbed-discipline (canonical Phase 4 path).** The monitor agent IS the implementer for the issue it claims — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — all in one agent's context. The main session orchestrator relaunches the monitor between issues so each one gets a fresh top-level `Agent` call with full tool access. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch its own inner implementer. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "the monitor agent now does the implementation work itself in this same context", NOT a nested subagent dispatch. `AUTOSPEC_BATCH_SIZE` semantics are preserved: a single agent can still process up to N issues sequentially within its 40-tool-call budget, exiting with `BATCH_COMPLETE` when the budget is approaching or after N issues, whichever comes first.
+
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
@@ -515,7 +517,7 @@ inline label-swap path below.
 >   echo "[monitor] goal: ${ISSUE_GOAL:-<not provided>}"
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
->   process(ISSUE)   # foreground subagent — see template below
+>   process(ISSUE)   # single-agent absorbed-discipline — the monitor IS the implementer; see template below
 >   batch_issue_count=$((batch_issue_count + 1))
 >   if [ "$batch_issue_count" -ge "${effective_batch_size:-$BATCH_SIZE}" ]; then
 >     bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/diary-write.sh" \
@@ -546,7 +548,7 @@ inline label-swap path below.
 >
 > Both paths share the same outer monitor loop (queue scan, lock-step compliance, label-based locking, heartbeat updates, post-process pickup). The selection only changes the inner subagent prompt body.
 >
-> `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
+> `process(ISSUE)` is single-agent absorbed-discipline: the monitor agent performs the implementation work itself, in-context, using the prompt below as its working brief. There is NO nested subagent dispatch here — subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so the monitor must own the work directly:
 >
 > **Prompt construction (cache-prefix + dynamic suffix):**
 > Before dispatch, the orchestrator builds the subagent prompt. Two options:

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -231,6 +231,8 @@ This writes the UTC ISO 8601 timestamp to `~/.autospec/.run-batch-start` (idempo
 
 ## Phase 4 — Background autonomous monitor
 
+**Single-agent absorbed-discipline (canonical Phase 4 path).** The monitor agent IS the implementer for the issue it claims — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — all in one agent's context. The main session orchestrator relaunches the monitor between issues so each one gets a fresh top-level `Agent` call with full tool access. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch its own inner implementer. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "the monitor agent now does the implementation work itself in this same context", NOT a nested subagent dispatch. `AUTOSPEC_BATCH_SIZE` semantics are preserved: a single agent can still process up to N issues sequentially within its 40-tool-call budget, exiting with `BATCH_COMPLETE` when the budget is approaching or after N issues, whichever comes first.
+
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
 
 > **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
@@ -519,7 +521,7 @@ inline label-swap path below.
 >   echo "[monitor] goal: ${ISSUE_GOAL:-<not provided>}"
 >   echo "[monitor] smoke: ${ISSUE_SMOKE:-<not provided>}"
 >   echo "[monitor] scope: ${ISSUE_SCOPE:-<not provided>}"
->   process(ISSUE)   # foreground subagent — see template below
+>   process(ISSUE)   # single-agent absorbed-discipline — the monitor IS the implementer; see template below
 >   batch_issue_count=$((batch_issue_count + 1))
 >   if [ "$batch_issue_count" -ge "${effective_batch_size:-$BATCH_SIZE}" ]; then
 >     bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/diary-write.sh" \
@@ -550,7 +552,7 @@ inline label-swap path below.
 >
 > Both paths share the same outer monitor loop (queue scan, lock-step compliance, label-based locking, heartbeat updates, post-process pickup). The selection only changes the inner subagent prompt body.
 >
-> `process(ISSUE)` dispatches a **foreground subagent** (wait for return) with this prompt:
+> `process(ISSUE)` is single-agent absorbed-discipline: the monitor agent performs the implementation work itself, in-context, using the prompt below as its working brief. There is NO nested subagent dispatch here — subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so the monitor must own the work directly:
 >
 > **Prompt construction (cache-prefix + dynamic suffix):**
 > Before dispatch, the orchestrator builds the subagent prompt. Two options:

--- a/skills/autospec-run/prompts/phase4-implementer.md
+++ b/skills/autospec-run/prompts/phase4-implementer.md
@@ -1,8 +1,10 @@
 # Phase 4 implementer prompt (autospec:v2-flow)
 
-You are the autospec Phase 4 implementer subagent. You have been handed one GitHub issue carrying the `autospec:v2-flow` label. Your job is to take it from "open" to "PR merged" without operator intervention, following the steps below in order.
+You are the autospec Phase 4 implementer. You have been handed one GitHub issue carrying the `autospec:v2-flow` label. Your job is to take it from "open" to "PR merged" without operator intervention, following the steps below in order.
 
-**Do not invoke any Skill tool from within this subagent.** Every instruction you need is here. This prompt absorbs turbo's expand → implement → finalize → peer-review → evaluate discipline inline so Phase 4 stays self-contained and is not subject to upstream turbo prompt drift.
+**You are a single-agent absorbed-discipline implementer — there is no nested subagent.** You ARE the monitor; you ARE the implementer; the work happens in your context, end-to-end. Do not attempt to dispatch a nested `Agent` (Claude Code), `task` (OpenCode), or nested CLI session (Codex) for the implementation work — own it yourself. **Constraint:** In Claude Code, Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch its own inner implementer; the only safe execution model is for the main session orchestrator to launch you as a top-level agent and for you to do the expand → implement → finalize → peer-review → evaluate-findings → PR → merge cycle yourself.
+
+**Do not invoke any Skill tool from within this agent.** Every instruction you need is here. This prompt absorbs turbo's expand → implement → finalize → peer-review → evaluate discipline inline so Phase 4 stays self-contained and is not subject to upstream turbo prompt drift.
 
 ## Inputs
 

--- a/tests/phase4/test_single_agent_discipline.bats
+++ b/tests/phase4/test_single_agent_discipline.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+#
+# Phase 4 single-agent absorbed-discipline lockstep test (issue #648).
+#
+# Asserts that all 3 autospec-run adapter files contain the canonical sentence
+# stating that subagents spawned by background `Agent` calls do NOT inherit the
+# `Agent` tool, plus a reference to the single-agent rewrite. Also asserts
+# that the legacy `process(ISSUE) # foreground subagent` pattern is gone.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+TRIO=(
+    "$REPO_ROOT/skills/autospec-run/SKILL.md"
+    "$REPO_ROOT/skills/autospec-run/codex/prompt.md"
+    "$REPO_ROOT/skills/autospec-run/opencode/agent.md"
+)
+
+@test "trio contains the canonical single-agent constraint sentence" {
+    for f in "${TRIO[@]}"; do
+        run grep -F "Subagents spawned by background \`Agent\` calls do NOT inherit the \`Agent\` tool" "$f"
+        [ "$status" -eq 0 ] || {
+            echo "missing canonical constraint sentence in: $f"
+            return 1
+        }
+    done
+}
+
+@test "trio references the single-agent absorbed-discipline rewrite" {
+    for f in "${TRIO[@]}"; do
+        run grep -F "single-agent absorbed-discipline" "$f"
+        [ "$status" -eq 0 ] || {
+            echo "missing 'single-agent absorbed-discipline' reference in: $f"
+            return 1
+        }
+    done
+}
+
+@test "trio mentions top-level Agent launch requirement" {
+    for f in "${TRIO[@]}"; do
+        run grep -F "top-level agents launched directly by the main session orchestrator" "$f"
+        [ "$status" -eq 0 ] || {
+            echo "missing top-level orchestrator launch sentence in: $f"
+            return 1
+        }
+    done
+}
+
+@test "legacy 'foreground subagent' Phase 4 pattern is gone" {
+    for f in "${TRIO[@]}"; do
+        # The legacy comment annotated the nested-dispatch dispatch line.
+        # Allow no occurrences of the exact pattern that misled operators.
+        if grep -F "process(ISSUE)   # foreground subagent" "$f" >/dev/null 2>&1; then
+            echo "legacy 'process(ISSUE)   # foreground subagent' pattern still present in: $f"
+            return 1
+        fi
+        if grep -F "dispatches a **foreground subagent**" "$f" >/dev/null 2>&1; then
+            echo "legacy 'dispatches a **foreground subagent**' pattern still present in: $f"
+            return 1
+        fi
+    done
+}
+
+@test "phase4-implementer.md states the single-agent assumption" {
+    f="$REPO_ROOT/skills/autospec-run/prompts/phase4-implementer.md"
+    run grep -F "single-agent" "$f"
+    [ "$status" -eq 0 ]
+    run grep -F "Subagents spawned by background \`Agent\` calls do NOT inherit the \`Agent\` tool" "$f"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #648

## Summary

Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch a nested implementer. The prior trio prose led operators into that wall (observed when issue #637's monitor exited at "Agent tool isn't directly available"). This PR makes single-agent absorbed-discipline the canonical Phase 4 path so future operators do not hit the same trap.

## Changes

- **autospec-run trio lockstep prose** (`SKILL.md`, `codex/prompt.md`, `opencode/agent.md`):
  - Added a new "Single-agent absorbed-discipline (canonical Phase 4 path)" paragraph at the top of `## Phase 4 — Background autonomous monitor` containing the canonical constraint sentence and `AUTOSPEC_BATCH_SIZE` preservation note.
  - Replaced `process(ISSUE)   # foreground subagent` with single-agent absorbed-discipline annotation.
  - Replaced `dispatches a **foreground subagent**` sentence with an explicit "no nested dispatch" clarification.
- **`skills/autospec-run/prompts/phase4-implementer.md`**: prompt body now explicitly states the single-agent assumption and the subagent-inheritance constraint.
- **`scripts/validate.sh`**: new `check_phase4_single_agent_discipline()` gate enforces the canonical constraint sentence, single-agent reference, top-level orchestrator launch sentence, and absence of the legacy nested-dispatch patterns across the trio + implementer prompt.
- **`tests/phase4/test_single_agent_discipline.bats`**: 5 bats cases mirroring the gate.

Lockstep verified — SKILL.md body byte-identical to `codex/prompt.md` and `opencode/agent.md` body.

## Test plan
- [x] `bats tests/phase4/test_single_agent_discipline.bats` — 5/5 pass
- [x] `bash scripts/validate.sh` — new gate passes; only pre-existing `dogfood-detectors.sh` failures remain (unchanged from main, unrelated to this PR)
- [x] Trio lockstep diff clean