### PR TITLE
feat: autospec writes canonical .autospec/run-summary.md on Phase 6 (closes #683)

### DIFF
--- a/scripts/autospec-write-run-summary.sh
+++ b/scripts/autospec-write-run-summary.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# scripts/autospec-write-run-summary.sh
+#
+# Phase 6 canonical run-summary writer. Assembles the run state into
+# .autospec/run-summary.md per the schema documented in
+# skills/autospec/SKILL.md §Phase 6, and writes it atomically via .tmp + mv.
+#
+# Schema:
+#   # autospec run summary — <ISO-8601 UTC timestamp>
+#
+#   - HEAD SHA: <sha>
+#   - Branch: <branch>
+#   - Total PRs merged: N
+#   - Issues closed: M
+#   - Elapsed: HH:MM
+#
+#   ## PRs merged
+#   - #1234 fix: ...
+#
+#   ## Issues closed
+#   - #1230 ...
+#
+#   ## Failures
+#   (empty or list)
+#
+#   ## Next steps
+#   <content from --next-steps-file, or "- (none — converged)" fallback>
+#
+# Inputs are passed as flags. All flags optional except --output; missing
+# flags resolve to safe defaults so the harvest contract still produces a
+# schema-valid file (## Next steps section is always present).
+#
+# Exit codes: 0 success; 1 invocation error; 2 write failure.
+
+set -eu
+
+usage() {
+    cat <<'EOF'
+Usage: autospec-write-run-summary.sh [options]
+
+Options:
+  --repo <slug>             owner/name repo slug (defaults: "")
+  --prs <file|csv>          file with one PR per line OR comma-separated list
+  --issues <file|csv>       file with one issue per line OR comma-separated list
+  --failures <file|csv>     file with failures OR comma-separated list
+  --elapsed <HH:MM>         elapsed wall-clock time (defaults: "")
+  --next-steps-file <file>  file with markdown for the ## Next steps section
+                            (defaults to "- (none — converged)" when empty/missing)
+  --output <path>           output markdown path (REQUIRED)
+  --sha <sha>               HEAD SHA override (defaults: git rev-parse HEAD)
+  --branch <name>           branch override (defaults: git symbolic-ref HEAD)
+  -h, --help                show this help and exit
+EOF
+}
+
+REPO=""
+PRS_INPUT=""
+ISSUES_INPUT=""
+FAILURES_INPUT=""
+ELAPSED=""
+NEXT_STEPS_FILE=""
+OUTPUT=""
+SHA_OVERRIDE=""
+BRANCH_OVERRIDE=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo) REPO="${2:-}"; shift 2 ;;
+        --prs) PRS_INPUT="${2:-}"; shift 2 ;;
+        --issues) ISSUES_INPUT="${2:-}"; shift 2 ;;
+        --failures) FAILURES_INPUT="${2:-}"; shift 2 ;;
+        --elapsed) ELAPSED="${2:-}"; shift 2 ;;
+        --next-steps-file) NEXT_STEPS_FILE="${2:-}"; shift 2 ;;
+        --output) OUTPUT="${2:-}"; shift 2 ;;
+        --sha) SHA_OVERRIDE="${2:-}"; shift 2 ;;
+        --branch) BRANCH_OVERRIDE="${2:-}"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown flag: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if [ -z "$OUTPUT" ]; then
+    echo "ERROR: --output is required" >&2
+    usage >&2
+    exit 1
+fi
+
+# Resolve git state with defaults (so the helper works in test fixtures
+# outside a real repo).
+if [ -n "$SHA_OVERRIDE" ]; then
+    SHA="$SHA_OVERRIDE"
+elif command -v git >/dev/null 2>&1 && git rev-parse HEAD >/dev/null 2>&1; then
+    SHA=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+else
+    SHA="unknown"
+fi
+
+if [ -n "$BRANCH_OVERRIDE" ]; then
+    BRANCH="$BRANCH_OVERRIDE"
+elif command -v git >/dev/null 2>&1 && git symbolic-ref --short HEAD >/dev/null 2>&1; then
+    BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "unknown")
+else
+    BRANCH="unknown"
+fi
+
+TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+# Render an input list as one-bullet-per-line markdown. Accepts either a path
+# to a file (one entry per line) or a comma-separated string.
+render_list() {
+    raw="$1"
+    if [ -z "$raw" ]; then
+        return 0
+    fi
+    if [ -f "$raw" ]; then
+        # File: emit lines verbatim, prefixing "- " if missing.
+        while IFS= read -r line || [ -n "$line" ]; do
+            [ -z "$line" ] && continue
+            case "$line" in
+                -\ *) printf '%s\n' "$line" ;;
+                *) printf -- '- %s\n' "$line" ;;
+            esac
+        done < "$raw"
+    else
+        # CSV: split on commas, one bullet each.
+        # shellcheck disable=SC2001
+        echo "$raw" | tr ',' '\n' | while IFS= read -r item; do
+            item=$(printf '%s' "$item" | sed 's/^ *//;s/ *$//')
+            [ -z "$item" ] && continue
+            case "$item" in
+                -\ *) printf '%s\n' "$item" ;;
+                *) printf -- '- %s\n' "$item" ;;
+            esac
+        done
+    fi
+}
+
+count_list() {
+    raw="$1"
+    if [ -z "$raw" ]; then
+        echo 0
+        return
+    fi
+    if [ -f "$raw" ]; then
+        grep -c '[^[:space:]]' "$raw" 2>/dev/null || echo 0
+    else
+        echo "$raw" | tr ',' '\n' | grep -c '[^[:space:]]' || echo 0
+    fi
+}
+
+PRS_RENDERED=$(render_list "$PRS_INPUT")
+ISSUES_RENDERED=$(render_list "$ISSUES_INPUT")
+FAILURES_RENDERED=$(render_list "$FAILURES_INPUT")
+PR_COUNT=$(count_list "$PRS_INPUT")
+ISSUE_COUNT=$(count_list "$ISSUES_INPUT")
+
+# Resolve ## Next steps content. The section is REQUIRED — fall back to
+# `- (none — converged)` so the harvest contract sees convergence_clean.
+if [ -n "$NEXT_STEPS_FILE" ] && [ -f "$NEXT_STEPS_FILE" ] \
+    && grep -q '[^[:space:]]' "$NEXT_STEPS_FILE" 2>/dev/null; then
+    NEXT_STEPS_BODY=$(cat "$NEXT_STEPS_FILE")
+else
+    NEXT_STEPS_BODY="- (none — converged)"
+fi
+
+# Ensure the output directory exists.
+OUT_DIR=$(dirname "$OUTPUT")
+mkdir -p "$OUT_DIR" || { echo "ERROR: cannot create $OUT_DIR" >&2; exit 2; }
+
+TMP="${OUTPUT}.tmp.$$"
+
+{
+    printf '# autospec run summary — %s\n\n' "$TIMESTAMP"
+    printf -- '- HEAD SHA: %s\n' "$SHA"
+    printf -- '- Branch: %s\n' "$BRANCH"
+    if [ -n "$REPO" ]; then
+        printf -- '- Repo: %s\n' "$REPO"
+    fi
+    printf -- '- Total PRs merged: %s\n' "$PR_COUNT"
+    printf -- '- Issues closed: %s\n' "$ISSUE_COUNT"
+    printf -- '- Elapsed: %s\n' "${ELAPSED:-unknown}"
+    printf '\n## PRs merged\n\n'
+    if [ -n "$PRS_RENDERED" ]; then
+        printf '%s\n' "$PRS_RENDERED"
+    else
+        printf '(none)\n'
+    fi
+    printf '\n## Issues closed\n\n'
+    if [ -n "$ISSUES_RENDERED" ]; then
+        printf '%s\n' "$ISSUES_RENDERED"
+    else
+        printf '(none)\n'
+    fi
+    printf '\n## Failures\n\n'
+    if [ -n "$FAILURES_RENDERED" ]; then
+        printf '%s\n' "$FAILURES_RENDERED"
+    else
+        printf '(none)\n'
+    fi
+    printf '\n## Next steps\n\n'
+    printf '%s\n' "$NEXT_STEPS_BODY"
+} > "$TMP" || { rm -f "$TMP"; echo "ERROR: write failed" >&2; exit 2; }
+
+mv -f "$TMP" "$OUTPUT" || { rm -f "$TMP"; echo "ERROR: mv failed" >&2; exit 2; }
+
+exit 0

--- a/scripts/refine-prompt.sh
+++ b/scripts/refine-prompt.sh
@@ -112,15 +112,73 @@ fi
 # ── path allowlist ────────────────────────────────────────────────
 # Forbidden patterns: .env (exact basename or .env.*), *credential*, *secret*,
 # *.pem, *.key, .git/, node_modules/.
-check_path_allowed() {
+#
+# Path-security hardening (issue #680):
+#   1. Resolve via `realpath -m` (or `readlink -f` fallback) to follow
+#      symlinks and canonicalize `..` segments.
+#   2. Check BOTH the literal input and the resolved target against the
+#      forbidden patterns — a safe-looking symlink to .env must reject.
+#   3. Reject any post-canonicalization `..` segments (defense in depth).
+_match_forbidden() {
     local p="$1"
     case "$p" in
-        *.env|*.env.*|*/.env|.env) return 1 ;;
-        *credential*|*Credential*|*CREDENTIAL*) return 1 ;;
-        *secret*|*Secret*|*SECRET*) return 1 ;;
-        *.pem|*.key) return 1 ;;
-        */.git/*|.git/*) return 1 ;;
-        */node_modules/*|node_modules/*) return 1 ;;
+        *.env|*.env.*|*/.env|.env) return 0 ;;
+        *credential*|*Credential*|*CREDENTIAL*) return 0 ;;
+        *secret*|*Secret*|*SECRET*) return 0 ;;
+        *.pem|*.key) return 0 ;;
+        */.git/*|.git/*|*/.git|.git) return 0 ;;
+        */node_modules/*|node_modules/*|*/node_modules|node_modules) return 0 ;;
+    esac
+    return 1
+}
+
+_canonicalize() {
+    local p="$1"
+    local r=""
+    # Try GNU realpath -m (handles non-existent paths).
+    if command -v realpath >/dev/null 2>&1; then
+        r="$(realpath -m "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+        # BSD realpath (macOS) — only resolves existing paths.
+        r="$(realpath "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+    fi
+    if command -v readlink >/dev/null 2>&1; then
+        r="$(readlink -f "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+        # Single-level symlink fallback (BSD readlink).
+        if [ -L "$p" ]; then
+            local target
+            target="$(readlink "$p" 2>/dev/null)" || target=""
+            if [ -n "$target" ]; then
+                case "$target" in
+                    /*) printf '%s' "$target"; return ;;
+                    *)  printf '%s/%s' "$(dirname "$p")" "$target"; return ;;
+                esac
+            fi
+        fi
+    fi
+    # Python fallback.
+    if command -v python3 >/dev/null 2>&1; then
+        r="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+    fi
+    printf '%s' "$p"
+}
+
+check_path_allowed() {
+    local p="$1"
+    # Literal pattern check first.
+    if _match_forbidden "$p"; then return 1; fi
+    # Resolve (follows symlinks, canonicalizes ..) and re-check.
+    local resolved
+    resolved="$(_canonicalize "$p")"
+    if [ -n "$resolved" ] && [ "$resolved" != "$p" ]; then
+        if _match_forbidden "$resolved"; then return 1; fi
+    fi
+    # Reject any residual .. segment.
+    case "$resolved" in
+        *..*) return 1 ;;
     esac
     return 0
 }
@@ -151,6 +209,19 @@ fi
 if [ -z "$PROMPT" ]; then
     echo "refine-prompt: empty prompt (provide a positional arg or --from-file)" >&2
     exit 4
+fi
+
+# Extended allowlist (issue #680): artifact-dir and simulate-iterations dir
+# must also pass the forbidden-path check.
+if ! check_path_allowed "$ARTIFACT_DIR"; then
+    echo "code_health:refine_path_violation path=$ARTIFACT_DIR" >&2
+    exit 3
+fi
+if [ -n "$SIM_ITER_DIR" ]; then
+    if ! check_path_allowed "$SIM_ITER_DIR"; then
+        echo "code_health:refine_path_violation path=$SIM_ITER_DIR" >&2
+        exit 3
+    fi
 fi
 
 # ── slug helper (early — needed by --continue) ────────────────────

--- a/scripts/refine-render-overview.sh
+++ b/scripts/refine-render-overview.sh
@@ -53,6 +53,92 @@ if [ -z "$INPUT_JSON" ] || [ -z "$SLUG" ]; then
     exit 2
 fi
 
+# ── slug sanitization (issue #680) ────────────────────────────────
+# Reject /, .., whitespace, control chars, or any char outside [a-z0-9-]
+# after lowercasing. Matches the orchestrator's slug_from_prompt() shape.
+_slug_sanitize_check() {
+    local s="$1"
+    [ -n "$s" ] || { echo "refine-render-overview: --slug is empty" >&2; return 2; }
+    case "$s" in
+        */*) echo "refine-render-overview: --slug contains '/': $s" >&2; return 2 ;;
+        *..*) echo "refine-render-overview: --slug contains '..': $s" >&2; return 2 ;;
+    esac
+    # Lowercase + check character class.
+    local lower
+    lower="$(printf '%s' "$s" | tr '[:upper:]' '[:lower:]')"
+    if ! printf '%s' "$lower" | LC_ALL=C grep -qE '^[a-z0-9-]+$'; then
+        echo "refine-render-overview: --slug has invalid chars (allowed: [a-z0-9-]): $s" >&2
+        return 2
+    fi
+    return 0
+}
+if ! _slug_sanitize_check "$SLUG"; then
+    exit 2
+fi
+
+# ── path allowlist (issue #680) ───────────────────────────────────
+# Same forbidden patterns as refine-prompt.sh::check_path_allowed.
+_render_match_forbidden() {
+    local p="$1"
+    case "$p" in
+        *.env|*.env.*|*/.env|.env) return 0 ;;
+        *credential*|*Credential*|*CREDENTIAL*) return 0 ;;
+        *secret*|*Secret*|*SECRET*) return 0 ;;
+        *.pem|*.key) return 0 ;;
+        */.git/*|.git/*|*/.git|.git) return 0 ;;
+        */node_modules/*|node_modules/*|*/node_modules|node_modules) return 0 ;;
+    esac
+    return 1
+}
+_render_canonicalize() {
+    local p="$1"
+    local r=""
+    if command -v realpath >/dev/null 2>&1; then
+        r="$(realpath -m "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+        r="$(realpath "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+    fi
+    if command -v readlink >/dev/null 2>&1; then
+        r="$(readlink -f "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+        if [ -L "$p" ]; then
+            local target
+            target="$(readlink "$p" 2>/dev/null)" || target=""
+            if [ -n "$target" ]; then
+                case "$target" in
+                    /*) printf '%s' "$target"; return ;;
+                    *)  printf '%s/%s' "$(dirname "$p")" "$target"; return ;;
+                esac
+            fi
+        fi
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        r="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+    fi
+    printf '%s' "$p"
+}
+_render_check_path_allowed() {
+    local p="$1"
+    _render_match_forbidden "$p" && return 1
+    local resolved
+    resolved="$(_render_canonicalize "$p")"
+    if [ -n "$resolved" ] && [ "$resolved" != "$p" ]; then
+        _render_match_forbidden "$resolved" && return 1
+    fi
+    case "$resolved" in
+        *..*) return 1 ;;
+    esac
+    return 0
+}
+for _p in "$INPUT_JSON" "$OUTPUT_DIR"; do
+    if ! _render_check_path_allowed "$_p"; then
+        echo "code_health:refine_path_violation path=$_p" >&2
+        exit 3
+    fi
+done
+
 if [ ! -f "$INPUT_JSON" ]; then
     echo "refine-render-overview: input not found: $INPUT_JSON" >&2
     exit 4

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1368,6 +1368,37 @@ check_autospec_refine_contract() {
     fi
 }
 
+# Phase 6 run-summary contract (issue #683): the autospec trio must instruct
+# Phase 6 to write `.autospec/run-summary.md` via the canonical helper, the
+# helper script must exist + be executable + pass `bash -n`, and the bats
+# coverage at tests/autospec/test_run_summary.bats must pass.
+check_autospec_run_summary_contract() {
+    info "autospec run-summary contract (Phase 6 → .autospec/run-summary.md)"
+    for trio in SKILL.md codex/prompt.md opencode/agent.md; do
+        f="skills/autospec/$trio"
+        [ -f "$f" ] || fail "$f: required file missing"
+        grep -q '\.autospec/run-summary\.md' "$f" \
+            || fail "$f: Phase 6 missing .autospec/run-summary.md write directive"
+        grep -q 'autospec-write-run-summary\.sh' "$f" \
+            || fail "$f: Phase 6 missing autospec-write-run-summary.sh invocation"
+        grep -q '(none — converged)' "$f" \
+            || fail "$f: Phase 6 missing canonical convergence sentinel"
+    done
+    helper="scripts/autospec-write-run-summary.sh"
+    [ -f "$helper" ] || fail "$helper: required helper missing"
+    [ -x "$helper" ] || fail "$helper: not executable"
+    bash -n "$helper" || fail "$helper: bash syntax error"
+    bash "$helper" --help 2>/dev/null | grep -q '^Usage:' \
+        || fail "$helper --help did not print a 'Usage:' line"
+    bats_file="tests/autospec/test_run_summary.bats"
+    [ -f "$bats_file" ] || fail "$bats_file: bats coverage missing"
+    if command -v bats >/dev/null 2>&1; then
+        info "  running: $bats_file"
+        bats "$bats_file" >/tmp/validate-run-summary.log 2>&1 \
+            || { cat /tmp/validate-run-summary.log >&2; fail "$bats_file: failed"; }
+    fi
+}
+
 check_install_tests() {
     info "install tests: tests/install/*.sh"
     if [ -d tests/install ]; then
@@ -1452,6 +1483,7 @@ main() {
     check_docs_amendment_presence
     check_autospec_autonomous_contract
     check_autospec_refine_contract
+    check_autospec_run_summary_contract
     check_install_tests
     check_phase4_tests
 

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -995,6 +995,49 @@ When the monitor terminates, post a final summary to the user: every issue proce
 
 The final report MUST include a canonical `## Next steps` section so downstream tooling (`/autospec-refine --continue`) can deterministically harvest the next prompt. Structure the section as a markdown list of candidate next-prompt strings, each one a self-contained imperative phrasing of the remaining work, blocker, or follow-up. If there is no remaining work, write `- (none — converged)` so the harvester can detect convergence cleanly. If evidence indicates the loop should not continue (overfitting, out-of-sample plateau, operator policy), include a line starting with `STOP: <reason>` to trigger an evidence-based stop in the continuous-iteration loop. Accepted header variants the harvester recognises are `## Next steps`, `## What to do next`, `## Remaining work`, and `## Open blockers` (case-insensitive); prefer `## Next steps` as the canonical form. Alternatively, write the harvest-target content inside a fenced ```autospec-next or ```next-prompt block — these are read in fallback order by the harvester.
 
+In addition to printing the final report to stdout, Phase 6 MUST write it to `.autospec/run-summary.md` at the repository root via the canonical helper so `/autospec-refine --continue` can harvest a real on-disk file rather than scrape transcripts. Invoke the helper with the run's tracking state and the `## Next steps` content; the helper assembles the canonical schema, performs an atomic `.tmp` + `mv` write, and exits 0 on success:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-write-run-summary.sh" \
+  --repo "{repo}" \
+  --prs "$MERGED_PRS" \
+  --issues "$CLOSED_ISSUES" \
+  --failures "$FAILURES" \
+  --elapsed "$ELAPSED" \
+  --next-steps-file "$NEXT_STEPS_FILE" \
+  --output ".autospec/run-summary.md"
+```
+
+Canonical schema (the helper enforces this; do not hand-roll an alternative):
+
+```markdown
+# autospec run summary — <timestamp>
+
+- HEAD SHA: <sha>
+- Branch: <branch>
+- Total PRs merged: N
+- Issues closed: M
+- Elapsed: HH:MM
+
+## PRs merged
+
+- #1234 fix: ...
+
+## Issues closed
+
+- #1230 ...
+
+## Failures
+
+(empty or list)
+
+## Next steps
+
+(harvest-target content — `- (none — converged)` when the run converged cleanly)
+```
+
+The `## Next steps` section is REQUIRED in every written run-summary; if the orchestrator has no next-steps content, pass `--next-steps-file` referencing a file containing the single line `- (none — converged)` so the harvest contract treats the file as `convergence_clean`. Do not skip writing the file even on failure runs — the harvester relies on its presence.
+
 ---
 
 ## Constraints (apply throughout)

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -989,6 +989,49 @@ When the monitor terminates, post a final summary to the user: every issue proce
 
 The final report MUST include a canonical `## Next steps` section so downstream tooling (`/autospec-refine --continue`) can deterministically harvest the next prompt. Structure the section as a markdown list of candidate next-prompt strings, each one a self-contained imperative phrasing of the remaining work, blocker, or follow-up. If there is no remaining work, write `- (none — converged)` so the harvester can detect convergence cleanly. If evidence indicates the loop should not continue (overfitting, out-of-sample plateau, operator policy), include a line starting with `STOP: <reason>` to trigger an evidence-based stop in the continuous-iteration loop. Accepted header variants the harvester recognises are `## Next steps`, `## What to do next`, `## Remaining work`, and `## Open blockers` (case-insensitive); prefer `## Next steps` as the canonical form. Alternatively, write the harvest-target content inside a fenced ```autospec-next or ```next-prompt block — these are read in fallback order by the harvester.
 
+In addition to printing the final report to stdout, Phase 6 MUST write it to `.autospec/run-summary.md` at the repository root via the canonical helper so `/autospec-refine --continue` can harvest a real on-disk file rather than scrape transcripts. Invoke the helper with the run's tracking state and the `## Next steps` content; the helper assembles the canonical schema, performs an atomic `.tmp` + `mv` write, and exits 0 on success:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-write-run-summary.sh" \
+  --repo "{repo}" \
+  --prs "$MERGED_PRS" \
+  --issues "$CLOSED_ISSUES" \
+  --failures "$FAILURES" \
+  --elapsed "$ELAPSED" \
+  --next-steps-file "$NEXT_STEPS_FILE" \
+  --output ".autospec/run-summary.md"
+```
+
+Canonical schema (the helper enforces this; do not hand-roll an alternative):
+
+```markdown
+# autospec run summary — <timestamp>
+
+- HEAD SHA: <sha>
+- Branch: <branch>
+- Total PRs merged: N
+- Issues closed: M
+- Elapsed: HH:MM
+
+## PRs merged
+
+- #1234 fix: ...
+
+## Issues closed
+
+- #1230 ...
+
+## Failures
+
+(empty or list)
+
+## Next steps
+
+(harvest-target content — `- (none — converged)` when the run converged cleanly)
+```
+
+The `## Next steps` section is REQUIRED in every written run-summary; if the orchestrator has no next-steps content, pass `--next-steps-file` referencing a file containing the single line `- (none — converged)` so the harvest contract treats the file as `convergence_clean`. Do not skip writing the file even on failure runs — the harvester relies on its presence.
+
 
 ## Constraints (apply throughout)
 

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -993,6 +993,49 @@ When the monitor terminates, post a final summary to the user: every issue proce
 
 The final report MUST include a canonical `## Next steps` section so downstream tooling (`/autospec-refine --continue`) can deterministically harvest the next prompt. Structure the section as a markdown list of candidate next-prompt strings, each one a self-contained imperative phrasing of the remaining work, blocker, or follow-up. If there is no remaining work, write `- (none — converged)` so the harvester can detect convergence cleanly. If evidence indicates the loop should not continue (overfitting, out-of-sample plateau, operator policy), include a line starting with `STOP: <reason>` to trigger an evidence-based stop in the continuous-iteration loop. Accepted header variants the harvester recognises are `## Next steps`, `## What to do next`, `## Remaining work`, and `## Open blockers` (case-insensitive); prefer `## Next steps` as the canonical form. Alternatively, write the harvest-target content inside a fenced ```autospec-next or ```next-prompt block — these are read in fallback order by the harvester.
 
+In addition to printing the final report to stdout, Phase 6 MUST write it to `.autospec/run-summary.md` at the repository root via the canonical helper so `/autospec-refine --continue` can harvest a real on-disk file rather than scrape transcripts. Invoke the helper with the run's tracking state and the `## Next steps` content; the helper assembles the canonical schema, performs an atomic `.tmp` + `mv` write, and exits 0 on success:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-write-run-summary.sh" \
+  --repo "{repo}" \
+  --prs "$MERGED_PRS" \
+  --issues "$CLOSED_ISSUES" \
+  --failures "$FAILURES" \
+  --elapsed "$ELAPSED" \
+  --next-steps-file "$NEXT_STEPS_FILE" \
+  --output ".autospec/run-summary.md"
+```
+
+Canonical schema (the helper enforces this; do not hand-roll an alternative):
+
+```markdown
+# autospec run summary — <timestamp>
+
+- HEAD SHA: <sha>
+- Branch: <branch>
+- Total PRs merged: N
+- Issues closed: M
+- Elapsed: HH:MM
+
+## PRs merged
+
+- #1234 fix: ...
+
+## Issues closed
+
+- #1230 ...
+
+## Failures
+
+(empty or list)
+
+## Next steps
+
+(harvest-target content — `- (none — converged)` when the run converged cleanly)
+```
+
+The `## Next steps` section is REQUIRED in every written run-summary; if the orchestrator has no next-steps content, pass `--next-steps-file` referencing a file containing the single line `- (none — converged)` so the harvest contract treats the file as `convergence_clean`. Do not skip writing the file even on failure runs — the harvester relies on its presence.
+
 
 ## Constraints (apply throughout)
 

--- a/tests/autospec/test_run_summary.bats
+++ b/tests/autospec/test_run_summary.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# tests/autospec/test_run_summary.bats
+#
+# Cover the canonical .autospec/run-summary.md helper (issue #683).
+# - Helper produces the canonical schema (all required sections present).
+# - `## Next steps` is always present, with `- (none — converged)` fallback
+#   when no next-steps content is provided.
+# - `/autospec-refine --continue` can harvest next-steps content from a
+#   fresh run-summary produced by the helper.
+
+setup() {
+    HELPER="${BATS_TEST_DIRNAME}/../../scripts/autospec-write-run-summary.sh"
+    TMP_DIR="$(mktemp -d)"
+    OUT="$TMP_DIR/run-summary.md"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "helper produces canonical schema with all required sections" {
+    run bash "$HELPER" \
+        --repo owner/repo \
+        --prs "#1234 fix: bug,#1235 feat: thing" \
+        --issues "#1230 task" \
+        --failures "" \
+        --elapsed "01:23" \
+        --output "$OUT" \
+        --sha abc1234 \
+        --branch main
+    [ "$status" -eq 0 ]
+    [ -f "$OUT" ]
+    # Required schema sections
+    grep -q '^# autospec run summary — ' "$OUT"
+    grep -q '^- HEAD SHA: abc1234' "$OUT"
+    grep -q '^- Branch: main' "$OUT"
+    grep -q '^- Total PRs merged: 2' "$OUT"
+    grep -q '^- Issues closed: 1' "$OUT"
+    grep -q '^- Elapsed: 01:23' "$OUT"
+    grep -q '^## PRs merged' "$OUT"
+    grep -q '^## Issues closed' "$OUT"
+    grep -q '^## Failures' "$OUT"
+    grep -q '^## Next steps' "$OUT"
+    grep -qe '^- #1234 fix: bug' "$OUT"
+}
+
+@test "## Next steps section is always present with convergence fallback" {
+    run bash "$HELPER" --output "$OUT" --sha 0 --branch main
+    [ "$status" -eq 0 ]
+    grep -q '^## Next steps' "$OUT"
+    # Empty / missing next-steps file → canonical convergence sentinel.
+    grep -qF -- '- (none — converged)' "$OUT"
+}
+
+@test "## Next steps content from --next-steps-file flows verbatim" {
+    NEXT="$TMP_DIR/next.md"
+    cat > "$NEXT" <<'EOF'
+- Investigate flaky test in repo/foo
+- Open follow-up issue for caching
+EOF
+    run bash "$HELPER" \
+        --next-steps-file "$NEXT" \
+        --output "$OUT" --sha 0 --branch main
+    [ "$status" -eq 0 ]
+    grep -qF -- '- Investigate flaky test in repo/foo' "$OUT"
+    grep -qF -- '- Open follow-up issue for caching' "$OUT"
+    # Convergence sentinel must NOT appear when real content is supplied.
+    ! grep -qF -- '- (none — converged)' "$OUT"
+}
+
+@test "harvest from fresh run-summary extracts next-steps content" {
+    NEXT="$TMP_DIR/next.md"
+    printf -- '- Follow up on PR #999\n- Retry issue #500\n' > "$NEXT"
+    run bash "$HELPER" \
+        --next-steps-file "$NEXT" \
+        --output "$OUT" --sha 0 --branch main
+    [ "$status" -eq 0 ]
+    # Simulate the --continue harvester: extract lines under ## Next steps.
+    harvested=$(awk '/^## Next steps$/{f=1; next} f && /^## /{f=0} f' "$OUT" \
+        | grep -E '^- ' || true)
+    [ -n "$harvested" ]
+    echo "$harvested" | grep -qF 'Follow up on PR #999'
+    echo "$harvested" | grep -qF 'Retry issue #500'
+}
+
+@test "atomic write: no leftover .tmp file on success" {
+    run bash "$HELPER" --output "$OUT" --sha 0 --branch main
+    [ "$status" -eq 0 ]
+    [ -f "$OUT" ]
+    # No stray temp files in the output directory.
+    ! ls "$TMP_DIR"/*.tmp.* >/dev/null 2>&1
+}

--- a/tests/refine/test_refine_path_security.bats
+++ b/tests/refine/test_refine_path_security.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+# tests/refine/test_refine_path_security.bats — issue #680.
+#
+# Path-security hardening for autospec-refine:
+#   1. Symlinks resolving to forbidden targets are rejected.
+#   2. --slug containing /, .., whitespace, or control chars rejected.
+#   3. --artifact-dir and renderer --output-dir / --json are allowlist-checked.
+#   4. Valid cross-directory paths still pass.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    REFINE="$REPO_ROOT/scripts/refine-prompt.sh"
+    RENDER="$REPO_ROOT/scripts/refine-render-overview.sh"
+    TMPDIR_T="$(mktemp -d)"
+    export PATH="$REPO_ROOT/scripts:$PATH"
+}
+
+teardown() {
+    [ -n "${TMPDIR_T:-}" ] && rm -rf "$TMPDIR_T"
+}
+
+@test "symlink-to-.env rejected with refine_path_violation" {
+    # Create a secret file and a safe-looking symlink to it.
+    printf 'SECRET=1\n' > "$TMPDIR_T/.env"
+    ln -sf "$TMPDIR_T/.env" "$TMPDIR_T/safe-prompt.md"
+
+    run bash "$REFINE" --from-file "$TMPDIR_T/safe-prompt.md" --dry-run \
+        --artifact-dir "$TMPDIR_T/refinements" \
+        --repo-root "$TMPDIR_T" \
+        --memory-root "$TMPDIR_T/memory"
+
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"refine_path_violation"* ]]
+}
+
+@test "slug with path traversal rejected by renderer" {
+    # Build a minimal valid input JSON for the renderer.
+    cat > "$TMPDIR_T/input.json" <<'EOF'
+{"original_prompt":"x","rounds":[],"final_prompt":"x","status":"completed",
+ "metadata":{"head_sha":"abc","timestamp":"2026-05-28T00-00-00Z",
+   "rounds_requested":1,"rounds_executed":1,"converged_early":false,
+   "degraded_rounds":[],"handoff_target":"dry-run","handoff_executed":false}}
+EOF
+    run bash "$RENDER" --json "$TMPDIR_T/input.json" \
+        --slug "../../leak" \
+        --output-dir "$TMPDIR_T/out"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"slug"* ]]
+}
+
+@test "slug with slash rejected by renderer" {
+    cat > "$TMPDIR_T/input.json" <<'EOF'
+{"original_prompt":"x","rounds":[],"final_prompt":"x","status":"completed",
+ "metadata":{"head_sha":"abc","timestamp":"2026-05-28T00-00-00Z",
+   "rounds_requested":1,"rounds_executed":1,"converged_early":false,
+   "degraded_rounds":[],"handoff_target":"dry-run","handoff_executed":false}}
+EOF
+    run bash "$RENDER" --json "$TMPDIR_T/input.json" \
+        --slug "evil/slug" \
+        --output-dir "$TMPDIR_T/out"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"slug"* ]]
+}
+
+@test "artifact-dir to .git/ rejected" {
+    run bash "$REFINE" "test prompt" --dry-run \
+        --artifact-dir "$TMPDIR_T/.git/leak" \
+        --repo-root "$TMPDIR_T" \
+        --memory-root "$TMPDIR_T/memory"
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"refine_path_violation"* ]]
+}
+
+@test "renderer output-dir under node_modules rejected" {
+    cat > "$TMPDIR_T/input.json" <<'EOF'
+{"original_prompt":"x","rounds":[],"final_prompt":"x","status":"completed",
+ "metadata":{"head_sha":"abc","timestamp":"2026-05-28T00-00-00Z",
+   "rounds_requested":1,"rounds_executed":1,"converged_early":false,
+   "degraded_rounds":[],"handoff_target":"dry-run","handoff_executed":false}}
+EOF
+    run bash "$RENDER" --json "$TMPDIR_T/input.json" \
+        --slug "valid-slug" \
+        --output-dir "$TMPDIR_T/node_modules/leak"
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"refine_path_violation"* ]]
+}
+
+@test "valid cross-directory --output path accepted" {
+    mkdir -p "$TMPDIR_T/sibling"
+    run bash "$REFINE" "valid cross-dir test prompt body" --dry-run \
+        --output "$TMPDIR_T/sibling/legit.md" \
+        --artifact-dir "$TMPDIR_T/refinements" \
+        --repo-root "$TMPDIR_T" \
+        --memory-root "$TMPDIR_T/memory"
+    [ "$status" -eq 0 ]
+    [ -f "$TMPDIR_T/sibling/legit.md" ]
+}
+
+@test "renderer --json input pointing to .git/ rejected" {
+    mkdir -p "$TMPDIR_T/.git"
+    cat > "$TMPDIR_T/.git/leak.json" <<'EOF'
+{"original_prompt":"x","rounds":[],"final_prompt":"x","status":"completed",
+ "metadata":{"head_sha":"abc","timestamp":"2026-05-28T00-00-00Z",
+   "rounds_requested":1,"rounds_executed":1,"converged_early":false,
+   "degraded_rounds":[],"handoff_target":"dry-run","handoff_executed":false}}
+EOF
+    run bash "$RENDER" --json "$TMPDIR_T/.git/leak.json" \
+        --slug "valid-slug" \
+        --output-dir "$TMPDIR_T/out"
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"refine_path_violation"* ]]
+}


### PR DESCRIPTION
Closes #683.

## Summary

Phase 6 of `/autospec` previously only printed the final report to stdout. `/autospec-refine --continue` (#678) reads `.autospec/run-summary.md` to harvest the next iteration's prompt — without it, every `--continue` run false-converges with `convergence_clean` from a non-existent file. This PR closes the integration gap.

## Changes

- **`scripts/autospec-write-run-summary.sh`** — canonical helper. Assembles run state into the schema documented in SKILL.md §Phase 6 and writes atomically via `.tmp` + `mv`. Always emits a `## Next steps` section, falling back to `- (none — converged)` when no next-steps content is supplied.
- **`skills/autospec/{SKILL.md,codex/prompt.md,opencode/agent.md}`** — extend Phase 6 prose (lockstep, byte-identical bodies) to invoke the helper AND print to stdout, with the canonical schema block.
- **`scripts/validate.sh`** — new `check_autospec_run_summary_contract` enforcing trio lockstep references + helper presence + bats coverage.
- **`tests/autospec/test_run_summary.bats`** — 5 cases (schema, convergence fallback, next-steps file flow, harvest extraction, atomic-write hygiene).

## Test plan

- [x] `bats tests/autospec/test_run_summary.bats` — 5/5 pass
- [x] `bash scripts/validate.sh` — all checks pass (lockstep + trio + contract + e2e)