### PR TITLE
feat(context-monitor): handoff content validation gate before /clear

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
@@ -25,12 +25,14 @@ import argparse
 import json
 import os
 import signal
+import subprocess
 import sys
 import time
 from pathlib import Path
 
 from .adapters.base import TranscriptNotFoundError, Usage
 from .engine import Action, Engine, State
+from .handoff import validate_handoff
 from .injector import SessionGone, inject, session_exists, wait_for_cancel
 
 _POLL_INTERVAL = 15  # seconds
@@ -94,6 +96,22 @@ def _dispatch(action: Action, tmux_session: str, logf: Path) -> bool:
         return False
 
     if action.kind == "clear":
+        # --- Handoff validation gate ---
+        handoff_dir = Path.home() / ".turbo" / "handoff"
+        hfiles = sorted(handoff_dir.glob("*.md"), key=lambda p: p.stat().st_mtime) if handoff_dir.exists() else []
+        if hfiles:
+            ok, missing = validate_handoff(hfiles[-1])
+            if not ok:
+                msg = f"autospec: handoff invalid (missing: {', '.join(missing)}) — rollover aborted"
+                _log(logf, {"event": "handoff invalid: missing", "missing": missing, "kind": "clear"})
+                subprocess.run(["tmux", "display-message", msg], check=False)
+                subprocess.run(
+                    ["tmux", "send-keys", "-t", tmux_session, "-l", "\a"],
+                    check=False,
+                )
+                return True
+
+        # --- Cancel window ---
         _log(logf, {"event": "cancel_window_start", "kind": "clear"})
         if wait_for_cancel(tmux_session):
             _log(logf, {"event": "rollover canceled by user", "kind": "clear"})

--- a/packages/autospec_context_monitor/autospec_context_monitor/handoff.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/handoff.py
@@ -1,8 +1,9 @@
-"""Handoff-file polling for autospec-context-monitor.
+"""Handoff-file polling and validation for autospec-context-monitor.
 
-Provides :func:`wait_for_handoff` which blocks until a new handoff Markdown
-file appears in ``<repo_root>/.turbo/handoff/`` with a modification time
-strictly after ``since``.
+Provides:
+- :func:`wait_for_handoff` — block until a new handoff file appears.
+- :func:`validate_handoff` — check that a handoff file has required headings
+  and minimum size before allowing ``/clear`` to proceed.
 
 The caller is responsible for passing the ``since`` timestamp (e.g.
 ``time.time()`` captured just before issuing the ``/create-handoff`` command)
@@ -10,9 +11,59 @@ so that pre-existing files are correctly ignored.
 """
 from __future__ import annotations
 
+import re
 import time
 from datetime import date
 from pathlib import Path
+
+# Minimum byte-size for a handoff to be considered non-trivial.
+_MIN_SIZE = 200
+
+# Required headings (case-insensitive multiline match).
+_REQUIRED_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("# heading", re.compile(r"^# \S", re.MULTILINE)),
+    ("## Status", re.compile(r"^## Status\b", re.MULTILINE | re.IGNORECASE)),
+    ("## Next step", re.compile(r"^## Next step\b", re.MULTILINE | re.IGNORECASE)),
+]
+
+
+def validate_handoff(path: Path) -> tuple[bool, list[str]]:
+    """Check that *path* is a structurally valid handoff file.
+
+    Checks (in order):
+    1. File is at least :data:`_MIN_SIZE` bytes.
+    2. Contains a top-level ``# <title>`` heading.
+    3. Contains a ``## Status`` section.
+    4. Contains a ``## Next step`` section.
+
+    Args:
+        path: Path to the handoff Markdown file.
+
+    Returns:
+        A ``(ok, missing)`` tuple where *ok* is ``True`` iff all checks pass
+        and *missing* is a list of the failed check names (empty on success).
+    """
+    missing: list[str] = []
+
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return False, ["size", "# heading", "## Status", "## Next step"]
+
+    if size < _MIN_SIZE:
+        missing.append("size")
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        missing.extend(name for name, _ in _REQUIRED_PATTERNS)
+        return False, missing
+
+    for name, pattern in _REQUIRED_PATTERNS:
+        if not pattern.search(text):
+            missing.append(name)
+
+    return (len(missing) == 0), missing
 
 
 class HandoffTimeoutError(TimeoutError):

--- a/packages/autospec_context_monitor/tests/fixtures/handoff/full.md
+++ b/packages/autospec_context_monitor/tests/fixtures/handoff/full.md
@@ -1,0 +1,11 @@
+# Implement feature X rollover handoff
+
+## Status
+
+In progress. The main loop changes are complete and tests pass locally.
+The PR is open and awaiting review. CI is green.
+
+## Next step
+
+Merge the PR, then start on the follow-up issue for the cancel-window overlay.
+Make sure to update CHANGELOG.md before merging.

--- a/packages/autospec_context_monitor/tests/fixtures/handoff/partial.md
+++ b/packages/autospec_context_monitor/tests/fixtures/handoff/partial.md
@@ -1,0 +1,7 @@
+# Partial handoff — missing Next step section
+
+## Status
+
+In progress. Working on the context monitor daemon. The injector tests pass.
+The handoff polling tests pass. Still need to wire cancel window and validation.
+This file intentionally omits the Next step section to test the validator.

--- a/packages/autospec_context_monitor/tests/fixtures/handoff/stub.md
+++ b/packages/autospec_context_monitor/tests/fixtures/handoff/stub.md
@@ -1,0 +1,3 @@
+# stub
+
+Too short.

--- a/packages/autospec_context_monitor/tests/test_handoff_validation.py
+++ b/packages/autospec_context_monitor/tests/test_handoff_validation.py
@@ -1,0 +1,44 @@
+"""Unit tests for handoff.validate_handoff.
+
+Uses three fixture files:
+- tests/fixtures/handoff/full.md    — valid (>= 200 bytes, all headings)
+- tests/fixtures/handoff/stub.md    — too small (< 200 bytes)
+- tests/fixtures/handoff/partial.md — missing ## Next step
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autospec_context_monitor.handoff import validate_handoff
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "handoff"
+
+
+def test_full_handoff_is_valid():
+    """full.md must pass all checks and return (True, [])."""
+    path = _FIXTURES / "full.md"
+    ok, missing = validate_handoff(path)
+    assert ok is True
+    assert missing == []
+
+
+def test_stub_handoff_fails_size():
+    """stub.md is under 200 bytes; validate_handoff must report 'size' in missing."""
+    path = _FIXTURES / "stub.md"
+    assert path.stat().st_size < 200, "fixture must be < 200 bytes for this test to be meaningful"
+    ok, missing = validate_handoff(path)
+    assert ok is False
+    assert "size" in missing
+
+
+def test_partial_handoff_missing_next_step():
+    """partial.md has # heading and ## Status but lacks ## Next step."""
+    path = _FIXTURES / "partial.md"
+    ok, missing = validate_handoff(path)
+    assert ok is False
+    assert "## Next step" in missing
+    # Must NOT report status or heading missing
+    assert "## Status" not in missing
+    assert "# heading" not in missing

--- a/packages/autospec_context_monitor/tests/test_monitor_invalid_handoff.py
+++ b/packages/autospec_context_monitor/tests/test_monitor_invalid_handoff.py
@@ -1,0 +1,73 @@
+"""Monitor-level test: /clear is NOT injected when the handoff file is invalid.
+
+Scenario:
+1. _dispatch receives a "clear" action.
+2. The most recent file in ~/.turbo/handoff/ is the stub fixture (< 200 bytes).
+3. validate_handoff returns (False, ["size"]).
+4. _dispatch logs the failure, shows overlay, returns True (canceled).
+5. The main loop reverts engine state to COMPACTED.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autospec_context_monitor.__main__ import _dispatch, _log
+from autospec_context_monitor.engine import Action, Engine, State
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "handoff"
+
+
+def test_clear_not_sent_when_handoff_invalid(tmp_path):
+    """_dispatch('clear') returns True (canceled) when handoff fails validation."""
+    logf = tmp_path / "test.log"
+
+    # Point ~/.turbo/handoff to a directory containing only the stub fixture.
+    handoff_dir = tmp_path / ".turbo" / "handoff"
+    handoff_dir.mkdir(parents=True)
+    stub_src = _FIXTURES / "stub.md"
+    stub_dest = handoff_dir / "2026-05-31-stub.md"
+    stub_dest.write_bytes(stub_src.read_bytes())
+
+    inject_calls: list = []
+
+    def _fake_inject(session, text, **_kw):
+        inject_calls.append(text)
+
+    with patch("autospec_context_monitor.__main__.Path.home", return_value=tmp_path):
+        with patch("autospec_context_monitor.__main__.inject", _fake_inject):
+            with patch("autospec_context_monitor.__main__.wait_for_cancel", return_value=False):
+                with patch("autospec_context_monitor.__main__.subprocess") as sp_mock:
+                    sp_mock.run = MagicMock(return_value=MagicMock(returncode=0))
+                    result = _dispatch(Action("clear"), "test-sess", logf)
+
+    assert result is True, "_dispatch must return True (canceled) for invalid handoff"
+    assert "/clear" not in inject_calls, "/clear must NOT be injected when handoff invalid"
+
+    # Log must contain the invalid handoff event
+    log_lines = [json.loads(l) for l in logf.read_text().splitlines() if l.strip()]
+    events = [l["event"] for l in log_lines]
+    assert any("handoff invalid" in e for e in events), (
+        "Log must record 'handoff invalid: missing' event"
+    )
+
+
+def test_state_stays_compacted_after_invalid_handoff():
+    """Engine state reverts to COMPACTED when clear dispatch is aborted."""
+    engine = Engine()
+    # Manually advance to ROLLED (simulating dispatch already fired)
+    engine._state = State.ROLLED  # noqa: SLF001
+
+    # Simulate caller reverting state on cancel
+    engine._state = State.COMPACTED  # noqa: SLF001
+    assert engine.state is State.COMPACTED
+
+    # Next 80% reading should re-fire the rollover
+    from autospec_context_monitor.adapters.base import Usage
+    actions = engine.classify(Usage(used_tokens=800, max_tokens=1000, model="test", estimated=False))
+    assert engine.state is State.ROLLED
+    assert [a.kind for a in actions] == ["handoff", "clear", "resume"]


### PR DESCRIPTION
Closes #756

Adds a validation gate that checks the handoff file before injecting `/clear` at 80% rollover. If the file is under 200 bytes or missing `# heading`, `## Status`, or `## Next step` sections, the rollover is aborted with a tmux overlay message and engine state reverts to COMPACTED.

**Changes:**
- `handoff.py`: new `validate_handoff(path) -> tuple[bool, list[str]]` — checks size >= 200 bytes and three required Markdown headings (case-insensitive)
- `__main__.py`: `_dispatch` for `"clear"` now finds the latest handoff file, validates it, and returns `True` (aborted) on failure; logs `handoff invalid: missing` with the list of failing checks
- 3 fixture files: `full.md` (valid), `stub.md` (< 200 bytes), `partial.md` (missing `## Next step`)
- 5 tests across `test_handoff_validation.py` and `test_monitor_invalid_handoff.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)