### PR TITLE
feat: autospec-refine skill scaffold (closes #669)

### DIFF
--- a/skills/autospec-refine/README.md
+++ b/skills/autospec-refine/README.md
@@ -1,0 +1,111 @@
+# autospec-refine
+
+N-round prompt refinement with repo-grounded lenses. Takes an operator-supplied
+prompt (or feature request) and iteratively refines it over N rounds, grounding
+each round in current repo knowledge (`AGENTS.md`, recent specs, recent
+commits, tagged memory). After operator approval, hands off the final refined
+prompt to `/autospec --autonomous` for end-to-end implementation.
+
+Goal: better prompts → better code, fewer mid-implementation course
+corrections, fewer rounds of operator feedback.
+
+Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
+
+## Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-refine/install.sh | sh -s -- --harness all
+```
+
+Per-harness:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-refine/install.sh | sh -s -- --harness claude
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-refine/install.sh | sh -s -- --harness opencode
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-refine/install.sh | sh -s -- --harness codex
+```
+
+From a clone:
+
+```bash
+cd skills/autospec-refine
+./install.sh --harness all
+```
+
+## Invocation
+
+```
+/autospec-refine "<initial prompt>" [--rounds N] [--from-file <path>] \
+                 [--interactive | --autonomous (default) | --dry-run] \
+                 [--lenses <comma-list>] [--output <path>] \
+                 [--continue [--max-iterations N]]
+```
+
+- `--rounds N` — number of refinement passes. Default `3`. Max `10`.
+- `--from-file <path>` — read the initial prompt from a file.
+- `--autonomous` (default) — hand off to `/autospec --autonomous "<refined>"`.
+- `--interactive` — hand off to plain `/autospec "<refined>"`.
+- `--dry-run` — produce the artifact only, do not hand off.
+- `--lenses repo,clarity,sizing,adversarial` — override the default lens order.
+- `--output <path>` — write the final refined prompt to a file.
+- `--continue` — continuous iteration mode (refine → handoff → execute →
+  harvest-report → re-refine, bounded by termination rules).
+
+## Lenses
+
+Four registered lenses, applied in order one per round:
+
+1. **`repo-grounding`** — replace generic verbs with project-specific file
+   paths, conventions, lockstep, TDD, no-mock, conventional commits.
+2. **`clarity-ac`** — extract implicit acceptance criteria into `- [ ]`
+   checkboxes; disambiguate hedging language.
+3. **`sizing`** — enforce small-LLM sizing caps (≤400 words, ≤3 files, ≤30
+   outline lines); split oversize prompts into parent+child fragments.
+4. **`adversarial`** — apply the autospec-qa 20-question critical-question
+   checklist.
+
+## Artifacts
+
+- `.autospec/refinements/<slug>-<ts>.json` — structured per-round record.
+- `.autospec/refinements/<slug>-<ts>.md` — human-readable report.
+- `schemas/autospec-refinement.schema.json` — schema validated by
+  `scripts/validate.sh`.
+
+For continuous mode:
+
+- `.autospec/refinements/<slug>-loop.json` — per-iteration record.
+
+## Related skills
+
+| Skill | Purpose |
+| --- | --- |
+| [`autospec`](../autospec/README.md) | Full pipeline (Phases 0–6) for plan + ship. |
+| [`autospec-define`](../autospec-define/README.md) | Planning half (Phases 0–3). Receives refined prompts from `autospec-refine`. |
+| [`autospec-run`](../autospec-run/README.md) | Implementation half (Phases 4–6). |
+
+## Self-update
+
+Run the skill with the literal argument `update` to refresh in place:
+
+```
+/autospec-refine update
+```
+
+Or re-run the installer with `--update`:
+
+```bash
+./install.sh --harness all --update
+```
+
+## Stop
+
+Halt a running refinement loop:
+
+```
+/autospec-refine stop --graceful   # finish current iteration, then exit
+/autospec-refine stop --immediate  # abort at next iteration boundary
+```
+
+## License
+
+MIT — see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autospec-refine/SKILL.md
+++ b/skills/autospec-refine/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: autospec-refine
+description: Use when the user wants to refine a prompt or feature request over N rounds of repo-grounded lenses before handing off to /autospec for implementation. Supports --rounds, --lenses, --autonomous, --interactive, --dry-run, and --continue (continuous iteration mode).
+---
+
+# autospec-refine workflow (harness-neutral)
+
+Take an operator-supplied prompt (or feature request) and iteratively refine it
+over N rounds, grounding each round in current repo knowledge (AGENTS.md,
+recent specs, recent commits, tagged memory). After operator approval, hand off
+the final refined prompt to `/autospec --autonomous` (default) or
+`/autospec` (interactive) for end-to-end implementation.
+
+Goal: better prompts → better code, fewer mid-implementation course
+corrections, fewer rounds of operator feedback. This skill closes the gap
+between under-specified raw requests and hand-crafted long prompts by
+automating the prompt-improvement loop operators currently run in their heads.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your
+harness supports it; do not investigate or write the refined prompt directly in
+the main conversation when a subagent can do it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-refine   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-refine
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-refine/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-refine.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-refine.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter the refinement pipeline. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-refine found; run install.sh first.` and exit.
+
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$` (case-insensitive), this skill enters stop mode and does not run the normal pipeline:
+
+1. Delegate to the shared stop helper:
+   ```bash
+   bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"
+   ```
+2. Honor `--graceful` (write `~/.autospec/stop.flag`; running iteration finishes) and `--immediate` (write `~/.autospec/refine-loop-stop.flag` plus stop.flag; abort at next iteration boundary).
+3. Print the stop summary and exit. Do not enter the refinement pipeline.
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — recognized by Claude Code, OpenCode, and Codex. Per AGENTS.md, subagent dispatches use the two-tier policy: Tier A for spec/refinement work (each lens applies fresh-eyes reasoning to the prompt), Tier B for implementation. This skill is refinement-only and dispatches at Tier A. Fall back UP the tier on quota/capacity failure.
+
+## Harness detection (run once at skill start, before refinement begins)
+
+Detect your harness by checking available tools before any lens runs:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness, silently retry the same subagent dispatch with `TIER_A`. Preserve parent context on retry. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
+## Architecture
+
+`autospec-refine` is a new top-level skill that mirrors the existing
+`autospec-define` and `autospec-qa` skill-family shape:
+
+- `skills/autospec-refine/SKILL.md` — Claude Code adapter (authoritative).
+- `skills/autospec-refine/codex/prompt.md` — Codex CLI mirror (lockstep).
+- `skills/autospec-refine/opencode/agent.md` — OpenCode mirror (lockstep).
+- `skills/autospec-refine/install.sh` — installer; mirrors existing skills.
+- `skills/autospec-refine/uninstall.sh` — uninstaller; mirrors existing skills.
+- `skills/autospec-refine/README.md` — usage doc.
+- `scripts/refine-prompt.sh` — orchestrator: parses args, dispatches lenses,
+  writes artifacts, performs handoff. **Stubbed by this scaffold; implemented
+  in the orchestrator child issue.**
+- `scripts/refine-render-overview.sh` — produces dual markdown + JSON artifact.
+  **Stubbed by this scaffold; implemented in the renderer child issue.**
+
+This SKILL.md is the scaffold contract. Subsequent child issues fill in
+`scripts/refine-prompt.sh`, the lens helpers, the renderer, the handoff
+plumbing, and the continuous-iteration loop.
+
+## Invocation
+
+```
+/autospec-refine "<initial prompt>" [--rounds N] [--from-file <path>] \
+                 [--interactive | --autonomous (default) | --dry-run] \
+                 [--lenses <comma-list>] [--output <path>] \
+                 [--continue [--max-iterations N]]
+```
+
+> **Model tier:** `TIER_A` (spec work) — each refinement round dispatches a fresh-eyes lens subagent at top model with extended thinking; resolved at startup.
+
+- `--rounds N` — number of refinement passes. Default `3`. Max `10`. Rounds
+  apply the named lenses in order; if `N` < number of lenses, the trailing
+  lenses are skipped. If `N` > number of lenses, the adversarial lens repeats.
+- `--from-file <path>` — read the initial prompt from a file instead of
+  inline string. Mutually exclusive with positional prompt.
+- `--autonomous` (default) — on operator approval, hand off to
+  `/autospec --autonomous "<refined>"` (no-confirmation autospec).
+- `--interactive` — hand off to plain `/autospec "<refined>"` (full Phase 2
+  brainstorm gate).
+- `--dry-run` — produce the artifact only, do not hand off.
+- `--lenses repo,clarity,sizing,adversarial` — override the default lens
+  order. Comma-separated, drawn from the registered lens names.
+- `--output <path>` — write the final refined prompt to a file (in addition
+  to the `.autospec/refinements/` artifact).
+- `--continue` — enter continuous-iteration mode: refine → handoff → execute
+  → harvest-report → re-refine. See **Continuous-iteration mode** below.
+
+## Refinement lenses
+
+Four lenses, applied in order one per round:
+
+1. **`repo-grounding`** — read `AGENTS.md`, recent `docs/specs/**` (last 30
+   days), `git log --since=7d`, and tag-matched
+   `~/.autospec/projects/*/memory/feedback_*.md`. Replace generic verbs with
+   project-specific file paths, conventions, and constraints (lockstep, TDD,
+   no-mock, conventional commits, sizing caps).
+2. **`clarity-ac`** — extract implicit acceptance criteria and convert prose
+   into `- [ ]` checkbox list. Disambiguate hedging language (`should
+   probably`, `might`, `could try`). Name unambiguous test commands.
+3. **`sizing`** — enforce small-LLM execution caps from the autospec
+   decomposer rule (body ≤400 words, ≤3 files per child issue, ≤30 lines of
+   implementation outline). If the refined prompt would produce a child that
+   exceeds caps, split into a parent + child sequence and emit linked prompt
+   fragments.
+4. **`adversarial`** — critical-question pass. Apply the 20-question
+   checklist from `autospec-qa`. For each high-risk answer that's actionable
+   inside the scope, add a test requirement or scope clarification.
+
+Operators may override the default set with `--lenses`. Custom lens registry
+is out of scope for v1.
+
+## Convergence and degradation
+
+- **Convergence** — if round N's refined prompt is byte-identical to round
+  N-1's, exit early with status `converged` and final round = N-1.
+- **Degradation** — if round N's prompt is shorter than round N-1's by more
+  than 25% by word count, flag `degraded:<lens>` and surface to operator.
+  This catches lens implementations that over-aggressively prune scope.
+- **Round cap** — hard limit `AUTOSPEC_REFINE_MAX_ROUNDS=10`. Beyond this,
+  exit with `round_cap_reached`.
+
+## Repo context scope
+
+| Source | Read pattern |
+|---|---|
+| `AGENTS.md` | Always read in full. Highest-signal source. |
+| `docs/specs/**/*.md` | Last 30 days by file mtime + commit date. Cap at 5 specs to avoid prompt bloat. |
+| `git log --since=7d --oneline` + per-commit `git show --stat` | Last 7 days. Use to surface recently-changed files the prompt might intersect. |
+| `~/.autospec/projects/*/memory/feedback_*.md` | Keyword match against the prompt. Cap at 5 most-relevant entries. |
+
+The orchestrator MUST NOT read `.env`, `.git/`, files under `node_modules/`,
+or any path matching `*credential*`, `*secret*`, `*.pem`, `*.key`. Path
+allowlist is enforced in `refine-prompt.sh`.
+
+## Data model
+
+`.autospec/refinements/<slug>-<ISO-timestamp>.json`:
+
+```json
+{
+  "original_prompt": "...",
+  "rounds": [
+    {
+      "round_number": 1,
+      "lens": "repo-grounding",
+      "sources_used": ["AGENTS.md", "docs/specs/2026-05-28-foo.md"],
+      "refined_prompt": "...",
+      "diff_summary": "added paths/conventions/lockstep refs",
+      "word_count_delta": 87,
+      "reasoning": "..."
+    }
+  ],
+  "final_prompt": "...",
+  "status": "approved|converged|degraded|round_cap_reached|aborted",
+  "metadata": {
+    "head_sha": "...",
+    "timestamp": "...",
+    "rounds_requested": 3,
+    "rounds_executed": 3,
+    "converged_early": false,
+    "degraded_rounds": [],
+    "handoff_target": "/autospec --autonomous",
+    "handoff_executed": true
+  }
+}
+```
+
+`.autospec/refinements/<slug>-<ISO-timestamp>.md` — human-readable: original
+prompt → per-round headings with diff blocks → final prompt → handoff record.
+
+A JSON schema lives at `schemas/autospec-refinement.schema.json` and is
+validated by `scripts/validate.sh`.
+
+## Error handling
+
+- Empty prompt → usage error, exit 2.
+- LLM call fails (rate limit, auth, network) → retry once with backoff, then
+  surface to operator and write partial artifact.
+- Repo context insufficient (no `AGENTS.md`, no specs) → log warning, use
+  generic refinements, mark `metadata.context_sparse: true`.
+- Forbidden path access attempt (the allowlist enforced) → fail loudly with
+  `code_health:refine_path_violation`; do not silently strip.
+- Handoff target unavailable (e.g. `/autospec --autonomous` missing) → write
+  artifact, print the refined prompt to stdout, exit with clear message.
+
+## Continuous-iteration mode (`--continue`)
+
+`/autospec-refine --continue "<initial prompt>" [--max-iterations N]` runs the
+refine → handoff → execute → harvest-report cycle in a loop. After each
+`/autospec` run completes, the orchestrator reads the run's final report
+(from `.autospec/run-summary.md` or the equivalent), extracts the "next
+steps" / "blockers" / "remaining work" section, and uses THAT content as the
+input prompt for the next refinement round.
+
+### Termination (any one)
+
+- **Convergence — no next-steps content.** The harvested report contains no
+  actionable "next steps" section, OR the section is empty / says "done".
+- **Oscillation.** Iteration N+1's harvested prompt equals iteration N's
+  (hashed by content). Loop exits with `oscillation_detected`.
+- **Round cap.** `AUTOSPEC_REFINE_LOOP_MAX_ITERATIONS` (default 5).
+- **Budget cap.** Tokens > `AUTOSPEC_REFINE_LOOP_TOKEN_CAP` (default 2M) or
+  wall time > `AUTOSPEC_REFINE_LOOP_TIME_CAP` (default 6h).
+- **Evidence-based stop.** The harvested report contains an explicit
+  `STOP: <reason>` marker.
+- **Operator escape.** `~/.autospec/stop.flag` (graceful) or
+  `~/.autospec/refine-loop-stop.flag` terminates at the next iteration
+  boundary.
+
+### Per-iteration record
+
+Each loop iteration appends to `.autospec/refinements/<slug>-loop.json`:
+
+```json
+{
+  "iteration": 2,
+  "harvested_from_report": ".autospec/runs/2026-05-28T14:00Z/report.md",
+  "harvested_prompt": "Implement a deterministic ChemOnt-aligned ontology classifier...",
+  "refinement_artifact": ".autospec/refinements/<slug>-iter2-<ts>.json",
+  "handoff_pr_count": 3,
+  "handoff_pr_numbers": [672, 673, 674],
+  "stop_reason": null
+}
+```
+
+### Report harvest contract
+
+The orchestrator reads the LAST autospec run's report and looks for, in order:
+
+1. A section header matching `## Next steps`, `## What to do next`,
+   `## Remaining work`, or `## Open blockers` (case-insensitive).
+2. If absent, fenced code blocks tagged with ` ```autospec-next` or
+   ` ```next-prompt`.
+3. If absent, the report's `Out-of-sample`, `Stop condition`, or
+   `Evidence-backed stop` sections are inspected. If they say "stop", the
+   loop terminates with `evidence_based_stop`.
+4. If none of the above are present → convergence (loop exits cleanly).
+
+### Safety guardrails
+
+- The `--autonomous` mode safety guardrails (`scripts/autospec-autonomy-gate.sh`)
+  still apply on every loop iteration.
+- The continuous loop inherits the autospec autonomy scope rules; it does
+  NOT escalate privileges.
+- Every iteration's per-PR merge still goes through the rebase-and-retest
+  gate.
+
+## Testing
+
+- `tests/refine/test_refine_orchestrator.bats`:
+  - happy path: 3-round refinement with all 4 lenses → artifact written, JSON
+    schema-valid, rounds populated.
+  - convergence: round 2 == round 1 → early exit, status `converged`.
+  - degradation: synthetic round that drops 30% of words → flag emitted.
+  - round cap: `--rounds 15` → capped at 10, status `round_cap_reached`.
+  - context sparse: no `AGENTS.md` + no specs → completes with warning.
+  - forbidden path: lens tries to read `.env` → exits with
+    `code_health:refine_path_violation`.
+- `tests/refine/test_refine_lenses.bats`: per-lens isolation tests, one
+  fixture each (4 tests).
+- `tests/refine/test_refine_overview.bats`: dual-artifact renderer produces
+  valid markdown + JSON.
+- `tests/refine/test_refine_handoff.bats`: `--autonomous`, `--interactive`,
+  `--dry-run` each route correctly (mocked `gh` / `claude` invocations).
+- `tests/refine/test_refine_loop.bats`: continuous-iteration mode termination
+  paths.
+
+## Handoff
+
+After all rounds complete (or convergence/degradation/cap exit), present the
+final refined prompt to the operator with the per-round diff summary. On
+approval, hand off according to the invocation flag:
+
+- `--autonomous` (default) → `/autospec --autonomous "<refined>"`.
+- `--interactive` → `/autospec "<refined>"`.
+- `--dry-run` → print artifact paths, stop.
+
+For `--continue` mode, the handoff runs autonomously every iteration; the
+loop summary table is printed at loop end.

--- a/skills/autospec-refine/codex/prompt.md
+++ b/skills/autospec-refine/codex/prompt.md
@@ -1,0 +1,367 @@
+
+# autospec-refine workflow (harness-neutral)
+
+Take an operator-supplied prompt (or feature request) and iteratively refine it
+over N rounds, grounding each round in current repo knowledge (AGENTS.md,
+recent specs, recent commits, tagged memory). After operator approval, hand off
+the final refined prompt to `/autospec --autonomous` (default) or
+`/autospec` (interactive) for end-to-end implementation.
+
+Goal: better prompts → better code, fewer mid-implementation course
+corrections, fewer rounds of operator feedback. This skill closes the gap
+between under-specified raw requests and hand-crafted long prompts by
+automating the prompt-improvement loop operators currently run in their heads.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your
+harness supports it; do not investigate or write the refined prompt directly in
+the main conversation when a subagent can do it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-refine   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-refine
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-refine/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-refine.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-refine.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter the refinement pipeline. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-refine found; run install.sh first.` and exit.
+
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$` (case-insensitive), this skill enters stop mode and does not run the normal pipeline:
+
+1. Delegate to the shared stop helper:
+   ```bash
+   bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"
+   ```
+2. Honor `--graceful` (write `~/.autospec/stop.flag`; running iteration finishes) and `--immediate` (write `~/.autospec/refine-loop-stop.flag` plus stop.flag; abort at next iteration boundary).
+3. Print the stop summary and exit. Do not enter the refinement pipeline.
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — recognized by Claude Code, OpenCode, and Codex. Per AGENTS.md, subagent dispatches use the two-tier policy: Tier A for spec/refinement work (each lens applies fresh-eyes reasoning to the prompt), Tier B for implementation. This skill is refinement-only and dispatches at Tier A. Fall back UP the tier on quota/capacity failure.
+
+## Harness detection (run once at skill start, before refinement begins)
+
+Detect your harness by checking available tools before any lens runs:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness, silently retry the same subagent dispatch with `TIER_A`. Preserve parent context on retry. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
+## Architecture
+
+`autospec-refine` is a new top-level skill that mirrors the existing
+`autospec-define` and `autospec-qa` skill-family shape:
+
+- `skills/autospec-refine/SKILL.md` — Claude Code adapter (authoritative).
+- `skills/autospec-refine/codex/prompt.md` — Codex CLI mirror (lockstep).
+- `skills/autospec-refine/opencode/agent.md` — OpenCode mirror (lockstep).
+- `skills/autospec-refine/install.sh` — installer; mirrors existing skills.
+- `skills/autospec-refine/uninstall.sh` — uninstaller; mirrors existing skills.
+- `skills/autospec-refine/README.md` — usage doc.
+- `scripts/refine-prompt.sh` — orchestrator: parses args, dispatches lenses,
+  writes artifacts, performs handoff. **Stubbed by this scaffold; implemented
+  in the orchestrator child issue.**
+- `scripts/refine-render-overview.sh` — produces dual markdown + JSON artifact.
+  **Stubbed by this scaffold; implemented in the renderer child issue.**
+
+This SKILL.md is the scaffold contract. Subsequent child issues fill in
+`scripts/refine-prompt.sh`, the lens helpers, the renderer, the handoff
+plumbing, and the continuous-iteration loop.
+
+## Invocation
+
+```
+/autospec-refine "<initial prompt>" [--rounds N] [--from-file <path>] \
+                 [--interactive | --autonomous (default) | --dry-run] \
+                 [--lenses <comma-list>] [--output <path>] \
+                 [--continue [--max-iterations N]]
+```
+
+> **Model tier:** `TIER_A` (spec work) — each refinement round dispatches a fresh-eyes lens subagent at top model with extended thinking; resolved at startup.
+
+- `--rounds N` — number of refinement passes. Default `3`. Max `10`. Rounds
+  apply the named lenses in order; if `N` < number of lenses, the trailing
+  lenses are skipped. If `N` > number of lenses, the adversarial lens repeats.
+- `--from-file <path>` — read the initial prompt from a file instead of
+  inline string. Mutually exclusive with positional prompt.
+- `--autonomous` (default) — on operator approval, hand off to
+  `/autospec --autonomous "<refined>"` (no-confirmation autospec).
+- `--interactive` — hand off to plain `/autospec "<refined>"` (full Phase 2
+  brainstorm gate).
+- `--dry-run` — produce the artifact only, do not hand off.
+- `--lenses repo,clarity,sizing,adversarial` — override the default lens
+  order. Comma-separated, drawn from the registered lens names.
+- `--output <path>` — write the final refined prompt to a file (in addition
+  to the `.autospec/refinements/` artifact).
+- `--continue` — enter continuous-iteration mode: refine → handoff → execute
+  → harvest-report → re-refine. See **Continuous-iteration mode** below.
+
+## Refinement lenses
+
+Four lenses, applied in order one per round:
+
+1. **`repo-grounding`** — read `AGENTS.md`, recent `docs/specs/**` (last 30
+   days), `git log --since=7d`, and tag-matched
+   `~/.autospec/projects/*/memory/feedback_*.md`. Replace generic verbs with
+   project-specific file paths, conventions, and constraints (lockstep, TDD,
+   no-mock, conventional commits, sizing caps).
+2. **`clarity-ac`** — extract implicit acceptance criteria and convert prose
+   into `- [ ]` checkbox list. Disambiguate hedging language (`should
+   probably`, `might`, `could try`). Name unambiguous test commands.
+3. **`sizing`** — enforce small-LLM execution caps from the autospec
+   decomposer rule (body ≤400 words, ≤3 files per child issue, ≤30 lines of
+   implementation outline). If the refined prompt would produce a child that
+   exceeds caps, split into a parent + child sequence and emit linked prompt
+   fragments.
+4. **`adversarial`** — critical-question pass. Apply the 20-question
+   checklist from `autospec-qa`. For each high-risk answer that's actionable
+   inside the scope, add a test requirement or scope clarification.
+
+Operators may override the default set with `--lenses`. Custom lens registry
+is out of scope for v1.
+
+## Convergence and degradation
+
+- **Convergence** — if round N's refined prompt is byte-identical to round
+  N-1's, exit early with status `converged` and final round = N-1.
+- **Degradation** — if round N's prompt is shorter than round N-1's by more
+  than 25% by word count, flag `degraded:<lens>` and surface to operator.
+  This catches lens implementations that over-aggressively prune scope.
+- **Round cap** — hard limit `AUTOSPEC_REFINE_MAX_ROUNDS=10`. Beyond this,
+  exit with `round_cap_reached`.
+
+## Repo context scope
+
+| Source | Read pattern |
+|---|---|
+| `AGENTS.md` | Always read in full. Highest-signal source. |
+| `docs/specs/**/*.md` | Last 30 days by file mtime + commit date. Cap at 5 specs to avoid prompt bloat. |
+| `git log --since=7d --oneline` + per-commit `git show --stat` | Last 7 days. Use to surface recently-changed files the prompt might intersect. |
+| `~/.autospec/projects/*/memory/feedback_*.md` | Keyword match against the prompt. Cap at 5 most-relevant entries. |
+
+The orchestrator MUST NOT read `.env`, `.git/`, files under `node_modules/`,
+or any path matching `*credential*`, `*secret*`, `*.pem`, `*.key`. Path
+allowlist is enforced in `refine-prompt.sh`.
+
+## Data model
+
+`.autospec/refinements/<slug>-<ISO-timestamp>.json`:
+
+```json
+{
+  "original_prompt": "...",
+  "rounds": [
+    {
+      "round_number": 1,
+      "lens": "repo-grounding",
+      "sources_used": ["AGENTS.md", "docs/specs/2026-05-28-foo.md"],
+      "refined_prompt": "...",
+      "diff_summary": "added paths/conventions/lockstep refs",
+      "word_count_delta": 87,
+      "reasoning": "..."
+    }
+  ],
+  "final_prompt": "...",
+  "status": "approved|converged|degraded|round_cap_reached|aborted",
+  "metadata": {
+    "head_sha": "...",
+    "timestamp": "...",
+    "rounds_requested": 3,
+    "rounds_executed": 3,
+    "converged_early": false,
+    "degraded_rounds": [],
+    "handoff_target": "/autospec --autonomous",
+    "handoff_executed": true
+  }
+}
+```
+
+`.autospec/refinements/<slug>-<ISO-timestamp>.md` — human-readable: original
+prompt → per-round headings with diff blocks → final prompt → handoff record.
+
+A JSON schema lives at `schemas/autospec-refinement.schema.json` and is
+validated by `scripts/validate.sh`.
+
+## Error handling
+
+- Empty prompt → usage error, exit 2.
+- LLM call fails (rate limit, auth, network) → retry once with backoff, then
+  surface to operator and write partial artifact.
+- Repo context insufficient (no `AGENTS.md`, no specs) → log warning, use
+  generic refinements, mark `metadata.context_sparse: true`.
+- Forbidden path access attempt (the allowlist enforced) → fail loudly with
+  `code_health:refine_path_violation`; do not silently strip.
+- Handoff target unavailable (e.g. `/autospec --autonomous` missing) → write
+  artifact, print the refined prompt to stdout, exit with clear message.
+
+## Continuous-iteration mode (`--continue`)
+
+`/autospec-refine --continue "<initial prompt>" [--max-iterations N]` runs the
+refine → handoff → execute → harvest-report cycle in a loop. After each
+`/autospec` run completes, the orchestrator reads the run's final report
+(from `.autospec/run-summary.md` or the equivalent), extracts the "next
+steps" / "blockers" / "remaining work" section, and uses THAT content as the
+input prompt for the next refinement round.
+
+### Termination (any one)
+
+- **Convergence — no next-steps content.** The harvested report contains no
+  actionable "next steps" section, OR the section is empty / says "done".
+- **Oscillation.** Iteration N+1's harvested prompt equals iteration N's
+  (hashed by content). Loop exits with `oscillation_detected`.
+- **Round cap.** `AUTOSPEC_REFINE_LOOP_MAX_ITERATIONS` (default 5).
+- **Budget cap.** Tokens > `AUTOSPEC_REFINE_LOOP_TOKEN_CAP` (default 2M) or
+  wall time > `AUTOSPEC_REFINE_LOOP_TIME_CAP` (default 6h).
+- **Evidence-based stop.** The harvested report contains an explicit
+  `STOP: <reason>` marker.
+- **Operator escape.** `~/.autospec/stop.flag` (graceful) or
+  `~/.autospec/refine-loop-stop.flag` terminates at the next iteration
+  boundary.
+
+### Per-iteration record
+
+Each loop iteration appends to `.autospec/refinements/<slug>-loop.json`:
+
+```json
+{
+  "iteration": 2,
+  "harvested_from_report": ".autospec/runs/2026-05-28T14:00Z/report.md",
+  "harvested_prompt": "Implement a deterministic ChemOnt-aligned ontology classifier...",
+  "refinement_artifact": ".autospec/refinements/<slug>-iter2-<ts>.json",
+  "handoff_pr_count": 3,
+  "handoff_pr_numbers": [672, 673, 674],
+  "stop_reason": null
+}
+```
+
+### Report harvest contract
+
+The orchestrator reads the LAST autospec run's report and looks for, in order:
+
+1. A section header matching `## Next steps`, `## What to do next`,
+   `## Remaining work`, or `## Open blockers` (case-insensitive).
+2. If absent, fenced code blocks tagged with ` ```autospec-next` or
+   ` ```next-prompt`.
+3. If absent, the report's `Out-of-sample`, `Stop condition`, or
+   `Evidence-backed stop` sections are inspected. If they say "stop", the
+   loop terminates with `evidence_based_stop`.
+4. If none of the above are present → convergence (loop exits cleanly).
+
+### Safety guardrails
+
+- The `--autonomous` mode safety guardrails (`scripts/autospec-autonomy-gate.sh`)
+  still apply on every loop iteration.
+- The continuous loop inherits the autospec autonomy scope rules; it does
+  NOT escalate privileges.
+- Every iteration's per-PR merge still goes through the rebase-and-retest
+  gate.
+
+## Testing
+
+- `tests/refine/test_refine_orchestrator.bats`:
+  - happy path: 3-round refinement with all 4 lenses → artifact written, JSON
+    schema-valid, rounds populated.
+  - convergence: round 2 == round 1 → early exit, status `converged`.
+  - degradation: synthetic round that drops 30% of words → flag emitted.
+  - round cap: `--rounds 15` → capped at 10, status `round_cap_reached`.
+  - context sparse: no `AGENTS.md` + no specs → completes with warning.
+  - forbidden path: lens tries to read `.env` → exits with
+    `code_health:refine_path_violation`.
+- `tests/refine/test_refine_lenses.bats`: per-lens isolation tests, one
+  fixture each (4 tests).
+- `tests/refine/test_refine_overview.bats`: dual-artifact renderer produces
+  valid markdown + JSON.
+- `tests/refine/test_refine_handoff.bats`: `--autonomous`, `--interactive`,
+  `--dry-run` each route correctly (mocked `gh` / `claude` invocations).
+- `tests/refine/test_refine_loop.bats`: continuous-iteration mode termination
+  paths.
+
+## Handoff
+
+After all rounds complete (or convergence/degradation/cap exit), present the
+final refined prompt to the operator with the per-round diff summary. On
+approval, hand off according to the invocation flag:
+
+- `--autonomous` (default) → `/autospec --autonomous "<refined>"`.
+- `--interactive` → `/autospec "<refined>"`.
+- `--dry-run` → print artifact paths, stop.
+
+For `--continue` mode, the handoff runs autonomously every iteration; the
+loop summary table is printed at loop end.

--- a/skills/autospec-refine/install.sh
+++ b/skills/autospec-refine/install.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --symlink           # symlink instead of copy (updates propagate)
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-refine/install.sh \
+#     | sh -s -- --harness all
+# When piped, the script auto-downloads the skill files from the same branch.
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPEC_REFINE_REF         (default: main) — git ref to fetch from when piped
+#   AUTOSPEC_REFINE_RAW_BASE    (override the raw URL base entirely)
+#
+# Idempotent: re-running upgrades the install. Exits non-zero on hard failure;
+# exits zero with warnings on missing optional deps.
+
+set -eu
+
+SKILL_NAME="autospec-refine"
+SKILL_RAW_BASE="${AUTOSPEC_REFINE_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_REFINE_REF:-main}/skills/autospec-refine}"
+
+# Resolve the directory containing this script. When piped through stdin (e.g.
+# `curl ... | sh`), $0 will not be a real file — detect that and fall back to
+# downloading the source files from the raw GitHub URL.
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+UPDATE_MODE=0
+TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+
+# ---------- helpers --------------------------------------------------------
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
+
+Installs the ${SKILL_NAME} skill into the chosen harness's standard
+skill/agent/prompt directory.
+
+Examples:
+  $0                          # interactive
+  $0 --harness all            # install everywhere
+  $0 --harness claude         # Claude Code only
+  $0 --harness opencode       # OpenCode only
+  $0 --harness codex          # Codex CLI only
+  $0 --harness all --symlink  # symlink instead of copy
+  $0 --dry-run --harness all  # print plan, change nothing
+  $0 --harness claude --update  # idempotent re-install (overwrite existing)
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    # Download the files we need into a temp dir and set SKILL_DIR to it.
+    if ! command -v curl >/dev/null 2>&1; then
+        err "curl is required when running from stdin (e.g. piped via 'curl | sh')."
+        exit 1
+    fi
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/$rel"
+            exit 1
+        fi
+    done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autospec helper scripts"
+        return 1
+    fi
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    dest_dir="$(dirname "$dest")"
+
+    if [ ! -f "$src" ]; then
+        err "missing source file: $src"
+        return 1
+    fi
+
+    run "mkdir -p \"$dest_dir\""
+
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --symlink)
+            USE_SYMLINK=1
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        --update)
+            UPDATE_MODE=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# ---------- harness prompt -------------------------------------------------
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- ensure source files are available ------------------------------
+
+# If we couldn't resolve a local SKILL_DIR (piped from curl) OR the local dir
+# doesn't actually contain the skill files, fall back to remote fetch.
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+
+if [ "$need_fetch" -eq 1 ]; then
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        err "--symlink requires running from a checkout of the codex-skills repo (no local files to symlink to)."
+        exit 2
+    fi
+    fetch_source_files
+fi
+
+# ---------- dependency checks ---------------------------------------------
+
+dep_warnings=0
+
+check_dep() {
+    name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        warn "$name not found on PATH (required by the skill at runtime)"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+}
+
+check_dep git
+check_dep gh
+check_dep jq
+
+if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+        warn "gh is installed but not authenticated. Run: gh auth login"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+fi
+
+if [ "$dep_warnings" -gt 0 ]; then
+    warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
+fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+CLAUDE_SRC="$SKILL_DIR/SKILL.md"
+OPENCODE_SRC="$SKILL_DIR/opencode/agent.md"
+CODEX_SRC="$SKILL_DIR/codex/prompt.md"
+
+# ---------- install --------------------------------------------------------
+
+installed_paths=""
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_SRC" "$CLAUDE_DEST"
+    installed_paths="${installed_paths}  Claude Code: ${CLAUDE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_SRC" "$OPENCODE_DEST"
+    installed_paths="${installed_paths}  OpenCode:    ${OPENCODE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+    installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
+fi
+
+# ---------- final summary --------------------------------------------------
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    if [ "$UPDATE_MODE" -eq 1 ]; then
+        info "Updated (idempotent overwrite):"
+    else
+        info "Installed:"
+    fi
+    printf '%b' "$installed_paths"
+    info ""
+    info "Invoke with:"
+    info "  Claude Code:  /${SKILL_NAME} <feature description>"
+    info "  OpenCode:     @${SKILL_NAME} <feature description>"
+    info "  Codex CLI:    /${SKILL_NAME} <feature description>"
+fi
+
+exit 0

--- a/skills/autospec-refine/opencode/agent.md
+++ b/skills/autospec-refine/opencode/agent.md
@@ -1,0 +1,371 @@
+---
+description: Use when the user wants to refine a prompt or feature request over N rounds of repo-grounded lenses before handing off to /autospec for implementation. Supports --rounds, --lenses, --autonomous, --interactive, --dry-run, and --continue (continuous iteration mode).
+mode: primary
+---
+
+# autospec-refine workflow (harness-neutral)
+
+Take an operator-supplied prompt (or feature request) and iteratively refine it
+over N rounds, grounding each round in current repo knowledge (AGENTS.md,
+recent specs, recent commits, tagged memory). After operator approval, hand off
+the final refined prompt to `/autospec --autonomous` (default) or
+`/autospec` (interactive) for end-to-end implementation.
+
+Goal: better prompts → better code, fewer mid-implementation course
+corrections, fewer rounds of operator feedback. This skill closes the gap
+between under-specified raw requests and hand-crafted long prompts by
+automating the prompt-improvement loop operators currently run in their heads.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your
+harness supports it; do not investigate or write the refined prompt directly in
+the main conversation when a subagent can do it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-refine   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-refine
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-refine/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-refine.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-refine.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter the refinement pipeline. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-refine found; run install.sh first.` and exit.
+
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$` (case-insensitive), this skill enters stop mode and does not run the normal pipeline:
+
+1. Delegate to the shared stop helper:
+   ```bash
+   bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"
+   ```
+2. Honor `--graceful` (write `~/.autospec/stop.flag`; running iteration finishes) and `--immediate` (write `~/.autospec/refine-loop-stop.flag` plus stop.flag; abort at next iteration boundary).
+3. Print the stop summary and exit. Do not enter the refinement pipeline.
+
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — recognized by Claude Code, OpenCode, and Codex. Per AGENTS.md, subagent dispatches use the two-tier policy: Tier A for spec/refinement work (each lens applies fresh-eyes reasoning to the prompt), Tier B for implementation. This skill is refinement-only and dispatches at Tier A. Fall back UP the tier on quota/capacity failure.
+
+## Harness detection (run once at skill start, before refinement begins)
+
+Detect your harness by checking available tools before any lens runs:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness, silently retry the same subagent dispatch with `TIER_A`. Preserve parent context on retry. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
+## Architecture
+
+`autospec-refine` is a new top-level skill that mirrors the existing
+`autospec-define` and `autospec-qa` skill-family shape:
+
+- `skills/autospec-refine/SKILL.md` — Claude Code adapter (authoritative).
+- `skills/autospec-refine/codex/prompt.md` — Codex CLI mirror (lockstep).
+- `skills/autospec-refine/opencode/agent.md` — OpenCode mirror (lockstep).
+- `skills/autospec-refine/install.sh` — installer; mirrors existing skills.
+- `skills/autospec-refine/uninstall.sh` — uninstaller; mirrors existing skills.
+- `skills/autospec-refine/README.md` — usage doc.
+- `scripts/refine-prompt.sh` — orchestrator: parses args, dispatches lenses,
+  writes artifacts, performs handoff. **Stubbed by this scaffold; implemented
+  in the orchestrator child issue.**
+- `scripts/refine-render-overview.sh` — produces dual markdown + JSON artifact.
+  **Stubbed by this scaffold; implemented in the renderer child issue.**
+
+This SKILL.md is the scaffold contract. Subsequent child issues fill in
+`scripts/refine-prompt.sh`, the lens helpers, the renderer, the handoff
+plumbing, and the continuous-iteration loop.
+
+## Invocation
+
+```
+/autospec-refine "<initial prompt>" [--rounds N] [--from-file <path>] \
+                 [--interactive | --autonomous (default) | --dry-run] \
+                 [--lenses <comma-list>] [--output <path>] \
+                 [--continue [--max-iterations N]]
+```
+
+> **Model tier:** `TIER_A` (spec work) — each refinement round dispatches a fresh-eyes lens subagent at top model with extended thinking; resolved at startup.
+
+- `--rounds N` — number of refinement passes. Default `3`. Max `10`. Rounds
+  apply the named lenses in order; if `N` < number of lenses, the trailing
+  lenses are skipped. If `N` > number of lenses, the adversarial lens repeats.
+- `--from-file <path>` — read the initial prompt from a file instead of
+  inline string. Mutually exclusive with positional prompt.
+- `--autonomous` (default) — on operator approval, hand off to
+  `/autospec --autonomous "<refined>"` (no-confirmation autospec).
+- `--interactive` — hand off to plain `/autospec "<refined>"` (full Phase 2
+  brainstorm gate).
+- `--dry-run` — produce the artifact only, do not hand off.
+- `--lenses repo,clarity,sizing,adversarial` — override the default lens
+  order. Comma-separated, drawn from the registered lens names.
+- `--output <path>` — write the final refined prompt to a file (in addition
+  to the `.autospec/refinements/` artifact).
+- `--continue` — enter continuous-iteration mode: refine → handoff → execute
+  → harvest-report → re-refine. See **Continuous-iteration mode** below.
+
+## Refinement lenses
+
+Four lenses, applied in order one per round:
+
+1. **`repo-grounding`** — read `AGENTS.md`, recent `docs/specs/**` (last 30
+   days), `git log --since=7d`, and tag-matched
+   `~/.autospec/projects/*/memory/feedback_*.md`. Replace generic verbs with
+   project-specific file paths, conventions, and constraints (lockstep, TDD,
+   no-mock, conventional commits, sizing caps).
+2. **`clarity-ac`** — extract implicit acceptance criteria and convert prose
+   into `- [ ]` checkbox list. Disambiguate hedging language (`should
+   probably`, `might`, `could try`). Name unambiguous test commands.
+3. **`sizing`** — enforce small-LLM execution caps from the autospec
+   decomposer rule (body ≤400 words, ≤3 files per child issue, ≤30 lines of
+   implementation outline). If the refined prompt would produce a child that
+   exceeds caps, split into a parent + child sequence and emit linked prompt
+   fragments.
+4. **`adversarial`** — critical-question pass. Apply the 20-question
+   checklist from `autospec-qa`. For each high-risk answer that's actionable
+   inside the scope, add a test requirement or scope clarification.
+
+Operators may override the default set with `--lenses`. Custom lens registry
+is out of scope for v1.
+
+## Convergence and degradation
+
+- **Convergence** — if round N's refined prompt is byte-identical to round
+  N-1's, exit early with status `converged` and final round = N-1.
+- **Degradation** — if round N's prompt is shorter than round N-1's by more
+  than 25% by word count, flag `degraded:<lens>` and surface to operator.
+  This catches lens implementations that over-aggressively prune scope.
+- **Round cap** — hard limit `AUTOSPEC_REFINE_MAX_ROUNDS=10`. Beyond this,
+  exit with `round_cap_reached`.
+
+## Repo context scope
+
+| Source | Read pattern |
+|---|---|
+| `AGENTS.md` | Always read in full. Highest-signal source. |
+| `docs/specs/**/*.md` | Last 30 days by file mtime + commit date. Cap at 5 specs to avoid prompt bloat. |
+| `git log --since=7d --oneline` + per-commit `git show --stat` | Last 7 days. Use to surface recently-changed files the prompt might intersect. |
+| `~/.autospec/projects/*/memory/feedback_*.md` | Keyword match against the prompt. Cap at 5 most-relevant entries. |
+
+The orchestrator MUST NOT read `.env`, `.git/`, files under `node_modules/`,
+or any path matching `*credential*`, `*secret*`, `*.pem`, `*.key`. Path
+allowlist is enforced in `refine-prompt.sh`.
+
+## Data model
+
+`.autospec/refinements/<slug>-<ISO-timestamp>.json`:
+
+```json
+{
+  "original_prompt": "...",
+  "rounds": [
+    {
+      "round_number": 1,
+      "lens": "repo-grounding",
+      "sources_used": ["AGENTS.md", "docs/specs/2026-05-28-foo.md"],
+      "refined_prompt": "...",
+      "diff_summary": "added paths/conventions/lockstep refs",
+      "word_count_delta": 87,
+      "reasoning": "..."
+    }
+  ],
+  "final_prompt": "...",
+  "status": "approved|converged|degraded|round_cap_reached|aborted",
+  "metadata": {
+    "head_sha": "...",
+    "timestamp": "...",
+    "rounds_requested": 3,
+    "rounds_executed": 3,
+    "converged_early": false,
+    "degraded_rounds": [],
+    "handoff_target": "/autospec --autonomous",
+    "handoff_executed": true
+  }
+}
+```
+
+`.autospec/refinements/<slug>-<ISO-timestamp>.md` — human-readable: original
+prompt → per-round headings with diff blocks → final prompt → handoff record.
+
+A JSON schema lives at `schemas/autospec-refinement.schema.json` and is
+validated by `scripts/validate.sh`.
+
+## Error handling
+
+- Empty prompt → usage error, exit 2.
+- LLM call fails (rate limit, auth, network) → retry once with backoff, then
+  surface to operator and write partial artifact.
+- Repo context insufficient (no `AGENTS.md`, no specs) → log warning, use
+  generic refinements, mark `metadata.context_sparse: true`.
+- Forbidden path access attempt (the allowlist enforced) → fail loudly with
+  `code_health:refine_path_violation`; do not silently strip.
+- Handoff target unavailable (e.g. `/autospec --autonomous` missing) → write
+  artifact, print the refined prompt to stdout, exit with clear message.
+
+## Continuous-iteration mode (`--continue`)
+
+`/autospec-refine --continue "<initial prompt>" [--max-iterations N]` runs the
+refine → handoff → execute → harvest-report cycle in a loop. After each
+`/autospec` run completes, the orchestrator reads the run's final report
+(from `.autospec/run-summary.md` or the equivalent), extracts the "next
+steps" / "blockers" / "remaining work" section, and uses THAT content as the
+input prompt for the next refinement round.
+
+### Termination (any one)
+
+- **Convergence — no next-steps content.** The harvested report contains no
+  actionable "next steps" section, OR the section is empty / says "done".
+- **Oscillation.** Iteration N+1's harvested prompt equals iteration N's
+  (hashed by content). Loop exits with `oscillation_detected`.
+- **Round cap.** `AUTOSPEC_REFINE_LOOP_MAX_ITERATIONS` (default 5).
+- **Budget cap.** Tokens > `AUTOSPEC_REFINE_LOOP_TOKEN_CAP` (default 2M) or
+  wall time > `AUTOSPEC_REFINE_LOOP_TIME_CAP` (default 6h).
+- **Evidence-based stop.** The harvested report contains an explicit
+  `STOP: <reason>` marker.
+- **Operator escape.** `~/.autospec/stop.flag` (graceful) or
+  `~/.autospec/refine-loop-stop.flag` terminates at the next iteration
+  boundary.
+
+### Per-iteration record
+
+Each loop iteration appends to `.autospec/refinements/<slug>-loop.json`:
+
+```json
+{
+  "iteration": 2,
+  "harvested_from_report": ".autospec/runs/2026-05-28T14:00Z/report.md",
+  "harvested_prompt": "Implement a deterministic ChemOnt-aligned ontology classifier...",
+  "refinement_artifact": ".autospec/refinements/<slug>-iter2-<ts>.json",
+  "handoff_pr_count": 3,
+  "handoff_pr_numbers": [672, 673, 674],
+  "stop_reason": null
+}
+```
+
+### Report harvest contract
+
+The orchestrator reads the LAST autospec run's report and looks for, in order:
+
+1. A section header matching `## Next steps`, `## What to do next`,
+   `## Remaining work`, or `## Open blockers` (case-insensitive).
+2. If absent, fenced code blocks tagged with ` ```autospec-next` or
+   ` ```next-prompt`.
+3. If absent, the report's `Out-of-sample`, `Stop condition`, or
+   `Evidence-backed stop` sections are inspected. If they say "stop", the
+   loop terminates with `evidence_based_stop`.
+4. If none of the above are present → convergence (loop exits cleanly).
+
+### Safety guardrails
+
+- The `--autonomous` mode safety guardrails (`scripts/autospec-autonomy-gate.sh`)
+  still apply on every loop iteration.
+- The continuous loop inherits the autospec autonomy scope rules; it does
+  NOT escalate privileges.
+- Every iteration's per-PR merge still goes through the rebase-and-retest
+  gate.
+
+## Testing
+
+- `tests/refine/test_refine_orchestrator.bats`:
+  - happy path: 3-round refinement with all 4 lenses → artifact written, JSON
+    schema-valid, rounds populated.
+  - convergence: round 2 == round 1 → early exit, status `converged`.
+  - degradation: synthetic round that drops 30% of words → flag emitted.
+  - round cap: `--rounds 15` → capped at 10, status `round_cap_reached`.
+  - context sparse: no `AGENTS.md` + no specs → completes with warning.
+  - forbidden path: lens tries to read `.env` → exits with
+    `code_health:refine_path_violation`.
+- `tests/refine/test_refine_lenses.bats`: per-lens isolation tests, one
+  fixture each (4 tests).
+- `tests/refine/test_refine_overview.bats`: dual-artifact renderer produces
+  valid markdown + JSON.
+- `tests/refine/test_refine_handoff.bats`: `--autonomous`, `--interactive`,
+  `--dry-run` each route correctly (mocked `gh` / `claude` invocations).
+- `tests/refine/test_refine_loop.bats`: continuous-iteration mode termination
+  paths.
+
+## Handoff
+
+After all rounds complete (or convergence/degradation/cap exit), present the
+final refined prompt to the operator with the per-round diff summary. On
+approval, hand off according to the invocation flag:
+
+- `--autonomous` (default) → `/autospec --autonomous "<refined>"`.
+- `--interactive` → `/autospec "<refined>"`.
+- `--dry-run` → print artifact paths, stop.
+
+For `--continue` mode, the handoff runs autonomously every iteration; the
+loop summary table is printed at loop end.

--- a/skills/autospec-refine/uninstall.sh
+++ b/skills/autospec-refine/uninstall.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autospec-refine"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        # Try to remove an empty parent skill directory (Claude only — its layout
+        # has a per-skill subdir).
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+# ---------- remove ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0


### PR DESCRIPTION
Closes #669

First issue in the 5-issue chain for the new `autospec-refine` skill family
(spec: `docs/specs/2026-05-28-autospec-refine-design.md`). Scaffolds the
6-file trio so subsequent issues (#670–#673) can fill in the orchestrator,
lenses, renderer, handoff, and continuous-iteration loop.

## Summary

- Adds `skills/autospec-refine/` with SKILL.md + codex/prompt.md +
  opencode/agent.md + install.sh + uninstall.sh + README.md.
- SKILL.md carries every structural section required by the autospec
  discovery contract: frontmatter, Startup self-update, Self-update mode,
  Stop mode, Required capabilities & harness adapter (with the Subagent
  model tier row), Harness detection (TIER_A/TIER_B), plus the
  Architecture / Invocation / Refinement lenses / Convergence and
  degradation / Repo context scope / Data model / Error handling /
  Continuous-iteration mode / Testing / Handoff sections from the spec.
- Trio bodies are byte-identical (`check_lockstep` passes).
- install.sh accepts `--update` and `--dry-run`; mirrors autospec-define's
  installer (downloads scaffold files when piped via curl, installs shared
  helpers into `~/.autospec/scripts`).

## Out of scope (queued for follow-on issues)

- `scripts/refine-prompt.sh` orchestrator and the four lens helpers.
- `scripts/refine-render-overview.sh` and JSON schema.
- Handoff plumbing + `check_autospec_refine_contract()` validate.sh hook.
- Continuous-iteration mode runtime + report-harvest logic.

## Verification

- `bash scripts/validate.sh` → OK (lockstep, required files, self-update,
  bash -n all pass).
- `bash skills/autospec-refine/install.sh --harness all --dry-run` →
  reports planned install paths for Claude Code, OpenCode, and Codex CLI.