### PR TITLE
feat: autospec-qa exhaustiveness flags (closes #660)

### DIFF
--- a/scripts/qa-exhaustiveness-check.sh
+++ b/scripts/qa-exhaustiveness-check.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# scripts/qa-exhaustiveness-check.sh — explicit exhaustiveness gates.
+#
+# Implements the four flags introduced in issue #660 that convert the
+# autospec-qa adapter's prose discipline ("Reliability exhaustion loop",
+# the 20-question Critical self-questioning checkpoint, etc.) into hard
+# machine-checkable gates:
+#
+#   --every-spec-row    Every spec acceptance criterion must have a
+#                       non-NOT_TESTED row in .autospec/proof-matrix.json.
+#                       Missing rows emit findings with category
+#                       code_health:incomplete_traceability.
+#
+#   --mutation-each     Every workflow the spec lists must have at least
+#                       one mutation/breakage entry in
+#                       .autospec/mutation-proof.json. Missing entries
+#                       emit category code_health:incomplete_mutation_proof.
+#
+#   --no-mock-each      Every backend-backed feature must have a no-mock
+#                       canary entry in .autospec/canary-results.json
+#                       (or an explicit exception in
+#                       .autospec/reliability.yml). Missing entries emit
+#                       category code_health:incomplete_no_mock_coverage.
+#
+#   --exhaustive        Turns the three above on.
+#
+# Each failed gate appends a release_blocking finding to the verdict file
+# (atomic write: tmp in same dir + rename) and demotes the verdict to
+# PARTIAL (if it was PASS) or preserves FAIL (precedence). The list of
+# flags actually requested is recorded under .requested_flags on the
+# verdict so downstream skills (e.g. /autospec-release) see what was
+# enforced.
+#
+# Exit codes:
+#   0 — all requested gates passed (or no flags supplied).
+#   1 — at least one gate failed; verdict + findings updated.
+#   2 — usage / bad arguments.
+
+set -u
+
+usage() {
+    cat <<'EOF'
+Usage: qa-exhaustiveness-check.sh [flags] [paths]
+
+Flags (one or more):
+  --every-spec-row      Require non-NOT_TESTED proof-matrix row per AC
+  --mutation-each       Require mutation-proof entry per spec workflow
+  --no-mock-each        Require canary entry per backend-backed feature
+  --exhaustive          Shortcut for all three above
+
+Paths:
+  --verdict <p>         .autospec/qa-verdict.json (default)
+  --proof-matrix <p>    .autospec/proof-matrix.json (default)
+  --mutation-proof <p>  .autospec/mutation-proof.json (default)
+  --canary <p>          .autospec/canary-results.json (default)
+  --reliability <p>     .autospec/reliability.yml (default)
+  --spec <p>            Spec file (repeatable). At least one is required
+                        when any flag is active.
+  -h, --help            Show this help.
+
+Exit 0 if every requested gate passes. Exit 1 if any gate fails;
+findings have been appended to the verdict file and .verdict demoted.
+EOF
+}
+
+VERDICT=".autospec/qa-verdict.json"
+PROOF_MATRIX=".autospec/proof-matrix.json"
+MUTATION_PROOF=".autospec/mutation-proof.json"
+CANARY=".autospec/canary-results.json"
+RELIABILITY=".autospec/reliability.yml"
+SPECS=()
+FLAGS=()
+
+flag_every_spec_row=0
+flag_mutation_each=0
+flag_no_mock_each=0
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --every-spec-row)  flag_every_spec_row=1; FLAGS+=("--every-spec-row"); shift ;;
+        --mutation-each)   flag_mutation_each=1;  FLAGS+=("--mutation-each");  shift ;;
+        --no-mock-each)    flag_no_mock_each=1;   FLAGS+=("--no-mock-each");   shift ;;
+        --exhaustive)
+            flag_every_spec_row=1
+            flag_mutation_each=1
+            flag_no_mock_each=1
+            FLAGS+=("--exhaustive")
+            shift
+            ;;
+        --verdict)         VERDICT="$2"; shift 2 ;;
+        --proof-matrix)    PROOF_MATRIX="$2"; shift 2 ;;
+        --mutation-proof)  MUTATION_PROOF="$2"; shift 2 ;;
+        --canary)          CANARY="$2"; shift 2 ;;
+        --reliability)     RELIABILITY="$2"; shift 2 ;;
+        --spec)            SPECS+=("$2"); shift 2 ;;
+        -h|--help)         usage; exit 0 ;;
+        *)                 echo "unknown arg: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+# No flags requested → no-op success (backwards-compat).
+if [ "$flag_every_spec_row" = "0" ] \
+        && [ "$flag_mutation_each" = "0" ] \
+        && [ "$flag_no_mock_each" = "0" ]; then
+    exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "qa-exhaustiveness-check: jq is required" >&2
+    exit 2
+fi
+
+if [ "${#SPECS[@]}" = "0" ]; then
+    echo "qa-exhaustiveness-check: at least one --spec <path> is required when a flag is active" >&2
+    exit 2
+fi
+
+VERDICT_DIR="$(dirname "$VERDICT")"
+mkdir -p "$VERDICT_DIR"
+# Atomic init: write tmp in same dir, then rename.
+if [ ! -f "$VERDICT" ]; then
+    init_tmp="$(mktemp "$VERDICT_DIR/.qa-verdict.XXXXXX")"
+    printf '{"verdict":"PASS","findings":[]}\n' > "$init_tmp" && mv "$init_tmp" "$VERDICT"
+fi
+if ! jq -e '.findings | type == "array"' "$VERDICT" >/dev/null 2>&1; then
+    tmp="$(mktemp "$VERDICT_DIR/.qa-verdict.XXXXXX")"
+    jq '. + {findings: (.findings // [])}' "$VERDICT" > "$tmp" && mv "$tmp" "$VERDICT"
+fi
+
+# Record requested flags on the verdict (idempotent).
+{
+    tmp="$(mktemp "$VERDICT_DIR/.qa-verdict.XXXXXX")"
+    # shellcheck disable=SC2016
+    jq --argjson f "$(printf '%s\n' "${FLAGS[@]}" | jq -R . | jq -s .)" \
+        '.requested_flags = ((.requested_flags // []) + $f | unique)' \
+        "$VERDICT" > "$tmp" && mv "$tmp" "$VERDICT"
+}
+
+append_finding() {
+    # $1 = category, $2 = summary, $3 = evidence
+    local category="$1" summary="$2" evidence="$3"
+    local tmp
+    tmp="$(mktemp "$VERDICT_DIR/.qa-verdict.XXXXXX")"
+    jq --arg cat "$category" \
+       --arg summary "$summary" \
+       --arg evidence "$evidence" \
+       '.findings += [{
+            "category": $cat,
+            "release_blocking": true,
+            "status": "FAIL",
+            "summary": $summary,
+            "evidence": $evidence
+        }]' "$VERDICT" > "$tmp" && mv "$tmp" "$VERDICT"
+}
+
+demote_verdict() {
+    # FAIL > PARTIAL > PASS precedence — never upgrade.
+    local current
+    current="$(jq -r '.verdict // "PASS"' "$VERDICT")"
+    case "$current" in
+        FAIL)    return ;;                # preserve
+        PARTIAL) return ;;                # already demoted
+        PASS|*)
+            local tmp
+            tmp="$(mktemp "$VERDICT_DIR/.qa-verdict.XXXXXX")"
+            jq '.verdict = "PARTIAL"' "$VERDICT" > "$tmp" && mv "$tmp" "$VERDICT"
+            ;;
+    esac
+}
+
+# --- Spec parsing helpers ---------------------------------------------------
+
+# Extract acceptance criteria from a spec markdown file. We accept either:
+#   - lines under an "## Acceptance" / "## Acceptance Criteria" heading that
+#     start with "- " or "* " or "<digit>." until the next "## " heading.
+#   - lines of the form "AC<n>: ..." or "AC-<n>: ..." anywhere in the file.
+# Emits one AC identifier per line (the verbatim first ~80 chars, lowercased
+# for matching). Caller is responsible for de-duping.
+extract_acs() {
+    local spec="$1"
+    awk '
+        BEGIN { in_ac = 0 }
+        /^## / {
+            if (tolower($0) ~ /acceptance/) { in_ac = 1; next }
+            in_ac = 0
+        }
+        in_ac && /^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]+/ {
+            sub(/^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]+/, "")
+            print
+        }
+        /^AC[-_]?[0-9]+[:[:space:]]/ {
+            print
+        }
+    ' "$spec"
+}
+
+# Extract workflows from a spec. Convention used by autospec-qa:
+#   - "## Workflows" section with "- " bullets, OR
+#   - lines like "Workflow: <name>" / "workflow_id: <name>".
+extract_workflows() {
+    local spec="$1"
+    awk '
+        BEGIN { in_wf = 0 }
+        /^## / {
+            if (tolower($0) ~ /workflows?$/) { in_wf = 1; next }
+            in_wf = 0
+        }
+        in_wf && /^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]+/ {
+            sub(/^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]+/, "")
+            print
+        }
+        /^[Ww]orkflow(_id)?:[[:space:]]/ {
+            sub(/^[Ww]orkflow(_id)?:[[:space:]]*/, "")
+            print
+        }
+    ' "$spec"
+}
+
+# Extract backend-backed features: lines under "## Backend Features" or
+# "## Backend-backed features" heading; OR lines tagged "backend: true".
+extract_backend_features() {
+    local spec="$1"
+    awk '
+        BEGIN { in_bf = 0 }
+        /^## / {
+            if (tolower($0) ~ /backend[- ]?(backed )?features?/) { in_bf = 1; next }
+            in_bf = 0
+        }
+        in_bf && /^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]+/ {
+            sub(/^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]+/, "")
+            print
+        }
+    ' "$spec"
+}
+
+# Normalise a string for matching: lower-case, collapse whitespace.
+norm() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//'; }
+
+exit_code=0
+
+# --- Gate 1: --every-spec-row ----------------------------------------------
+
+if [ "$flag_every_spec_row" = "1" ]; then
+    matrix_rows="[]"
+    if [ -f "$PROOF_MATRIX" ] && jq empty "$PROOF_MATRIX" >/dev/null 2>&1; then
+        # Accept either { rows: [...] } or a top-level array.
+        kind="$(jq -r 'type' "$PROOF_MATRIX")"
+        if [ "$kind" = "array" ]; then
+            matrix_rows="$(jq '.' "$PROOF_MATRIX")"
+        else
+            matrix_rows="$(jq '.rows // []' "$PROOF_MATRIX")"
+        fi
+    fi
+    for spec in "${SPECS[@]}"; do
+        if [ ! -f "$spec" ]; then
+            append_finding "code_health:incomplete_traceability" \
+                "spec file missing: $spec" "$spec"
+            exit_code=1
+            continue
+        fi
+        while IFS= read -r ac; do
+            [ -z "$ac" ] && continue
+            ac_norm="$(norm "$ac")"
+            # Match if any row's ac/criterion field, normalised, contains the AC
+            # text (or vice-versa) AND its status is not NOT_TESTED.
+            covered="$(printf '%s' "$matrix_rows" | jq --arg ac "$ac_norm" '
+                map(select(
+                    (((.ac // .criterion // .acceptance_criterion // "") | ascii_downcase | gsub("\\s+"; " ") | ltrimstr(" ") | rtrimstr(" ")) as $row
+                     | ($row == $ac or ($row | contains($ac)) or ($ac | contains($row)) and $row != ""))
+                    and (.status // "") != "NOT_TESTED"
+                )) | length
+            ')"
+            if [ "${covered:-0}" = "0" ]; then
+                short="$(printf '%s' "$ac" | head -c 120)"
+                append_finding "code_health:incomplete_traceability" \
+                    "spec acceptance criterion has no non-NOT_TESTED proof-matrix row: $short" \
+                    "spec=$spec ac=$short"
+                exit_code=1
+            fi
+        done < <(extract_acs "$spec" | sort -u)
+    done
+fi
+
+# --- Gate 2: --mutation-each -----------------------------------------------
+
+if [ "$flag_mutation_each" = "1" ]; then
+    mutations="[]"
+    if [ -f "$MUTATION_PROOF" ] && jq empty "$MUTATION_PROOF" >/dev/null 2>&1; then
+        mutations="$(jq '.mutations // []' "$MUTATION_PROOF")"
+    fi
+    for spec in "${SPECS[@]}"; do
+        [ -f "$spec" ] || continue
+        while IFS= read -r wf; do
+            [ -z "$wf" ] && continue
+            wf_norm="$(norm "$wf")"
+            covered="$(printf '%s' "$mutations" | jq --arg wf "$wf_norm" '
+                map(select(
+                    ((.workflow_id // .workflow // "") | ascii_downcase | gsub("\\s+"; " ") | ltrimstr(" ") | rtrimstr(" ")) as $row
+                    | ($row == $wf or ($row | contains($wf)) or ($wf | contains($row)) and $row != "")
+                )) | length
+            ')"
+            if [ "${covered:-0}" = "0" ]; then
+                short="$(printf '%s' "$wf" | head -c 120)"
+                append_finding "code_health:incomplete_mutation_proof" \
+                    "spec workflow has no mutation-proof entry: $short" \
+                    "spec=$spec workflow=$short"
+                exit_code=1
+            fi
+        done < <(extract_workflows "$spec" | sort -u)
+    done
+fi
+
+# --- Gate 3: --no-mock-each -------------------------------------------------
+
+if [ "$flag_no_mock_each" = "1" ]; then
+    canary_entries="[]"
+    if [ -f "$CANARY" ] && jq empty "$CANARY" >/dev/null 2>&1; then
+        kind="$(jq -r 'type' "$CANARY")"
+        if [ "$kind" = "array" ]; then
+            canary_entries="$(jq '.' "$CANARY")"
+        else
+            canary_entries="$(jq '.entries // .canaries // .results // []' "$CANARY")"
+        fi
+    fi
+    # Exceptions: features explicitly listed under reliability.yml's
+    # no_mock_exempt (or no_mock.exempt) list bypass this gate. Plain grep
+    # is sufficient — yq is not assumed installed.
+    exempt_text=""
+    if [ -f "$RELIABILITY" ]; then
+        exempt_text="$(awk '
+            /^no_mock_exempt:/ { capture = 1; next }
+            /^no_mock:/        { capture = 0; next }
+            /^[a-zA-Z_]+:/     { capture = 0 }
+            capture && /^[[:space:]]*-[[:space:]]+/ { sub(/^[[:space:]]*-[[:space:]]+/, ""); print }
+        ' "$RELIABILITY")"
+    fi
+    for spec in "${SPECS[@]}"; do
+        [ -f "$spec" ] || continue
+        while IFS= read -r feat; do
+            [ -z "$feat" ] && continue
+            feat_norm="$(norm "$feat")"
+            # exempt?
+            if [ -n "$exempt_text" ]; then
+                if printf '%s\n' "$exempt_text" | while IFS= read -r e; do
+                    en="$(norm "$e")"
+                    [ -n "$en" ] && [ "$en" = "$feat_norm" ] && exit 0
+                done; then
+                    : # placeholder; the actual check is the if below
+                fi
+                if printf '%s\n' "$exempt_text" | grep -qiF "$feat"; then
+                    continue
+                fi
+            fi
+            covered="$(printf '%s' "$canary_entries" | jq --arg f "$feat_norm" '
+                map(select(
+                    ((.feature // .name // .id // "") | ascii_downcase | gsub("\\s+"; " ") | ltrimstr(" ") | rtrimstr(" ")) as $row
+                    | ($row == $f or ($row | contains($f)) or ($f | contains($row)) and $row != "")
+                )) | length
+            ')"
+            if [ "${covered:-0}" = "0" ]; then
+                short="$(printf '%s' "$feat" | head -c 120)"
+                append_finding "code_health:incomplete_no_mock_coverage" \
+                    "backend-backed feature has no no-mock canary entry: $short" \
+                    "spec=$spec feature=$short"
+                exit_code=1
+            fi
+        done < <(extract_backend_features "$spec" | sort -u)
+    done
+fi
+
+if [ "$exit_code" = "1" ]; then
+    demote_verdict
+fi
+
+exit "$exit_code"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1220,6 +1220,31 @@ check_qa_incident_contract() {
     fi
 }
 
+check_qa_exhaustiveness_contract() {
+    info "qa exhaustiveness flags: script + adapter lockstep (issue #660)"
+    local script="scripts/qa-exhaustiveness-check.sh"
+    local bats="tests/qa/test_exhaustiveness.bats"
+    [ -f "$script" ] || fail "$script: file missing (issue #660)"
+    [ -x "$script" ] || fail "$script: file not executable (issue #660)"
+    bash -n "$script" || fail "$script: bash syntax error (issue #660)"
+    [ -f "$bats" ] || fail "$bats: bats coverage missing (issue #660)"
+    for trio in skills/autospec-qa/SKILL.md skills/autospec-qa/codex/prompt.md skills/autospec-qa/opencode/agent.md; do
+        grep -q '^## Exhaustiveness flags' "$trio" \
+            || fail "$trio missing '## Exhaustiveness flags' section (issue #660)"
+        grep -q 'qa-exhaustiveness-check\.sh' "$trio" \
+            || fail "$trio missing reference to qa-exhaustiveness-check.sh (issue #660)"
+        for flag in --every-spec-row --mutation-each --no-mock-each --exhaustive; do
+            grep -q -- "$flag" "$trio" \
+                || fail "$trio missing $flag documentation (issue #660)"
+        done
+    done
+    if command -v bats >/dev/null 2>&1; then
+        info "  running: $bats"
+        bats "$bats" >/tmp/validate-exhaustiveness.log 2>&1 \
+            || { cat /tmp/validate-exhaustiveness.log >&2; fail "$bats: failed"; }
+    fi
+}
+
 check_lint_heredoc_handling() {
     info "lint-implementation heredoc handling: tests/lint/test_complexity_heredoc.bats"
     [ -f tests/lint/test_complexity_heredoc.bats ] \
@@ -1307,6 +1332,7 @@ main() {
     check_dogfood_detectors
     check_qa_verify_first_discipline
     check_qa_incident_contract
+    check_qa_exhaustiveness_contract
     check_autospec_release_contract
     check_qa_verdict_contract
     check_release_verdict_script

--- a/skills/autospec-qa/SKILL.md
+++ b/skills/autospec-qa/SKILL.md
@@ -662,6 +662,53 @@ Required outcome:
   and the remediation status.
 ```
 
+## Exhaustiveness flags
+
+The orchestrator soft-discipline sections above (the reliability exhaustion
+loop, the 20-question Critical self-questioning checkpoint, "no-mock minimum
+coverage", etc.) drive depth of coverage by prose. When clusters skip a step
+the report can still say PASS while a production bug ships. The operator MAY
+invoke `/autospec-qa` with one or more explicit machine-checkable flags that
+convert that prose into a hard gate. With no flag, behavior is unchanged.
+
+- `--every-spec-row` — fail the run with `code_health:incomplete_traceability`
+  if any spec acceptance criterion lacks a non-`NOT_TESTED` row in
+  `.autospec/proof-matrix.json`. Forces the orchestrator to extract every
+  AC, not just the ones it judged "important".
+- `--mutation-each` — require a mutation/breakage entry in
+  `.autospec/mutation-proof.json` for every workflow listed in the spec,
+  not just "critical" ones. Missing entries emit
+  `code_health:incomplete_mutation_proof`.
+- `--no-mock-each` — require a no-mock deployed/dev smoke path in
+  `.autospec/canary-results.json` for every backend-backed feature.
+  Exceptions must be declared explicitly under `no_mock_exempt` in
+  `.autospec/reliability.yml`. Missing entries emit
+  `code_health:incomplete_no_mock_coverage`.
+- `--exhaustive` — turns the three above on.
+
+Enforcement runs after the existing verdict computation but BEFORE writing
+`.autospec/qa-verdict.json` as final. The helper appends one
+`release_blocking: true` finding per gap and demotes the verdict from
+PASS to PARTIAL (FAIL is preserved). The list of flags actually requested
+is recorded under `requested_flags` on the verdict so downstream skills
+(notably `/autospec-release`) can see what was enforced. Both the
+orchestrator prompt and the regeneration loop call this helper:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/qa-exhaustiveness-check.sh" \
+    --exhaustive \
+    --verdict        .autospec/qa-verdict.json \
+    --proof-matrix   .autospec/proof-matrix.json \
+    --mutation-proof .autospec/mutation-proof.json \
+    --canary         .autospec/canary-results.json \
+    --reliability    .autospec/reliability.yml \
+    --spec docs/specs/<feature>.md
+```
+
+Exit 0 means every requested gate passed. Exit 1 means at least one gate
+failed and the verdict + findings have been updated atomically. Backwards-
+compatible: invoking with no flag is a no-op.
+
 ## Production incident regression check
 
 When QA passes but production breaks, the same bug class tends to leak again the

--- a/skills/autospec-qa/codex/prompt.md
+++ b/skills/autospec-qa/codex/prompt.md
@@ -658,6 +658,53 @@ Required outcome:
   and the remediation status.
 ```
 
+## Exhaustiveness flags
+
+The orchestrator soft-discipline sections above (the reliability exhaustion
+loop, the 20-question Critical self-questioning checkpoint, "no-mock minimum
+coverage", etc.) drive depth of coverage by prose. When clusters skip a step
+the report can still say PASS while a production bug ships. The operator MAY
+invoke `/autospec-qa` with one or more explicit machine-checkable flags that
+convert that prose into a hard gate. With no flag, behavior is unchanged.
+
+- `--every-spec-row` — fail the run with `code_health:incomplete_traceability`
+  if any spec acceptance criterion lacks a non-`NOT_TESTED` row in
+  `.autospec/proof-matrix.json`. Forces the orchestrator to extract every
+  AC, not just the ones it judged "important".
+- `--mutation-each` — require a mutation/breakage entry in
+  `.autospec/mutation-proof.json` for every workflow listed in the spec,
+  not just "critical" ones. Missing entries emit
+  `code_health:incomplete_mutation_proof`.
+- `--no-mock-each` — require a no-mock deployed/dev smoke path in
+  `.autospec/canary-results.json` for every backend-backed feature.
+  Exceptions must be declared explicitly under `no_mock_exempt` in
+  `.autospec/reliability.yml`. Missing entries emit
+  `code_health:incomplete_no_mock_coverage`.
+- `--exhaustive` — turns the three above on.
+
+Enforcement runs after the existing verdict computation but BEFORE writing
+`.autospec/qa-verdict.json` as final. The helper appends one
+`release_blocking: true` finding per gap and demotes the verdict from
+PASS to PARTIAL (FAIL is preserved). The list of flags actually requested
+is recorded under `requested_flags` on the verdict so downstream skills
+(notably `/autospec-release`) can see what was enforced. Both the
+orchestrator prompt and the regeneration loop call this helper:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/qa-exhaustiveness-check.sh" \
+    --exhaustive \
+    --verdict        .autospec/qa-verdict.json \
+    --proof-matrix   .autospec/proof-matrix.json \
+    --mutation-proof .autospec/mutation-proof.json \
+    --canary         .autospec/canary-results.json \
+    --reliability    .autospec/reliability.yml \
+    --spec docs/specs/<feature>.md
+```
+
+Exit 0 means every requested gate passed. Exit 1 means at least one gate
+failed and the verdict + findings have been updated atomically. Backwards-
+compatible: invoking with no flag is a no-op.
+
 ## Production incident regression check
 
 When QA passes but production breaks, the same bug class tends to leak again the

--- a/skills/autospec-qa/opencode/agent.md
+++ b/skills/autospec-qa/opencode/agent.md
@@ -662,6 +662,53 @@ Required outcome:
   and the remediation status.
 ```
 
+## Exhaustiveness flags
+
+The orchestrator soft-discipline sections above (the reliability exhaustion
+loop, the 20-question Critical self-questioning checkpoint, "no-mock minimum
+coverage", etc.) drive depth of coverage by prose. When clusters skip a step
+the report can still say PASS while a production bug ships. The operator MAY
+invoke `/autospec-qa` with one or more explicit machine-checkable flags that
+convert that prose into a hard gate. With no flag, behavior is unchanged.
+
+- `--every-spec-row` — fail the run with `code_health:incomplete_traceability`
+  if any spec acceptance criterion lacks a non-`NOT_TESTED` row in
+  `.autospec/proof-matrix.json`. Forces the orchestrator to extract every
+  AC, not just the ones it judged "important".
+- `--mutation-each` — require a mutation/breakage entry in
+  `.autospec/mutation-proof.json` for every workflow listed in the spec,
+  not just "critical" ones. Missing entries emit
+  `code_health:incomplete_mutation_proof`.
+- `--no-mock-each` — require a no-mock deployed/dev smoke path in
+  `.autospec/canary-results.json` for every backend-backed feature.
+  Exceptions must be declared explicitly under `no_mock_exempt` in
+  `.autospec/reliability.yml`. Missing entries emit
+  `code_health:incomplete_no_mock_coverage`.
+- `--exhaustive` — turns the three above on.
+
+Enforcement runs after the existing verdict computation but BEFORE writing
+`.autospec/qa-verdict.json` as final. The helper appends one
+`release_blocking: true` finding per gap and demotes the verdict from
+PASS to PARTIAL (FAIL is preserved). The list of flags actually requested
+is recorded under `requested_flags` on the verdict so downstream skills
+(notably `/autospec-release`) can see what was enforced. Both the
+orchestrator prompt and the regeneration loop call this helper:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/qa-exhaustiveness-check.sh" \
+    --exhaustive \
+    --verdict        .autospec/qa-verdict.json \
+    --proof-matrix   .autospec/proof-matrix.json \
+    --mutation-proof .autospec/mutation-proof.json \
+    --canary         .autospec/canary-results.json \
+    --reliability    .autospec/reliability.yml \
+    --spec docs/specs/<feature>.md
+```
+
+Exit 0 means every requested gate passed. Exit 1 means at least one gate
+failed and the verdict + findings have been updated atomically. Backwards-
+compatible: invoking with no flag is a no-op.
+
 ## Production incident regression check
 
 When QA passes but production breaks, the same bug class tends to leak again the

--- a/tests/qa/test_exhaustiveness.bats
+++ b/tests/qa/test_exhaustiveness.bats
@@ -1,0 +1,244 @@
+#!/usr/bin/env bats
+# tests/qa/test_exhaustiveness.bats
+#
+# Coverage for scripts/qa-exhaustiveness-check.sh (issue #660).
+#
+# Each fixture is self-contained: synthetic spec + synthetic artifact files,
+# invoked through the explicit flag under test. Backwards-compat: no flags
+# = no-op success (the script's behavior when called with no flags
+# matches today's adapter behavior).
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../../scripts/qa-exhaustiveness-check.sh"
+    [ -x "$SCRIPT" ] || skip "qa-exhaustiveness-check.sh not installed"
+    command -v jq >/dev/null 2>&1 || skip "jq required"
+    TMPDIR_T="$(mktemp -d)"
+    VERDICT="$TMPDIR_T/qa-verdict.json"
+    PROOF="$TMPDIR_T/proof-matrix.json"
+    MUT="$TMPDIR_T/mutation-proof.json"
+    CAN="$TMPDIR_T/canary-results.json"
+    REL="$TMPDIR_T/reliability.yml"
+    SPEC="$TMPDIR_T/spec.md"
+}
+
+teardown() {
+    [ -n "${TMPDIR_T:-}" ] && rm -rf "$TMPDIR_T"
+    return 0
+}
+
+@test "no flags → no-op success (backwards-compat)" {
+    run bash "$SCRIPT" --verdict "$VERDICT"
+    [ "$status" -eq 0 ]
+    [ ! -f "$VERDICT" ]
+}
+
+@test "--every-spec-row passes when every AC has a non-NOT_TESTED row" {
+    cat > "$SPEC" <<'EOF'
+# Feature
+
+## Acceptance
+
+- user can log in with valid credentials
+- user is shown an error on invalid password
+EOF
+    cat > "$PROOF" <<'EOF'
+{
+  "rows": [
+    { "ac": "user can log in with valid credentials", "status": "PASS" },
+    { "ac": "user is shown an error on invalid password", "status": "PARTIAL" }
+  ]
+}
+EOF
+    run bash "$SCRIPT" --every-spec-row \
+        --verdict "$VERDICT" --proof-matrix "$PROOF" --spec "$SPEC"
+    [ "$status" -eq 0 ]
+}
+
+@test "--every-spec-row fails with 5 ACs / 4 covered → missing AC named" {
+    cat > "$SPEC" <<'EOF'
+# Feature
+
+## Acceptance
+
+- ac one alpha
+- ac two beta
+- ac three gamma
+- ac four delta
+- ac five epsilon uncovered
+EOF
+    cat > "$PROOF" <<'EOF'
+{
+  "rows": [
+    { "ac": "ac one alpha",   "status": "PASS" },
+    { "ac": "ac two beta",    "status": "PASS" },
+    { "ac": "ac three gamma", "status": "PARTIAL" },
+    { "ac": "ac four delta",  "status": "PASS" }
+  ]
+}
+EOF
+    run bash "$SCRIPT" --every-spec-row \
+        --verdict "$VERDICT" --proof-matrix "$PROOF" --spec "$SPEC"
+    [ "$status" -eq 1 ]
+    cat="$(jq -r '.findings[0].category' "$VERDICT")"
+    [ "$cat" = "code_health:incomplete_traceability" ]
+    summary="$(jq -r '.findings[0].summary' "$VERDICT")"
+    [[ "$summary" == *"ac five epsilon uncovered"* ]]
+    verdict="$(jq -r '.verdict' "$VERDICT")"
+    [ "$verdict" = "PARTIAL" ]
+}
+
+@test "--every-spec-row treats NOT_TESTED rows as uncovered" {
+    cat > "$SPEC" <<'EOF'
+# Feature
+
+## Acceptance
+
+- only criterion
+EOF
+    cat > "$PROOF" <<'EOF'
+{ "rows": [ { "ac": "only criterion", "status": "NOT_TESTED" } ] }
+EOF
+    run bash "$SCRIPT" --every-spec-row \
+        --verdict "$VERDICT" --proof-matrix "$PROOF" --spec "$SPEC"
+    [ "$status" -eq 1 ]
+    cat="$(jq -r '.findings[0].category' "$VERDICT")"
+    [ "$cat" = "code_health:incomplete_traceability" ]
+}
+
+@test "--mutation-each fails when 3 workflows / 2 covered" {
+    cat > "$SPEC" <<'EOF'
+# Feature
+
+## Workflows
+
+- checkout
+- refund
+- subscription renew
+EOF
+    cat > "$MUT" <<'EOF'
+{
+  "mutations": [
+    { "workflow_id": "checkout", "observed_result": "failed_as_expected" },
+    { "workflow_id": "refund",   "observed_result": "failed_as_expected" }
+  ]
+}
+EOF
+    run bash "$SCRIPT" --mutation-each \
+        --verdict "$VERDICT" --mutation-proof "$MUT" --spec "$SPEC"
+    [ "$status" -eq 1 ]
+    cat="$(jq -r '.findings[0].category' "$VERDICT")"
+    [ "$cat" = "code_health:incomplete_mutation_proof" ]
+    summary="$(jq -r '.findings[0].summary' "$VERDICT")"
+    [[ "$summary" == *"subscription renew"* ]]
+}
+
+@test "--no-mock-each fails when a backend feature has no canary entry" {
+    cat > "$SPEC" <<'EOF'
+# Feature
+
+## Backend-backed Features
+
+- billing/charge
+- billing/refund
+EOF
+    cat > "$CAN" <<'EOF'
+[
+  { "feature": "billing/charge", "status": "PASS" }
+]
+EOF
+    run bash "$SCRIPT" --no-mock-each \
+        --verdict "$VERDICT" --canary "$CAN" --spec "$SPEC"
+    [ "$status" -eq 1 ]
+    cat="$(jq -r '.findings[0].category' "$VERDICT")"
+    [ "$cat" = "code_health:incomplete_no_mock_coverage" ]
+    summary="$(jq -r '.findings[0].summary' "$VERDICT")"
+    [[ "$summary" == *"billing/refund"* ]]
+}
+
+@test "--no-mock-each honours reliability.yml exemptions" {
+    cat > "$SPEC" <<'EOF'
+# Feature
+
+## Backend-backed Features
+
+- billing/exempt-feature
+EOF
+    cat > "$CAN" <<'EOF'
+[]
+EOF
+    cat > "$REL" <<'EOF'
+no_mock_exempt:
+  - billing/exempt-feature
+EOF
+    run bash "$SCRIPT" --no-mock-each \
+        --verdict "$VERDICT" --canary "$CAN" --reliability "$REL" --spec "$SPEC"
+    [ "$status" -eq 0 ]
+}
+
+@test "--exhaustive aggregates all three gates and records requested_flags" {
+    cat > "$SPEC" <<'EOF'
+# Feature
+
+## Acceptance
+
+- alpha
+- beta
+
+## Workflows
+
+- alpha-flow
+
+## Backend-backed Features
+
+- alpha-service
+EOF
+    # Nothing covered → all three gates should fail.
+    cat > "$PROOF" <<'EOF'
+{ "rows": [] }
+EOF
+    cat > "$MUT" <<'EOF'
+{ "mutations": [] }
+EOF
+    cat > "$CAN" <<'EOF'
+[]
+EOF
+    run bash "$SCRIPT" --exhaustive \
+        --verdict "$VERDICT" \
+        --proof-matrix "$PROOF" \
+        --mutation-proof "$MUT" \
+        --canary "$CAN" \
+        --spec "$SPEC"
+    [ "$status" -eq 1 ]
+    # At least 4 findings: 2 ACs + 1 workflow + 1 backend feature.
+    count="$(jq '.findings | length' "$VERDICT")"
+    [ "$count" -ge 4 ]
+    # Flags persisted.
+    has="$(jq -r '.requested_flags | index("--exhaustive")' "$VERDICT")"
+    [ "$has" != "null" ]
+    verdict="$(jq -r '.verdict' "$VERDICT")"
+    [ "$verdict" = "PARTIAL" ]
+}
+
+@test "FAIL verdict is preserved (not upgraded) when gate fires" {
+    printf '%s\n' '{"verdict":"FAIL","findings":[]}' > "$VERDICT"
+    cat > "$SPEC" <<'EOF'
+# Feature
+
+## Acceptance
+
+- only criterion
+EOF
+    cat > "$PROOF" <<'EOF'
+{ "rows": [] }
+EOF
+    run bash "$SCRIPT" --every-spec-row \
+        --verdict "$VERDICT" --proof-matrix "$PROOF" --spec "$SPEC"
+    [ "$status" -eq 1 ]
+    verdict="$(jq -r '.verdict' "$VERDICT")"
+    [ "$verdict" = "FAIL" ]
+}
+
+@test "missing --spec when a flag is active → usage error (exit 2)" {
+    run bash "$SCRIPT" --every-spec-row --verdict "$VERDICT"
+    [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## Summary
- Adds `--every-spec-row` / `--mutation-each` / `--no-mock-each` / `--exhaustive` flags converting soft prose discipline into hard machine-checkable gates.
- New `scripts/qa-exhaustiveness-check.sh` emits findings with proper categories, preserves FAIL > PARTIAL > PASS precedence, records `requested_flags[]` in `qa-verdict.json`.
- Lockstep `## Exhaustiveness flags` section across autospec-qa trio.
- `check_qa_exhaustiveness_contract()` enforces script + adapter lockstep + all 4 flags + bats.

## Test plan
- [x] `bats tests/qa/test_exhaustiveness.bats` → 10/10 PASS
- [x] `bash scripts/validate.sh` → all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)