### PR TITLE
feat(context-monitor): autospec-session bash launcher with tmux session + cleanup trap

### DIFF
--- a/scripts/autospec-session
+++ b/scripts/autospec-session
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# scripts/autospec-session — create a tmux session, launch a harness, and
+# optionally spawn the context-window monitor daemon.
+#
+# Usage:
+#   autospec-session <harness> [harness-args...] [--no-monitor]
+#   autospec-session --doctor
+#
+# <harness>: claude | codex | opencode (or any executable)
+# --no-monitor: skip spawning the Python monitor daemon
+# --doctor:     check system health and exit
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+err()  { printf 'autospec-session: %s\n' "$*" >&2; }
+info() { printf 'autospec-session: %s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: autospec-session <harness> [args...] [--no-monitor]
+       autospec-session --doctor
+
+Options:
+  --no-monitor   Start the tmux session without the context-monitor daemon.
+  --doctor       Run the context-monitor health check and exit.
+  -h, --help     Show this help message.
+
+Examples:
+  autospec-session claude
+  autospec-session codex --no-monitor
+  autospec-session opencode --some-flag
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+if [[ $# -eq 0 ]]; then
+    err "harness argument required."
+    usage >&2
+    exit 1
+fi
+
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    --doctor)
+        exec python3 -m autospec_context_monitor.doctor "$@"
+        ;;
+esac
+
+harness="$1"; shift
+
+# Scan remaining args for --no-monitor (may appear anywhere after harness)
+no_monitor=0
+remaining_args=()
+for arg in "$@"; do
+    if [[ "$arg" == "--no-monitor" ]]; then
+        no_monitor=1
+    else
+        remaining_args+=("$arg")
+    fi
+done
+set -- "${remaining_args[@]+"${remaining_args[@]}"}"
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+
+if ! command -v tmux >/dev/null 2>&1; then
+    err "tmux not installed. Install tmux and retry."
+    exit 127
+fi
+
+# ---------------------------------------------------------------------------
+# Generate unique session name: as-<8 hex chars>
+# ---------------------------------------------------------------------------
+
+if command -v uuidgen >/dev/null 2>&1; then
+    session="as-$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-' | cut -c1-8)"
+else
+    # Fallback: use /proc/sys/kernel/random/uuid or od
+    session="as-$(od -A n -t x1 -N 4 /dev/urandom | tr -d ' \n')"
+fi
+
+info "Creating tmux session '${session}' with harness '${harness}'."
+
+# ---------------------------------------------------------------------------
+# Create detached tmux session running the harness
+# ---------------------------------------------------------------------------
+
+started_at="$(date +%s)"
+
+if [[ $# -gt 0 ]]; then
+    tmux new-session -d -s "$session" "$harness" "$@"
+else
+    tmux new-session -d -s "$session" "$harness"
+fi
+
+# ---------------------------------------------------------------------------
+# Spawn monitor daemon (unless --no-monitor)
+# ---------------------------------------------------------------------------
+
+mon_pid=""
+
+if [[ "$no_monitor" -eq 0 ]]; then
+    monitor_log_dir="${HOME}/.autospec/monitors"
+    mkdir -p "$monitor_log_dir"
+    boot_log="${monitor_log_dir}/${session}.boot.log"
+
+    nohup python3 -m autospec_context_monitor \
+        --tmux-session "$session" \
+        --harness "$harness" \
+        --cwd "$PWD" \
+        --started-at "$started_at" \
+        >>"$boot_log" 2>&1 &
+    mon_pid=$!
+
+    info "Monitor daemon started (PID ${mon_pid}). Boot log: ${boot_log}"
+
+    # Register tmux hook to SIGTERM the monitor when the session closes.
+    # session-closed fires after the last window exits.
+    tmux set-hook -t "$session" session-closed \
+        "run-shell 'kill -TERM ${mon_pid} 2>/dev/null || true'"
+fi
+
+# ---------------------------------------------------------------------------
+# Attach to the session (replaces the current process)
+# ---------------------------------------------------------------------------
+
+exec tmux attach-session -t "$session"

--- a/tests/autospec-session.bats
+++ b/tests/autospec-session.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# tests/autospec-session.bats — tests for scripts/autospec-session
+# Covers: tmux-missing error, --no-monitor flag, session name pattern,
+# harness args pass-through.
+
+bats_require_minimum_version 1.5.0
+
+SESSION_SCRIPT="${BATS_TEST_DIRNAME}/../scripts/autospec-session"
+
+setup() {
+    STUB_DIR="$(mktemp -d)"
+    export HOME="${BATS_TMPDIR}/home-$$"
+    mkdir -p "${HOME}/.autospec/monitors"
+}
+
+teardown() {
+    rm -rf "${STUB_DIR}" "${HOME}"
+}
+
+# ---------------------------------------------------------------------------
+# test_errors_when_tmux_missing
+# ---------------------------------------------------------------------------
+
+@test "exits 127 when tmux is not installed" {
+    # PATH with no tmux — use a stub dir that has no tmux binary.
+    empty_path="$(mktemp -d)"
+
+    # Provide uuidgen so argument parsing works before the tmux check.
+    printf '#!/usr/bin/env bash\nprintf "ABCDEF12-3456-7890-ABCD-EF1234567890\n"\n' \
+        > "${empty_path}/uuidgen"
+    chmod +x "${empty_path}/uuidgen"
+
+    run -127 env PATH="${empty_path}" bash "${SESSION_SCRIPT}" claude
+    rm -rf "${empty_path}"
+
+    [ "$status" -eq 127 ]
+}
+
+# ---------------------------------------------------------------------------
+# test_no_monitor_flag_skips_python_spawn
+# ---------------------------------------------------------------------------
+
+@test "--no-monitor skips python -m autospec_context_monitor spawn" {
+    python3_called="${STUB_DIR}/.python3_called"
+
+    # tmux stub
+    cat > "${STUB_DIR}/tmux" <<TMUX
+#!/usr/bin/env bash
+case "\$1" in
+    new-session)    exit 0 ;;
+    set-hook)       exit 0 ;;
+    attach-session) exit 0 ;;
+    attach)         exit 0 ;;
+    *)              exit 0 ;;
+esac
+TMUX
+    chmod +x "${STUB_DIR}/tmux"
+
+    # python3 stub records if called
+    cat > "${STUB_DIR}/python3" <<PY
+#!/usr/bin/env bash
+touch "${python3_called}"
+exit 0
+PY
+    chmod +x "${STUB_DIR}/python3"
+
+    # uuidgen stub
+    printf '#!/usr/bin/env bash\nprintf "abcdef12-3456-7890-abcd-ef1234567890\n"\n' \
+        > "${STUB_DIR}/uuidgen"
+    chmod +x "${STUB_DIR}/uuidgen"
+
+    run env PATH="${STUB_DIR}:${PATH}" bash "${SESSION_SCRIPT}" claude --no-monitor
+
+    [ "$status" -eq 0 ]
+    [ ! -f "${python3_called}" ]
+}
+
+# ---------------------------------------------------------------------------
+# test_session_name_starts_with_as_prefix
+# ---------------------------------------------------------------------------
+
+@test "session name starts with 'as-' prefix and matches ^as-[a-f0-9]{8}$" {
+    session_file="${STUB_DIR}/.session_name"
+
+    # tmux stub captures session name from new-session -d -s NAME ...
+    cat > "${STUB_DIR}/tmux" <<TMUX
+#!/usr/bin/env bash
+case "\$1" in
+    new-session)
+        # Parse -s flag
+        while [[ \$# -gt 0 ]]; do
+            if [[ "\$1" == "-s" ]]; then
+                printf '%s' "\$2" > "${session_file}"
+                break
+            fi
+            shift
+        done
+        exit 0
+        ;;
+    set-hook)       exit 0 ;;
+    attach-session) exit 0 ;;
+    attach)         exit 0 ;;
+    *)              exit 0 ;;
+esac
+TMUX
+    chmod +x "${STUB_DIR}/tmux"
+
+    # python3 stub
+    printf '#!/usr/bin/env bash\nexit 0\n' > "${STUB_DIR}/python3"
+    chmod +x "${STUB_DIR}/python3"
+
+    # uuidgen stub: produces a known UUID with uppercase + lowercase mix to test tr
+    printf '#!/usr/bin/env bash\nprintf "ABCDEF12-3456-7890-ABCD-EF1234567890\n"\n' \
+        > "${STUB_DIR}/uuidgen"
+    chmod +x "${STUB_DIR}/uuidgen"
+
+    run env PATH="${STUB_DIR}:${PATH}" bash "${SESSION_SCRIPT}" claude --no-monitor
+
+    [ "$status" -eq 0 ]
+    [ -f "${session_file}" ]
+    session_name="$(cat "${session_file}")"
+    [[ "$session_name" =~ ^as-[a-f0-9]{8}$ ]]
+}
+
+# ---------------------------------------------------------------------------
+# test_passes_harness_args_through_to_tmux
+# ---------------------------------------------------------------------------
+
+@test "passes extra harness args through to tmux new-session" {
+    args_file="${STUB_DIR}/.tmux_args"
+
+    cat > "${STUB_DIR}/tmux" <<TMUX
+#!/usr/bin/env bash
+case "\$1" in
+    new-session)
+        printf '%s\n' "\$@" > "${args_file}"
+        exit 0
+        ;;
+    set-hook)       exit 0 ;;
+    attach-session) exit 0 ;;
+    attach)         exit 0 ;;
+    *)              exit 0 ;;
+esac
+TMUX
+    chmod +x "${STUB_DIR}/tmux"
+
+    printf '#!/usr/bin/env bash\nexit 0\n' > "${STUB_DIR}/python3"
+    chmod +x "${STUB_DIR}/python3"
+
+    printf '#!/usr/bin/env bash\nprintf "ABCDEF12-3456-7890-ABCD-EF1234567890\n"\n' \
+        > "${STUB_DIR}/uuidgen"
+    chmod +x "${STUB_DIR}/uuidgen"
+
+    run env PATH="${STUB_DIR}:${PATH}" bash "${SESSION_SCRIPT}" claude --no-monitor --extra-arg somevalue
+
+    [ "$status" -eq 0 ]
+    [ -f "${args_file}" ]
+    grep -q "claude" "${args_file}"
+    grep -q "somevalue" "${args_file}"
+}


### PR DESCRIPTION
Closes #749

Implements `scripts/autospec-session` — the bash entry-point that wires together a tmux session, the AI harness, and the context-monitor daemon:

- Generates a unique session name `as-<8 hex chars>` via `uuidgen`
- Creates a detached tmux session running the chosen harness (`claude`/`codex`/`opencode`)
- Spawns `python3 -m autospec_context_monitor` via `nohup` (monitor PID captured)
- Registers `tmux set-hook session-closed` to `kill -TERM $mon_pid` when the session ends
- `--no-monitor` skips daemon spawn entirely
- Exits 127 with a human-readable error when tmux is not installed
- `exec tmux attach-session` replaces the launcher process so the shell stays clean

4 bats tests cover: tmux-missing exit 127, --no-monitor skips python spawn, session name matches `^as-[a-f0-9]{8}$`, extra args passed through to tmux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)