### PR TITLE
feat: autospec-continue loops by default + --no-loop opt-out (closes #710)

### DIFF
--- a/scripts/autospec-continue.sh
+++ b/scripts/autospec-continue.sh
@@ -8,6 +8,10 @@
 #
 # Flags:
 #   --from-message <path>          Read the source assistant message from <path>.
+#   --no-loop, --once              Disable the default continuous loop and run
+#                                  exactly one extract→refine→handoff pass
+#                                  (legacy single-pass behavior). Also honored
+#                                  via ~/.autospec/continue-no-loop.flag.
 #   --skip-refine                  Bypass the refine step; hand off the
 #                                  extracted block directly to /autospec.
 #   --ask-confirm                  After (or instead of) refine, surface the
@@ -58,6 +62,10 @@ Required:
   --from-message <path>          Source assistant message file.
 
 Flags:
+  --no-loop, --once              Disable continuous loop; run a single
+                                 extract→refine→handoff pass (legacy
+                                 behavior). Also honored via
+                                 ~/.autospec/continue-no-loop.flag.
   --skip-refine                  Skip the refine step; hand off extracted
                                  block directly.
   --ask-confirm                  Gate on operator approval before handoff.
@@ -81,10 +89,12 @@ LENS_MODE=""
 HANDOFF_MODE="autonomous"
 ARTIFACT_DIR=""
 REPO_ROOT="."
+NO_LOOP=0
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --from-message)  FROM_MESSAGE="${2:-}"; shift 2 ;;
+        --no-loop|--once) NO_LOOP=1; shift ;;
         --skip-refine)   SKIP_REFINE=1; shift ;;
         --ask-confirm)   ASK_CONFIRM=1; shift ;;
         --lens-mode)     LENS_MODE="${2:-}"; shift 2 ;;
@@ -215,6 +225,33 @@ if command -v jq >/dev/null 2>&1; then
             "$NOW" "$SOURCE_HASH" "$EXTRACTED_HASH" > "$HISTORY_TMP"
     fi
     mv "$HISTORY_TMP" "$HISTORY_FILE"
+fi
+
+# ── Step 1.5: continuous loop mode (issue #710) ────────────────────
+# Default behavior: invoke the shared loop driver from
+# scripts/lib/autospec-loop.sh (#708) — extract → refine → handoff →
+# harvest → re-extract → loop until convergence/oscillation/stop/cap.
+# Opt-outs: --no-loop / --once flag, or ~/.autospec/continue-no-loop.flag.
+LOOP_FLAG_FILE="${HOME}/.autospec/continue-no-loop.flag"
+if [ -f "$LOOP_FLAG_FILE" ]; then
+    NO_LOOP=1
+fi
+
+if [ "$NO_LOOP" -eq 0 ] && declare -F autospec_loop_run >/dev/null 2>&1; then
+    # Resolve the refine-prompt.sh script path the shared driver dispatches
+    # each iteration to.
+    SCRIPT_PATH="$REFINE_SH"
+    PROMPT="$EXTRACTED"
+    ARTIFACT_DIR="${ARTIFACT_DIR:-.autospec/refinements}"
+    MEMORY_ROOT="${MEMORY_ROOT:-$REPO_ROOT/.autospec/memory}"
+    ROUNDS="${ROUNDS:-3}"
+    MAX_ITERATIONS="${AUTOSPEC_LOOP_MAX_ITERATIONS:-${MAX_ITERATIONS:-5}}"
+    TOKEN_CAP="${AUTOSPEC_LOOP_TOKEN_CAP:-2000000}"
+    TIME_CAP="${AUTOSPEC_LOOP_TIME_CAP:-21600}"
+    mkdir -p "$ARTIFACT_DIR" 2>/dev/null || true
+    echo "autospec-continue: entering continuous loop mode (--no-loop to opt out)" >&2
+    autospec_loop_run
+    exit $?
 fi
 
 # ── Step 2: refine (unless --skip-refine) ─────────────────────────

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1481,6 +1481,24 @@ check_autospec_continue_contract() {
     matcher_lib="scripts/lib/extract-matchers.sh"
     [ -f "$matcher_lib" ] || fail "$matcher_lib: file missing (issue #707)"
     bash -n "$matcher_lib" || fail "$matcher_lib: bash syntax error (issue #707)"
+    # Default-on continuous loop (issue #710): trio docs default-loop, opt-outs
+    # via --no-loop and ~/.autospec/continue-no-loop.flag; orchestrator parses
+    # both --no-loop and --once.
+    for trio in skills/autospec-continue/SKILL.md skills/autospec-continue/codex/prompt.md skills/autospec-continue/opencode/agent.md; do
+        [ -f "$trio" ] || continue
+        grep -q '^## Continuous loop mode' "$trio" \
+            || fail "$trio: missing '## Continuous loop mode' section (issue #710)"
+        grep -q -- '--no-loop' "$trio" \
+            || fail "$trio: missing --no-loop opt-out documentation (issue #710)"
+        grep -q 'continue-no-loop\.flag' "$trio" \
+            || fail "$trio: missing continue-no-loop.flag preference file (issue #710)"
+    done
+    grep -q -- '--no-loop|--once' scripts/autospec-continue.sh \
+        || fail "scripts/autospec-continue.sh: --no-loop/--once flags missing (issue #710)"
+    grep -q 'continue-no-loop\.flag' scripts/autospec-continue.sh \
+        || fail "scripts/autospec-continue.sh: continue-no-loop.flag honor missing (issue #710)"
+    grep -q 'autospec_loop_run' scripts/autospec-continue.sh \
+        || fail "scripts/autospec-continue.sh: autospec_loop_run dispatch missing (issue #710)"
     if command -v bats >/dev/null 2>&1; then
         if [ -d tests/continue ]; then
             for t in tests/continue/test_continue_*.bats; do

--- a/skills/autospec-continue/SKILL.md
+++ b/skills/autospec-continue/SKILL.md
@@ -144,12 +144,22 @@ gate in `scripts/validate.sh`.
 ## Invocation
 
 ```
-/autospec-continue [--skip-refine] [--ask-confirm] [--lens-mode deterministic|llm]
-                   [--from-message <path>]
+/autospec-continue [--no-loop|--once] [--skip-refine] [--ask-confirm]
+                   [--lens-mode deterministic|llm] [--from-message <path>]
 ```
 
 > **Model tier:** `TIER_B` for the deterministic extraction step; the downstream `/autospec-refine` call inherits `TIER_A` per its own contract.
 
+- **Default behavior (issue #710):** `/autospec-continue` runs the shared
+  continuous loop driver from `scripts/lib/autospec-loop.sh` (#708) — it
+  keeps cycling extract → refine → handoff → harvest-next → re-extract
+  until one of the six termination conditions fires (see
+  "Continuous loop mode" below). Operators who want today's single-pass
+  behavior pass `--no-loop`.
+- `--no-loop` (alias `--once`) — disable the loop; run a single
+  extract → refine → handoff pass and exit. Also honored via the operator
+  preference file `~/.autospec/continue-no-loop.flag` (same effect, no
+  flag needed per invocation).
 - `--skip-refine` — bypass `/autospec-refine`; hand the extracted prompt
   directly to `/autospec --autonomous`.
 - `--ask-confirm` — after refine but before handoff, surface the refined
@@ -159,6 +169,31 @@ gate in `scripts/validate.sh`.
 - `--from-message <path>` — read the source message from a file instead of
   the harness's "last assistant turn". Test/integration path; not the
   primary use case.
+
+## Continuous loop mode
+
+When invoked without `--no-loop` (and without `~/.autospec/continue-no-loop.flag`
+present), `/autospec-continue` invokes `autospec_loop_run` from
+`scripts/lib/autospec-loop.sh` — the same shared loop driver used by
+`/autospec --loop` (#708) and `/autospec-refine --continue` (#678). Six
+termination conditions stop the loop:
+
+1. `evidence_based_stop` — iteration report contains `STOP: <reason>`.
+2. `convergence_clean` — harvest finds no next-step content (`(none — converged)`).
+3. `oscillation_detected` — same harvested prompt hash two iterations running.
+4. `operator_stop` — `~/.autospec/stop.flag` or `~/.autospec/refine-loop-stop.flag` present.
+5. `budget_cap_reached` — `AUTOSPEC_LOOP_TOKEN_CAP` (default 2,000,000) or
+   `AUTOSPEC_LOOP_TIME_CAP` (default 21,600s) exceeded.
+6. `round_cap_reached` — `AUTOSPEC_LOOP_MAX_ITERATIONS` (default 5).
+
+**Rate limit interaction (PR #704):** the 60-second duplicate / 60-minute
+oscillation rate limit applies at the OUTER invocation level — once per
+`/autospec-continue` call, not once per inner iteration. Inner iterations
+are bounded by the round cap above.
+
+**Opt-out files:** `~/.autospec/continue-no-loop.flag` flips the default
+to single-pass for every invocation under this `$HOME`. Delete the file
+to restore loop-by-default.
 
 ## Extraction contract
 

--- a/skills/autospec-continue/codex/prompt.md
+++ b/skills/autospec-continue/codex/prompt.md
@@ -140,12 +140,22 @@ gate in `scripts/validate.sh`.
 ## Invocation
 
 ```
-/autospec-continue [--skip-refine] [--ask-confirm] [--lens-mode deterministic|llm]
-                   [--from-message <path>]
+/autospec-continue [--no-loop|--once] [--skip-refine] [--ask-confirm]
+                   [--lens-mode deterministic|llm] [--from-message <path>]
 ```
 
 > **Model tier:** `TIER_B` for the deterministic extraction step; the downstream `/autospec-refine` call inherits `TIER_A` per its own contract.
 
+- **Default behavior (issue #710):** `/autospec-continue` runs the shared
+  continuous loop driver from `scripts/lib/autospec-loop.sh` (#708) — it
+  keeps cycling extract → refine → handoff → harvest-next → re-extract
+  until one of the six termination conditions fires (see
+  "Continuous loop mode" below). Operators who want today's single-pass
+  behavior pass `--no-loop`.
+- `--no-loop` (alias `--once`) — disable the loop; run a single
+  extract → refine → handoff pass and exit. Also honored via the operator
+  preference file `~/.autospec/continue-no-loop.flag` (same effect, no
+  flag needed per invocation).
 - `--skip-refine` — bypass `/autospec-refine`; hand the extracted prompt
   directly to `/autospec --autonomous`.
 - `--ask-confirm` — after refine but before handoff, surface the refined
@@ -155,6 +165,31 @@ gate in `scripts/validate.sh`.
 - `--from-message <path>` — read the source message from a file instead of
   the harness's "last assistant turn". Test/integration path; not the
   primary use case.
+
+## Continuous loop mode
+
+When invoked without `--no-loop` (and without `~/.autospec/continue-no-loop.flag`
+present), `/autospec-continue` invokes `autospec_loop_run` from
+`scripts/lib/autospec-loop.sh` — the same shared loop driver used by
+`/autospec --loop` (#708) and `/autospec-refine --continue` (#678). Six
+termination conditions stop the loop:
+
+1. `evidence_based_stop` — iteration report contains `STOP: <reason>`.
+2. `convergence_clean` — harvest finds no next-step content (`(none — converged)`).
+3. `oscillation_detected` — same harvested prompt hash two iterations running.
+4. `operator_stop` — `~/.autospec/stop.flag` or `~/.autospec/refine-loop-stop.flag` present.
+5. `budget_cap_reached` — `AUTOSPEC_LOOP_TOKEN_CAP` (default 2,000,000) or
+   `AUTOSPEC_LOOP_TIME_CAP` (default 21,600s) exceeded.
+6. `round_cap_reached` — `AUTOSPEC_LOOP_MAX_ITERATIONS` (default 5).
+
+**Rate limit interaction (PR #704):** the 60-second duplicate / 60-minute
+oscillation rate limit applies at the OUTER invocation level — once per
+`/autospec-continue` call, not once per inner iteration. Inner iterations
+are bounded by the round cap above.
+
+**Opt-out files:** `~/.autospec/continue-no-loop.flag` flips the default
+to single-pass for every invocation under this `$HOME`. Delete the file
+to restore loop-by-default.
 
 ## Extraction contract
 

--- a/skills/autospec-continue/opencode/agent.md
+++ b/skills/autospec-continue/opencode/agent.md
@@ -144,12 +144,22 @@ gate in `scripts/validate.sh`.
 ## Invocation
 
 ```
-/autospec-continue [--skip-refine] [--ask-confirm] [--lens-mode deterministic|llm]
-                   [--from-message <path>]
+/autospec-continue [--no-loop|--once] [--skip-refine] [--ask-confirm]
+                   [--lens-mode deterministic|llm] [--from-message <path>]
 ```
 
 > **Model tier:** `TIER_B` for the deterministic extraction step; the downstream `/autospec-refine` call inherits `TIER_A` per its own contract.
 
+- **Default behavior (issue #710):** `/autospec-continue` runs the shared
+  continuous loop driver from `scripts/lib/autospec-loop.sh` (#708) — it
+  keeps cycling extract → refine → handoff → harvest-next → re-extract
+  until one of the six termination conditions fires (see
+  "Continuous loop mode" below). Operators who want today's single-pass
+  behavior pass `--no-loop`.
+- `--no-loop` (alias `--once`) — disable the loop; run a single
+  extract → refine → handoff pass and exit. Also honored via the operator
+  preference file `~/.autospec/continue-no-loop.flag` (same effect, no
+  flag needed per invocation).
 - `--skip-refine` — bypass `/autospec-refine`; hand the extracted prompt
   directly to `/autospec --autonomous`.
 - `--ask-confirm` — after refine but before handoff, surface the refined
@@ -159,6 +169,31 @@ gate in `scripts/validate.sh`.
 - `--from-message <path>` — read the source message from a file instead of
   the harness's "last assistant turn". Test/integration path; not the
   primary use case.
+
+## Continuous loop mode
+
+When invoked without `--no-loop` (and without `~/.autospec/continue-no-loop.flag`
+present), `/autospec-continue` invokes `autospec_loop_run` from
+`scripts/lib/autospec-loop.sh` — the same shared loop driver used by
+`/autospec --loop` (#708) and `/autospec-refine --continue` (#678). Six
+termination conditions stop the loop:
+
+1. `evidence_based_stop` — iteration report contains `STOP: <reason>`.
+2. `convergence_clean` — harvest finds no next-step content (`(none — converged)`).
+3. `oscillation_detected` — same harvested prompt hash two iterations running.
+4. `operator_stop` — `~/.autospec/stop.flag` or `~/.autospec/refine-loop-stop.flag` present.
+5. `budget_cap_reached` — `AUTOSPEC_LOOP_TOKEN_CAP` (default 2,000,000) or
+   `AUTOSPEC_LOOP_TIME_CAP` (default 21,600s) exceeded.
+6. `round_cap_reached` — `AUTOSPEC_LOOP_MAX_ITERATIONS` (default 5).
+
+**Rate limit interaction (PR #704):** the 60-second duplicate / 60-minute
+oscillation rate limit applies at the OUTER invocation level — once per
+`/autospec-continue` call, not once per inner iteration. Inner iterations
+are bounded by the round cap above.
+
+**Opt-out files:** `~/.autospec/continue-no-loop.flag` flips the default
+to single-pass for every invocation under this `$HOME`. Delete the file
+to restore loop-by-default.
 
 ## Extraction contract
 

--- a/tests/continue/test_continue_handoff.bats
+++ b/tests/continue/test_continue_handoff.bats
@@ -64,8 +64,8 @@ teardown() {
     rm -rf "$WORK"
 }
 
-@test "--skip-refine routes directly to autospec without going through refine" {
-    run bash "$SCRIPT" --from-message "$MSG" --skip-refine
+@test "--no-loop --skip-refine routes directly to autospec without going through refine" {
+    run bash "$SCRIPT" --from-message "$MSG" --no-loop --skip-refine
     [ "$status" -eq 0 ]
     # Stub got invoked.
     [ -f "$STUB_LOG" ]
@@ -87,13 +87,13 @@ teardown() {
 }
 
 @test "--ask-confirm with operator 'proceed' completes handoff" {
-    run bash -c "printf 'proceed\n' | '$SCRIPT' --from-message '$MSG' --skip-refine --ask-confirm"
+    run bash -c "printf 'proceed\n' | '$SCRIPT' --from-message '$MSG' --no-loop --skip-refine --ask-confirm"
     [ "$status" -eq 0 ]
     grep -q '^STUB_CLAUDE\|^STUB_AUTOSPEC' "$STUB_LOG"
 }
 
 @test "--ask-confirm with operator 'cancel' aborts before handoff" {
-    run bash -c "printf 'cancel\n' | '$SCRIPT' --from-message '$MSG' --skip-refine --ask-confirm"
+    run bash -c "printf 'cancel\n' | '$SCRIPT' --from-message '$MSG' --no-loop --skip-refine --ask-confirm"
     # Cancel exits non-zero (3) and no stub call recorded.
     [ "$status" -eq 3 ]
     [ ! -s "$STUB_LOG" ] || ! grep -q '^STUB_' "$STUB_LOG"
@@ -101,7 +101,7 @@ teardown() {
 
 @test "--from-message reads from the file path end-to-end" {
     # Confirms the file-source path works without any extra plumbing.
-    run bash "$SCRIPT" --from-message "$MSG" --skip-refine
+    run bash "$SCRIPT" --from-message "$MSG" --no-loop --skip-refine
     [ "$status" -eq 0 ]
     # The extracted recommendation must have been forwarded to the dispatcher.
     # Stubs log the full argv joined by '|'; assert the keyword "orchestrator"
@@ -110,6 +110,6 @@ teardown() {
 }
 
 @test "--from-message rejects a missing file with exit 2" {
-    run bash "$SCRIPT" --from-message "$WORK/does-not-exist.md" --skip-refine
+    run bash "$SCRIPT" --from-message "$WORK/does-not-exist.md" --no-loop --skip-refine
     [ "$status" -eq 2 ]
 }

--- a/tests/continue/test_continue_loop.bats
+++ b/tests/continue/test_continue_loop.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# tests/continue/test_continue_loop.bats — issue #710.
+#
+# Default-on continuous loop behavior for /autospec-continue. The default
+# invocation runs the shared loop driver (scripts/lib/autospec-loop.sh, #708)
+# until convergence; --no-loop / --once and ~/.autospec/continue-no-loop.flag
+# bypass the loop and restore today's single-pass behavior.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/autospec-continue.sh"
+    WORK="$(mktemp -d -t autospec-continue-loop.XXXXXX)"
+    STUB_BIN="$WORK/bin"
+    mkdir -p "$STUB_BIN"
+    STUB_LOG="$WORK/stub.log"
+    export STUB_LOG
+
+    # `claude` stub — logs argv (one line per call), exits 0.
+    cat > "$STUB_BIN/claude" <<'EOF'
+#!/usr/bin/env bash
+{
+    printf 'STUB_CLAUDE'
+    for a in "$@"; do printf '|%s' "$a"; done
+    printf '\n'
+} >> "$STUB_LOG"
+exit 0
+EOF
+    chmod +x "$STUB_BIN/claude"
+
+    export HOME="$WORK"
+    export AUTOSPEC_CONTINUE_HISTORY="$WORK/continue-history.json"
+    export AUTOSPEC_HANDOFF_DISPATCHER=1
+    export PATH="$STUB_BIN:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"
+
+    MSG="$WORK/msg.md"
+    cat > "$MSG" <<'EOF'
+Some prose.
+
+## Next steps
+- Ship the loop default-on change.
+EOF
+}
+
+teardown() {
+    rm -rf "$WORK"
+}
+
+@test "--no-loop runs exactly once (single-pass legacy behavior)" {
+    run bash "$SCRIPT" --from-message "$MSG" --skip-refine --no-loop
+    [ "$status" -eq 0 ]
+    # Exactly one handoff invocation.
+    n=$(grep -c '^STUB_CLAUDE' "$STUB_LOG" 2>/dev/null || echo 0)
+    [ "$n" -eq 1 ]
+}
+
+@test "--once is an alias for --no-loop" {
+    run bash "$SCRIPT" --from-message "$MSG" --skip-refine --once
+    [ "$status" -eq 0 ]
+    n=$(grep -c '^STUB_CLAUDE' "$STUB_LOG" 2>/dev/null || echo 0)
+    [ "$n" -eq 1 ]
+}
+
+@test "~/.autospec/continue-no-loop.flag forces single-pass" {
+    mkdir -p "$HOME/.autospec"
+    : > "$HOME/.autospec/continue-no-loop.flag"
+    run bash "$SCRIPT" --from-message "$MSG" --skip-refine
+    [ "$status" -eq 0 ]
+    n=$(grep -c '^STUB_CLAUDE' "$STUB_LOG" 2>/dev/null || echo 0)
+    [ "$n" -eq 1 ]
+}
+
+@test "default invocation enters loop mode (announces loop on stderr)" {
+    # Force the loop to converge on iteration 1 by setting MAX_ITERATIONS=1
+    # via the env var the shared driver consumes. The dispatcher stub returns
+    # 0 immediately, so the loop terminates at the round cap after 1 pass.
+    export AUTOSPEC_LOOP_MAX_ITERATIONS=1
+    run bash "$SCRIPT" --from-message "$MSG" --skip-refine
+    [ "$status" -eq 0 ]
+    # The loop announces itself on stderr.
+    [[ "$output" == *"loop"* ]] || [[ "$output" == *"continuous"* ]] || [[ "$output" == *"iteration"* ]]
+}
+
+@test "--help mentions --no-loop opt-out" {
+    run bash "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--no-loop"* ]]
+}

--- a/tests/continue/test_continue_rate_limit.bats
+++ b/tests/continue/test_continue_rate_limit.bats
@@ -52,23 +52,23 @@ teardown() {
 
 @test "duplicate source message within 60s exits 3 with continue_recent_duplicate" {
     export AUTOSPEC_CONTINUE_NOW=1000
-    run bash "$SCRIPT" --from-message "$MSG" --skip-refine
+    run bash "$SCRIPT" --from-message "$MSG" --no-loop --skip-refine
     [ "$status" -eq 0 ]
 
     # Second run at +10s (within 60s window) — must reject.
     export AUTOSPEC_CONTINUE_NOW=1010
-    run bash "$SCRIPT" --from-message "$MSG" --skip-refine
+    run bash "$SCRIPT" --from-message "$MSG" --no-loop --skip-refine
     [ "$status" -eq 3 ]
     [[ "$output" == *"code_health:continue_recent_duplicate"* ]]
 }
 
 @test "duplicate source message after 60s window is allowed" {
     export AUTOSPEC_CONTINUE_NOW=1000
-    run bash "$SCRIPT" --from-message "$MSG" --skip-refine
+    run bash "$SCRIPT" --from-message "$MSG" --no-loop --skip-refine
     [ "$status" -eq 0 ]
 
     export AUTOSPEC_CONTINUE_NOW=1100   # +100s, outside window
-    run bash "$SCRIPT" --from-message "$MSG" --skip-refine
+    run bash "$SCRIPT" --from-message "$MSG" --no-loop --skip-refine
     [ "$status" -eq 0 ]
 }
 
@@ -83,21 +83,21 @@ teardown() {
     printf 'preamble C\n\n%s' "$common" > "$M3"
 
     export AUTOSPEC_CONTINUE_NOW=1000
-    run bash "$SCRIPT" --from-message "$M1" --skip-refine
+    run bash "$SCRIPT" --from-message "$M1" --no-loop --skip-refine
     [ "$status" -eq 0 ]
     export AUTOSPEC_CONTINUE_NOW=2000
-    run bash "$SCRIPT" --from-message "$M2" --skip-refine
+    run bash "$SCRIPT" --from-message "$M2" --no-loop --skip-refine
     [ "$status" -eq 0 ]
     # Third occurrence within 60min window of first — must trip oscillation.
     export AUTOSPEC_CONTINUE_NOW=3000
-    run bash "$SCRIPT" --from-message "$M3" --skip-refine
+    run bash "$SCRIPT" --from-message "$M3" --no-loop --skip-refine
     [ "$status" -eq 3 ]
     [[ "$output" == *"code_health:continue_oscillation"* ]]
 }
 
 @test "state file is deletable to reset rate limits" {
     export AUTOSPEC_CONTINUE_NOW=1000
-    run bash "$SCRIPT" --from-message "$MSG" --skip-refine
+    run bash "$SCRIPT" --from-message "$MSG" --no-loop --skip-refine
     [ "$status" -eq 0 ]
     [ -f "$AUTOSPEC_CONTINUE_HISTORY" ]
 
@@ -105,7 +105,7 @@ teardown() {
     [ ! -f "$AUTOSPEC_CONTINUE_HISTORY" ]
 
     export AUTOSPEC_CONTINUE_NOW=1010  # Would have tripped duplicate, but state was reset.
-    run bash "$SCRIPT" --from-message "$MSG" --skip-refine
+    run bash "$SCRIPT" --from-message "$MSG" --no-loop --skip-refine
     [ "$status" -eq 0 ]
 }
 
@@ -118,7 +118,7 @@ some prose
 ## Next steps
 - $SECRET
 EOF
-    run bash "$SCRIPT" --from-message "$MSG" --skip-refine
+    run bash "$SCRIPT" --from-message "$MSG" --no-loop --skip-refine
     [ "$status" -eq 0 ]
     [ -f "$AUTOSPEC_CONTINUE_HISTORY" ]
 


### PR DESCRIPTION
Closes #710

## Summary
- Flip `/autospec-continue` default to loop-on; invoke shared `autospec_loop_run` from `scripts/lib/autospec-loop.sh` (#708) after extraction.
- New `--no-loop` (alias `--once`) flag and `~/.autospec/continue-no-loop.flag` opt-out restore today's single-pass behavior.
- Autospec-continue trio (SKILL.md + codex/prompt.md + opencode/agent.md) lockstep with new `## Continuous loop mode` section enumerating six termination conditions.
- `check_autospec_continue_contract()` extended to enforce default-on docs + opt-out flag presence.
- Existing `tests/continue/test_continue_handoff.bats` + `test_continue_rate_limit.bats` get `--no-loop` to preserve single-pass semantics; new `test_continue_loop.bats` covers loop default + opt-outs.

## Test plan
- [x] `bash scripts/validate.sh` — all checks pass.
- [x] `bats tests/continue/` — 46/46 pass (28 prior + 5 new loop + matchers).