### PR TITLE
feat: context-monitor Python package skeleton + Usage + HarnessAdapter Protocol (#741)

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/__init__.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/__init__.py
@@ -1,0 +1,11 @@
+"""autospec-context-monitor — Python package for context-window monitoring.
+
+Public API (importable from this top-level package):
+
+- :class:`Usage` — frozen dataclass with token-usage snapshot.
+- :class:`HarnessAdapter` — runtime-checkable Protocol every adapter must satisfy.
+- :class:`TranscriptNotFoundError` — raised when a live transcript cannot be located.
+"""
+from .adapters.base import HarnessAdapter, TranscriptNotFoundError, Usage
+
+__all__ = ["Usage", "HarnessAdapter", "TranscriptNotFoundError"]

--- a/packages/autospec_context_monitor/autospec_context_monitor/adapters/__init__.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/adapters/__init__.py
@@ -1,0 +1,1 @@
+# Adapter sub-package — concrete adapters live here alongside base.py.

--- a/packages/autospec_context_monitor/autospec_context_monitor/adapters/base.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/adapters/base.py
@@ -1,0 +1,74 @@
+"""Base adapter contract for autospec-context-monitor.
+
+Defines the frozen Usage dataclass, the HarnessAdapter Protocol, and
+TranscriptNotFoundError — the three shared types every concrete adapter
+must satisfy.
+"""
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import Literal, Protocol, runtime_checkable
+
+
+@dataclasses.dataclass(frozen=True)
+class Usage:
+    """Token-usage snapshot returned by a harness adapter.
+
+    Attributes:
+        used_tokens: Tokens consumed so far in this session.
+        max_tokens:  Context-window size for the active model.
+        model:       Model identifier string (e.g. ``"claude-sonnet-4-6"``).
+        estimated:   ``True`` when counts are derived from text length rather
+                     than explicit API metadata.
+    """
+
+    used_tokens: int
+    max_tokens: int
+    model: str
+    estimated: bool
+
+    @property
+    def pct(self) -> float:
+        """Return the fraction of context consumed (``used_tokens / max_tokens``)."""
+        if self.max_tokens == 0:
+            return 0.0
+        return self.used_tokens / self.max_tokens
+
+
+class TranscriptNotFoundError(FileNotFoundError):
+    """Raised by :meth:`HarnessAdapter.find_transcript` when no live transcript
+    can be located within the allowed wait period."""
+
+
+@runtime_checkable
+class HarnessAdapter(Protocol):
+    """Per-harness adapter contract.
+
+    Concrete implementations live in sibling modules (``adapters/claude.py``,
+    ``adapters/codex.py``, ``adapters/opencode.py``).  The engine only calls
+    these three methods so adapters remain fully decoupled from I/O plumbing.
+    """
+
+    name: str  # "claude" | "codex" | "opencode"
+
+    def find_transcript(self, hint: dict) -> Path:
+        """Locate the live transcript for this session.
+
+        *hint* contains ``{cwd, tmux_session, pid, started_at}``.  Returns the
+        newest matching transcript path, or raises :class:`TranscriptNotFoundError`
+        after a 30-second wait.
+        """
+        ...
+
+    def read_usage(self, transcript: Path) -> Usage:
+        """Return a :class:`Usage` snapshot from *transcript*.
+
+        Set ``estimated=True`` when token counts are derived from character
+        length rather than explicit API metadata.
+        """
+        ...
+
+    def command(self, logical: Literal["clear", "compact", "handoff"]) -> str:
+        """Map a logical command name to the harness-specific slash command."""
+        ...

--- a/packages/autospec_context_monitor/pyproject.toml
+++ b/packages/autospec_context_monitor/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "autospec-context-monitor"
+version = "0.1.0"
+description = "Context-window monitor daemon for the autospec multi-harness workflow suite"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.10"
+dependencies = []
+
+[project.urls]
+Repository = "https://github.com/berlinguyinca/autospec"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["autospec_context_monitor*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/adapters/test_base.py
+++ b/tests/adapters/test_base.py
@@ -1,0 +1,69 @@
+"""Tests for autospec_context_monitor.adapters.base"""
+import dataclasses
+import sys
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+
+def test_usage_is_frozen():
+    """Assigning to a Usage field must raise FrozenInstanceError."""
+    from autospec_context_monitor.adapters.base import Usage
+
+    u = Usage(used_tokens=10, max_tokens=100, model="claude-3-5-sonnet", estimated=False)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        u.used_tokens = 99  # type: ignore[misc]
+
+
+def test_usage_fields():
+    """Usage has exactly 4 fields: used_tokens, max_tokens, model, estimated."""
+    from autospec_context_monitor.adapters.base import Usage
+
+    fields = {f.name for f in dataclasses.fields(Usage)}
+    assert fields == {"used_tokens", "max_tokens", "model", "estimated"}
+
+
+def test_usage_pct_helper():
+    """If pct property/method exists, it returns used/max."""
+    from autospec_context_monitor.adapters.base import Usage
+
+    u = Usage(used_tokens=50, max_tokens=100, model="x", estimated=False)
+    if hasattr(u, "pct"):
+        assert u.pct == 0.5
+
+
+def test_protocol_runtime_checkable():
+    """A concrete class implementing HarnessAdapter passes isinstance check."""
+    from autospec_context_monitor.adapters.base import HarnessAdapter, Usage
+
+    class ConcreteAdapter:
+        name = "test"
+
+        def find_transcript(self, hint: dict) -> Path:
+            return Path("/tmp/transcript.jsonl")
+
+        def read_usage(self, transcript: Path) -> Usage:
+            return Usage(used_tokens=10, max_tokens=100, model="x", estimated=False)
+
+        def command(self, logical: Literal["clear", "compact", "handoff"]) -> str:
+            return f"/{logical}"
+
+    adapter = ConcreteAdapter()
+    assert isinstance(adapter, HarnessAdapter)
+
+
+def test_transcript_not_found_is_filenotfound_subclass():
+    """TranscriptNotFoundError must be a subclass of FileNotFoundError."""
+    from autospec_context_monitor.adapters.base import TranscriptNotFoundError
+
+    assert issubclass(TranscriptNotFoundError, FileNotFoundError)
+
+
+def test_import_from_package_root():
+    """All three public names are importable from autospec_context_monitor directly."""
+    from autospec_context_monitor import HarnessAdapter, TranscriptNotFoundError, Usage
+
+    assert Usage is not None
+    assert HarnessAdapter is not None
+    assert TranscriptNotFoundError is not None


### PR DESCRIPTION
Closes #741

Scaffolds the `packages/autospec_context_monitor/` Python package that all downstream context-monitor issues depend on. Ships the frozen `Usage` dataclass (4 fields: `used_tokens`, `max_tokens`, `model`, `estimated`), the `@runtime_checkable HarnessAdapter` Protocol (3-method contract), and `TranscriptNotFoundError(FileNotFoundError)` — all exported from the top-level `__init__`. Includes a `pyproject.toml` (setuptools, `requires-python>=3.10`) and 6 TDD tests covering frozen-ness, field count, pct helper, Protocol isinstance check, error hierarchy, and top-level importability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)