### PR TITLE
feat: extend harvest matchers to recognize Next best / continuation prefix patterns (closes #707)

### DIFF
--- a/scripts/extract-conversational-recommendation.sh
+++ b/scripts/extract-conversational-recommendation.sh
@@ -4,6 +4,8 @@
 #   1. section-heading matcher (## Next steps / What to do next / etc.)
 #   2. fenced-block matcher (```autospec-next / ```next-prompt)
 #   3. numbered-list-with-action-verbs matcher (>=50% imperative)
+#   3.5 Next-prefix / continuation prefixes (Next best slice:, Next step:,
+#       Continue with:, Proceed with:, Move on to:, etc. — issue #707)
 #   4. you-should / I-suggest / I-recommend / next-step-is sentence matcher
 # then concatenates all matches and runs a prompt-injection guard.
 #
@@ -61,128 +63,23 @@ fi
 
 MSG="$(cat "$MESSAGE_PATH")"
 
-# -----------------------------------------------------------------------------
-# Matcher 1: section headings (case-insensitive via tolower()).
-# Headings recognised:
-#   ## Next steps
-#   ## What to do next
-#   ## Remaining work
-#   ## Open blockers
-#   ## Suggestions
-#   ## Proposed follow-ups
-# Extract from the heading line through the next "## " heading or end.
-# -----------------------------------------------------------------------------
-extract_section_headings() {
-    awk '
-        BEGIN { in_section = 0 }
-        {
-            low = tolower($0)
-        }
-        low ~ /^##[[:space:]]+(next steps|what to do next|remaining work|open blockers|suggestions|proposed follow-ups)[[:space:]]*$/ {
-            in_section = 1
-            print
-            next
-        }
-        /^##[[:space:]]+/ {
-            if (in_section) { in_section = 0 }
-            next
-        }
-        {
-            if (in_section) print
-        }
-    ' <<<"$MSG"
-}
-
-# -----------------------------------------------------------------------------
-# Matcher 2: fenced blocks ```autospec-next / ```next-prompt
-# -----------------------------------------------------------------------------
-extract_fenced_blocks() {
-    awk '
-        BEGIN { in_block = 0 }
-        /^```(autospec-next|next-prompt)[[:space:]]*$/ {
-            in_block = 1
-            next
-        }
-        /^```[[:space:]]*$/ {
-            if (in_block) { in_block = 0; next }
-            next
-        }
-        {
-            if (in_block) print
-        }
-    ' <<<"$MSG"
-}
-
-# -----------------------------------------------------------------------------
-# Matcher 3: numbered lists where >=50% items start with imperative verbs.
-# -----------------------------------------------------------------------------
-extract_numbered_action_list() {
-    awk '
-        BEGIN {
-            verbs = "^(fix|add|implement|update|review|refactor|ship|merge|remove|delete|create|build|write|test|run|deploy|document|rename|move|split|extract)([[:space:]]|$)"
-            block_lines = ""
-            total = 0
-            imperative = 0
-        }
-        function flush() {
-            if (total > 0 && imperative * 2 >= total) {
-                printf "%s", block_lines
-            }
-            block_lines = ""
-            total = 0
-            imperative = 0
-        }
-        /^[[:space:]]*[0-9]+\.[[:space:]]+/ {
-            body = $0
-            sub(/^[[:space:]]*[0-9]+\.[[:space:]]+/, "", body)
-            low = tolower(body)
-            total++
-            if (match(low, verbs)) imperative++
-            block_lines = block_lines $0 "\n"
-            next
-        }
-        /^[[:space:]]*$/ {
-            flush()
-            next
-        }
-        {
-            flush()
-        }
-        END { flush() }
-    ' <<<"$MSG"
-}
-
-# -----------------------------------------------------------------------------
-# Matcher 4: "you should" / "I suggest" / "I recommend" / "next step is" /
-# "the next thing to do is" sentences plus the following paragraph.
-# -----------------------------------------------------------------------------
-extract_recommend_sentences() {
-    awk '
-        BEGIN {
-            pat = "(you should|i suggest|i recommend|next step is|the next thing to do is)"
-            in_para = 0
-        }
-        {
-            low = tolower($0)
-            if (match(low, pat)) {
-                in_para = 1
-                print
-                next
-            }
-            if (in_para) {
-                if ($0 ~ /^[[:space:]]*$/) {
-                    in_para = 0
-                } else {
-                    print
-                }
-            }
-        }
-    ' <<<"$MSG"
-}
+# Shared matcher library (issue #707) — sourced for both this script and
+# scripts/refine-prompt.sh::run_continue_loop(). Defines:
+#   extract_section_headings, extract_fenced_blocks,
+#   extract_numbered_action_list, extract_next_prefix_continuations,
+#   extract_recommend_sentences
+_MATCHER_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/extract-matchers.sh"
+if [ ! -f "$_MATCHER_LIB" ]; then
+    echo "extract-conversational-recommendation.sh: missing matcher library: $_MATCHER_LIB" >&2
+    exit 2
+fi
+# shellcheck source=lib/extract-matchers.sh
+. "$_MATCHER_LIB"
 
 S1="$(extract_section_headings)"
 S2="$(extract_fenced_blocks)"
 S3="$(extract_numbered_action_list)"
+S3_5="$(extract_next_prefix_continuations)"
 S4="$(extract_recommend_sentences)"
 
 COMBINED=""
@@ -201,6 +98,7 @@ append_if_nonempty() {
 append_if_nonempty "$S1"
 append_if_nonempty "$S2"
 append_if_nonempty "$S3"
+append_if_nonempty "$S3_5"
 append_if_nonempty "$S4"
 
 if [ -z "$COMBINED" ]; then

--- a/scripts/lib/extract-matchers.sh
+++ b/scripts/lib/extract-matchers.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# scripts/lib/extract-matchers.sh — shared matcher library for
+# autospec-continue and autospec-refine harvest paths (issue #707).
+#
+# Sourced by:
+#   - scripts/extract-conversational-recommendation.sh  (PR #702)
+#   - scripts/refine-prompt.sh::run_continue_loop()      (PR #678 + #693)
+#
+# Matcher priority chain (highest -> lowest):
+#   1. Section headings:   ## Next steps / What to do next / Remaining work /
+#                          Open blockers / Suggestions / Proposed follow-ups
+#   2. Fenced blocks:      ```autospec-next / ```next-prompt
+#   3. Numbered list with >=50% imperative-verb items
+#   3.5. Next-prefix / continuation prefixes (issue #707):
+#           Next best slice:, Next best step:, Next slice:, Next step:,
+#           Next:, Continue with:, Proceed with:, Move on to:, Move to:,
+#           Then:, Up next:, Up next is:, Suggested next:
+#         Each match extracts the matched line + following paragraph
+#         (up to next blank line or `##` heading).
+#   4. Sentences starting with you should / I suggest / I recommend /
+#      next step is / the next thing to do is
+#
+# Every function reads from $MSG (set by the caller) and writes its
+# extracted text to stdout.
+
+# -----------------------------------------------------------------------------
+# Matcher 1: section headings.
+# -----------------------------------------------------------------------------
+extract_section_headings() {
+    awk '
+        BEGIN { in_section = 0 }
+        {
+            low = tolower($0)
+        }
+        low ~ /^##[[:space:]]+(next steps|what to do next|remaining work|open blockers|suggestions|proposed follow-ups)[[:space:]]*$/ {
+            in_section = 1
+            print
+            next
+        }
+        /^##[[:space:]]+/ {
+            if (in_section) { in_section = 0 }
+            next
+        }
+        {
+            if (in_section) print
+        }
+    ' <<<"$MSG"
+}
+
+# -----------------------------------------------------------------------------
+# Matcher 2: fenced ```autospec-next / ```next-prompt blocks.
+# -----------------------------------------------------------------------------
+extract_fenced_blocks() {
+    awk '
+        BEGIN { in_block = 0 }
+        /^```(autospec-next|next-prompt)[[:space:]]*$/ {
+            in_block = 1
+            next
+        }
+        /^```[[:space:]]*$/ {
+            if (in_block) { in_block = 0; next }
+            next
+        }
+        {
+            if (in_block) print
+        }
+    ' <<<"$MSG"
+}
+
+# -----------------------------------------------------------------------------
+# Matcher 3: numbered lists where >=50% items start with imperative verbs.
+# -----------------------------------------------------------------------------
+extract_numbered_action_list() {
+    awk '
+        BEGIN {
+            verbs = "^(fix|add|implement|update|review|refactor|ship|merge|remove|delete|create|build|write|test|run|deploy|document|rename|move|split|extract)([[:space:]]|$)"
+            block_lines = ""
+            total = 0
+            imperative = 0
+        }
+        function flush() {
+            if (total > 0 && imperative * 2 >= total) {
+                printf "%s", block_lines
+            }
+            block_lines = ""
+            total = 0
+            imperative = 0
+        }
+        /^[[:space:]]*[0-9]+\.[[:space:]]+/ {
+            body = $0
+            sub(/^[[:space:]]*[0-9]+\.[[:space:]]+/, "", body)
+            low = tolower(body)
+            total++
+            if (match(low, verbs)) imperative++
+            block_lines = block_lines $0 "\n"
+            next
+        }
+        /^[[:space:]]*$/ {
+            flush()
+            next
+        }
+        {
+            flush()
+        }
+        END { flush() }
+    ' <<<"$MSG"
+}
+
+# -----------------------------------------------------------------------------
+# Matcher 3.5: Next-prefix / continuation prefixes (issue #707).
+#
+# Recognised (case-insensitive, sentence-start):
+#   Next best slice:, Next best step:, Next slice:, Next step:, Next:,
+#   Continue with:, Proceed with:, Move on to:, Move to:, Then:,
+#   Up next:, Up next is:, Suggested next:
+#
+# Each match extracts the matched line + the following paragraph (up to the
+# next blank line or `##` heading).
+# -----------------------------------------------------------------------------
+extract_next_prefix_continuations() {
+    awk '
+        BEGIN {
+            # Order matters: longer / more specific prefixes first so awk
+            # matches "Next best slice:" before "Next:".
+            pat = "^[[:space:]]*(next best slice:|next best step:|next slice:|next step:|continue with:|proceed with:|move on to:|move to:|up next is:|up next:|suggested next:|then:|next:)"
+            in_para = 0
+        }
+        {
+            low = tolower($0)
+            if (match(low, pat)) {
+                in_para = 1
+                print
+                next
+            }
+            if (in_para) {
+                if ($0 ~ /^[[:space:]]*$/) {
+                    in_para = 0
+                    next
+                }
+                if ($0 ~ /^##[[:space:]]+/) {
+                    in_para = 0
+                    next
+                }
+                print
+            }
+        }
+    ' <<<"$MSG"
+}
+
+# -----------------------------------------------------------------------------
+# Matcher 4: "you should" / "I suggest" / "I recommend" / "next step is" /
+# "the next thing to do is" sentences plus the following paragraph.
+# -----------------------------------------------------------------------------
+extract_recommend_sentences() {
+    awk '
+        BEGIN {
+            pat = "(you should|i suggest|i recommend|next step is|the next thing to do is)"
+            in_para = 0
+        }
+        {
+            low = tolower($0)
+            if (match(low, pat)) {
+                in_para = 1
+                print
+                next
+            }
+            if (in_para) {
+                if ($0 ~ /^[[:space:]]*$/) {
+                    in_para = 0
+                } else {
+                    print
+                }
+            }
+        }
+    ' <<<"$MSG"
+}

--- a/scripts/refine-prompt.sh
+++ b/scripts/refine-prompt.sh
@@ -267,6 +267,14 @@ slug_from_prompt_early() {
 # Per-iteration record + summary table per spec
 # (docs/specs/2026-05-28-autospec-refine-design.md §Continuous-iteration mode).
 
+# Shared matcher library (issue #707). Sourced once so harvest_next_prompt
+# can invoke the same matchers as scripts/extract-conversational-recommendation.sh.
+_REFINE_MATCHER_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/extract-matchers.sh"
+if [ -f "$_REFINE_MATCHER_LIB" ]; then
+    # shellcheck source=lib/extract-matchers.sh
+    . "$_REFINE_MATCHER_LIB"
+fi
+
 harvest_next_prompt() {
     local report="$1"
     [ -f "$report" ] || { printf ''; return 0; }
@@ -316,6 +324,29 @@ harvest_next_prompt() {
     if [ -n "$fenced" ]; then
         printf '%s' "$fenced" | head -1
         return 0
+    fi
+    # 3.5 Next-prefix / continuation prefixes (issue #707).
+    # Recognises "Next best slice:", "Next step:", "Continue with:",
+    # "Proceed with:", "Move on to:", "Then:", "Up next:", "Suggested next:",
+    # etc. Extracts the matched line + following paragraph, then strips the
+    # leading prefix so the harvested prompt is the actionable body.
+    if declare -F extract_next_prefix_continuations >/dev/null 2>&1; then
+        local next_pref
+        MSG="$(cat "$report")" next_pref="$(MSG="$(cat "$report")" extract_next_prefix_continuations)"
+        if [ -n "$next_pref" ]; then
+            # Use the first line; strip the leading "Next best slice:" / etc.
+            local first_line
+            first_line="$(printf '%s\n' "$next_pref" | head -1)"
+            # Case-insensitive strip of recognised prefixes.
+            local stripped
+            stripped="$(printf '%s' "$first_line" | sed -E 's/^[[:space:]]*([Nn]ext best slice|[Nn]ext best step|[Nn]ext slice|[Nn]ext step|[Cc]ontinue with|[Pp]roceed with|[Mm]ove on to|[Mm]ove to|[Uu]p next is|[Uu]p next|[Ss]uggested next|[Tt]hen|[Nn]ext):[[:space:]]*//')"
+            if [ -n "$stripped" ]; then
+                printf '%s' "$stripped"
+            else
+                printf '%s' "$first_line"
+            fi
+            return 0
+        fi
     fi
     # 4. Nothing found — convergence.
     printf ''

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1344,6 +1344,10 @@ check_autospec_refine_contract() {
     [ -f "$prompt_sh" ] || fail "$prompt_sh: file missing (issue #672)"
     [ -x "$prompt_sh" ] || fail "$prompt_sh: not executable (issue #672)"
     bash -n "$prompt_sh" || fail "$prompt_sh: bash syntax error (issue #672)"
+    # Shared matcher library (issue #707).
+    matcher_lib="scripts/lib/extract-matchers.sh"
+    [ -f "$matcher_lib" ] || fail "$matcher_lib: file missing (issue #707)"
+    bash -n "$matcher_lib" || fail "$matcher_lib: bash syntax error (issue #707)"
     [ -f "$lens_llm_sh" ] || fail "$lens_llm_sh: file missing (issue #684)"
     [ -x "$lens_llm_sh" ] || fail "$lens_llm_sh: not executable (issue #684)"
     bash -n "$lens_llm_sh" || fail "$lens_llm_sh: bash syntax error (issue #684)"
@@ -1471,6 +1475,12 @@ check_autospec_continue_contract() {
         [ -x "$helper" ] || fail "$helper: not executable (issue #700)"
         bash -n "$helper" || fail "$helper: bash syntax error (issue #700)"
     done
+    # Shared matcher library (issue #707): both extract-conversational-
+    # recommendation.sh and refine-prompt.sh::run_continue_loop() source this
+    # so future matcher additions land in one place.
+    matcher_lib="scripts/lib/extract-matchers.sh"
+    [ -f "$matcher_lib" ] || fail "$matcher_lib: file missing (issue #707)"
+    bash -n "$matcher_lib" || fail "$matcher_lib: bash syntax error (issue #707)"
     if command -v bats >/dev/null 2>&1; then
         if [ -d tests/continue ]; then
             for t in tests/continue/test_continue_*.bats; do

--- a/skills/autospec-continue/SKILL.md
+++ b/skills/autospec-continue/SKILL.md
@@ -183,9 +183,22 @@ The skill prose tells the LLM:
      items start with imperative verbs (`fix`, `add`, `implement`,
      `update`, `review`, `refactor`, `ship`, `merge`, etc.). Extract the
      whole list.
+   - **Next-prefix / continuation prefixes (tier 3.5, issue #707):**
+     sentence-start prefixes `Next best slice:`, `Next best step:`,
+     `Next slice:`, `Next step:`, `Next:`, `Continue with:`,
+     `Proceed with:`, `Move on to:`, `Move to:`, `Then:`, `Up next:`,
+     `Up next is:`, `Suggested next:` (case-insensitive). Extract the
+     matched line plus the following paragraph (up to next blank line or
+     `##` heading).
    - **"You should / I suggest" patterns:** sentences starting with
      `you should`, `I suggest`, `I recommend`, `next step is`, `the next
      thing to do is`. Extract that sentence plus the following paragraph.
+
+   All matcher functions live in the shared library
+   `scripts/lib/extract-matchers.sh` (issue #707) — sourced by both
+   `scripts/extract-conversational-recommendation.sh` and
+   `scripts/refine-prompt.sh::run_continue_loop()` so future additions land
+   in one place.
 3. **Combine matches** (operator confirmed default: pass everything as one
    prompt). Refine's sizing lens splits into multiple issues if needed.
 4. **Empty-recommendation case:** if NO matcher hits, exit with

--- a/skills/autospec-continue/codex/prompt.md
+++ b/skills/autospec-continue/codex/prompt.md
@@ -179,9 +179,22 @@ The skill prose tells the LLM:
      items start with imperative verbs (`fix`, `add`, `implement`,
      `update`, `review`, `refactor`, `ship`, `merge`, etc.). Extract the
      whole list.
+   - **Next-prefix / continuation prefixes (tier 3.5, issue #707):**
+     sentence-start prefixes `Next best slice:`, `Next best step:`,
+     `Next slice:`, `Next step:`, `Next:`, `Continue with:`,
+     `Proceed with:`, `Move on to:`, `Move to:`, `Then:`, `Up next:`,
+     `Up next is:`, `Suggested next:` (case-insensitive). Extract the
+     matched line plus the following paragraph (up to next blank line or
+     `##` heading).
    - **"You should / I suggest" patterns:** sentences starting with
      `you should`, `I suggest`, `I recommend`, `next step is`, `the next
      thing to do is`. Extract that sentence plus the following paragraph.
+
+   All matcher functions live in the shared library
+   `scripts/lib/extract-matchers.sh` (issue #707) — sourced by both
+   `scripts/extract-conversational-recommendation.sh` and
+   `scripts/refine-prompt.sh::run_continue_loop()` so future additions land
+   in one place.
 3. **Combine matches** (operator confirmed default: pass everything as one
    prompt). Refine's sizing lens splits into multiple issues if needed.
 4. **Empty-recommendation case:** if NO matcher hits, exit with

--- a/skills/autospec-continue/opencode/agent.md
+++ b/skills/autospec-continue/opencode/agent.md
@@ -183,9 +183,22 @@ The skill prose tells the LLM:
      items start with imperative verbs (`fix`, `add`, `implement`,
      `update`, `review`, `refactor`, `ship`, `merge`, etc.). Extract the
      whole list.
+   - **Next-prefix / continuation prefixes (tier 3.5, issue #707):**
+     sentence-start prefixes `Next best slice:`, `Next best step:`,
+     `Next slice:`, `Next step:`, `Next:`, `Continue with:`,
+     `Proceed with:`, `Move on to:`, `Move to:`, `Then:`, `Up next:`,
+     `Up next is:`, `Suggested next:` (case-insensitive). Extract the
+     matched line plus the following paragraph (up to next blank line or
+     `##` heading).
    - **"You should / I suggest" patterns:** sentences starting with
      `you should`, `I suggest`, `I recommend`, `next step is`, `the next
      thing to do is`. Extract that sentence plus the following paragraph.
+
+   All matcher functions live in the shared library
+   `scripts/lib/extract-matchers.sh` (issue #707) — sourced by both
+   `scripts/extract-conversational-recommendation.sh` and
+   `scripts/refine-prompt.sh::run_continue_loop()` so future additions land
+   in one place.
 3. **Combine matches** (operator confirmed default: pass everything as one
    prompt). Refine's sizing lens splits into multiple issues if needed.
 4. **Empty-recommendation case:** if NO matcher hits, exit with

--- a/skills/autospec-refine/SKILL.md
+++ b/skills/autospec-refine/SKILL.md
@@ -323,10 +323,18 @@ The orchestrator reads the LAST autospec run's report and looks for, in order:
    `## Remaining work`, or `## Open blockers` (case-insensitive).
 2. If absent, fenced code blocks tagged with ` ```autospec-next` or
    ` ```next-prompt`.
-3. If absent, the report's `Out-of-sample`, `Stop condition`, or
+3. If absent, sentence-start continuation prefixes (tier 3.5, issue #707):
+   `Next best slice:`, `Next best step:`, `Next slice:`, `Next step:`,
+   `Next:`, `Continue with:`, `Proceed with:`, `Move on to:`, `Move to:`,
+   `Then:`, `Up next:`, `Up next is:`, `Suggested next:` (case-insensitive).
+   The matched line plus its following paragraph (up to next blank line or
+   `##` heading) becomes the harvested prompt. All matcher functions live
+   in the shared library `scripts/lib/extract-matchers.sh` so additions to
+   either harvest path land in one place.
+4. If absent, the report's `Out-of-sample`, `Stop condition`, or
    `Evidence-backed stop` sections are inspected. If they say "stop", the
    loop terminates with `evidence_based_stop`.
-4. If none of the above are present → convergence (loop exits cleanly).
+5. If none of the above are present → convergence (loop exits cleanly).
 
 ### Safety guardrails
 

--- a/skills/autospec-refine/codex/prompt.md
+++ b/skills/autospec-refine/codex/prompt.md
@@ -319,10 +319,18 @@ The orchestrator reads the LAST autospec run's report and looks for, in order:
    `## Remaining work`, or `## Open blockers` (case-insensitive).
 2. If absent, fenced code blocks tagged with ` ```autospec-next` or
    ` ```next-prompt`.
-3. If absent, the report's `Out-of-sample`, `Stop condition`, or
+3. If absent, sentence-start continuation prefixes (tier 3.5, issue #707):
+   `Next best slice:`, `Next best step:`, `Next slice:`, `Next step:`,
+   `Next:`, `Continue with:`, `Proceed with:`, `Move on to:`, `Move to:`,
+   `Then:`, `Up next:`, `Up next is:`, `Suggested next:` (case-insensitive).
+   The matched line plus its following paragraph (up to next blank line or
+   `##` heading) becomes the harvested prompt. All matcher functions live
+   in the shared library `scripts/lib/extract-matchers.sh` so additions to
+   either harvest path land in one place.
+4. If absent, the report's `Out-of-sample`, `Stop condition`, or
    `Evidence-backed stop` sections are inspected. If they say "stop", the
    loop terminates with `evidence_based_stop`.
-4. If none of the above are present → convergence (loop exits cleanly).
+5. If none of the above are present → convergence (loop exits cleanly).
 
 ### Safety guardrails
 

--- a/skills/autospec-refine/opencode/agent.md
+++ b/skills/autospec-refine/opencode/agent.md
@@ -323,10 +323,18 @@ The orchestrator reads the LAST autospec run's report and looks for, in order:
    `## Remaining work`, or `## Open blockers` (case-insensitive).
 2. If absent, fenced code blocks tagged with ` ```autospec-next` or
    ` ```next-prompt`.
-3. If absent, the report's `Out-of-sample`, `Stop condition`, or
+3. If absent, sentence-start continuation prefixes (tier 3.5, issue #707):
+   `Next best slice:`, `Next best step:`, `Next slice:`, `Next step:`,
+   `Next:`, `Continue with:`, `Proceed with:`, `Move on to:`, `Move to:`,
+   `Then:`, `Up next:`, `Up next is:`, `Suggested next:` (case-insensitive).
+   The matched line plus its following paragraph (up to next blank line or
+   `##` heading) becomes the harvested prompt. All matcher functions live
+   in the shared library `scripts/lib/extract-matchers.sh` so additions to
+   either harvest path land in one place.
+4. If absent, the report's `Out-of-sample`, `Stop condition`, or
    `Evidence-backed stop` sections are inspected. If they say "stop", the
    loop terminates with `evidence_based_stop`.
-4. If none of the above are present → convergence (loop exits cleanly).
+5. If none of the above are present → convergence (loop exits cleanly).
 
 ### Safety guardrails
 

--- a/tests/continue/test_continue_extract.bats
+++ b/tests/continue/test_continue_extract.bats
@@ -119,6 +119,140 @@ EOF
     [[ "$output" == *"I recommend reviewing the diff"* ]]
 }
 
+@test "tier 3.5 Next best slice: prefix is extracted (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+Some prose before.
+
+Next best slice: the 2 remaining Aromatic anilides rows, but only with blockers for pyridinecarboxamide and oligopeptide rows; otherwise move to Organic acids and derivatives > Carboxylic acids and derivatives.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Aromatic anilides"* ]]
+    [[ "$output" == *"Organic acids"* ]]
+}
+
+@test "tier 3.5 Next step: prefix is extracted (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+Next step: rebuild the index and re-run the bench.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"rebuild the index"* ]]
+}
+
+@test "tier 3.5 Next: prefix is extracted (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+Next: extend the harvest matchers across both trios in lockstep.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"extend the harvest matchers"* ]]
+}
+
+@test "tier 3.5 Continue with: prefix is extracted (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+Continue with: porting the remaining adapter rows.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"porting the remaining"* ]]
+}
+
+@test "tier 3.5 Proceed with: prefix is extracted (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+Proceed with: shipping the gap-remediation patch.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"gap-remediation"* ]]
+}
+
+@test "tier 3.5 Move on to: prefix is extracted (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+Move on to: the Organic acids subtree once anilides converge.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Organic acids subtree"* ]]
+}
+
+@test "tier 3.5 Move to: prefix is extracted (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+Move to: the next anilide cluster after this PR lands.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"anilide cluster"* ]]
+}
+
+@test "tier 3.5 Up next: prefix is extracted (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+Up next: regenerate the test fixtures.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"regenerate the test fixtures"* ]]
+}
+
+@test "tier 3.5 Up next is: prefix is extracted (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+Up next is: closing out the validate.sh hook on the new matcher lib.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"validate.sh hook"* ]]
+}
+
+@test "tier 3.5 Suggested next: prefix is extracted (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+Suggested next: extend bats coverage with adversarial fixtures.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"extend bats coverage"* ]]
+}
+
+@test "tier 3.5 Then: prefix is extracted (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+Then: review the diff and ship via admin-merge.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"review the diff"* ]]
+}
+
+@test "tier 3.5 Next slice: prefix is extracted (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+Next slice: tighten the validate.sh lockstep checks.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tighten the validate.sh"* ]]
+}
+
+@test "tier 3.5 Next best step: prefix is extracted (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+Next best step: re-run the bats suite end-to-end.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"re-run the bats suite"* ]]
+}
+
+@test "tier 3.5 does NOT shadow section heading priority (issue #707)" {
+    cat >"$TMPDIR_T/msg" <<'EOF'
+## Next steps
+
+- fix the heading bug
+
+Next step: this should also appear but after the section.
+EOF
+    run bash "$SCRIPT" --message "$TMPDIR_T/msg"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"fix the heading bug"* ]]
+    [[ "$output" == *"this should also appear"* ]]
+}
+
 @test "empty message exits 3 with continue_no_recommendation" {
     : >"$TMPDIR_T/msg"
     run bash "$SCRIPT" --message "$TMPDIR_T/msg"

--- a/tests/refine/test_refine_loop.bats
+++ b/tests/refine/test_refine_loop.bats
@@ -197,6 +197,49 @@ EOF
     grep -q 'Final status:' "$LOOP_SUMMARY"
 }
 
+@test "tier 3.5 Next best slice: in report triggers continuation (issue #707)" {
+    cat > "$SIM_DIR/iter-1-report.md" <<'EOF'
+# autospec run summary
+
+Some prose.
+
+Next best slice: extend the harvest matchers across both trios.
+EOF
+    cat > "$SIM_DIR/iter-2-report.md" <<'EOF'
+## Next steps
+
+- (none — converged)
+EOF
+    run bash "$SCRIPT" "fix harvest" --continue --max-iterations 3 \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT" \
+        --simulate-iterations "$SIM_DIR"
+    [ "$status" -eq 0 ]
+    LOOP_JSON=$(ls "$ART_DIR"/*-loop.json | head -1)
+    # iter 1 should harvest non-empty (the next-best-slice prefix), iter 2 converges.
+    run jq -r '.iterations[0].harvested_prompt' "$LOOP_JSON"
+    [[ "$output" == *"extend the harvest matchers"* ]]
+    run jq -r '.status' "$LOOP_JSON"
+    [ "$output" = "convergence_clean" ]
+}
+
+@test "tier 3.5 chemontology fixture: Next best slice: extracts body (issue #707)" {
+    cat > "$SIM_DIR/iter-1-report.md" <<'EOF'
+Next best slice: the 2 remaining Aromatic anilides rows, but only with blockers for pyridinecarboxamide and oligopeptide rows; otherwise move to Organic acids and derivatives > Carboxylic acids and derivatives.
+EOF
+    cat > "$SIM_DIR/iter-2-report.md" <<'EOF'
+## Next steps
+
+- (none — converged)
+EOF
+    run bash "$SCRIPT" "chemont" --continue --max-iterations 3 \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT" \
+        --simulate-iterations "$SIM_DIR"
+    [ "$status" -eq 0 ]
+    LOOP_JSON=$(ls "$ART_DIR"/*-loop.json | head -1)
+    run jq -r '.iterations[0].harvested_prompt' "$LOOP_JSON"
+    [[ "$output" == *"Aromatic anilides"* ]]
+}
+
 @test "autospec trio carries canonical ## Next steps section" {
     # Lockstep guard: all three autospec trio files must document the section.
     REPO="${BATS_TEST_DIRNAME}/../.."


### PR DESCRIPTION
Closes #707

## Summary

Adds tier 3.5 continuation-prefix matchers between the existing numbered-list and you-should tiers across both `/autospec-continue` (PR #702) and `/autospec-refine --continue` (PR #678/#693) harvest paths.

Recognised prefixes (case-insensitive, sentence-start): `Next best slice:`, `Next best step:`, `Next slice:`, `Next step:`, `Next:`, `Continue with:`, `Proceed with:`, `Move on to:`, `Move to:`, `Then:`, `Up next:`, `Up next is:`, `Suggested next:`.

Each match extracts the matched line plus the following paragraph (up to next blank line or `##` heading). Existing matcher priority is preserved — section headings / fenced blocks / numbered lists still win.

## Architecture

Shared matcher library at `scripts/lib/extract-matchers.sh`, sourced by:
- `scripts/extract-conversational-recommendation.sh`
- `scripts/refine-prompt.sh::run_continue_loop()::harvest_next_prompt`

So future matcher additions land in one place.

## Lockstep

- autospec-continue trio (SKILL.md + codex/prompt.md + opencode/agent.md) — Extraction contract section updated.
- autospec-refine trio (SKILL.md + codex/prompt.md + opencode/agent.md) — Report harvest contract section updated.
- `scripts/validate.sh` — both `check_autospec_continue_contract` and `check_autospec_refine_contract` assert `scripts/lib/extract-matchers.sh` exists.

## Test plan

- [x] `bats tests/continue/test_continue_extract.bats` — 23 tests pass (13 new tier-3.5 fixtures + existing 10).
- [x] `bats tests/refine/test_refine_loop.bats` — 10 tests pass (2 new + existing 8) including chemontology fixture.
- [x] `bash scripts/validate.sh` — green end-to-end.
- [x] Real fixture: "Next best slice: the 2 remaining Aromatic anilides rows..." extracts non-empty harvested prompt.