### PR TITLE
feat: autospec-explore research cycle + 4 deterministic researchers (closes #719)

### DIFF
--- a/scripts/explore-research-cycle.sh
+++ b/scripts/explore-research-cycle.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# scripts/explore-research-cycle.sh — autospec-explore research cycle aggregator.
+#
+# Runs the enabled deterministic researchers in parallel, aggregates their
+# proposals, deduplicates by normalized title, ranks by weighted score,
+# filters out proposals matching titles created in the last 7 days, and
+# caps output at --max-issues-per-round.
+#
+# Implements the "Research cycle contract" + "Per-researcher contracts"
+# rows 1-4 in docs/specs/2026-05-29-autospec-explore-design.md.
+#
+# Output: JSON to stdout with shape:
+#   { "round": "<iso-date>",
+#     "proposals_total": N,
+#     "proposals_after_dedup": N,
+#     "proposals_after_recent_filter": N,
+#     "proposals": [ ...top --max-issues-per-round... ] }
+#
+# Each proposal carries: title, evidence, estimated_complexity, confidence,
+# source, score.
+
+set -u
+
+REPO_ROOT="${AUTOSPEC_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESEARCH_DIR="${AUTOSPEC_RESEARCH_DIR:-$SCRIPT_DIR/explore-research}"
+
+usage() {
+    cat <<'EOF'
+Usage: explore-research-cycle.sh [options]
+
+Options:
+  --max-issues-per-round N     Cap final proposals (default 5).
+  --research-sources LIST      Comma-separated subset of:
+                                 spec-vs-code,prior-reports,codebase-signals,open-issues
+                               Default: all 4.
+  --out PATH                   Write JSON to PATH (atomic) instead of stdout.
+  -h, --help                   Print this help.
+
+Env:
+  AUTOSPEC_REPO_ROOT             Repo root (default: git rev-parse).
+  AUTOSPEC_RESEARCH_DIR          Researcher directory.
+  AUTOSPEC_TEST_ISSUES_JSON      Inject fake gh issue list (testing).
+  AUTOSPEC_TEST_RECENT_TITLES    Newline-separated titles created in last 7d
+                                 (testing — bypasses gh search).
+EOF
+}
+
+MAX_ISSUES=5
+SOURCES="spec-vs-code,prior-reports,codebase-signals,open-issues"
+OUT=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --max-issues-per-round) MAX_ISSUES="$2"; shift 2 ;;
+        --research-sources)     SOURCES="$2"; shift 2 ;;
+        --out)                  OUT="$2"; shift 2 ;;
+        -h|--help)              usage; exit 0 ;;
+        *) echo "explore-research-cycle: unknown arg: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+cd "$REPO_ROOT" || { echo '{"proposals":[]}'; exit 0; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "explore-research-cycle: python3 required" >&2
+    exit 2
+fi
+
+# Run each enabled researcher in parallel, write to a sibling tmp file.
+work_dir="$(mktemp -d -t explore-cycle.XXXXXX)"
+trap 'rm -rf "$work_dir"' EXIT
+
+pids=()
+IFS=','
+for src in $SOURCES; do
+    src="$(printf '%s' "$src" | tr -d ' ')"
+    [ -z "$src" ] && continue
+    script="$RESEARCH_DIR/$src.sh"
+    if [ ! -f "$script" ]; then
+        echo '{"source":"'"$src"'","proposals":[],"error":"missing_script"}' \
+            > "$work_dir/$src.json"
+        continue
+    fi
+    (
+        bash "$script" > "$work_dir/$src.json" 2>"$work_dir/$src.err" \
+            || echo '{"source":"'"$src"'","proposals":[],"error":"researcher_failed"}' \
+                 > "$work_dir/$src.json"
+    ) &
+    pids+=("$!")
+done
+unset IFS
+
+# Wait for all background researchers.
+for p in "${pids[@]:-}"; do
+    [ -n "$p" ] && wait "$p" 2>/dev/null || true
+done
+
+# Gather recent titles (last 7 days) to filter against. Allow injection.
+recent_titles_file="$work_dir/recent.txt"
+if [ -n "${AUTOSPEC_TEST_RECENT_TITLES:-}" ]; then
+    printf '%s\n' "$AUTOSPEC_TEST_RECENT_TITLES" > "$recent_titles_file"
+elif command -v gh >/dev/null 2>&1; then
+    # Last 7 days = created:>=YYYY-MM-DD
+    since="$(python3 -c 'import datetime; print((datetime.date.today() - datetime.timedelta(days=7)).isoformat())')"
+    gh issue list --search "created:>=$since" --state all --limit 200 \
+        --json title 2>/dev/null \
+        | python3 -c 'import json,sys; [print(t["title"]) for t in json.load(sys.stdin)]' \
+        > "$recent_titles_file" 2>/dev/null || : > "$recent_titles_file"
+else
+    : > "$recent_titles_file"
+fi
+
+# Aggregate, dedup, rank, filter, cap.
+WORK_DIR="$work_dir" \
+MAX_ISSUES="$MAX_ISSUES" \
+RECENT_FILE="$recent_titles_file" \
+python3 - <<'PY' > "$work_dir/final.json"
+import json, os, re, glob, datetime
+
+work     = os.environ["WORK_DIR"]
+cap      = int(os.environ["MAX_ISSUES"])
+recent_f = os.environ["RECENT_FILE"]
+
+# Source weights per the spec.
+SRC_WEIGHTS = {
+    "spec-vs-code":     1.0,
+    "prior-reports":    0.9,
+    "codebase-signals": 0.7,
+    "open-issues":      0.6,
+    "source-analysis":  0.5,
+    "internet":         0.4,
+}
+COMPLEXITY = {"small": 1.0, "medium": 2.0, "large": 4.0}
+
+def normalize_title(t):
+    s = t.lower()
+    # Strip leading conventional-commit prefix.
+    s = re.sub(r'^\s*(feat|fix|chore|docs|test|refactor|perf|track|ci)\s*:\s*', '', s)
+    s = re.sub(r'[^a-z0-9 ]+', ' ', s)
+    s = re.sub(r'\s+', ' ', s).strip()
+    # Drop stopwords for normalization (keep verb + subject signal).
+    return s[:120]
+
+all_props = []
+total = 0
+for f in sorted(glob.glob(os.path.join(work, "*.json"))):
+    if os.path.basename(f) == "final.json":
+        continue
+    try:
+        with open(f, 'r', encoding='utf-8') as fh:
+            data = json.load(fh)
+    except Exception:
+        continue
+    src = data.get("source", "unknown")
+    for p in data.get("proposals", []) or []:
+        if not isinstance(p, dict): continue
+        title = (p.get("title") or "").strip()
+        if not title: continue
+        comp = (p.get("estimated_complexity") or "medium").lower()
+        try:
+            conf = float(p.get("confidence", 0.5))
+        except Exception:
+            conf = 0.5
+        weight = SRC_WEIGHTS.get(src, 0.5)
+        cscale = COMPLEXITY.get(comp, 2.0)
+        score = conf * weight / cscale
+        all_props.append({
+            "title": title,
+            "evidence": p.get("evidence",""),
+            "estimated_complexity": comp,
+            "confidence": conf,
+            "source": src,
+            "score": round(score, 4),
+        })
+        total += 1
+
+# Dedup by normalized title — keep highest score.
+by_norm = {}
+for p in all_props:
+    n = normalize_title(p["title"])
+    if n not in by_norm or p["score"] > by_norm[n]["score"]:
+        by_norm[n] = p
+deduped = list(by_norm.values())
+
+# Filter against recent titles.
+recent_norms = set()
+try:
+    with open(recent_f, 'r', encoding='utf-8') as fh:
+        for line in fh:
+            n = normalize_title(line.strip())
+            if n:
+                recent_norms.add(n)
+except FileNotFoundError:
+    pass
+
+filtered = [p for p in deduped if normalize_title(p["title"]) not in recent_norms]
+
+# Rank descending by score; cap.
+filtered.sort(key=lambda p: p["score"], reverse=True)
+final = filtered[:cap]
+
+out = {
+    "round": datetime.date.today().isoformat(),
+    "proposals_total": total,
+    "proposals_after_dedup": len(deduped),
+    "proposals_after_recent_filter": len(filtered),
+    "proposals": final,
+}
+print(json.dumps(out, indent=2))
+PY
+
+if [ -n "$OUT" ]; then
+    # Atomic write.
+    case "$OUT" in
+        /*) abs="$OUT" ;;
+        *)  abs="$(cd "$(dirname "$OUT")" && pwd)/$(basename "$OUT")" ;;
+    esac
+    mv "$work_dir/final.json" "$abs.tmp"
+    mv "$abs.tmp" "$abs"
+else
+    cat "$work_dir/final.json"
+fi

--- a/scripts/explore-research/codebase-signals.sh
+++ b/scripts/explore-research/codebase-signals.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# scripts/explore-research/codebase-signals.sh — deterministic researcher #3 of 4.
+#
+# Greps the repo for TODO/FIXME comments, optionally parses a coverage report
+# at .autospec/coverage.json or coverage/*.json, and emits one proposal per
+# signal.
+#
+# Cap: 200 signals per round.
+#
+# Output: JSON to stdout per the spec contract.
+
+set -u
+
+REPO_ROOT="${AUTOSPEC_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+MAX_SIGNALS=200
+
+cd "$REPO_ROOT" || { echo '{"source":"codebase-signals","proposals":[]}'; exit 0; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo '{"source":"codebase-signals","proposals":[]}'
+    exit 0
+fi
+
+todo_tmp="$(mktemp -t codebase-signals.XXXXXX)"
+cov_tmp="$(mktemp -t codebase-signals-cov.XXXXXX)"
+trap 'rm -f "$todo_tmp" "$cov_tmp"' EXIT
+
+# Collect TODO/FIXME signals from tracked files (capped).
+if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git grep -n -I -E '(TODO|FIXME|XXX|HACK)[: ]' -- ':!*.md' 2>/dev/null \
+        | head -n "$MAX_SIGNALS" > "$todo_tmp" || true
+fi
+
+# Coverage report (optional).
+for cov in ".autospec/coverage.json" coverage/coverage-summary.json coverage/*.json; do
+    if [ -f "$cov" ]; then
+        cp "$cov" "$cov_tmp"
+        break
+    fi
+done
+
+python3 - "$todo_tmp" "$cov_tmp" "$MAX_SIGNALS" <<'PY'
+import json, sys, os, re
+
+todo_path = sys.argv[1]
+cov_path  = sys.argv[2]
+cap       = int(sys.argv[3])
+
+proposals = []
+
+# TODO/FIXME signals.
+try:
+    with open(todo_path, 'r', encoding='utf-8', errors='ignore') as fh:
+        for line in fh:
+            line = line.rstrip('\n')
+            if not line:
+                continue
+            # Format: path:lineno:content
+            m = re.match(r'^(.+?):(\d+):(.+)$', line)
+            if not m:
+                continue
+            path, lineno, content = m.group(1), m.group(2), m.group(3).strip()
+            kind = "TODO"
+            for k in ("FIXME","XXX","HACK","TODO"):
+                if k in content:
+                    kind = k
+                    break
+            snippet = content[:80].replace('"', "'")
+            proposals.append({
+                "title": f"chore: address {kind} in {path}:{lineno}",
+                "evidence": f"{kind} at {path}:{lineno}: {content[:200]}",
+                "estimated_complexity": "small",
+                "confidence": 0.55,
+            })
+            if len(proposals) >= cap:
+                break
+except FileNotFoundError:
+    pass
+
+# Coverage signals (low coverage files).
+if len(proposals) < cap and os.path.exists(cov_path) and os.path.getsize(cov_path) > 0:
+    try:
+        with open(cov_path, 'r', encoding='utf-8', errors='ignore') as fh:
+            cov = json.load(fh)
+        # istanbul-style: { "/abs/path/file.js": { "lines": {"pct": 42.0}, ... }, ... }
+        if isinstance(cov, dict):
+            for path, data in cov.items():
+                if not isinstance(data, dict):
+                    continue
+                pct = None
+                lines = data.get("lines")
+                if isinstance(lines, dict):
+                    pct = lines.get("pct")
+                elif isinstance(data.get("pct"), (int, float)):
+                    pct = data["pct"]
+                if pct is None:
+                    continue
+                try:
+                    pct = float(pct)
+                except (TypeError, ValueError):
+                    continue
+                if pct >= 60.0:
+                    continue
+                proposals.append({
+                    "title": f"test: increase coverage for {os.path.basename(path)}",
+                    "evidence": f"Coverage report shows {path} at {pct:.1f}% line coverage",
+                    "estimated_complexity": "medium",
+                    "confidence": 0.60,
+                })
+                if len(proposals) >= cap:
+                    break
+    except Exception:
+        pass
+
+print(json.dumps({"source": "codebase-signals", "proposals": proposals}))
+PY

--- a/scripts/explore-research/open-issues.sh
+++ b/scripts/explore-research/open-issues.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# scripts/explore-research/open-issues.sh — deterministic researcher #4 of 4.
+#
+# Lists open GitHub issues excluding the autospec:v2-flow label and emits
+# one proposal per issue, carrying the issue title + URL as citation.
+#
+# Cap: 50 issues per round.
+#
+# Output: JSON to stdout per the spec contract.
+
+set -u
+
+REPO_ROOT="${AUTOSPEC_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+MAX_ISSUES=50
+
+cd "$REPO_ROOT" || { echo '{"source":"open-issues","proposals":[]}'; exit 0; }
+
+# In test mode, allow injection via AUTOSPEC_TEST_ISSUES_JSON (path to JSON file).
+if [ -n "${AUTOSPEC_TEST_ISSUES_JSON:-}" ] && [ -f "$AUTOSPEC_TEST_ISSUES_JSON" ]; then
+    RAW_JSON="$(cat "$AUTOSPEC_TEST_ISSUES_JSON")"
+elif command -v gh >/dev/null 2>&1; then
+    RAW_JSON="$(gh issue list --state open --limit "$MAX_ISSUES" \
+        --json number,title,url,labels 2>/dev/null || echo '[]')"
+else
+    RAW_JSON='[]'
+fi
+
+export RAW_JSON
+export MAX_ISSUES
+
+python3 - <<'PY'
+import json, os
+cap = int(os.environ.get("MAX_ISSUES","50"))
+try:
+    issues = json.loads(os.environ.get("RAW_JSON","[]"))
+except Exception:
+    issues = []
+proposals = []
+for it in issues:
+    if not isinstance(it, dict):
+        continue
+    labels = it.get("labels") or []
+    label_names = []
+    for l in labels:
+        if isinstance(l, dict):
+            label_names.append(l.get("name",""))
+        elif isinstance(l, str):
+            label_names.append(l)
+    if "autospec:v2-flow" in label_names:
+        continue
+    title = (it.get("title") or "").strip()
+    url   = it.get("url") or ""
+    num   = it.get("number")
+    if not title:
+        continue
+    proposals.append({
+        "title": f"track: open issue #{num} — {title[:80]}",
+        "evidence": f"Open GitHub issue #{num} ({url}): {title}",
+        "estimated_complexity": "medium",
+        "confidence": 0.65,
+    })
+    if len(proposals) >= cap:
+        break
+print(json.dumps({"source":"open-issues","proposals":proposals}))
+PY

--- a/scripts/explore-research/prior-reports.sh
+++ b/scripts/explore-research/prior-reports.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# scripts/explore-research/prior-reports.sh — deterministic researcher #2 of 4.
+#
+# Reads .autospec/run-summary.md, .autospec/explore-summary.md, and the last
+# 10 .autospec/runs/*/report.md. Uses the matchers from
+# scripts/lib/extract-matchers.sh to harvest unconsumed Next-steps content
+# and emits a proposal per harvested item.
+#
+# Cap: last 10 reports.
+#
+# Output: JSON to stdout per the spec contract.
+
+set -u
+
+REPO_ROOT="${AUTOSPEC_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Matchers live alongside this script (../lib/extract-matchers.sh), NOT in the
+# target repo being explored. Allow override via env.
+MATCHERS="${AUTOSPEC_MATCHERS_LIB:-$SCRIPT_DIR/../lib/extract-matchers.sh}"
+SUMMARY_DIR="${AUTOSPEC_SUMMARY_DIR:-$REPO_ROOT/.autospec}"
+MAX_REPORTS=10
+
+cd "$REPO_ROOT" || { echo '{"source":"prior-reports","proposals":[]}'; exit 0; }
+
+if [ ! -f "$MATCHERS" ]; then
+    echo '{"source":"prior-reports","proposals":[]}'
+    exit 0
+fi
+
+# shellcheck disable=SC1090
+. "$MATCHERS"
+
+# Build the list of input files.
+inputs=()
+[ -f "$SUMMARY_DIR/run-summary.md" ]     && inputs+=("$SUMMARY_DIR/run-summary.md")
+[ -f "$SUMMARY_DIR/explore-summary.md" ] && inputs+=("$SUMMARY_DIR/explore-summary.md")
+if [ -d "$SUMMARY_DIR/runs" ]; then
+    # most recent N report.md files
+    while IFS= read -r f; do
+        inputs+=("$f")
+    done < <(find "$SUMMARY_DIR/runs" -type f -name 'report.md' 2>/dev/null \
+        | xargs -I{} stat -f '%m %N' {} 2>/dev/null \
+        | sort -rn | head -n "$MAX_REPORTS" | awk '{$1=""; sub(/^ /,""); print}')
+    # Fallback for GNU stat (Linux)
+    if [ "${#inputs[@]}" -le 2 ]; then
+        while IFS= read -r f; do
+            inputs+=("$f")
+        done < <(find "$SUMMARY_DIR/runs" -type f -name 'report.md' \
+            -printf '%T@ %p\n' 2>/dev/null \
+            | sort -rn | head -n "$MAX_REPORTS" | awk '{$1=""; sub(/^ /,""); print}')
+    fi
+fi
+
+if [ "${#inputs[@]}" -eq 0 ]; then
+    echo '{"source":"prior-reports","proposals":[]}'
+    exit 0
+fi
+
+# Harvest from each input via all 4 matchers; collect into a Python aggregator.
+harvest_tmp="$(mktemp -t prior-reports.XXXXXX)"
+trap 'rm -f "$harvest_tmp"' EXIT
+
+for f in "${inputs[@]}"; do
+    [ -f "$f" ] || continue
+    MSG="$(cat "$f" 2>/dev/null)"
+    [ -z "$MSG" ] && continue
+    {
+        echo "===SOURCE: $f==="
+        echo "---section-headings---"
+        MSG="$MSG" extract_section_headings
+        echo "---fenced-blocks---"
+        MSG="$MSG" extract_fenced_blocks
+        echo "---numbered-action---"
+        MSG="$MSG" extract_numbered_action_list
+        echo "---next-prefix---"
+        MSG="$MSG" extract_next_prefix_continuations
+        echo "---recommend---"
+        MSG="$MSG" extract_recommend_sentences
+    } >> "$harvest_tmp"
+done
+
+python3 - "$harvest_tmp" <<'PY'
+import json, sys, re
+
+path = sys.argv[1]
+with open(path, 'r', encoding='utf-8', errors='ignore') as fh:
+    text = fh.read()
+
+proposals = []
+current_source = "unknown"
+seen = set()
+
+# Split by SOURCE markers to track which report each item came from.
+chunks = re.split(r'===SOURCE: (.+?)===', text)
+# chunks[0] is whatever was before the first SOURCE (usually empty);
+# then pairs of (source_path, body).
+for i in range(1, len(chunks), 2):
+    src = chunks[i].strip()
+    body = chunks[i+1] if i+1 < len(chunks) else ""
+    for line in body.splitlines():
+        s = line.strip()
+        # Skip section dividers and blanks and markdown headings.
+        if not s or s.startswith('---') or s.startswith('##'):
+            continue
+        # Strip leading list/bullet/number markers.
+        cleaned = re.sub(r'^\s*([0-9]+\.|[-*+])\s+', '', s)
+        cleaned = cleaned.strip(' \t-*`')
+        if len(cleaned) < 12:
+            continue
+        norm = cleaned.lower()[:80]
+        if norm in seen:
+            continue
+        seen.add(norm)
+        title_snip = cleaned[:80].replace('"', "'")
+        proposals.append({
+            "title": f"chore: follow up on prior report — {title_snip}",
+            "evidence": f"Unconsumed Next-steps content from {src}: {cleaned[:240]}",
+            "estimated_complexity": "small",
+            "confidence": 0.70,
+        })
+
+print(json.dumps({"source": "prior-reports", "proposals": proposals}))
+PY

--- a/scripts/explore-research/spec-vs-code.sh
+++ b/scripts/explore-research/spec-vs-code.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# scripts/explore-research/spec-vs-code.sh — deterministic researcher #1 of 4.
+#
+# Walks docs/specs/**.md, extracts acceptance criteria (`- [ ]` checkboxes),
+# greps the repo for matching code, and emits one proposal per unmatched AC.
+#
+# Cap: 100 specs scanned per round.
+#
+# Output: JSON to stdout matching the contract in
+# docs/specs/2026-05-29-autospec-explore-design.md — Research cycle contract.
+
+set -u
+
+REPO_ROOT="${AUTOSPEC_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+SPEC_GLOB="${AUTOSPEC_SPEC_GLOB:-docs/specs}"
+MAX_SPECS=100
+
+cd "$REPO_ROOT" || { echo '{"source":"spec-vs-code","proposals":[]}'; exit 0; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo '{"source":"spec-vs-code","proposals":[]}'
+    exit 0
+fi
+
+# Collect specs (capped).
+specs=()
+if [ -d "$SPEC_GLOB" ]; then
+    while IFS= read -r f; do
+        specs+=("$f")
+        [ "${#specs[@]}" -ge "$MAX_SPECS" ] && break
+    done < <(find "$SPEC_GLOB" -type f -name '*.md' 2>/dev/null | sort)
+fi
+
+python3 - "${specs[@]}" <<'PY'
+import json, os, re, sys, subprocess
+
+specs = sys.argv[1:]
+proposals = []
+ac_pat = re.compile(r'^\s*-\s*\[\s*\]\s+(.+)$')
+
+def has_code_signal(text, spec_path):
+    # Extract identifier-like tokens (>=4 chars, alnum/underscore/dash)
+    tokens = re.findall(r'[A-Za-z][A-Za-z0-9_\-]{3,}', text)
+    # Skip pure stopwords
+    stop = {'the','and','for','with','from','that','this','must','should',
+            'when','then','will','have','add','use','via','into','onto',
+            'each','also','only','also','tests','test','code','file','files',
+            'spec','specs','main','docs'}
+    tokens = [t for t in tokens if t.lower() not in stop]
+    if not tokens:
+        return True  # nothing to grep; assume covered
+    # Try first 3 distinctive tokens
+    for tok in tokens[:3]:
+        try:
+            r = subprocess.run(
+                ['git','grep','-l','-F','-i','--',tok],
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                timeout=5,
+            )
+            hits = [l for l in r.stdout.decode('utf-8','ignore').splitlines()
+                    if l and l != spec_path]
+            if hits:
+                return True
+        except Exception:
+            pass
+    return False
+
+for spec in specs:
+    try:
+        with open(spec, 'r', encoding='utf-8', errors='ignore') as fh:
+            lines = fh.readlines()
+    except Exception:
+        continue
+    for i, line in enumerate(lines, start=1):
+        m = ac_pat.match(line)
+        if not m:
+            continue
+        ac_text = m.group(1).strip()
+        if len(ac_text) < 8:
+            continue
+        if has_code_signal(ac_text, spec):
+            continue
+        title = f"feat: implement unmatched AC from {spec}"
+        # truncate ac_text to keep title bounded
+        snippet = ac_text[:80].replace('`','').replace('"',"'")
+        proposals.append({
+            "title": f"feat: implement \"{snippet}\" from {spec}",
+            "evidence": f"Acceptance criterion at {spec}:{i} has no matching code: {ac_text[:200]}",
+            "estimated_complexity": "medium",
+            "confidence": 0.75,
+        })
+
+print(json.dumps({"source": "spec-vs-code", "proposals": proposals}))
+PY

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1662,6 +1662,7 @@ main() {
     check_autospec_parallel_dispatch_contract
     check_autospec_explore_implementer_base
     check_loop_handoff_harness_awareness
+    check_autospec_explore_researchers_deterministic
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.
@@ -1768,6 +1769,35 @@ check_autospec_explore_implementer_base() {
         bats "$bats_file" >/tmp/validate-explore-impl-base.log 2>&1 \
             || { cat /tmp/validate-explore-impl-base.log >&2; fail "$bats_file: failed"; }
     fi
+}
+
+# autospec-explore research cycle + 4 deterministic researchers (issue #719):
+# all 4 researcher scripts + the aggregator must exist, be executable, and
+# pass `bash -n`. Runs tests/explore/test_explore_researchers.bats and
+# tests/explore/test_explore_research_cycle.bats when bats is on PATH.
+check_autospec_explore_researchers_deterministic() {
+    info "autospec-explore deterministic researchers + cycle aggregator"
+    local aggregator="scripts/explore-research-cycle.sh"
+    [ -f "$aggregator" ] || fail "$aggregator: required file missing"
+    [ -x "$aggregator" ] || fail "$aggregator: file not executable"
+    bash -n "$aggregator" || fail "$aggregator: bash syntax error"
+    for r in spec-vs-code prior-reports codebase-signals open-issues; do
+        local script="scripts/explore-research/$r.sh"
+        [ -f "$script" ] || fail "$script: required file missing"
+        [ -x "$script" ] || fail "$script: file not executable"
+        bash -n "$script" || fail "$script: bash syntax error"
+    done
+    for bats_file in \
+        tests/explore/test_explore_researchers.bats \
+        tests/explore/test_explore_research_cycle.bats
+    do
+        [ -f "$bats_file" ] || fail "$bats_file: bats coverage missing"
+        if command -v bats >/dev/null 2>&1; then
+            info "  running: $bats_file"
+            bats "$bats_file" >/tmp/validate-explore-researchers.log 2>&1 \
+                || { cat /tmp/validate-explore-researchers.log >&2; fail "$bats_file: failed"; }
+        fi
+    done
 }
 
 main "$@"

--- a/tests/explore/test_explore_research_cycle.bats
+++ b/tests/explore/test_explore_research_cycle.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# tests/explore/test_explore_research_cycle.bats — aggregator behavior:
+# parallel run, dedup by normalized title, weighted ranking, recent-title
+# filter, cap.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    TMP="$(mktemp -d -t explore-cycle.XXXXXX)"
+    cd "$TMP"
+    git init -q
+    git config user.email t@t.t
+    git config user.name t
+    export AUTOSPEC_REPO_ROOT="$TMP"
+    # Override gh; aggregator must still succeed without it.
+    export PATH="$TMP/bin:$PATH"
+    mkdir -p "$TMP/bin"
+    # Fake gh that exits non-zero so the recent-title fetch silently produces empty.
+    cat > "$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$TMP/bin/gh"
+
+    # Build a fake research dir with deterministic mini-researchers we control.
+    export AUTOSPEC_RESEARCH_DIR="$TMP/fake-research"
+    mkdir -p "$AUTOSPEC_RESEARCH_DIR"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+make_fake_researcher() {
+    local name="$1"
+    local payload="$2"
+    cat > "$AUTOSPEC_RESEARCH_DIR/$name.sh" <<EOF
+#!/usr/bin/env bash
+cat <<JSON
+$payload
+JSON
+EOF
+    chmod +x "$AUTOSPEC_RESEARCH_DIR/$name.sh"
+}
+
+@test "aggregator produces well-formed top-level JSON with all expected keys" {
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: alpha widget","evidence":"e1","estimated_complexity":"small","confidence":0.9}]}'
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[]}'
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys
+output_json = sys.stdin.read()
+
+import json
+d = json.loads(output_json)
+for k in ('round','proposals_total','proposals_after_dedup','proposals_after_recent_filter','proposals'):
+    assert k in d, f'missing key {k}'
+assert d['proposals_total'] == 1
+assert d['proposals_after_dedup'] == 1
+assert len(d['proposals']) == 1
+assert d['proposals'][0]['source'] == 'spec-vs-code'
+assert 'score' in d['proposals'][0]
+"
+}
+
+@test "aggregator dedups by normalized title across researchers" {
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: Add login flow","evidence":"e1","estimated_complexity":"small","confidence":0.9}]}'
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[{"title":"chore: add login flow","evidence":"e2","estimated_complexity":"medium","confidence":0.6}]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[]}'
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys
+output_json = sys.stdin.read()
+
+import json
+d = json.loads(output_json)
+assert d['proposals_total'] == 2
+assert d['proposals_after_dedup'] == 1
+# Higher-scored should win: spec-vs-code (weight 1.0, conf 0.9, small) > prior-reports.
+assert d['proposals'][0]['source'] == 'spec-vs-code', d['proposals'][0]
+"
+}
+
+@test "aggregator ranks by weighted score and caps to --max-issues-per-round" {
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: A","evidence":"e","estimated_complexity":"small","confidence":0.9},{"title":"feat: B","evidence":"e","estimated_complexity":"large","confidence":0.5}]}'
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[{"title":"feat: C","evidence":"e","estimated_complexity":"small","confidence":0.8}]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[{"title":"feat: D","evidence":"e","estimated_complexity":"small","confidence":0.7}]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[{"title":"feat: E","evidence":"e","estimated_complexity":"small","confidence":0.6}]}'
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 2
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys
+output_json = sys.stdin.read()
+
+import json
+d = json.loads(output_json)
+assert len(d['proposals']) == 2
+# Highest weighted: A (1.0*0.9/1.0=0.9) and C (0.9*0.8/1.0=0.72) should be top 2.
+titles = [p['title'] for p in d['proposals']]
+assert d['proposals'][0]['title'] == 'feat: A', titles
+assert d['proposals'][1]['title'] == 'feat: C', titles
+"
+}
+
+@test "aggregator filters proposals matching recent titles" {
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: alpha","evidence":"e","estimated_complexity":"small","confidence":0.9},{"title":"feat: beta","evidence":"e","estimated_complexity":"small","confidence":0.8}]}'
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[]}'
+
+    # alpha should be filtered out as a "recent" title.
+    export AUTOSPEC_TEST_RECENT_TITLES="feat: alpha"
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys
+output_json = sys.stdin.read()
+
+import json
+d = json.loads(output_json)
+assert d['proposals_total'] == 2
+assert d['proposals_after_recent_filter'] == 1
+assert d['proposals'][0]['title'] == 'feat: beta'
+"
+}

--- a/tests/explore/test_explore_researchers.bats
+++ b/tests/explore/test_explore_researchers.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+# tests/explore/test_explore_researchers.bats — fixtures for each of the 4
+# deterministic explore researchers. Each test asserts well-formed JSON
+# matching the contract in docs/specs/2026-05-29-autospec-explore-design.md
+# (Research cycle contract).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    TMP="$(mktemp -d -t explore-research.XXXXXX)"
+    cd "$TMP"
+    git init -q
+    git config user.email t@t.t
+    git config user.name t
+    export AUTOSPEC_REPO_ROOT="$TMP"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+assert_well_formed() {
+    local json="$1"
+    printf '%s' "$json" | python3 -c '
+import json,sys
+d = json.load(sys.stdin)
+assert isinstance(d, dict), "top-level must be object"
+assert "source" in d, "missing source"
+assert "proposals" in d, "missing proposals"
+assert isinstance(d["proposals"], list), "proposals must be list"
+for p in d["proposals"]:
+    for k in ("title","evidence","estimated_complexity","confidence"):
+        assert k in p, f"proposal missing {k}"
+    assert p["estimated_complexity"] in ("small","medium","large"), "bad complexity"
+    assert 0.0 <= float(p["confidence"]) <= 1.0, "bad confidence"
+'
+}
+
+@test "spec-vs-code emits well-formed JSON from a spec with unmatched AC" {
+    mkdir -p docs/specs
+    cat > docs/specs/example.md <<'EOF'
+# Example spec
+## Acceptance criteria
+- [ ] Implement the zzzunique-xyzqqq-marker widget for users
+- [x] Already done item
+EOF
+    git add -A && git commit -q -m init
+    run bash "$REPO_ROOT/scripts/explore-research/spec-vs-code.sh"
+    [ "$status" -eq 0 ]
+    assert_well_formed "$output"
+    [[ "$output" == *"spec-vs-code"* ]]
+    [[ "$output" == *"zzzunique-xyzqqq-marker"* ]]
+}
+
+@test "prior-reports emits well-formed JSON harvesting Next steps section" {
+    mkdir -p .autospec
+    cat > .autospec/run-summary.md <<'EOF'
+# Run summary
+Result: PASS
+
+## Next steps
+- fix the broken loader handler in service xyz
+- add coverage for the streaming endpoint module
+EOF
+    git add -A && git commit -q -m init
+    run bash "$REPO_ROOT/scripts/explore-research/prior-reports.sh"
+    [ "$status" -eq 0 ]
+    assert_well_formed "$output"
+    [[ "$output" == *"prior-reports"* ]]
+    [[ "$output" == *"broken loader handler"* || "$output" == *"streaming endpoint"* ]]
+}
+
+@test "codebase-signals emits well-formed JSON from TODO comments" {
+    mkdir -p src
+    cat > src/foo.py <<'EOF'
+def foo():
+    # TODO: implement properly
+    return 1
+EOF
+    git add -A && git commit -q -m init
+    run bash "$REPO_ROOT/scripts/explore-research/codebase-signals.sh"
+    [ "$status" -eq 0 ]
+    assert_well_formed "$output"
+    [[ "$output" == *"codebase-signals"* ]]
+    [[ "$output" == *"TODO"* ]]
+}
+
+@test "open-issues emits well-formed JSON from injected fake gh output" {
+    cat > issues.json <<'EOF'
+[
+  {"number":1,"title":"Fix login redirect","url":"https://example.com/1","labels":[]},
+  {"number":2,"title":"v2 flow refactor","url":"https://example.com/2","labels":[{"name":"autospec:v2-flow"}]}
+]
+EOF
+    export AUTOSPEC_TEST_ISSUES_JSON="$TMP/issues.json"
+    run bash "$REPO_ROOT/scripts/explore-research/open-issues.sh"
+    [ "$status" -eq 0 ]
+    assert_well_formed "$output"
+    [[ "$output" == *"open-issues"* ]]
+    [[ "$output" == *"Fix login redirect"* ]]
+    # v2-flow labeled issue must be excluded
+    [[ "$output" != *"v2 flow refactor"* ]]
+}


### PR DESCRIPTION
Closes #719

## Summary

Ships the deterministic half of the autospec-explore research cycle (issue 3 of 5 in the explore chain).

- 4 deterministic researchers in `scripts/explore-research/`:
  - `spec-vs-code.sh` — walks `docs/specs/**.md`, greps for unmatched ACs
  - `prior-reports.sh` — harvests Next-steps content via shared matchers (PR #709)
  - `codebase-signals.sh` — TODO/FIXME + optional coverage parsing
  - `open-issues.sh` — `gh issue list` minus `autospec:v2-flow`
- `scripts/explore-research-cycle.sh` aggregator — parallel run, dedup by normalized title, weighted ranking (`confidence × source_weight ÷ complexity`), recent-title filter (last 7 days), `--max-issues-per-round` cap.
- `tests/explore/test_explore_researchers.bats` + `test_explore_research_cycle.bats` — 8 tests covering each researcher and the aggregator (dedup, ranking, filter).
- `scripts/validate.sh`: new `check_autospec_explore_researchers_deterministic()` gate.

## Spec

`docs/specs/2026-05-29-autospec-explore-design.md` — Research cycle contract + Per-researcher contracts rows 1-4.

## Verification

- `bats tests/explore/test_explore_researchers.bats tests/explore/test_explore_research_cycle.bats` — 8/8 pass
- `bash scripts/validate.sh` — OK

LLM-driven `source-analysis` and `internet` researchers are out of scope (issue #720).