### PR TITLE
fix(context-monitor): resolve SessionStart hook — Option A + conftest subprocess scope (g-011)

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/adapters/claude_hook.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/adapters/claude_hook.py
@@ -20,6 +20,15 @@ Install integration:
     ``hooks.SessionStart`` to ``~/.claude/settings.json`` (merge, not
     overwrite) so Claude Code invokes ``python -m autospec_context_monitor
     --hook-event PreCompact`` on every compaction opportunity.
+
+SessionStart handling decision (g-011):
+    Option A was chosen: ``SessionStart`` **is** registered in ``install.sh``
+    and **is** handled in ``_run_hook_mode`` (as a documented no-op reserved
+    for future resume-hint functionality).  This keeps the registered hook and
+    its handler in sync so Claude Code's dispatcher does not encounter a
+    handler-less registration.  Do NOT remove the ``SessionStart`` entry from
+    ``install.sh`` without also adding handling for it in ``_run_hook_mode``,
+    and vice versa.
 """
 from __future__ import annotations
 

--- a/packages/autospec_context_monitor/tests/conftest.py
+++ b/packages/autospec_context_monitor/tests/conftest.py
@@ -1,11 +1,19 @@
 """Shared pytest configuration for autospec_context_monitor tests.
 
-Provides a module-scoped autouse fixture that stubs subprocess.run so that
-tmux display-message overlay calls (added in g-009) don't require a real
-tmux binary during the unit-test suite.
+Provides an autouse fixture that stubs the ``subprocess`` name inside
+``autospec_context_monitor.__main__`` so that tmux display-message overlay
+calls (added in g-009) don't require a real tmux binary during the unit-test
+suite.
+
+IMPORTANT: we replace the *module-level name* ``autospec_context_monitor.__main__.subprocess``
+with a ``MagicMock`` rather than patching ``subprocess.run`` directly on the
+real ``subprocess`` module.  Patching the real module would affect every
+``subprocess.run`` call in the process, including calls in test helpers such as
+``install.sh`` invocations via ``subprocess.run(["bash", ...])``.
 """
 from __future__ import annotations
 
+import types
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,7 +21,9 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _stub_subprocess_run(monkeypatch):
-    """Stub subprocess.run so tmux overlay calls succeed without a real tmux binary."""
+    """Replace the subprocess name in __main__ with a stub so tmux calls are no-ops."""
     import autospec_context_monitor.__main__ as _main
 
-    monkeypatch.setattr(_main.subprocess, "run", MagicMock(return_value=MagicMock(returncode=0)))
+    fake_subprocess = MagicMock()
+    fake_subprocess.run = MagicMock(return_value=MagicMock(returncode=0))
+    monkeypatch.setattr(_main, "subprocess", fake_subprocess)

--- a/packages/autospec_context_monitor/tests/test_session_start_handler.py
+++ b/packages/autospec_context_monitor/tests/test_session_start_handler.py
@@ -1,0 +1,88 @@
+"""Tests for g-011: SessionStart hook handler in _run_hook_mode.
+
+Verifies that:
+- _run_hook_mode with hook_event="SessionStart" returns without error (Option A: no-op).
+- install.sh --hook-mode claude registers SessionStart in settings.json.
+- The registration and handler are consistent (both present).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test 1: _run_hook_mode("SessionStart") returns without error
+# ---------------------------------------------------------------------------
+
+def test_run_hook_mode_session_start_noop(tmp_path):
+    """_run_hook_mode with SessionStart fires without raising; logs hook_noop event."""
+    from autospec_context_monitor.__main__ import _run_hook_mode
+
+    args = argparse.Namespace(
+        hook_event="SessionStart",
+        tmux_session=None,
+        harness=None,
+        cwd=None,
+        started_at=None,
+    )
+
+    # Redirect _MONITORS_DIR to tmp_path so logs don't pollute ~/.autospec/monitors.
+    import autospec_context_monitor.__main__ as _main
+    original_dir = _main._MONITORS_DIR
+    _main._MONITORS_DIR = tmp_path / "monitors"
+    try:
+        # Must return without raising.
+        _run_hook_mode(args)
+    finally:
+        _main._MONITORS_DIR = original_dir
+
+    # Log file must contain hook_noop event.
+    logf = tmp_path / "monitors" / "hook-SessionStart.log"
+    assert logf.exists(), "hook-SessionStart.log must be written"
+    events = [json.loads(l)["event"] for l in logf.read_text().splitlines() if l.strip()]
+    assert "hook_noop" in events, (
+        "SessionStart handler must log a hook_noop event; events: " + str(events)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: install.sh --hook-mode claude registers SessionStart
+# ---------------------------------------------------------------------------
+
+_INSTALL_SH = Path(__file__).resolve().parents[3] / "install.sh"
+
+
+@pytest.mark.skipif(not _INSTALL_SH.exists(), reason="install.sh not found")
+def test_install_sh_registers_session_start():
+    """install.sh --hook-mode claude must add hooks.SessionStart to settings.json."""
+    with tempfile.TemporaryDirectory() as tmp_home:
+        settings = Path(tmp_home) / ".claude" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        settings.write_text("{}", encoding="utf-8")
+
+        env = {**os.environ, "HOME": tmp_home}
+        result = subprocess.run(
+            ["bash", str(_INSTALL_SH), "--hook-mode", "claude"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"install.sh failed:\n{result.stderr}"
+
+        data = json.loads(settings.read_text())
+        hooks = data.get("hooks", {})
+        assert "SessionStart" in hooks, (
+            "hooks.SessionStart must be registered by --hook-mode claude"
+        )
+        sess_cmds = hooks["SessionStart"]
+        assert any(
+            "autospec_context_monitor" in cmd and "SessionStart" in cmd
+            for cmd in sess_cmds
+        ), f"SessionStart hook must invoke autospec_context_monitor; got: {sess_cmds}"

--- a/packages/autospec_context_monitor/tests/test_ux_overlays.py
+++ b/packages/autospec_context_monitor/tests/test_ux_overlays.py
@@ -33,6 +33,7 @@ def _fake_adapter(kind: str) -> MagicMock:
 _PATCH_INJECT = "autospec_context_monitor.__main__.inject"
 _PATCH_WAIT_HANDOFF = "autospec_context_monitor.__main__.wait_for_handoff"
 _PATCH_WAIT_CANCEL = "autospec_context_monitor.__main__.wait_for_cancel"
+_PATCH_WAIT_FOR_PROMPT = "autospec_context_monitor.__main__.wait_for_prompt"
 _PATCH_SUBPROCESS = "autospec_context_monitor.__main__.subprocess"
 
 
@@ -66,15 +67,16 @@ def test_overlay_message_for_action(tmp_path, kind, expected_msg):
     with patch(_PATCH_INJECT):
         with patch(_PATCH_WAIT_HANDOFF, return_value=_FakeHandoffPath()):
             with patch(_PATCH_WAIT_CANCEL, return_value=False):
-                with patch(_PATCH_SUBPROCESS) as sp_mock:
-                    sp_mock.run = MagicMock(return_value=MagicMock(returncode=0))
-                    _dispatch(
-                        Action(kind),
-                        "test-session",
-                        logf,
-                        cwd=str(tmp_path),
-                        adapter=_fake_adapter(kind),
-                    )
+                with patch(_PATCH_WAIT_FOR_PROMPT, return_value=True):
+                    with patch(_PATCH_SUBPROCESS) as sp_mock:
+                        sp_mock.run = MagicMock(return_value=MagicMock(returncode=0))
+                        _dispatch(
+                            Action(kind),
+                            "test-session",
+                            logf,
+                            cwd=str(tmp_path),
+                            adapter=_fake_adapter(kind),
+                        )
 
     # Find the display-message call among all subprocess.run calls.
     display_calls = [


### PR DESCRIPTION
Closes #789

Chooses Option A: SessionStart hook is **both** registered in `install.sh` and handled in `_run_hook_mode` as a documented no-op reserved for future resume hints. Adds a decision comment to `claude_hook.py`'s module docstring to prevent future handler/registration drift. Adds unit tests confirming the handler returns without error and `install.sh --hook-mode claude` registers SessionStart.

Also fixes a pre-existing conftest.py scoping bug: the autouse fixture was patching `subprocess.run` on the real shared `subprocess` module, silently breaking any test that invoked `subprocess.run` directly (e.g. `install.sh` tests). Now replaces the `subprocess` name in `__main__`'s namespace only, isolating the stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)