### PR TITLE
fix(context-monitor): handoff validation runs before cancel window in _dispatch (g-015)

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
@@ -209,42 +209,66 @@ def _dispatch(
         return False
 
     if action.kind == "clear":
-        # --- Handoff validation gate ---
+        # --- Handoff validation gate (must run BEFORE cancel window per spec) ---
         hfiles = (
             sorted(handoff_dir.glob("*.md"), key=lambda p: p.stat().st_mtime)
             if handoff_dir.exists()
             else []
         )
-        if hfiles:
-            ok, missing = validate_handoff(hfiles[-1])
-            if not ok:
-                msg = (
-                    f"autospec: handoff invalid (missing: {', '.join(missing)}) "
-                    "— rollover aborted"
-                )
-                _log(
-                    logf,
-                    {
-                        "event": "handoff invalid: missing",
-                        "missing": missing,
-                        "kind": "clear",
-                    },
-                )
-                _stats.record(
-                    "handoff_invalid",
-                    harness=harness,
-                    tmux_session=tmux_session,
-                    pct=round(pct, 4),
-                    cwd=cwd,
-                )
-                subprocess.run(["tmux", "display-message", msg], check=False)
-                subprocess.run(
-                    ["tmux", "send-keys", "-t", tmux_session, "-l", "\a"],
-                    check=False,
-                )
-                return True
+        if not hfiles:
+            # No handoff file found — abort rollover before showing cancel window.
+            msg = "autospec: no handoff file found — rollover aborted"
+            _log(
+                logf,
+                {
+                    "event": "no_handoff_file",
+                    "kind": "clear",
+                    "msg": msg,
+                },
+            )
+            _stats.record(
+                "handoff_invalid",
+                harness=harness,
+                tmux_session=tmux_session,
+                pct=round(pct, 4),
+                cwd=cwd,
+            )
+            subprocess.run(["tmux", "display-message", msg], check=False)
+            subprocess.run(
+                ["tmux", "send-keys", "-t", tmux_session, "-l", "\a"],
+                check=False,
+            )
+            return True
 
-        # --- Cancel window ---
+        ok, missing = validate_handoff(hfiles[-1])
+        if not ok:
+            msg = (
+                f"autospec: handoff invalid (missing: {', '.join(missing)}) "
+                "— rollover aborted"
+            )
+            _log(
+                logf,
+                {
+                    "event": "handoff invalid: missing",
+                    "missing": missing,
+                    "kind": "clear",
+                },
+            )
+            _stats.record(
+                "handoff_invalid",
+                harness=harness,
+                tmux_session=tmux_session,
+                pct=round(pct, 4),
+                cwd=cwd,
+            )
+            subprocess.run(["tmux", "display-message", msg], check=False)
+            subprocess.run(
+                ["tmux", "send-keys", "-t", tmux_session, "-l", "\a"],
+                check=False,
+            )
+            return True
+
+        # --- Cancel window (only reached when handoff validation passes) ---
         _log(logf, {"event": "cancel_window_start", "kind": "clear"})
         if wait_for_cancel(tmux_session):
             _log(logf, {"event": "rollover canceled by user", "kind": "clear"})

--- a/packages/autospec_context_monitor/tests/test_handoff_validation_order.py
+++ b/packages/autospec_context_monitor/tests/test_handoff_validation_order.py
@@ -1,0 +1,139 @@
+"""Regression tests for g-015: handoff validation must run before cancel window.
+
+Covers:
+  - dispatch aborts with a log warning when no handoff file exists (before cancel window)
+  - dispatch proceeds to cancel window when a valid handoff file exists
+  - cancel-window mock is NOT called when validation fails (ordering regression)
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from autospec_context_monitor.__main__ import _dispatch
+from autospec_context_monitor.engine import Action
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_logf(tmp_path: Path) -> Path:
+    logf = tmp_path / "test.log"
+    logf.touch()
+    return logf
+
+
+def _make_adapter():
+    adapter = MagicMock()
+    adapter.command.return_value = "/clear"
+    adapter.prompt_marker.return_value = None  # no prompt guard
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Test 1: no handoff file → abort before cancel window
+# ---------------------------------------------------------------------------
+
+def test_dispatch_clear_aborts_when_no_handoff_file(tmp_path):
+    """When handoff_dir is empty, dispatch aborts early (returns True) without
+    invoking the cancel-window."""
+    logf = _make_logf(tmp_path)
+    handoff_dir = tmp_path / "handoff"
+    handoff_dir.mkdir()  # exists but no .md files
+    cwd = str(tmp_path)
+
+    with (
+        patch("autospec_context_monitor.__main__.wait_for_cancel") as mock_cancel,
+        patch("autospec_context_monitor.__main__.session_exists", return_value=True),
+        patch("autospec_context_monitor.__main__.inject"),
+        patch("autospec_context_monitor.__main__.subprocess.run"),
+    ):
+        result = _dispatch(
+            Action("clear"),
+            tmux_session="test-session",
+            logf=logf,
+            harness="claude",
+            cwd=cwd,
+            pct=0.85,
+            adapter=_make_adapter(),
+        )
+
+    assert result is True, "dispatch should abort (return True) when no handoff file found"
+    mock_cancel.assert_not_called(), "cancel window must NOT be shown when validation fails"
+
+    # Check that a warning was logged
+    log_lines = [json.loads(line) for line in logf.read_text().splitlines() if line.strip()]
+    warning_events = [l for l in log_lines if "no_handoff" in l.get("event", "") or "handoff" in l.get("event", "")]
+    assert warning_events, f"Expected a handoff warning log entry, got: {log_lines}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: valid handoff file → proceeds to cancel window
+# ---------------------------------------------------------------------------
+
+def test_dispatch_clear_proceeds_to_cancel_window_when_handoff_exists(tmp_path):
+    """When a valid handoff file exists, dispatch proceeds to cancel window."""
+    logf = _make_logf(tmp_path)
+    handoff_dir = tmp_path / ".turbo" / "handoff"
+    handoff_dir.mkdir(parents=True)
+    handoff_file = handoff_dir / "handoff.md"
+    # Write a minimal valid handoff file (validate_handoff checks sections)
+    handoff_file.write_text("## Summary\n\n## Status\n\n## Next Steps\n")
+    cwd = str(tmp_path)
+
+    with (
+        patch("autospec_context_monitor.__main__.wait_for_cancel", return_value=True) as mock_cancel,
+        patch("autospec_context_monitor.__main__.validate_handoff", return_value=(True, [])),
+        patch("autospec_context_monitor.__main__.session_exists", return_value=True),
+        patch("autospec_context_monitor.__main__.inject"),
+        patch("autospec_context_monitor.__main__.subprocess.run"),
+    ):
+        result = _dispatch(
+            Action("clear"),
+            tmux_session="test-session",
+            logf=logf,
+            harness="claude",
+            cwd=cwd,
+            pct=0.85,
+            adapter=_make_adapter(),
+        )
+
+    mock_cancel.assert_called_once(), "cancel window should be shown when handoff is valid"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: regression — cancel window NOT called when validation fails
+# ---------------------------------------------------------------------------
+
+def test_cancel_window_not_called_when_validation_fails(tmp_path):
+    """Regression: if handoff validation fails, wait_for_cancel must not be invoked."""
+    logf = _make_logf(tmp_path)
+    handoff_dir = tmp_path / ".turbo" / "handoff"
+    handoff_dir.mkdir(parents=True)
+    handoff_file = handoff_dir / "handoff.md"
+    handoff_file.write_text("incomplete handoff")
+    cwd = str(tmp_path)
+
+    with (
+        patch("autospec_context_monitor.__main__.wait_for_cancel") as mock_cancel,
+        patch("autospec_context_monitor.__main__.validate_handoff", return_value=(False, ["Summary", "Next Steps"])),
+        patch("autospec_context_monitor.__main__.session_exists", return_value=True),
+        patch("autospec_context_monitor.__main__.inject"),
+        patch("autospec_context_monitor.__main__.subprocess.run"),
+    ):
+        result = _dispatch(
+            Action("clear"),
+            tmux_session="test-session",
+            logf=logf,
+            harness="claude",
+            cwd=cwd,
+            pct=0.85,
+            adapter=_make_adapter(),
+        )
+
+    assert result is True
+    mock_cancel.assert_not_called(), "cancel window must NOT be called when handoff validation fails"


### PR DESCRIPTION
Closes #793

Fixes ordering bug: when no handoff file exists, the rollover now aborts with a logged warning before showing the cancel window, matching spec §Threshold state machine step order. Also unconditionally validates handoff file content before the cancel window (previously skipped validation when hfiles existed but was only checked inside the `if hfiles:` branch).

Three regression tests added covering: no-handoff abort, valid-handoff proceeds to cancel, and cancel-window-not-called-on-failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)