### PR TITLE
fix(install): add warning comment above fish uninstall awk block for edited markers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -605,6 +605,11 @@ remove_rollover_block() {
     if [ -f "$fish_config" ] && grep -qF "$_ROLLOVER_MARKER_START" "$fish_config"; then
         local tmp
         tmp=$(mktemp)
+        # WARNING: fish uninstall uses awk to remove lines between marker comments.
+        # If you have manually edited or removed the marker comments, this awk command
+        # will leave stale autospec lines in config.fish.
+        # Recovery: manually delete lines between '# >>> autospec auto-rollover >>>'
+        # and '# <<< autospec auto-rollover <<<' in ~/.config/fish/config.fish.
         awk "
             /$_ROLLOVER_MARKER_START/{skip=1}
             !skip{print}


### PR DESCRIPTION
Closes #794

Inserts a 5-line warning comment immediately above the awk command in the fish-shell uninstall block in `install.sh`. The comment names the marker strings (`# >>> autospec auto-rollover >>>` / `# <<< autospec auto-rollover <<<`) and provides the recovery path (manually delete lines between markers in `~/.config/fish/config.fish`) for operators who have manually edited or removed the marker comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)