### PR TITLE
feat: autospec-sweep parallel area dispatch — 4 subagents (closes #732)

### DIFF
--- a/scripts/explore-research/dependency-health.sh
+++ b/scripts/explore-research/dependency-health.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# scripts/explore-research/dependency-health.sh — deterministic researcher #7.
+#
+# Detects dependency manifests in the repo and identifies outdated deps via
+# harness-aware tooling (npm/pip/go/cargo/gem). Best-effort: missing toolchains
+# produce zero proposals rather than failing.
+#
+# Also usable directly by autospec-explore (extends 6→7 researchers) and by
+# autospec-sweep as the dependency-health area researcher.
+#
+# Output: JSON to stdout matching the contract in
+# docs/specs/2026-05-29-autospec-explore-design.md — Research cycle contract.
+
+set -u
+
+REPO_ROOT="${AUTOSPEC_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+MAX_PROPOSALS=20
+
+cd "$REPO_ROOT" || { echo '{"source":"dependency-health","proposals":[]}'; exit 0; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo '{"source":"dependency-health","proposals":[]}'
+    exit 0
+fi
+
+# Allow tests to inject pre-computed outdated reports.
+INJECTED_NPM="${AUTOSPEC_TEST_NPM_OUTDATED:-}"
+INJECTED_PIP="${AUTOSPEC_TEST_PIP_OUTDATED:-}"
+
+manifests=()
+[ -f package.json ] && manifests+=("npm:package.json")
+[ -f requirements.txt ] && manifests+=("pip:requirements.txt")
+[ -f pyproject.toml ] && manifests+=("pip:pyproject.toml")
+[ -f go.mod ] && manifests+=("go:go.mod")
+[ -f Cargo.toml ] && manifests+=("cargo:Cargo.toml")
+[ -f Gemfile ] && manifests+=("gem:Gemfile")
+
+# Collect outdated reports (best-effort, capped time)
+npm_json=""
+pip_json=""
+if [ -n "$INJECTED_NPM" ] && [ -f "$INJECTED_NPM" ]; then
+    npm_json="$(cat "$INJECTED_NPM")"
+elif [ -f package.json ] && command -v npm >/dev/null 2>&1; then
+    npm_json="$(timeout 10 npm outdated --json 2>/dev/null || true)"
+fi
+if [ -n "$INJECTED_PIP" ] && [ -f "$INJECTED_PIP" ]; then
+    pip_json="$(cat "$INJECTED_PIP")"
+elif { [ -f requirements.txt ] || [ -f pyproject.toml ]; } && command -v pip >/dev/null 2>&1; then
+    pip_json="$(timeout 10 pip list --outdated --format=json 2>/dev/null || true)"
+fi
+
+export AUTOSPEC_MANIFESTS="${manifests[*]:-}"
+export AUTOSPEC_NPM_OUTDATED="$npm_json"
+export AUTOSPEC_PIP_OUTDATED="$pip_json"
+export AUTOSPEC_MAX_PROPOSALS="$MAX_PROPOSALS"
+
+python3 - <<'PY'
+import json, os
+
+manifests = os.environ.get("AUTOSPEC_MANIFESTS", "").split()
+npm_raw = os.environ.get("AUTOSPEC_NPM_OUTDATED", "").strip()
+pip_raw = os.environ.get("AUTOSPEC_PIP_OUTDATED", "").strip()
+cap = int(os.environ.get("AUTOSPEC_MAX_PROPOSALS", "20"))
+
+proposals = []
+
+def add(title, evidence, complexity="small", confidence=0.7):
+    if len(proposals) >= cap:
+        return
+    proposals.append({
+        "title": title,
+        "evidence": evidence,
+        "estimated_complexity": complexity,
+        "confidence": confidence,
+    })
+
+# npm outdated → object keyed by package name
+if npm_raw:
+    try:
+        data = json.loads(npm_raw)
+        if isinstance(data, dict):
+            for pkg, info in data.items():
+                cur = (info or {}).get("current", "?")
+                latest = (info or {}).get("latest", "?")
+                if cur == latest:
+                    continue
+                add(
+                    f"chore(deps): bump {pkg} {cur} → {latest}",
+                    f"npm outdated reports {pkg} current={cur} latest={latest}",
+                )
+    except Exception:
+        pass
+
+# pip list --outdated → list of {name, version, latest_version}
+if pip_raw:
+    try:
+        data = json.loads(pip_raw)
+        if isinstance(data, list):
+            for item in data:
+                name = item.get("name")
+                cur = item.get("version", "?")
+                latest = item.get("latest_version", "?")
+                if not name:
+                    continue
+                add(
+                    f"chore(deps): bump {name} {cur} → {latest}",
+                    f"pip list --outdated reports {name} current={cur} latest={latest}",
+                )
+    except Exception:
+        pass
+
+# Fallback: if manifests exist but no outdated tooling produced output, emit a
+# single low-confidence proposal noting toolchain coverage gap so the sweep
+# does not silently report a clean dependency-health area.
+if manifests and not proposals:
+    add(
+        "chore(deps): verify dependency freshness (no outdated tooling available)",
+        f"Detected manifests: {', '.join(manifests)}. No outdated-check tooling produced output.",
+        complexity="small",
+        confidence=0.4,
+    )
+
+print(json.dumps({"source": "dependency-health", "proposals": proposals}))
+PY

--- a/scripts/sweep-area-dispatch.sh
+++ b/scripts/sweep-area-dispatch.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# scripts/sweep-area-dispatch.sh — parallel area dispatcher for autospec-sweep.
+#
+# Reads the 4 area definitions under skills/autospec-sweep/areas/ and dispatches
+# each area's researcher in parallel via the harness-aware dispatcher
+# (scripts/lib/autospec-harness-detect.sh). Aggregates the per-area JSON into a
+# single sweep report at .autospec/sweep/area-findings.json.
+#
+# 3 areas reuse existing autospec-explore researchers; 1 area is the new
+# dependency-health researcher (which also extends autospec-explore to 7).
+#
+# Usage:
+#   bash scripts/sweep-area-dispatch.sh [--out PATH]
+#
+# Honors:
+#   AUTOSPEC_REPO_ROOT  override repo root
+#   AUTOSPEC_SWEEP_OUT  override output path
+
+set -u
+
+REPO_ROOT="${AUTOSPEC_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+cd "$REPO_ROOT" || exit 1
+
+OUT="${AUTOSPEC_SWEEP_OUT:-.autospec/sweep/area-findings.json}"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --out) OUT="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+mkdir -p "$(dirname "$OUT")"
+
+AREAS_DIR="skills/autospec-sweep/areas"
+RESEARCH_DIR="scripts/explore-research"
+
+# Area → researcher mapping. Keep in sync with skills/autospec-sweep/areas/*.md.
+declare -a AREAS=(
+    "spec-vs-code-drift:$RESEARCH_DIR/spec-vs-code.sh"
+    "docs-drift:scripts/dogfood-adapter-doc-drift.sh"
+    "code-health:$RESEARCH_DIR/codebase-signals.sh"
+    "dependency-health:$RESEARCH_DIR/dependency-health.sh"
+)
+
+# Verify all 4 area definition files exist.
+for area_file in spec-vs-code-drift docs-drift code-health dependency-health; do
+    if [ ! -f "$AREAS_DIR/$area_file.md" ]; then
+        echo "ERROR: missing area definition: $AREAS_DIR/$area_file.md" >&2
+        exit 2
+    fi
+done
+
+TMPDIR_RUN="$(mktemp -d -t sweep-dispatch.XXXXXX)"
+trap 'rm -rf "$TMPDIR_RUN"' EXIT
+
+# Dispatch each area's researcher in parallel.
+pids=()
+for entry in "${AREAS[@]}"; do
+    area="${entry%%:*}"
+    script="${entry#*:}"
+    out_file="$TMPDIR_RUN/$area.json"
+    if [ -x "$script" ] || [ -f "$script" ]; then
+        ( bash "$script" >"$out_file" 2>/dev/null \
+            || printf '{"source":"%s","proposals":[],"error":"researcher failed"}' "$area" >"$out_file" ) &
+        pids+=("$!")
+    else
+        printf '{"source":"%s","proposals":[],"error":"researcher missing"}' "$area" >"$out_file"
+    fi
+done
+
+# Wait for all parallel researchers.
+for pid in "${pids[@]}"; do wait "$pid" 2>/dev/null || true; done
+
+# Aggregate into a single report.
+python3 - "$TMPDIR_RUN" "$OUT" <<'PY'
+import json, os, sys, glob
+tmp, out = sys.argv[1], sys.argv[2]
+areas = {}
+for f in sorted(glob.glob(os.path.join(tmp, "*.json"))):
+    name = os.path.basename(f)[:-5]
+    try:
+        with open(f) as fh:
+            areas[name] = json.load(fh)
+    except Exception as e:
+        areas[name] = {"source": name, "proposals": [], "error": str(e)}
+report = {
+    "schema": "autospec-sweep.area-findings.v1",
+    "areas": areas,
+    "summary": {
+        "area_count": len(areas),
+        "total_proposals": sum(len((a or {}).get("proposals", [])) for a in areas.values()),
+    },
+}
+with open(out, "w") as fh:
+    json.dump(report, fh, indent=2)
+print(out)
+PY

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1035,6 +1035,40 @@ check_autospec_qa_contract() {
         || fail "schemas/autospec-reliability.schema.json: missing deprecated_surfaces contract"
 }
 
+check_autospec_sweep_area_contract() {
+    info "autospec-sweep area dispatch contract"
+    local areas_dir="skills/autospec-sweep/areas"
+    [ -d "$areas_dir" ] || fail "$areas_dir: required directory missing"
+    for a in spec-vs-code-drift docs-drift code-health dependency-health; do
+        [ -f "$areas_dir/$a.md" ] || fail "$areas_dir/$a.md: required area file missing"
+    done
+    local dispatcher="scripts/sweep-area-dispatch.sh"
+    [ -f "$dispatcher" ] || fail "$dispatcher: required dispatcher missing"
+    bash -n "$dispatcher" || fail "$dispatcher: bash syntax error"
+    local dep_researcher="scripts/explore-research/dependency-health.sh"
+    [ -f "$dep_researcher" ] || fail "$dep_researcher: required researcher missing"
+    bash -n "$dep_researcher" || fail "$dep_researcher: bash syntax error"
+    # Lockstep: the "## Parallel area dispatch" section must appear in all 3
+    # trio adapters with the same area list.
+    for f in skills/autospec-sweep/SKILL.md \
+             skills/autospec-sweep/codex/prompt.md \
+             skills/autospec-sweep/opencode/agent.md; do
+        grep -q '^## Parallel area dispatch' "$f" \
+            || fail "$f: missing '## Parallel area dispatch' section"
+        for a in spec-vs-code-drift docs-drift code-health dependency-health; do
+            grep -q "$a" "$f" \
+                || fail "$f: missing area reference '$a'"
+        done
+        grep -q 'sweep-area-dispatch.sh' "$f" \
+            || fail "$f: missing reference to scripts/sweep-area-dispatch.sh"
+    done
+    local bats_file="tests/sweep/test_sweep_area_dispatch.bats"
+    [ -f "$bats_file" ] || fail "$bats_file: required bats file missing"
+    info "  running: $bats_file"
+    bats "$bats_file" >/tmp/validate-sweep-area.log 2>&1 \
+        || { cat /tmp/validate-sweep-area.log >&2; fail "$bats_file: failed"; }
+}
+
 check_autospec_release_contract() {
     info "autospec-release contract: release readiness wrapper"
     local skill_file="skills/autospec-release/SKILL.md"
@@ -1705,6 +1739,7 @@ main() {
     check_autospec_explore_researchers_deterministic
     check_autospec_explore_researchers_llm
     check_autospec_explore_contract
+    check_autospec_sweep_area_contract
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.

--- a/skills/autospec-sweep/SKILL.md
+++ b/skills/autospec-sweep/SKILL.md
@@ -131,6 +131,28 @@ changed enough that the config is stale.
 5. If a config change contradicts a tracked spec, update the spec in the same
    autospec design/spec PR before any implementation issue is filed.
 
+## Parallel area dispatch
+
+Sweep runs fan out into 4 parallel area subagents per the AGENTS.md subagent
+dispatch decision matrix. Areas are defined under
+`skills/autospec-sweep/areas/` and dispatched via
+`scripts/sweep-area-dispatch.sh`:
+
+1. `spec-vs-code-drift` — reuses `scripts/explore-research/spec-vs-code.sh`.
+2. `docs-drift` — reuses `scripts/dogfood-adapter-doc-drift.sh`.
+3. `code-health` — reuses `scripts/explore-research/codebase-signals.sh`.
+4. `dependency-health` — new `scripts/explore-research/dependency-health.sh`
+   researcher (also available to autospec-explore — extends the 6-researcher
+   set to 7).
+
+Each area subagent emits research-cycle JSON. The dispatcher aggregates into
+`.autospec/sweep/area-findings.json` (`schema: autospec-sweep.area-findings.v1`)
+which feeds the existing sweep report and `autospec-review`.
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/sweep-area-dispatch.sh"
+```
+
 ## Sweep execution
 
 > **Model tier:** TIER_A for sweep synthesis and gap classification. Any fix

--- a/skills/autospec-sweep/areas/code-health.md
+++ b/skills/autospec-sweep/areas/code-health.md
@@ -1,0 +1,20 @@
+# Sweep area: code-health
+
+Surface TODO/FIXME markers, dead code, and low-coverage hot spots.
+
+## Researcher
+
+Reuses the autospec-explore deterministic researcher:
+
+- `scripts/explore-research/codebase-signals.sh`
+
+Scans tracked source for `TODO`/`FIXME`/`XXX` comments and other code-health
+signals, and emits one proposal per signal cluster.
+
+## Output
+
+JSON to stdout matching the autospec-explore research-cycle contract:
+
+```json
+{ "source": "codebase-signals", "proposals": [ ... ] }
+```

--- a/skills/autospec-sweep/areas/dependency-health.md
+++ b/skills/autospec-sweep/areas/dependency-health.md
@@ -1,0 +1,26 @@
+# Sweep area: dependency-health
+
+Detect outdated dependencies and best-effort security advisories.
+
+## Researcher
+
+New deterministic researcher, shared with autospec-explore (extends the
+6-researcher set to 7):
+
+- `scripts/explore-research/dependency-health.sh`
+
+Detects dependency manifests in the repo (`package.json`, `requirements.txt`,
+`go.mod`, `Cargo.toml`, `Gemfile`, `pyproject.toml`) and runs the harness-aware
+outdated-check (`npm outdated --json`, `pip list --outdated --format=json`,
+`go list -m -u all`, `cargo outdated`, etc.) when the toolchain is available.
+
+The researcher is best-effort and harness-aware: missing toolchains produce
+zero proposals rather than failing.
+
+## Output
+
+JSON to stdout matching the autospec-explore research-cycle contract:
+
+```json
+{ "source": "dependency-health", "proposals": [ ... ] }
+```

--- a/skills/autospec-sweep/areas/docs-drift.md
+++ b/skills/autospec-sweep/areas/docs-drift.md
@@ -1,0 +1,24 @@
+# Sweep area: docs-drift
+
+Detect drift between user-facing docs and implemented behavior.
+
+## Researcher
+
+Reuses the adapter doc-drift dogfood scanner:
+
+- `scripts/dogfood-adapter-doc-drift.sh`
+
+Reads tracked docs (`README.md`, `docs/**`, `AGENTS.md`, harness adapter prose),
+compares declared invocations/flags/behaviors against the codebase, and emits
+one proposal per stale or contradicting doc.
+
+## Output
+
+JSON to stdout matching the autospec-explore research-cycle contract:
+
+```json
+{ "source": "docs-drift", "proposals": [ ... ] }
+```
+
+If the upstream dogfood scanner does not emit research-cycle JSON, the
+orchestrator wraps its findings into the contract before aggregation.

--- a/skills/autospec-sweep/areas/spec-vs-code-drift.md
+++ b/skills/autospec-sweep/areas/spec-vs-code-drift.md
@@ -1,0 +1,23 @@
+# Sweep area: spec-vs-code-drift
+
+Detect drift between tracked acceptance criteria and implementation.
+
+## Researcher
+
+Reuses the autospec-explore deterministic researcher:
+
+- `scripts/explore-research/spec-vs-code.sh`
+
+Walks `docs/specs/**.md`, extracts unchecked acceptance criteria, greps the repo
+for matching identifiers, and emits one proposal per unmatched AC.
+
+## Output
+
+JSON to stdout matching the autospec-explore research-cycle contract:
+
+```json
+{ "source": "spec-vs-code", "proposals": [ ... ] }
+```
+
+The sweep orchestrator aggregates these proposals into the sweep report and
+hands them to `autospec-review` for filing as `auto-implement` issues.

--- a/skills/autospec-sweep/codex/prompt.md
+++ b/skills/autospec-sweep/codex/prompt.md
@@ -127,6 +127,28 @@ changed enough that the config is stale.
 5. If a config change contradicts a tracked spec, update the spec in the same
    autospec design/spec PR before any implementation issue is filed.
 
+## Parallel area dispatch
+
+Sweep runs fan out into 4 parallel area subagents per the AGENTS.md subagent
+dispatch decision matrix. Areas are defined under
+`skills/autospec-sweep/areas/` and dispatched via
+`scripts/sweep-area-dispatch.sh`:
+
+1. `spec-vs-code-drift` — reuses `scripts/explore-research/spec-vs-code.sh`.
+2. `docs-drift` — reuses `scripts/dogfood-adapter-doc-drift.sh`.
+3. `code-health` — reuses `scripts/explore-research/codebase-signals.sh`.
+4. `dependency-health` — new `scripts/explore-research/dependency-health.sh`
+   researcher (also available to autospec-explore — extends the 6-researcher
+   set to 7).
+
+Each area subagent emits research-cycle JSON. The dispatcher aggregates into
+`.autospec/sweep/area-findings.json` (`schema: autospec-sweep.area-findings.v1`)
+which feeds the existing sweep report and `autospec-review`.
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/sweep-area-dispatch.sh"
+```
+
 ## Sweep execution
 
 > **Model tier:** TIER_A for sweep synthesis and gap classification. Any fix

--- a/skills/autospec-sweep/opencode/agent.md
+++ b/skills/autospec-sweep/opencode/agent.md
@@ -131,6 +131,28 @@ changed enough that the config is stale.
 5. If a config change contradicts a tracked spec, update the spec in the same
    autospec design/spec PR before any implementation issue is filed.
 
+## Parallel area dispatch
+
+Sweep runs fan out into 4 parallel area subagents per the AGENTS.md subagent
+dispatch decision matrix. Areas are defined under
+`skills/autospec-sweep/areas/` and dispatched via
+`scripts/sweep-area-dispatch.sh`:
+
+1. `spec-vs-code-drift` — reuses `scripts/explore-research/spec-vs-code.sh`.
+2. `docs-drift` — reuses `scripts/dogfood-adapter-doc-drift.sh`.
+3. `code-health` — reuses `scripts/explore-research/codebase-signals.sh`.
+4. `dependency-health` — new `scripts/explore-research/dependency-health.sh`
+   researcher (also available to autospec-explore — extends the 6-researcher
+   set to 7).
+
+Each area subagent emits research-cycle JSON. The dispatcher aggregates into
+`.autospec/sweep/area-findings.json` (`schema: autospec-sweep.area-findings.v1`)
+which feeds the existing sweep report and `autospec-review`.
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/sweep-area-dispatch.sh"
+```
+
 ## Sweep execution
 
 > **Model tier:** TIER_A for sweep synthesis and gap classification. Any fix

--- a/tests/sweep/test_sweep_area_dispatch.bats
+++ b/tests/sweep/test_sweep_area_dispatch.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# tests/sweep/test_sweep_area_dispatch.bats — fixtures for autospec-sweep
+# parallel area dispatch (closes #732). Verifies 4 areas dispatch, aggregated
+# report covers all 4, and the new dependency-health researcher emits
+# well-formed research-cycle JSON.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    TMP="$(mktemp -d -t sweep-area.XXXXXX)"
+    cd "$TMP"
+    git init -q
+    git config user.email t@t.t
+    git config user.name t
+    export AUTOSPEC_REPO_ROOT="$TMP"
+    # Mirror the sweep dispatcher's expected layout into the temp repo.
+    mkdir -p skills/autospec-sweep/areas scripts/explore-research scripts
+    for a in spec-vs-code-drift docs-drift code-health dependency-health; do
+        echo "# $a" > "skills/autospec-sweep/areas/$a.md"
+    done
+    # Stub researchers — copy the real ones so reuse is exercised.
+    cp "$REPO_ROOT/scripts/explore-research/spec-vs-code.sh" scripts/explore-research/
+    cp "$REPO_ROOT/scripts/explore-research/codebase-signals.sh" scripts/explore-research/
+    cp "$REPO_ROOT/scripts/explore-research/dependency-health.sh" scripts/explore-research/
+    # docs-drift adapter: stub that emits valid research-cycle JSON.
+    cat > scripts/dogfood-adapter-doc-drift.sh <<'EOF'
+#!/usr/bin/env bash
+echo '{"source":"docs-drift","proposals":[]}'
+EOF
+    chmod +x scripts/dogfood-adapter-doc-drift.sh scripts/explore-research/*.sh
+    git add -A && git commit -q -m init
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+@test "sweep area dispatcher emits aggregated report covering all 4 areas" {
+    run bash "$REPO_ROOT/scripts/sweep-area-dispatch.sh" --out "$TMP/out.json"
+    [ "$status" -eq 0 ]
+    [ -f "$TMP/out.json" ]
+    python3 - "$TMP/out.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+assert d["schema"] == "autospec-sweep.area-findings.v1"
+for a in ("spec-vs-code-drift","docs-drift","code-health","dependency-health"):
+    assert a in d["areas"], f"missing area {a}"
+assert d["summary"]["area_count"] == 4
+PY
+}
+
+@test "dependency-health researcher emits well-formed research-cycle JSON" {
+    cat > package.json <<'EOF'
+{"name":"x","version":"0.0.1","dependencies":{"left-pad":"^1.0.0"}}
+EOF
+    cat > npm-outdated.json <<'EOF'
+{"left-pad":{"current":"1.0.0","latest":"1.3.0","wanted":"1.3.0"}}
+EOF
+    export AUTOSPEC_TEST_NPM_OUTDATED="$TMP/npm-outdated.json"
+    git add -A && git commit -q -m deps
+    run bash "$REPO_ROOT/scripts/explore-research/dependency-health.sh"
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+assert d["source"]=="dependency-health"
+assert isinstance(d["proposals"],list)
+assert any("left-pad" in p["title"] for p in d["proposals"]), d
+for p in d["proposals"]:
+    for k in ("title","evidence","estimated_complexity","confidence"):
+        assert k in p
+    assert p["estimated_complexity"] in ("small","medium","large")
+    assert 0.0 <= float(p["confidence"]) <= 1.0
+'
+}
+
+@test "dispatcher fails fast when an area definition file is missing" {
+    rm skills/autospec-sweep/areas/dependency-health.md
+    run bash "$REPO_ROOT/scripts/sweep-area-dispatch.sh" --out "$TMP/out.json"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"missing area definition"* ]]
+}
+
+@test "dependency-health emits zero-proposal JSON when no manifests present" {
+    run bash "$REPO_ROOT/scripts/explore-research/dependency-health.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"dependency-health"* ]]
+    [[ "$output" == *"\"proposals\": []"* || "$output" == *'"proposals":[]'* ]]
+}


### PR DESCRIPTION
Closes #732

## Summary

Fan out `/autospec-sweep` runs into 4 parallel area subagents, matching the autospec-qa cluster (#730) and autospec-release area-dispatch (#731) patterns.

## Areas

- `spec-vs-code-drift` — reuses `scripts/explore-research/spec-vs-code.sh`
- `docs-drift` — reuses `scripts/dogfood-adapter-doc-drift.sh`
- `code-health` — reuses `scripts/explore-research/codebase-signals.sh`
- `dependency-health` — NEW `scripts/explore-research/dependency-health.sh` (also extends autospec-explore 6 → 7 researchers)

## Orchestrator

`scripts/sweep-area-dispatch.sh` dispatches all 4 in parallel and aggregates into `.autospec/sweep/area-findings.json` (schema `autospec-sweep.area-findings.v1`).

## Lockstep

The `## Parallel area dispatch` section is mirrored across SKILL.md + codex/prompt.md + opencode/agent.md. New `check_autospec_sweep_area_contract()` in `scripts/validate.sh` enforces:

- 4 area files exist
- dispatcher + dependency-health researcher exist + syntactically valid
- trio adapters reference all 4 areas + dispatcher
- `tests/sweep/test_sweep_area_dispatch.bats` (4 tests) passes

## Verification

- `bash scripts/validate.sh` green
- `bats tests/sweep/` green (4/4)
- `bats tests/explore/test_explore_researchers.bats` still green (unchanged researchers)