### PR TITLE
feat(listen): refine/optimize→autospec-refine, context-gated run→autospec-run, + combined refine-and-run shorthand

### DIFF
--- a/scripts/listener-match.sh
+++ b/scripts/listener-match.sh
@@ -141,11 +141,15 @@ EOF
 # Emit the classifier JSON object. All fields always present.
 emit_classify_json() {
     # $1=match(true|false) $2=skill $3=trigger $4=intent $5=confidence $6=autonomous(true|false, optional)
+    # $7=chain(skill|empty) $8=gate(string|empty)
     match="$1"; skill="$2"; trigger="$3"; intent="$4"; conf="$5"; autonomous="${6:-false}"
+    chain="${7:-}"; gate="${8:-}"
     skill_json="null"; [ -n "$skill" ] && skill_json="\"$skill\""
     trigger_json="null"; [ -n "$trigger" ] && trigger_json="\"$trigger\""
-    printf '{"match":%s,"skill":%s,"trigger":%s,"intent":"%s","confidence":%s,"autonomous":%s}\n' \
-        "$match" "$skill_json" "$trigger_json" "$intent" "$conf" "$autonomous"
+    chain_json="null"; [ -n "$chain" ] && chain_json="\"$chain\""
+    gate_json="null"; [ -n "$gate" ] && gate_json="\"$gate\""
+    printf '{"match":%s,"skill":%s,"trigger":%s,"intent":"%s","confidence":%s,"autonomous":%s,"chain":%s,"gate":%s}\n' \
+        "$match" "$skill_json" "$trigger_json" "$intent" "$conf" "$autonomous" "$chain_json" "$gate_json"
 }
 
 # Autonomous-phrase detection (issue #662): scan the lowercased text for
@@ -267,7 +271,86 @@ EOF
     fi
 
     # Verb → skill map (D3). Order matters: most specific first.
-    skill=""; trigger=""
+    skill=""; trigger=""; chain=""; gate=""
+
+    # ── 1. Combined refine+run (most specific) ──────────────────────────────
+    # Phrases that mean "refine then also run the pipeline". Matched before
+    # bare refine/run so the combined semantics win.
+    _is_combined=0
+    for _combo in "refine and run" "refine then run" "refine & run" \
+                  "optimize and run" "optimize then run" "polish and run" \
+                  "tune up" "tune it up" "tune things up"; do
+        case "$text_lc" in
+            *"$_combo"*) _is_combined=1; break ;;
+        esac
+    done
+    if [ "$_is_combined" -eq 1 ]; then
+        if is_imperative "$text_lc"; then
+            emit_classify_json true autospec-refine refine-and-run imperative 0.8 "$is_auto" autospec-run ""
+        else
+            emit_classify_json false autospec-refine refine-and-run incidental 0.2 false "" ""
+        fi
+        return 0
+    fi
+
+    # ── 2. Run — scoped phrases (unconditional, no gate) ────────────────────
+    # Explicit "run <autospec-object>" phrases that unambiguously mean the
+    # autospec-run pipeline; no context gate required.
+    _is_run_scoped=0
+    for _scoped in "run autospec" "run the loop" "run the queue" "run the batch" \
+                   "run the pipeline" "run it" "run them" "drain the queue"; do
+        case "$text_lc" in
+            *"$_scoped"*) _is_run_scoped=1; break ;;
+        esac
+    done
+    if [ "$_is_run_scoped" -eq 1 ]; then
+        if is_imperative "$text_lc"; then
+            emit_classify_json true autospec-run run imperative 0.8 "$is_auto" "" ""
+        else
+            emit_classify_json false autospec-run run incidental 0.2 false "" ""
+        fi
+        return 0
+    fi
+
+    # ── 3. Run — bare (context-gated) ───────────────────────────────────────
+    # A bare "run" that is NOT followed by a non-autospec object. Requires the
+    # auto-implement-open gate: only route if open auto-implement issues exist.
+    # Gerund "running" and suppressed objects fall through.
+    if has_word "$text_lc" "run"; then
+        # Gerund suppressor: "running" as a word.
+        _is_gerund=0
+        case "$text_lc" in
+            *"running"*) _is_gerund=1 ;;
+        esac
+
+        # Suppressed objects: "run <non-autospec-thing>".
+        _is_suppressed=0
+        for _obj in "run the test" "run the tests" "run the suite" \
+                    "run the build" "run the builds" \
+                    "run the script" "run the scripts" \
+                    "run the server" "run the dev server" \
+                    "run the app" "run lint" "run the linter" \
+                    "run ci" "run the ci" \
+                    "run the benchmark" "run the benchmarks" \
+                    "run the migration" "run the migrations" \
+                    "run the demo" "run the command" "run the commands"; do
+            case "$text_lc" in
+                *"$_obj"*) _is_suppressed=1; break ;;
+            esac
+        done
+
+        if [ "$_is_gerund" -eq 0 ] && [ "$_is_suppressed" -eq 0 ]; then
+            if is_imperative "$text_lc"; then
+                emit_classify_json true autospec-run run imperative 0.7 "$is_auto" "" auto-implement-open
+            else
+                emit_classify_json false autospec-run run incidental 0.2 false "" ""
+            fi
+            return 0
+        fi
+        # Suppressed / gerund: fall through to remaining verbs.
+    fi
+
+    # Existing branches (preserved in order).
     if has_word "$text_lc" "autospec"; then
         skill="autospec"; trigger="autospec"
     elif has_word "$text_lc" "implement" || has_word "$text_lc" "build" \
@@ -276,6 +359,18 @@ EOF
         if has_word "$text_lc" "implement"; then trigger="implement"
         elif has_word "$text_lc" "build"; then trigger="build"
         else trigger="ship"; fi
+    # ── 4. Refine words ─────────────────────────────────────────────────────
+    # After implement/build/ship so those more-specific verbs take precedence;
+    # before design/spec so refine doesn't shadow them.
+    elif has_word "$text_lc" "refine" || has_word "$text_lc" "optimize" \
+        || has_word "$text_lc" "polish" || has_word "$text_lc" "improve" \
+        || has_word "$text_lc" "tune"; then
+        skill="autospec-refine"
+        if has_word "$text_lc" "refine"; then trigger="refine"
+        elif has_word "$text_lc" "optimize"; then trigger="optimize"
+        elif has_word "$text_lc" "polish"; then trigger="polish"
+        elif has_word "$text_lc" "improve"; then trigger="improve"
+        else trigger="tune"; fi
     elif has_word "$text_lc" "design" || has_word "$text_lc" "redesign" \
         || has_word "$text_lc" "new feature" \
         || (has_word "$text_lc" "spec" && ! has_word "$text_lc" "specification"); then
@@ -293,18 +388,18 @@ EOF
     # so the operator gets the end-to-end pipeline.
     if [ -z "$skill" ]; then
         if [ "$is_auto" = "true" ] && is_imperative "$text_lc"; then
-            emit_classify_json true autospec autospec imperative 0.6 true
+            emit_classify_json true autospec autospec imperative 0.6 true "" ""
         else
-            emit_classify_json false "" "" none 0 false
+            emit_classify_json false "" "" none 0 false "" ""
         fi
         return 0
     fi
 
     # A verb matched — apply the intent gate.
     if is_imperative "$text_lc"; then
-        emit_classify_json true "$skill" "$trigger" imperative 0.8 "$is_auto"
+        emit_classify_json true "$skill" "$trigger" imperative 0.8 "$is_auto" "$chain" "$gate"
     else
-        emit_classify_json false "$skill" "$trigger" incidental 0.2 false
+        emit_classify_json false "$skill" "$trigger" incidental 0.2 false "$chain" "$gate"
     fi
 }
 

--- a/scripts/listener-match.sh
+++ b/scripts/listener-match.sh
@@ -339,7 +339,16 @@ EOF
             esac
         done
 
-        if [ "$_is_gerund" -eq 0 ] && [ "$_is_suppressed" -eq 0 ]; then
+        # Suppressed "run the <non-autospec-object>" (e.g. "run the build",
+        # "run the tests"): the user means that object, not autospec. Emit a
+        # clean no-match and return so an embedded build/ship/implement word in
+        # the object cannot re-trigger autospec-run in the verb map below.
+        if [ "$_is_suppressed" -eq 1 ]; then
+            emit_classify_json false "" "" none 0 false "" ""
+            return 0
+        fi
+
+        if [ "$_is_gerund" -eq 0 ]; then
             if is_imperative "$text_lc"; then
                 emit_classify_json true autospec-run run imperative 0.7 "$is_auto" "" auto-implement-open
             else
@@ -347,7 +356,7 @@ EOF
             fi
             return 0
         fi
-        # Suppressed / gerund: fall through to remaining verbs.
+        # Gerund ("running"): fall through to remaining verbs.
     fi
 
     # Existing branches (preserved in order).

--- a/skills/autospec-listen/SKILL.md
+++ b/skills/autospec-listen/SKILL.md
@@ -101,7 +101,11 @@ Beyond the explicit issue/spec triggers, this listener routes common build/chang
 bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/listener-match.sh" --classify "<user message>"
 ```
 
-It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidental|none","confidence":0-1}`. The gate is biased to false-negatives: descriptive ("the design is nice"), past-tense ("I reviewed it"), negated ("don't implement yet"), and interrogative ("should we redesign?") uses return `match:false` and MUST NOT route. Prefer no route over a misfire.
+It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidental|none","confidence":0-1,"autonomous":bool,"chain":<skill|null>,"gate":<string|null>}`. The gate is biased to false-negatives: descriptive ("the design is nice"), past-tense ("I reviewed it"), negated ("don't implement yet"), and interrogative ("should we redesign?") uses return `match:false` and MUST NOT route. Prefer no route over a misfire.
+
+The two new trailing fields:
+- `chain` — after the primary skill completes, invoke the chained skill (e.g. `/autospec-run` after `/autospec-refine`). Null when no chain applies.
+- `gate` — before routing, the listener must satisfy the named context gate; `auto-implement-open` means run `gh issue list --repo <repo> --label auto-implement --state open --json number --jq 'length'` and route only if > 0, else stay in plain mode. Null means no gate.
 
 **Verb → skill map (D3).**
 
@@ -109,6 +113,9 @@ It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidenta
 |----------------------------------|-----------|
 | `design` / `new feature` / `spec` | `/autospec-define` |
 | `implement` / `build` / `ship` | `/autospec-run` (or `/autospec` end-to-end when no issues exist yet) |
+| `refine` / `optimize` / `polish` / `improve` / `tune` | `/autospec-refine` |
+| `run` (scoped: "run it", "run the loop", "run autospec"; bare "run" only when open `auto-implement` issues exist) | `/autospec-run` |
+| `refine and run` / `tune up` (combined) | `/autospec-refine` then `/autospec-run` |
 | `review` | `/autospec-review` |
 | `autospec …` | the umbrella `/autospec` |
 
@@ -117,6 +124,8 @@ It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidenta
 ```
 Routing to /<skill> — say "plain" to opt out.
 ```
+
+If `gate` is non-null, perform the gate check first and skip routing (plain mode) if unmet. If `chain` is non-null, after the mapped skill completes, invoke the chained skill (printing one opt-out line as usual).
 
 On a non-match or `intent:incidental`/`none`, do nothing — the session proceeds normally in plain mode.
 

--- a/skills/autospec-listen/codex/prompt.md
+++ b/skills/autospec-listen/codex/prompt.md
@@ -96,7 +96,11 @@ Beyond the explicit issue/spec triggers, this listener routes common build/chang
 bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/listener-match.sh" --classify "<user message>"
 ```
 
-It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidental|none","confidence":0-1}`. The gate is biased to false-negatives: descriptive ("the design is nice"), past-tense ("I reviewed it"), negated ("don't implement yet"), and interrogative ("should we redesign?") uses return `match:false` and MUST NOT route. Prefer no route over a misfire.
+It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidental|none","confidence":0-1,"autonomous":bool,"chain":<skill|null>,"gate":<string|null>}`. The gate is biased to false-negatives: descriptive ("the design is nice"), past-tense ("I reviewed it"), negated ("don't implement yet"), and interrogative ("should we redesign?") uses return `match:false` and MUST NOT route. Prefer no route over a misfire.
+
+The two new trailing fields:
+- `chain` — after the primary skill completes, invoke the chained skill (e.g. `/autospec-run` after `/autospec-refine`). Null when no chain applies.
+- `gate` — before routing, the listener must satisfy the named context gate; `auto-implement-open` means run `gh issue list --repo <repo> --label auto-implement --state open --json number --jq 'length'` and route only if > 0, else stay in plain mode. Null means no gate.
 
 **Verb → skill map (D3).**
 
@@ -104,6 +108,9 @@ It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidenta
 |----------------------------------|-----------|
 | `design` / `new feature` / `spec` | `/autospec-define` |
 | `implement` / `build` / `ship` | `/autospec-run` (or `/autospec` end-to-end when no issues exist yet) |
+| `refine` / `optimize` / `polish` / `improve` / `tune` | `/autospec-refine` |
+| `run` (scoped: "run it", "run the loop", "run autospec"; bare "run" only when open `auto-implement` issues exist) | `/autospec-run` |
+| `refine and run` / `tune up` (combined) | `/autospec-refine` then `/autospec-run` |
 | `review` | `/autospec-review` |
 | `autospec …` | the umbrella `/autospec` |
 
@@ -112,6 +119,8 @@ It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidenta
 ```
 Routing to /<skill> — say "plain" to opt out.
 ```
+
+If `gate` is non-null, perform the gate check first and skip routing (plain mode) if unmet. If `chain` is non-null, after the mapped skill completes, invoke the chained skill (printing one opt-out line as usual).
 
 On a non-match or `intent:incidental`/`none`, do nothing — the session proceeds normally in plain mode.
 

--- a/skills/autospec-listen/opencode/agent.md
+++ b/skills/autospec-listen/opencode/agent.md
@@ -100,7 +100,11 @@ Beyond the explicit issue/spec triggers, this listener routes common build/chang
 bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/listener-match.sh" --classify "<user message>"
 ```
 
-It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidental|none","confidence":0-1}`. The gate is biased to false-negatives: descriptive ("the design is nice"), past-tense ("I reviewed it"), negated ("don't implement yet"), and interrogative ("should we redesign?") uses return `match:false` and MUST NOT route. Prefer no route over a misfire.
+It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidental|none","confidence":0-1,"autonomous":bool,"chain":<skill|null>,"gate":<string|null>}`. The gate is biased to false-negatives: descriptive ("the design is nice"), past-tense ("I reviewed it"), negated ("don't implement yet"), and interrogative ("should we redesign?") uses return `match:false` and MUST NOT route. Prefer no route over a misfire.
+
+The two new trailing fields:
+- `chain` — after the primary skill completes, invoke the chained skill (e.g. `/autospec-run` after `/autospec-refine`). Null when no chain applies.
+- `gate` — before routing, the listener must satisfy the named context gate; `auto-implement-open` means run `gh issue list --repo <repo> --label auto-implement --state open --json number --jq 'length'` and route only if > 0, else stay in plain mode. Null means no gate.
 
 **Verb → skill map (D3).**
 
@@ -108,6 +112,9 @@ It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidenta
 |----------------------------------|-----------|
 | `design` / `new feature` / `spec` | `/autospec-define` |
 | `implement` / `build` / `ship` | `/autospec-run` (or `/autospec` end-to-end when no issues exist yet) |
+| `refine` / `optimize` / `polish` / `improve` / `tune` | `/autospec-refine` |
+| `run` (scoped: "run it", "run the loop", "run autospec"; bare "run" only when open `auto-implement` issues exist) | `/autospec-run` |
+| `refine and run` / `tune up` (combined) | `/autospec-refine` then `/autospec-run` |
 | `review` | `/autospec-review` |
 | `autospec …` | the umbrella `/autospec` |
 
@@ -116,6 +123,8 @@ It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidenta
 ```
 Routing to /<skill> — say "plain" to opt out.
 ```
+
+If `gate` is non-null, perform the gate check first and skip routing (plain mode) if unmet. If `chain` is non-null, after the mapped skill completes, invoke the chained skill (printing one opt-out line as usual).
 
 On a non-match or `intent:incidental`/`none`, do nothing — the session proceeds normally in plain mode.
 

--- a/tests/unit/test_listener_classify.bats
+++ b/tests/unit/test_listener_classify.bats
@@ -105,25 +105,21 @@ setup() {
 
 # ── Suppressed run-objects: must NOT be autospec-run ─────────────────────────
 
-@test "classify: 'run the tests' → NOT autospec-run" {
+@test "classify: 'run the tests' → clean no-match (match:false, skill:null)" {
     run "$MATCH" --classify "run the tests"
     [ "$status" -eq 0 ]
-    skill="$(printf '%s' "$output" | jq -r .skill)"
-    [ "$skill" != "autospec-run" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "null" ]
 }
 
-@test "classify: 'run the build' → not routed to autospec-run (match:false or skill differs)" {
+@test "classify: 'run the build' → clean no-match (embedded 'build' must not leak autospec-run)" {
     run "$MATCH" --classify "run the build"
     [ "$status" -eq 0 ]
-    # Either no match, or the skill is not autospec-run via run-branch routing.
-    match_val="$(printf '%s' "$output" | jq -r .match)"
-    skill="$(printf '%s' "$output" | jq -r .skill)"
-    # At least one of: match is false, or the skill is something other than
-    # autospec-run being routed by the run-scoped/bare branch.
-    # We verify the *build* route (not autospec-run via run-path) by checking
-    # the trigger is not "run".
-    trigger="$(printf '%s' "$output" | jq -r .trigger)"
-    [ "$match_val" = "false" ] || [ "$trigger" != "run" ]
+    # Regression: a suppressed "run the <object>" must be a clean no-match —
+    # the embedded 'build' verb must NOT re-trigger autospec-run as stale
+    # metadata. match:false AND skill:null.
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "null" ]
 }
 
 @test "classify: 'run lint' → NOT autospec-run" {

--- a/tests/unit/test_listener_classify.bats
+++ b/tests/unit/test_listener_classify.bats
@@ -1,0 +1,232 @@
+#!/usr/bin/env bats
+# tests/unit/test_listener_classify.bats — classify-mode tests for
+# scripts/listener-match.sh --classify, covering the new verbs added in
+# issue #852: refine/optimize/polish/improve/tune → autospec-refine,
+# run (scoped and bare) → autospec-run, and combined refine+run → chain.
+#
+# Style follows tests/unit/test_listener_keywords.bats:
+#   setup() resolves REPO_ROOT + MATCH
+#   run "$MATCH" --classify "<phrase>"
+#   assert with jq
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    MATCH="$REPO_ROOT/scripts/listener-match.sh"
+}
+
+# ── Positive: refine verbs → autospec-refine ─────────────────────────────────
+
+@test "classify: 'optimize the fleet config' → autospec-refine" {
+    run "$MATCH" --classify "optimize the fleet config"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-refine" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+}
+
+@test "classify: 'refine the prompt' → autospec-refine" {
+    run "$MATCH" --classify "refine the prompt"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-refine" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+}
+
+@test "classify: 'polish it up' → autospec-refine" {
+    run "$MATCH" --classify "polish it up"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-refine" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+}
+
+@test "classify: 'tune the prompt' → autospec-refine" {
+    run "$MATCH" --classify "tune the prompt"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-refine" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+}
+
+@test "classify: 'improve the launcher' → autospec-refine" {
+    run "$MATCH" --classify "improve the launcher"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-refine" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+}
+
+# ── Positive: run (scoped phrases) → autospec-run, gate=null ─────────────────
+
+@test "classify: 'run it' → autospec-run, gate null" {
+    run "$MATCH" --classify "run it"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-run" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "null" ]
+}
+
+@test "classify: 'run autospec' → autospec-run, gate null" {
+    run "$MATCH" --classify "run autospec"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-run" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "null" ]
+}
+
+@test "classify: 'run the loop' → autospec-run, gate null" {
+    run "$MATCH" --classify "run the loop"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-run" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "null" ]
+}
+
+@test "classify: 'drain the queue' → autospec-run, gate null" {
+    run "$MATCH" --classify "drain the queue"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-run" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "null" ]
+}
+
+# ── Positive: run (bare, context-gated) → autospec-run, gate=auto-implement-open
+
+@test "classify: 'run' → autospec-run, gate=auto-implement-open" {
+    run "$MATCH" --classify "run"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-run" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "auto-implement-open" ]
+}
+
+@test "classify: 'please run' → autospec-run, gate=auto-implement-open" {
+    run "$MATCH" --classify "please run"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-run" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "auto-implement-open" ]
+}
+
+# ── Suppressed run-objects: must NOT be autospec-run ─────────────────────────
+
+@test "classify: 'run the tests' → NOT autospec-run" {
+    run "$MATCH" --classify "run the tests"
+    [ "$status" -eq 0 ]
+    skill="$(printf '%s' "$output" | jq -r .skill)"
+    [ "$skill" != "autospec-run" ]
+}
+
+@test "classify: 'run the build' → not routed to autospec-run (match:false or skill differs)" {
+    run "$MATCH" --classify "run the build"
+    [ "$status" -eq 0 ]
+    # Either no match, or the skill is not autospec-run via run-branch routing.
+    match_val="$(printf '%s' "$output" | jq -r .match)"
+    skill="$(printf '%s' "$output" | jq -r .skill)"
+    # At least one of: match is false, or the skill is something other than
+    # autospec-run being routed by the run-scoped/bare branch.
+    # We verify the *build* route (not autospec-run via run-path) by checking
+    # the trigger is not "run".
+    trigger="$(printf '%s' "$output" | jq -r .trigger)"
+    [ "$match_val" = "false" ] || [ "$trigger" != "run" ]
+}
+
+@test "classify: 'run lint' → NOT autospec-run" {
+    run "$MATCH" --classify "run lint"
+    [ "$status" -eq 0 ]
+    skill="$(printf '%s' "$output" | jq -r .skill)"
+    [ "$skill" != "autospec-run" ]
+}
+
+@test "classify: 'run the server' → NOT autospec-run" {
+    run "$MATCH" --classify "run the server"
+    [ "$status" -eq 0 ]
+    skill="$(printf '%s' "$output" | jq -r .skill)"
+    [ "$skill" != "autospec-run" ]
+}
+
+@test "classify: 'run the dev server' → NOT autospec-run" {
+    run "$MATCH" --classify "run the dev server"
+    [ "$status" -eq 0 ]
+    skill="$(printf '%s' "$output" | jq -r .skill)"
+    [ "$skill" != "autospec-run" ]
+}
+
+@test "classify: 'run the migrations' → NOT autospec-run" {
+    run "$MATCH" --classify "run the migrations"
+    [ "$status" -eq 0 ]
+    skill="$(printf '%s' "$output" | jq -r .skill)"
+    [ "$skill" != "autospec-run" ]
+}
+
+# ── Combined refine+run → skill=autospec-refine, chain=autospec-run ──────────
+
+@test "classify: 'refine and run the queue' → autospec-refine, chain=autospec-run" {
+    run "$MATCH" --classify "refine and run the queue"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-refine" ]
+    [ "$(printf '%s' "$output" | jq -r .chain)" = "autospec-run" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+}
+
+@test "classify: 'tune it up' → autospec-refine, chain=autospec-run" {
+    run "$MATCH" --classify "tune it up"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-refine" ]
+    [ "$(printf '%s' "$output" | jq -r .chain)" = "autospec-run" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+}
+
+@test "classify: 'optimize and run' → autospec-refine, chain=autospec-run" {
+    run "$MATCH" --classify "optimize and run"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-refine" ]
+    [ "$(printf '%s' "$output" | jq -r .chain)" = "autospec-run" ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+}
+
+# ── Negatives via intent gate ─────────────────────────────────────────────────
+
+@test "classify: 'I optimized it already' (past tense) → match:false" {
+    run "$MATCH" --classify "I optimized it already"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'should we refine?' (question) → match:false" {
+    run "$MATCH" --classify "should we refine?"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: \"don't run it\" (negation) → match:false" {
+    run "$MATCH" --classify "don't run it"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'the optimization is done' (descriptive/past) → match:false" {
+    run "$MATCH" --classify "the optimization is done"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+# ── New JSON fields present (chain / gate always emitted) ─────────────────────
+
+@test "classify: existing verb 'implement X' → chain and gate fields present" {
+    run "$MATCH" --classify "implement the auth module"
+    [ "$status" -eq 0 ]
+    # Both new fields must be present (null or string).
+    printf '%s' "$output" | jq -e 'has("chain")' >/dev/null
+    printf '%s' "$output" | jq -e 'has("gate")' >/dev/null
+}
+
+@test "classify: no-match phrase → chain and gate fields present and null" {
+    run "$MATCH" --classify "hello world"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .chain)" = "null" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "null" ]
+}
+
+# ── Refine verb: chain=null when no combined phrase ───────────────────────────
+
+@test "classify: 'refine the prompt' → chain=null (no combined trigger)" {
+    run "$MATCH" --classify "refine the prompt"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .chain)" = "null" ]
+}


### PR DESCRIPTION
Closes #852

## Summary

- **`refine/optimize/polish/improve/tune` → `/autospec-refine`**: New branch in `classify_phrase` (placed after `implement/build/ship`, before `design/spec`) routes these five verbs to `autospec-refine` with confidence 0.8, intent-gated.
- **`run` (scoped, no gate)**: Explicit phrases like `run it`, `run the loop`, `run autospec`, `drain the queue` route to `autospec-run` unconditionally (gate=null).
- **`run` (bare, context-gated)**: A bare `run` not followed by a suppressed non-autospec object routes to `autospec-run` with `gate=auto-implement-open` (confidence 0.7). Suppressed objects: tests, build, lint, server, ci, migrations, etc. Gerund `running` is also suppressed.
- **Combined `refine-and-run`**: Phrases like `refine and run`, `tune it up`, `optimize and run`, `polish and run`, `tune up` → `skill=autospec-refine`, `trigger=refine-and-run`, `chain=autospec-run`.
- **`emit_classify_json` extended**: Two new trailing fields `chain` (skill to invoke after primary completes) and `gate` (context gate name or null) are always emitted; back-compat preserved (existing callers see null for both fields).
- **Lockstep trio updated** (byte-identical in `SKILL.md`, `opencode/agent.md`, `codex/prompt.md`): D3 verb→skill table gains the new rows; classifier output description documents `chain`/`gate`; auto-route behavior documents gate check and chain invocation.

## Test plan

- [x] TDD: `tests/unit/test_listener_classify.bats` written first (27 tests), confirmed red, then implementation made them green
- [x] All 27 new classify tests pass
- [x] All 39 existing `tests/unit/test_listener_keywords.bats` tests pass (no regressions)
- [x] `tests/unit/test_install_listener.bats` (7 tests) pass
- [x] `bash -n scripts/listener-match.sh` — syntax clean
- [x] Lockstep check: `diff <(strip_body SKILL.md) codex/prompt.md` and `diff <(strip_body SKILL.md) <(strip_body opencode/agent.md)` both pass
- [x] `validate.sh` keyword-routing section check passes; no FAILs in full validate.sh run (terminated at timeout, not failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)