### PR TITLE
feat(autospec-run): mandatory executable smoke test gate before Phase 4 PR merge

### DIFF
--- a/skills/autospec-run/prompts/phase4-implementer.md
+++ b/skills/autospec-run/prompts/phase4-implementer.md
@@ -221,6 +221,48 @@ if [ -f .autospec/explore-mode.json ] && [ "$PR_BASE" = "main" ]; then
 fi
 ```
 
+## Smoke test gate
+
+After all unit/integration tests pass and before opening the PR, run the
+**Primary smoke test** command from the issue body. This must be an executable
+shell command (single fenced block), not prose. If the issue body does not
+contain an executable smoke command (e.g. it is multi-line prose with no
+runnable command), treat it as a missing AC and comment on the issue:
+
+```bash
+gh issue comment <ISSUE> --body "Smoke test section is not executable — cannot merge without a runnable smoke command. Needs operator update."
+exit 1
+```
+
+Extract and run the smoke command:
+
+```bash
+# Extract the first shell command from the Primary smoke test section.
+smoke_cmd=$(gh issue view <ISSUE> --json body --jq '.body' \
+    | awk '/### Primary smoke test/{found=1} found && /^```/{if(++fence==1){next} if(fence==2){exit}} found && fence==1{print}' \
+    | head -5)
+
+if [ -z "$smoke_cmd" ]; then
+    gh issue comment <ISSUE> --body "No executable smoke command found in issue body — aborting merge."
+    exit 1
+fi
+
+# smoke_test_passes: run the smoke command in the worktree.
+if ! eval "$smoke_cmd"; then
+    gh issue comment <ISSUE> --body "Smoke test FAILED (command: \`$smoke_cmd\`). Not merging until smoke passes."
+    exit 1
+fi
+```
+
+If smoke passes, proceed. If smoke fails, do NOT open the PR — comment on the
+issue with the failure output and exit. Operators must fix the smoke command or
+the implementation before re-running.
+
+> **Decomposer constraint:** Issue bodies filed by `/autospec-split` or
+> `/autospec-define` must include a `### Primary smoke test (inner loop)`
+> section whose code fence contains a single runnable shell command. Multi-line
+> prose without a runnable command is rejected by this gate.
+
 ## Rebase-and-retest gate
 
 Immediately before `gh pr merge --admin --squash --delete-branch`, run the

--- a/tests/test_phase4_executable_smoke_gate.bats
+++ b/tests/test_phase4_executable_smoke_gate.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# tests/test_phase4_executable_smoke_gate.bats — regression for feat(autospec-run) #804
+#
+# The Phase 4 implementer prompt must contain a mandatory executable smoke
+# test gate that runs before merge and fails the PR if smoke fails.
+
+PHASE4_PROMPT="${BATS_TEST_DIRNAME}/../skills/autospec-run/prompts/phase4-implementer.md"
+SPLIT_PROMPT="${BATS_TEST_DIRNAME}/../skills/autospec-split/codex/prompt.md"
+DEFINE_PROMPT="${BATS_TEST_DIRNAME}/../skills/autospec-define/codex/prompt.md"
+
+@test "phase4-implementer.md contains smoke_test_passes or eval smoke call" {
+    run grep -c "smoke_test_passes\|eval.*smoke" "$PHASE4_PROMPT"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "phase4-implementer.md contains a Smoke test gate section" {
+    run grep -c "Smoke test gate" "$PHASE4_PROMPT"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "phase4-implementer.md smoke gate aborts on failure with issue comment" {
+    # Must comment on the issue AND exit 1 when smoke fails.
+    run grep -c "exit 1" "$PHASE4_PROMPT"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "autospec-split decomposer enforces SMOKE_NOT_FENCED and SMOKE_MULTI_LINE" {
+    run grep -c "SMOKE_NOT_FENCED\|SMOKE_MULTI_LINE" "$SPLIT_PROMPT"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "autospec-define decomposer enforces SMOKE_NOT_FENCED and SMOKE_MULTI_LINE" {
+    run grep -c "SMOKE_NOT_FENCED\|SMOKE_MULTI_LINE" "$DEFINE_PROMPT"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}


### PR DESCRIPTION
Closes #804

Adds a `## Smoke test gate` section to `phase4-implementer.md` that extracts and runs the issue's `### Primary smoke test` shell command before opening a PR. If the smoke command is missing, non-executable (prose), or fails, the implementer comments on the issue and exits without merging. The decomposer prompts (`autospec-split` / `autospec-define`) already enforce `SMOKE_NOT_FENCED` and `SMOKE_MULTI_LINE` lint rules. Five bats assertions added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)