### PR TITLE
feat: autospec-refine handoff modes + validate gate (closes #672)

### DIFF
--- a/scripts/refine-prompt.sh
+++ b/scripts/refine-prompt.sh
@@ -37,6 +37,8 @@ Flags:
   --from-file <path>     Read the initial prompt from a file.
   --output <path>        Also write the final refined prompt to this file.
   --dry-run              Skip handoff, write artifact only.
+  --interactive          After refinement, hand off to /autospec (interactive).
+  --autonomous           After refinement, hand off to /autospec --autonomous (default).
   --artifact-dir DIR     Override .autospec/refinements (test hook).
   --repo-root DIR        Override repo root (test hook).
   --memory-root DIR      Override ~/.autospec/projects memory root (test hook).
@@ -54,6 +56,7 @@ ROUNDS=3
 LENSES_RAW=""
 OUTPUT=""
 DRY_RUN=0
+HANDOFF_MODE="autonomous"
 ARTIFACT_DIR=".autospec/refinements"
 REPO_ROOT="."
 MEMORY_ROOT="${HOME}/.autospec/projects"
@@ -66,6 +69,8 @@ while [ $# -gt 0 ]; do
         --from-file) FROM_FILE="$2"; shift ;;
         --output) OUTPUT="$2"; shift ;;
         --dry-run) DRY_RUN=1 ;;
+        --interactive) HANDOFF_MODE="interactive" ;;
+        --autonomous) HANDOFF_MODE="autonomous" ;;
         --artifact-dir) ARTIFACT_DIR="$2"; shift ;;
         --repo-root) REPO_ROOT="$2"; shift ;;
         --memory-root) MEMORY_ROOT="$2"; shift ;;
@@ -418,10 +423,15 @@ HEAD_SHA="$( ( cd "$REPO_ROOT" && git rev-parse HEAD 2>/dev/null ) || echo unkno
 # Degraded rounds array.
 DEGRADED_JSON="$(printf '%s\n' "${DEGRADED_ROUNDS[@]:-}" | python3 -c 'import json,sys; arr=[l for l in sys.stdin.read().splitlines() if l]; sys.stdout.write(json.dumps(arr))')"
 
-HANDOFF_TARGET="/autospec --autonomous"
 HANDOFF_EXECUTED=false
 if [ "$DRY_RUN" = 1 ]; then
     HANDOFF_TARGET="dry-run"
+elif [ "$HANDOFF_MODE" = "interactive" ]; then
+    HANDOFF_TARGET="/autospec"
+    HANDOFF_EXECUTED=true
+else
+    HANDOFF_TARGET="/autospec --autonomous"
+    HANDOFF_EXECUTED=true
 fi
 
 CONTEXT_SPARSE_JSON="$CONTEXT_SPARSE"
@@ -455,4 +465,27 @@ if [ -n "$OUTPUT" ]; then
 fi
 
 echo "refine-prompt: status=$STATUS rounds_executed=$ROUNDS_EXECUTED artifact=$ARTIFACT"
+
+# ── handoff dispatch ──────────────────────────────────────────────
+# --dry-run skips handoff. Otherwise invoke the autospec entry point via
+# `claude` (slash-command dispatcher) if available, falling back to the
+# `autospec` binary on PATH. Test harnesses stub both.
+if [ "$DRY_RUN" != 1 ]; then
+    if command -v claude >/dev/null 2>&1; then
+        if [ "$HANDOFF_MODE" = "interactive" ]; then
+            claude "/autospec" "$FINAL_PROMPT" || true
+        else
+            claude "/autospec" "--autonomous" "$FINAL_PROMPT" || true
+        fi
+    elif command -v autospec >/dev/null 2>&1; then
+        if [ "$HANDOFF_MODE" = "interactive" ]; then
+            autospec "$FINAL_PROMPT" || true
+        else
+            autospec --autonomous "$FINAL_PROMPT" || true
+        fi
+    else
+        echo "refine-prompt: WARN — no handoff dispatcher (claude/autospec) on PATH; artifact retained" >&2
+    fi
+fi
+
 exit 0

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1331,6 +1331,37 @@ check_autospec_autonomous_contract() {
     fi
 }
 
+check_autospec_refine_contract() {
+    info "autospec-refine contract: trio + scripts + schema + bats (issue #672)"
+    # Trio lockstep is enforced by the discover_skills loop in main(); here we
+    # only assert the per-feature files referenced by the contract exist and
+    # the bats coverage runs.
+    local prompt_sh="scripts/refine-prompt.sh"
+    local overview_sh="scripts/refine-render-overview.sh"
+    local schema="schemas/autospec-refinement.schema.json"
+    [ -f "$prompt_sh" ] || fail "$prompt_sh: file missing (issue #672)"
+    [ -x "$prompt_sh" ] || fail "$prompt_sh: not executable (issue #672)"
+    bash -n "$prompt_sh" || fail "$prompt_sh: bash syntax error (issue #672)"
+    [ -f "$overview_sh" ] || fail "$overview_sh: file missing (issue #672)"
+    [ -x "$overview_sh" ] || fail "$overview_sh: not executable (issue #672)"
+    bash -n "$overview_sh" || fail "$overview_sh: bash syntax error (issue #672)"
+    [ -f "$schema" ] || fail "$schema: file missing (issue #672)"
+    # autospec-refine trio existence (lockstep checked separately).
+    for trio in skills/autospec-refine/SKILL.md skills/autospec-refine/codex/prompt.md skills/autospec-refine/opencode/agent.md; do
+        [ -f "$trio" ] || fail "$trio: missing (issue #672)"
+    done
+    if command -v bats >/dev/null 2>&1; then
+        if [ -d tests/refine ]; then
+            for t in tests/refine/test_refine_*.bats; do
+                [ -f "$t" ] || continue
+                info "  running: $t"
+                bats "$t" >/tmp/validate-refine.log 2>&1 \
+                    || { cat /tmp/validate-refine.log >&2; fail "$t: failed"; }
+            done
+        fi
+    fi
+}
+
 check_install_tests() {
     info "install tests: tests/install/*.sh"
     if [ -d tests/install ]; then
@@ -1414,6 +1445,7 @@ main() {
     check_release_verdict_script
     check_docs_amendment_presence
     check_autospec_autonomous_contract
+    check_autospec_refine_contract
     check_install_tests
     check_phase4_tests
 

--- a/tests/refine/test_refine_handoff.bats
+++ b/tests/refine/test_refine_handoff.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# tests/refine/test_refine_handoff.bats — handoff modes (issue #672).
+# Covers: --dry-run (no handoff), --interactive → /autospec, default → /autospec --autonomous.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../scripts/refine-prompt.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d -t refine-handoff.XXXXXX)"
+    REPO_ROOT="$TEST_TMP/repo"
+    mkdir -p "$REPO_ROOT/docs/specs"
+    ART_DIR="$TEST_TMP/artifacts"
+    MEMORY_ROOT="$TEST_TMP/memory"
+    mkdir -p "$MEMORY_ROOT"
+
+    # PATH stubs for handoff target.
+    STUB_BIN="$TEST_TMP/bin"
+    mkdir -p "$STUB_BIN"
+    HANDOFF_LOG="$TEST_TMP/handoff.log"
+
+    # Stub 'claude' (used as the handoff dispatcher).
+    cat > "$STUB_BIN/claude" <<EOF
+#!/usr/bin/env bash
+echo "claude-stub args=\$@" >> "$HANDOFF_LOG"
+exit 0
+EOF
+    chmod +x "$STUB_BIN/claude"
+
+    # Stub 'autospec' (used when invoked directly).
+    cat > "$STUB_BIN/autospec" <<EOF
+#!/usr/bin/env bash
+echo "autospec-stub args=\$@" >> "$HANDOFF_LOG"
+exit 0
+EOF
+    chmod +x "$STUB_BIN/autospec"
+
+    export PATH="$STUB_BIN:$PATH"
+}
+
+teardown() {
+    [ -d "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
+}
+
+@test "--dry-run: writes artifact, exits 0, no handoff invocation" {
+    run bash "$SCRIPT" "fix login button" --rounds 1 --dry-run \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -eq 0 ]
+    f=$(ls "$ART_DIR"/*.json | head -1)
+    [ -f "$f" ]
+    run jq -r '.metadata.handoff_target' "$f"
+    [ "$output" = "dry-run" ]
+    run jq -r '.metadata.handoff_executed' "$f"
+    [ "$output" = "false" ]
+    [ ! -f "$HANDOFF_LOG" ]
+}
+
+@test "--interactive: invokes /autospec (interactive entry point) with final prompt" {
+    run bash "$SCRIPT" "fix login button" --rounds 1 --interactive \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -eq 0 ]
+    [ -f "$HANDOFF_LOG" ]
+    run cat "$HANDOFF_LOG"
+    [[ "$output" == *"/autospec"* ]]
+    [[ "$output" != *"--autonomous"* ]]
+    f=$(ls "$ART_DIR"/*.json | head -1)
+    run jq -r '.metadata.handoff_target' "$f"
+    [ "$output" = "/autospec" ]
+    run jq -r '.metadata.handoff_executed' "$f"
+    [ "$output" = "true" ]
+}
+
+@test "default (autonomous): invokes /autospec --autonomous with final prompt" {
+    run bash "$SCRIPT" "fix login button" --rounds 1 \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -eq 0 ]
+    [ -f "$HANDOFF_LOG" ]
+    run cat "$HANDOFF_LOG"
+    [[ "$output" == *"/autospec"* ]]
+    [[ "$output" == *"--autonomous"* ]]
+    f=$(ls "$ART_DIR"/*.json | head -1)
+    run jq -r '.metadata.handoff_target' "$f"
+    [ "$output" = "/autospec --autonomous" ]
+    run jq -r '.metadata.handoff_executed' "$f"
+    [ "$output" = "true" ]
+}


### PR DESCRIPTION
Closes #672

## Summary

- `scripts/refine-prompt.sh` gains `--interactive` / `--autonomous` (default) / `--dry-run` handoff branching. After the artifact is written:
  - `--dry-run` skips handoff entirely.
  - `--interactive` invokes `/autospec` with the final prompt.
  - default `--autonomous` invokes `/autospec --autonomous` with the final prompt (inherits PR #664 autonomy-gate guardrails).
  - Dispatch prefers `claude` on PATH, falls back to `autospec`.
- `scripts/validate.sh` gains `check_autospec_refine_contract()` (mirrors `check_qa_exhaustiveness_contract`) asserting trio + scripts + schema exist and running `tests/refine/test_refine_*.bats`. Wired into `main()`.
- New TDD coverage: `tests/refine/test_refine_handoff.bats` with PATH-stubbed dispatchers covering all three modes.

## Test plan

- [x] `bats tests/refine/test_refine_handoff.bats` — 3/3 pass
- [x] `bash scripts/validate.sh` — green end-to-end

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>