### PR TITLE
feat: autospec-refine dual artifact renderer + schema (closes #671)

### DIFF
--- a/schemas/autospec-refinement.schema.json
+++ b/schemas/autospec-refinement.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-refinement.schema.json",
+  "title": "autospec-refine round-by-round refinement artifact",
+  "description": "JSON record produced by scripts/refine-prompt.sh capturing the original prompt, per-round lens application, final refined prompt, and run metadata. Consumed by scripts/refine-render-overview.sh to produce the dual markdown overview.",
+  "type": "object",
+  "required": ["original_prompt", "rounds", "final_prompt", "status", "metadata"],
+  "additionalProperties": false,
+  "properties": {
+    "original_prompt": { "type": "string", "minLength": 1 },
+    "rounds": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/round" }
+    },
+    "final_prompt": { "type": "string", "minLength": 1 },
+    "status": {
+      "type": "string",
+      "enum": ["approved", "completed", "converged", "degraded", "round_cap_reached", "aborted"]
+    },
+    "metadata": { "$ref": "#/$defs/metadata" }
+  },
+  "$defs": {
+    "round": {
+      "type": "object",
+      "required": [
+        "round_number",
+        "lens",
+        "sources_used",
+        "refined_prompt",
+        "diff_summary",
+        "word_count_delta",
+        "reasoning"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "round_number": { "type": "integer", "minimum": 1 },
+        "lens": {
+          "type": "string",
+          "enum": ["repo-grounding", "clarity-ac", "sizing", "adversarial"]
+        },
+        "sources_used": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "refined_prompt": { "type": "string", "minLength": 1 },
+        "diff_summary": { "type": "string" },
+        "word_count_delta": { "type": "integer" },
+        "reasoning": { "type": "string" }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "head_sha",
+        "timestamp",
+        "rounds_requested",
+        "rounds_executed",
+        "converged_early",
+        "degraded_rounds",
+        "handoff_target",
+        "handoff_executed"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "head_sha": { "type": "string", "minLength": 1 },
+        "timestamp": { "type": "string", "minLength": 1 },
+        "rounds_requested": { "type": "integer", "minimum": 1 },
+        "rounds_executed": { "type": "integer", "minimum": 0 },
+        "converged_early": { "type": "boolean" },
+        "degraded_rounds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "context_sparse": { "type": "boolean" },
+        "handoff_target": { "type": "string", "minLength": 1 },
+        "handoff_executed": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/scripts/refine-render-overview.sh
+++ b/scripts/refine-render-overview.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# scripts/refine-render-overview.sh — dual-artifact renderer for autospec-refine
+# (issue #671). Reads the orchestrator JSON output written by
+# scripts/refine-prompt.sh (issue #670) and emits:
+#   <output-dir>/<slug>-<timestamp>.md   human-readable overview
+#   <output-dir>/<slug>-<timestamp>.json  copy of the input JSON (canonical)
+#
+# Both files are written atomically (.tmp + mv). The input JSON is validated
+# against schemas/autospec-refinement.schema.json before rendering.
+#
+# Usage:
+#   refine-render-overview.sh --json <input.json> --slug <slug> \
+#       [--output-dir <dir>]
+#
+# Exit codes:
+#   0  on success
+#   2  on usage / bad args
+#   3  on schema validation failure
+#   4  on missing input
+
+set -u
+
+usage() {
+    cat <<'EOF'
+Usage: refine-render-overview.sh --json <input> --slug <slug> [--output-dir <dir>]
+
+Reads the autospec-refine orchestrator JSON output and writes a dual
+(markdown + JSON) artifact pair to <output-dir>, defaulting to
+.autospec/refinements/. Files are written atomically via .tmp + mv.
+EOF
+}
+
+INPUT_JSON=""
+SLUG=""
+OUTPUT_DIR=".autospec/refinements"
+SCHEMA=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --json) INPUT_JSON="$2"; shift ;;
+        --slug) SLUG="$2"; shift ;;
+        --output-dir) OUTPUT_DIR="$2"; shift ;;
+        --schema) SCHEMA="$2"; shift ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "refine-render-overview: unknown arg: $1" >&2; usage >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$INPUT_JSON" ] || [ -z "$SLUG" ]; then
+    echo "refine-render-overview: --json and --slug are required" >&2
+    usage >&2
+    exit 2
+fi
+
+if [ ! -f "$INPUT_JSON" ]; then
+    echo "refine-render-overview: input not found: $INPUT_JSON" >&2
+    exit 4
+fi
+
+# Locate the schema. Honor --schema, then sibling schemas/ dir.
+if [ -z "$SCHEMA" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+    CANDIDATE="$SCRIPT_DIR/../schemas/autospec-refinement.schema.json"
+    if [ -f "$CANDIDATE" ]; then
+        SCHEMA="$CANDIDATE"
+    fi
+fi
+
+# ── schema validation ─────────────────────────────────────────────
+# Prefer ajv-cli, fall back to python3 jsonschema, fall back to a shape check.
+validate_with_ajv() {
+    command -v ajv >/dev/null 2>&1 || return 2
+    # Try draft2020 spec first (matches our schema), fall back to default.
+    if ajv validate --spec=draft2020 -s "$SCHEMA" -d "$INPUT_JSON" >/dev/null 2>&1; then
+        return 0
+    fi
+    # If ajv can't even load the schema (e.g. unsupported draft URI on this
+    # ajv build), treat as "tool unable to validate" (rc=2) so we fall through
+    # to python jsonschema, NOT as a validation failure.
+    local err
+    err="$(ajv validate -s "$SCHEMA" -d "$INPUT_JSON" 2>&1)"
+    if printf '%s' "$err" | grep -q "schema .* is invalid\|no schema with key or ref"; then
+        return 2
+    fi
+    return 1
+}
+
+validate_with_python() {
+    command -v python3 >/dev/null 2>&1 || return 2
+    python3 - "$SCHEMA" "$INPUT_JSON" <<'PY' 2>/dev/null
+import json, sys
+try:
+    import jsonschema
+except Exception:
+    sys.exit(2)
+schema = json.load(open(sys.argv[1]))
+data = json.load(open(sys.argv[2]))
+try:
+    jsonschema.validate(data, schema)
+except Exception as e:
+    print(str(e), file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+validate_shape_check() {
+    # Minimum awk/python3-driven shape check: must have the 5 top-level keys.
+    command -v python3 >/dev/null 2>&1 || return 0
+    python3 - "$INPUT_JSON" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+required = ["original_prompt", "rounds", "final_prompt", "status", "metadata"]
+missing = [k for k in required if k not in data]
+if missing:
+    print("missing keys: " + ",".join(missing), file=sys.stderr)
+    sys.exit(1)
+if not isinstance(data["rounds"], list):
+    print("rounds must be array", file=sys.stderr); sys.exit(1)
+md = data["metadata"]
+for k in ["head_sha","timestamp","rounds_requested","rounds_executed",
+          "converged_early","degraded_rounds","handoff_target","handoff_executed"]:
+    if k not in md:
+        print("metadata missing: " + k, file=sys.stderr); sys.exit(1)
+allowed_status = {"approved","completed","converged","degraded","round_cap_reached","aborted"}
+if data["status"] not in allowed_status:
+    print("bad status: " + data["status"], file=sys.stderr); sys.exit(1)
+PY
+}
+
+VALIDATED=0
+if [ -n "$SCHEMA" ] && [ -f "$SCHEMA" ]; then
+    if validate_with_ajv; then
+        VALIDATED=1
+    else
+        rc=$?
+        if [ "$rc" -eq 1 ]; then
+            echo "refine-render-overview: schema validation failed (ajv) for $INPUT_JSON" >&2
+            exit 3
+        fi
+        if validate_with_python; then
+            VALIDATED=1
+        else
+            rc=$?
+            if [ "$rc" -eq 1 ]; then
+                echo "refine-render-overview: schema validation failed (jsonschema) for $INPUT_JSON" >&2
+                exit 3
+            fi
+        fi
+    fi
+fi
+
+if [ "$VALIDATED" = 0 ]; then
+    # Fallback shape check — exits 1 on shape failure.
+    if ! validate_shape_check; then
+        echo "refine-render-overview: shape check failed for $INPUT_JSON" >&2
+        exit 3
+    fi
+fi
+
+# ── render markdown ───────────────────────────────────────────────
+mkdir -p "$OUTPUT_DIR"
+TS="$(date -u +'%Y-%m-%dT%H-%M-%SZ')"
+BASE="$OUTPUT_DIR/${SLUG}-${TS}"
+MD_PATH="$BASE.md"
+JSON_PATH="$BASE.json"
+MD_TMP="$MD_PATH.tmp"
+JSON_TMP="$JSON_PATH.tmp"
+
+python3 - "$INPUT_JSON" "$MD_TMP" "$SLUG" <<'PY'
+import json, sys, difflib
+
+src, md_path, slug = sys.argv[1], sys.argv[2], sys.argv[3]
+data = json.load(open(src))
+
+orig = data["original_prompt"]
+rounds = data.get("rounds", [])
+final = data["final_prompt"]
+status = data["status"]
+md = data["metadata"]
+
+lines = []
+lines.append(f"# autospec-refine overview: {slug}")
+lines.append("")
+lines.append(f"- Status: `{status}`")
+lines.append(f"- Head SHA: `{md.get('head_sha','unknown')}`")
+lines.append(f"- Timestamp: `{md.get('timestamp','')}`")
+lines.append(f"- Rounds requested / executed: "
+             f"{md.get('rounds_requested','?')} / {md.get('rounds_executed','?')}")
+lines.append(f"- Converged early: `{md.get('converged_early', False)}`")
+deg = md.get("degraded_rounds", []) or []
+lines.append(f"- Degraded rounds: {', '.join(deg) if deg else 'none'}")
+lines.append(f"- Handoff target: `{md.get('handoff_target','')}`")
+lines.append(f"- Handoff executed: `{md.get('handoff_executed', False)}`")
+if "context_sparse" in md:
+    lines.append(f"- Context sparse: `{md['context_sparse']}`")
+lines.append("")
+
+lines.append("## Original prompt")
+lines.append("")
+lines.append("```")
+lines.append(orig)
+lines.append("```")
+lines.append("")
+
+prev = orig
+for r in rounds:
+    n = r.get("round_number", "?")
+    lens = r.get("lens", "?")
+    lines.append(f"## Round {n} — lens: `{lens}`")
+    lines.append("")
+    srcs = r.get("sources_used", []) or []
+    if srcs:
+        lines.append("Sources used:")
+        for s in srcs:
+            lines.append(f"- `{s}`")
+    else:
+        lines.append("Sources used: _none_")
+    lines.append("")
+    ds = r.get("diff_summary", "")
+    if ds:
+        lines.append(f"Diff summary: {ds}")
+    wcd = r.get("word_count_delta", 0)
+    lines.append(f"Word count delta: {wcd:+d}" if isinstance(wcd, int) else
+                 f"Word count delta: {wcd}")
+    lines.append("")
+    refined = r.get("refined_prompt", "")
+    diff = difflib.unified_diff(
+        prev.splitlines(),
+        refined.splitlines(),
+        fromfile=f"round-{int(n)-1 if isinstance(n,int) else 'prev'}",
+        tofile=f"round-{n}",
+        lineterm="",
+    )
+    diff_text = "\n".join(diff)
+    lines.append("Unified diff vs previous round:")
+    lines.append("")
+    lines.append("```diff")
+    if diff_text.strip():
+        lines.append(diff_text)
+    else:
+        lines.append("(no textual change)")
+    lines.append("```")
+    lines.append("")
+    reasoning = r.get("reasoning", "")
+    if reasoning:
+        lines.append(f"Reasoning: {reasoning}")
+        lines.append("")
+    prev = refined
+
+lines.append("## Final prompt")
+lines.append("")
+lines.append("```")
+lines.append(final)
+lines.append("```")
+lines.append("")
+
+with open(md_path, "w") as f:
+    f.write("\n".join(lines))
+PY
+
+# Copy the input JSON atomically as well.
+cp "$INPUT_JSON" "$JSON_TMP"
+
+mv "$MD_TMP" "$MD_PATH"
+mv "$JSON_TMP" "$JSON_PATH"
+
+echo "refine-render-overview: wrote $MD_PATH and $JSON_PATH"
+exit 0

--- a/tests/refine/test_refine_overview.bats
+++ b/tests/refine/test_refine_overview.bats
@@ -1,0 +1,193 @@
+#!/usr/bin/env bats
+# tests/refine/test_refine_overview.bats — dual-artifact renderer (issue #671).
+# Covers: (a) markdown renders correctly for a 3-round happy path,
+#         (b) JSON validates against schemas/autospec-refinement.schema.json,
+#         (c) atomic write via `.tmp` + `mv`.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../scripts/refine-render-overview.sh"
+SCHEMA="${BATS_TEST_DIRNAME}/../../schemas/autospec-refinement.schema.json"
+
+setup() {
+    TEST_TMP="$(mktemp -d -t refine-render.XXXXXX)"
+    OUT_DIR="$TEST_TMP/out"
+    INPUT="$TEST_TMP/input.json"
+
+    cat > "$INPUT" <<'JSON'
+{
+  "original_prompt": "fix login button",
+  "rounds": [
+    {
+      "round_number": 1,
+      "lens": "repo-grounding",
+      "sources_used": ["AGENTS.md", "docs/specs/2026-05-28-foo.md"],
+      "refined_prompt": "fix login button\n\nGrounded in AGENTS.md and docs/specs.",
+      "diff_summary": "added paths/conventions",
+      "word_count_delta": 7,
+      "reasoning": "repo-grounding lens v1"
+    },
+    {
+      "round_number": 2,
+      "lens": "clarity-ac",
+      "sources_used": ["AGENTS.md"],
+      "refined_prompt": "fix login button\n\nGrounded in AGENTS.md and docs/specs.\n\n- [ ] Implementation matches the disambiguated prompt.\n- [ ] Tests cover happy + adversarial.",
+      "diff_summary": "added AC checkboxes",
+      "word_count_delta": 13,
+      "reasoning": "clarity-ac lens v1"
+    },
+    {
+      "round_number": 3,
+      "lens": "sizing",
+      "sources_used": [],
+      "refined_prompt": "fix login button\n\nGrounded in AGENTS.md and docs/specs.\n\n- [ ] Implementation matches the disambiguated prompt.\n- [ ] Tests cover happy + adversarial.\n\nWithin sizing cap.",
+      "diff_summary": "sizing review",
+      "word_count_delta": 3,
+      "reasoning": "sizing lens v1"
+    }
+  ],
+  "final_prompt": "fix login button\n\nGrounded in AGENTS.md and docs/specs.\n\n- [ ] Implementation matches the disambiguated prompt.\n- [ ] Tests cover happy + adversarial.\n\nWithin sizing cap.",
+  "status": "completed",
+  "metadata": {
+    "head_sha": "abcdef1",
+    "timestamp": "2026-05-28T12-34-56Z",
+    "rounds_requested": 3,
+    "rounds_executed": 3,
+    "converged_early": false,
+    "degraded_rounds": [],
+    "context_sparse": false,
+    "handoff_target": "dry-run",
+    "handoff_executed": false
+  }
+}
+JSON
+}
+
+teardown() {
+    [ -d "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
+}
+
+@test "renderer emits both .md and .json under output-dir" {
+    run bash "$SCRIPT" --json "$INPUT" --slug "fix-login-button" \
+        --output-dir "$OUT_DIR" --schema "$SCHEMA"
+    [ "$status" -eq 0 ]
+    local md json
+    md=$(ls "$OUT_DIR"/*.md | head -1)
+    json=$(ls "$OUT_DIR"/*.json | head -1)
+    [ -f "$md" ]
+    [ -f "$json" ]
+}
+
+@test "markdown overview contains per-round headings, diff blocks, sources_used, final prompt" {
+    run bash "$SCRIPT" --json "$INPUT" --slug "fix-login-button" \
+        --output-dir "$OUT_DIR" --schema "$SCHEMA"
+    [ "$status" -eq 0 ]
+    local md
+    md=$(ls "$OUT_DIR"/*.md | head -1)
+
+    grep -q "^# autospec-refine overview" "$md"
+    grep -q "^## Original prompt" "$md"
+    grep -q "^## Round 1 — lens: \`repo-grounding\`" "$md"
+    grep -q "^## Round 2 — lens: \`clarity-ac\`" "$md"
+    grep -q "^## Round 3 — lens: \`sizing\`" "$md"
+    grep -q "^## Final prompt" "$md"
+    grep -q "AGENTS.md" "$md"
+    grep -q "docs/specs/2026-05-28-foo.md" "$md"
+    grep -q '```diff' "$md"
+}
+
+@test "JSON copy validates against schemas/autospec-refinement.schema.json" {
+    run bash "$SCRIPT" --json "$INPUT" --slug "fix-login-button" \
+        --output-dir "$OUT_DIR" --schema "$SCHEMA"
+    [ "$status" -eq 0 ]
+    local json
+    json=$(ls "$OUT_DIR"/*.json | head -1)
+    [ -f "$json" ]
+
+    # Schema must exist and be JSON-parseable.
+    run python3 -c "import json; json.load(open('$SCHEMA'))"
+    [ "$status" -eq 0 ]
+
+    # Validate via jsonschema if available; else assert shape.
+    if python3 -c "import jsonschema" 2>/dev/null; then
+        run python3 -c "
+import json, jsonschema
+schema = json.load(open('$SCHEMA'))
+data = json.load(open('$json'))
+jsonschema.validate(data, schema)
+print('ok')
+"
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"ok"* ]]
+    else
+        run python3 -c "
+import json, sys
+d = json.load(open('$json'))
+required = ['original_prompt','rounds','final_prompt','status','metadata']
+assert all(k in d for k in required)
+assert d['status'] in ('approved','completed','converged','degraded','round_cap_reached','aborted')
+print('ok')
+"
+        [ "$status" -eq 0 ]
+    fi
+}
+
+@test "atomic write: no .tmp files survive a successful run" {
+    run bash "$SCRIPT" --json "$INPUT" --slug "fix-login-button" \
+        --output-dir "$OUT_DIR" --schema "$SCHEMA"
+    [ "$status" -eq 0 ]
+    run bash -c "ls $OUT_DIR/*.tmp 2>/dev/null | wc -l | tr -d ' '"
+    [ "$output" = "0" ]
+}
+
+@test "atomic write: final paths exist and .tmp paths do not" {
+    run bash "$SCRIPT" --json "$INPUT" --slug "fix-login-button" \
+        --output-dir "$OUT_DIR" --schema "$SCHEMA"
+    [ "$status" -eq 0 ]
+    local md json
+    md=$(ls "$OUT_DIR"/*.md | head -1)
+    json=$(ls "$OUT_DIR"/*.json | head -1)
+    [ -f "$md" ]
+    [ -f "$json" ]
+    [ ! -f "$md.tmp" ]
+    [ ! -f "$json.tmp" ]
+}
+
+@test "schema rejects payload missing required metadata fields" {
+    local bad="$TEST_TMP/bad.json"
+    cat > "$bad" <<'JSON'
+{
+  "original_prompt": "x",
+  "rounds": [],
+  "final_prompt": "x",
+  "status": "completed",
+  "metadata": {"head_sha": "abc", "timestamp": "t"}
+}
+JSON
+    run bash "$SCRIPT" --json "$bad" --slug "bad" \
+        --output-dir "$OUT_DIR" --schema "$SCHEMA"
+    [ "$status" -eq 3 ]
+}
+
+@test "happy-path orchestrator output renders cleanly end-to-end" {
+    # Generate a real orchestrator artifact and feed it through the renderer.
+    local repo="$TEST_TMP/repo"
+    local mem="$TEST_TMP/mem"
+    local art="$TEST_TMP/art"
+    mkdir -p "$repo/docs/specs" "$mem/proj/memory"
+    cat > "$repo/AGENTS.md" <<'EOF'
+# AGENTS
+Follow lockstep. See scripts/refine-prompt.sh.
+EOF
+    cat > "$repo/docs/specs/2026-05-28-foo.md" <<'EOF'
+# Foo
+EOF
+    run bash "${BATS_TEST_DIRNAME}/../../scripts/refine-prompt.sh" \
+        "fix login button" --rounds 3 --dry-run \
+        --artifact-dir "$art" --repo-root "$repo" --memory-root "$mem"
+    [ "$status" -eq 0 ]
+    local orch
+    orch=$(ls "$art"/*.json | head -1)
+    [ -f "$orch" ]
+    run bash "$SCRIPT" --json "$orch" --slug "fix-login-button" \
+        --output-dir "$OUT_DIR" --schema "$SCHEMA"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #671 — Issue 3 of 5 in the autospec-refine chain (depends on #670).

## Summary
- Adds `scripts/refine-render-overview.sh` consuming the orchestrator JSON from #670 and emitting a dual `.md` + `.json` artifact pair under `.autospec/refinements/<slug>-<ISO>.{md,json}`.
- Adds `schemas/autospec-refinement.schema.json` (draft 2020-12) modeled on `autospec-proof-matrix.schema.json`. Locks original_prompt, rounds[] (lens enum + sources_used + word_count_delta + reasoning + diff_summary), final_prompt, status enum, and full metadata block.
- Markdown overview: front-matter summary, original prompt fence, per-round headings, sources_used lists, unified diff blocks vs prior round, final prompt fence.
- Atomic write via `.tmp` + `mv` for both artifacts.
- Schema validation tries ajv-cli (`--spec=draft2020`) first, falls back to `python3 -m jsonschema`, then to a shape check — exactly the contract the spec calls out.

## Tests
`tests/refine/test_refine_overview.bats` — 7 tests:
1. Renderer writes both `.md` and `.json`.
2. Markdown contains per-round headings, diff blocks, sources_used, final prompt.
3. JSON copy validates against the schema.
4. No `.tmp` files survive a successful run.
5. Final paths exist; `.tmp` paths do not.
6. Schema rejects payloads missing required metadata fields (exit 3).
7. End-to-end: feed a real `refine-prompt.sh` artifact through the renderer.

## Verification
- `bats tests/refine/test_refine_overview.bats` — 7/7 pass.
- `bash scripts/validate.sh` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)