### PR TITLE
feat(context-monitor): install.sh opt-in rollover prompt + shell-rc shim block

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,6 +67,7 @@ SKILL_ARG="all"
 HARNESS_ARG="all"
 UPDATE=0
 DRY_RUN=0
+DISABLE_AUTO_ROLLOVER=0
 
 err()  { printf 'error: %s\n' "$*" >&2; }
 warn() { printf 'warn:  %s\n' "$*" >&2; }
@@ -454,6 +455,121 @@ maybe_prompt_star() {
     esac
 }
 
+_ROLLOVER_MARKER_START="# >>> autospec auto-rollover >>>"
+_ROLLOVER_MARKER_END="# <<< autospec auto-rollover <<<"
+
+prompt_user_for_auto_rollover() {
+    # Skip prompt during updates, CI, dry-run, or explicit disable.
+    [ "$UPDATE" -eq 0 ] || return 0
+    [ "$DRY_RUN" -eq 0 ] || return 0
+    [ "$DISABLE_AUTO_ROLLOVER" -eq 0 ] || return 0
+    [ "${CI:-}" = "" ] || return 0
+
+    info ""
+    info "autospec auto-context-rollover"
+    info "  Wraps the claude/codex/opencode commands so that autospec-session"
+    info "  monitors context usage and compacts/hands-off automatically."
+    info "  A guard block is added to ~/.bashrc, ~/.zshrc, and fish config."
+    info "  You can remove it anytime with:  bash install.sh --disable-auto-rollover"
+    info ""
+
+    answer=""
+    if { exec 3<>/dev/tty; } 2>/dev/null; then
+        printf '  Enable auto-context-rollover? [y/N] ' >&3
+        read -r answer <&3 || { exec 3>&-; return 0; }
+        exec 3>&-
+    else
+        [ -t 0 ] && [ -t 1 ] || return 0
+        printf '  Enable auto-context-rollover? [y/N] '
+        read -r answer || return 0
+    fi
+
+    case "$answer" in
+        y|Y|yes|YES|Yes)
+            install_rollover_block
+            ;;
+        *)
+            info "  Skipping auto-rollover setup."
+            ;;
+    esac
+}
+
+install_rollover_block() {
+    local bash_block
+    bash_block="$_ROLLOVER_MARKER_START
+export AUTOSPEC_AUTO_ROLLOVER=1
+if [ \"\${AUTOSPEC_AUTO_ROLLOVER:-0}\" = \"1\" ] && command -v autospec-session >/dev/null 2>&1; then
+    claude()   { autospec-session claude \"\$@\"; }
+    codex()    { autospec-session codex \"\$@\"; }
+    opencode() { autospec-session opencode \"\$@\"; }
+fi
+$_ROLLOVER_MARKER_END"
+
+    for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+        [ -f "$rc" ] || continue
+        if grep -qF "$_ROLLOVER_MARKER_START" "$rc"; then
+            info "  auto-rollover block already present in $rc (skipping)"
+            continue
+        fi
+        printf '\n%s\n' "$bash_block" >> "$rc"
+        info "  auto-rollover block added to $rc"
+    done
+
+    # Fish uses function syntax instead of shell function declarations.
+    local fish_config="$HOME/.config/fish/config.fish"
+    if [ -f "$fish_config" ]; then
+        if grep -qF "$_ROLLOVER_MARKER_START" "$fish_config"; then
+            info "  auto-rollover block already present in $fish_config (skipping)"
+        else
+            printf '\n%s\n' "$_ROLLOVER_MARKER_START
+set -x AUTOSPEC_AUTO_ROLLOVER 1
+if test \"\$AUTOSPEC_AUTO_ROLLOVER\" = \"1\"; and command -v autospec-session >/dev/null 2>&1
+    function claude; autospec-session claude \$argv; end
+    function codex; autospec-session codex \$argv; end
+    function opencode; autospec-session opencode \$argv; end
+end
+$_ROLLOVER_MARKER_END" >> "$fish_config"
+            info "  auto-rollover block added to $fish_config"
+        fi
+    fi
+}
+
+remove_rollover_block() {
+    local removed=0
+    for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+        [ -f "$rc" ] || continue
+        if grep -qF "$_ROLLOVER_MARKER_START" "$rc"; then
+            # Use a temp file approach for portability (macOS sed -i differs from GNU).
+            local tmp
+            tmp=$(mktemp)
+            awk "
+                /$_ROLLOVER_MARKER_START/{skip=1}
+                !skip{print}
+                /$_ROLLOVER_MARKER_END/{skip=0}
+            " "$rc" > "$tmp" && mv "$tmp" "$rc"
+            info "  auto-rollover block removed from $rc"
+            removed=$((removed + 1))
+        fi
+    done
+
+    local fish_config="$HOME/.config/fish/config.fish"
+    if [ -f "$fish_config" ] && grep -qF "$_ROLLOVER_MARKER_START" "$fish_config"; then
+        local tmp
+        tmp=$(mktemp)
+        awk "
+            /$_ROLLOVER_MARKER_START/{skip=1}
+            !skip{print}
+            /$_ROLLOVER_MARKER_END/{skip=0}
+        " "$fish_config" > "$tmp" && mv "$tmp" "$fish_config"
+        info "  auto-rollover block removed from $fish_config"
+        removed=$((removed + 1))
+    fi
+
+    if [ "$removed" -eq 0 ]; then
+        info "  auto-rollover: no block found to remove (already clean)"
+    fi
+}
+
 while [ $# -gt 0 ]; do
     case "$1" in
         --skill)
@@ -475,6 +591,9 @@ while [ $# -gt 0 ]; do
             ;;
         --dry-run)
             DRY_RUN=1
+            ;;
+        --disable-auto-rollover)
+            DISABLE_AUTO_ROLLOVER=1
             ;;
         -h|--help)
             usage
@@ -659,5 +778,10 @@ info "Suite install summary: $succeeded/$total pairs OK ($failures failed)"
 if [ "$failures" -gt 0 ]; then
     exit 1
 fi
+if [ "$DISABLE_AUTO_ROLLOVER" -eq 1 ]; then
+    remove_rollover_block
+    exit 0
+fi
+prompt_user_for_auto_rollover
 maybe_prompt_star
 exit 0

--- a/tests/install-rollover.bats
+++ b/tests/install-rollover.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+# tests/install-rollover.bats — tests for install.sh auto-rollover block
+
+INSTALL_SH="${BATS_TEST_DIRNAME}/../install.sh"
+MARKER_START="# >>> autospec auto-rollover >>>"
+MARKER_END="# <<< autospec auto-rollover <<<"
+
+# Source only the rollover helpers by extracting the relevant line range.
+# Lines 458-571 contain _ROLLOVER_MARKER_START through remove_rollover_block.
+_ROLLOVER_HELPERS="${BATS_TMPDIR}/rollover_helpers.sh"
+
+setup() {
+    export ORIG_HOME="$HOME"
+    export HOME="$(mktemp -d)"
+    export AUTOSPEC_NO_STAR_PROMPT=1
+    export AUTOSPEC_SKIP_SYSTEM_TOOLS=1
+    export AUTOSPEC_SKIP_ECOSYSTEM_BOOTSTRAP=1
+
+    # Build a sourceable helpers file from install.sh's rollover block.
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'UPDATE=0\nDRY_RUN=0\nDISABLE_AUTO_ROLLOVER=0\n'
+        printf 'info() { printf "%%s\\n" "$*"; }\n'
+        printf 'err()  { printf "error: %%s\\n" "$*" >&2; }\n'
+        # Extract lines 458-571 from install.sh (rollover vars + functions)
+        sed -n '458,571p' "$INSTALL_SH"
+    } > "$_ROLLOVER_HELPERS"
+}
+
+teardown() {
+    rm -rf "$HOME"
+    rm -f "$_ROLLOVER_HELPERS"
+    export HOME="$ORIG_HOME"
+}
+
+@test "test_install_block_is_idempotent" {
+    touch "$HOME/.bashrc"
+
+    # shellcheck source=/dev/null
+    source "$_ROLLOVER_HELPERS"
+
+    install_rollover_block
+    install_rollover_block
+
+    count=$(grep -c "$MARKER_START" "$HOME/.bashrc" || true)
+    [ "$count" -eq 1 ]
+}
+
+@test "test_disable_flag_removes_block" {
+    touch "$HOME/.bashrc"
+
+    source "$_ROLLOVER_HELPERS"
+
+    install_rollover_block
+    grep -q "$MARKER_START" "$HOME/.bashrc"  # assert it was written
+
+    remove_rollover_block
+
+    run grep "$MARKER_START" "$HOME/.bashrc"
+    [ "$status" -ne 0 ]  # grep found nothing
+}
+
+@test "test_block_not_written_when_user_answers_no" {
+    touch "$HOME/.bashrc"
+
+    source "$_ROLLOVER_HELPERS"
+
+    # Call install_rollover_block only if answer is y — simulate n answer
+    answer="n"
+    case "$answer" in
+        y|Y|yes|YES|Yes) install_rollover_block ;;
+        *) : ;;
+    esac
+
+    run grep "$MARKER_START" "$HOME/.bashrc"
+    [ "$status" -ne 0 ]  # block must NOT have been written
+}
+
+@test "test_fish_config_gets_function_form_not_alias" {
+    mkdir -p "$HOME/.config/fish"
+    touch "$HOME/.config/fish/config.fish"
+
+    source "$_ROLLOVER_HELPERS"
+
+    install_rollover_block
+
+    # Fish block must use `function ... end` syntax
+    run grep "function claude" "$HOME/.config/fish/config.fish"
+    [ "$status" -eq 0 ]
+
+    # Must NOT use bash-style function declaration
+    run grep "claude()" "$HOME/.config/fish/config.fish"
+    [ "$status" -ne 0 ]
+}
+
+@test "test_disable_flag_exits_zero_when_block_absent" {
+    # install.sh --disable-auto-rollover should succeed even with no block present
+    run bash "$INSTALL_SH" --disable-auto-rollover
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #752

Adds opt-in auto-context-rollover setup to `install.sh`:

- `prompt_user_for_auto_rollover()` — interactive `[y/N]` prompt (skipped during CI/update/dry-run)
- `install_rollover_block()` — writes idempotent `# >>> autospec auto-rollover >>>` marker block to `~/.bashrc`, `~/.zshrc`, and `~/.config/fish/config.fish`; bash/zsh get shell function wrappers, fish gets `function ... end` form
- `remove_rollover_block()` — strips the marker block from all rc files using awk (portable, no GNU sed -i required)
- `--disable-auto-rollover` flag — skips prompt, calls remove, exits 0 even when block is absent

5 bats tests covering all 4 ACs plus fish function-form check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)