### PR TITLE
feat: context-monitor Claude Code adapter — transcript discovery + JSONL usage (#742)

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/adapters/claude.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/adapters/claude.py
@@ -1,0 +1,105 @@
+"""Claude Code adapter for autospec-context-monitor.
+
+Implements the HarnessAdapter Protocol for Claude Code, locating transcripts
+under ``~/.claude/projects/<cwd-slug>/`` and summing token usage from JSONL.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Literal
+
+from .base import HarnessAdapter, TranscriptNotFoundError, Usage
+
+# Context-window sizes by model identifier.
+# Add new models here as Claude Code ships them.
+MODEL_MAX: dict[str, int] = {
+    "claude-sonnet-4-5": 200_000,
+    "claude-sonnet-4-5-1m": 1_000_000,
+    "claude-sonnet-4-6": 200_000,
+    "claude-sonnet-4-7": 200_000,
+    "claude-opus-4-7": 200_000,
+    "claude-opus-4-5": 200_000,
+    "claude-haiku-4-5": 200_000,
+    # Legacy identifiers
+    "claude-3-5-sonnet-20241022": 200_000,
+    "claude-3-5-haiku-20241022": 200_000,
+    "claude-3-opus-20240229": 200_000,
+}
+
+_DEFAULT_MAX = 200_000
+
+_HANDOFF_PROMPT = (
+    "Please run /create-handoff and wait for the file to be written "
+    "before responding further."
+)
+
+_COMMAND_MAP: dict[str, str] = {
+    "clear": "/clear",
+    "compact": "/compact",
+    "handoff": _HANDOFF_PROMPT,
+}
+
+
+class ClaudeAdapter:
+    """HarnessAdapter implementation for Claude Code (claude CLI)."""
+
+    name: str = "claude"
+
+    def find_transcript(self, hint: dict) -> Path:
+        """Locate the newest ``.jsonl`` transcript for this session.
+
+        Derives the project slug from ``hint["cwd"]`` (``/``→``-``, strip
+        leading ``-``), then returns the most-recently-modified ``.jsonl``
+        found at ``~/.claude/projects/<slug>/``.
+
+        Raises :class:`~autospec_context_monitor.adapters.base.TranscriptNotFoundError`
+        if no transcript exists.
+        """
+        cwd: str = hint.get("cwd", "")
+        slug = cwd.replace("/", "-").lstrip("-")
+        root = Path.home() / ".claude" / "projects" / slug
+        candidates = sorted(
+            root.glob("*.jsonl"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if not candidates:
+            raise TranscriptNotFoundError(
+                f"No Claude transcript found under {root} (cwd={cwd!r})"
+            )
+        return candidates[0]
+
+    def read_usage(self, transcript: Path) -> Usage:
+        """Sum ``input_tokens + output_tokens`` from every JSONL line that has
+        ``message.usage``.  The last ``message.model`` seen is used for the
+        model-name lookup.
+        """
+        used = 0
+        model = "unknown"
+        for raw in transcript.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            msg = obj.get("message", {})
+            u = msg.get("usage")
+            if u:
+                used += u.get("input_tokens", 0) + u.get("output_tokens", 0)
+            m = msg.get("model")
+            if m:
+                model = m
+        max_tokens = MODEL_MAX.get(model, _DEFAULT_MAX)
+        return Usage(
+            used_tokens=used,
+            max_tokens=max_tokens,
+            model=model,
+            estimated=False,
+        )
+
+    def command(self, logical: Literal["clear", "compact", "handoff"]) -> str:
+        """Map a logical command to the Claude Code slash command or prompt."""
+        return _COMMAND_MAP[logical]

--- a/tests/adapters/test_claude.py
+++ b/tests/adapters/test_claude.py
@@ -1,0 +1,81 @@
+"""Tests for autospec_context_monitor.adapters.claude (ClaudeAdapter)."""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "claude"
+
+
+@pytest.fixture()
+def adapter():
+    from autospec_context_monitor.adapters.claude import ClaudeAdapter
+    return ClaudeAdapter()
+
+
+def test_find_transcript_picks_newest_by_mtime(tmp_path, adapter, monkeypatch):
+    """find_transcript returns the most-recently-modified .jsonl in the slug dir."""
+    slug = "Users-test-project"
+    session_dir = tmp_path / ".claude" / "projects" / slug
+    session_dir.mkdir(parents=True)
+
+    older = session_dir / "aaa.jsonl"
+    newer = session_dir / "bbb.jsonl"
+    older.write_text('{"type":"message"}\n')
+    time.sleep(0.05)
+    newer.write_text('{"type":"message"}\n')
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Patch Path.home() to return tmp_path
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    result = adapter.find_transcript({"cwd": "/Users/test/project"})
+    assert result == newer
+
+
+def test_find_transcript_raises_when_missing(tmp_path, adapter, monkeypatch):
+    """find_transcript raises TranscriptNotFoundError when no .jsonl files exist."""
+    from autospec_context_monitor.adapters.base import TranscriptNotFoundError
+
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    with pytest.raises(TranscriptNotFoundError):
+        adapter.find_transcript({"cwd": "/nonexistent/project"})
+
+
+def test_read_usage_sums_input_output_tokens(adapter):
+    """read_usage correctly sums input+output tokens from short-session.jsonl."""
+    fixture = FIXTURES / "short-session.jsonl"
+    usage = adapter.read_usage(fixture)
+    # 150+50 + 200+75 = 475
+    assert usage.used_tokens == 475
+    assert usage.model == "claude-sonnet-4-5"
+    assert usage.max_tokens == 200_000
+    assert usage.estimated is False
+
+
+def test_read_usage_handles_missing_usage_field(adapter):
+    """read_usage returns 0 tokens and doesn't crash when usage field is absent."""
+    fixture = FIXTURES / "missing-usage.jsonl"
+    usage = adapter.read_usage(fixture)
+    assert usage.used_tokens == 0
+    assert usage.model == "claude-sonnet-4-5"  # model is still picked up
+    assert usage.estimated is False
+
+
+def test_read_usage_picks_up_1m_model_max(adapter):
+    """read_usage returns max_tokens=1_000_000 for the sonnet-1m model."""
+    fixture = FIXTURES / "sonnet-1m.jsonl"
+    usage = adapter.read_usage(fixture)
+    assert usage.max_tokens == 1_000_000
+    assert usage.model == "claude-sonnet-4-5-1m"
+    assert usage.used_tokens == 6000  # 5000+1000
+
+
+def test_command_maps_clear_compact_handoff(adapter):
+    """command() returns the correct string for each logical command."""
+    assert adapter.command("clear") == "/clear"
+    assert adapter.command("compact") == "/compact"
+    assert "create-handoff" in adapter.command("handoff")

--- a/tests/fixtures/claude/missing-usage.jsonl
+++ b/tests/fixtures/claude/missing-usage.jsonl
@@ -1,0 +1,2 @@
+{"type":"system","message":{"role":"system","content":"System init"}}
+{"type":"message","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"No usage field here"}]}}

--- a/tests/fixtures/claude/short-session.jsonl
+++ b/tests/fixtures/claude/short-session.jsonl
@@ -1,0 +1,2 @@
+{"type":"message","message":{"role":"assistant","model":"claude-sonnet-4-5","usage":{"input_tokens":150,"output_tokens":50},"content":[{"type":"text","text":"Hello"}]}}
+{"type":"message","message":{"role":"assistant","model":"claude-sonnet-4-5","usage":{"input_tokens":200,"output_tokens":75},"content":[{"type":"text","text":"World"}]}}

--- a/tests/fixtures/claude/sonnet-1m.jsonl
+++ b/tests/fixtures/claude/sonnet-1m.jsonl
@@ -1,0 +1,1 @@
+{"type":"message","message":{"role":"assistant","model":"claude-sonnet-4-5-1m","usage":{"input_tokens":5000,"output_tokens":1000},"content":[{"type":"text","text":"Long context response"}]}}


### PR DESCRIPTION
Closes #742

Implements `ClaudeAdapter` (satisfies `HarnessAdapter` Protocol) in `packages/autospec_context_monitor/autospec_context_monitor/adapters/claude.py`. Transcript discovery derives a cwd-slug from `hint["cwd"]`, globs `~/.claude/projects/<slug>/*.jsonl`, and returns the newest by mtime. Usage summation iterates JSONL lines, accumulates `input_tokens + output_tokens` from `message.usage`, and resolves `max_tokens` from a `MODEL_MAX` table covering sonnet-4-5, sonnet-4-5-1m (1M ctx), opus/haiku variants. Command mapping covers `/clear`, `/compact`, and the full `/create-handoff` prompt. Includes 3 hermetic JSONL fixtures and 6 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)