### PR TITLE
fix: autospec-refine schema realignment — degraded status + loop schema (closes #682)

### DIFF
--- a/schemas/autospec-refinement-loop.schema.json
+++ b/schemas/autospec-refinement-loop.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-refinement-loop.schema.json",
+  "title": "autospec-refine --continue loop artifact",
+  "description": "JSON record produced by scripts/refine-prompt.sh --continue capturing the per-iteration harvest/refine/handoff loop and the final termination status. Separate from the single-pass autospec-refinement.schema.json because the status enum is disjoint (loop termination conditions vs. single-pass round outcomes). See issue #682.",
+  "type": "object",
+  "required": ["slug", "status", "iterations_executed", "max_iterations", "tokens_used", "iterations"],
+  "additionalProperties": true,
+  "properties": {
+    "slug": { "type": "string", "minLength": 1 },
+    "status": {
+      "type": "string",
+      "enum": [
+        "convergence_clean",
+        "oscillation_detected",
+        "evidence_based_stop",
+        "budget_cap_reached",
+        "operator_stop",
+        "round_cap_reached",
+        "handoff_failed",
+        "iteration_error"
+      ]
+    },
+    "iterations_executed": { "type": "integer", "minimum": 0 },
+    "max_iterations": { "type": "integer", "minimum": 1 },
+    "tokens_used": { "type": "integer", "minimum": 0 },
+    "iterations": {
+      "type": "array",
+      "items": { "type": "object" }
+    }
+  }
+}

--- a/scripts/refine-prompt.sh
+++ b/scripts/refine-prompt.sh
@@ -520,6 +520,28 @@ EOF
 }
 EOF
 
+    # Validate loop JSON against loop schema (issue #682). Non-fatal warn
+    # if jsonschema is unavailable; fatal if validation actually fails.
+    _loop_schema="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/schemas/autospec-refinement-loop.schema.json"
+    if [ -f "$_loop_schema" ] && command -v python3 >/dev/null 2>&1; then
+        python3 - "$loop_json" "$_loop_schema" <<'PY' || {
+import json, sys
+try:
+    import jsonschema
+except ImportError:
+    sys.exit(0)
+with open(sys.argv[1]) as f: doc = json.load(f)
+with open(sys.argv[2]) as f: sch = json.load(f)
+try:
+    jsonschema.validate(doc, sch)
+except jsonschema.ValidationError as e:
+    sys.stderr.write(f"refine-prompt: loop schema validation failed: {e.message}\n")
+    sys.exit(1)
+PY
+            echo "refine-prompt: WARN — loop artifact failed schema validation: $loop_json" >&2
+        }
+    fi
+
     # Write markdown summary.
     {
         printf '## /autospec-refine continuous loop summary\n\n'
@@ -810,6 +832,13 @@ EOF
 done
 
 FINAL_PROMPT="$PREV_PROMPT"
+
+# Degraded status: when word-count-delta degradation was detected and no
+# other terminating condition (converged / round_cap_reached) already set
+# the status. Issue #682 — `degraded` was previously dead in the schema.
+if [ "$STATUS" = "completed" ] && [ "${#DEGRADED_ROUNDS[@]}" -gt 0 ]; then
+    STATUS="degraded"
+fi
 
 # ── write artifact ────────────────────────────────────────────────
 ORIG_JSON="$(printf '%s' "$PROMPT" | json_escape)"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1339,6 +1339,7 @@ check_autospec_refine_contract() {
     local prompt_sh="scripts/refine-prompt.sh"
     local overview_sh="scripts/refine-render-overview.sh"
     local schema="schemas/autospec-refinement.schema.json"
+    local loop_schema="schemas/autospec-refinement-loop.schema.json"
     [ -f "$prompt_sh" ] || fail "$prompt_sh: file missing (issue #672)"
     [ -x "$prompt_sh" ] || fail "$prompt_sh: not executable (issue #672)"
     bash -n "$prompt_sh" || fail "$prompt_sh: bash syntax error (issue #672)"
@@ -1346,6 +1347,21 @@ check_autospec_refine_contract() {
     [ -x "$overview_sh" ] || fail "$overview_sh: not executable (issue #672)"
     bash -n "$overview_sh" || fail "$overview_sh: bash syntax error (issue #672)"
     [ -f "$schema" ] || fail "$schema: file missing (issue #672)"
+    [ -f "$loop_schema" ] || fail "$loop_schema: file missing (issue #682)"
+    # Both schemas must parse as valid JSON Schema (issue #682).
+    if command -v python3 >/dev/null 2>&1; then
+        for s in "$schema" "$loop_schema"; do
+            python3 - "$s" <<'PY' || fail "$s: schema parse/check_schema failed (issue #682)"
+import json, sys
+try:
+    import jsonschema
+except ImportError:
+    sys.exit(0)
+with open(sys.argv[1]) as f: sch = json.load(f)
+jsonschema.Draft202012Validator.check_schema(sch)
+PY
+        done
+    fi
     # autospec-refine trio existence (lockstep checked separately).
     for trio in skills/autospec-refine/SKILL.md skills/autospec-refine/codex/prompt.md skills/autospec-refine/opencode/agent.md; do
         [ -f "$trio" ] || fail "$trio: missing (issue #672)"

--- a/tests/refine/test_refine_schema_alignment.bats
+++ b/tests/refine/test_refine_schema_alignment.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+# Schema-alignment coverage for issue #682:
+#   - Single-pass schema accepts status=degraded and status=completed.
+#   - Loop schema accepts all 8 loop termination statuses.
+#   - Single-pass output does NOT validate against loop schema.
+#   - Loop output does NOT validate against single-pass schema.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SINGLE_SCHEMA="$REPO_ROOT/schemas/autospec-refinement.schema.json"
+    LOOP_SCHEMA="$REPO_ROOT/schemas/autospec-refinement-loop.schema.json"
+    TMP="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+# Validate $1=json-file against $2=schema using python jsonschema.
+_validate() {
+    local json="$1" schema="$2"
+    python3 - "$json" "$schema" <<'PY'
+import json, sys
+try:
+    import jsonschema
+except ImportError:
+    sys.stderr.write("SKIP_NO_JSONSCHEMA\n")
+    sys.exit(77)
+with open(sys.argv[1]) as f: doc = json.load(f)
+with open(sys.argv[2]) as f: sch = json.load(f)
+try:
+    jsonschema.validate(doc, sch)
+except jsonschema.ValidationError as e:
+    sys.stderr.write(f"VALIDATION_FAIL: {e.message}\n")
+    sys.exit(1)
+PY
+}
+
+@test "single-pass schema accepts status=degraded" {
+    cat > "$TMP/single-degraded.json" <<'JSON'
+{
+  "original_prompt": "x",
+  "rounds": [],
+  "final_prompt": "x",
+  "status": "degraded",
+  "metadata": {
+    "head_sha": "abc",
+    "timestamp": "2026-05-28T00-00-00Z",
+    "rounds_requested": 1,
+    "rounds_executed": 1,
+    "converged_early": false,
+    "degraded_rounds": ["1:repo-grounding"],
+    "handoff_target": "dry-run",
+    "handoff_executed": false
+  }
+}
+JSON
+    run _validate "$TMP/single-degraded.json" "$SINGLE_SCHEMA"
+    [ "$status" -eq 77 ] && skip "jsonschema not installed"
+    [ "$status" -eq 0 ]
+}
+
+@test "single-pass schema accepts status=completed" {
+    cat > "$TMP/single-completed.json" <<'JSON'
+{
+  "original_prompt": "x",
+  "rounds": [],
+  "final_prompt": "x",
+  "status": "completed",
+  "metadata": {
+    "head_sha": "abc",
+    "timestamp": "2026-05-28T00-00-00Z",
+    "rounds_requested": 1,
+    "rounds_executed": 1,
+    "converged_early": false,
+    "degraded_rounds": [],
+    "handoff_target": "dry-run",
+    "handoff_executed": false
+  }
+}
+JSON
+    run _validate "$TMP/single-completed.json" "$SINGLE_SCHEMA"
+    [ "$status" -eq 77 ] && skip "jsonschema not installed"
+    [ "$status" -eq 0 ]
+}
+
+@test "loop schema accepts all 8 loop statuses" {
+    for s in convergence_clean oscillation_detected evidence_based_stop budget_cap_reached operator_stop round_cap_reached handoff_failed iteration_error; do
+        cat > "$TMP/loop-$s.json" <<JSON
+{
+  "slug": "x",
+  "status": "$s",
+  "iterations_executed": 1,
+  "max_iterations": 5,
+  "tokens_used": 0,
+  "iterations": []
+}
+JSON
+        run _validate "$TMP/loop-$s.json" "$LOOP_SCHEMA"
+        [ "$status" -eq 77 ] && skip "jsonschema not installed"
+        [ "$status" -eq 0 ] || { echo "loop status $s rejected"; return 1; }
+    done
+}
+
+@test "single-pass output does NOT validate against loop schema" {
+    cat > "$TMP/single.json" <<'JSON'
+{
+  "original_prompt": "x",
+  "rounds": [],
+  "final_prompt": "x",
+  "status": "degraded",
+  "metadata": {
+    "head_sha": "abc",
+    "timestamp": "t",
+    "rounds_requested": 1,
+    "rounds_executed": 1,
+    "converged_early": false,
+    "degraded_rounds": [],
+    "handoff_target": "dry-run",
+    "handoff_executed": false
+  }
+}
+JSON
+    run _validate "$TMP/single.json" "$LOOP_SCHEMA"
+    [ "$status" -eq 77 ] && skip "jsonschema not installed"
+    [ "$status" -ne 0 ]
+}
+
+@test "loop output does NOT validate against single-pass schema" {
+    cat > "$TMP/loop.json" <<'JSON'
+{
+  "slug": "x",
+  "status": "convergence_clean",
+  "iterations_executed": 1,
+  "max_iterations": 5,
+  "tokens_used": 0,
+  "iterations": []
+}
+JSON
+    run _validate "$TMP/loop.json" "$SINGLE_SCHEMA"
+    [ "$status" -eq 77 ] && skip "jsonschema not installed"
+    [ "$status" -ne 0 ]
+}
+
+@test "both schemas parse as valid JSON Schema" {
+    python3 - "$SINGLE_SCHEMA" "$LOOP_SCHEMA" <<'PY' || skip "jsonschema not installed"
+import json, sys
+try:
+    import jsonschema
+except ImportError:
+    sys.exit(77)
+for p in sys.argv[1:]:
+    with open(p) as f: sch = json.load(f)
+    jsonschema.Draft202012Validator.check_schema(sch)
+PY
+}


### PR DESCRIPTION
Closes #682

## Summary
- Add `schemas/autospec-refinement-loop.schema.json` for the `--continue` loop artifact with the 8 loop termination statuses.
- `scripts/refine-prompt.sh` now emits `status=degraded` when word-count degradation was detected and no other terminating condition applied; loop JSON is validated against the new loop schema before exit.
- `scripts/validate.sh::check_autospec_refine_contract()` asserts both schemas are JSON-Schema parseable.
- New `tests/refine/test_refine_schema_alignment.bats` with positive + negative cross-schema coverage (single-pass output rejected by loop schema, loop output rejected by single-pass schema).

## Test plan
- [x] `bash scripts/validate.sh` green
- [x] `bats tests/refine/test_refine_schema_alignment.bats` green