### PR TITLE
fix: autospec-refine wave-2 codex follow-ups (closes #692)

### DIFF
--- a/schemas/autospec-refinement.schema.json
+++ b/schemas/autospec-refinement.schema.json
@@ -15,7 +15,7 @@
     "final_prompt": { "type": "string", "minLength": 1 },
     "status": {
       "type": "string",
-      "enum": ["approved", "completed", "converged", "degraded", "round_cap_reached", "aborted"]
+      "enum": ["approved", "completed", "converged", "degraded", "round_cap_reached", "aborted", "handoff_failed"]
     },
     "metadata": { "$ref": "#/$defs/metadata" }
   },
@@ -78,7 +78,8 @@
         },
         "context_sparse": { "type": "boolean" },
         "handoff_target": { "type": "string", "minLength": 1 },
-        "handoff_executed": { "type": "boolean" }
+        "handoff_executed": { "type": "boolean" },
+        "handoff_exit_code": { "type": ["integer", "null"] }
       }
     }
   }

--- a/scripts/refine-prompt-lens-llm.sh
+++ b/scripts/refine-prompt-lens-llm.sh
@@ -99,12 +99,49 @@ EOF
 }
 
 # ── dispatcher path-safety ────────────────────────────────────────
+_canonicalize() {
+    local p="$1"
+    local r=""
+    if command -v realpath >/dev/null 2>&1; then
+        r="$(realpath -m "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+        r="$(realpath "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+    fi
+    if command -v readlink >/dev/null 2>&1; then
+        r="$(readlink -f "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+        if [ -L "$p" ]; then
+            local target
+            target="$(readlink "$p" 2>/dev/null)" || target=""
+            if [ -n "$target" ]; then
+                case "$target" in
+                    /*) printf '%s' "$target"; return ;;
+                    *)  printf '%s/%s' "$(dirname "$p")" "$target"; return ;;
+                esac
+            fi
+        fi
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        r="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$p" 2>/dev/null)" || r=""
+        if [ -n "$r" ]; then printf '%s' "$r"; return; fi
+    fi
+    printf '%s' "$p"
+}
+
 _dispatcher_safe() {
     local resolved="$1"
     [ -n "$resolved" ] || return 1
     if [ -n "${AUTOSPEC_LLM_DISPATCHER:-}" ]; then
-        return 0
+        # Even under override, reject relative paths (issue #692).
+        case "$resolved" in /*) return 0 ;; *) return 1 ;; esac
     fi
+    # Reject relative paths outright.
+    case "$resolved" in
+        /*) ;;
+        *) return 1 ;;
+    esac
+    # Raw path tmpdir check.
     case "$resolved" in
         /tmp/*|/private/tmp/*|/var/tmp/*|/var/folders/*) return 1 ;;
     esac
@@ -112,6 +149,19 @@ _dispatcher_safe() {
         case "$resolved" in
             "$TMPDIR"*|"${TMPDIR%/}"/*) return 1 ;;
         esac
+    fi
+    # Canonicalize and re-check — symlink-to-tmpdir attack defense (issue #692).
+    local canon
+    canon="$(_canonicalize "$resolved")"
+    if [ -n "$canon" ] && [ "$canon" != "$resolved" ]; then
+        case "$canon" in
+            /tmp/*|/private/tmp/*|/var/tmp/*|/var/folders/*) return 1 ;;
+        esac
+        if [ -n "${TMPDIR:-}" ]; then
+            case "$canon" in
+                "$TMPDIR"*|"${TMPDIR%/}"/*) return 1 ;;
+            esac
+        fi
     fi
     return 0
 }

--- a/scripts/refine-prompt.sh
+++ b/scripts/refine-prompt.sh
@@ -360,6 +360,17 @@ run_continue_loop() {
         mkdir -p "$iter_artifact_subdir"
         local refine_log="$iter_artifact_subdir/refine.log"
         local refine_status=0
+
+        # Staleness guard (issue #692 fix 2): capture mtime of any pre-existing
+        # run-summary.md and move it aside so this iteration must produce a
+        # fresh, non-empty file with newer mtime. Real-mode only.
+        local run_summary="$REPO_ROOT/.autospec/run-summary.md"
+        local mtime_before=0
+        if [ -z "$SIM_ITER_DIR" ] && [ -f "$run_summary" ]; then
+            mtime_before="$(stat -c%Y "$run_summary" 2>/dev/null || stat -f%m "$run_summary" 2>/dev/null || echo 0)"
+            mv "$run_summary" "$run_summary.prev-iter${iter}" 2>/dev/null || true
+        fi
+
         if [ -n "$SIM_ITER_DIR" ]; then
             # Test-only path: dry-run, no real /autospec dispatch.
             bash "$0" "$cur_prompt" --rounds "$ROUNDS" --dry-run \
@@ -399,6 +410,34 @@ run_continue_loop() {
             report_path="$SIM_ITER_DIR/iter-${iter}-report.md"
         else
             report_path="$REPO_ROOT/.autospec/run-summary.md"
+        fi
+
+        # Staleness post-check (issue #692 fix 2): in real mode, the handoff
+        # must produce a fresh, non-empty run-summary.md with mtime > mtime_before.
+        # Missing / empty / stale → iteration_error.
+        if [ -z "$SIM_ITER_DIR" ]; then
+            local stale_reason=""
+            if [ ! -f "$report_path" ]; then
+                stale_reason="run_summary_missing_after_handoff"
+            elif [ ! -s "$report_path" ]; then
+                stale_reason="run_summary_empty_after_handoff"
+            else
+                local mtime_after
+                mtime_after="$(stat -c%Y "$report_path" 2>/dev/null || stat -f%m "$report_path" 2>/dev/null || echo 0)"
+                if [ "$mtime_after" -le "$mtime_before" ] 2>/dev/null; then
+                    stale_reason="run_summary_stale_after_handoff"
+                fi
+            fi
+            if [ -n "$stale_reason" ]; then
+                echo "code_health:$stale_reason path=$report_path" >&2
+                status="iteration_error"
+                local row
+                row="$(printf '| %4d | %-21s | %-60s | %10s | %4s | %-20s |' \
+                    "$iter" "$(printf '%s' "$cur_source" | head -c 21)" \
+                    "$stale_reason" "0" "-" "iteration_error")"
+                if [ -z "$table_rows" ]; then table_rows="$row"; else table_rows="$table_rows"$'\n'"$row"; fi
+                break
+            fi
         fi
 
         # Harvest next prompt from the report.
@@ -1031,8 +1070,16 @@ _handoff_dispatcher_safe() {
     local resolved="$1"
     [ -n "$resolved" ] || return 1
     if [ -n "${AUTOSPEC_HANDOFF_DISPATCHER:-}" ]; then
-        return 0
+        # Even under override, reject relative paths — they're ambiguous and
+        # can be hijacked by cwd shadowing.
+        case "$resolved" in /*) return 0 ;; *) return 1 ;; esac
     fi
+    # Reject relative paths outright (issue #692).
+    case "$resolved" in
+        /*) ;;
+        *) return 1 ;;
+    esac
+    # Check raw path against tmpdir denylist.
     case "$resolved" in
         /tmp/*|/private/tmp/*|/var/tmp/*|/var/folders/*) return 1 ;;
     esac
@@ -1040,6 +1087,20 @@ _handoff_dispatcher_safe() {
         case "$resolved" in
             "$TMPDIR"*|"${TMPDIR%/}"/*) return 1 ;;
         esac
+    fi
+    # Canonicalize (follows symlinks) and re-check — symlink at safe path
+    # pointing into tmpdir must be rejected (issue #692).
+    local canon
+    canon="$(_canonicalize "$resolved")"
+    if [ -n "$canon" ] && [ "$canon" != "$resolved" ]; then
+        case "$canon" in
+            /tmp/*|/private/tmp/*|/var/tmp/*|/var/folders/*) return 1 ;;
+        esac
+        if [ -n "${TMPDIR:-}" ]; then
+            case "$canon" in
+                "$TMPDIR"*|"${TMPDIR%/}"/*) return 1 ;;
+            esac
+        fi
     fi
     return 0
 }

--- a/tests/refine/test_refine_codex_followups.bats
+++ b/tests/refine/test_refine_codex_followups.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+# tests/refine/test_refine_codex_followups.bats — issue #692.
+#
+# Four fixtures from the issue body:
+#   1. Handoff failure → schema-valid artifact with status=handoff_failed and
+#      metadata.handoff_exit_code present.
+#   2. Missing .autospec/run-summary.md after iteration → iteration_error.
+#   3. Stale .autospec/run-summary.md (predating iteration) → iteration_error.
+#   4. Symlink at <bindir>/claude → /tmp/evil rejected by LLM dispatcher.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    REFINE="$REPO_ROOT/scripts/refine-prompt.sh"
+    LENS_LLM="$REPO_ROOT/scripts/refine-prompt-lens-llm.sh"
+    TMPWORK="$(mktemp -d -t refine-692.XXXXXX)"
+    SCHEMA_SINGLE="$REPO_ROOT/schemas/autospec-refinement.schema.json"
+    SCHEMA_LOOP="$REPO_ROOT/schemas/autospec-refinement-loop.schema.json"
+}
+
+teardown() {
+    [ -n "${TMPWORK:-}" ] && rm -rf "$TMPWORK" || true
+}
+
+_stat_mtime() {
+    stat -c%Y "$1" 2>/dev/null || stat -f%m "$1" 2>/dev/null || echo 0
+}
+
+# ── Fix 1 — schema completeness ───────────────────────────────────
+
+@test "schema declares handoff_exit_code in metadata" {
+    run grep -q '"handoff_exit_code"' "$SCHEMA_SINGLE"
+    [ "$status" -eq 0 ]
+}
+
+@test "schema status enum includes handoff_failed" {
+    run grep -E '"handoff_failed"' "$SCHEMA_SINGLE"
+    [ "$status" -eq 0 ]
+}
+
+@test "real orchestrator artifact validates against single-pass schema" {
+    if ! python3 -c 'import jsonschema' 2>/dev/null; then skip "jsonschema unavailable"; fi
+    cd "$TMPWORK"
+    mkdir -p ref
+    run bash "$REFINE" "demo prompt for schema check" --rounds 1 --dry-run \
+        --artifact-dir "$TMPWORK/ref" --repo-root "$TMPWORK" --memory-root "$TMPWORK/none"
+    [ "$status" -eq 0 ]
+    artifact="$(ls "$TMPWORK"/ref/*.json | head -1)"
+    [ -n "$artifact" ]
+    run python3 -c "
+import json, sys, jsonschema
+doc = json.load(open('$artifact'))
+sch = json.load(open('$SCHEMA_SINGLE'))
+jsonschema.validate(doc, sch)
+print('ok')
+"
+    [ "$status" -eq 0 ]
+}
+
+# ── Fix 2 — staleness guard ───────────────────────────────────────
+
+@test "missing run-summary.md after handoff → iteration_error" {
+    cd "$TMPWORK"
+    mkdir -p fake-bin
+    # Fake claude dispatcher that always succeeds but writes NO run-summary.
+    cat > fake-bin/claude <<EOF
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x fake-bin/claude
+    mkdir -p .autospec
+    AUTOSPEC_HANDOFF_DISPATCHER=1 PATH="$TMPWORK/fake-bin:$PATH" \
+        run bash "$REFINE" "iterating prompt missing summary" \
+        --continue --max-iterations 1 --rounds 1 \
+        --artifact-dir "$TMPWORK/ref" --repo-root "$TMPWORK" --memory-root "$TMPWORK/none"
+    [ "$status" -eq 0 ]
+    loop_json="$(ls "$TMPWORK"/ref/*-loop.json | head -1)"
+    [ -n "$loop_json" ]
+    run grep -q '"status": "iteration_error"' "$loop_json"
+    [ "$status" -eq 0 ]
+}
+
+@test "stale run-summary.md predating iteration → iteration_error" {
+    cd "$TMPWORK"
+    mkdir -p fake-bin .autospec
+    # Pre-stage stale run-summary.md with old mtime.
+    cat > .autospec/run-summary.md <<'EOF'
+## Next steps
+- stale work from prior run
+EOF
+    # Set very old mtime (2020-01-01).
+    touch -t 202001010000 .autospec/run-summary.md
+    # Fake dispatcher exits 0 but does NOT touch run-summary.md.
+    cat > fake-bin/claude <<EOF
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x fake-bin/claude
+    AUTOSPEC_HANDOFF_DISPATCHER=1 PATH="$TMPWORK/fake-bin:$PATH" \
+        run bash "$REFINE" "stale summary check" \
+        --continue --max-iterations 1 --rounds 1 \
+        --artifact-dir "$TMPWORK/ref" --repo-root "$TMPWORK" --memory-root "$TMPWORK/none"
+    [ "$status" -eq 0 ]
+    loop_json="$(ls "$TMPWORK"/ref/*-loop.json | head -1)"
+    [ -n "$loop_json" ]
+    run grep -q '"status": "iteration_error"' "$loop_json"
+    [ "$status" -eq 0 ]
+}
+
+# ── Fix 3 — dispatcher canonicalization ───────────────────────────
+
+@test "LLM dispatcher rejects symlink whose target is in /tmp" {
+    cd "$TMPWORK"
+    mkdir -p safe-bin
+    # Real target lives in /tmp (forbidden after canonicalization).
+    cat > /tmp/evil-claude-692-$$ <<'EOF'
+#!/usr/bin/env bash
+echo "evil"; exit 0
+EOF
+    chmod +x /tmp/evil-claude-692-$$
+    ln -sf "/tmp/evil-claude-692-$$" "$TMPWORK/safe-bin/claude"
+    run bash "$LENS_LLM" --lens repo-grounding --prompt "x" \
+        --llm-binary "$TMPWORK/safe-bin/claude"
+    rm -f "/tmp/evil-claude-692-$$"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "tmpdir" ]] || [[ "$output" =~ "refusing" ]]
+}
+
+@test "handoff dispatcher rejects symlink whose target is in /tmp" {
+    cd "$TMPWORK"
+    mkdir -p safe-bin .autospec
+    cat > /tmp/evil-claude-692-h-$$ <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x /tmp/evil-claude-692-h-$$
+    ln -sf "/tmp/evil-claude-692-h-$$" "$TMPWORK/safe-bin/claude"
+    PATH="$TMPWORK/safe-bin:/usr/bin:/bin" \
+        run bash "$REFINE" "handoff symlink check" --rounds 1 \
+        --artifact-dir "$TMPWORK/ref" --repo-root "$TMPWORK" --memory-root "$TMPWORK/none"
+    rm -f "/tmp/evil-claude-692-h-$$"
+    # Should fail with rc 5 (unsafe dispatcher) — handoff_dispatcher_safe rejects.
+    [ "$status" -eq 5 ]
+}


### PR DESCRIPTION
Closes #692.

## Summary

Three correctness/security fixes flagged by codex peer-review on the autospec-refine hardening wave (PRs #685-#689):

1. **Schema completeness** — `schemas/autospec-refinement.schema.json` declares `metadata.handoff_exit_code` and adds `handoff_failed` to the `status` enum so every real orchestrator artifact validates against itself.

2. **Run-summary staleness guard** — `run_continue_loop()` captures the pre-iteration mtime of `.autospec/run-summary.md`, moves any existing file to `.prev-iter<N>`, and requires a fresh non-empty file with newer mtime after handoff. Missing / empty / stale → `status=iteration_error` with `code_health:run_summary_*_after_handoff` log.

3. **Dispatcher canonicalization** — both `refine-prompt.sh::_handoff_dispatcher_safe` and `refine-prompt-lens-llm.sh::_dispatcher_safe` canonicalize via realpath / readlink / python3 fallback before re-checking the tmpdir denylist. Symlink at `/safe/path/claude` → `/tmp/evil` is now rejected. Relative paths in resolved output are rejected unless `AUTOSPEC_*_DISPATCHER=1`.

## Test plan

- [x] `tests/refine/test_refine_codex_followups.bats` — 7 fixtures covering schema fields, real-artifact validation, missing/stale run-summary handling, symlink-to-tmpdir rejection on both dispatchers.
- [x] `bats tests/refine/` — 65 green (58 existing + 7 new).
- [x] `bash scripts/validate.sh` — OK.

Portable `stat` (`stat -c%Y || stat -f%m`) used for BSD/GNU compatibility.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>