### PR TITLE
fix: autospec-refine correctness — real --continue handoff + mktemp atomics + failure propagation (closes #681)

### DIFF
--- a/scripts/refine-prompt.sh
+++ b/scripts/refine-prompt.sh
@@ -246,7 +246,19 @@ slug_from_prompt_early() {
 #
 # Termination:
 #   convergence_clean | oscillation_detected | round_cap_reached |
-#   evidence_based_stop | operator_stop | budget_cap_reached.
+#   evidence_based_stop | operator_stop | budget_cap_reached |
+#   iteration_error (real handoff returned non-zero — issue #681).
+#
+# Real-mode vs simulated test mode:
+#   --simulate-iterations DIR  — test-only path; per-iteration refine runs
+#                                with --dry-run and reports are read from
+#                                pre-staged DIR/iter-<N>-report.md fixtures.
+#                                No real /autospec dispatch happens.
+#   (default real mode)        — each iteration runs the FULL refine +
+#                                handoff path; the report is harvested from
+#                                $REPO_ROOT/.autospec/run-summary.md and
+#                                handoff failure stops the loop with
+#                                status=iteration_error.
 #
 # Per-iteration record + summary table per spec
 # (docs/specs/2026-05-28-autospec-refine-design.md §Continuous-iteration mode).
@@ -335,20 +347,47 @@ run_continue_loop() {
         fi
 
         # Run refine on current prompt — inline by re-invoking the same script
-        # WITHOUT --continue so the single-pass path executes.
+        # WITHOUT --continue so the single-pass path executes. In real
+        # operation we invoke the FULL handoff path (refine + dispatch to
+        # /autospec) and harvest the resulting .autospec/run-summary.md.
+        # The --simulate-iterations test hook short-circuits to --dry-run and
+        # reads pre-staged iter-<N>-report.md fixtures.
         local iter_artifact_subdir="$ARTIFACT_DIR/iter-${iter}"
         mkdir -p "$iter_artifact_subdir"
         local refine_log="$iter_artifact_subdir/refine.log"
         local refine_status=0
-        bash "$0" "$cur_prompt" --rounds "$ROUNDS" --dry-run \
-            --artifact-dir "$iter_artifact_subdir" \
-            --repo-root "$REPO_ROOT" \
-            --memory-root "$MEMORY_ROOT" \
-            > "$refine_log" 2>&1 || refine_status=$?
+        if [ -n "$SIM_ITER_DIR" ]; then
+            # Test-only path: dry-run, no real /autospec dispatch.
+            bash "$0" "$cur_prompt" --rounds "$ROUNDS" --dry-run \
+                --artifact-dir "$iter_artifact_subdir" \
+                --repo-root "$REPO_ROOT" \
+                --memory-root "$MEMORY_ROOT" \
+                > "$refine_log" 2>&1 || refine_status=$?
+        else
+            # Real path: refine + handoff. handoff_exit_code in the artifact
+            # reflects whether /autospec ran cleanly.
+            bash "$0" "$cur_prompt" --rounds "$ROUNDS" \
+                --artifact-dir "$iter_artifact_subdir" \
+                --repo-root "$REPO_ROOT" \
+                --memory-root "$MEMORY_ROOT" \
+                > "$refine_log" 2>&1 || refine_status=$?
+        fi
 
         local refinement_artifact
         refinement_artifact="$(ls "$iter_artifact_subdir"/*.json 2>/dev/null | head -1)"
         [ -n "$refinement_artifact" ] || refinement_artifact=""
+
+        # If real handoff failed, stop the loop with iteration_error.
+        if [ -z "$SIM_ITER_DIR" ] && [ "$refine_status" -ne 0 ]; then
+            status="iteration_error"
+            row_status="iteration_error"
+            local row
+            row="$(printf '| %4d | %-21s | %-60s | %10s | %4s | %-20s |' \
+                "$iter" "$(printf '%s' "$cur_source" | head -c 21)" \
+                "handoff failed rc=$refine_status" "0" "-" "iteration_error")"
+            if [ -z "$table_rows" ]; then table_rows="$row"; else table_rows="$table_rows"$'\n'"$row"; fi
+            break
+        fi
 
         # Determine where the iteration report lives.
         local report_path=""
@@ -781,19 +820,23 @@ HEAD_SHA="$( ( cd "$REPO_ROOT" && git rev-parse HEAD 2>/dev/null ) || echo unkno
 DEGRADED_JSON="$(printf '%s\n' "${DEGRADED_ROUNDS[@]:-}" | python3 -c 'import json,sys; arr=[l for l in sys.stdin.read().splitlines() if l]; sys.stdout.write(json.dumps(arr))')"
 
 HANDOFF_EXECUTED=false
+HANDOFF_EXIT_CODE="null"
 if [ "$DRY_RUN" = 1 ]; then
     HANDOFF_TARGET="dry-run"
 elif [ "$HANDOFF_MODE" = "interactive" ]; then
     HANDOFF_TARGET="/autospec"
-    HANDOFF_EXECUTED=true
 else
     HANDOFF_TARGET="/autospec --autonomous"
-    HANDOFF_EXECUTED=true
 fi
+# handoff_executed flips to true ONLY after a real handoff returns 0 — see
+# the dispatch block below (issue #681 Finding 6). The artifact is written
+# once here with the pessimistic default, then rewritten post-dispatch if
+# the handoff succeeded.
 
 CONTEXT_SPARSE_JSON="$CONTEXT_SPARSE"
 
-cat > "$ARTIFACT" <<EOF
+write_artifact() {
+    cat > "$ARTIFACT" <<EOF
 {
   "original_prompt": $ORIG_JSON,
   "rounds": [$ROUNDS_JSON],
@@ -808,10 +851,13 @@ cat > "$ARTIFACT" <<EOF
     "degraded_rounds": $DEGRADED_JSON,
     "context_sparse": $CONTEXT_SPARSE_JSON,
     "handoff_target": "$HANDOFF_TARGET",
-    "handoff_executed": $HANDOFF_EXECUTED
+    "handoff_executed": $HANDOFF_EXECUTED,
+    "handoff_exit_code": $HANDOFF_EXIT_CODE
   }
 }
 EOF
+}
+write_artifact
 
 if [ -n "$OUTPUT" ]; then
     if ! check_path_allowed "$OUTPUT"; then
@@ -835,24 +881,92 @@ fi
 echo "refine-prompt: status=$STATUS rounds_executed=$ROUNDS_EXECUTED artifact=$ARTIFACT"
 
 # ── handoff dispatch ──────────────────────────────────────────────
-# --dry-run skips handoff. Otherwise invoke the autospec entry point via
+# --dry-run skips handoff. Otherwise resolve the autospec entry point via
 # `claude` (slash-command dispatcher) if available, falling back to the
 # `autospec` binary on PATH. Test harnesses stub both.
-if [ "$DRY_RUN" != 1 ]; then
+#
+# Path-safety (issue #681 Finding 6): reject any resolved dispatcher that
+# lives under /tmp/ or the operator's home tmpdir unless explicitly
+# overridden via AUTOSPEC_HANDOFF_DISPATCHER=1. This blocks the common
+# PATH-stub attack where a writable temp directory shadows a system binary.
+#
+# Bookkeeping (issue #681 Finding 6): handoff_executed=true ONLY after the
+# binary returns 0; capture exit code as metadata.handoff_exit_code; drop
+# `|| true` so failures propagate. Re-write the artifact at the end.
+
+_handoff_dispatcher_safe() {
+    local resolved="$1"
+    [ -n "$resolved" ] || return 1
+    if [ -n "${AUTOSPEC_HANDOFF_DISPATCHER:-}" ]; then
+        return 0
+    fi
+    case "$resolved" in
+        /tmp/*|/private/tmp/*|/var/tmp/*|/var/folders/*) return 1 ;;
+    esac
+    if [ -n "${TMPDIR:-}" ]; then
+        case "$resolved" in
+            "$TMPDIR"*|"${TMPDIR%/}"/*) return 1 ;;
+        esac
+    fi
+    return 0
+}
+
+run_handoff() {
+    local rc=0
+    local dispatcher=""
     if command -v claude >/dev/null 2>&1; then
+        dispatcher="$(command -v claude)"
+        if ! _handoff_dispatcher_safe "$dispatcher"; then
+            echo "refine-prompt: ERROR — refusing handoff: dispatcher in tmpdir: $dispatcher (set AUTOSPEC_HANDOFF_DISPATCHER=1 to override)" >&2
+            return 5
+        fi
+        echo "refine-prompt: handoff dispatcher=$dispatcher" >&2
         if [ "$HANDOFF_MODE" = "interactive" ]; then
-            claude "/autospec" "$FINAL_PROMPT" || true
+            "$dispatcher" "/autospec" "$FINAL_PROMPT"
+            rc=$?
         else
-            claude "/autospec" "--autonomous" "$FINAL_PROMPT" || true
+            "$dispatcher" "/autospec" "--autonomous" "$FINAL_PROMPT"
+            rc=$?
         fi
     elif command -v autospec >/dev/null 2>&1; then
+        dispatcher="$(command -v autospec)"
+        if ! _handoff_dispatcher_safe "$dispatcher"; then
+            echo "refine-prompt: ERROR — refusing handoff: dispatcher in tmpdir: $dispatcher (set AUTOSPEC_HANDOFF_DISPATCHER=1 to override)" >&2
+            return 5
+        fi
+        echo "refine-prompt: handoff dispatcher=$dispatcher" >&2
         if [ "$HANDOFF_MODE" = "interactive" ]; then
-            autospec "$FINAL_PROMPT" || true
+            "$dispatcher" "$FINAL_PROMPT"
+            rc=$?
         else
-            autospec --autonomous "$FINAL_PROMPT" || true
+            "$dispatcher" --autonomous "$FINAL_PROMPT"
+            rc=$?
         fi
     else
         echo "refine-prompt: WARN — no handoff dispatcher (claude/autospec) on PATH; artifact retained" >&2
+        return 127
+    fi
+    return $rc
+}
+
+if [ "$DRY_RUN" != 1 ]; then
+    set +e
+    run_handoff
+    HANDOFF_RC=$?
+    set -e
+    HANDOFF_EXIT_CODE="$HANDOFF_RC"
+    if [ "$HANDOFF_RC" = "0" ]; then
+        HANDOFF_EXECUTED=true
+    else
+        HANDOFF_EXECUTED=false
+        STATUS="handoff_failed"
+    fi
+    write_artifact
+    if [ "$HANDOFF_RC" != "0" ] && [ "$HANDOFF_RC" != "127" ]; then
+        # 127 = no dispatcher on PATH — preserve legacy behavior (warn,
+        # exit 0). Any other non-zero is a real failure and must propagate.
+        echo "refine-prompt: handoff failed rc=$HANDOFF_RC" >&2
+        exit "$HANDOFF_RC"
     fi
 fi
 

--- a/scripts/refine-render-overview.sh
+++ b/scripts/refine-render-overview.sh
@@ -18,7 +18,7 @@
 #   3  on schema validation failure
 #   4  on missing input
 
-set -u
+set -euo pipefail
 
 usage() {
     cat <<'EOF'
@@ -261,8 +261,13 @@ fi
 BASE="$OUTPUT_DIR/${SLUG}-${TS}"
 MD_PATH="$BASE.md"
 JSON_PATH="$BASE.json"
-MD_TMP="$MD_PATH.tmp"
-JSON_TMP="$JSON_PATH.tmp"
+# Atomic write (issue #681 Finding 5): use mktemp in $OUTPUT_DIR so the temp
+# file shares a filesystem with the destination (atomic mv), and a trap so
+# any failure path cleans up partial state. Predictable .tmp names would
+# allow concurrent renders to clobber each other.
+MD_TMP="$(mktemp "$OUTPUT_DIR/refine-render.XXXXXX")"
+JSON_TMP="$(mktemp "$OUTPUT_DIR/refine-render.XXXXXX")"
+trap 'rm -f "$MD_TMP" "$JSON_TMP"' EXIT
 
 python3 - "$INPUT_JSON" "$MD_TMP" "$SLUG" <<'PY'
 import json, sys, difflib
@@ -359,8 +364,17 @@ PY
 # Copy the input JSON atomically as well.
 cp "$INPUT_JSON" "$JSON_TMP"
 
+# Both temps must exist and be non-empty before we promote them.
+if [ ! -s "$MD_TMP" ] || [ ! -s "$JSON_TMP" ]; then
+    echo "refine-render-overview: refusing to publish empty temp files" >&2
+    exit 3
+fi
+
 mv "$MD_TMP" "$MD_PATH"
 mv "$JSON_TMP" "$JSON_PATH"
+# Clear trap targets so the EXIT trap doesn't delete published files.
+MD_TMP=""
+JSON_TMP=""
 
 echo "refine-render-overview: wrote $MD_PATH and $JSON_PATH"
 exit 0

--- a/tests/refine/test_refine_correctness.bats
+++ b/tests/refine/test_refine_correctness.bats
@@ -1,0 +1,224 @@
+#!/usr/bin/env bats
+# tests/refine/test_refine_correctness.bats — autospec-refine correctness
+# (issue #681). Covers:
+#   1. --continue with real handoff fixture (mocked binary, but really invoked
+#      per iteration — NOT --dry-run). Loop must terminate cleanly when the
+#      harvested run-summary.md reports convergence.
+#   2. Concurrent renders to the same output dir don't clobber each other
+#      (mktemp atomics).
+#   3. Handoff failure propagates: exit non-zero + status=handoff_failed +
+#      handoff_executed=false + handoff_exit_code recorded.
+#   4. PATH-stub in /tmp/ rejected unless AUTOSPEC_HANDOFF_DISPATCHER=1.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../scripts/refine-prompt.sh"
+RENDER="${BATS_TEST_DIRNAME}/../../scripts/refine-render-overview.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d -t refine-correct.XXXXXX)"
+    REPO_ROOT="$TEST_TMP/repo"
+    mkdir -p "$REPO_ROOT/docs/specs" "$REPO_ROOT/.autospec"
+    ART_DIR="$TEST_TMP/artifacts"
+    MEMORY_ROOT="$TEST_TMP/memory"
+    mkdir -p "$MEMORY_ROOT"
+
+    FAKE_HOME="$TEST_TMP/home"
+    mkdir -p "$FAKE_HOME/.autospec"
+    export HOME="$FAKE_HOME"
+
+    STUB_BIN="$TEST_TMP/bin"
+    mkdir -p "$STUB_BIN"
+    HANDOFF_LOG="$TEST_TMP/handoff.log"
+}
+
+teardown() {
+    [ -d "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
+}
+
+# ───────────────────────────── 1. real --continue handoff ─────────────────
+@test "issue #681: --continue invokes the real handoff per iteration (not --dry-run)" {
+    # claude stub writes a run-summary.md announcing convergence so the loop
+    # terminates cleanly on iteration 1 — but ONLY if the orchestrator
+    # actually invoked the stub (the broken code path skipped the dispatcher
+    # entirely under --continue).
+    cat > "$STUB_BIN/claude" <<EOF
+#!/usr/bin/env bash
+echo "claude-invoked args=\$*" >> "$HANDOFF_LOG"
+mkdir -p "$REPO_ROOT/.autospec"
+cat > "$REPO_ROOT/.autospec/run-summary.md" <<'INNER'
+# autospec run summary
+
+## Next steps
+
+- (none — converged)
+INNER
+exit 0
+EOF
+    chmod +x "$STUB_BIN/claude"
+    export PATH="$STUB_BIN:$PATH"
+    export AUTOSPEC_HANDOFF_DISPATCHER=1  # stub lives outside tmpdir-deny on some platforms
+
+    run bash "$SCRIPT" "fix login button" --continue --max-iterations 3 \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -eq 0 ]
+    # The stub MUST have been invoked at least once — proves real handoff path.
+    [ -f "$HANDOFF_LOG" ]
+    grep -q "claude-invoked" "$HANDOFF_LOG"
+    # Loop summary records convergence_clean.
+    LOOP_JSON=$(ls "$ART_DIR"/*-loop.json | head -1)
+    [ -f "$LOOP_JSON" ]
+    run jq -r '.status' "$LOOP_JSON"
+    [ "$output" = "convergence_clean" ]
+}
+
+@test "issue #681: --continue stops with iteration_error when real handoff fails" {
+    cat > "$STUB_BIN/claude" <<EOF
+#!/usr/bin/env bash
+echo "claude-failed" >> "$HANDOFF_LOG"
+exit 7
+EOF
+    chmod +x "$STUB_BIN/claude"
+    export PATH="$STUB_BIN:$PATH"
+    export AUTOSPEC_HANDOFF_DISPATCHER=1
+
+    run bash "$SCRIPT" "broken feature" --continue --max-iterations 3 \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -eq 0 ]  # outer continue-loop swallows iteration error into status field
+    LOOP_JSON=$(ls "$ART_DIR"/*-loop.json | head -1)
+    run jq -r '.status' "$LOOP_JSON"
+    [ "$output" = "iteration_error" ]
+}
+
+# ───────────────────────────── 2. concurrent renders ──────────────────────
+@test "issue #681 Finding 5: concurrent renders to same output dir don't clobber" {
+    # Build a minimal valid input.json that satisfies the shape check.
+    OUTDIR="$TEST_TMP/renders"
+    mkdir -p "$OUTDIR"
+    INPUT="$TEST_TMP/input.json"
+    cat > "$INPUT" <<'EOF'
+{
+  "original_prompt": "p",
+  "rounds": [],
+  "final_prompt": "p",
+  "status": "completed",
+  "metadata": {
+    "head_sha": "abc",
+    "timestamp": "2026-05-28T00-00-00Z",
+    "rounds_requested": 1,
+    "rounds_executed": 0,
+    "converged_early": false,
+    "degraded_rounds": [],
+    "handoff_target": "dry-run",
+    "handoff_executed": false
+  }
+}
+EOF
+
+    # Fire two renders in parallel using distinct slugs so they target
+    # different basenames but share OUTPUT_DIR. With predictable .tmp names
+    # they would race on the same OUTPUT_DIR/refine-render.* mktemp pool;
+    # mktemp guarantees unique temps per process.
+    (bash "$RENDER" --json "$INPUT" --slug "alpha" --output-dir "$OUTDIR") &
+    PID1=$!
+    (bash "$RENDER" --json "$INPUT" --slug "beta" --output-dir "$OUTDIR") &
+    PID2=$!
+    wait "$PID1"
+    R1=$?
+    wait "$PID2"
+    R2=$?
+    [ "$R1" -eq 0 ]
+    [ "$R2" -eq 0 ]
+    # Both alpha and beta artifacts present, non-empty, no stale .tmp left.
+    ls "$OUTDIR"/alpha-*.md >/dev/null
+    ls "$OUTDIR"/beta-*.md  >/dev/null
+    ls "$OUTDIR"/alpha-*.json >/dev/null
+    ls "$OUTDIR"/beta-*.json  >/dev/null
+    # No leftover mktemp scratch files.
+    run bash -c "ls $OUTDIR/refine-render.* 2>/dev/null | wc -l | tr -d ' '"
+    [ "$output" = "0" ]
+}
+
+# ───────────────────────────── 3. handoff failure propagates ──────────────
+@test "issue #681 Finding 6: handoff failure propagates to exit code + status" {
+    cat > "$STUB_BIN/claude" <<EOF
+#!/usr/bin/env bash
+exit 13
+EOF
+    chmod +x "$STUB_BIN/claude"
+    export PATH="$STUB_BIN:$PATH"
+    export AUTOSPEC_HANDOFF_DISPATCHER=1
+
+    run bash "$SCRIPT" "fix bug" --rounds 1 \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -eq 13 ]
+    f=$(ls "$ART_DIR"/*.json | head -1)
+    run jq -r '.status' "$f"
+    [ "$output" = "handoff_failed" ]
+    run jq -r '.metadata.handoff_executed' "$f"
+    [ "$output" = "false" ]
+    run jq -r '.metadata.handoff_exit_code' "$f"
+    [ "$output" = "13" ]
+}
+
+@test "issue #681 Finding 6: handoff success records exit_code=0 + handoff_executed=true" {
+    cat > "$STUB_BIN/claude" <<EOF
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$STUB_BIN/claude"
+    export PATH="$STUB_BIN:$PATH"
+    export AUTOSPEC_HANDOFF_DISPATCHER=1
+
+    run bash "$SCRIPT" "fix bug" --rounds 1 \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -eq 0 ]
+    f=$(ls "$ART_DIR"/*.json | head -1)
+    run jq -r '.metadata.handoff_executed' "$f"
+    [ "$output" = "true" ]
+    run jq -r '.metadata.handoff_exit_code' "$f"
+    [ "$output" = "0" ]
+}
+
+# ───────────────────────────── 4. PATH-stub safety ────────────────────────
+@test "issue #681 Finding 6: PATH-stub dispatcher in /tmp/ rejected without override" {
+    # Place the stub in a tmpdir-like path. mktemp -d under /tmp ensures
+    # the dispatcher resolves to /tmp/... or /private/tmp/... on macOS.
+    TMPSTUB="$(mktemp -d -t refine-stub.XXXXXX)"
+    cat > "$TMPSTUB/claude" <<EOF
+#!/usr/bin/env bash
+echo "STUB-RAN" > "$TEST_TMP/should-not-exist"
+exit 0
+EOF
+    chmod +x "$TMPSTUB/claude"
+    # Prepend the tmpdir stub so command -v claude resolves to it.
+    OLDPATH="$PATH"
+    export PATH="$TMPSTUB:$PATH"
+    unset AUTOSPEC_HANDOFF_DISPATCHER
+
+    run bash "$SCRIPT" "fix bug" --rounds 1 \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    # Refusal exits non-zero (rc=5 from _handoff_dispatcher_safe).
+    [ "$status" -ne 0 ]
+    # Stub MUST NOT have been executed.
+    [ ! -f "$TEST_TMP/should-not-exist" ]
+    [[ "$output" == *"refusing handoff"* ]]
+    rm -rf "$TMPSTUB"
+    export PATH="$OLDPATH"
+}
+
+@test "issue #681 Finding 6: AUTOSPEC_HANDOFF_DISPATCHER=1 allows tmpdir dispatcher" {
+    TMPSTUB="$(mktemp -d -t refine-stub-allowed.XXXXXX)"
+    cat > "$TMPSTUB/claude" <<EOF
+#!/usr/bin/env bash
+echo "STUB-RAN" > "$TEST_TMP/stub-ran"
+exit 0
+EOF
+    chmod +x "$TMPSTUB/claude"
+    export PATH="$TMPSTUB:$PATH"
+    export AUTOSPEC_HANDOFF_DISPATCHER=1
+
+    run bash "$SCRIPT" "fix bug" --rounds 1 \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_TMP/stub-ran" ]
+    rm -rf "$TMPSTUB"
+}

--- a/tests/refine/test_refine_handoff.bats
+++ b/tests/refine/test_refine_handoff.bats
@@ -34,6 +34,9 @@ EOF
     chmod +x "$STUB_BIN/autospec"
 
     export PATH="$STUB_BIN:$PATH"
+    # Stubs live under macOS $TMPDIR; opt in to bypass the dispatcher
+    # path-safety check (issue #681 Finding 6).
+    export AUTOSPEC_HANDOFF_DISPATCHER=1
 }
 
 teardown() {

--- a/tests/refine/test_refine_loop.bats
+++ b/tests/refine/test_refine_loop.bats
@@ -39,6 +39,7 @@ exit 0
 EOF
     chmod +x "$STUB_BIN/claude"
     export PATH="$STUB_BIN:$PATH"
+    export AUTOSPEC_HANDOFF_DISPATCHER=1
 }
 
 teardown() {


### PR DESCRIPTION
Closes #681

## Summary

Three correctness fixes from codex peer-review on the autospec-refine chain (PRs #674-#678):

- **Finding 2 — real `--continue` handoff**: `run_continue_loop()` now invokes the real refine + `/autospec` handoff per iteration (was self-`--dry-run`) and harvests the resulting `.autospec/run-summary.md`. Handoff failure stops the loop with `status=iteration_error`. `--simulate-iterations` is retained as the test-only path and documented.
- **Finding 5 — atomic write via mktemp + trap**: `refine-render-overview.sh` switches to `mktemp` templates in `$OUTPUT_DIR` with `set -euo pipefail` and an `EXIT` trap. Concurrent renders cannot clobber each other and partial failures cannot promote empty temps.
- **Finding 6 — handoff bookkeeping + PATH safety**: `handoff_executed=true` only after the dispatcher returns 0; exit code captured as `metadata.handoff_exit_code`; non-zero propagates as `status=handoff_failed` and the orchestrator exits non-zero (dropped `|| true`). Resolved dispatcher path is logged to stderr; any dispatcher in `/tmp`, `/private/tmp`, `/var/tmp`, `/var/folders/`, or `$TMPDIR` is rejected unless `AUTOSPEC_HANDOFF_DISPATCHER=1` explicitly permits it.

## Test plan

- [x] `bats tests/refine/test_refine_correctness.bats` — 7 new fixtures pass
- [x] `bats tests/refine/` — all 47 pass
- [x] `bash scripts/validate.sh` — green end-to-end