### PR TITLE
fix(autospec-rollover-status): add missing Subagent dispatch policy row (g-007)

### DIFF
--- a/skills/autospec-rollover-status/SKILL.md
+++ b/skills/autospec-rollover-status/SKILL.md
@@ -86,6 +86,7 @@ Runs `bash skills/autospec-rollover-status/show.sh` and presents the output.
 |------------------------|-------------|-------------|-------------|----------------------------------|
 | Run shell command       | `Bash`      | `bash` tool | `shell`     | Ask user to run manually         |
 | Subagent model tier    | Tier A: `haiku` — read-only, no reasoning | Tier A: smallest tier | Tier A | inline |
+| Subagent dispatch policy | per AGENTS.md decision matrix        | per AGENTS.md decision matrix            | per AGENTS.md decision matrix            | inline with main-session token cost                |
 
 **Model tier:** Tier A (haiku) — pure log read, no judgment needed.
 


### PR DESCRIPTION
Closes #780

Adds the missing Subagent dispatch policy row to the Required-capabilities table in `skills/autospec-rollover-status/SKILL.md`, matching the canonical row in `autospec-sweep`. `bash scripts/validate.sh` now exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)