### PR TITLE
feat(autospec-run): mandatory Pattern survey section before Phase 4 code generation

### DIFF
--- a/skills/autospec-run/prompts/phase4-implementer.md
+++ b/skills/autospec-run/prompts/phase4-implementer.md
@@ -13,6 +13,22 @@ You are the autospec Phase 4 implementer. You have been handed one GitHub issue 
 - **Tier labels** — `ctx:*` and `reasoning:*` set your context budget and reasoning depth (see autospec model-tier rules in AGENTS.md).
 - **Lock-step deps** — `Depends on issue #N` lines in the body are parsed by the monitor. Re-check the merge status of each dep immediately before opening your PR.
 
+## Pattern survey
+
+**Mandatory before any code is written.** Search the codebase for analogous utilities, helpers, and patterns in the issue's domain. Return the top 3 candidates as a markdown list in your internal notes:
+
+```
+grep -r "<key term from issue>" --include="*.<ext>" -l | head -10
+find . -name "<pattern>" | head -10
+```
+
+For each candidate, note the file path and a one-line description of what it does. Then choose one of:
+
+- **(a) Reuse:** State `"Reusing <X> because <Y>"` in a comment above the code and in your PR body.
+- **(b) No reuse:** State `"No reuse — <reason>"` in your PR body (e.g. "No reuse — existing helpers are HTTP-only, this is a file-system operation").
+
+Skipping this step or leaving the reuse decision undocumented in the PR body is a policy violation.
+
 ## Expand
 
 Before changing any code:

--- a/tests/test_phase4_pattern_survey.bats
+++ b/tests/test_phase4_pattern_survey.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+# tests/test_phase4_pattern_survey.bats — regression for feat(autospec-run) #803
+#
+# The Phase 4 implementer prompt must contain a mandatory "Pattern survey"
+# section so implementers survey analogous utilities before writing code,
+# preventing duplicate helpers and enforcing explicit reuse decisions.
+
+PHASE4_PROMPT="${BATS_TEST_DIRNAME}/../skills/autospec-run/prompts/phase4-implementer.md"
+
+@test "phase4-implementer.md contains a Pattern survey section" {
+    run grep -c "Pattern survey" "$PHASE4_PROMPT"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "Pattern survey section appears before Expand section" {
+    survey_line=$(grep -n "Pattern survey" "$PHASE4_PROMPT" | head -1 | cut -d: -f1)
+    expand_line=$(grep -n "^## Expand" "$PHASE4_PROMPT" | head -1 | cut -d: -f1)
+    [ -n "$survey_line" ]
+    [ -n "$expand_line" ]
+    [ "$survey_line" -lt "$expand_line" ]
+}
+
+@test "Pattern survey section documents the reuse/no-reuse decision requirement" {
+    run grep -c "Reusing\|No reuse" "$PHASE4_PROMPT"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}


### PR DESCRIPTION
Closes #803

Injects a `## Pattern survey` section into `phase4-implementer.md` immediately before `## Expand`. The section requires implementers to search for top-3 analogous utilities/helpers before writing any code, then document their reuse decision (either `"Reusing X because Y"` or `"No reuse — Z"`) in the PR body. Three bats assertions added to `tests/test_phase4_pattern_survey.bats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)