### PR TITLE
feat: context-monitor Codex CLI adapter with info:null text-length fallback (#743)

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/adapters/codex.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/adapters/codex.py
@@ -1,0 +1,129 @@
+"""Codex CLI adapter for autospec-context-monitor.
+
+Implements the HarnessAdapter Protocol for Codex CLI, locating rollout
+transcripts under ``~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`` and
+summing token usage from ``event_msg.payload.info``.  When ``info`` is
+``null`` or absent, falls back to character-count estimation and sets
+``estimated=True``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Literal
+
+from .base import HarnessAdapter, TranscriptNotFoundError, Usage
+
+# Context-window sizes by model identifier.
+MODEL_MAX: dict[str, int] = {
+    "gpt-5": 200_000,
+    "gpt-5-codex": 200_000,
+    "gpt-4o": 128_000,
+    "gpt-4o-mini": 128_000,
+    "o1": 200_000,
+    "o1-mini": 128_000,
+    "o3": 200_000,
+    "o3-mini": 200_000,
+}
+
+_DEFAULT_MAX = 128_000
+
+_HANDOFF_PROMPT = (
+    "Write a handoff file to .turbo/handoff/<YYYY-MM-DD>-<slug>.md capturing "
+    "current task, status, open decisions, in-flight changes, and next step. "
+    "Confirm the path when done."
+)
+
+_COMMAND_MAP: dict[str, str] = {
+    "clear": "/new",
+    "compact": "/compact",
+    "handoff": _HANDOFF_PROMPT,
+}
+
+# Chars-per-token heuristic used when explicit counts are unavailable.
+_CHARS_PER_TOKEN = 3.5
+
+
+class CodexAdapter:
+    """HarnessAdapter implementation for Codex CLI."""
+
+    name: str = "codex"
+
+    def find_transcript(self, hint: dict) -> Path:
+        """Locate the newest ``rollout-*.jsonl`` transcript.
+
+        Searches ``~/.codex/sessions/**/rollout-*.jsonl`` recursively and
+        returns the most-recently-modified match.
+
+        Raises :class:`~autospec_context_monitor.adapters.base.TranscriptNotFoundError`
+        if no transcript is found.
+        """
+        root = Path.home() / ".codex" / "sessions"
+        candidates = sorted(
+            root.rglob("rollout-*.jsonl"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if not candidates:
+            raise TranscriptNotFoundError(
+                f"No Codex rollout transcript found under {root}"
+            )
+        return candidates[0]
+
+    def read_usage(self, transcript: Path) -> Usage:
+        """Sum token usage from ``event_msg.payload.info``.
+
+        When ``info`` is ``null`` or absent for every line, estimates token
+        count from character length (``len(raw) / 3.5``) and sets
+        ``estimated=True``.  Partial files with a mix of explicit and null
+        entries use explicit counts only and leave ``estimated=False``.
+        """
+        used = 0
+        estimated = False
+        model = "unknown"
+        text_total = 0
+        has_explicit = False
+
+        for raw in transcript.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+
+            # Extract model
+            m = obj.get("model")
+            if not m:
+                m = (
+                    obj.get("event_msg", {})
+                    .get("payload", {})
+                    .get("model")
+                )
+            if m:
+                model = m
+
+            # Extract token counts
+            info = obj.get("event_msg", {}).get("payload", {}).get("info")
+            if info:
+                used += info.get("input_tokens", 0) + info.get("output_tokens", 0)
+                has_explicit = True
+            else:
+                # Accumulate raw bytes for fallback estimation
+                text_total += len(raw)
+
+        if not has_explicit and text_total > 0:
+            used = int(text_total / _CHARS_PER_TOKEN)
+            estimated = True
+
+        return Usage(
+            used_tokens=used,
+            max_tokens=MODEL_MAX.get(model, _DEFAULT_MAX),
+            model=model,
+            estimated=estimated,
+        )
+
+    def command(self, logical: Literal["clear", "compact", "handoff"]) -> str:
+        """Map a logical command to the Codex CLI command or prompt."""
+        return _COMMAND_MAP[logical]

--- a/tests/adapters/test_codex.py
+++ b/tests/adapters/test_codex.py
@@ -1,0 +1,76 @@
+"""Tests for autospec_context_monitor.adapters.codex (CodexAdapter)."""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "codex"
+
+
+@pytest.fixture()
+def adapter():
+    from autospec_context_monitor.adapters.codex import CodexAdapter
+    return CodexAdapter()
+
+
+def test_read_usage_with_info_populated_uses_explicit_tokens(adapter):
+    """When info is populated, uses explicit token counts and estimated=False."""
+    fixture = FIXTURES / "info-populated.jsonl"
+    usage = adapter.read_usage(fixture)
+    # 1200+300 + 800+200 = 2500
+    assert usage.used_tokens == 2500
+    assert usage.estimated is False
+    assert usage.model == "gpt-5"
+    assert usage.max_tokens == 200_000
+
+
+def test_read_usage_with_info_null_falls_back_to_text_length(adapter):
+    """When info is null, falls back to text-length estimation and estimated=True."""
+    fixture = FIXTURES / "info-null.jsonl"
+    usage = adapter.read_usage(fixture)
+    assert usage.estimated is True
+    assert usage.used_tokens > 0
+
+
+def test_command_clear_maps_to_slash_new(adapter):
+    """command('clear') returns '/new' for Codex CLI."""
+    assert adapter.command("clear") == "/new"
+
+
+def test_command_compact_and_handoff(adapter):
+    """compact maps to /compact; handoff contains expected prose."""
+    assert adapter.command("compact") == "/compact"
+    handoff = adapter.command("handoff")
+    assert "handoff" in handoff.lower()
+    assert ".turbo/handoff" in handoff
+
+
+def test_find_transcript_picks_newest_rollout(tmp_path, adapter, monkeypatch):
+    """find_transcript returns the most-recently-modified rollout-*.jsonl."""
+    from pathlib import Path as _Path
+
+    session_dir = tmp_path / ".codex" / "sessions" / "2026" / "05" / "31"
+    session_dir.mkdir(parents=True)
+
+    older = session_dir / "rollout-aaa.jsonl"
+    newer = session_dir / "rollout-bbb.jsonl"
+    older.write_text('{"type":"event"}\n')
+    time.sleep(0.05)
+    newer.write_text('{"type":"event"}\n')
+
+    monkeypatch.setattr(_Path, "home", staticmethod(lambda: tmp_path))
+
+    result = adapter.find_transcript({"cwd": "/irrelevant"})
+    assert result == newer
+
+
+def test_find_transcript_raises_when_missing(tmp_path, adapter, monkeypatch):
+    """find_transcript raises TranscriptNotFoundError when no rollout files exist."""
+    from pathlib import Path as _Path
+    from autospec_context_monitor.adapters.base import TranscriptNotFoundError
+
+    monkeypatch.setattr(_Path, "home", staticmethod(lambda: tmp_path))
+    with pytest.raises(TranscriptNotFoundError):
+        adapter.find_transcript({"cwd": "/any"})

--- a/tests/fixtures/codex/info-null.jsonl
+++ b/tests/fixtures/codex/info-null.jsonl
@@ -1,0 +1,2 @@
+{"type":"event","model":"gpt-5","event_msg":{"type":"response","payload":{"info":null,"content":"Response without explicit token counts"}}}
+{"type":"event","model":"gpt-5","event_msg":{"type":"response","payload":{"info":null,"content":"Another response without token counts, longer text here to have something to estimate"}}}

--- a/tests/fixtures/codex/info-populated.jsonl
+++ b/tests/fixtures/codex/info-populated.jsonl
@@ -1,0 +1,2 @@
+{"type":"event","model":"gpt-5","event_msg":{"type":"response","payload":{"info":{"input_tokens":1200,"output_tokens":300},"content":"First response"}}}
+{"type":"event","model":"gpt-5","event_msg":{"type":"response","payload":{"info":{"input_tokens":800,"output_tokens":200},"content":"Second response"}}}


### PR DESCRIPTION
Closes #743

Implements `CodexAdapter` (satisfies `HarnessAdapter` Protocol) in `packages/autospec_context_monitor/autospec_context_monitor/adapters/codex.py`. Transcript discovery recursively globs `~/.codex/sessions/**/rollout-*.jsonl` and returns the newest by mtime. Usage summation reads `event_msg.payload.info.input_tokens/output_tokens`; when `info` is `null` or absent for all lines, falls back to `len(raw)/3.5` character-count estimation and sets `estimated=True`. Command maps `clear→/new`, `compact→/compact`, `handoff→prose`. Includes 2 JSONL fixtures (explicit tokens + null-info) and 6 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)