### PR TITLE
fix(context-monitor): add prompt-ready guards before each inject (g-010)

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
@@ -41,7 +41,7 @@ from pathlib import Path
 from .adapters.base import TranscriptNotFoundError, Usage
 from .engine import Action, Engine, State
 from .handoff import HandoffTimeoutError, validate_handoff, wait_for_handoff
-from .injector import SessionGone, inject, session_exists, wait_for_cancel
+from .injector import SessionGone, inject, session_exists, wait_for_cancel, wait_for_prompt
 from . import stats as _stats
 
 _POLL_INTERVAL = 15  # seconds
@@ -151,9 +151,23 @@ def _dispatch(
     if overlay_msg and tmux_session:
         subprocess.run(["tmux", "display-message", "-d", "3000", overlay_msg], check=False)
 
+    # Prompt-ready guard helper: returns the marker and whether the prompt is ready.
+    def _prompt_ok(kind: str) -> bool:
+        if not tmux_session or adapter is None:
+            return True  # no guard when tmux or adapter absent (e.g. hook mode / tests)
+        marker = adapter.prompt_marker()
+        if not marker:
+            return True
+        ready = wait_for_prompt(tmux_session, marker)
+        if not ready:
+            _log(logf, {"event": "prompt_not_ready", "kind": kind, "marker": marker})
+        return ready
+
     if action.kind == "compact":
         cmd = adapter.command("compact") if adapter is not None else "/compact"
         _log(logf, {"event": "inject", "kind": "compact", "cmd": cmd})
+        if not _prompt_ok("compact"):
+            return False
         inject(tmux_session, cmd)
         _stats.record(
             "compact_fired",
@@ -168,6 +182,8 @@ def _dispatch(
         cmd = adapter.command("handoff") if adapter is not None else "/create-handoff"
         since = time.time()
         _log(logf, {"event": "inject", "kind": "handoff", "cmd": cmd})
+        if not _prompt_ok("handoff"):
+            return False
         inject(tmux_session, cmd)
         # Block until the harness writes a fresh handoff file under
         # <cwd>/.turbo/handoff/.  Must complete before /clear (next action
@@ -243,6 +259,8 @@ def _dispatch(
 
         cmd = adapter.command("clear") if adapter is not None else "/clear"
         _log(logf, {"event": "inject", "kind": "clear", "cmd": cmd})
+        if not _prompt_ok("clear"):
+            return False
         inject(tmux_session, cmd)
         _stats.record(
             "rollover_fired",
@@ -277,6 +295,8 @@ def _dispatch(
                 "file": str(latest) if latest else None,
             },
         )
+        if not _prompt_ok("resume"):
+            return False
         inject(tmux_session, resume_text)
         return False
 

--- a/packages/autospec_context_monitor/autospec_context_monitor/adapters/base.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/adapters/base.py
@@ -72,3 +72,14 @@ class HarnessAdapter(Protocol):
     def command(self, logical: Literal["clear", "compact", "handoff"]) -> str:
         """Map a logical command name to the harness-specific slash command."""
         ...
+
+    def prompt_marker(self) -> str:
+        """Return a string that identifies an idle shell prompt in the tmux pane.
+
+        ``_dispatch`` captures pane output and checks for this marker before
+        injecting a command.  Each adapter should return a marker that reliably
+        appears at the end of the prompt line when the harness is idle and ready
+        to accept input (e.g. ``"> "`` for Claude Code, ``"$ "`` for a bare
+        shell, ``"% "`` for zsh).
+        """
+        ...

--- a/packages/autospec_context_monitor/autospec_context_monitor/injector.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/injector.py
@@ -87,6 +87,25 @@ def inject(session: str, text: str, *, submit: bool = True) -> None:
             )
 
 
+def wait_for_prompt(session: str, marker: str, attempts: int = 3, delay: float = 2.0) -> bool:
+    """Poll the pane output until *marker* appears; return ``False`` after exhausting attempts.
+
+    This is the public guard function used by ``_dispatch`` before each inject.
+    It delegates to :func:`prompt_ready` with the spec-aligned parameter names
+    (``attempts`` / ``delay`` instead of ``retries`` / ``wait``).
+
+    Args:
+        session:  Tmux session name.
+        marker:   String to look for in the captured pane output.
+        attempts: Maximum number of polling attempts (default 3).
+        delay:    Seconds to wait between attempts (default 2.0).
+
+    Returns:
+        ``True`` when the marker is seen; ``False`` after all attempts are exhausted.
+    """
+    return prompt_ready(session, marker, retries=attempts, wait=delay)
+
+
 def wait_for_cancel(tmux_session: str, timeout: int = 10) -> bool:
     """Show a countdown overlay and return ``True`` if the user pressed Esc.
 

--- a/packages/autospec_context_monitor/tests/test_prompt_ready_guards.py
+++ b/packages/autospec_context_monitor/tests/test_prompt_ready_guards.py
@@ -1,0 +1,112 @@
+"""Unit tests for prompt-ready guards (g-010).
+
+Covers:
+- wait_for_prompt returns True when marker is present on first poll.
+- wait_for_prompt returns False after all attempts exhausted.
+- _dispatch skips inject when wait_for_prompt returns False.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autospec_context_monitor.engine import Action
+from autospec_context_monitor.injector import wait_for_prompt
+
+
+# ---------------------------------------------------------------------------
+# wait_for_prompt unit tests
+# ---------------------------------------------------------------------------
+
+_PATCH_PROMPT_READY = "autospec_context_monitor.injector.prompt_ready"
+
+
+def test_wait_for_prompt_returns_true_when_marker_found():
+    """wait_for_prompt returns True immediately when prompt_ready succeeds."""
+    with patch(_PATCH_PROMPT_READY, return_value=True) as mock_pr:
+        result = wait_for_prompt("sess", "> ", attempts=3, delay=0.0)
+
+    assert result is True
+    mock_pr.assert_called_once_with("sess", "> ", retries=3, wait=0.0)
+
+
+def test_wait_for_prompt_returns_false_when_exhausted():
+    """wait_for_prompt returns False when prompt_ready always fails."""
+    with patch(_PATCH_PROMPT_READY, return_value=False) as mock_pr:
+        result = wait_for_prompt("sess", "> ", attempts=2, delay=0.0)
+
+    assert result is False
+    mock_pr.assert_called_once_with("sess", "> ", retries=2, wait=0.0)
+
+
+# ---------------------------------------------------------------------------
+# _dispatch prompt guard integration tests
+# ---------------------------------------------------------------------------
+
+_PATCH_INJECT = "autospec_context_monitor.__main__.inject"
+_PATCH_WAIT_FOR_PROMPT = "autospec_context_monitor.__main__.wait_for_prompt"
+
+
+class _MarkerAdapter:
+    """Fake adapter that reports a prompt marker."""
+
+    name = "fake"
+
+    def command(self, logical: str) -> str:
+        return f"/{logical}"
+
+    def prompt_marker(self) -> str:
+        return "> "
+
+
+def test_dispatch_skips_inject_when_prompt_not_ready(tmp_path):
+    """_dispatch returns False and skips inject when wait_for_prompt returns False."""
+    from autospec_context_monitor.__main__ import _dispatch
+
+    logf = tmp_path / "test.log"
+    inject_calls: list = []
+
+    def _fake_inject(session, text, **_kw):
+        inject_calls.append(text)
+
+    with patch(_PATCH_INJECT, _fake_inject):
+        with patch(_PATCH_WAIT_FOR_PROMPT, return_value=False):
+            result = _dispatch(
+                Action("compact"),
+                "test-sess",
+                logf,
+                adapter=_MarkerAdapter(),
+            )
+
+    assert result is False, "_dispatch must return False (not canceled) when prompt guard fails"
+    assert not inject_calls, "inject must NOT be called when wait_for_prompt returns False"
+
+    # Log must contain the prompt_not_ready event
+    import json
+    log_lines = [json.loads(l) for l in logf.read_text().splitlines() if l.strip()]
+    events = [l["event"] for l in log_lines]
+    assert "prompt_not_ready" in events, "Log must record prompt_not_ready event"
+
+
+def test_dispatch_proceeds_when_prompt_ready(tmp_path):
+    """_dispatch calls inject when wait_for_prompt returns True."""
+    from autospec_context_monitor.__main__ import _dispatch
+
+    logf = tmp_path / "test.log"
+    inject_calls: list = []
+
+    def _fake_inject(session, text, **_kw):
+        inject_calls.append(text)
+
+    with patch(_PATCH_INJECT, _fake_inject):
+        with patch(_PATCH_WAIT_FOR_PROMPT, return_value=True):
+            _dispatch(
+                Action("compact"),
+                "test-sess",
+                logf,
+                adapter=_MarkerAdapter(),
+            )
+
+    assert inject_calls, "inject must be called when wait_for_prompt returns True"


### PR DESCRIPTION
Closes #788

Adds `wait_for_prompt()` to `injector.py` as a spec-aligned wrapper over the existing `prompt_ready()` (uses `attempts`/`delay` param names). Adds `prompt_marker()` abstract method to `HarnessAdapter` in `adapters/base.py`. Wires a `_prompt_ok()` guard into all four inject sites in `_dispatch` — compact, handoff, clear, and resume — logging a `prompt_not_ready` event and skipping the inject when the guard returns False. Guard is bypassed when `tmux_session` or `adapter` is absent for backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)