### PR TITLE
fix(context-monitor): doctor lists transcript paths for all adapters (g-012)

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/adapters/claude.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/adapters/claude.py
@@ -11,6 +11,11 @@ from typing import Literal
 
 from .base import HarnessAdapter, TranscriptNotFoundError, Usage
 
+# Transcript directories checked by `doctor.py` for write-access.
+PATHS_TO_CHECK: list[Path] = [
+    Path.home() / ".claude" / "projects",
+]
+
 # Context-window sizes by model identifier.
 # Add new models here as Claude Code ships them.
 MODEL_MAX: dict[str, int] = {

--- a/packages/autospec_context_monitor/autospec_context_monitor/adapters/codex.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/adapters/codex.py
@@ -14,6 +14,11 @@ from typing import Literal
 
 from .base import HarnessAdapter, TranscriptNotFoundError, Usage
 
+# Transcript directories checked by `doctor.py` for write-access.
+PATHS_TO_CHECK: list[Path] = [
+    Path.home() / ".codex" / "sessions",
+]
+
 # Context-window sizes by model identifier.
 MODEL_MAX: dict[str, int] = {
     "gpt-5": 200_000,

--- a/packages/autospec_context_monitor/autospec_context_monitor/adapters/opencode.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/adapters/opencode.py
@@ -13,6 +13,11 @@ from typing import Literal
 
 from .base import HarnessAdapter, TranscriptNotFoundError, Usage
 
+# Transcript path (SQLite DB) checked by `doctor.py` for write-access.
+PATHS_TO_CHECK: list[Path] = [
+    Path.home() / ".local" / "share" / "opencode" / "opencode.db",
+]
+
 # Context-window sizes by model identifier.
 MODEL_MAX: dict[str, int] = {
     "claude-sonnet-4-5": 200_000,

--- a/packages/autospec_context_monitor/autospec_context_monitor/doctor.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/doctor.py
@@ -41,12 +41,39 @@ def _binary(name: str) -> str:
     return shutil.which(name) or "MISSING"
 
 
-def _transcripts_writable() -> bool:
-    path = _TRANSCRIPTS_DIR
-    if path.exists():
-        return os.access(path, os.W_OK)
-    # parent must be writable so it can be created
-    return os.access(path.parent, os.W_OK)
+_ADAPTER_MODULES = [
+    "autospec_context_monitor.adapters.claude",
+    "autospec_context_monitor.adapters.codex",
+    "autospec_context_monitor.adapters.opencode",
+]
+
+
+def _transcripts_writable() -> list[str]:
+    """Return per-adapter transcript path write-access status.
+
+    Iterates each adapter's ``PATHS_TO_CHECK`` list and checks whether the
+    path (or its parent, when the path itself does not yet exist) is writable.
+    Each entry is labelled with the short adapter name so operators can
+    immediately identify which harness has a misconfigured transcript directory.
+
+    Adapters without a ``PATHS_TO_CHECK`` attribute are skipped gracefully.
+    """
+    results: list[str] = []
+    for mod_name in _ADAPTER_MODULES:
+        try:
+            mod = importlib.import_module(mod_name)
+        except Exception as exc:  # noqa: BLE001
+            results.append(f"{mod_name}: IMPORT_ERROR({exc})")
+            continue
+        paths: list[Path] = getattr(mod, "PATHS_TO_CHECK", [])
+        # Short adapter label, e.g. "claude", "codex", "opencode".
+        label = mod_name.split(".")[-1]
+        for path in paths:
+            check_target = path if path.exists() else path.parent
+            writable = os.access(check_target, os.W_OK)
+            status = "writable" if writable else "NOT_WRITABLE"
+            results.append(f"{label}:{path}:{status}")
+    return results
 
 
 def _import_all_adapters() -> str:
@@ -145,6 +172,11 @@ def _is_failing(value: Any) -> bool:
         return True
     if isinstance(value, str) and value.startswith("IMPORT_ERROR:"):
         return True
+    if isinstance(value, list):
+        return any(
+            isinstance(item, str) and ("NOT_WRITABLE" in item or "IMPORT_ERROR" in item)
+            for item in value
+        )
     return False
 
 

--- a/packages/autospec_context_monitor/tests/test_doctor_transcript_paths.py
+++ b/packages/autospec_context_monitor/tests/test_doctor_transcript_paths.py
@@ -1,0 +1,88 @@
+"""Tests for g-012: doctor _transcripts_writable iterates per-adapter PATHS_TO_CHECK.
+
+Verifies that:
+- _transcripts_writable reports entries for codex and opencode.
+- Missing PATHS_TO_CHECK on an adapter does not raise.
+"""
+from __future__ import annotations
+
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test 1: _transcripts_writable reports codex and opencode entries
+# ---------------------------------------------------------------------------
+
+def test_transcripts_writable_includes_codex_and_opencode(tmp_path):
+    """_transcripts_writable must include entries for codex and opencode adapters."""
+    from autospec_context_monitor.doctor import _transcripts_writable
+
+    # The function reads PATHS_TO_CHECK from real adapter modules.
+    result = _transcripts_writable()
+
+    assert isinstance(result, list), "_transcripts_writable must return a list"
+    labels = [entry.split(":")[0] for entry in result]
+    assert "codex" in labels, f"codex must appear in results; got: {result}"
+    assert "opencode" in labels, f"opencode must appear in results; got: {result}"
+    assert "claude" in labels, f"claude must appear in results; got: {result}"
+
+    # Each entry must have the form "label:path:status"
+    for entry in result:
+        parts = entry.split(":")
+        assert len(parts) >= 3, f"Entry must be 'label:path:status'; got: {entry!r}"
+        status = parts[-1]
+        assert status in ("writable", "NOT_WRITABLE"), (
+            f"Status must be 'writable' or 'NOT_WRITABLE'; got: {status!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: adapters without PATHS_TO_CHECK do not raise
+# ---------------------------------------------------------------------------
+
+def test_transcripts_writable_skips_adapter_without_paths_to_check(monkeypatch):
+    """_transcripts_writable gracefully skips adapters with no PATHS_TO_CHECK."""
+    import autospec_context_monitor.doctor as doctor_mod
+
+    # Build a fake adapter module with no PATHS_TO_CHECK attribute.
+    fake_mod = types.ModuleType("autospec_context_monitor.adapters.fake")
+    # (no PATHS_TO_CHECK attribute)
+
+    original_modules = doctor_mod._ADAPTER_MODULES
+    monkeypatch.setattr(doctor_mod, "_ADAPTER_MODULES", [
+        "autospec_context_monitor.adapters.fake",
+    ])
+
+    import sys
+    sys.modules["autospec_context_monitor.adapters.fake"] = fake_mod
+    try:
+        result = doctor_mod._transcripts_writable()
+    finally:
+        del sys.modules["autospec_context_monitor.adapters.fake"]
+
+    # Must return an empty list without raising.
+    assert result == [], f"Expected empty list for adapter with no PATHS_TO_CHECK; got: {result}"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: PATHS_TO_CHECK is defined on codex and opencode
+# ---------------------------------------------------------------------------
+
+def test_adapter_modules_export_paths_to_check():
+    """codex and opencode adapter modules must export PATHS_TO_CHECK."""
+    from autospec_context_monitor.adapters import codex, opencode, claude
+
+    for mod, name in [(codex, "codex"), (opencode, "opencode"), (claude, "claude")]:
+        assert hasattr(mod, "PATHS_TO_CHECK"), (
+            f"{name} adapter must define PATHS_TO_CHECK"
+        )
+        paths = mod.PATHS_TO_CHECK
+        assert isinstance(paths, list), f"{name}.PATHS_TO_CHECK must be a list"
+        assert len(paths) > 0, f"{name}.PATHS_TO_CHECK must be non-empty"
+        assert all(isinstance(p, Path) for p in paths), (
+            f"{name}.PATHS_TO_CHECK entries must be Path objects"
+        )


### PR DESCRIPTION
Closes #790

Adds `PATHS_TO_CHECK` to claude, codex, and opencode adapter modules. Rewrites `_transcripts_writable` in `doctor.py` to iterate each adapter's list and label every entry with the adapter name. Adapters without the attribute are skipped gracefully. Updates `_is_failing` to handle list returns containing `NOT_WRITABLE` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)