### PR TITLE
fix: wire refine-render-overview into refine-prompt artifact step

### DIFF
--- a/scripts/refine-prompt.sh
+++ b/scripts/refine-prompt.sh
@@ -750,6 +750,17 @@ if [ -n "$OUTPUT" ]; then
     printf '%s' "$FINAL_PROMPT" > "$OUTPUT"
 fi
 
+# Produce the human-readable markdown sibling next to the JSON. The
+# renderer reuses the JSON's timestamp so the .md and .json share a
+# base path; missing the .md (#671 shipped the renderer but didn't wire
+# it into the orchestrator's artifact step).
+RENDER_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/refine-render-overview.sh"
+if [ -x "$RENDER_SH" ]; then
+    "$RENDER_SH" --json "$ARTIFACT" --slug "$SLUG" \
+        --output-dir "$ARTIFACT_DIR" >/dev/null 2>&1 || \
+        echo "refine-prompt: WARN — overview render failed for $ARTIFACT" >&2
+fi
+
 echo "refine-prompt: status=$STATUS rounds_executed=$ROUNDS_EXECUTED artifact=$ARTIFACT"
 
 # ── handoff dispatch ──────────────────────────────────────────────

--- a/scripts/refine-render-overview.sh
+++ b/scripts/refine-render-overview.sh
@@ -160,7 +160,18 @@ fi
 
 # ── render markdown ───────────────────────────────────────────────
 mkdir -p "$OUTPUT_DIR"
-TS="$(date -u +'%Y-%m-%dT%H-%M-%SZ')"
+# Derive the timestamp from the input filename when it matches the
+# orchestrator's naming convention (<slug>-<ISO-ts>.json), so the .md
+# sibling lands beside its source .json instead of forking a new
+# timestamp. Falls back to "now" only when the input is renamed/synthetic.
+INPUT_BASE="$(basename "$INPUT_JSON" .json)"
+INPUT_TS="${INPUT_BASE#${SLUG}-}"
+if [ "$INPUT_TS" != "$INPUT_BASE" ] && \
+   printf '%s' "$INPUT_TS" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z$'; then
+    TS="$INPUT_TS"
+else
+    TS="$(date -u +'%Y-%m-%dT%H-%M-%SZ')"
+fi
 BASE="$OUTPUT_DIR/${SLUG}-${TS}"
 MD_PATH="$BASE.md"
 JSON_PATH="$BASE.json"


### PR DESCRIPTION
Wires the renderer (#676) into the orchestrator (#675). Codex peer-review on the merged chain caught it as the #1 finding.

## Test plan
- [x] `bats tests/refine/` → 33/33 pass
- [x] `bash scripts/validate.sh` → all checks pass
- [x] `bash scripts/refine-prompt.sh "X" --rounds 3 --dry-run` → produces both .json AND .md with matching timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)