### PR TITLE
fix(context-monitor): tmux display-message overlays for rollover actions (g-009)

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
@@ -140,6 +140,17 @@ def _dispatch(
         else Path.home() / ".turbo" / "handoff"
     )
 
+    # UX overlays: show a brief tmux message so the operator sees rollover is in progress.
+    _OVERLAY_MSG = {
+        "compact": "[autospec] compacting context…",
+        "handoff": "[autospec] writing handoff…",
+        "clear": "[autospec] clearing session…",
+        "resume": "[autospec] resuming…",
+    }
+    overlay_msg = _OVERLAY_MSG.get(action.kind)
+    if overlay_msg and tmux_session:
+        subprocess.run(["tmux", "display-message", "-d", "3000", overlay_msg], check=False)
+
     if action.kind == "compact":
         cmd = adapter.command("compact") if adapter is not None else "/compact"
         _log(logf, {"event": "inject", "kind": "compact", "cmd": cmd})

--- a/packages/autospec_context_monitor/tests/conftest.py
+++ b/packages/autospec_context_monitor/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Shared pytest configuration for autospec_context_monitor tests.
+
+Provides a module-scoped autouse fixture that stubs subprocess.run so that
+tmux display-message overlay calls (added in g-009) don't require a real
+tmux binary during the unit-test suite.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_subprocess_run(monkeypatch):
+    """Stub subprocess.run so tmux overlay calls succeed without a real tmux binary."""
+    import autospec_context_monitor.__main__ as _main
+
+    monkeypatch.setattr(_main.subprocess, "run", MagicMock(return_value=MagicMock(returncode=0)))

--- a/packages/autospec_context_monitor/tests/test_ux_overlays.py
+++ b/packages/autospec_context_monitor/tests/test_ux_overlays.py
@@ -1,0 +1,121 @@
+"""Unit tests for tmux display-message overlays in _dispatch (g-009).
+
+Verifies that:
+- Each of compact/handoff/clear/resume fires subprocess.run with the correct
+  display-message string.
+- No subprocess.run call is made when tmux_session is falsy.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from autospec_context_monitor.__main__ import _dispatch
+from autospec_context_monitor.engine import Action
+
+
+def _make_logf(tmp_path: Path) -> Path:
+    return tmp_path / "test.log"
+
+
+def _fake_adapter(kind: str) -> MagicMock:
+    adapter = MagicMock()
+    adapter.command.side_effect = lambda k: f"/{k}"
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Helpers that stub out side-effectful deps so _dispatch can complete.
+# ---------------------------------------------------------------------------
+
+_PATCH_INJECT = "autospec_context_monitor.__main__.inject"
+_PATCH_WAIT_HANDOFF = "autospec_context_monitor.__main__.wait_for_handoff"
+_PATCH_WAIT_CANCEL = "autospec_context_monitor.__main__.wait_for_cancel"
+_PATCH_SUBPROCESS = "autospec_context_monitor.__main__.subprocess"
+
+
+class _FakeHandoffPath:
+    """Minimal stand-in so wait_for_handoff result can be str()-ed."""
+    def __str__(self):
+        return "/tmp/fake-handoff.md"
+
+
+# ---------------------------------------------------------------------------
+# Overlay message tests (one per action kind)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("kind,expected_msg", [
+    ("compact", "[autospec] compacting context…"),
+    ("handoff", "[autospec] writing handoff…"),
+    ("clear",   "[autospec] clearing session…"),
+    ("resume",  "[autospec] resuming…"),
+])
+def test_overlay_message_for_action(tmp_path, kind, expected_msg):
+    """_dispatch calls tmux display-message with the correct overlay text."""
+    logf = _make_logf(tmp_path)
+
+    # For 'clear' we need a valid handoff dir with a file so validation passes.
+    if kind == "clear":
+        handoff_dir = tmp_path / ".turbo" / "handoff"
+        handoff_dir.mkdir(parents=True)
+        # Create a dummy handoff file big enough to pass validation.
+        (handoff_dir / "2026-05-31-handoff.md").write_text("x" * 300)
+
+    with patch(_PATCH_INJECT):
+        with patch(_PATCH_WAIT_HANDOFF, return_value=_FakeHandoffPath()):
+            with patch(_PATCH_WAIT_CANCEL, return_value=False):
+                with patch(_PATCH_SUBPROCESS) as sp_mock:
+                    sp_mock.run = MagicMock(return_value=MagicMock(returncode=0))
+                    _dispatch(
+                        Action(kind),
+                        "test-session",
+                        logf,
+                        cwd=str(tmp_path),
+                        adapter=_fake_adapter(kind),
+                    )
+
+    # Find the display-message call among all subprocess.run calls.
+    display_calls = [
+        c for c in sp_mock.run.call_args_list
+        if c.args and len(c.args[0]) >= 2 and c.args[0][1] == "display-message"
+    ]
+    assert display_calls, (
+        f"subprocess.run must be called with 'tmux display-message' for action '{kind}'"
+    )
+    cmd_args = display_calls[0].args[0]
+    assert cmd_args == ["tmux", "display-message", "-d", "3000", expected_msg], (
+        f"display-message args mismatch for '{kind}': got {cmd_args}"
+    )
+    assert display_calls[0].kwargs.get("check") is False, (
+        "display-message must use check=False"
+    )
+
+
+# ---------------------------------------------------------------------------
+# No overlay when tmux_session is falsy
+# ---------------------------------------------------------------------------
+
+def test_no_overlay_when_no_tmux_session(tmp_path):
+    """No tmux display-message call when tmux_session is empty/None."""
+    logf = _make_logf(tmp_path)
+
+    with patch(_PATCH_INJECT):
+        with patch(_PATCH_SUBPROCESS) as sp_mock:
+            sp_mock.run = MagicMock(return_value=MagicMock(returncode=0))
+            # Use compact — simplest branch, no extra deps.
+            _dispatch(
+                Action("compact"),
+                "",  # falsy tmux_session
+                logf,
+                adapter=_fake_adapter("compact"),
+            )
+
+    display_calls = [
+        c for c in sp_mock.run.call_args_list
+        if c.args and len(c.args[0]) >= 2 and c.args[0][1] == "display-message"
+    ]
+    assert not display_calls, (
+        "No tmux display-message should be issued when tmux_session is empty"
+    )


### PR DESCRIPTION
Closes #787

Adds non-blocking `tmux display-message` overlays to `_dispatch` in `__main__.py` for compact, handoff, clear, and resume actions. The overlay fires before each inject call with a human-readable message, and is skipped when `tmux_session` is falsy so hook-mode callers are unaffected. Also adds a `conftest.py` autouse fixture that stubs `subprocess.run` across all context-monitor tests, preventing test failures in CI environments without tmux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)