### PR TITLE
feat(context-monitor): handoff-file polling with 180s timeout (#746)

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/handoff.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/handoff.py
@@ -1,0 +1,68 @@
+"""Handoff-file polling for autospec-context-monitor.
+
+Provides :func:`wait_for_handoff` which blocks until a new handoff Markdown
+file appears in ``<repo_root>/.turbo/handoff/`` with a modification time
+strictly after ``since``.
+
+The caller is responsible for passing the ``since`` timestamp (e.g.
+``time.time()`` captured just before issuing the ``/create-handoff`` command)
+so that pre-existing files are correctly ignored.
+"""
+from __future__ import annotations
+
+import time
+from datetime import date
+from pathlib import Path
+
+
+class HandoffTimeoutError(TimeoutError):
+    """Raised when no handoff file appears within the allowed timeout."""
+
+
+def wait_for_handoff(
+    repo_root: Path,
+    since: float,
+    timeout: float = 180.0,
+    poll: float = 1.0,
+) -> Path:
+    """Block until a today-dated handoff file newer than *since* appears.
+
+    Polls ``<repo_root>/.turbo/handoff/<YYYY-MM-DD>-*.md`` every *poll*
+    seconds.  Returns the most-recently-modified matching file as soon as one
+    is found.
+
+    Args:
+        repo_root: Root directory of the repository (contains ``.turbo/``).
+        since:     POSIX timestamp (e.g. from :func:`time.time`).  Only files
+                   with ``st_mtime > since`` are considered.
+        timeout:   Maximum number of seconds to wait (default 180).
+        poll:      Polling interval in seconds (default 1.0).
+
+    Returns:
+        :class:`~pathlib.Path` to the newest matching handoff file.
+
+    Raises:
+        :class:`HandoffTimeoutError`: If no qualifying file appears before the
+            deadline.  The error message includes the expected directory and
+            the ``since`` cutoff so users know where to look.
+    """
+    deadline = time.monotonic() + timeout
+    handoff_dir = repo_root / ".turbo" / "handoff"
+    today_glob = f"{date.today().isoformat()}-*.md"
+
+    while time.monotonic() < deadline:
+        if handoff_dir.exists():
+            candidates = [
+                p
+                for p in handoff_dir.glob(today_glob)
+                if p.stat().st_mtime > since
+            ]
+            if candidates:
+                return max(candidates, key=lambda p: p.stat().st_mtime)
+        time.sleep(poll)
+
+    raise HandoffTimeoutError(
+        f"No handoff file found in {handoff_dir} matching {today_glob!r} "
+        f"with mtime > {since:.3f} within {timeout}s. "
+        f"Ensure the harness wrote a file there via /create-handoff."
+    )

--- a/tests/engine/test_handoff.py
+++ b/tests/engine/test_handoff.py
@@ -1,0 +1,90 @@
+"""Tests for autospec_context_monitor.handoff."""
+from __future__ import annotations
+
+import time
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+
+def _write_md(directory: Path, name: str, content: str = "# handoff\n") -> Path:
+    """Write a Markdown file to *directory* and return its path."""
+    directory.mkdir(parents=True, exist_ok=True)
+    p = directory / name
+    p.write_text(content)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TODAY = date.today().isoformat()
+YESTERDAY = (date.today() - timedelta(days=1)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_returns_newest_file_after_since(tmp_path):
+    """wait_for_handoff returns the most-recently-modified file newer than since."""
+    from autospec_context_monitor.handoff import wait_for_handoff
+
+    handoff_dir = tmp_path / ".turbo" / "handoff"
+    since = time.time() - 1  # anchor in the past so new files qualify
+
+    older = _write_md(handoff_dir, f"{TODAY}-task-a.md")
+    time.sleep(0.05)
+    newer = _write_md(handoff_dir, f"{TODAY}-task-b.md")
+
+    result = wait_for_handoff(tmp_path, since=since, timeout=5.0, poll=0.05)
+    assert result == newer
+
+
+def test_ignores_files_older_than_since(tmp_path):
+    """wait_for_handoff ignores existing files written before the since anchor."""
+    from autospec_context_monitor.handoff import wait_for_handoff, HandoffTimeoutError
+
+    handoff_dir = tmp_path / ".turbo" / "handoff"
+    # Write a file first, then anchor since AFTER the file's mtime.
+    old_file = _write_md(handoff_dir, f"{TODAY}-old-task.md")
+    since = old_file.stat().st_mtime + 1  # guarantee it's older than since
+
+    with pytest.raises(HandoffTimeoutError):
+        wait_for_handoff(tmp_path, since=since, timeout=0.3, poll=0.05)
+
+
+def test_raises_handoff_timeout_when_nothing_appears(tmp_path):
+    """wait_for_handoff raises HandoffTimeoutError after timeout with no files."""
+    from autospec_context_monitor.handoff import wait_for_handoff, HandoffTimeoutError
+
+    since = time.time()
+    with pytest.raises(HandoffTimeoutError) as exc_info:
+        wait_for_handoff(tmp_path, since=since, timeout=0.3, poll=0.05)
+
+    # Error message should mention the expected directory
+    assert ".turbo" in str(exc_info.value)
+    assert "handoff" in str(exc_info.value)
+
+
+def test_handoff_timeout_error_is_timeout_error(tmp_path):
+    """HandoffTimeoutError subclasses TimeoutError."""
+    from autospec_context_monitor.handoff import HandoffTimeoutError
+
+    assert issubclass(HandoffTimeoutError, TimeoutError)
+
+
+def test_returns_only_today_dated_files(tmp_path):
+    """wait_for_handoff ignores yesterday-prefixed files even if they are newer than since."""
+    from autospec_context_monitor.handoff import wait_for_handoff, HandoffTimeoutError
+
+    handoff_dir = tmp_path / ".turbo" / "handoff"
+    since = time.time() - 1
+
+    # Write a yesterday-dated file — should be ignored
+    _write_md(handoff_dir, f"{YESTERDAY}-stale-task.md")
+
+    with pytest.raises(HandoffTimeoutError):
+        wait_for_handoff(tmp_path, since=since, timeout=0.3, poll=0.05)


### PR DESCRIPTION
Closes #746

Implements `wait_for_handoff(repo_root, since, timeout=180.0, poll=1.0)` in `packages/autospec_context_monitor/autospec_context_monitor/handoff.py`. Polls `<repo_root>/.turbo/handoff/<YYYY-MM-DD>-*.md` for files with `mtime > since` and returns the newest match. Raises `HandoffTimeoutError(TimeoutError)` if nothing appears within the timeout, with an actionable message naming the expected directory. 5 tests cover all ACs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)