### PR TITLE
feat(fleet): lockstep /autospec-fleet gui subcommand + validate.sh check

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -372,6 +372,20 @@ check_autospec_fleet_scripts() {
     done
 }
 
+# Lockstep check: the literal line '/autospec-fleet gui' must appear in all
+# three adapter files for the fleet skill (SKILL.md, codex/prompt.md,
+# opencode/agent.md). Introduced by issue #829.
+check_fleet_gui_subcommand_lockstep() {
+    local needle='/autospec-fleet gui'
+    info "fleet-gui subcommand lockstep"
+    for f in skills/autospec-fleet/SKILL.md \
+              skills/autospec-fleet/codex/prompt.md \
+              skills/autospec-fleet/opencode/agent.md; do
+        grep -qF "$needle" "$f" \
+            || fail "fleet-gui lockstep: '$needle' missing in $f"
+    done
+}
+
 # Harness detection block validation.
 # If a SKILL.md contains a "## Harness detection" heading, verify that the
 # section body includes TIER_A, TIER_B, and a "silently" fallback reference.
@@ -1709,6 +1723,7 @@ main() {
     check_phase4_adaptive_retry
     check_autospec_sweep_config_contract
     check_autospec_fleet_scripts
+    check_fleet_gui_subcommand_lockstep
     check_team_personality_contract
     check_autospec_run_priority_sort_lockstep
     check_autospec_run_regression_review_lockstep

--- a/skills/autospec-fleet/SKILL.md
+++ b/skills/autospec-fleet/SKILL.md
@@ -102,6 +102,27 @@ and exit.
 - `status` summarizes queue state, active workers, open PRs, and recent
   failures across configured repositories.
 - `stop` forwards existing autospec stop semantics to active repo workers.
+- `gui` launches a local one-page browser GUI on `127.0.0.1` with a random
+  port and URL token; lets the operator toggle repos and edit top-level config.
+
+## GUI mode
+
+```text
+/autospec-fleet gui
+```
+
+Runs `skills/autospec-fleet/scripts/fleet-gui.sh`, which:
+
+1. Checks for `gh` on PATH (exits 1 with `code_health:fleet_gui_missing_gh`
+   if absent).
+2. Picks a random port (49152–65535) and 16-hex URL token.
+3. Starts a Python stdlib HTTP server bound to `127.0.0.1`.
+4. Opens the default browser at `http://127.0.0.1:<port>/?t=<token>`.
+5. Serves `GET /api/repos`, `GET /api/config`, and `POST /api/config`.
+6. Exits after save or after 15 min idle (`AUTOSPEC_GUI_IDLE_SECS` to
+   override).
+
+Flags: `--no-browser`, `--print-url`, `--once` (smoke-test mode).
 
 ## Required capabilities & harness adapter
 

--- a/skills/autospec-fleet/codex/prompt.md
+++ b/skills/autospec-fleet/codex/prompt.md
@@ -98,6 +98,27 @@ and exit.
 - `status` summarizes queue state, active workers, open PRs, and recent
   failures across configured repositories.
 - `stop` forwards existing autospec stop semantics to active repo workers.
+- `gui` launches a local one-page browser GUI on `127.0.0.1` with a random
+  port and URL token; lets the operator toggle repos and edit top-level config.
+
+## GUI mode
+
+```text
+/autospec-fleet gui
+```
+
+Runs `skills/autospec-fleet/scripts/fleet-gui.sh`, which:
+
+1. Checks for `gh` on PATH (exits 1 with `code_health:fleet_gui_missing_gh`
+   if absent).
+2. Picks a random port (49152–65535) and 16-hex URL token.
+3. Starts a Python stdlib HTTP server bound to `127.0.0.1`.
+4. Opens the default browser at `http://127.0.0.1:<port>/?t=<token>`.
+5. Serves `GET /api/repos`, `GET /api/config`, and `POST /api/config`.
+6. Exits after save or after 15 min idle (`AUTOSPEC_GUI_IDLE_SECS` to
+   override).
+
+Flags: `--no-browser`, `--print-url`, `--once` (smoke-test mode).
 
 ## Required capabilities & harness adapter
 

--- a/skills/autospec-fleet/opencode/agent.md
+++ b/skills/autospec-fleet/opencode/agent.md
@@ -102,6 +102,27 @@ and exit.
 - `status` summarizes queue state, active workers, open PRs, and recent
   failures across configured repositories.
 - `stop` forwards existing autospec stop semantics to active repo workers.
+- `gui` launches a local one-page browser GUI on `127.0.0.1` with a random
+  port and URL token; lets the operator toggle repos and edit top-level config.
+
+## GUI mode
+
+```text
+/autospec-fleet gui
+```
+
+Runs `skills/autospec-fleet/scripts/fleet-gui.sh`, which:
+
+1. Checks for `gh` on PATH (exits 1 with `code_health:fleet_gui_missing_gh`
+   if absent).
+2. Picks a random port (49152–65535) and 16-hex URL token.
+3. Starts a Python stdlib HTTP server bound to `127.0.0.1`.
+4. Opens the default browser at `http://127.0.0.1:<port>/?t=<token>`.
+5. Serves `GET /api/repos`, `GET /api/config`, and `POST /api/config`.
+6. Exits after save or after 15 min idle (`AUTOSPEC_GUI_IDLE_SECS` to
+   override).
+
+Flags: `--no-browser`, `--print-url`, `--once` (smoke-test mode).
 
 ## Required capabilities & harness adapter
 


### PR DESCRIPTION
Closes #829

## Summary

Adds the `/autospec-fleet gui` subcommand documentation to all three lockstep adapter files and wires a new validate.sh check.

### Changes

**Three adapter files (byte-identical body):**
- `skills/autospec-fleet/SKILL.md` — adds `/autospec-fleet gui` to the invocation list and adds a new `## GUI mode` section (~18 lines)
- `skills/autospec-fleet/codex/prompt.md` — mirrors SKILL.md body identically (preserves leading blank line)
- `skills/autospec-fleet/opencode/agent.md` — mirrors SKILL.md body identically

**validate.sh:**
- New `check_fleet_gui_subcommand_lockstep()` function that asserts `/autospec-fleet gui` appears in all three adapter files
- Wired into the main runner after `check_autospec_fleet_scripts`

### Verification

```bash
# Literal line present in all 3 files
grep -F '/autospec-fleet gui' skills/autospec-fleet/SKILL.md skills/autospec-fleet/codex/prompt.md skills/autospec-fleet/opencode/agent.md
# → 3 hits

# Lockstep check (body identical)
diff <(awk '/^---$/{c++; next} c>=2' skills/autospec-fleet/SKILL.md) skills/autospec-fleet/codex/prompt.md
diff <(awk '/^---$/{c++; next} c>=2' skills/autospec-fleet/SKILL.md) <(awk '/^---$/{c++; next} c>=2' skills/autospec-fleet/opencode/agent.md)
# → both exit 0 (no diff)

# validate.sh syntax check
bash -n scripts/validate.sh
```