### PR TITLE
fix: unregister PR-time dogfood adapters; gate keeps whole-repo scans only

### DIFF
--- a/.autospec/dogfood.yml
+++ b/.autospec/dogfood.yml
@@ -21,17 +21,19 @@
 #   tests/dogfood/allowlist/dogfood-adapter-doc-drift.json
 #   tests/dogfood/allowlist/dogfood-adapter-lint.json
 
-# PR-time detectors (doc-drift, lint-implementation) need a diff to make
-# sense. The dogfood gate runs on `main` where there is no PR diff, so the
-# adapters use clean-tree semantics: doc-drift runs `--working-tree` and
-# lint runs against `git diff --cached`. On a clean checkout both return
-# zero findings. Earlier baseline-pin and HEAD~1..HEAD designs both
-# accumulated noise as `main` advanced (issues #651 + follow-up). The
-# real PR-time enforcement still happens in the pre-commit hook and in
-# the fused guardian/LGTM reviewer at PR time.
+# PR-time detectors (doc-drift, lint-implementation) are deliberately NOT
+# registered here. They need a diff context to operate, which the dogfood
+# gate (running on `main` against a clean tree) cannot provide. Earlier
+# attempts to wrap them as dogfood adapters all failed in shape — HEAD~1
+# slides every merge, pinned baselines accumulate findings, and clean-
+# tree mode catches nothing in CI. Real PR-time enforcement still happens
+# in the pre-commit hook and the fused guardian/LGTM reviewer at PR time.
+#
+# The adapter scripts at `scripts/dogfood-adapter-{doc-drift,lint}.sh`
+# remain available for ad-hoc local runs (e.g. an operator who wants to
+# scan their own staged tree). They are simply not in the CI gate.
+#
+# Future adapters should be whole-repo invariant scanners (like
+# qa-brute-force-sweep), not diff-based PR-time tools.
 
-adapters:
-  - detector: skills/autospec-shared/scripts/check-doc-drift.sh
-    adapter:  scripts/dogfood-adapter-doc-drift.sh
-  - detector: scripts/lint-implementation.sh
-    adapter:  scripts/dogfood-adapter-lint.sh
+adapters: []

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1126,6 +1126,11 @@ check_dogfood_detectors() {
         || fail ".autospec/dogfood.yml: missing (issue #646 adapter registry)"
     grep -q '^adapters:' .autospec/dogfood.yml \
         || fail ".autospec/dogfood.yml: missing 'adapters:' schema (issue #646)"
+    # The adapter scripts remain available for ad-hoc local runs even when
+    # they are intentionally unregistered in dogfood.yml (PR-time tools
+    # without a diff context cannot anchor a CI gate — see dogfood.yml
+    # rationale comment). Presence + executability + syntax are still
+    # checked; registration is no longer required.
     for adapter in scripts/dogfood-adapter-doc-drift.sh scripts/dogfood-adapter-lint.sh; do
         [ -f "$adapter" ] \
             || fail "$adapter: required adapter missing (issue #646)"
@@ -1133,8 +1138,6 @@ check_dogfood_detectors() {
             || fail "$adapter: adapter not executable (issue #646)"
         bash -n "$adapter" \
             || fail "$adapter: bash syntax error (issue #646)"
-        grep -q "$(basename "$adapter")" .autospec/dogfood.yml \
-            || fail ".autospec/dogfood.yml: missing registration for $(basename "$adapter")"
     done
 
     info "dogfood detectors: running driver against this repo"


### PR DESCRIPTION
## Summary
- Unregister `dogfood-adapter-doc-drift.sh` and `dogfood-adapter-lint.sh` from `.autospec/dogfood.yml`. PR-time tools need a diff context the dogfood gate can't provide; clean-tree semantics from #654 made the gate vestigial.
- Dogfood now runs only `qa-brute-force-sweep.sh` (a true whole-repo invariant scan).
- Adapter scripts remain for ad-hoc local use; `validate.sh` keeps presence/exec/syntax checks, drops registration requirement.
- COMPLEXITY findings against `qa-finding-filter.sh`/`qa-verify-finding.sh` were false positives — `lint-implementation.sh` counts heredoc content as code nesting. Tracked in #656.

## Test plan
- [x] `bash scripts/dogfood-detectors.sh` → 1/1 detector PASS
- [x] `bash scripts/validate.sh` → all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)