### PR TITLE
fix(install): handle PEP 668 externally-managed-environment in install_context_monitor_pkg

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -553,9 +553,16 @@ install_context_monitor_pkg() {
     fi
 
     info "  autospec_context_monitor: pip install --user -e $pkg_dir"
-    if python3 -m pip install --user --quiet -e "$pkg_dir" 2>&1 | grep -v -E '^(WARNING|$)' >&2; then
-        true  # pip succeeded; grep just filters its noisy WARNING lines
-    fi
+    # --break-system-packages handles PEP 668 (externally-managed-environment) on
+    # Homebrew Python, Apt-managed Python 3.11+, etc.  It is a no-op on Python
+    # installations that do not enforce the marker file.
+    local pip_out
+    pip_out=$(python3 -m pip install --user --quiet --break-system-packages -e "$pkg_dir" 2>&1) || {
+        err "  autospec_context_monitor: pip install failed"
+        printf '%s\n' "$pip_out" | grep -v -E '^(WARNING|$)' >&2 || true
+        err "  Recovery: run 'python3 -m pip install --user --break-system-packages -e $pkg_dir'"
+        return 1
+    }
 
     if python3 -c "import autospec_context_monitor" 2>/dev/null; then
         info "  autospec_context_monitor: import OK"

--- a/tests/test_install_pip_context_monitor.bats
+++ b/tests/test_install_pip_context_monitor.bats
@@ -36,3 +36,15 @@ INSTALL_SH="${BATS_TEST_DIRNAME}/../install.sh"
     echo "$block" | grep -qE 'pip[[:space:]]+install'
     echo "$block" | grep -qF 'autospec_context_monitor'
 }
+
+@test "g-021: pip install passes --break-system-packages for PEP 668 compatibility" {
+    block=$(awk '/^install_context_monitor_pkg\(\)/{flag=1} flag{print} /^}$/{if(flag){flag=0; exit}}' "$INSTALL_SH")
+    echo "$block" | grep -qF -- '--break-system-packages'
+}
+
+@test "g-021: install_context_monitor_pkg returns non-zero when pip install fails" {
+    # The function must propagate pip failures (no silent pass).
+    # Verify by checking that a failure path exists with 'return 1'.
+    block=$(awk '/^install_context_monitor_pkg\(\)/{flag=1} flag{print} /^}$/{if(flag){flag=0; exit}}' "$INSTALL_SH")
+    echo "$block" | grep -qF 'return 1'
+}


### PR DESCRIPTION
Closes #800

Adds `--break-system-packages` to the `pip install` call in `install_context_monitor_pkg` so the daemon package installs correctly on Homebrew Python, Apt-managed Python 3.11+, and other PEP 668-enforcing environments. Fixes the silent-failure bug where the grep pipe swallowed pip's exit code — failures now propagate as `return 1` with a recovery hint. Two new bats assertions added to `test_install_pip_context_monitor.bats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)