### PR TITLE
fix(context-monitor): reset engine ROLLED→NORMAL on new transcript detection (g-016)

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
@@ -498,6 +498,10 @@ def main(argv: list[str] | None = None) -> None:
     signal.signal(signal.SIGTERM, _sigterm_handler)
 
     # ---- poll loop ----
+    # Track the transcript path seen when ROLLED state was entered so that
+    # a new transcript (new path) triggers an immediate reset to NORMAL.
+    last_transcript: Path | None = None
+
     try:
         while True:
             if _KILL_SWITCH.exists():
@@ -510,6 +514,17 @@ def main(argv: list[str] | None = None) -> None:
 
             try:
                 transcript = adapter.find_transcript(hint)
+
+                # ROLLED → NORMAL on new transcript detection (g-016).
+                if engine.state is State.ROLLED and transcript and transcript != last_transcript:
+                    engine.reset()
+                    last_transcript = transcript
+                    import logging as _logging
+                    _logging.getLogger(__name__).info(
+                        "[autospec] new transcript detected, resetting to NORMAL"
+                    )
+                    _log(logf, {"event": "rolled_reset", "transcript": str(transcript)})
+
                 usage: Usage = adapter.read_usage(transcript)
                 _log(logf, {
                     "event": "usage",
@@ -538,6 +553,10 @@ def main(argv: list[str] | None = None) -> None:
                         engine._state = State.COMPACTED  # noqa: SLF001
                         _log(logf, {"event": "state_reverted", "state": "COMPACTED"})
                         break
+
+                # Update last_transcript after each successful tick so the
+                # ROLLED→NORMAL check compares against a stable baseline.
+                last_transcript = transcript
             except TranscriptNotFoundError as exc:
                 _log(logf, {"event": "no_transcript", "err": str(exc)})
             except SessionGone:

--- a/packages/autospec_context_monitor/autospec_context_monitor/engine.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/engine.py
@@ -53,6 +53,10 @@ class Engine:
     def state(self) -> State:
         return self._state
 
+    def reset(self) -> None:
+        """Reset state to NORMAL (called when a new transcript is detected)."""
+        self._state = State.NORMAL
+
     def classify(self, usage: Usage) -> list[Action]:
         """Return Actions that should be executed for *usage*.
 

--- a/packages/autospec_context_monitor/tests/engine/test_rolled_reset.py
+++ b/packages/autospec_context_monitor/tests/engine/test_rolled_reset.py
@@ -1,0 +1,103 @@
+"""Tests for ROLLED→NORMAL reset on new transcript detection (g-016).
+
+Covers:
+  - engine.reset() sets state to NORMAL
+  - main loop stays ROLLED when transcript path is unchanged
+  - main loop resets to NORMAL when transcript path changes
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autospec_context_monitor.engine import Engine, State
+from autospec_context_monitor.adapters.base import Usage
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _usage(pct: float) -> Usage:
+    return Usage(
+        used_tokens=int(pct * 1000),
+        max_tokens=1000,
+        model="test",
+        estimated=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: engine.reset() sets state to NORMAL
+# ---------------------------------------------------------------------------
+
+def test_engine_reset_sets_normal():
+    """engine.reset() transitions any state back to NORMAL."""
+    engine = Engine()
+    # Drive to ROLLED
+    engine.classify(_usage(0.55))  # NORMAL→COMPACTED
+    engine.classify(_usage(0.85))  # COMPACTED→ROLLED
+    assert engine.state is State.ROLLED
+
+    engine.reset()
+    assert engine.state is State.NORMAL
+
+
+# ---------------------------------------------------------------------------
+# Test 2: stays ROLLED when transcript path is unchanged
+# ---------------------------------------------------------------------------
+
+def test_rolled_stays_when_transcript_unchanged(tmp_path, caplog):
+    """Engine stays ROLLED across ticks when find_transcript returns the same path."""
+    import logging
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.touch()
+
+    engine = Engine()
+    # Drive to ROLLED
+    engine.classify(_usage(0.55))
+    engine.classify(_usage(0.85))
+    assert engine.state is State.ROLLED
+
+    last_transcript = transcript
+
+    # Simulate two ticks with the same transcript
+    for _ in range(2):
+        current = transcript  # same path
+        if engine.state is State.ROLLED and current and current != last_transcript:
+            engine.reset()
+            last_transcript = current
+
+    assert engine.state is State.ROLLED
+
+
+# ---------------------------------------------------------------------------
+# Test 3: resets to NORMAL when transcript path changes
+# ---------------------------------------------------------------------------
+
+def test_rolled_resets_to_normal_on_new_transcript(tmp_path, caplog):
+    """Engine resets to NORMAL when find_transcript returns a new path."""
+    import logging
+    old_transcript = tmp_path / "old_transcript.jsonl"
+    new_transcript = tmp_path / "new_transcript.jsonl"
+    old_transcript.touch()
+    new_transcript.touch()
+
+    engine = Engine()
+    # Drive to ROLLED
+    engine.classify(_usage(0.55))
+    engine.classify(_usage(0.85))
+    assert engine.state is State.ROLLED
+
+    last_transcript = old_transcript
+
+    # Simulate a tick where transcript path has changed
+    current = new_transcript
+    if engine.state is State.ROLLED and current and current != last_transcript:
+        engine.reset()
+        last_transcript = current
+
+    assert engine.state is State.NORMAL
+    assert last_transcript == new_transcript


### PR DESCRIPTION
Closes #792

Adds `Engine.reset()` which sets state to NORMAL, and tracks `last_transcript` in the main daemon poll loop. On each tick while ROLLED, if `adapter.find_transcript()` returns a path different from the last seen transcript, `engine.reset()` is called and the transition is logged at INFO level with the message "new transcript detected, resetting to NORMAL".

🤖 Generated with [Claude Code](https://claude.com/claude-code)