### PR TITLE
fix: autospec-refine path-security hardening (closes #680)

### DIFF
--- a/scripts/refine-prompt.sh
+++ b/scripts/refine-prompt.sh
@@ -112,15 +112,73 @@ fi
 # ── path allowlist ────────────────────────────────────────────────
 # Forbidden patterns: .env (exact basename or .env.*), *credential*, *secret*,
 # *.pem, *.key, .git/, node_modules/.
-check_path_allowed() {
+#
+# Path-security hardening (issue #680):
+#   1. Resolve via `realpath -m` (or `readlink -f` fallback) to follow
+#      symlinks and canonicalize `..` segments.
+#   2. Check BOTH the literal input and the resolved target against the
+#      forbidden patterns — a safe-looking symlink to .env must reject.
+#   3. Reject any post-canonicalization `..` segments (defense in depth).
+_match_forbidden() {
     local p="$1"
     case "$p" in
-        *.env|*.env.*|*/.env|.env) return 1 ;;
-        *credential*|*Credential*|*CREDENTIAL*) return 1 ;;
-        *secret*|*Secret*|*SECRET*) return 1 ;;
-        *.pem|*.key) return 1 ;;
-        */.git/*|.git/*) return 1 ;;
-        */node_modules/*|node_modules/*) return 1 ;;
+        *.env|*.env.*|*/.env|.env) return 0 ;;
+        *credential*|*Credential*|*CREDENTIAL*) return 0 ;;
+        *secret*|*Secret*|*SECRET*) return 0 ;;
+        *.pem|*.key) return 0 ;;
+        */.git/*|.git/*|*/.git|.git) return 0 ;;
+        */node_modules/*|node_modules/*|*/node_modules|node_modules) return 0 ;;
+    esac
+    return 1
+}
+
+_canonicalize() {
+    local p="$1"
+    local r=""
+    # Try GNU realpath -m (handles non-existent paths).
+    if command -v realpath >/dev/null 2>&1; then
+        r="$(realpath -m "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+        # BSD realpath (macOS) — only resolves existing paths.
+        r="$(realpath "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+    fi
+    if command -v readlink >/dev/null 2>&1; then
+        r="$(readlink -f "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+        # Single-level symlink fallback (BSD readlink).
+        if [ -L "$p" ]; then
+            local target
+            target="$(readlink "$p" 2>/dev/null)" || target=""
+            if [ -n "$target" ]; then
+                case "$target" in
+                    /*) printf '%s' "$target"; return ;;
+                    *)  printf '%s/%s' "$(dirname "$p")" "$target"; return ;;
+                esac
+            fi
+        fi
+    fi
+    # Python fallback.
+    if command -v python3 >/dev/null 2>&1; then
+        r="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+    fi
+    printf '%s' "$p"
+}
+
+check_path_allowed() {
+    local p="$1"
+    # Literal pattern check first.
+    if _match_forbidden "$p"; then return 1; fi
+    # Resolve (follows symlinks, canonicalizes ..) and re-check.
+    local resolved
+    resolved="$(_canonicalize "$p")"
+    if [ -n "$resolved" ] && [ "$resolved" != "$p" ]; then
+        if _match_forbidden "$resolved"; then return 1; fi
+    fi
+    # Reject any residual .. segment.
+    case "$resolved" in
+        *..*) return 1 ;;
     esac
     return 0
 }
@@ -151,6 +209,19 @@ fi
 if [ -z "$PROMPT" ]; then
     echo "refine-prompt: empty prompt (provide a positional arg or --from-file)" >&2
     exit 4
+fi
+
+# Extended allowlist (issue #680): artifact-dir and simulate-iterations dir
+# must also pass the forbidden-path check.
+if ! check_path_allowed "$ARTIFACT_DIR"; then
+    echo "code_health:refine_path_violation path=$ARTIFACT_DIR" >&2
+    exit 3
+fi
+if [ -n "$SIM_ITER_DIR" ]; then
+    if ! check_path_allowed "$SIM_ITER_DIR"; then
+        echo "code_health:refine_path_violation path=$SIM_ITER_DIR" >&2
+        exit 3
+    fi
 fi
 
 # ── slug helper (early — needed by --continue) ────────────────────

--- a/scripts/refine-render-overview.sh
+++ b/scripts/refine-render-overview.sh
@@ -53,6 +53,92 @@ if [ -z "$INPUT_JSON" ] || [ -z "$SLUG" ]; then
     exit 2
 fi
 
+# ── slug sanitization (issue #680) ────────────────────────────────
+# Reject /, .., whitespace, control chars, or any char outside [a-z0-9-]
+# after lowercasing. Matches the orchestrator's slug_from_prompt() shape.
+_slug_sanitize_check() {
+    local s="$1"
+    [ -n "$s" ] || { echo "refine-render-overview: --slug is empty" >&2; return 2; }
+    case "$s" in
+        */*) echo "refine-render-overview: --slug contains '/': $s" >&2; return 2 ;;
+        *..*) echo "refine-render-overview: --slug contains '..': $s" >&2; return 2 ;;
+    esac
+    # Lowercase + check character class.
+    local lower
+    lower="$(printf '%s' "$s" | tr '[:upper:]' '[:lower:]')"
+    if ! printf '%s' "$lower" | LC_ALL=C grep -qE '^[a-z0-9-]+$'; then
+        echo "refine-render-overview: --slug has invalid chars (allowed: [a-z0-9-]): $s" >&2
+        return 2
+    fi
+    return 0
+}
+if ! _slug_sanitize_check "$SLUG"; then
+    exit 2
+fi
+
+# ── path allowlist (issue #680) ───────────────────────────────────
+# Same forbidden patterns as refine-prompt.sh::check_path_allowed.
+_render_match_forbidden() {
+    local p="$1"
+    case "$p" in
+        *.env|*.env.*|*/.env|.env) return 0 ;;
+        *credential*|*Credential*|*CREDENTIAL*) return 0 ;;
+        *secret*|*Secret*|*SECRET*) return 0 ;;
+        *.pem|*.key) return 0 ;;
+        */.git/*|.git/*|*/.git|.git) return 0 ;;
+        */node_modules/*|node_modules/*|*/node_modules|node_modules) return 0 ;;
+    esac
+    return 1
+}
+_render_canonicalize() {
+    local p="$1"
+    local r=""
+    if command -v realpath >/dev/null 2>&1; then
+        r="$(realpath -m "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+        r="$(realpath "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+    fi
+    if command -v readlink >/dev/null 2>&1; then
+        r="$(readlink -f "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+        if [ -L "$p" ]; then
+            local target
+            target="$(readlink "$p" 2>/dev/null)" || target=""
+            if [ -n "$target" ]; then
+                case "$target" in
+                    /*) printf '%s' "$target"; return ;;
+                    *)  printf '%s/%s' "$(dirname "$p")" "$target"; return ;;
+                esac
+            fi
+        fi
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        r="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+    fi
+    printf '%s' "$p"
+}
+_render_check_path_allowed() {
+    local p="$1"
+    _render_match_forbidden "$p" && return 1
+    local resolved
+    resolved="$(_render_canonicalize "$p")"
+    if [ -n "$resolved" ] && [ "$resolved" != "$p" ]; then
+        _render_match_forbidden "$resolved" && return 1
+    fi
+    case "$resolved" in
+        *..*) return 1 ;;
+    esac
+    return 0
+}
+for _p in "$INPUT_JSON" "$OUTPUT_DIR"; do
+    if ! _render_check_path_allowed "$_p"; then
+        echo "code_health:refine_path_violation path=$_p" >&2
+        exit 3
+    fi
+done
+
 if [ ! -f "$INPUT_JSON" ]; then
     echo "refine-render-overview: input not found: $INPUT_JSON" >&2
     exit 4

--- a/tests/refine/test_refine_path_security.bats
+++ b/tests/refine/test_refine_path_security.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+# tests/refine/test_refine_path_security.bats — issue #680.
+#
+# Path-security hardening for autospec-refine:
+#   1. Symlinks resolving to forbidden targets are rejected.
+#   2. --slug containing /, .., whitespace, or control chars rejected.
+#   3. --artifact-dir and renderer --output-dir / --json are allowlist-checked.
+#   4. Valid cross-directory paths still pass.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    REFINE="$REPO_ROOT/scripts/refine-prompt.sh"
+    RENDER="$REPO_ROOT/scripts/refine-render-overview.sh"
+    TMPDIR_T="$(mktemp -d)"
+    export PATH="$REPO_ROOT/scripts:$PATH"
+}
+
+teardown() {
+    [ -n "${TMPDIR_T:-}" ] && rm -rf "$TMPDIR_T"
+}
+
+@test "symlink-to-.env rejected with refine_path_violation" {
+    # Create a secret file and a safe-looking symlink to it.
+    printf 'SECRET=1\n' > "$TMPDIR_T/.env"
+    ln -sf "$TMPDIR_T/.env" "$TMPDIR_T/safe-prompt.md"
+
+    run bash "$REFINE" --from-file "$TMPDIR_T/safe-prompt.md" --dry-run \
+        --artifact-dir "$TMPDIR_T/refinements" \
+        --repo-root "$TMPDIR_T" \
+        --memory-root "$TMPDIR_T/memory"
+
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"refine_path_violation"* ]]
+}
+
+@test "slug with path traversal rejected by renderer" {
+    # Build a minimal valid input JSON for the renderer.
+    cat > "$TMPDIR_T/input.json" <<'EOF'
+{"original_prompt":"x","rounds":[],"final_prompt":"x","status":"completed",
+ "metadata":{"head_sha":"abc","timestamp":"2026-05-28T00-00-00Z",
+   "rounds_requested":1,"rounds_executed":1,"converged_early":false,
+   "degraded_rounds":[],"handoff_target":"dry-run","handoff_executed":false}}
+EOF
+    run bash "$RENDER" --json "$TMPDIR_T/input.json" \
+        --slug "../../leak" \
+        --output-dir "$TMPDIR_T/out"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"slug"* ]]
+}
+
+@test "slug with slash rejected by renderer" {
+    cat > "$TMPDIR_T/input.json" <<'EOF'
+{"original_prompt":"x","rounds":[],"final_prompt":"x","status":"completed",
+ "metadata":{"head_sha":"abc","timestamp":"2026-05-28T00-00-00Z",
+   "rounds_requested":1,"rounds_executed":1,"converged_early":false,
+   "degraded_rounds":[],"handoff_target":"dry-run","handoff_executed":false}}
+EOF
+    run bash "$RENDER" --json "$TMPDIR_T/input.json" \
+        --slug "evil/slug" \
+        --output-dir "$TMPDIR_T/out"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"slug"* ]]
+}
+
+@test "artifact-dir to .git/ rejected" {
+    run bash "$REFINE" "test prompt" --dry-run \
+        --artifact-dir "$TMPDIR_T/.git/leak" \
+        --repo-root "$TMPDIR_T" \
+        --memory-root "$TMPDIR_T/memory"
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"refine_path_violation"* ]]
+}
+
+@test "renderer output-dir under node_modules rejected" {
+    cat > "$TMPDIR_T/input.json" <<'EOF'
+{"original_prompt":"x","rounds":[],"final_prompt":"x","status":"completed",
+ "metadata":{"head_sha":"abc","timestamp":"2026-05-28T00-00-00Z",
+   "rounds_requested":1,"rounds_executed":1,"converged_early":false,
+   "degraded_rounds":[],"handoff_target":"dry-run","handoff_executed":false}}
+EOF
+    run bash "$RENDER" --json "$TMPDIR_T/input.json" \
+        --slug "valid-slug" \
+        --output-dir "$TMPDIR_T/node_modules/leak"
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"refine_path_violation"* ]]
+}
+
+@test "valid cross-directory --output path accepted" {
+    mkdir -p "$TMPDIR_T/sibling"
+    run bash "$REFINE" "valid cross-dir test prompt body" --dry-run \
+        --output "$TMPDIR_T/sibling/legit.md" \
+        --artifact-dir "$TMPDIR_T/refinements" \
+        --repo-root "$TMPDIR_T" \
+        --memory-root "$TMPDIR_T/memory"
+    [ "$status" -eq 0 ]
+    [ -f "$TMPDIR_T/sibling/legit.md" ]
+}
+
+@test "renderer --json input pointing to .git/ rejected" {
+    mkdir -p "$TMPDIR_T/.git"
+    cat > "$TMPDIR_T/.git/leak.json" <<'EOF'
+{"original_prompt":"x","rounds":[],"final_prompt":"x","status":"completed",
+ "metadata":{"head_sha":"abc","timestamp":"2026-05-28T00-00-00Z",
+   "rounds_requested":1,"rounds_executed":1,"converged_early":false,
+   "degraded_rounds":[],"handoff_target":"dry-run","handoff_executed":false}}
+EOF
+    run bash "$RENDER" --json "$TMPDIR_T/.git/leak.json" \
+        --slug "valid-slug" \
+        --output-dir "$TMPDIR_T/out"
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"refine_path_violation"* ]]
+}


### PR DESCRIPTION
Closes #680

## Summary

Three related path-security fixes from Codex peer-review of the autospec-refine chain (PRs #674-#678):

- **Symlink resolution** in `check_path_allowed()`: canonicalize via `realpath` / `readlink` / python fallback, re-check the resolved target against forbidden patterns, and reject residual `..`.
- **Slug sanitization** in `refine-render-overview.sh`: reject `--slug` containing `/`, `..`, whitespace, control chars, or anything outside `[a-z0-9-]` after lowercasing.
- **Extended allowlist** to `--artifact-dir`, `--simulate-iterations`, renderer `--output-dir`, and renderer `--json`.

## Test plan

- [x] New `tests/refine/test_refine_path_security.bats` — 7 fixtures (symlink bypass, slug traversal, slug with `/`, forbidden artifact-dir, forbidden renderer output-dir, forbidden renderer `--json`, valid cross-directory accept).
- [x] `bats tests/refine/` — all 40 tests pass (33 prior + 7 new).
- [x] `bash scripts/validate.sh` — green end-to-end.