### PR TITLE
feat: parallel implementer worktree isolation (closes #690)

### DIFF
--- a/scripts/dispatch-implementer.sh
+++ b/scripts/dispatch-implementer.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# scripts/dispatch-implementer.sh — canonical helper for parallel-safe
+# Phase 4 implementer dispatch.
+#
+# Per issue #690: when the orchestrator dispatches multiple background
+# implementer Agents in the same git workdir, they collide on `git checkout`
+# even when file-level scopes are disjoint. This helper enforces worktree
+# isolation by creating /tmp/wt-<branch> and pre-pending a worktree directive
+# to the implementer prompt so the LLM cannot stray into the main checkout.
+#
+# Usage:
+#   dispatch-implementer.sh --issue <N> --branch <name> --prompt-file <path>
+#   dispatch-implementer.sh --issue <N> --branch <name> --prompt-file <path> --cleanup
+#
+# Modes:
+#   default: create worktree, emit augmented prompt on stdout, exit 0
+#   --cleanup: remove the worktree at /tmp/wt-<branch> and exit
+#
+# Exit codes:
+#   0  success
+#   1  bad arguments
+#   2  worktree creation/removal failed
+#   3  prompt-file missing or unreadable
+
+set -eu
+
+usage() {
+    cat <<'EOF'
+Usage: dispatch-implementer.sh --issue <N> --branch <name> --prompt-file <path>
+       dispatch-implementer.sh --issue <N> --branch <name> --cleanup
+
+Creates /tmp/wt-<branch> via `git worktree add` and pre-pends a worktree
+directive to the implementer prompt. Pass --cleanup to remove the worktree
+after the implementer has completed.
+EOF
+}
+
+ISSUE=""
+BRANCH=""
+PROMPT_FILE=""
+CLEANUP=0
+BASE_REF="${AUTOSPEC_DISPATCH_BASE_REF:-origin/main}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --issue)       ISSUE="$2"; shift 2 ;;
+        --branch)      BRANCH="$2"; shift 2 ;;
+        --prompt-file) PROMPT_FILE="$2"; shift 2 ;;
+        --cleanup)     CLEANUP=1; shift ;;
+        --base)        BASE_REF="$2"; shift 2 ;;
+        -h|--help)     usage; exit 0 ;;
+        *)             echo "dispatch-implementer.sh: unknown arg: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if [ -z "$ISSUE" ] || [ -z "$BRANCH" ]; then
+    echo "dispatch-implementer.sh: --issue and --branch are required" >&2
+    usage >&2
+    exit 1
+fi
+
+WT_PATH="/tmp/wt-${BRANCH}"
+
+if [ "$CLEANUP" -eq 1 ]; then
+    if [ -d "$WT_PATH" ]; then
+        git worktree remove --force "$WT_PATH" 2>/dev/null \
+            || rm -rf "$WT_PATH" \
+            || { echo "dispatch-implementer.sh: failed to remove $WT_PATH" >&2; exit 2; }
+    fi
+    exit 0
+fi
+
+if [ -z "$PROMPT_FILE" ] || [ ! -r "$PROMPT_FILE" ]; then
+    echo "dispatch-implementer.sh: --prompt-file must point to a readable file" >&2
+    exit 3
+fi
+
+# Create the worktree. If it already exists (rare; orchestrator restart), reuse.
+if [ ! -d "$WT_PATH" ]; then
+    git worktree add -b "$BRANCH" "$WT_PATH" "$BASE_REF" >/dev/null 2>&1 \
+        || git worktree add "$WT_PATH" "$BRANCH" >/dev/null 2>&1 \
+        || { echo "dispatch-implementer.sh: failed to create worktree at $WT_PATH" >&2; exit 2; }
+fi
+
+# Emit the augmented prompt: worktree directive + original prompt body.
+cat <<EOF
+**Workdir:** \`$WT_PATH\` (worktree). All \`cd\`, \`git\`, \`gh\`, edit, and
+test commands MUST run from this worktree. Do NOT touch the main checkout.
+Do NOT \`git checkout\` other branches. This is parallel-safety isolation
+per autospec-run Phase 4 worktree contract (issue #690).
+
+Issue: #$ISSUE
+Branch: $BRANCH
+
+---
+
+EOF
+cat "$PROMPT_FILE"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1431,6 +1431,32 @@ check_install_tests() {
     fi
 }
 
+# Parallel implementer worktree isolation contract (issue #690):
+# every autospec-run trio file must carry a `### Parallel implementer worktree
+# isolation` subsection; scripts/dispatch-implementer.sh must be present,
+# executable, and bash -n clean; tests/autospec-run/test_parallel_dispatch.bats
+# must exist and (if bats is available) pass.
+check_autospec_parallel_dispatch_contract() {
+    info "autospec parallel dispatch contract"
+    for f in skills/autospec-run/SKILL.md skills/autospec-run/codex/prompt.md skills/autospec-run/opencode/agent.md; do
+        grep -q '### Parallel implementer worktree isolation' "$f" \
+            || fail "$f missing '### Parallel implementer worktree isolation' subsection"
+        grep -q 'dispatch-implementer.sh' "$f" \
+            || fail "$f missing reference to scripts/dispatch-implementer.sh"
+    done
+    helper="scripts/dispatch-implementer.sh"
+    [ -f "$helper" ] || fail "$helper: required file missing"
+    [ -x "$helper" ] || fail "$helper: file not executable"
+    bash -n "$helper" || fail "$helper: bash syntax error"
+    bats_file="tests/autospec-run/test_parallel_dispatch.bats"
+    [ -f "$bats_file" ] || fail "$bats_file: bats coverage missing"
+    if command -v bats >/dev/null 2>&1; then
+        info "  running: $bats_file"
+        bats "$bats_file" >/tmp/validate-parallel-dispatch.log 2>&1 \
+            || { cat /tmp/validate-parallel-dispatch.log >&2; fail "$bats_file: failed"; }
+    fi
+}
+
 main() {
     info "scanning multi-harness skills under skills/ ..."
     skills="$(discover_skills)"
@@ -1506,6 +1532,7 @@ main() {
     check_autospec_run_summary_contract
     check_install_tests
     check_phase4_tests
+    check_autospec_parallel_dispatch_contract
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -540,6 +540,31 @@ inline label-swap path below.
 >   # by the merge or failure cleanup that just completed.
 > ```
 >
+> ### Parallel implementer worktree isolation
+>
+> Background `Agent` implementers in the same git workdir collide on `git checkout`
+> even when their file-level scopes are disjoint — first agent to call
+> `git checkout -b <BRANCH>` wins; the second lands on the wrong branch and must
+> recover via cherry-pick. File-level disjointness is necessary but NOT sufficient
+> for parallel safety; the collision is at the git-branch level.
+>
+> When dispatching multiple Phase 4 implementers in parallel, the orchestrator
+> MUST wrap each dispatch via `scripts/dispatch-implementer.sh` (or an inline
+> equivalent that produces the same contract):
+>
+> 1. Create a per-issue worktree at `/tmp/wt-<BRANCH>` off `origin/main` via
+>    `git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main`.
+> 2. Pre-pend the implementer prompt with an explicit workdir directive naming
+>    `/tmp/wt-<BRANCH>` and forbidding `cd`/`git checkout` into the main checkout
+>    or sibling branches.
+> 3. On agent completion, remove the worktree via
+>    `git worktree remove --force /tmp/wt-<BRANCH>` (defer cleanup until the PR
+>    has merged so the worktree stays available for retries).
+>
+> Sequential dispatch in the main checkout is the safe default; worktree-isolated
+> parallel dispatch is the only safe parallelism. See `scripts/dispatch-implementer.sh`
+> and `tests/autospec-run/test_parallel_dispatch.bats` for the canonical contract.
+>
 > ### Implementer prompt selection (turbo-integration routing)
 >
 > Before dispatching, read the issue's labels:

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -535,6 +535,31 @@ inline label-swap path below.
 >   # by the merge or failure cleanup that just completed.
 > ```
 >
+> ### Parallel implementer worktree isolation
+>
+> Background `Agent` implementers in the same git workdir collide on `git checkout`
+> even when their file-level scopes are disjoint — first agent to call
+> `git checkout -b <BRANCH>` wins; the second lands on the wrong branch and must
+> recover via cherry-pick. File-level disjointness is necessary but NOT sufficient
+> for parallel safety; the collision is at the git-branch level.
+>
+> When dispatching multiple Phase 4 implementers in parallel, the orchestrator
+> MUST wrap each dispatch via `scripts/dispatch-implementer.sh` (or an inline
+> equivalent that produces the same contract):
+>
+> 1. Create a per-issue worktree at `/tmp/wt-<BRANCH>` off `origin/main` via
+>    `git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main`.
+> 2. Pre-pend the implementer prompt with an explicit workdir directive naming
+>    `/tmp/wt-<BRANCH>` and forbidding `cd`/`git checkout` into the main checkout
+>    or sibling branches.
+> 3. On agent completion, remove the worktree via
+>    `git worktree remove --force /tmp/wt-<BRANCH>` (defer cleanup until the PR
+>    has merged so the worktree stays available for retries).
+>
+> Sequential dispatch in the main checkout is the safe default; worktree-isolated
+> parallel dispatch is the only safe parallelism. See `scripts/dispatch-implementer.sh`
+> and `tests/autospec-run/test_parallel_dispatch.bats` for the canonical contract.
+>
 > ### Implementer prompt selection (turbo-integration routing)
 >
 > Before dispatching, read the issue's labels:

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -539,6 +539,31 @@ inline label-swap path below.
 >   # by the merge or failure cleanup that just completed.
 > ```
 >
+> ### Parallel implementer worktree isolation
+>
+> Background `Agent` implementers in the same git workdir collide on `git checkout`
+> even when their file-level scopes are disjoint — first agent to call
+> `git checkout -b <BRANCH>` wins; the second lands on the wrong branch and must
+> recover via cherry-pick. File-level disjointness is necessary but NOT sufficient
+> for parallel safety; the collision is at the git-branch level.
+>
+> When dispatching multiple Phase 4 implementers in parallel, the orchestrator
+> MUST wrap each dispatch via `scripts/dispatch-implementer.sh` (or an inline
+> equivalent that produces the same contract):
+>
+> 1. Create a per-issue worktree at `/tmp/wt-<BRANCH>` off `origin/main` via
+>    `git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main`.
+> 2. Pre-pend the implementer prompt with an explicit workdir directive naming
+>    `/tmp/wt-<BRANCH>` and forbidding `cd`/`git checkout` into the main checkout
+>    or sibling branches.
+> 3. On agent completion, remove the worktree via
+>    `git worktree remove --force /tmp/wt-<BRANCH>` (defer cleanup until the PR
+>    has merged so the worktree stays available for retries).
+>
+> Sequential dispatch in the main checkout is the safe default; worktree-isolated
+> parallel dispatch is the only safe parallelism. See `scripts/dispatch-implementer.sh`
+> and `tests/autospec-run/test_parallel_dispatch.bats` for the canonical contract.
+>
 > ### Implementer prompt selection (turbo-integration routing)
 >
 > Before dispatching, read the issue's labels:

--- a/tests/autospec-run/test_parallel_dispatch.bats
+++ b/tests/autospec-run/test_parallel_dispatch.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# tests/autospec-run/test_parallel_dispatch.bats — parallel implementer
+# worktree isolation contract (issue #690).
+#
+# Fixtures (per spec):
+#   a. helper creates worktree at /tmp/wt-<branch>
+#   b. prompt pre-pend includes worktree path
+#   c. helper removes worktree on completion (--cleanup)
+#   d. two parallel invocations don't collide (distinct worktrees, distinct branches)
+
+setup() {
+    REPO_ROOT="$(git rev-parse --show-toplevel)"
+    HELPER="$REPO_ROOT/scripts/dispatch-implementer.sh"
+    TMPDIR_BATS="$(mktemp -d)"
+    PROMPT_FILE="$TMPDIR_BATS/prompt.md"
+    printf 'IMPLEMENTER_PROMPT_BODY\n' > "$PROMPT_FILE"
+    BRANCH_A="test-690-fixture-a-$$"
+    BRANCH_B="test-690-fixture-b-$$"
+}
+
+teardown() {
+    bash "$HELPER" --issue 690 --branch "$BRANCH_A" --cleanup 2>/dev/null || true
+    bash "$HELPER" --issue 690 --branch "$BRANCH_B" --cleanup 2>/dev/null || true
+    rm -rf "$TMPDIR_BATS"
+}
+
+@test "fixture a: helper creates worktree at /tmp/wt-<branch>" {
+    run bash "$HELPER" --issue 690 --branch "$BRANCH_A" --prompt-file "$PROMPT_FILE"
+    [ "$status" -eq 0 ]
+    [ -d "/tmp/wt-$BRANCH_A" ]
+}
+
+@test "fixture b: prompt pre-pend includes worktree path" {
+    run bash "$HELPER" --issue 690 --branch "$BRANCH_A" --prompt-file "$PROMPT_FILE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"/tmp/wt-$BRANCH_A"* ]]
+    [[ "$output" == *"IMPLEMENTER_PROMPT_BODY"* ]]
+    [[ "$output" == *"Workdir:"* ]]
+}
+
+@test "fixture c: helper removes worktree on --cleanup" {
+    bash "$HELPER" --issue 690 --branch "$BRANCH_A" --prompt-file "$PROMPT_FILE" >/dev/null
+    [ -d "/tmp/wt-$BRANCH_A" ]
+    run bash "$HELPER" --issue 690 --branch "$BRANCH_A" --cleanup
+    [ "$status" -eq 0 ]
+    [ ! -d "/tmp/wt-$BRANCH_A" ]
+}
+
+@test "fixture d: two parallel invocations produce distinct worktrees" {
+    bash "$HELPER" --issue 690 --branch "$BRANCH_A" --prompt-file "$PROMPT_FILE" >/dev/null
+    bash "$HELPER" --issue 691 --branch "$BRANCH_B" --prompt-file "$PROMPT_FILE" >/dev/null
+    [ -d "/tmp/wt-$BRANCH_A" ]
+    [ -d "/tmp/wt-$BRANCH_B" ]
+    [ "/tmp/wt-$BRANCH_A" != "/tmp/wt-$BRANCH_B" ]
+    # Confirm each worktree is on the expected branch.
+    branch_a_head="$(git -C "/tmp/wt-$BRANCH_A" rev-parse --abbrev-ref HEAD)"
+    branch_b_head="$(git -C "/tmp/wt-$BRANCH_B" rev-parse --abbrev-ref HEAD)"
+    [ "$branch_a_head" = "$BRANCH_A" ]
+    [ "$branch_b_head" = "$BRANCH_B" ]
+}


### PR DESCRIPTION
Closes #690

## Summary

Adds canonical dispatcher helper plus trio-lockstep prose so parallel Phase 4 implementer dispatches no longer collide at the git-branch level in the same workdir.

- `scripts/dispatch-implementer.sh`: creates `/tmp/wt-<branch>` off `origin/main`, pre-pends a workdir directive to the implementer prompt, supports `--cleanup` for post-merge teardown.
- Lockstep `### Parallel implementer worktree isolation` subsection in all three autospec-run adapter files (SKILL.md / codex/prompt.md / opencode/agent.md).
- `check_autospec_parallel_dispatch_contract()` in scripts/validate.sh enforces trio lockstep, helper presence/exec/syntax, and runs the bats fixture.
- `tests/autospec-run/test_parallel_dispatch.bats`: 4 fixtures (helper creates worktree, prompt pre-pend includes path, --cleanup removes worktree, parallel invocations produce distinct worktrees).

## Test plan
- [x] `bash scripts/validate.sh` green
- [x] `bats tests/autospec-run/test_parallel_dispatch.bats` green
- [x] Dogfooded: this PR's own implementation ran in `/tmp/wt-feat-690` worktree per the very contract being shipped.