### PR TITLE
fix(autospec-fleet): --once smoke mode boots the server and hits both endpoints (#839)

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -131,6 +131,12 @@ lower parallel cap, then emits worker IDs such as
 - `status --json`: return a `repos` array with ready, blocked, claimed, conflict, and batch counts.
 - `stop --graceful|--immediate`: forward the existing autospec stop helper to active managed checkouts.
 
+**Configuration GUI:** `bash skills/autospec-fleet/scripts/fleet-gui.sh` opens a
+one-page browser GUI for editing `autospec-fleet.yml`. Its `--once` flag is a
+smoke-test mode that starts the server, self-issues one GET to `/api/repos` and
+`/api/config`, asserts both return 200, then exits 0 — verifying the live HTTP
+surface (not merely that the port binds).
+
 ### `/autospec-sweep`
 
 <!-- autospec-doc-scope:

--- a/docs/specs/2026-06-01-autospec-fleet-gui-design.md
+++ b/docs/specs/2026-06-01-autospec-fleet-gui-design.md
@@ -251,7 +251,7 @@ bash skills/autospec-fleet/scripts/fleet-gui.sh --no-browser --print-url --once
 | --- | --- |
 | `--no-browser` | Start the server without opening the system browser. |
 | `--print-url` | Print the full URL (with token) to stdout before serving. |
-| `--once` | Smoke-test mode: verify setup (port bindable) and exit 0 immediately. |
+| `--once` | Smoke-test mode: start the server, self-issue one GET to `/api/repos` and `/api/config`, assert both return 200, then exit 0. Bypasses the 15-min loop. |
 
 Environment variable: `AUTOSPEC_GUI_IDLE_SECS` — idle timeout in seconds (default 900 = 15 min).
 

--- a/skills/autospec-fleet/README.md
+++ b/skills/autospec-fleet/README.md
@@ -44,7 +44,7 @@ bash skills/autospec-fleet/scripts/fleet-gui.sh [--no-browser] [--print-url] [--
 | --- | --- |
 | `--no-browser` | Start the server without opening the system browser. |
 | `--print-url` | Print the full URL (with token) to stdout before serving. |
-| `--once` | Smoke-test mode: verify setup (port bindable) and exit 0 immediately. |
+| `--once` | Smoke-test mode: start the server, self-issue one GET to `/api/repos` and `/api/config`, assert both return 200, then exit 0. Bypasses the 15-min loop. |
 
 Environment: `AUTOSPEC_GUI_IDLE_SECS` — idle timeout in seconds (default 900 = 15 min).
 

--- a/skills/autospec-fleet/scripts/fleet-gui-server.py
+++ b/skills/autospec-fleet/scripts/fleet-gui-server.py
@@ -37,6 +37,15 @@ DEFAULT_SKELETON = {
 last_activity = time.time()
 shutdown_event = threading.Event()
 
+# In --once smoke mode the server must serve BOTH /api/repos and /api/config
+# before shutting down (the launcher self-issues one GET to each). Tracking which
+# endpoints have been served — and only shutting down once both are — keeps the
+# smoke run deterministic: a shutdown armed after the first hit could race the
+# second request and tear the server down before /api/config is served.
+ONCE_REQUIRED = {"/api/repos", "/api/config"}
+_once_lock = threading.Lock()
+_once_served = set()
+
 
 def record_activity(ts=None):
     """Record the current time as the last activity timestamp."""
@@ -203,6 +212,22 @@ def schedule_shutdown(post_save=False):
     threading.Timer(delay, shutdown_event.set).start()
 
 
+def once_served(path):
+    """Record that a --once smoke endpoint was served; shut down once both are.
+
+    The launcher hits /api/repos and /api/config exactly once each in --once
+    mode. Shutting down only after BOTH have been served (rather than after the
+    first) makes the smoke run deterministic — see ONCE_REQUIRED above.
+    """
+    if not ONCE:
+        return
+    with _once_lock:
+        _once_served.add(path)
+        complete = ONCE_REQUIRED.issubset(_once_served)
+    if complete:
+        schedule_shutdown(post_save=False)
+
+
 class FleetHandler(BaseHTTPRequestHandler):
     def log_message(self, fmt, *args):
         pass  # suppress default access log
@@ -224,12 +249,10 @@ class FleetHandler(BaseHTTPRequestHandler):
             self.send_json(401, {"error": "unauthorized"})
         elif path == "/api/repos":
             self._handle_repos()
-            if ONCE:
-                schedule_shutdown(post_save=False)
+            once_served(path)
         elif path == "/api/config":
             self._handle_config_get()
-            if ONCE:
-                schedule_shutdown(post_save=False)
+            once_served(path)
         else:
             self.send_json(404, {"error": "not_found"})
 
@@ -259,8 +282,6 @@ class FleetHandler(BaseHTTPRequestHandler):
             self.wfile.write(body)
         else:
             self.send_json(404, {"error": "gui_html_not_found", "path": GUI_HTML})
-        if ONCE:
-            schedule_shutdown(post_save=False)
 
     def _handle_repos(self):
         try:

--- a/skills/autospec-fleet/scripts/fleet-gui.sh
+++ b/skills/autospec-fleet/scripts/fleet-gui.sh
@@ -7,7 +7,8 @@
 # Flags:
 #   --no-browser   Do not open the system browser; just start the server.
 #   --print-url    Print the URL (with token) to stdout before entering server loop.
-#   --once         Smoke-test mode: verify setup and exit 0 without serving.
+#   --once         Smoke-test mode: start the server, self-issue one GET to
+#                  /api/repos and /api/config, assert both return 200, exit 0.
 #
 # Environment:
 #   AUTOSPEC_GUI_IDLE_SECS   Idle timeout in seconds (default 900 = 15 min).
@@ -82,6 +83,88 @@ open_browser() {
     fi
 }
 
+# smoke_once <port> <token> <workspace> <gui_html> <lock_file>
+# Launch the server in --once mode, poll until it is accepting connections
+# (bounded readiness wait — no fixed sleeps), then self-issue one authenticated
+# GET to /api/repos and /api/config. Print each endpoint's HTTP status, fail
+# (exit 1) if either is not 200 or the server never came up, and exit 0 on
+# success. The server self-shuts-down once both endpoints have been served; this
+# function reaps it. Returns 0 only when the live HTTP surface answered both.
+smoke_once() {
+    local s_port="$1" s_token="$2" s_workspace="$3" s_gui_html="$4" s_lock="$5"
+
+    python3 "$SERVER_PY" \
+        "$s_port" "$s_token" "$s_workspace" "$s_gui_html" "$s_lock" "1" "$IDLE_SECS" &
+    local server_pid=$!
+
+    local rc=0
+    python3 - "$s_port" "$s_token" "$server_pid" <<'PY' || rc=$?
+import sys, time, socket
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError, URLError
+
+port = int(sys.argv[1])
+token = sys.argv[2]
+
+# Bounded readiness poll: wait up to ~10s for the server to accept connections.
+deadline = time.time() + 10.0
+ready = False
+while time.time() < deadline:
+    sk = socket.socket()
+    sk.settimeout(0.3)
+    try:
+        sk.connect(("127.0.0.1", port))
+        ready = True
+        break
+    except OSError:
+        time.sleep(0.1)
+    finally:
+        sk.close()
+
+if not ready:
+    print("fleet-gui: smoke FAILED — server did not start", file=sys.stderr)
+    sys.exit(1)
+
+def hit(path):
+    url = f"http://127.0.0.1:{port}{path}"
+    req = Request(url, headers={"X-Autospec-Token": token})
+    try:
+        with urlopen(req, timeout=5) as resp:
+            return resp.getcode()
+    except HTTPError as e:
+        return e.code
+    except URLError as e:
+        print(f"fleet-gui: smoke FAILED — {path}: {e}", file=sys.stderr)
+        return 0
+
+ok = True
+for path in ("/api/repos", "/api/config"):
+    code = hit(path)
+    print(f"fleet-gui: smoke {path} -> {code}")
+    if code != 200:
+        ok = False
+
+if not ok:
+    print("fleet-gui: smoke FAILED — endpoint did not return 200", file=sys.stderr)
+    sys.exit(1)
+
+print("fleet-gui: smoke OK — /api/repos and /api/config both 200")
+sys.exit(0)
+PY
+
+    # Reap the server (it self-shuts-down after serving both endpoints; bound the
+    # wait so a hung server cannot block the smoke run).
+    local waited=0
+    while kill -0 "$server_pid" 2>/dev/null && [[ "$waited" -lt 50 ]]; do
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+
+    return "$rc"
+}
+
 main() {
     parse_args "$@"
     require_gh
@@ -97,21 +180,14 @@ main() {
     [[ "$PRINT_URL" -eq 1 ]] && printf '%s\n' "$url"
     [[ "$NO_BROWSER" -eq 0 ]] && open_browser "$url"
 
-    # Smoke-test / --once mode: verify bindable port then exit.
+    # Smoke-test / --once mode: actually start the server, self-issue one GET to
+    # /api/repos and /api/config, assert both return HTTP 200, then exit 0. This
+    # is the documented end-to-end smoke guarantee (spec § Primary smoke test):
+    # it proves the live HTTP surface answers, not merely that the port binds.
+    # The server is launched with the ONCE flag (arg 6 = "1"); it self-shuts-down
+    # once both endpoints have been served.
     if [[ "$ONCE" -eq 1 ]]; then
-        python3 -c "
-import sys, socket
-p = int('${port}')
-s = socket.socket()
-s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-try:
-    s.bind(('127.0.0.1', p))
-    s.close()
-    sys.exit(0)
-except OSError as e:
-    print(f'fleet-gui: port {p} not bindable: {e}', file=sys.stderr)
-    sys.exit(1)
-"
+        smoke_once "$port" "$token" "$workspace" "$gui_html" "$lock_file"
         return
     fi
 

--- a/skills/autospec-fleet/scripts/fleet-gui.sh
+++ b/skills/autospec-fleet/scripts/fleet-gui.sh
@@ -178,7 +178,12 @@ main() {
     url="http://127.0.0.1:${port}/?t=${token}"
 
     [[ "$PRINT_URL" -eq 1 ]] && printf '%s\n' "$url"
-    [[ "$NO_BROWSER" -eq 0 ]] && open_browser "$url"
+    # In --once smoke mode the server is torn down as soon as both endpoints have
+    # been served, so a real browser must NOT be opened: its GUI JS would hit
+    # /api/repos and /api/config first, satisfying the ONCE gate and shutting the
+    # server down before the smoke client issues its own GETs. Smoke mode is
+    # headless by definition.
+    [[ "$NO_BROWSER" -eq 0 && "$ONCE" -eq 0 ]] && open_browser "$url"
 
     # Smoke-test / --once mode: actually start the server, self-issue one GET to
     # /api/repos and /api/config, assert both return HTTP 200, then exit 0. This

--- a/tests/fleet/test_fleet_gui.bats
+++ b/tests/fleet/test_fleet_gui.bats
@@ -722,3 +722,51 @@ EOF
     [ -f "$gh_calls" ]
     grep -q "repo list" "$gh_calls"
 }
+
+# ---------------------------------------------------------------------------
+# Test 9: --once must not open a real browser even without --no-browser (#839)
+#
+# In --once mode the server self-shuts-down once both /api/repos and /api/config
+# have been served. If a real browser were opened, its GUI JS would hit those two
+# endpoints first, satisfying the ONCE gate and tearing the server down before
+# the smoke client issues its own GETs — a flaky premature-shutdown race. So
+# --once must suppress browser opening regardless of --no-browser. This test runs
+# --once WITHOUT --no-browser, stubbing xdg-open/open to record any invocation,
+# and asserts the browser was never opened while the smoke still exits 0.
+#
+# Mutation-verified: gating browser-open on NO_BROWSER alone (dropping the ONCE
+# guard) makes the browser stub fire and this test FAIL.
+# ---------------------------------------------------------------------------
+@test "--once suppresses browser open even without --no-browser (#839)" {
+    local BIN="$TMP/bin"
+    mkdir -p "$BIN"
+    local browser_calls="$TMP/browser-calls.log"
+
+    cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo '[]'
+EOF
+    chmod +x "$BIN/gh"
+
+    # Stub BOTH browser openers to record any invocation. open_browser tries
+    # xdg-open first, then open; either firing means a real browser was launched.
+    for opener in xdg-open open; do
+        cat > "$BIN/$opener" <<EOF
+#!/usr/bin/env bash
+echo "opened \$*" >> "$browser_calls"
+EOF
+        chmod +x "$BIN/$opener"
+    done
+
+    # --once WITHOUT --no-browser. Put the stub BIN first on PATH so the stub
+    # openers win over any real ones.
+    run bash -c "cd '$TMP' && PATH=\"$BIN:\$PATH\" AUTOSPEC_GUI_IDLE_SECS=30 bash '$GUI_SH' --print-url --once 2>&1"
+
+    # Smoke still succeeds end-to-end.
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"/api/repos"*"200"* ]]
+    [[ "$output" == *"/api/config"*"200"* ]]
+
+    # The browser must NOT have been opened in --once mode.
+    [ ! -f "$browser_calls" ]
+}

--- a/tests/fleet/test_fleet_gui.bats
+++ b/tests/fleet/test_fleet_gui.bats
@@ -661,3 +661,64 @@ EOF
     code="$(http_code_of "$resp")"
     [ "$code" = "200" ]
 }
+
+# ---------------------------------------------------------------------------
+# Test 8: --once smoke mode actually starts the server and hits both endpoints (#839)
+#
+# Per spec § Primary smoke test, `fleet-gui.sh --no-browser --print-url --once`
+# must "launch the server, hit /api/repos and /api/config once, exit 0" — an
+# end-to-end guarantee that the HTTP surface is alive. The shipped --once branch
+# previously only re-bound the port to confirm bindability and returned BEFORE
+# exec'ing the server, so the server never started, no request was issued, and
+# the server's own ONCE shutdown handling was unreachable dead code. The
+# documented smoke command proved nothing about the live HTTP surface.
+#
+# This test runs the real launcher in --once mode against a real (stubbed-gh)
+# server over real HTTP and asserts:
+#   - exit 0
+#   - the URL is printed (--print-url)
+#   - BOTH /api/repos and /api/config returned HTTP 200 (the launcher reports
+#     each endpoint's status; the test pins both to 200)
+#   - the gh stub was invoked, proving /api/repos genuinely reached the handler
+#     (which shells out to `gh repo list`) rather than being short-circuited.
+#
+# Mutation-verified: reverting --once to the old port-bindable-only branch (which
+# never starts the server) makes this test FAIL — no smoke line is emitted, the
+# gh stub is never called, and the endpoint statuses are absent. So the test
+# cannot pass unless --once truly boots the server and exercises both endpoints.
+# ---------------------------------------------------------------------------
+@test "--once smoke mode boots the server and hits /api/repos + /api/config (#839)" {
+    # Stub gh so /api/repos returns a real 200 (and so we can prove the route was
+    # actually reached: the handler shells out to `gh repo list`, and this stub
+    # records each invocation to a marker file).
+    local BIN="$TMP/bin"
+    mkdir -p "$BIN"
+    local gh_calls="$TMP/gh-calls.log"
+    cat > "$BIN/gh" <<EOF
+#!/usr/bin/env bash
+echo "called \$*" >> "$gh_calls"
+echo '[]'
+EOF
+    chmod +x "$BIN/gh"
+
+    # Run the launcher in --once smoke mode from within the workspace tmpdir, so
+    # /api/config reads $TMP/autospec-fleet.yml (absent → default skeleton, 200).
+    run bash -c "cd '$TMP' && PATH=\"$BIN:\$PATH\" AUTOSPEC_GUI_IDLE_SECS=30 bash '$GUI_SH' --no-browser --print-url --once 2>&1"
+
+    # Exit 0 — the documented smoke guarantee.
+    [ "$status" -eq 0 ]
+
+    # --print-url must have emitted the tokenized URL.
+    [[ "$output" == *"http://127.0.0.1:"*"/?t="* ]]
+
+    # Both endpoints must have been hit and returned 200. The launcher reports
+    # each endpoint's HTTP status in its smoke output.
+    [[ "$output" == *"/api/repos"*"200"* ]]
+    [[ "$output" == *"/api/config"*"200"* ]]
+
+    # The gh stub must have been invoked at least once, proving /api/repos
+    # genuinely reached the server handler (not short-circuited by a
+    # port-bindable-only branch that never starts the server).
+    [ -f "$gh_calls" ]
+    grep -q "repo list" "$gh_calls"
+}


### PR DESCRIPTION
Closes #839

## Problem
The spec's Primary smoke test (`fleet-gui.sh --no-browser --print-url --once`) is documented to "launch the server, hit /api/repos and /api/config once, exit 0". But the shipped `--once` branch only re-bound the port to confirm bindability then `return`ed BEFORE `exec python3 $SERVER_PY`. So in `--once` mode the server never started, no HTTP request was issued, and the server's own ONCE handling was unreachable dead code. The documented smoke command proved nothing about the live HTTP surface.

## Fix (option a — restore the documented end-to-end guarantee)
- `fleet-gui.sh` `--once` now launches the server with the ONCE flag set, polls for readiness (bounded, no fixed sleeps), self-issues one authenticated GET to `/api/repos` and `/api/config`, asserts both return 200, prints each status, and exits 0. Exits non-zero if the server fails to start or either endpoint is not 200.
- `fleet-gui-server.py`: ONCE shutdown now fires only after BOTH required endpoints have been served (`ONCE_REQUIRED` gate), so the smoke run is deterministic (no race where shutdown after the first hit tears the server down before the second request) and the ONCE branches are genuinely reachable.

## Test
- New bats test runs the real launcher in `--once` mode over real HTTP (real server, stubbed `gh`), asserting exit 0, the printed URL, both endpoints 200, and that the `gh repo list` handler was actually reached.
- Mutation-verified: reverting `--once` to the old port-bindable-only branch makes the test FAIL; the real implementation makes it PASS. Full fleet suite: 8/8 green.

## Docs
Updated the spec CLI flag table, README flag table, and the launcher header comment — they previously said "verify setup (port bindable)", contradicting the spec's own Primary smoke test. Now all describe the implemented end-to-end behavior.