### PR TITLE
fix(repos): guard json.loads on gh stdout, return 503 gh_bad_output (#844)

### DIFF
--- a/skills/autospec-fleet/scripts/fleet-gui-server.py
+++ b/skills/autospec-fleet/scripts/fleet-gui-server.py
@@ -304,7 +304,11 @@ class FleetHandler(BaseHTTPRequestHandler):
         if result.returncode != 0:
             self._repos_error(result.stderr.strip())
             return
-        repos = json.loads(result.stdout or "[]")
+        try:
+            repos = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError:
+            self.send_json(503, {"error": "gh_bad_output"})
+            return
         repos.sort(key=lambda r: r.get("pushedAt", ""), reverse=True)
         self.send_json(200, repos)
 

--- a/tests/fleet/test_fleet_gui.bats
+++ b/tests/fleet/test_fleet_gui.bats
@@ -979,3 +979,51 @@ EOF
     code="$(http_code_of "$resp")"
     [ "$code" = "401" ]
 }
+
+# ---------------------------------------------------------------------------
+# Test 15: gh exits 0 with non-JSON stdout → 503 gh_bad_output (#844)
+#
+# _handle_repos calls json.loads(result.stdout) after checking returncode==0 only.
+# A gh that exits 0 with a non-JSON warning banner or unexpected output causes an
+# unhandled JSONDecodeError that surfaces as a 500 traceback. Fix: wrap json.loads
+# in try/except json.JSONDecodeError and return 503 {"error":"gh_bad_output"}.
+#
+# This test stubs gh to exit 0 with non-JSON stdout and asserts:
+#   - HTTP 503 (not 500)
+#   - body is {"error": "gh_bad_output"}
+#
+# Mutation-verified: removing the try/except and reverting to bare json.loads makes
+# the server return HTTP 500 (unhandled exception), causing the 503 assertion here
+# to fail.
+# ---------------------------------------------------------------------------
+@test "fail-mode: gh exits 0 with non-JSON stdout → 503 gh_bad_output (#844)" {
+    local port
+    port="$(pick_free_port)"
+    local BIN="$TMP/bin"
+    mkdir -p "$BIN"
+
+    # Stub gh: exits 0 but prints a non-JSON warning banner (simulates deprecation
+    # notice, auth banner, or format change that slips past returncode==0 check).
+    cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "Warning: this CLI version is deprecated. Please upgrade."
+exit 0
+EOF
+    chmod +x "$BIN/gh"
+
+    PATH="$BIN:$PATH" start_server "$port"
+
+    local resp http_code body
+    resp="$(curl -s -w '\n%{http_code}' \
+        -H "X-Autospec-Token: $TOKEN" \
+        "http://127.0.0.1:${port}/api/repos")"
+    http_code="$(http_code_of "$resp")"
+    body="$(body_of "$resp")"
+
+    [ "$http_code" = "503" ]
+    echo "$body" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['error'] == 'gh_bad_output', f'expected gh_bad_output, got: {d}'
+"
+}


### PR DESCRIPTION
Closes #844

## Summary

Wrap `json.loads(result.stdout or "[]")` in `_handle_repos` with `try/except json.JSONDecodeError` and return `503 {"error": "gh_bad_output"}` on failure. This mirrors the existing `gh_not_authenticated` / `gh_timeout` / `gh_failed` error responses and prevents an unhandled `JSONDecodeError` from escaping the handler and surfacing as a 500 traceback when `gh` exits 0 with non-JSON output (e.g. a deprecation warning banner).

## Test

Added test 15 to `tests/fleet/test_fleet_gui.bats`:
- Stubs `gh` to exit 0 with a non-JSON warning string
- Asserts HTTP 503 and `{"error": "gh_bad_output"}` body
- Mutation-verified: removing the try/except causes the server to return HTTP 500 (unhandled exception), failing the 503 assertion

All 15 tests pass.