### PR TITLE
feat(context-monitor): cost/value telemetry JSONL ledger + --stats flag

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
@@ -34,6 +34,7 @@ from .adapters.base import TranscriptNotFoundError, Usage
 from .engine import Action, Engine, State
 from .handoff import validate_handoff
 from .injector import SessionGone, inject, session_exists, wait_for_cancel
+from . import stats as _stats
 
 _POLL_INTERVAL = 15  # seconds
 _KILL_SWITCH = Path.home() / ".autospec" / "no-auto-rollover.flag"
@@ -73,7 +74,14 @@ def _load_adapter(harness: str):
 # Action dispatcher
 # ---------------------------------------------------------------------------
 
-def _dispatch(action: Action, tmux_session: str, logf: Path) -> bool:
+def _dispatch(
+    action: Action,
+    tmux_session: str,
+    logf: Path,
+    harness: str = "",
+    cwd: str = "",
+    pct: float = 0.0,
+) -> bool:
     """Execute *action* by injecting into the tmux session.
 
     Returns:
@@ -87,6 +95,13 @@ def _dispatch(action: Action, tmux_session: str, logf: Path) -> bool:
     if action.kind == "compact":
         _log(logf, {"event": "inject", "kind": "compact"})
         inject(tmux_session, "/compact")
+        _stats.record(
+            "compact_fired",
+            harness=harness,
+            tmux_session=tmux_session,
+            pct=round(pct, 4),
+            cwd=cwd,
+        )
         return False
 
     if action.kind == "handoff":
@@ -104,6 +119,13 @@ def _dispatch(action: Action, tmux_session: str, logf: Path) -> bool:
             if not ok:
                 msg = f"autospec: handoff invalid (missing: {', '.join(missing)}) — rollover aborted"
                 _log(logf, {"event": "handoff invalid: missing", "missing": missing, "kind": "clear"})
+                _stats.record(
+                    "handoff_invalid",
+                    harness=harness,
+                    tmux_session=tmux_session,
+                    pct=round(pct, 4),
+                    cwd=cwd,
+                )
                 subprocess.run(["tmux", "display-message", msg], check=False)
                 subprocess.run(
                     ["tmux", "send-keys", "-t", tmux_session, "-l", "\a"],
@@ -115,9 +137,23 @@ def _dispatch(action: Action, tmux_session: str, logf: Path) -> bool:
         _log(logf, {"event": "cancel_window_start", "kind": "clear"})
         if wait_for_cancel(tmux_session):
             _log(logf, {"event": "rollover canceled by user", "kind": "clear"})
+            _stats.record(
+                "rollover_aborted",
+                harness=harness,
+                tmux_session=tmux_session,
+                pct=round(pct, 4),
+                cwd=cwd,
+            )
             return True
         _log(logf, {"event": "inject", "kind": "clear"})
         inject(tmux_session, "/clear")
+        _stats.record(
+            "rollover_fired",
+            harness=harness,
+            tmux_session=tmux_session,
+            pct=round(pct, 4),
+            cwd=cwd,
+        )
         return False
 
     if action.kind == "resume":
@@ -219,7 +255,14 @@ def main(argv: list[str] | None = None) -> None:
                 })
                 actions = engine.classify(usage)
                 for action in actions:
-                    canceled = _dispatch(action, args.tmux_session, logf)
+                    canceled = _dispatch(
+                        action,
+                        args.tmux_session,
+                        logf,
+                        harness=args.harness,
+                        cwd=args.cwd,
+                        pct=round(usage.used_tokens / usage.max_tokens, 4),
+                    )
                     if canceled:
                         # User pressed Esc during cancel window — revert state
                         # so the engine re-fires the rollover on the next 80%

--- a/packages/autospec_context_monitor/autospec_context_monitor/doctor.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/doctor.py
@@ -10,6 +10,8 @@ Exits 0 when all checks pass; non-zero when any check reports a problem.
 from __future__ import annotations
 
 import argparse
+import collections
+import datetime
 import importlib
 import json
 import os
@@ -22,6 +24,7 @@ from typing import Any, Callable, List, Tuple
 
 _MONITORS_DIR = Path.home() / ".autospec" / "monitors"
 _TRANSCRIPTS_DIR = Path.home() / ".claude" / "projects"
+_STATS_FILE = Path.home() / ".autospec" / "monitors" / "stats.jsonl"
 
 # ---------------------------------------------------------------------------
 # Check helpers
@@ -175,6 +178,81 @@ def _print_table(results: List[Tuple[str, Any]]) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Stats aggregation
+# ---------------------------------------------------------------------------
+
+def _print_stats(filter_cwd: str | None = None) -> None:
+    """Read stats.jsonl and print last-7-day counts per event type and harness."""
+    if not _STATS_FILE.exists():
+        print("No stats ledger found at", _STATS_FILE)
+        return
+
+    cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7)
+    by_event: collections.Counter[str] = collections.Counter()
+    by_harness: collections.Counter[str] = collections.Counter()
+    total = 0
+    skipped = 0
+
+    with _STATS_FILE.open() as fh:
+        for lineno, raw in enumerate(fh, 1):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                row = json.loads(raw)
+            except json.JSONDecodeError:
+                skipped += 1
+                continue
+
+            # Filter by cwd when requested
+            if filter_cwd is not None and row.get("cwd") != filter_cwd:
+                continue
+
+            # Filter by 7-day window
+            ts_str = row.get("ts", "")
+            try:
+                ts = datetime.datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ").replace(
+                    tzinfo=datetime.timezone.utc
+                )
+            except (ValueError, TypeError):
+                ts = datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+
+            if ts < cutoff:
+                continue
+
+            total += 1
+            event = row.get("event", "(unknown)")
+            harness = row.get("harness", "(unknown)")
+            by_event[event] += 1
+            by_harness[harness] += 1
+
+    print(f"autospec stats — last 7 days  (ledger: {_STATS_FILE})")
+    if filter_cwd:
+        print(f"  filtered to cwd: {filter_cwd}")
+    print(f"  total events : {total}")
+    if skipped:
+        print(f"  malformed lines skipped: {skipped}")
+    print()
+
+    print("By event type:")
+    if by_event:
+        width = max(len(k) for k in by_event)
+        for event, count in sorted(by_event.items(), key=lambda x: -x[1]):
+            print(f"  {event:<{width}}  {count}")
+    else:
+        print("  (none)")
+
+    print()
+    print("By harness:")
+    if by_harness:
+        width = max(len(k) for k in by_harness)
+        for harness, count in sorted(by_harness.items(), key=lambda x: -x[1]):
+            print(f"  {harness:<{width}}  {count}")
+    else:
+        print("  (none)")
+
+
+# ---------------------------------------------------------------------------
 # CLI entry point
 # ---------------------------------------------------------------------------
 
@@ -198,7 +276,23 @@ def main(argv: list[str] | None = None) -> int:
         default=False,
         help="After checks, run pytest over the adapter and engine test suites.",
     )
+    parser.add_argument(
+        "--stats",
+        action="store_true",
+        default=False,
+        help="Print last-7-day counts from the stats ledger (~/.autospec/monitors/stats.jsonl).",
+    )
+    parser.add_argument(
+        "--cwd",
+        default=None,
+        help="When used with --stats, filter events to this working directory.",
+    )
     args = parser.parse_args(argv)
+
+    # Short-circuit: if --stats is requested, print and exit.
+    if args.stats:
+        _print_stats(filter_cwd=args.cwd)
+        return 0
 
     checks = _build_checks()
     results: List[Tuple[str, Any]] = [(name, _safe_run(fn)) for name, fn in checks]

--- a/packages/autospec_context_monitor/autospec_context_monitor/stats.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/stats.py
@@ -1,0 +1,59 @@
+"""autospec_context_monitor.stats — append-only JSONL telemetry ledger.
+
+Records rollover/compact events to ``~/.autospec/monitors/stats.jsonl``.
+Never raises on disk errors; silently logs and returns.
+
+Usage::
+
+    from autospec_context_monitor.stats import record
+
+    record("compact_fired", harness="claude", tmux_session="my-cc",
+           pct=0.52, cwd="/home/user/myproject")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+_STATS_FILE = Path.home() / ".autospec" / "monitors" / "stats.jsonl"
+
+_logger = logging.getLogger(__name__)
+
+
+def record(event_type: str, **fields) -> None:  # noqa: ANN003
+    """Append a single JSON event line to the stats ledger.
+
+    Args:
+        event_type: One of ``compact_fired``, ``rollover_fired``,
+                    ``rollover_aborted``, ``handoff_invalid``.
+        **fields:   Extra scalar fields merged into the record.
+                    Typical keys: ``harness``, ``tmux_session``, ``pct``, ``cwd``.
+
+    The record written has at minimum::
+
+        {"ts": "<ISO-8601-UTC>", "event": "<event_type>", ...fields}
+
+    Never raises: disk errors are logged at WARNING level and the function
+    returns silently to avoid disrupting the monitor loop.
+    """
+    row: dict = {
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "event": event_type,
+    }
+    row.update(fields)
+
+    try:
+        _STATS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        # O_APPEND guarantees atomic single-write appends on POSIX.
+        fd = os.open(str(_STATS_FILE), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            line = json.dumps(row) + "\n"
+            os.write(fd, line.encode())
+        finally:
+            os.close(fd)
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("stats.record: failed to write event %r: %s", event_type, exc)

--- a/packages/autospec_context_monitor/tests/test_stats.py
+++ b/packages/autospec_context_monitor/tests/test_stats.py
@@ -1,0 +1,142 @@
+"""Tests for autospec_context_monitor.stats JSONL telemetry ledger.
+
+Covers:
+- Append idempotence: two records → two lines.
+- Malformed-line tolerance: bad JSON in ledger doesn't crash the reader.
+- No-PII contract: only 'cwd' is a path key; no home-dir expansion in other keys.
+- Integration: engine classify → dispatch → ledger contains expected events.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def tmp_stats(tmp_path, monkeypatch):
+    """Redirect _STATS_FILE to a temp location for test isolation."""
+    stats_file = tmp_path / "monitors" / "stats.jsonl"
+    import autospec_context_monitor.stats as stats_mod
+    monkeypatch.setattr(stats_mod, "_STATS_FILE", stats_file)
+    return stats_file
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+def test_append_idempotence(tmp_stats):
+    """Two record() calls produce exactly two newline-separated JSON lines."""
+    from autospec_context_monitor import stats
+
+    stats.record("compact_fired", harness="claude", tmux_session="s1", pct=0.52, cwd="/proj")
+    stats.record("rollover_fired", harness="claude", tmux_session="s1", pct=0.81, cwd="/proj")
+
+    lines = tmp_stats.read_text().splitlines()
+    assert len(lines) == 2, f"Expected 2 lines, got {len(lines)}"
+    row0 = json.loads(lines[0])
+    row1 = json.loads(lines[1])
+    assert row0["event"] == "compact_fired"
+    assert row1["event"] == "rollover_fired"
+
+
+def test_malformed_line_tolerance(tmp_stats):
+    """Reading the ledger after a malformed line doesn't crash; doctor skips it."""
+    from autospec_context_monitor import stats
+
+    # Inject a bad line directly.
+    tmp_stats.parent.mkdir(parents=True, exist_ok=True)
+    tmp_stats.write_text("NOT VALID JSON\n")
+
+    # record() should still succeed and append a valid line.
+    stats.record("compact_fired", harness="codex", tmux_session="s2", pct=0.55, cwd="/p")
+
+    lines = tmp_stats.read_text().splitlines()
+    assert len(lines) == 2
+    # First line is the bad one; second must be valid JSON.
+    row = json.loads(lines[1])
+    assert row["event"] == "compact_fired"
+
+
+def test_no_pii_contract(tmp_stats):
+    """Only 'cwd' is a path key; no home directory expansion in other fields."""
+    from autospec_context_monitor import stats
+
+    home = str(Path.home())
+    stats.record(
+        "rollover_aborted",
+        harness="claude",
+        tmux_session="no-home-here",
+        pct=0.80,
+        cwd="/some/project",
+    )
+
+    row = json.loads(tmp_stats.read_text().strip())
+    # Permitted path key: cwd only.
+    path_keys = [k for k, v in row.items() if k != "cwd" and isinstance(v, str) and home in v]
+    assert path_keys == [], f"Unexpected path-containing keys (other than cwd): {path_keys}"
+    # ts, event, harness, tmux_session, pct, cwd must all be present.
+    for key in ("ts", "event", "harness", "tmux_session", "pct", "cwd"):
+        assert key in row, f"Missing required key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# Integration test: engine classify → dispatch → ledger
+# ---------------------------------------------------------------------------
+
+def test_integration_compact_and_rollover(tmp_stats, tmp_path, monkeypatch):
+    """Scripted usage sequence produces exactly 1 compact_fired + 1 rollover_fired."""
+    from autospec_context_monitor.engine import Engine, Action
+    from autospec_context_monitor.adapters.base import Usage
+
+    # We need to exercise _dispatch without a real tmux session.
+    # Patch inject, session_exists, wait_for_cancel so no tmux calls happen.
+    import autospec_context_monitor.__main__ as main_mod
+
+    monkeypatch.setattr(main_mod, "inject", lambda session, cmd: None)
+    monkeypatch.setattr(main_mod, "wait_for_cancel", lambda session: False)
+    # Also redirect stats in __main__ to use tmp_stats.
+    import autospec_context_monitor.stats as stats_mod
+    monkeypatch.setattr(stats_mod, "_STATS_FILE", tmp_stats)
+
+    logf = tmp_path / "test.log"
+    logf.touch()
+
+    engine = Engine()
+    harness = "claude"
+    tmux_session = "integ-test"
+    cwd = "/integ/project"
+
+    # Tick 1: 52% → compact_fired
+    usage1 = Usage(used_tokens=52, max_tokens=100, model="test", estimated=False)
+    actions1 = engine.classify(usage1)
+    assert len(actions1) == 1 and actions1[0].kind == "compact"
+    for action in actions1:
+        main_mod._dispatch(
+            action, tmux_session, logf, harness=harness, cwd=cwd, pct=0.52
+        )
+
+    # Tick 2: 81% → rollover: handoff + clear + resume
+    usage2 = Usage(used_tokens=81, max_tokens=100, model="test", estimated=False)
+    actions2 = engine.classify(usage2)
+    assert any(a.kind == "handoff" for a in actions2)
+    assert any(a.kind == "clear" for a in actions2)
+    for action in actions2:
+        main_mod._dispatch(
+            action, tmux_session, logf, harness=harness, cwd=cwd, pct=0.81
+        )
+
+    # Verify ledger
+    lines = tmp_stats.read_text().splitlines()
+    events = [json.loads(l)["event"] for l in lines if l.strip()]
+    assert events.count("compact_fired") == 1, f"Expected 1 compact_fired, got events={events}"
+    assert events.count("rollover_fired") == 1, f"Expected 1 rollover_fired, got events={events}"


### PR DESCRIPTION
Closes #758

Adds append-only JSONL telemetry ledger for rollover/compact events, a `--stats` flag to the doctor command, and 4 tests covering all acceptance criteria.

**Changes:**
- `stats.py` (new): `record(event_type, **fields)` appends `{ts, event, harness, tmux_session, pct, cwd}` to `~/.autospec/monitors/stats.jsonl` via `O_APPEND`; never raises on disk errors.
- `__main__.py`: `_dispatch()` gains `harness`, `cwd`, `pct` params; calls `stats.record()` for `compact_fired`, `rollover_fired`, `rollover_aborted`, `handoff_invalid`.
- `doctor.py`: `--stats [--cwd]` flag prints last-7-day counts per event type and per harness from the ledger.
- `tests/test_stats.py`: 4 tests — append idempotence, malformed-line tolerance, no-PII contract, integration end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)