### PR TITLE
docs(context-monitor): README + AGENTS.md documentation for auto context rollover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,6 +327,10 @@ Scripts for managing project memory files under `AUTOSPEC_MEMORY_DIR`
 `AUTOSPEC_MEMORY_DIR` — override for the memory directory path (default: auto-detected
 from `$HOME/.claude/projects/`).
 
+## Auto context rollover skills
+
+- `/autospec-rollover-status` — reports current context % and last rollover event for the active session (see [`docs/specs/2026-05-31-auto-context-rollover-design.md`](docs/specs/2026-05-31-auto-context-rollover-design.md)).
+
 `AUTOSPEC_COMPRESS_THRESHOLD` — LOC threshold for `mempalace-compress.sh` (default: `5000`).
 `AUTOSPEC_COMPRESS_EVERY` — invoke compress every N calls to `auto-init-memory.sh` (default: `10`).
 `AUTOSPEC_MINE_PR_HISTORY` — set to `1` to enable PR history mining in `auto-init-memory.sh` (off by default; bandwidth-heavy).

--- a/README.md
+++ b/README.md
@@ -519,3 +519,22 @@ LGTM first-pass rate, and top-10 cost outliers by issue. To publish to GitHub Pa
   profiles and project board mapping.
 - [`AGENTS.md`](AGENTS.md) - repository operating contract and merge authority
   rules.
+
+## Auto context rollover (opt-in)
+
+Wraps `claude`, `codex`, and `opencode` in a tmux session monitored by
+`autospec-context-monitor`. At 50% context usage the monitor injects
+`/compact`; at 80% it triggers `/create-handoff` → `/clear` → resume — same
+terminal, same process, new conversation.
+
+**Enable:** run `bash install.sh` and answer `y` to the auto-rollover prompt.
+
+**Disable at any time:**
+- `bash install.sh --disable-auto-rollover` — removes the shim permanently.
+- `AUTOSPEC_AUTO_ROLLOVER=0 claude` — single-session bypass.
+- `command claude` — bypasses the shim entirely.
+- `touch ~/.autospec/no-auto-rollover.flag` — global kill-switch without reinstalling.
+
+Check current status with the `/autospec-rollover-status` skill. See the
+[design spec](docs/specs/2026-05-31-auto-context-rollover-design.md) for full
+architecture details.

--- a/tests/docs/test_rollover_docs.bats
+++ b/tests/docs/test_rollover_docs.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+# tests/docs/test_rollover_docs.bats
+#
+# Validates README.md and AGENTS.md documentation for auto context rollover
+# feature as required by issue #754.
+#
+# Run: bats tests/docs/test_rollover_docs.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+README="$REPO_ROOT/README.md"
+AGENTS="$REPO_ROOT/AGENTS.md"
+
+@test "test_readme_has_auto_context_rollover_heading" {
+  grep -q '^## Auto context rollover (opt-in)' "$README"
+}
+
+@test "test_readme_lists_at_least_3_escape_hatches" {
+  count=$(grep -c -- '--disable-auto-rollover\|AUTOSPEC_AUTO_ROLLOVER=0\|command claude\|no-auto-rollover\.flag\|--no-monitor' "$README")
+  [ "$count" -ge 3 ]
+}
+
+@test "test_agents_md_mentions_autospec_rollover_status" {
+  grep -q '/autospec-rollover-status' "$AGENTS"
+}
+
+@test "test_readme_links_to_spec_path" {
+  grep -q 'docs/specs/2026-05-31-auto-context-rollover-design\.md' "$README"
+}


### PR DESCRIPTION
Closes #754

Appends an `## Auto context rollover (opt-in)` section to `README.md` covering feature overview, enable/disable instructions, four escape hatches, and a link to the design spec. Appends a one-line `/autospec-rollover-status` skill pointer to `AGENTS.md`. Companion `tests/docs/test_rollover_docs.bats` validates heading, escape-hatch count, AGENTS pointer, and spec link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)