### PR TITLE
feat(skills): auto-file Phase 5.5 audit tracker issue in autospec-split and autospec-define post-decomposition

### DIFF
--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -580,6 +580,12 @@ defaults to `defer`).
 
 No daemon auto-detection — always ask explicitly.
 
+After all decomposition issues are filed (and before asking the gate question),
+file one additional child issue titled
+`"Phase 5.5 audit + remediation — <feature-name>"` with labels
+`auto-implement,priority:high,audit`, then post a comment on the umbrella issue
+linking it: `"Phase 5.5 audit tracker: #<N>"`.
+
 After the user answers `run` or `defer` (i.e. the design is locked and issues
 are filed), call `diary-write.sh` to record the brainstorm decision:
 

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -573,6 +573,12 @@ defaults to `defer`).
 
 No daemon auto-detection — always ask explicitly.
 
+After all decomposition issues are filed (and before asking the gate question),
+file one additional child issue titled
+`"Phase 5.5 audit + remediation — <feature-name>"` with labels
+`auto-implement,priority:high,audit`, then post a comment on the umbrella issue
+linking it: `"Phase 5.5 audit tracker: #<N>"`.
+
 After the user answers `run` or `defer` (i.e. the design is locked and issues
 are filed), call `diary-write.sh` to record the brainstorm decision:
 

--- a/skills/autospec-split/SKILL.md
+++ b/skills/autospec-split/SKILL.md
@@ -458,6 +458,12 @@ defaults to `defer`).
 
 No daemon auto-detection — always ask explicitly.
 
+After all decomposition issues are filed (and before asking the gate question),
+file one additional child issue titled
+`"Phase 5.5 audit + remediation — <feature-name>"` with labels
+`auto-implement,priority:high,audit`, then post a comment on the umbrella issue
+linking it: `"Phase 5.5 audit tracker: #<N>"`.
+
 ## Handoff
 
 If the gate answer was `run`, hand off to `/autospec-run --profile <name>`

--- a/skills/autospec-split/codex/prompt.md
+++ b/skills/autospec-split/codex/prompt.md
@@ -451,6 +451,12 @@ defaults to `defer`).
 
 No daemon auto-detection — always ask explicitly.
 
+After all decomposition issues are filed (and before asking the gate question),
+file one additional child issue titled
+`"Phase 5.5 audit + remediation — <feature-name>"` with labels
+`auto-implement,priority:high,audit`, then post a comment on the umbrella issue
+linking it: `"Phase 5.5 audit tracker: #<N>"`.
+
 ## Handoff
 
 If the gate answer was `run`, hand off to `/autospec-run --profile <name>`


### PR DESCRIPTION
Closes #798

Adds a prose instruction to both `autospec-split` and `autospec-define` (SKILL.md + codex/prompt.md lockstep duos) directing the skill to file a `"Phase 5.5 audit + remediation — <feature-name>"` child issue with labels `auto-implement,priority:high,audit` after all decomposition issues are filed, and post a linking comment on the umbrella. Prevents post-ship integration gaps from going untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)