### PR TITLE
fix(auth): use hmac.compare_digest for constant-time token comparison (#843)

### DIFF
--- a/skills/autospec-fleet/scripts/fleet-gui-server.py
+++ b/skills/autospec-fleet/scripts/fleet-gui-server.py
@@ -13,6 +13,7 @@ import threading
 import time
 import tempfile
 import fcntl
+import hmac
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
 
@@ -199,11 +200,14 @@ def dump_yaml_config(data):
 
 
 def auth_ok(handler):
-    """Return True if the request carries the correct URL token."""
-    if handler.headers.get("X-Autospec-Token", "") == TOKEN:
+    """Return True if the request carries the correct URL token.
+
+    Both comparisons use hmac.compare_digest to avoid timing side-channels.
+    """
+    if hmac.compare_digest(handler.headers.get("X-Autospec-Token", ""), TOKEN):
         return True
     qs = parse_qs(urlparse(handler.path).query)
-    return qs.get("t", [""])[0] == TOKEN
+    return hmac.compare_digest(qs.get("t", [""])[0], TOKEN)
 
 
 def schedule_shutdown(post_save=False):

--- a/tests/fleet/test_fleet_gui.bats
+++ b/tests/fleet/test_fleet_gui.bats
@@ -916,3 +916,66 @@ EOF
     [ "$http_code" = "200" ]
     echo "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d.get('warning')=='yaml_partial', d"
 }
+
+# ---------------------------------------------------------------------------
+# Test 14: auth_ok uses hmac.compare_digest — constant-time token comparison (#843)
+#
+# Token comparison with == is theoretically timing-observable; hmac.compare_digest
+# provides a constant-time alternative. The fix: replace both == TOKEN comparisons
+# in auth_ok with hmac.compare_digest(candidate, TOKEN).
+#
+# This test has two parts:
+#   1. Static: auth_ok in fleet-gui-server.py must use hmac.compare_digest (grep).
+#      This FAILS on the unfixed server (where == TOKEN is used) and PASSES once
+#      the fix is applied — it is the primary "failing test first" gate.
+#   2. Functional: the server must still correctly accept the right token (200)
+#      and reject a wrong token (401), confirming the replacement did not break
+#      auth semantics.
+#
+# Mutation-verified: reverting hmac.compare_digest back to == TOKEN causes the
+# grep assertion to fail; changing hmac.compare_digest to always return True causes
+# the wrong-token 401 assertion to fail.
+# ---------------------------------------------------------------------------
+@test "auth_ok uses hmac.compare_digest for constant-time token comparison (#843)" {
+    # --- Part 1: static check — source must use hmac.compare_digest in auth_ok ---
+    # grep for hmac.compare_digest in the server source; fails on unfixed code.
+    grep -q "hmac.compare_digest" "$SERVER_PY"
+
+    # --- Part 2: functional — correct token allows, wrong token blocks ----------
+    local port
+    port="$(pick_free_port)"
+
+    local BIN="$TMP/bin"
+    mkdir -p "$BIN"
+    cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo '[]'
+EOF
+    chmod +x "$BIN/gh"
+
+    PATH="$BIN:$PATH" start_server "$port"
+
+    local resp code
+
+    # Correct token via header → 200
+    resp="$(curl -s -w '\n%{http_code}' \
+        -H "X-Autospec-Token: $TOKEN" \
+        "http://127.0.0.1:${port}/api/config")"
+    code="$(http_code_of "$resp")"
+    [ "$code" = "200" ]
+
+    # Correct token via ?t= query param → 200
+    resp="$(raw_get "$port" "/api/config?t=$TOKEN")"
+    code="$(http_code_of "$resp")"
+    [ "$code" = "200" ]
+
+    # Wrong token via header → 401
+    resp="$(raw_get "$port" "/api/config" "wrong-token")"
+    code="$(http_code_of "$resp")"
+    [ "$code" = "401" ]
+
+    # Wrong token via ?t= query param → 401
+    resp="$(raw_get "$port" "/api/config?t=wrong-token")"
+    code="$(http_code_of "$resp")"
+    [ "$code" = "401" ]
+}


### PR DESCRIPTION
Closes #843

## Summary

Replace `== TOKEN` with `hmac.compare_digest(candidate, TOKEN)` in `auth_ok` (fleet-gui-server.py) for both the `X-Autospec-Token` header path and the `?t=` query-param path, eliminating theoretical timing side-channels on token comparisons.

Import `hmac` from stdlib (no new dependencies).

## Test

Added test 14 to `tests/fleet/test_fleet_gui.bats`:
- **Static gate**: `grep -q "hmac.compare_digest"` in the server source — fails on unfixed code, passes once fixed.
- **Functional**: verifies correct token (header + query param) yields 200 and wrong token yields 401.
- Mutation-verified: reverting to `== TOKEN` fails the grep; wiring `compare_digest` to `return True` fails the 401 assertion.

All 14 tests pass.