### PR TITLE
fix(fleet-gui): preserve unmanaged YAML keys when PyYAML is absent

### DIFF
--- a/skills/autospec-fleet/scripts/fleet-gui-server.py
+++ b/skills/autospec-fleet/scripts/fleet-gui-server.py
@@ -74,8 +74,13 @@ def _basic_yaml_dump(data):
     lines = []
     for k, v in data.items():
         if isinstance(v, list):
-            lines.append(f"{k}:")
-            lines.extend(_yaml_list_items(v))
+            if not v:
+                # Emit an explicit empty-list flow form so the stdlib reader
+                # round-trips it as [] (a bare "k:" loads as None, like PyYAML).
+                lines.append(f"{k}: []")
+            else:
+                lines.append(f"{k}:")
+                lines.extend(_yaml_list_items(v))
         elif v is None:
             lines.append(f"{k}:")
         else:
@@ -94,6 +99,8 @@ def _yaml_load_scalar(text):
         return True
     if t in ("false", "False"):
         return False
+    if t == "[]":
+        return []
     if t in ("", "~", "null", "None"):
         return None
     if (len(t) >= 2) and ((t[0] == t[-1] == '"') or (t[0] == t[-1] == "'")):

--- a/skills/autospec-fleet/scripts/fleet-gui-server.py
+++ b/skills/autospec-fleet/scripts/fleet-gui-server.py
@@ -83,19 +83,94 @@ def _basic_yaml_dump(data):
     return "\n".join(lines) + "\n"
 
 
+def _yaml_load_scalar(text):
+    """Parse a scalar YAML token into bool / int / None / str.
+
+    Mirrors the value forms emitted by _yaml_scalar (true/false/ints) plus
+    bare strings; quotes are stripped so dumped-then-loaded values round-trip.
+    """
+    t = text.strip()
+    if t in ("true", "True"):
+        return True
+    if t in ("false", "False"):
+        return False
+    if t in ("", "~", "null", "None"):
+        return None
+    if (len(t) >= 2) and ((t[0] == t[-1] == '"') or (t[0] == t[-1] == "'")):
+        return t[1:-1]
+    try:
+        return int(t)
+    except ValueError:
+        return t
+
+
+def _basic_yaml_load(text):
+    """Minimal stdlib YAML reader for the simple dict/list shapes this server
+    writes (top-level scalars and lists of flat dicts).
+
+    Stdlib has no YAML parser, so this is the round-trip counterpart to
+    _basic_yaml_dump. It preserves every top-level key — including unmanaged
+    ones — so a save cannot silently drop them when PyYAML is unavailable.
+    """
+    result = {}
+    cur_key = None  # key whose value is being filled by following list lines
+    cur_item = None  # dict item currently being built inside that list
+    empty_key = None  # top-level "key:" with no value yet seen → None unless a
+    #                   list item follows, in which case it becomes a list
+    for raw in text.splitlines():
+        line = raw.rstrip("\n")
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+        if indent == 0 and not stripped.startswith("- "):
+            # top-level "key:" or "key: value"
+            cur_item = None
+            key, sep, val = stripped.partition(":")
+            key = key.strip()
+            if sep and val.strip() == "":
+                result[key] = None  # provisional: None unless list items follow
+                cur_key = key
+                empty_key = key
+            else:
+                result[key] = _yaml_load_scalar(val)
+                cur_key = None
+                empty_key = None
+        elif cur_key is not None and stripped.startswith("- "):
+            if empty_key == cur_key:
+                result[cur_key] = []  # promote None → list on first item
+                empty_key = None
+            rest = stripped[2:]
+            if ":" in rest:
+                cur_item = {}
+                k, _, v = rest.partition(":")
+                cur_item[k.strip()] = _yaml_load_scalar(v)
+                result[cur_key].append(cur_item)
+            else:
+                cur_item = None
+                result[cur_key].append(_yaml_load_scalar(rest))
+        elif cur_key is not None and cur_item is not None:
+            # continuation key of the current dict list-item
+            k, _, v = stripped.partition(":")
+            cur_item[k.strip()] = _yaml_load_scalar(v)
+    return result
+
+
 def load_yaml_config(path):
-    """Load YAML config. Uses PyYAML if available; falls back to JSON."""
+    """Load YAML config. Uses PyYAML if available; otherwise a stdlib reader.
+
+    The stdlib reader preserves all top-level keys so unmanaged config keys
+    survive a save round-trip even when PyYAML is not installed (the spec
+    assumes stdlib-only). It must NOT fall back to json.load on a YAML file —
+    that returns {} for any real YAML and silently destroys unmanaged keys.
+    """
     try:
         import yaml
-        with open(path) as f:
-            return yaml.safe_load(f) or {}
     except ImportError:
-        pass
-    try:
         with open(path) as f:
-            return json.load(f)
-    except Exception:
-        return {}
+            return _basic_yaml_load(f.read())
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
 
 
 def dump_yaml_config(data):

--- a/tests/fleet/test_fleet_gui.bats
+++ b/tests/fleet/test_fleet_gui.bats
@@ -76,6 +76,7 @@ teardown() {
 }
 
 # start_server <port>: start the fleet-gui-server in background, sets GUI_PID
+# Honors an exported PYTHONPATH (used by the no-PyYAML test to shim out yaml).
 start_server() {
     local port="$1"
     IDLE_SECS="${IDLE_SECS:-3600}"
@@ -354,4 +355,81 @@ for k in ('version', 'workspace', 'default_profile', 'parallel_repos', 'repos'):
 assert isinstance(cfg['repos'], list)
 print('OK — profile:', profile)
 " "$config_file"
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: no-PyYAML fallback must NOT destroy unmanaged keys on save (#836)
+#
+# The spec's autonomous assumption is "Python 3 stdlib only — no pip packages",
+# so PyYAML may be absent at runtime. When it is, load_yaml_config must still
+# parse a real YAML file (not fall through to json.load and silently return {}),
+# otherwise _merge_config drops every unmanaged on-disk key during a save.
+#
+# This test forces `import yaml` to fail (a PYTHONPATH shim raising ImportError),
+# seeds a real YAML config carrying an unmanaged key, POSTs a managed-only
+# update, and asserts the unmanaged key survives the save round-trip. It FAILS
+# against the buggy json-fallback implementation and PASSES once load/dump are
+# stdlib-correct without PyYAML.
+# ---------------------------------------------------------------------------
+@test "no-PyYAML fallback preserves unmanaged keys on save (#836)" {
+    local port
+    port="$(pick_free_port)"
+
+    # Shim that makes `import yaml` raise ImportError inside the server process.
+    local YAMLSTUB="$TMP/yamlstub"
+    mkdir -p "$YAMLSTUB"
+    cat > "$YAMLSTUB/yaml.py" <<'EOF'
+raise ImportError("PyYAML forced unavailable for test")
+EOF
+
+    # Stub gh so the server starts cleanly.
+    local BIN="$TMP/bin"
+    mkdir -p "$BIN"
+    cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo '[]'
+EOF
+    chmod +x "$BIN/gh"
+
+    # Seed a REAL YAML config on disk with managed + unmanaged keys.
+    # experimental_thing is unmanaged and must survive the save.
+    local config_file="$TMP/autospec-fleet.yml"
+    cat > "$config_file" <<'EOF'
+version: 1
+workspace: .autospec-fleet/repos
+default_profile: qwen3-32b-laptop
+parallel_repos: 2
+repos:
+  - url: https://github.com/org/seeded-repo
+    enabled: true
+experimental_thing: 42
+EOF
+
+    # Start the server with yaml shimmed out — its `import yaml` must fail.
+    PYTHONPATH="$YAMLSTUB" PATH="$BIN:$PATH" start_server "$port"
+
+    # POST an update touching only managed keys (no experimental_thing).
+    local post_body
+    post_body='{"version":1,"workspace":".autospec-fleet/repos","default_profile":"changed-profile","parallel_repos":4,"repos":[]}'
+
+    local post_resp
+    post_resp="$(api_post "$port" "/api/config" "$post_body")"
+
+    python3 -c "
+import json, sys
+d = json.loads(sys.argv[1])
+assert d.get('saved') == True, f'expected saved=true, got: {d}'
+" "$post_resp"
+
+    # Wait out the post-save shutdown timer.
+    sleep 1.5
+    GUI_PID=""
+
+    [ -f "$config_file" ]
+
+    # Verify WITHOUT PyYAML (raw text scan): the unmanaged key must still be on
+    # disk, and the managed update must have applied. A bug that returns {} on
+    # load would have dropped experimental_thing entirely.
+    grep -Eq '^experimental_thing:[[:space:]]*42$' "$config_file"
+    grep -Eq '^default_profile:[[:space:]]*changed-profile$' "$config_file"
 }

--- a/tests/fleet/test_fleet_gui.bats
+++ b/tests/fleet/test_fleet_gui.bats
@@ -432,4 +432,25 @@ assert d.get('saved') == True, f'expected saved=true, got: {d}'
     # load would have dropped experimental_thing entirely.
     grep -Eq '^experimental_thing:[[:space:]]*42$' "$config_file"
     grep -Eq '^default_profile:[[:space:]]*changed-profile$' "$config_file"
+
+    # GET round-trip, still without PyYAML: the stdlib reader must return the
+    # unmanaged key AND parse the empty repos list as [] (not null), so the GUI
+    # renders a real list. Start a fresh server with yaml still shimmed out.
+    local port2
+    port2="$(pick_free_port)"
+    GUI_PID=""
+    PYTHONPATH="$YAMLSTUB" PATH="$BIN:$PATH" start_server "$port2"
+
+    local get_resp
+    get_resp="$(api_get "$port2" "/api/config")"
+
+    python3 -c "
+import json, sys
+d = json.loads(sys.argv[1])
+assert d.get('exists') == True, f'expected exists=true, got: {d}'
+cfg = d.get('config', {})
+assert cfg.get('experimental_thing') == 42, f'unmanaged key lost on GET: {cfg}'
+assert cfg.get('default_profile') == 'changed-profile', f'managed update lost: {cfg}'
+assert cfg.get('repos') == [], f'empty repos should round-trip as [] not {cfg.get(\"repos\")!r}: {cfg}'
+" "$get_resp"
 }


### PR DESCRIPTION
Closes #836

## Problem
`load_yaml_config` fell through to `json.load()` on a YAML file when PyYAML was unavailable. `json.load` raises, the bare `except Exception: return {}` swallowed it, and `_merge_config` then saw `existing={}` and wrote back only GUI-managed keys — **silently destroying every unmanaged key on disk** (e.g. `experimental_thing: 42`). The spec's autonomous assumption is "Python 3 stdlib only — no pip packages", so PyYAML is not guaranteed at runtime; Test 2 only passed because the dev machine happened to have PyYAML installed.

## Fix
Removed the dangerous json fallback. Added `_basic_yaml_load`, a stdlib reader that is the round-trip counterpart to the existing `_basic_yaml_dump`. Verified byte-for-byte equivalent to PyYAML on every shape this server reads (top-level scalars/bools/ints, URLs containing colons, empty values, lists of flat dicts), so all top-level keys — including unmanaged ones — survive a save round-trip without PyYAML. Stays stdlib-only per the spec assumption; no new dependency.

## Test
New bats test `no-PyYAML fallback preserves unmanaged keys on save (#836)` shims `import yaml` to raise ImportError via a PYTHONPATH stub, seeds a real YAML config with an unmanaged key, POSTs a managed-only update, and asserts the unmanaged key survives (raw-text scan, no PyYAML). Confirmed via mutation test: the test FAILS against the json-fallback bug and PASSES with the stdlib reader. All 6 fleet bats tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)