### PR TITLE
fix(autospec-split): forbid needs-autospec-template in Phase 3 decomposer prompt

### DIFF
--- a/skills/autospec-split/SKILL.md
+++ b/skills/autospec-split/SKILL.md
@@ -228,6 +228,8 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
 >
+> **Label guard — Phase 3 ONLY:** Children receive `auto-implement` plus any domain labels. Do NOT apply `needs-autospec-template`, `ctx:*`, or `reasoning:*` at child-create time. Those labels are applied exclusively by Phase 3.5 after it evaluates the child body. Applying them in Phase 3 causes Phase 3.5 to skip those children entirely, defeating classification.
+>
 > Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
 >
 > - **Goal** — 1 sentence outcome.

--- a/skills/autospec-split/codex/prompt.md
+++ b/skills/autospec-split/codex/prompt.md
@@ -222,6 +222,8 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
 >
+> **Label guard — Phase 3 ONLY:** Children receive `auto-implement` plus any domain labels. Do NOT apply `needs-autospec-template`, `ctx:*`, or `reasoning:*` at child-create time. Those labels are applied exclusively by Phase 3.5 after it evaluates the child body. Applying them in Phase 3 causes Phase 3.5 to skip those children entirely, defeating classification.
+>
 > Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
 >
 > - **Goal** — 1 sentence outcome.

--- a/skills/autospec-split/opencode/agent.md
+++ b/skills/autospec-split/opencode/agent.md
@@ -226,6 +226,8 @@ Dispatch a **foreground subagent** with this prompt (substitute the spec path an
 >
 > Create labels (idempotent with `--force`): `auto-implement` (#0e8a16), `epic` (#b60205), plus any domain labels the spec calls for. Then create exactly N issues — first an EPIC umbrella (no `auto-implement` label, just `epic` + domain), then N-1 children all carrying `auto-implement`. After creating children, edit the umbrella body with a checklist linking them. Return JSON: `{umbrella, children:[…], labels_created:[…]}`. Use `gh` CLI only. Do NOT modify code. Do NOT push branches. Do NOT create PRs.
 >
+> **Label guard — Phase 3 ONLY:** Children receive `auto-implement` plus any domain labels. Do NOT apply `needs-autospec-template`, `ctx:*`, or `reasoning:*` at child-create time. Those labels are applied exclusively by Phase 3.5 after it evaluates the child body. Applying them in Phase 3 causes Phase 3.5 to skip those children entirely, defeating classification.
+>
 > Each child body must be a **self-contained mini-spec** sized for execution by a 32B-class local LLM, with these sections in order:
 >
 > - **Goal** — 1 sentence outcome.


### PR DESCRIPTION
Closes #759

The Phase 3 decomposer was applying \`needs-autospec-template\` to all child issues at create time. Phase 3.5 uses that label as a skip signal (children already carrying it are skipped), so this caused Phase 3.5 to skip classification of every child (observed in the #740 run — all 14 children #741-#754 had to be manually stripped).

**Fix:** Add an explicit **Label guard** paragraph to the Phase 3 child-create instruction in all three lockstep files:
- \`skills/autospec-split/SKILL.md\`
- \`skills/autospec-split/codex/prompt.md\`
- \`skills/autospec-split/opencode/agent.md\`

Children now receive only \`auto-implement\` + domain labels at create time. \`needs-autospec-template\`, \`ctx:*\`, and \`reasoning:*\` are reserved exclusively for Phase 3.5 after it evaluates the child body.

\`bash scripts/validate.sh\` pre-existing failure in \`autospec-rollover-status\` (missing Subagent dispatch policy row) is unrelated to this change and exists on \`origin/main\` as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)