### PR TITLE
feat: autospec-explore skill scaffold + sandbox branch management (closes #717)

### DIFF
--- a/scripts/explore-sandbox.sh
+++ b/scripts/explore-sandbox.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# scripts/explore-sandbox.sh — create or reuse the autospec-explore sandbox branch.
+#
+# Creates `autospec/explore/<YYYY-MM-DD>-<slug>` off `origin/<base>` if not
+# present, pushes the branch to `origin`, and writes `.autospec/explore-mode.json`
+# with `{branch, slug, base, head_sha, created_at}`.
+#
+# Idempotent: re-invocation with the same `--slug` reuses the existing sandbox
+# branch — no error, no duplicate, no force-push. The script verifies the existing
+# branch's recorded base matches `--base`; mismatch exits 3 with
+# `code_health:explore_sandbox_base_mismatch`.
+#
+# Usage:
+#   scripts/explore-sandbox.sh [--slug <slug>] [--base <branch>] [--dry-run]
+#
+# Defaults:
+#   --slug   ISO-date + 6-char random suffix
+#   --base   main
+
+set -euo pipefail
+
+SLUG=""
+BASE="main"
+DRY_RUN=0
+
+usage() {
+    cat <<EOF
+Usage: $0 [--slug <slug>] [--base <branch>] [--dry-run]
+
+Creates or reuses an autospec-explore sandbox branch off origin/<base>,
+pushes it, and writes .autospec/explore-mode.json.
+
+Idempotent: re-invocation with the same slug reuses the existing branch.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --slug)        shift; SLUG="${1:-}" ;;
+        --slug=*)      SLUG="${1#--slug=}" ;;
+        --base)        shift; BASE="${1:-main}" ;;
+        --base=*)      BASE="${1#--base=}" ;;
+        --dry-run)     DRY_RUN=1 ;;
+        -h|--help)     usage; exit 0 ;;
+        *) printf 'error: unknown arg: %s\n' "$1" >&2; usage; exit 2 ;;
+    esac
+    shift
+done
+
+DATE_PREFIX="$(date -u +%Y-%m-%d)"
+
+if [ -z "$SLUG" ]; then
+    RAND="$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom 2>/dev/null | head -c 6 || echo "$$$(date +%s)" | tr -dc 'a-z0-9' | head -c 6)"
+    SLUG="auto-${RAND}"
+fi
+
+BRANCH="autospec/explore/${DATE_PREFIX}-${SLUG}"
+MODE_FILE=".autospec/explore-mode.json"
+CREATED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+info() { printf '%s\n' "$*"; }
+err()  { printf 'error: %s\n' "$*" >&2; }
+
+# Repo sanity
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+    err "not inside a git repository"
+    exit 2
+fi
+
+# Fetch the base so we can branch off the remote tip
+run "git fetch origin \"$BASE\" --quiet || true"
+
+# Idempotency check: if .autospec/explore-mode.json already records this slug,
+# verify the base matches and just refresh head_sha.
+if [ -f "$MODE_FILE" ]; then
+    EXISTING_SLUG="$(grep -o '"slug"[[:space:]]*:[[:space:]]*"[^"]*"' "$MODE_FILE" | sed 's/.*"slug"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+    EXISTING_BASE="$(grep -o '"base"[[:space:]]*:[[:space:]]*"[^"]*"' "$MODE_FILE" | sed 's/.*"base"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+    if [ "$EXISTING_SLUG" = "$SLUG" ] && [ -n "$EXISTING_BASE" ] && [ "$EXISTING_BASE" != "$BASE" ]; then
+        err "code_health:explore_sandbox_base_mismatch — slug=$SLUG existing base=$EXISTING_BASE requested base=$BASE"
+        exit 3
+    fi
+fi
+
+# Does the branch already exist locally or on origin?
+BRANCH_EXISTS_LOCAL=0
+BRANCH_EXISTS_REMOTE=0
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then BRANCH_EXISTS_LOCAL=1; fi
+if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then BRANCH_EXISTS_REMOTE=1; fi
+
+if [ "$BRANCH_EXISTS_LOCAL" -eq 1 ] || [ "$BRANCH_EXISTS_REMOTE" -eq 1 ]; then
+    info "sandbox branch already exists: $BRANCH (reusing — idempotent)"
+    if [ "$BRANCH_EXISTS_LOCAL" -eq 0 ] && [ "$BRANCH_EXISTS_REMOTE" -eq 1 ]; then
+        run "git fetch origin \"$BRANCH:$BRANCH\" --quiet"
+    fi
+else
+    info "creating sandbox branch: $BRANCH off origin/$BASE"
+    run "git branch \"$BRANCH\" \"origin/$BASE\""
+    run "git push -u origin \"$BRANCH\""
+fi
+
+# Capture the head SHA of the sandbox branch (post-create or pre-existing).
+if [ "$DRY_RUN" -eq 1 ]; then
+    HEAD_SHA="dryrun0000000000000000000000000000000000"
+else
+    HEAD_SHA="$(git rev-parse "$BRANCH")"
+fi
+
+# Write .autospec/explore-mode.json
+run "mkdir -p .autospec"
+JSON_PAYLOAD=$(printf '{\n  "branch": "%s",\n  "slug": "%s",\n  "base": "%s",\n  "head_sha": "%s",\n  "created_at": "%s"\n}\n' \
+    "$BRANCH" "$SLUG" "$BASE" "$HEAD_SHA" "$CREATED_AT")
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  [dry-run] write %s:\n%s\n' "$MODE_FILE" "$JSON_PAYLOAD"
+else
+    printf '%s' "$JSON_PAYLOAD" > "$MODE_FILE"
+    info "wrote $MODE_FILE"
+fi
+
+info ""
+info "Sandbox ready:"
+info "  branch:   $BRANCH"
+info "  base:     $BASE"
+info "  head_sha: $HEAD_SHA"
+info ""
+info "All PRs from /autospec-explore will target this branch — main is never written to directly."
+
+exit 0

--- a/skills/autospec-explore/README.md
+++ b/skills/autospec-explore/README.md
@@ -1,0 +1,105 @@
+# autospec-explore
+
+Perpetual autonomous research + ship loop on an isolated sandbox branch.
+`/autospec-explore "<initial prompt>"` creates `autospec/explore/<date>-<slug>` off
+`origin/main`, runs 6 parallel researchers each round (spec-vs-code, prior reports,
+codebase signals, open issues, source analysis, internet), files 1-5 auto-implement
+issues per round, drains them via `/autospec-run` with PRs targeting the sandbox,
+and continues until the operator stops it.
+
+The point: any time you want the model to keep proposing + shipping autonomously
+without writing to `main`, type `/autospec-explore "<your seed prompt>"`. When the
+sandbox looks good, merge it; if it looks bad, discard the branch — `main` is never
+touched directly.
+
+Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
+
+## Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-explore/install.sh | sh -s -- --harness all
+```
+
+Per-harness:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-explore/install.sh | sh -s -- --harness claude
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-explore/install.sh | sh -s -- --harness opencode
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-explore/install.sh | sh -s -- --harness codex
+```
+
+From a clone:
+
+```bash
+cd skills/autospec-explore
+./install.sh --harness all
+```
+
+## Invocation
+
+```
+/autospec-explore "<initial prompt>" \
+    [--max-iterations N] \
+    [--max-issues-per-round N] \
+    [--budget-tokens N] \
+    [--budget-hours N] \
+    [--sandbox-slug <slug>] \
+    [--research-sources <comma-list>] \
+    [--no-internet] \
+    [--internet-allowlist <comma-list>]
+```
+
+## Sandbox branch contract
+
+- At run start, `scripts/explore-sandbox.sh --slug <slug>` creates
+  `autospec/explore/<YYYY-MM-DD>-<slug>` off `origin/main`, pushes it, and writes
+  `.autospec/explore-mode.json` with `{branch, slug, base, head_sha, created_at}`.
+- **Idempotent**: re-invocation with the same slug reuses the existing branch.
+- All child-issue PRs target the sandbox branch, not `main` (enforced by the
+  Phase 4 implementer integration).
+- Operator merges or discards the sandbox manually.
+
+## Safety
+
+- **Sandbox isolation** — no PR ever targets `main` while
+  `.autospec/explore-mode.json` is present.
+- **Internet researcher hardening** — domain allowlist, prompt-injection guard,
+  rate limit (max 5 fetches/round, 30/session), content sanitization.
+- **Operator stop** — `~/.autospec/explore-stop.flag` or `~/.autospec/stop.flag`
+  halts the loop at the next iteration boundary.
+
+## Related skills
+
+| Skill | Purpose |
+| --- | --- |
+| [`autospec`](../autospec/README.md) | Full pipeline (Phases 0–6) for plan + ship. |
+| [`autospec-refine`](../autospec-refine/README.md) | N-round prompt refinement. |
+| [`autospec-run`](../autospec-run/README.md) | Implementation half; honors sandbox base branch. |
+| [`autospec-continue`](../autospec-continue/README.md) | Continuation loop driver — sibling skill. |
+
+## Self-update
+
+Run the skill with the literal argument `update` to refresh in place:
+
+```
+/autospec-explore update
+```
+
+Or re-run the installer with `--update`:
+
+```bash
+./install.sh --harness all --update
+```
+
+## Stop
+
+Halt a running explore loop:
+
+```
+/autospec-explore stop --graceful   # finish current iteration, then exit
+/autospec-explore stop --immediate  # abort at next iteration boundary
+```
+
+## License
+
+MIT — see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autospec-explore/SKILL.md
+++ b/skills/autospec-explore/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: autospec-explore
+description: Use when the user wants /autospec-explore to start a perpetual autonomous research + ship loop on an isolated sandbox branch — 6 researchers propose features from spec/code gaps, prior reports, codebase signals, open issues, repo source analysis, and competitor research, then drain via /autospec-run with PRs targeting the sandbox branch (never main).
+---
+
+# autospec-explore workflow (harness-neutral)
+
+Start a perpetual autonomous research + ship loop. `/autospec-explore "<initial prompt>"`
+creates an isolated sandbox branch (`autospec/explore/<date>-<slug>`) off `origin/main`,
+runs 6 parallel researchers each round (spec-vs-code, prior reports, codebase signals,
+open issues, source analysis, internet), files 1-5 auto-implement issues per round,
+drains them via `/autospec-run` with PRs targeting the sandbox, and continues until
+the operator stops it. The operator inspects the sandbox when ready and either merges
+into `main` or discards.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your
+harness supports it; do not run researchers or aggregate proposals directly in the
+main conversation when a subagent can do it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-explore   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-refine / autospec-continue / autospec-explore
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-explore/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-explore.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-explore.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter the explore pipeline. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-explore found; run install.sh first.` and exit.
+
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$` (case-insensitive), this skill enters stop mode and does not run the normal pipeline:
+
+1. Delegate to the shared stop helper:
+   ```bash
+   bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"
+   ```
+2. Honor `--graceful` (write `~/.autospec/stop.flag` and `~/.autospec/explore-stop.flag`; running iteration finishes) and `--immediate` (also write `~/.autospec/refine-loop-stop.flag`; abort at next iteration boundary).
+3. Print the stop summary and exit. Do not enter the explore pipeline.
+
+## Required capabilities & harness adapter
+
+This workflow assumes six capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — recognized by Claude Code, OpenCode, and Codex. Per AGENTS.md, subagent dispatches use the two-tier policy: Tier A for research aggregation and proposal ranking, Tier B for individual deterministic researchers and downstream implementer dispatches (inherited from `/autospec-run`).
+
+## Harness detection (run once at skill start, before sandbox creation)
+
+Detect your harness by checking available tools before any sandbox or research step runs:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness, silently retry the same subagent dispatch with `TIER_A`. Preserve parent context on retry. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
+## Architecture
+
+```
+/autospec-explore "<prompt>"
+        │
+        ▼
+   create sandbox branch
+   autospec/explore/<date>-<slug> off origin/main
+        │
+        ▼
+   ┌──────────────────────────────────────────┐
+   │  perpetual loop (single iteration shown) │
+   │                                          │
+   │  1. research cycle:                      │
+   │     - 6 researchers run in parallel      │
+   │     - aggregate proposals, dedup, rank   │
+   │  2. file 1-5 auto-implement issues       │
+   │     (max per round, configurable)        │
+   │  3. drain via /autospec-run              │
+   │     - implementer PRs target SANDBOX,    │
+   │       not main                           │
+   │  4. update .autospec/explore-summary.md  │
+   │  5. check termination:                   │
+   │     - operator stop flag                 │
+   │     - round cap / time cap / token cap   │
+   │     - usage-limit supervisor arms        │
+   │  6. loop                                  │
+   └──────────────────────────────────────────┘
+        │
+        ▼ (operator decides)
+   git merge autospec/explore/<date>-<slug> → main
+        │
+   OR discard: gh branch -D
+```
+
+Skill family layout (mirrors existing autospec-refine / autospec-continue):
+
+- `skills/autospec-explore/SKILL.md` — Claude Code adapter (authoritative).
+- `skills/autospec-explore/codex/prompt.md` — Codex CLI mirror (lockstep).
+- `skills/autospec-explore/opencode/agent.md` — OpenCode mirror (lockstep).
+- `skills/autospec-explore/install.sh`, `uninstall.sh`, `README.md`.
+- `scripts/autospec-explore.sh` — orchestrator. **Stubbed by Issue E.**
+- `scripts/explore-sandbox.sh` — sandbox branch creation + `.autospec/explore-mode.json`.
+- `scripts/explore-research-cycle.sh` — runs all researchers, aggregates. **Stubbed by Issue C.**
+- `scripts/explore-research/` (subdir) — one researcher per source. **Stubbed by Issues C+D.**
+
+This SKILL.md is the scaffold contract. Subsequent child issues fill in the
+implementer PR-base integration (B), researchers (C+D), the orchestrator + loop
+integration (E), and the `check_autospec_explore_contract` gate in `scripts/validate.sh` (E).
+
+## Invocation
+
+```
+/autospec-explore "<initial prompt>" \
+    [--max-iterations N] \
+    [--max-issues-per-round N] \
+    [--budget-tokens N] \
+    [--budget-hours N] \
+    [--sandbox-slug <slug>] \
+    [--research-sources <comma-list>] \
+    [--no-internet] \
+    [--internet-allowlist <comma-list>]
+```
+
+> **Model tier:** `TIER_A` for the aggregator + proposal ranker; `TIER_B` for the
+> deterministic researchers and downstream implementer dispatches (inherited from
+> `/autospec-run`).
+
+- `--max-iterations N` — outer loop round cap. Default unlimited.
+- `--max-issues-per-round N` — research output cap. Default 5.
+- `--budget-tokens N` — token budget across all iterations. Default 10M.
+- `--budget-hours N` — wall-time budget. Default 24h.
+- `--sandbox-slug <slug>` — override sandbox branch slug.
+- `--research-sources <list>` — limit to a comma-separated subset of the
+  6 researcher names. Default: all 6.
+- `--no-internet` — disable internet research (the most expensive +
+  highest-risk source).
+- `--internet-allowlist <list>` — comma-separated domains the internet
+  researcher is permitted to fetch. Default: a curated list of
+  competitor-research-appropriate domains (GitHub, official product
+  docs, HackerNews, etc.). Forbidden by default: paywalled content,
+  social media, pastebin-class sites.
+
+## Sandbox branch contract
+
+1. **Creation**: at run start, the orchestrator invokes
+   `scripts/explore-sandbox.sh --slug <slug> --base main` which creates
+   `autospec/explore/<YYYY-MM-DD>-<slug>` off `origin/main` (or the supplied
+   `--base`) if not already present, pushes the branch to `origin`, and writes
+   `.autospec/explore-mode.json` with `{branch, slug, base, head_sha, created_at}`.
+   The branch lives until the operator merges or deletes it.
+2. **Idempotency**: re-invocation with the same `--slug` reuses the existing
+   sandbox branch — no error, no duplicate, no force-push. The script verifies
+   the existing branch tracks the expected base via `git merge-base` and
+   refreshes `.autospec/explore-mode.json` with the current head SHA.
+3. **Implementer integration**: every child-issue implementer reads
+   `.autospec/explore-mode.json` (written by the sandbox script) to learn the
+   sandbox branch name. PRs target `--base <sandbox-branch>` instead of
+   `main`. This is enforced by extending the Phase 4 implementer prompt
+   template (`skills/autospec-run/prompts/phase4-implementer.md`) in Issue B.
+4. **No accidental main merges**: orchestrator refuses to invoke
+   `gh pr merge` against `main` while `.autospec/explore-mode.json` is
+   present. The sandbox → main merge is a separate explicit operator
+   action (`/autospec-explore-promote <sandbox-branch>` — out of scope
+   for v1; documented as the manual path).
+5. **Sandbox refresh policy**: the sandbox branch is NOT auto-rebased onto
+   main. Operator does that explicitly. This is intentional — rebasing
+   under autonomous shipping is unsafe.
+
+## Research cycle contract
+
+Each round runs the 6 researchers (or the operator-specified subset) in
+parallel. Each researcher returns 0-N proposals as JSON:
+
+```json
+{
+  "source": "spec-vs-code",
+  "proposals": [
+    {
+      "title": "feat: implement <X> from spec docs/specs/<Y>.md",
+      "evidence": "Acceptance criterion 3 in <Y>:42 has no implementation",
+      "estimated_complexity": "small|medium|large",
+      "confidence": 0.85
+    }
+  ]
+}
+```
+
+Aggregation:
+
+1. **Deduplication**: by normalized title (lowercased, action verb +
+   subject), drop duplicates across researchers.
+2. **Ranking**: weighted score = `confidence × source_weight ×
+   1/estimated_complexity`. Default source weights:
+   - `spec-vs-code` = 1.0 (highest — spec drift is concrete and grounded)
+   - `prior-reports` = 0.9 (operator-derived priorities)
+   - `codebase-signals` = 0.7
+   - `open-issues` = 0.6
+   - `source-analysis` = 0.5
+   - `internet` = 0.4 (lowest — least grounded)
+3. **Filtering**: drop proposals that match recently-filed issue titles
+   (last 7 days) to prevent oscillation.
+4. **Cap**: top `--max-issues-per-round` proposals become issues.
+
+Each researcher is a separate script and can be enabled/disabled via
+`--research-sources`. **Stubbed by Issue C; the JSON contract is the
+authoritative interface between researchers and the aggregator.**
+
+## Loop driver integration
+
+The outer loop uses `scripts/lib/autospec-loop.sh` from PR #712 with
+explore-specific callbacks (wired in Issue E):
+
+- **per-iteration callback**: `scripts/explore-research-cycle.sh` (file
+  issues for top N proposals).
+- **drain callback**: invoke `/autospec-run` (which honors sandbox base
+  branch via the Issue B integration).
+- **termination conditions**: inherited from #712 + new
+  `operator_stop` checks `~/.autospec/explore-stop.flag` AND
+  `~/.autospec/stop.flag`. No convergence-stop (explore is meant to keep
+  generating until operator says enough).
+
+## Usage-limit recovery
+
+Inherits `scripts/autospec-usage-limit.sh` (already wired for autospec-run
+per existing skill prose). When the harness reports a deterministic
+quota pause, the orchestrator arms the supervisor with the resume command
+(the same `/autospec-explore` invocation + the sandbox branch context recovered
+from `.autospec/explore-mode.json`) and exits. The supervisor relaunches after
+reset.
+
+## Loop summary
+
+`.autospec/explore-summary.md` (markdown, human-readable) +
+`.autospec/explore-loop.json` (machine-readable per-iteration log).
+Structurally identical to the loop summaries from `/autospec --loop`,
+`/autospec-continue`, `/autospec-qa --heal` (all four share the shape from
+PR #712).
+
+Markdown shape:
+
+```
+## /autospec-explore — sandbox autospec/explore/<date>-<slug>
+
+| Round | Researchers run | Proposals | Issues filed | PRs merged | Time | Status |
+|---|---|---|---|---|---|---|
+| 1 | 6/6 | 17 (deduped to 12) | 5 | 5 | 28m | round_complete |
+| 2 | 6/6 | 14 (deduped to 9) | 4 | 4 | 22m | round_complete |
+| 3 | 6/6 | 8 (deduped to 6) | 5 | 3 + 2 in flight | 31m | operator_stop |
+
+Final status: operator_stop after 3 rounds, 14 PRs merged on sandbox.
+
+To merge sandbox into main:
+  git checkout main && git merge autospec/explore/2026-05-29-X
+
+To discard:
+  git branch -D autospec/explore/2026-05-29-X && \
+    git push origin --delete autospec/explore/2026-05-29-X
+```
+
+## Error handling
+
+- **Researcher fails** (e.g., gh API error, LLM timeout) → that researcher
+  contributes 0 proposals, loop continues with the others. Logged.
+- **All researchers fail** → round produces no proposals → loop emits
+  `code_health:explore_all_researchers_failed` and pauses for operator.
+- **Issue-creation fails** → retry once, then skip that proposal.
+- **/autospec-run fails** → record failure, continue loop with reduced
+  rate (next round delayed by 5 min) to avoid hammering on a broken
+  state.
+- **Sandbox branch deleted out from under the loop** → orchestrator
+  detects via `git rev-parse --verify` before each iteration. Missing →
+  exit with `code_health:explore_sandbox_missing` and operator-recovery
+  instructions.
+- **Sandbox script idempotency violation** — if `explore-sandbox.sh` is
+  re-invoked with the same slug but a divergent base, exit 3 with
+  `code_health:explore_sandbox_base_mismatch` and refuse to overwrite.
+
+## Testing
+
+- `tests/explore/test_explore_sandbox.bats` — sandbox creation/management,
+  idempotency, no accidental main writes, `.autospec/explore-mode.json`
+  schema.
+- `tests/explore/test_explore_researchers.bats` — each of the 6
+  researchers produces well-formed JSON proposals from fixture inputs.
+  **Stubbed by Issues C+D.**
+- `tests/explore/test_explore_research_cycle.bats` — aggregation,
+  dedup, ranking, capping. **Stubbed by Issue C.**
+- `tests/explore/test_explore_loop.bats` — outer loop integration with
+  shared driver; termination conditions reachable. **Stubbed by Issue E.**
+- `tests/explore/test_explore_internet_safety.bats` — domain allowlist,
+  prompt-injection guard, rate limit, content sanitization.
+  **Stubbed by Issue D.**
+
+### Primary smoke test
+
+```
+bash scripts/validate.sh
+bash scripts/explore-sandbox.sh --slug smoke-test
+```

--- a/skills/autospec-explore/codex/prompt.md
+++ b/skills/autospec-explore/codex/prompt.md
@@ -1,0 +1,363 @@
+
+# autospec-explore workflow (harness-neutral)
+
+Start a perpetual autonomous research + ship loop. `/autospec-explore "<initial prompt>"`
+creates an isolated sandbox branch (`autospec/explore/<date>-<slug>`) off `origin/main`,
+runs 6 parallel researchers each round (spec-vs-code, prior reports, codebase signals,
+open issues, source analysis, internet), files 1-5 auto-implement issues per round,
+drains them via `/autospec-run` with PRs targeting the sandbox, and continues until
+the operator stops it. The operator inspects the sandbox when ready and either merges
+into `main` or discards.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your
+harness supports it; do not run researchers or aggregate proposals directly in the
+main conversation when a subagent can do it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-explore   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-refine / autospec-continue / autospec-explore
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-explore/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-explore.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-explore.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter the explore pipeline. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-explore found; run install.sh first.` and exit.
+
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$` (case-insensitive), this skill enters stop mode and does not run the normal pipeline:
+
+1. Delegate to the shared stop helper:
+   ```bash
+   bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"
+   ```
+2. Honor `--graceful` (write `~/.autospec/stop.flag` and `~/.autospec/explore-stop.flag`; running iteration finishes) and `--immediate` (also write `~/.autospec/refine-loop-stop.flag`; abort at next iteration boundary).
+3. Print the stop summary and exit. Do not enter the explore pipeline.
+
+## Required capabilities & harness adapter
+
+This workflow assumes six capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — recognized by Claude Code, OpenCode, and Codex. Per AGENTS.md, subagent dispatches use the two-tier policy: Tier A for research aggregation and proposal ranking, Tier B for individual deterministic researchers and downstream implementer dispatches (inherited from `/autospec-run`).
+
+## Harness detection (run once at skill start, before sandbox creation)
+
+Detect your harness by checking available tools before any sandbox or research step runs:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness, silently retry the same subagent dispatch with `TIER_A`. Preserve parent context on retry. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
+## Architecture
+
+```
+/autospec-explore "<prompt>"
+        │
+        ▼
+   create sandbox branch
+   autospec/explore/<date>-<slug> off origin/main
+        │
+        ▼
+   ┌──────────────────────────────────────────┐
+   │  perpetual loop (single iteration shown) │
+   │                                          │
+   │  1. research cycle:                      │
+   │     - 6 researchers run in parallel      │
+   │     - aggregate proposals, dedup, rank   │
+   │  2. file 1-5 auto-implement issues       │
+   │     (max per round, configurable)        │
+   │  3. drain via /autospec-run              │
+   │     - implementer PRs target SANDBOX,    │
+   │       not main                           │
+   │  4. update .autospec/explore-summary.md  │
+   │  5. check termination:                   │
+   │     - operator stop flag                 │
+   │     - round cap / time cap / token cap   │
+   │     - usage-limit supervisor arms        │
+   │  6. loop                                  │
+   └──────────────────────────────────────────┘
+        │
+        ▼ (operator decides)
+   git merge autospec/explore/<date>-<slug> → main
+        │
+   OR discard: gh branch -D
+```
+
+Skill family layout (mirrors existing autospec-refine / autospec-continue):
+
+- `skills/autospec-explore/SKILL.md` — Claude Code adapter (authoritative).
+- `skills/autospec-explore/codex/prompt.md` — Codex CLI mirror (lockstep).
+- `skills/autospec-explore/opencode/agent.md` — OpenCode mirror (lockstep).
+- `skills/autospec-explore/install.sh`, `uninstall.sh`, `README.md`.
+- `scripts/autospec-explore.sh` — orchestrator. **Stubbed by Issue E.**
+- `scripts/explore-sandbox.sh` — sandbox branch creation + `.autospec/explore-mode.json`.
+- `scripts/explore-research-cycle.sh` — runs all researchers, aggregates. **Stubbed by Issue C.**
+- `scripts/explore-research/` (subdir) — one researcher per source. **Stubbed by Issues C+D.**
+
+This SKILL.md is the scaffold contract. Subsequent child issues fill in the
+implementer PR-base integration (B), researchers (C+D), the orchestrator + loop
+integration (E), and the `check_autospec_explore_contract` gate in `scripts/validate.sh` (E).
+
+## Invocation
+
+```
+/autospec-explore "<initial prompt>" \
+    [--max-iterations N] \
+    [--max-issues-per-round N] \
+    [--budget-tokens N] \
+    [--budget-hours N] \
+    [--sandbox-slug <slug>] \
+    [--research-sources <comma-list>] \
+    [--no-internet] \
+    [--internet-allowlist <comma-list>]
+```
+
+> **Model tier:** `TIER_A` for the aggregator + proposal ranker; `TIER_B` for the
+> deterministic researchers and downstream implementer dispatches (inherited from
+> `/autospec-run`).
+
+- `--max-iterations N` — outer loop round cap. Default unlimited.
+- `--max-issues-per-round N` — research output cap. Default 5.
+- `--budget-tokens N` — token budget across all iterations. Default 10M.
+- `--budget-hours N` — wall-time budget. Default 24h.
+- `--sandbox-slug <slug>` — override sandbox branch slug.
+- `--research-sources <list>` — limit to a comma-separated subset of the
+  6 researcher names. Default: all 6.
+- `--no-internet` — disable internet research (the most expensive +
+  highest-risk source).
+- `--internet-allowlist <list>` — comma-separated domains the internet
+  researcher is permitted to fetch. Default: a curated list of
+  competitor-research-appropriate domains (GitHub, official product
+  docs, HackerNews, etc.). Forbidden by default: paywalled content,
+  social media, pastebin-class sites.
+
+## Sandbox branch contract
+
+1. **Creation**: at run start, the orchestrator invokes
+   `scripts/explore-sandbox.sh --slug <slug> --base main` which creates
+   `autospec/explore/<YYYY-MM-DD>-<slug>` off `origin/main` (or the supplied
+   `--base`) if not already present, pushes the branch to `origin`, and writes
+   `.autospec/explore-mode.json` with `{branch, slug, base, head_sha, created_at}`.
+   The branch lives until the operator merges or deletes it.
+2. **Idempotency**: re-invocation with the same `--slug` reuses the existing
+   sandbox branch — no error, no duplicate, no force-push. The script verifies
+   the existing branch tracks the expected base via `git merge-base` and
+   refreshes `.autospec/explore-mode.json` with the current head SHA.
+3. **Implementer integration**: every child-issue implementer reads
+   `.autospec/explore-mode.json` (written by the sandbox script) to learn the
+   sandbox branch name. PRs target `--base <sandbox-branch>` instead of
+   `main`. This is enforced by extending the Phase 4 implementer prompt
+   template (`skills/autospec-run/prompts/phase4-implementer.md`) in Issue B.
+4. **No accidental main merges**: orchestrator refuses to invoke
+   `gh pr merge` against `main` while `.autospec/explore-mode.json` is
+   present. The sandbox → main merge is a separate explicit operator
+   action (`/autospec-explore-promote <sandbox-branch>` — out of scope
+   for v1; documented as the manual path).
+5. **Sandbox refresh policy**: the sandbox branch is NOT auto-rebased onto
+   main. Operator does that explicitly. This is intentional — rebasing
+   under autonomous shipping is unsafe.
+
+## Research cycle contract
+
+Each round runs the 6 researchers (or the operator-specified subset) in
+parallel. Each researcher returns 0-N proposals as JSON:
+
+```json
+{
+  "source": "spec-vs-code",
+  "proposals": [
+    {
+      "title": "feat: implement <X> from spec docs/specs/<Y>.md",
+      "evidence": "Acceptance criterion 3 in <Y>:42 has no implementation",
+      "estimated_complexity": "small|medium|large",
+      "confidence": 0.85
+    }
+  ]
+}
+```
+
+Aggregation:
+
+1. **Deduplication**: by normalized title (lowercased, action verb +
+   subject), drop duplicates across researchers.
+2. **Ranking**: weighted score = `confidence × source_weight ×
+   1/estimated_complexity`. Default source weights:
+   - `spec-vs-code` = 1.0 (highest — spec drift is concrete and grounded)
+   - `prior-reports` = 0.9 (operator-derived priorities)
+   - `codebase-signals` = 0.7
+   - `open-issues` = 0.6
+   - `source-analysis` = 0.5
+   - `internet` = 0.4 (lowest — least grounded)
+3. **Filtering**: drop proposals that match recently-filed issue titles
+   (last 7 days) to prevent oscillation.
+4. **Cap**: top `--max-issues-per-round` proposals become issues.
+
+Each researcher is a separate script and can be enabled/disabled via
+`--research-sources`. **Stubbed by Issue C; the JSON contract is the
+authoritative interface between researchers and the aggregator.**
+
+## Loop driver integration
+
+The outer loop uses `scripts/lib/autospec-loop.sh` from PR #712 with
+explore-specific callbacks (wired in Issue E):
+
+- **per-iteration callback**: `scripts/explore-research-cycle.sh` (file
+  issues for top N proposals).
+- **drain callback**: invoke `/autospec-run` (which honors sandbox base
+  branch via the Issue B integration).
+- **termination conditions**: inherited from #712 + new
+  `operator_stop` checks `~/.autospec/explore-stop.flag` AND
+  `~/.autospec/stop.flag`. No convergence-stop (explore is meant to keep
+  generating until operator says enough).
+
+## Usage-limit recovery
+
+Inherits `scripts/autospec-usage-limit.sh` (already wired for autospec-run
+per existing skill prose). When the harness reports a deterministic
+quota pause, the orchestrator arms the supervisor with the resume command
+(the same `/autospec-explore` invocation + the sandbox branch context recovered
+from `.autospec/explore-mode.json`) and exits. The supervisor relaunches after
+reset.
+
+## Loop summary
+
+`.autospec/explore-summary.md` (markdown, human-readable) +
+`.autospec/explore-loop.json` (machine-readable per-iteration log).
+Structurally identical to the loop summaries from `/autospec --loop`,
+`/autospec-continue`, `/autospec-qa --heal` (all four share the shape from
+PR #712).
+
+Markdown shape:
+
+```
+## /autospec-explore — sandbox autospec/explore/<date>-<slug>
+
+| Round | Researchers run | Proposals | Issues filed | PRs merged | Time | Status |
+|---|---|---|---|---|---|---|
+| 1 | 6/6 | 17 (deduped to 12) | 5 | 5 | 28m | round_complete |
+| 2 | 6/6 | 14 (deduped to 9) | 4 | 4 | 22m | round_complete |
+| 3 | 6/6 | 8 (deduped to 6) | 5 | 3 + 2 in flight | 31m | operator_stop |
+
+Final status: operator_stop after 3 rounds, 14 PRs merged on sandbox.
+
+To merge sandbox into main:
+  git checkout main && git merge autospec/explore/2026-05-29-X
+
+To discard:
+  git branch -D autospec/explore/2026-05-29-X && \
+    git push origin --delete autospec/explore/2026-05-29-X
+```
+
+## Error handling
+
+- **Researcher fails** (e.g., gh API error, LLM timeout) → that researcher
+  contributes 0 proposals, loop continues with the others. Logged.
+- **All researchers fail** → round produces no proposals → loop emits
+  `code_health:explore_all_researchers_failed` and pauses for operator.
+- **Issue-creation fails** → retry once, then skip that proposal.
+- **/autospec-run fails** → record failure, continue loop with reduced
+  rate (next round delayed by 5 min) to avoid hammering on a broken
+  state.
+- **Sandbox branch deleted out from under the loop** → orchestrator
+  detects via `git rev-parse --verify` before each iteration. Missing →
+  exit with `code_health:explore_sandbox_missing` and operator-recovery
+  instructions.
+- **Sandbox script idempotency violation** — if `explore-sandbox.sh` is
+  re-invoked with the same slug but a divergent base, exit 3 with
+  `code_health:explore_sandbox_base_mismatch` and refuse to overwrite.
+
+## Testing
+
+- `tests/explore/test_explore_sandbox.bats` — sandbox creation/management,
+  idempotency, no accidental main writes, `.autospec/explore-mode.json`
+  schema.
+- `tests/explore/test_explore_researchers.bats` — each of the 6
+  researchers produces well-formed JSON proposals from fixture inputs.
+  **Stubbed by Issues C+D.**
+- `tests/explore/test_explore_research_cycle.bats` — aggregation,
+  dedup, ranking, capping. **Stubbed by Issue C.**
+- `tests/explore/test_explore_loop.bats` — outer loop integration with
+  shared driver; termination conditions reachable. **Stubbed by Issue E.**
+- `tests/explore/test_explore_internet_safety.bats` — domain allowlist,
+  prompt-injection guard, rate limit, content sanitization.
+  **Stubbed by Issue D.**
+
+### Primary smoke test
+
+```
+bash scripts/validate.sh
+bash scripts/explore-sandbox.sh --slug smoke-test
+```

--- a/skills/autospec-explore/install.sh
+++ b/skills/autospec-explore/install.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --symlink           # symlink instead of copy (updates propagate)
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-explore/install.sh \
+#     | sh -s -- --harness all
+# When piped, the script auto-downloads the skill files from the same branch.
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPEC_EXPLORE_REF         (default: main) — git ref to fetch from when piped
+#   AUTOSPEC_EXPLORE_RAW_BASE    (override the raw URL base entirely)
+#
+# Idempotent: re-running upgrades the install. Exits non-zero on hard failure;
+# exits zero with warnings on missing optional deps.
+
+set -eu
+
+SKILL_NAME="autospec-explore"
+SKILL_RAW_BASE="${AUTOSPEC_EXPLORE_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_EXPLORE_REF:-main}/skills/autospec-explore}"
+
+# Resolve the directory containing this script. When piped through stdin (e.g.
+# `curl ... | sh`), $0 will not be a real file — detect that and fall back to
+# downloading the source files from the raw GitHub URL.
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+UPDATE_MODE=0
+TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+
+# ---------- helpers --------------------------------------------------------
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
+
+Installs the ${SKILL_NAME} skill into the chosen harness's standard
+skill/agent/prompt directory.
+
+Examples:
+  $0                          # interactive
+  $0 --harness all            # install everywhere
+  $0 --harness claude         # Claude Code only
+  $0 --harness opencode       # OpenCode only
+  $0 --harness codex          # Codex CLI only
+  $0 --harness all --symlink  # symlink instead of copy
+  $0 --dry-run --harness all  # print plan, change nothing
+  $0 --harness claude --update  # idempotent re-install (overwrite existing)
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    # Download the files we need into a temp dir and set SKILL_DIR to it.
+    if ! command -v curl >/dev/null 2>&1; then
+        err "curl is required when running from stdin (e.g. piped via 'curl | sh')."
+        exit 1
+    fi
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/$rel"
+            exit 1
+        fi
+    done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autospec helper scripts"
+        return 1
+    fi
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    dest_dir="$(dirname "$dest")"
+
+    if [ ! -f "$src" ]; then
+        err "missing source file: $src"
+        return 1
+    fi
+
+    run "mkdir -p \"$dest_dir\""
+
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --symlink)
+            USE_SYMLINK=1
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        --update)
+            UPDATE_MODE=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# ---------- harness prompt -------------------------------------------------
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- ensure source files are available ------------------------------
+
+# If we couldn't resolve a local SKILL_DIR (piped from curl) OR the local dir
+# doesn't actually contain the skill files, fall back to remote fetch.
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+
+if [ "$need_fetch" -eq 1 ]; then
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        err "--symlink requires running from a checkout of the codex-skills repo (no local files to symlink to)."
+        exit 2
+    fi
+    fetch_source_files
+fi
+
+# ---------- dependency checks ---------------------------------------------
+
+dep_warnings=0
+
+check_dep() {
+    name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        warn "$name not found on PATH (required by the skill at runtime)"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+}
+
+check_dep git
+check_dep gh
+check_dep jq
+
+if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+        warn "gh is installed but not authenticated. Run: gh auth login"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+fi
+
+if [ "$dep_warnings" -gt 0 ]; then
+    warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
+fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+CLAUDE_SRC="$SKILL_DIR/SKILL.md"
+OPENCODE_SRC="$SKILL_DIR/opencode/agent.md"
+CODEX_SRC="$SKILL_DIR/codex/prompt.md"
+
+# ---------- install --------------------------------------------------------
+
+installed_paths=""
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_SRC" "$CLAUDE_DEST"
+    installed_paths="${installed_paths}  Claude Code: ${CLAUDE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_SRC" "$OPENCODE_DEST"
+    installed_paths="${installed_paths}  OpenCode:    ${OPENCODE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+    installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
+fi
+
+# ---------- final summary --------------------------------------------------
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    if [ "$UPDATE_MODE" -eq 1 ]; then
+        info "Updated (idempotent overwrite):"
+    else
+        info "Installed:"
+    fi
+    printf '%b' "$installed_paths"
+    info ""
+    info "Invoke with:"
+    info "  Claude Code:  /${SKILL_NAME} <feature description>"
+    info "  OpenCode:     @${SKILL_NAME} <feature description>"
+    info "  Codex CLI:    /${SKILL_NAME} <feature description>"
+fi
+
+exit 0

--- a/skills/autospec-explore/opencode/agent.md
+++ b/skills/autospec-explore/opencode/agent.md
@@ -1,0 +1,367 @@
+---
+description: Use when the user wants /autospec-explore to start a perpetual autonomous research + ship loop on an isolated sandbox branch — 6 researchers propose features from spec/code gaps, prior reports, codebase signals, open issues, repo source analysis, and competitor research, then drain via /autospec-run with PRs targeting the sandbox branch (never main).
+mode: primary
+---
+
+# autospec-explore workflow (harness-neutral)
+
+Start a perpetual autonomous research + ship loop. `/autospec-explore "<initial prompt>"`
+creates an isolated sandbox branch (`autospec/explore/<date>-<slug>`) off `origin/main`,
+runs 6 parallel researchers each round (spec-vs-code, prior reports, codebase signals,
+open issues, source analysis, internet), files 1-5 auto-implement issues per round,
+drains them via `/autospec-run` with PRs targeting the sandbox, and continues until
+the operator stops it. The operator inspects the sandbox when ready and either merges
+into `main` or discards.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your
+harness supports it; do not run researchers or aggregate proposals directly in the
+main conversation when a subagent can do it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-explore   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-refine / autospec-continue / autospec-explore
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-explore/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-explore.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-explore.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter the explore pipeline. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-explore found; run install.sh first.` and exit.
+
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$` (case-insensitive), this skill enters stop mode and does not run the normal pipeline:
+
+1. Delegate to the shared stop helper:
+   ```bash
+   bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" "$@"
+   ```
+2. Honor `--graceful` (write `~/.autospec/stop.flag` and `~/.autospec/explore-stop.flag`; running iteration finishes) and `--immediate` (also write `~/.autospec/refine-loop-stop.flag`; abort at next iteration boundary).
+3. Print the stop summary and exit. Do not enter the explore pipeline.
+
+## Required capabilities & harness adapter
+
+This workflow assumes six capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — recognized by Claude Code, OpenCode, and Codex. Per AGENTS.md, subagent dispatches use the two-tier policy: Tier A for research aggregation and proposal ranking, Tier B for individual deterministic researchers and downstream implementer dispatches (inherited from `/autospec-run`).
+
+## Harness detection (run once at skill start, before sandbox creation)
+
+Detect your harness by checking available tools before any sandbox or research step runs:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; `apply_patch` is the primary edit tool.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness, silently retry the same subagent dispatch with `TIER_A`. Preserve parent context on retry. Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run. Every "Tier A" and "Tier B" reference below resolves to these harness-specific values.
+
+## Architecture
+
+```
+/autospec-explore "<prompt>"
+        │
+        ▼
+   create sandbox branch
+   autospec/explore/<date>-<slug> off origin/main
+        │
+        ▼
+   ┌──────────────────────────────────────────┐
+   │  perpetual loop (single iteration shown) │
+   │                                          │
+   │  1. research cycle:                      │
+   │     - 6 researchers run in parallel      │
+   │     - aggregate proposals, dedup, rank   │
+   │  2. file 1-5 auto-implement issues       │
+   │     (max per round, configurable)        │
+   │  3. drain via /autospec-run              │
+   │     - implementer PRs target SANDBOX,    │
+   │       not main                           │
+   │  4. update .autospec/explore-summary.md  │
+   │  5. check termination:                   │
+   │     - operator stop flag                 │
+   │     - round cap / time cap / token cap   │
+   │     - usage-limit supervisor arms        │
+   │  6. loop                                  │
+   └──────────────────────────────────────────┘
+        │
+        ▼ (operator decides)
+   git merge autospec/explore/<date>-<slug> → main
+        │
+   OR discard: gh branch -D
+```
+
+Skill family layout (mirrors existing autospec-refine / autospec-continue):
+
+- `skills/autospec-explore/SKILL.md` — Claude Code adapter (authoritative).
+- `skills/autospec-explore/codex/prompt.md` — Codex CLI mirror (lockstep).
+- `skills/autospec-explore/opencode/agent.md` — OpenCode mirror (lockstep).
+- `skills/autospec-explore/install.sh`, `uninstall.sh`, `README.md`.
+- `scripts/autospec-explore.sh` — orchestrator. **Stubbed by Issue E.**
+- `scripts/explore-sandbox.sh` — sandbox branch creation + `.autospec/explore-mode.json`.
+- `scripts/explore-research-cycle.sh` — runs all researchers, aggregates. **Stubbed by Issue C.**
+- `scripts/explore-research/` (subdir) — one researcher per source. **Stubbed by Issues C+D.**
+
+This SKILL.md is the scaffold contract. Subsequent child issues fill in the
+implementer PR-base integration (B), researchers (C+D), the orchestrator + loop
+integration (E), and the `check_autospec_explore_contract` gate in `scripts/validate.sh` (E).
+
+## Invocation
+
+```
+/autospec-explore "<initial prompt>" \
+    [--max-iterations N] \
+    [--max-issues-per-round N] \
+    [--budget-tokens N] \
+    [--budget-hours N] \
+    [--sandbox-slug <slug>] \
+    [--research-sources <comma-list>] \
+    [--no-internet] \
+    [--internet-allowlist <comma-list>]
+```
+
+> **Model tier:** `TIER_A` for the aggregator + proposal ranker; `TIER_B` for the
+> deterministic researchers and downstream implementer dispatches (inherited from
+> `/autospec-run`).
+
+- `--max-iterations N` — outer loop round cap. Default unlimited.
+- `--max-issues-per-round N` — research output cap. Default 5.
+- `--budget-tokens N` — token budget across all iterations. Default 10M.
+- `--budget-hours N` — wall-time budget. Default 24h.
+- `--sandbox-slug <slug>` — override sandbox branch slug.
+- `--research-sources <list>` — limit to a comma-separated subset of the
+  6 researcher names. Default: all 6.
+- `--no-internet` — disable internet research (the most expensive +
+  highest-risk source).
+- `--internet-allowlist <list>` — comma-separated domains the internet
+  researcher is permitted to fetch. Default: a curated list of
+  competitor-research-appropriate domains (GitHub, official product
+  docs, HackerNews, etc.). Forbidden by default: paywalled content,
+  social media, pastebin-class sites.
+
+## Sandbox branch contract
+
+1. **Creation**: at run start, the orchestrator invokes
+   `scripts/explore-sandbox.sh --slug <slug> --base main` which creates
+   `autospec/explore/<YYYY-MM-DD>-<slug>` off `origin/main` (or the supplied
+   `--base`) if not already present, pushes the branch to `origin`, and writes
+   `.autospec/explore-mode.json` with `{branch, slug, base, head_sha, created_at}`.
+   The branch lives until the operator merges or deletes it.
+2. **Idempotency**: re-invocation with the same `--slug` reuses the existing
+   sandbox branch — no error, no duplicate, no force-push. The script verifies
+   the existing branch tracks the expected base via `git merge-base` and
+   refreshes `.autospec/explore-mode.json` with the current head SHA.
+3. **Implementer integration**: every child-issue implementer reads
+   `.autospec/explore-mode.json` (written by the sandbox script) to learn the
+   sandbox branch name. PRs target `--base <sandbox-branch>` instead of
+   `main`. This is enforced by extending the Phase 4 implementer prompt
+   template (`skills/autospec-run/prompts/phase4-implementer.md`) in Issue B.
+4. **No accidental main merges**: orchestrator refuses to invoke
+   `gh pr merge` against `main` while `.autospec/explore-mode.json` is
+   present. The sandbox → main merge is a separate explicit operator
+   action (`/autospec-explore-promote <sandbox-branch>` — out of scope
+   for v1; documented as the manual path).
+5. **Sandbox refresh policy**: the sandbox branch is NOT auto-rebased onto
+   main. Operator does that explicitly. This is intentional — rebasing
+   under autonomous shipping is unsafe.
+
+## Research cycle contract
+
+Each round runs the 6 researchers (or the operator-specified subset) in
+parallel. Each researcher returns 0-N proposals as JSON:
+
+```json
+{
+  "source": "spec-vs-code",
+  "proposals": [
+    {
+      "title": "feat: implement <X> from spec docs/specs/<Y>.md",
+      "evidence": "Acceptance criterion 3 in <Y>:42 has no implementation",
+      "estimated_complexity": "small|medium|large",
+      "confidence": 0.85
+    }
+  ]
+}
+```
+
+Aggregation:
+
+1. **Deduplication**: by normalized title (lowercased, action verb +
+   subject), drop duplicates across researchers.
+2. **Ranking**: weighted score = `confidence × source_weight ×
+   1/estimated_complexity`. Default source weights:
+   - `spec-vs-code` = 1.0 (highest — spec drift is concrete and grounded)
+   - `prior-reports` = 0.9 (operator-derived priorities)
+   - `codebase-signals` = 0.7
+   - `open-issues` = 0.6
+   - `source-analysis` = 0.5
+   - `internet` = 0.4 (lowest — least grounded)
+3. **Filtering**: drop proposals that match recently-filed issue titles
+   (last 7 days) to prevent oscillation.
+4. **Cap**: top `--max-issues-per-round` proposals become issues.
+
+Each researcher is a separate script and can be enabled/disabled via
+`--research-sources`. **Stubbed by Issue C; the JSON contract is the
+authoritative interface between researchers and the aggregator.**
+
+## Loop driver integration
+
+The outer loop uses `scripts/lib/autospec-loop.sh` from PR #712 with
+explore-specific callbacks (wired in Issue E):
+
+- **per-iteration callback**: `scripts/explore-research-cycle.sh` (file
+  issues for top N proposals).
+- **drain callback**: invoke `/autospec-run` (which honors sandbox base
+  branch via the Issue B integration).
+- **termination conditions**: inherited from #712 + new
+  `operator_stop` checks `~/.autospec/explore-stop.flag` AND
+  `~/.autospec/stop.flag`. No convergence-stop (explore is meant to keep
+  generating until operator says enough).
+
+## Usage-limit recovery
+
+Inherits `scripts/autospec-usage-limit.sh` (already wired for autospec-run
+per existing skill prose). When the harness reports a deterministic
+quota pause, the orchestrator arms the supervisor with the resume command
+(the same `/autospec-explore` invocation + the sandbox branch context recovered
+from `.autospec/explore-mode.json`) and exits. The supervisor relaunches after
+reset.
+
+## Loop summary
+
+`.autospec/explore-summary.md` (markdown, human-readable) +
+`.autospec/explore-loop.json` (machine-readable per-iteration log).
+Structurally identical to the loop summaries from `/autospec --loop`,
+`/autospec-continue`, `/autospec-qa --heal` (all four share the shape from
+PR #712).
+
+Markdown shape:
+
+```
+## /autospec-explore — sandbox autospec/explore/<date>-<slug>
+
+| Round | Researchers run | Proposals | Issues filed | PRs merged | Time | Status |
+|---|---|---|---|---|---|---|
+| 1 | 6/6 | 17 (deduped to 12) | 5 | 5 | 28m | round_complete |
+| 2 | 6/6 | 14 (deduped to 9) | 4 | 4 | 22m | round_complete |
+| 3 | 6/6 | 8 (deduped to 6) | 5 | 3 + 2 in flight | 31m | operator_stop |
+
+Final status: operator_stop after 3 rounds, 14 PRs merged on sandbox.
+
+To merge sandbox into main:
+  git checkout main && git merge autospec/explore/2026-05-29-X
+
+To discard:
+  git branch -D autospec/explore/2026-05-29-X && \
+    git push origin --delete autospec/explore/2026-05-29-X
+```
+
+## Error handling
+
+- **Researcher fails** (e.g., gh API error, LLM timeout) → that researcher
+  contributes 0 proposals, loop continues with the others. Logged.
+- **All researchers fail** → round produces no proposals → loop emits
+  `code_health:explore_all_researchers_failed` and pauses for operator.
+- **Issue-creation fails** → retry once, then skip that proposal.
+- **/autospec-run fails** → record failure, continue loop with reduced
+  rate (next round delayed by 5 min) to avoid hammering on a broken
+  state.
+- **Sandbox branch deleted out from under the loop** → orchestrator
+  detects via `git rev-parse --verify` before each iteration. Missing →
+  exit with `code_health:explore_sandbox_missing` and operator-recovery
+  instructions.
+- **Sandbox script idempotency violation** — if `explore-sandbox.sh` is
+  re-invoked with the same slug but a divergent base, exit 3 with
+  `code_health:explore_sandbox_base_mismatch` and refuse to overwrite.
+
+## Testing
+
+- `tests/explore/test_explore_sandbox.bats` — sandbox creation/management,
+  idempotency, no accidental main writes, `.autospec/explore-mode.json`
+  schema.
+- `tests/explore/test_explore_researchers.bats` — each of the 6
+  researchers produces well-formed JSON proposals from fixture inputs.
+  **Stubbed by Issues C+D.**
+- `tests/explore/test_explore_research_cycle.bats` — aggregation,
+  dedup, ranking, capping. **Stubbed by Issue C.**
+- `tests/explore/test_explore_loop.bats` — outer loop integration with
+  shared driver; termination conditions reachable. **Stubbed by Issue E.**
+- `tests/explore/test_explore_internet_safety.bats` — domain allowlist,
+  prompt-injection guard, rate limit, content sanitization.
+  **Stubbed by Issue D.**
+
+### Primary smoke test
+
+```
+bash scripts/validate.sh
+bash scripts/explore-sandbox.sh --slug smoke-test
+```

--- a/skills/autospec-explore/uninstall.sh
+++ b/skills/autospec-explore/uninstall.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autospec-explore"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        # Try to remove an empty parent skill directory (Claude only — its layout
+        # has a per-skill subdir).
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+# ---------- remove ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0


### PR DESCRIPTION
Closes #717.

## Summary

Scaffolds the `autospec-explore` skill family — first of 5 children under the
`/autospec-explore` umbrella (PR #715 = source spec). Trio + install/uninstall +
README mirror autospec-continue. Adds `scripts/explore-sandbox.sh` implementing
the sandbox branch contract from the spec.

- `skills/autospec-explore/{SKILL.md, codex/prompt.md, opencode/agent.md}` — full
  body byte-aligned across all three harnesses (lockstep enforced by
  `scripts/validate.sh`).
- All structural sections present: Frontmatter, Startup self-update, Self-update
  mode, Stop mode, Required capabilities & harness adapter (with Subagent model
  tier row), Harness detection, Architecture, Invocation, Sandbox branch
  contract, Research cycle contract, Loop driver integration, Usage-limit
  recovery, Loop summary, Error handling, Testing.
- `skills/autospec-explore/install.sh` / `uninstall.sh` / `README.md` — clone of
  autospec-continue, customized for explore.
- `scripts/explore-sandbox.sh` — creates `autospec/explore/<YYYY-MM-DD>-<slug>`
  off `origin/<base>` (default `main`), pushes, writes
  `.autospec/explore-mode.json` with `{branch, slug, base, head_sha, created_at}`.
  Idempotent on slug; exits 3 with `code_health:explore_sandbox_base_mismatch`
  if re-invoked against a divergent base.

## Out of scope (deferred to follow-up issues)

- Issue B: Phase 4 implementer PR-base integration.
- Issue C: research cycle aggregator + 4 deterministic researchers.
- Issue D: 2 LLM-heavy researchers + internet safety guards.
- Issue E: orchestrator + `scripts/lib/autospec-loop.sh` wiring + validate gate + e2e.

## Verification

- `bash scripts/validate.sh` — passes (lockstep trio + 251+ existing tests).
- `bash skills/autospec-explore/install.sh --harness all --dry-run` — reports
  install plan for all 3 harnesses.
- `bash scripts/explore-sandbox.sh --slug smoke-dryrun --dry-run` — reports
  branch creation + JSON payload.