### PR TITLE
feat: autospec-qa bug-class sibling sweep — one PR fixes all matching instances (closes #737)

### DIFF
--- a/scripts/qa-bug-class-sweep.sh
+++ b/scripts/qa-bug-class-sweep.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# scripts/qa-bug-class-sweep.sh — autospec-qa bug-class sibling sweep
+# (issue #737).
+#
+# For each release_blocking finding in the input qa-verdict.json whose
+# `category` ends in `:bug` (or is otherwise fingerprintable), this helper:
+#
+#   1. Reads the offending `file:line` and computes a deterministic
+#      pattern fingerprint over the offending line plus +/-5 context lines.
+#   2. Stores the fingerprint on the PARENT finding (`pattern_fingerprint`
+#      and `fingerprint_hash`) at finding-time so siblings are resolvable
+#      even after the parent line is mutated (pattern drift safety).
+#   3. Runs `git grep -nE <fingerprint>` over the repo, excluding
+#      `node_modules/`, `.git/`, `vendor/`, and the parent's own file:line.
+#   4. For each match, computes a confidence score (context-line match
+#      ratio * fingerprint specificity heuristic). If
+#      confidence >= AUTOSPEC_QA_BUG_CLASS_MIN_CONFIDENCE (default 0.7),
+#      appends a sibling finding with:
+#          category:            code_health:bug_class_sibling
+#          parent_fingerprint:  <hash>
+#          confidence:          <float>
+#          file, line
+#      Below-threshold matches are logged to
+#      `.autospec/qa-bug-class-flagged.json` (operator review, NOT filed).
+#   5. Applies the verify-first filter (qa-verify-finding.sh) to each
+#      candidate sibling. Siblings whose probe says "resolved" are dropped.
+#
+# All verdict mutations go through a temp file + atomic `mv` so partial
+# runs cannot corrupt the verdict.
+
+set -u
+
+usage() {
+    cat <<'EOF'
+Usage: qa-bug-class-sweep.sh --verdict <path> --repo-dir <path>
+
+Flags:
+  --verdict   PATH  qa-verdict.json to read+mutate (required)
+  --repo-dir  PATH  repo root to sweep (required)
+  --help            show this and exit
+
+Environment:
+  AUTOSPEC_QA_BUG_CLASS_MIN_CONFIDENCE  confidence threshold (default 0.7)
+EOF
+}
+
+VERDICT=""
+REPO_DIR=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --verdict)  VERDICT="$2"; shift 2 ;;
+        --repo-dir) REPO_DIR="$2"; shift 2 ;;
+        --help|-h)  usage; exit 0 ;;
+        *) echo "qa-bug-class-sweep: unknown arg: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$VERDICT" ] || [ -z "$REPO_DIR" ]; then
+    usage >&2
+    exit 2
+fi
+if [ ! -f "$VERDICT" ]; then
+    echo "qa-bug-class-sweep: verdict not found: $VERDICT" >&2
+    exit 2
+fi
+if [ ! -d "$REPO_DIR" ]; then
+    echo "qa-bug-class-sweep: repo-dir not found: $REPO_DIR" >&2
+    exit 2
+fi
+
+MIN_CONF="${AUTOSPEC_QA_BUG_CLASS_MIN_CONFIDENCE:-0.7}"
+FLAGGED="$(dirname "$VERDICT")/qa-bug-class-flagged.json"
+mkdir -p "$(dirname "$FLAGGED")"
+[ -f "$FLAGGED" ] || printf '{"flagged":[]}\n' > "$FLAGGED"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VERIFY_HELPER="$SCRIPT_DIR/qa-verify-finding.sh"
+
+# Extract a fingerprint regex from a file:line. Reads +/-5 context lines,
+# strips literals (strings, numbers) so the pattern matches sibling
+# instances that differ only in their arguments. Returns the regex on
+# stdout; empty stdout = unfingerprintable.
+extract_fingerprint() {
+    local file="$1" line="$2"
+    [ -f "$file" ] || { echo ""; return; }
+    local start=$((line > 5 ? line - 5 : 1))
+    local end=$((line + 5))
+    local target
+    target=$(awk -v n="$line" 'NR==n {print; exit}' "$file")
+    [ -n "$target" ] || { echo ""; return; }
+    # Normalize: strip leading whitespace, collapse strings to "", numbers to N.
+    local norm
+    norm=$(printf '%s' "$target" \
+        | sed -e 's/^[[:space:]]*//' \
+              -e 's/"[^"]*"/""/g' \
+              -e "s/'[^']*'/''/g" \
+              -e 's/[0-9][0-9]*/N/g')
+    # Extract the first identifier-ish token (function/method call name)
+    # for fingerprint anchor.
+    local anchor
+    anchor=$(printf '%s' "$norm" | grep -oE '[A-Za-z_][A-Za-z0-9_.]*' | head -1)
+    [ -n "$anchor" ] || { echo ""; return; }
+    # Compose a regex anchored on the identifier; specificity is captured
+    # via the anchor length (heuristic).
+    printf '%s' "$anchor"
+}
+
+# Compute a sha256 hash of the fingerprint for parent_fingerprint linkage.
+fingerprint_hash() {
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+}
+
+# Compute confidence for a candidate sibling match.
+#   ratio = matches in +/-5 context window / 11
+#   specificity = min(1.0, len(fingerprint)/8)
+#   confidence = ratio * specificity (clamped 0..1)
+compute_confidence() {
+    local file="$1" line="$2" fingerprint="$3"
+    [ -f "$file" ] || { printf '0.0\n'; return; }
+    local start=$((line > 5 ? line - 5 : 1))
+    local end=$((line + 5))
+    local hits
+    hits=$(awk -v s="$start" -v e="$end" -v p="$fingerprint" '
+        NR < s { next } NR > e { exit }
+        index($0, p) > 0 { c++ }
+        END { print c+0 }
+    ' "$file")
+    local len=${#fingerprint}
+    awk -v h="$hits" -v l="$len" 'BEGIN {
+        # Presence: 1.0 if anchor appears at least once in the +/-5 window,
+        # else 0. Density bonus for multi-hit windows (up to +0.2).
+        if (h <= 0) { printf "0.000\n"; exit }
+        presence = 1.0
+        density  = (h - 1) * 0.1
+        if (density > 0.2) density = 0.2
+        spec = (l >= 8 ? 1.0 : l/8.0)
+        c = (presence + density) * spec
+        if (c > 1.0) c = 1.0
+        if (c < 0.0) c = 0.0
+        printf "%.3f\n", c
+    }'
+}
+
+# Run verify-first probe for a sibling. Treat siblings as missing_function
+# probes anchored on the fingerprint anchor: if the anchor is absent from
+# the candidate file at HEAD, the bug has been resolved → DROP.
+verify_sibling() {
+    local file="$1" anchor="$2"
+    [ -x "$VERIFY_HELPER" ] || return 0   # no verifier → keep all
+    bash "$VERIFY_HELPER" --category missing_function \
+        --symbol "$anchor" --file "$file" >/dev/null 2>&1
+    # exit 0 = symbol absent (resolved upstream) → DROP this sibling
+    # exit 1 = symbol present → KEEP
+    case "$?" in
+        0) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# Phase 1: compute and STORE fingerprints on parent findings at
+# finding-time (pattern drift safety — issue #737 acceptance criterion).
+PARENTS_TMP="$(mktemp)"
+trap 'rm -f "$PARENTS_TMP"' EXIT
+
+jq -c '
+    (.findings // [])
+    | to_entries[]
+    | select(.value.release_blocking == true)
+    | select((.value.category // "") | test(":bug$|:bug_|^bug:|_bug$"))
+    | select(.value.file and .value.line)
+    | {idx: .key, file: .value.file, line: .value.line, category: .value.category}
+' "$VERDICT" > "$PARENTS_TMP" 2>/dev/null || true
+
+# Build a jq script that patches in fingerprint + sibling findings atomically.
+SIBLINGS_TMP="$(mktemp)"
+FLAGGED_TMP="$(mktemp)"
+PATCH_TMP="$(mktemp)"
+trap 'rm -f "$PARENTS_TMP" "$SIBLINGS_TMP" "$FLAGGED_TMP" "$PATCH_TMP"' EXIT
+
+printf '[]' > "$SIBLINGS_TMP"
+printf '[]' > "$FLAGGED_TMP"
+# parent_idx → fingerprint/hash patches
+printf '[]' > "$PATCH_TMP"
+
+while IFS= read -r parent; do
+    [ -n "$parent" ] || continue
+    idx=$(printf '%s' "$parent" | jq -r '.idx')
+    pfile=$(printf '%s' "$parent" | jq -r '.file')
+    pline=$(printf '%s' "$parent" | jq -r '.line')
+
+    abs_pfile="$pfile"
+    [ -f "$abs_pfile" ] || abs_pfile="$REPO_DIR/$pfile"
+    [ -f "$abs_pfile" ] || continue
+
+    fingerprint=$(extract_fingerprint "$abs_pfile" "$pline")
+    [ -n "$fingerprint" ] || continue
+    fhash=$(fingerprint_hash "$fingerprint")
+
+    # Record patch for parent.
+    jq --argjson idx "$idx" --arg fp "$fingerprint" --arg fh "$fhash" \
+        '. + [{idx: $idx, fingerprint: $fp, hash: $fh}]' \
+        "$PATCH_TMP" > "${PATCH_TMP}.new" && mv "${PATCH_TMP}.new" "$PATCH_TMP"
+
+    # Sweep the repo for sibling matches (exclude parent file:line).
+    while IFS=: read -r mfile mline mtext; do
+        [ -n "$mfile" ] || continue
+        [ -n "$mline" ] || continue
+        # Skip parent's own file:line.
+        case "$mfile" in
+            "$pfile"|"./$pfile")
+                [ "$mline" = "$pline" ] && continue
+                ;;
+        esac
+        abs_mfile="$mfile"
+        [ -f "$abs_mfile" ] || abs_mfile="$REPO_DIR/$mfile"
+        [ -f "$abs_mfile" ] || continue
+
+        conf=$(compute_confidence "$abs_mfile" "$mline" "$fingerprint")
+        # Numeric compare against threshold.
+        above=$(awk -v c="$conf" -v t="$MIN_CONF" 'BEGIN {print (c+0 >= t+0) ? 1 : 0}')
+
+        sib=$(jq -n \
+            --arg cat "code_health:bug_class_sibling" \
+            --arg pf "$fhash" \
+            --argjson c "$conf" \
+            --arg f "$mfile" \
+            --argjson l "$mline" \
+            '{category:$cat, parent_fingerprint:$pf, confidence:$c, file:$f, line:$l, release_blocking:true}')
+
+        if [ "$above" = "1" ]; then
+            # Apply verify-first filter.
+            if verify_sibling "$abs_mfile" "$fingerprint"; then
+                jq --argjson s "$sib" '. + [$s]' "$SIBLINGS_TMP" > "${SIBLINGS_TMP}.new" \
+                    && mv "${SIBLINGS_TMP}.new" "$SIBLINGS_TMP"
+            fi
+        else
+            jq --argjson s "$sib" '. + [$s]' "$FLAGGED_TMP" > "${FLAGGED_TMP}.new" \
+                && mv "${FLAGGED_TMP}.new" "$FLAGGED_TMP"
+        fi
+    done < <(
+        cd "$REPO_DIR" && git grep -nE "$fingerprint" -- \
+            ':(exclude)node_modules' ':(exclude).git' ':(exclude)vendor' \
+            2>/dev/null || true
+    )
+done < "$PARENTS_TMP"
+
+# Atomic verdict mutation: apply parent fingerprint patches + append siblings.
+VERDICT_TMP="${VERDICT}.tmp.$$"
+jq --slurpfile patches "$PATCH_TMP" --slurpfile sibs "$SIBLINGS_TMP" '
+    . as $root
+    | (.findings // []) as $f
+    | ($patches[0] // []) as $ps
+    | reduce $ps[] as $p ($f;
+        if .[$p.idx] then
+            .[$p.idx] = (.[$p.idx]
+                + {pattern_fingerprint: $p.fingerprint,
+                   fingerprint_hash:    $p.hash})
+        else . end)
+    | . + ($sibs[0] // [])
+    | $root + {findings: .}
+' "$VERDICT" > "$VERDICT_TMP" && mv "$VERDICT_TMP" "$VERDICT"
+
+# Atomic flagged log mutation.
+FLAGGED_OUT_TMP="${FLAGGED}.tmp.$$"
+jq --slurpfile sibs "$FLAGGED_TMP" '
+    .flagged = ((.flagged // []) + ($sibs[0] // []))
+' "$FLAGGED" > "$FLAGGED_OUT_TMP" && mv "$FLAGGED_OUT_TMP" "$FLAGGED"
+
+exit 0

--- a/scripts/qa-heal-loop.sh
+++ b/scripts/qa-heal-loop.sh
@@ -308,14 +308,51 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
         fi
     fi
 
-    # File issues for each release_blocking finding.
+    # File issues for each release_blocking finding. Bug-class sibling
+    # sweep (issue #737): when findings carry a `parent_fingerprint`,
+    # group them so the heal loop files ONE auto-implement issue per
+    # pattern class — implementer fixes every matching instance in a
+    # single PR. Findings without parent_fingerprint stay per-finding.
     FILED=0
+    # Group 1: per-class (one issue per parent_fingerprint).
+    while IFS= read -r class_hash; do
+        [ -n "$class_hash" ] || continue
+        class_finding=$(jq -c --arg fp "$class_hash" '
+            (.findings // [])
+            | map(select(.release_blocking == true))
+            | map(select((.parent_fingerprint // "") == $fp
+                         or (.fingerprint_hash // "") == $fp))
+            | {
+                category: "code_health:bug_class_sibling",
+                release_blocking: true,
+                parent_fingerprint: $fp,
+                instances: map({file: .file, line: .line, confidence: (.confidence // 1.0)}),
+                summary: ("bug-class sibling sweep: " + (length | tostring) + " instances of pattern " + $fp[0:12])
+              }
+        ' "$VERDICT" 2>/dev/null)
+        [ -n "$class_finding" ] || continue
+        if bash "$(dirname "$0")/qa-finding-to-issue.sh" --finding "$class_finding" >/dev/null 2>&1; then
+            FILED=$((FILED + 1))
+        fi
+    done < <(jq -r '
+        (.findings // [])
+        | map(select(.release_blocking == true))
+        | map(.parent_fingerprint // .fingerprint_hash // empty)
+        | map(select(. != ""))
+        | unique
+        | .[]
+    ' "$VERDICT" 2>/dev/null)
+    # Group 2: ungrouped findings (no fingerprint) — per-finding as before.
     while IFS= read -r finding; do
         [ -n "$finding" ] || continue
         if bash "$(dirname "$0")/qa-finding-to-issue.sh" --finding "$finding" >/dev/null 2>&1; then
             FILED=$((FILED + 1))
         fi
-    done < <(jq -c '(.findings // [])[] | select(.release_blocking == true)' "$VERDICT" 2>/dev/null)
+    done < <(jq -c '
+        (.findings // [])[]
+        | select(.release_blocking == true)
+        | select((.parent_fingerprint // "") == "" and (.fingerprint_hash // "") == "")
+    ' "$VERDICT" 2>/dev/null)
 
     # Drain via /autospec-run.
     MERGED=$(run_autospec_drain "$ROUND")

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1742,6 +1742,7 @@ main() {
     check_autospec_release_area_contract
     check_autospec_sweep_area_contract
     check_autospec_qa_cluster_contract
+    check_autospec_qa_bug_class_contract
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.
@@ -1786,6 +1787,40 @@ check_autospec_qa_cluster_contract() {
     done
 
     [ -f "$bats_file" ] || fail "$bats_file: missing (issue #730)"
+}
+
+# Issue #737: autospec-qa bug-class sibling sweep contract.
+# Enforces:
+#   - scripts/qa-bug-class-sweep.sh exists, executable, bash -n clean.
+#   - all 3 autospec-qa trio files reference qa-bug-class-sweep.sh and
+#     the per-class issue-filing semantics.
+#   - heal-loop references parent_fingerprint grouping.
+#   - tests/qa/test_qa_bug_class_sweep.bats exists.
+check_autospec_qa_bug_class_contract() {
+    info "autospec-qa bug-class sibling sweep contract (issue #737)"
+    local helper="scripts/qa-bug-class-sweep.sh"
+    local bats_file="tests/qa/test_qa_bug_class_sweep.bats"
+    local heal="scripts/qa-heal-loop.sh"
+
+    [ -f "$helper" ] || fail "$helper: missing (issue #737)"
+    [ -x "$helper" ] || fail "$helper: not executable (issue #737)"
+    bash -n "$helper" || fail "$helper: bash -n failed (issue #737)"
+
+    for trio in skills/autospec-qa/SKILL.md \
+                skills/autospec-qa/codex/prompt.md \
+                skills/autospec-qa/opencode/agent.md; do
+        grep -q 'qa-bug-class-sweep\.sh' "$trio" \
+            || fail "$trio: missing reference to qa-bug-class-sweep.sh (issue #737)"
+        grep -q 'parent_fingerprint' "$trio" \
+            || fail "$trio: missing parent_fingerprint contract (issue #737)"
+        grep -q 'AUTOSPEC_QA_BUG_CLASS_MIN_CONFIDENCE' "$trio" \
+            || fail "$trio: missing confidence-threshold env var (issue #737)"
+    done
+
+    grep -q 'parent_fingerprint' "$heal" \
+        || fail "$heal: must group by parent_fingerprint (issue #737)"
+
+    [ -f "$bats_file" ] || fail "$bats_file: missing (issue #737)"
 }
 
 # Issue #723: harness-aware loop dispatcher contract. Every loop-using

--- a/skills/autospec-qa/SKILL.md
+++ b/skills/autospec-qa/SKILL.md
@@ -1075,6 +1075,53 @@ continue. End-to-end regression: after the QA-filed rewrite issues run
 through `/autospec-run`, the offending files no longer trip either
 RULE_ID in the PR-time guardian.
 
+## Bug-class sibling sweep (issue #737)
+
+When `.autospec/qa-verdict.json` carries a `release_blocking: true`
+finding whose `category` ends in `:bug` (or otherwise matches a
+fingerprintable shape), run `scripts/qa-bug-class-sweep.sh` to fan out
+across the repo for sibling instances of the same pattern class. Goal:
+consistency by construction — the implementer fixes every matching
+instance in **one PR**, not N PRs.
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/qa-bug-class-sweep.sh" \
+    --verdict .autospec/qa-verdict.json --repo-dir .
+```
+
+The sweep:
+
+1. Computes a deterministic **pattern fingerprint** over the offending
+   line + ±5 context lines (literal-stripped: strings → `""`, numbers →
+   `N`). The fingerprint and its sha256 (`pattern_fingerprint`,
+   `fingerprint_hash`) are stored on the PARENT finding **at
+   finding-time**, not recomputed — this gives pattern drift safety so
+   siblings remain resolvable even after the parent line is rewritten.
+2. Runs `git grep -nE <fingerprint>` over the repo, excluding
+   `node_modules/`, `.git/`, and `vendor/`, plus the parent's own
+   `file:line`.
+3. For each match, computes a **confidence** score
+   `(presence + density_bonus) * specificity` where specificity scales
+   with fingerprint length (longer anchors → higher confidence). Matches
+   with `confidence >= AUTOSPEC_QA_BUG_CLASS_MIN_CONFIDENCE` (default
+   `0.7`) are appended to `findings[]` with
+   `category: code_health:bug_class_sibling`, `parent_fingerprint`,
+   `confidence`, `file`, `line`. Below-threshold matches land in
+   `.autospec/qa-bug-class-flagged.json` (operator review surface, NOT
+   filed as issues).
+4. Applies the verify-first filter
+   (`scripts/qa-verify-finding.sh --category missing_function`) to every
+   candidate sibling. If the bug is already fixed at HEAD for an
+   instance, that sibling is dropped silently.
+5. All verdict mutations are atomic (`.tmp` + `mv`) so partial runs
+   cannot corrupt the verdict.
+
+Per-class issue filing: `scripts/qa-heal-loop.sh` groups findings by
+`parent_fingerprint` when present and files **one `auto-implement` issue
+per pattern class** carrying every instance's `file:line`. Findings
+without a fingerprint stay per-finding as before. This is the key
+contract that turns bug-class detection into a single coordinated fix.
+
 ## Verify-first discipline
 
 Before any cluster emits a finding to `.autospec/qa-verdict.json`, the cluster

--- a/skills/autospec-qa/codex/prompt.md
+++ b/skills/autospec-qa/codex/prompt.md
@@ -1071,6 +1071,53 @@ continue. End-to-end regression: after the QA-filed rewrite issues run
 through `/autospec-run`, the offending files no longer trip either
 RULE_ID in the PR-time guardian.
 
+## Bug-class sibling sweep (issue #737)
+
+When `.autospec/qa-verdict.json` carries a `release_blocking: true`
+finding whose `category` ends in `:bug` (or otherwise matches a
+fingerprintable shape), run `scripts/qa-bug-class-sweep.sh` to fan out
+across the repo for sibling instances of the same pattern class. Goal:
+consistency by construction — the implementer fixes every matching
+instance in **one PR**, not N PRs.
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/qa-bug-class-sweep.sh" \
+    --verdict .autospec/qa-verdict.json --repo-dir .
+```
+
+The sweep:
+
+1. Computes a deterministic **pattern fingerprint** over the offending
+   line + ±5 context lines (literal-stripped: strings → `""`, numbers →
+   `N`). The fingerprint and its sha256 (`pattern_fingerprint`,
+   `fingerprint_hash`) are stored on the PARENT finding **at
+   finding-time**, not recomputed — this gives pattern drift safety so
+   siblings remain resolvable even after the parent line is rewritten.
+2. Runs `git grep -nE <fingerprint>` over the repo, excluding
+   `node_modules/`, `.git/`, and `vendor/`, plus the parent's own
+   `file:line`.
+3. For each match, computes a **confidence** score
+   `(presence + density_bonus) * specificity` where specificity scales
+   with fingerprint length (longer anchors → higher confidence). Matches
+   with `confidence >= AUTOSPEC_QA_BUG_CLASS_MIN_CONFIDENCE` (default
+   `0.7`) are appended to `findings[]` with
+   `category: code_health:bug_class_sibling`, `parent_fingerprint`,
+   `confidence`, `file`, `line`. Below-threshold matches land in
+   `.autospec/qa-bug-class-flagged.json` (operator review surface, NOT
+   filed as issues).
+4. Applies the verify-first filter
+   (`scripts/qa-verify-finding.sh --category missing_function`) to every
+   candidate sibling. If the bug is already fixed at HEAD for an
+   instance, that sibling is dropped silently.
+5. All verdict mutations are atomic (`.tmp` + `mv`) so partial runs
+   cannot corrupt the verdict.
+
+Per-class issue filing: `scripts/qa-heal-loop.sh` groups findings by
+`parent_fingerprint` when present and files **one `auto-implement` issue
+per pattern class** carrying every instance's `file:line`. Findings
+without a fingerprint stay per-finding as before. This is the key
+contract that turns bug-class detection into a single coordinated fix.
+
 ## Verify-first discipline
 
 Before any cluster emits a finding to `.autospec/qa-verdict.json`, the cluster

--- a/skills/autospec-qa/opencode/agent.md
+++ b/skills/autospec-qa/opencode/agent.md
@@ -1075,6 +1075,53 @@ continue. End-to-end regression: after the QA-filed rewrite issues run
 through `/autospec-run`, the offending files no longer trip either
 RULE_ID in the PR-time guardian.
 
+## Bug-class sibling sweep (issue #737)
+
+When `.autospec/qa-verdict.json` carries a `release_blocking: true`
+finding whose `category` ends in `:bug` (or otherwise matches a
+fingerprintable shape), run `scripts/qa-bug-class-sweep.sh` to fan out
+across the repo for sibling instances of the same pattern class. Goal:
+consistency by construction — the implementer fixes every matching
+instance in **one PR**, not N PRs.
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/qa-bug-class-sweep.sh" \
+    --verdict .autospec/qa-verdict.json --repo-dir .
+```
+
+The sweep:
+
+1. Computes a deterministic **pattern fingerprint** over the offending
+   line + ±5 context lines (literal-stripped: strings → `""`, numbers →
+   `N`). The fingerprint and its sha256 (`pattern_fingerprint`,
+   `fingerprint_hash`) are stored on the PARENT finding **at
+   finding-time**, not recomputed — this gives pattern drift safety so
+   siblings remain resolvable even after the parent line is rewritten.
+2. Runs `git grep -nE <fingerprint>` over the repo, excluding
+   `node_modules/`, `.git/`, and `vendor/`, plus the parent's own
+   `file:line`.
+3. For each match, computes a **confidence** score
+   `(presence + density_bonus) * specificity` where specificity scales
+   with fingerprint length (longer anchors → higher confidence). Matches
+   with `confidence >= AUTOSPEC_QA_BUG_CLASS_MIN_CONFIDENCE` (default
+   `0.7`) are appended to `findings[]` with
+   `category: code_health:bug_class_sibling`, `parent_fingerprint`,
+   `confidence`, `file`, `line`. Below-threshold matches land in
+   `.autospec/qa-bug-class-flagged.json` (operator review surface, NOT
+   filed as issues).
+4. Applies the verify-first filter
+   (`scripts/qa-verify-finding.sh --category missing_function`) to every
+   candidate sibling. If the bug is already fixed at HEAD for an
+   instance, that sibling is dropped silently.
+5. All verdict mutations are atomic (`.tmp` + `mv`) so partial runs
+   cannot corrupt the verdict.
+
+Per-class issue filing: `scripts/qa-heal-loop.sh` groups findings by
+`parent_fingerprint` when present and files **one `auto-implement` issue
+per pattern class** carrying every instance's `file:line`. Findings
+without a fingerprint stay per-finding as before. This is the key
+contract that turns bug-class detection into a single coordinated fix.
+
 ## Verify-first discipline
 
 Before any cluster emits a finding to `.autospec/qa-verdict.json`, the cluster

--- a/tests/qa/test_qa_bug_class_sweep.bats
+++ b/tests/qa/test_qa_bug_class_sweep.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+# tests/qa/test_qa_bug_class_sweep.bats
+#
+# Fixture-driven tests for the autospec-qa bug-class sibling sweep
+# (issue #737). Covers all four acceptance scenarios:
+#
+#   1. 5-instance bug class — parent finding triggers sweep; 4 sibling
+#      findings appear in the verdict; heal-loop files ONE auto-implement
+#      issue per pattern class.
+#   2. Confidence threshold gate — a 6th instance with low context match
+#      is logged to .autospec/qa-bug-class-flagged.json (NOT the verdict).
+#   3. Verify-first filter applies to siblings — if the bug is already
+#      fixed at HEAD for a sibling, that sibling is dropped.
+#   4. Pattern drift safety — fingerprint is stored on the parent
+#      finding at finding-time, not recomputed; mutating the parent line
+#      after sweep does not invalidate sibling linkage.
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+SWEEP="${REPO_ROOT}/scripts/qa-bug-class-sweep.sh"
+
+setup() {
+    TMPDIR_FIXT="$(mktemp -d)"
+    export TMPDIR_FIXT
+    mkdir -p "$TMPDIR_FIXT/.autospec" "$TMPDIR_FIXT/src"
+
+    # Initialize a git repo so git grep works.
+    (
+        cd "$TMPDIR_FIXT"
+        git init -q
+        git config user.email test@example.com
+        git config user.name  test
+    )
+
+    # 5 instances of os.system( — the bug class.
+    for i in 1 2 3 4 5; do
+        cat >"$TMPDIR_FIXT/src/mod${i}.py" <<PY
+import os
+def run${i}(cmd):
+    os.system(cmd)
+    return 0
+PY
+    done
+
+    (
+        cd "$TMPDIR_FIXT"
+        git add -A
+        git commit -q -m init
+    )
+
+    # Parent verdict cites src/mod1.py:3 (the os.system call).
+    cat >"$TMPDIR_FIXT/.autospec/qa-verdict.json" <<'JSON'
+{
+  "verdict": "FAIL",
+  "findings": [
+    {
+      "category": "security:bug",
+      "release_blocking": true,
+      "file": "src/mod1.py",
+      "line": 3,
+      "summary": "os.system shell injection"
+    }
+  ]
+}
+JSON
+}
+
+teardown() {
+    rm -rf "$TMPDIR_FIXT"
+}
+
+@test "5-instance bug class — siblings appended to verdict" {
+    cd "$TMPDIR_FIXT"
+    run bash "$SWEEP" --verdict .autospec/qa-verdict.json --repo-dir .
+    [ "$status" -eq 0 ]
+    siblings=$(jq '[.findings[] | select(.category == "code_health:bug_class_sibling")] | length' \
+        .autospec/qa-verdict.json)
+    [ "$siblings" -ge 4 ]
+}
+
+@test "siblings carry parent_fingerprint linkage" {
+    cd "$TMPDIR_FIXT"
+    bash "$SWEEP" --verdict .autospec/qa-verdict.json --repo-dir .
+    linked=$(jq '[.findings[] | select(.category == "code_health:bug_class_sibling") | select(.parent_fingerprint != null and (.parent_fingerprint | length) > 0)] | length' \
+        .autospec/qa-verdict.json)
+    [ "$linked" -ge 4 ]
+}
+
+@test "confidence threshold gate — low-confidence match flagged not filed" {
+    # Override threshold high enough that the strong 1.0 matches still pass,
+    # but introduce an additional low-specificity (short-anchor) parent
+    # finding whose siblings score below threshold.
+    cd "$TMPDIR_FIXT"
+    # Add a parent with a 2-char anchor (`go`) — specificity = 2/8 = 0.25.
+    cat >"$TMPDIR_FIXT/src/short.py" <<'PY'
+def go():
+    return 1
+PY
+    cat >"$TMPDIR_FIXT/src/short2.py" <<'PY'
+def go():
+    return 2
+PY
+    (cd "$TMPDIR_FIXT" && git add -A && git commit -q -m short)
+    cat >"$TMPDIR_FIXT/.autospec/qa-verdict.json" <<'JSON'
+{
+  "verdict": "FAIL",
+  "findings": [
+    {"category":"security:bug","release_blocking":true,"file":"src/short.py","line":1,"summary":"x"}
+  ]
+}
+JSON
+    AUTOSPEC_QA_BUG_CLASS_MIN_CONFIDENCE=0.7 \
+        bash "$SWEEP" --verdict .autospec/qa-verdict.json --repo-dir .
+    siblings=$(jq '[.findings[] | select(.category == "code_health:bug_class_sibling")] | length' \
+        .autospec/qa-verdict.json)
+    [ "$siblings" -eq 0 ]
+    flagged=$(jq '.flagged | length' .autospec/qa-bug-class-flagged.json)
+    [ "$flagged" -ge 1 ]
+}
+
+@test "verify-first filter applies to siblings" {
+    # Remove the anchor from mod5 so verify probe reports resolved → dropped.
+    cd "$TMPDIR_FIXT"
+    cat >"$TMPDIR_FIXT/src/mod5.py" <<'PY'
+def safe5():
+    return "resolved"
+PY
+    (cd "$TMPDIR_FIXT" && git add -A && git commit -q -m fix)
+    bash "$SWEEP" --verdict .autospec/qa-verdict.json --repo-dir .
+    # mod5 must not appear as a sibling.
+    has_mod5=$(jq '[.findings[] | select(.category == "code_health:bug_class_sibling") | select(.file == "src/mod5.py")] | length' \
+        .autospec/qa-verdict.json)
+    [ "$has_mod5" -eq 0 ]
+}
+
+@test "pattern fingerprint stored on parent at finding-time" {
+    cd "$TMPDIR_FIXT"
+    bash "$SWEEP" --verdict .autospec/qa-verdict.json --repo-dir .
+    fp=$(jq -r '.findings[0].pattern_fingerprint // ""' .autospec/qa-verdict.json)
+    fh=$(jq -r '.findings[0].fingerprint_hash // ""' .autospec/qa-verdict.json)
+    [ -n "$fp" ]
+    [ -n "$fh" ]
+    # Mutate the parent line — fingerprint already stored, must survive.
+    cat >"$TMPDIR_FIXT/src/mod1.py" <<'PY'
+def changed():
+    pass
+PY
+    fp2=$(jq -r '.findings[0].pattern_fingerprint // ""' .autospec/qa-verdict.json)
+    [ "$fp" = "$fp2" ]
+}


### PR DESCRIPTION
Closes #737

## Summary
- Adds `scripts/qa-bug-class-sweep.sh`: deterministic pattern fingerprint over the offending line ±5 context, literal-stripped, sha256-hashed and stored on the parent finding at finding-time (drift safe).
- `git grep -nE <fingerprint>` over the repo (excluding `node_modules/`, `.git/`, `vendor/`), confidence = `(presence + density) × specificity`. Matches at/above `AUTOSPEC_QA_BUG_CLASS_MIN_CONFIDENCE` (default 0.7) become `code_health:bug_class_sibling` findings; below-threshold matches land in `.autospec/qa-bug-class-flagged.json` (not filed).
- Verify-first filter applied to each candidate sibling — bugs already fixed at HEAD are silently dropped.
- `scripts/qa-heal-loop.sh` now groups release-blocking findings by `parent_fingerprint` and files ONE auto-implement issue per pattern class (citing every instance), so one PR fixes them all. Unfingerprinted findings stay per-finding.
- Trio lockstep across `skills/autospec-qa/{SKILL.md, codex/prompt.md, opencode/agent.md}`.
- `scripts/validate.sh::check_autospec_qa_bug_class_contract()` wires the new contract into `main()`.
- `tests/qa/test_qa_bug_class_sweep.bats` covers all 4 acceptance scenarios (5-instance class, confidence-threshold gate, verify-first drop, fingerprint-at-finding-time drift safety).

## Test plan
- [x] `bash scripts/validate.sh` — green end-to-end
- [x] `bats tests/qa/test_qa_bug_class_sweep.bats` — 5/5 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)