### PR TITLE
fix(install): write Claude hooks as objects, not bare strings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -682,16 +682,25 @@ hooks = data.setdefault("hooks", {})
 
 monitor_cmd = "python3 -m autospec_context_monitor --hook-event"
 
-hooks.setdefault("PreCompact",    [])
-hooks.setdefault("SessionStart",  [])
+# Claude Code's hooks schema requires each array entry to be an object with a
+# `hooks` list of {type, command} steps -- not a bare command string. Earlier
+# installs appended bare strings, which `claude doctor` flags as invalid.
+def merge(event):
+    cmd = "%s %s" % (monitor_cmd, event)
+    entries = hooks.setdefault(event, [])
+    # Drop any legacy bare-string form left by earlier installs, so re-running
+    # the installer self-heals configs already in the wild.
+    entries[:] = [e for e in entries if e != cmd]
+    already = any(
+        isinstance(e, dict)
+        and any(h.get("command") == cmd for h in e.get("hooks", []))
+        for e in entries
+    )
+    if not already:
+        entries.append({"hooks": [{"type": "command", "command": cmd}]})
 
-_pre  = monitor_cmd + " PreCompact"
-_sess = monitor_cmd + " SessionStart"
-
-if _pre  not in hooks["PreCompact"]:
-    hooks["PreCompact"].append(_pre)
-if _sess not in hooks["SessionStart"]:
-    hooks["SessionStart"].append(_sess)
+merge("PreCompact")
+merge("SessionStart")
 
 tmp = settings_path.with_suffix(".json.tmp")
 tmp.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")

--- a/tests/test_install_hook_entry_schema.bats
+++ b/tests/test_install_hook_entry_schema.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# tests/test_install_hook_entry_schema.bats — regression for the Claude Code
+# hooks-schema contract.
+#
+# Claude Code's settings.json hooks schema requires each entry in a hook-event
+# array to be an OBJECT of the form {"hooks": [{"type": "command", "command": ...}]}.
+# An earlier install_hook_mode_claude appended bare command STRINGS, which
+# `claude doctor` flags as:
+#   "hooks.SessionStart.N: Expected object, but received string".
+# These tests pin the corrected behavior so it can't silently regress.
+
+INSTALL_SH="${BATS_TEST_DIRNAME}/../install.sh"
+
+# Extract the install_hook_mode_claude function body and run it against an
+# isolated $HOME, so we exercise the real read-modify-write logic.
+run_install_hook_mode() {
+    local fn
+    fn=$(awk '/^install_hook_mode_claude\(\)/{flag=1} flag{print} /^}$/{if(flag){flag=0; exit}}' "$INSTALL_SH")
+    DRY_RUN=0 eval "info(){ :; }; $fn; install_hook_mode_claude"
+}
+
+@test "writes SessionStart/PreCompact entries as objects, not bare strings" {
+    export HOME="$BATS_TEST_TMPDIR/fresh"
+    mkdir -p "$HOME"
+    run_install_hook_mode
+
+    run python3 - "$HOME/.claude/settings.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+for ev in ("PreCompact", "SessionStart"):
+    entries = d["hooks"][ev]
+    assert entries, ev
+    e = entries[-1]
+    assert isinstance(e, dict), f"{ev} entry must be an object, got {type(e)}: {e!r}"
+    step = e["hooks"][0]
+    assert step["type"] == "command"
+    assert step["command"].endswith(ev), step
+print("ok")
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "self-heals legacy bare-string entries while preserving other hooks" {
+    export HOME="$BATS_TEST_TMPDIR/legacy"
+    mkdir -p "$HOME/.claude"
+    cat > "$HOME/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "PreCompact": ["python3 -m autospec_context_monitor --hook-event PreCompact"],
+    "SessionStart": [
+      {"hooks": [{"type": "command", "command": "budi hook session-start"}]},
+      "python3 -m autospec_context_monitor --hook-event SessionStart"
+    ]
+  }
+}
+JSON
+    run_install_hook_mode
+
+    run python3 - "$HOME/.claude/settings.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+# No bare strings survive anywhere in the hook arrays.
+for ev, entries in d["hooks"].items():
+    for e in entries:
+        assert isinstance(e, dict), f"{ev} still has bare string: {e!r}"
+# Pre-existing budi hook is preserved.
+cmds = [s["command"] for e in d["hooks"]["SessionStart"] for s in e["hooks"]]
+assert "budi hook session-start" in cmds, cmds
+assert any(c.endswith("SessionStart") for c in cmds), cmds
+print("ok")
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "re-running is idempotent (no duplicate monitor entries)" {
+    export HOME="$BATS_TEST_TMPDIR/idem"
+    mkdir -p "$HOME"
+    run_install_hook_mode
+    run_install_hook_mode
+
+    run python3 - "$HOME/.claude/settings.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+for ev in ("PreCompact", "SessionStart"):
+    monitor = [e for e in d["hooks"][ev]
+               if any("autospec_context_monitor" in s.get("command", "")
+                      for s in e.get("hooks", []))]
+    assert len(monitor) == 1, f"{ev}: expected 1 monitor entry, got {len(monitor)}"
+print("ok")
+PY
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Problem

`install_hook_mode_claude` registers the context-monitor into `~/.claude/settings.json` by appending **bare command strings** to the `PreCompact` and `SessionStart` hook arrays:

```python
hooks["PreCompact"].append("python3 -m autospec_context_monitor --hook-event PreCompact")
hooks["SessionStart"].append("python3 -m autospec_context_monitor --hook-event SessionStart")
```

But Claude Code's hooks schema requires each array entry to be an **object**:

```json
{ "hooks": [ { "type": "command", "command": "..." } ] }
```

So every hook-mode install fails `claude doctor` with:

```
Settings (~/.claude/settings.json › hooks.SessionStart.N): Expected object, but received string
Settings (~/.claude/settings.json › hooks.PreCompact.N):   Expected object, but received string
```

The hooks may still fire, but the config is schema-invalid and surfaces as an error to every user who ran the installer in hook mode.

## Fix

Write the proper object form, and strip any legacy bare-string entry on the way so **re-running the installer self-heals configs already in the wild**:

```python
def merge(event):
    cmd = "%s %s" % (monitor_cmd, event)
    entries = hooks.setdefault(event, [])
    entries[:] = [e for e in entries if e != cmd]          # drop legacy bare string
    already = any(isinstance(e, dict)
                  and any(h.get("command") == cmd for h in e.get("hooks", []))
                  for e in entries)
    if not already:
        entries.append({"hooks": [{"type": "command", "command": cmd}]})
```

The command run and the idempotency guarantee are unchanged. Pre-existing hooks (e.g. `budi`) in the same arrays are preserved.

## Tests

New `tests/test_install_hook_entry_schema.bats` runs the real `install_hook_mode_claude` against an isolated `$HOME` and asserts:

1. **Fresh install** — entries are objects with `type: command`, not strings.
2. **Legacy migration** — pre-seeded bare-string entries are rewritten to objects; unrelated hooks (e.g. `budi`) are preserved.
3. **Idempotent re-run** — no duplicate monitor entries.

```
$ bats tests/test_install_hook_entry_schema.bats
ok 1 writes SessionStart/PreCompact entries as objects, not bare strings
ok 2 self-heals legacy bare-string entries while preserving other hooks
ok 3 re-running is idempotent (no duplicate monitor entries)
```

Existing `tests/test_install_pip_context_monitor.bats` still passes (6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)