### PR TITLE
fix(docs-drift): exclude tests/** from source set + add fleet-GUI doc-scope (#851)

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -90,8 +90,8 @@ shipped during this run, emits surviving gaps as JSON (`emit-gaps.sh`), and file
 ### `/autospec-fleet`
 
 <!-- autospec-doc-scope:
-  src: ["skills/autospec-fleet/SKILL.md", "skills/autospec-fleet/README.md", "skills/autospec-fleet/scripts/fleet-run.sh", "skills/autospec-fleet/scripts/fleet-status.sh", "skills/autospec-fleet/scripts/fleet-stop.sh"]
-  reason: "User-facing invocation docs for autospec-fleet"
+  src: ["skills/autospec-fleet/SKILL.md", "skills/autospec-fleet/README.md", "skills/autospec-fleet/scripts/**", "skills/autospec-fleet/gui/**"]
+  reason: "User-facing invocation docs for autospec-fleet: CLI scripts, GUI server, and frontend"
   generated: true
 -->
 

--- a/skills/autospec-shared/scripts/check-doc-drift.sh
+++ b/skills/autospec-shared/scripts/check-doc-drift.sh
@@ -161,11 +161,17 @@ fi
 
 # ── Extract changed files from diff ──────────────────────────────────────────
 
-# Changed source files (not docs/) — one per line in a temp file
+# Changed source files (not docs/, not tests/) — one per line in a temp file.
+# tests/** is excluded: test files are internal QA artifacts and never require
+# a corresponding doc-scope annotation.  Including them causes exit 2
+# (missing-scope) on every test-only PR that touches a path not covered by any
+# declared scope — a false signal that degrades the gate without providing real
+# drift information (tests don't document user-facing surfaces).
 grep -E '^\+\+\+ ' "$WORK_DIR/diff.txt" 2>/dev/null \
     | sed 's|^+++ b/||; s|^+++ /dev/null||' \
     | grep -v '^$' \
     | grep -v '^docs/' \
+    | grep -v '^tests/' \
     | sort -u > "$WORK_DIR/changed_source.txt" || true
 
 # Changed doc files — one per line in a temp file

--- a/tests/unit/test_doc_drift_fleet_scope.bats
+++ b/tests/unit/test_doc_drift_fleet_scope.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+# tests/unit/test_doc_drift_fleet_scope.bats
+#
+# Regression tests for issue #851: docs-drift gate false-tripped (exit 2) on
+# PRs touching skills/autospec-fleet/scripts/**, skills/autospec-fleet/gui/**,
+# and tests/fleet/** (or any tests/**).
+#
+# Two fixes ship together:
+#   1. check-doc-drift.sh excludes tests/** from the source set so test-only
+#      diffs never trigger missing-scope (Option b).
+#   2. docs/USER_MANUAL.md has an autospec-doc-scope annotation whose src:
+#      globs cover skills/autospec-fleet/scripts/** and
+#      skills/autospec-fleet/gui/** so fleet-GUI diffs return exit 0/1
+#      (covered) rather than exit 2 (Option a).
+#
+# Each test builds a synthetic diff, runs check-doc-drift.sh against the real
+# docs/ tree, and asserts the expected exit code.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCAN_MJS="$REPO_ROOT/skills/autospec-shared/scripts/scan-doc-scope.mjs"
+    DRIFT_SH="$REPO_ROOT/skills/autospec-shared/scripts/check-doc-drift.sh"
+    WORK="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$WORK"
+}
+
+# Helper: run check-doc-drift.sh against the REAL docs/ tree using a diff file.
+run_drift() {
+    local diff_file="$1"
+    SCAN_DOC_SCOPE_MJS="$SCAN_MJS" \
+    AUTOSPEC_REPO_ROOT="$REPO_ROOT" \
+    AUTOSPEC_DOCS_DIR="$REPO_ROOT/docs" \
+    run bash "$DRIFT_SH" --diff "$diff_file"
+}
+
+# ── Regression A: tests-only diff must NOT return exit 2 ─────────────────────
+#
+# Before the fix: a diff touching only tests/fleet/test_fleet_gui.bats returned
+# exit 2 (missing-scope), falsely blocking the gate signal.  After the fix:
+# tests/** is excluded from the source set, so this diff returns exit 0 (clean,
+# no source files to check).
+#
+# Mutation-verified: removing the tests/ exclusion from check-doc-drift.sh
+# makes this test FAIL (exit 2 instead of exit 0).
+
+@test "tests-only diff (tests/fleet/**) does NOT return exit 2 (#851)" {
+    cat > "$WORK/diff.txt" <<'DIFF'
+diff --git a/tests/fleet/test_fleet_gui.bats b/tests/fleet/test_fleet_gui.bats
+index 0000000..1111111 100644
+--- a/tests/fleet/test_fleet_gui.bats
++++ b/tests/fleet/test_fleet_gui.bats
+@@ -1,3 +1,4 @@
+ #!/usr/bin/env bats
++# regression test added
+ echo hello
+DIFF
+
+    run_drift "$WORK/diff.txt"
+
+    # Must NOT be exit 2 (missing-scope). Exit 0 = clean (no source files to
+    # check); exit 1 = drift found but correctly categorized. Either is fine.
+    [ "$status" -ne 2 ]
+}
+
+@test "tests/** diff returns exit 0 (tests excluded from source set) (#851)" {
+    cat > "$WORK/diff.txt" <<'DIFF'
+diff --git a/tests/unit/test_some_unit.bats b/tests/unit/test_some_unit.bats
+index 0000000..1111111 100644
+--- a/tests/unit/test_some_unit.bats
++++ b/tests/unit/test_some_unit.bats
+@@ -1,3 +1,4 @@
+ #!/usr/bin/env bats
++# new unit test
+ echo hello
+DIFF
+
+    run_drift "$WORK/diff.txt"
+
+    # Tests-only diff: no documentable source file → exit 0 (clean/skipped).
+    [ "$status" -eq 0 ]
+    # Confirm missing_scope array is empty (tests path was excluded, not missed).
+    echo "$output" | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+ms = d.get('missing_scope', [])
+assert ms == [], f'expected empty missing_scope, got: {ms}'
+"
+}
+
+# ── Regression B: fleet scripts diff must return exit 0/1, not exit 2 ────────
+#
+# Before the fix: a diff touching skills/autospec-fleet/scripts/fleet-gui-server.py
+# returned exit 2 (no scope declared). After the fix: a doc-scope annotation in
+# docs/USER_MANUAL.md covers skills/autospec-fleet/scripts/** so the file is
+# "covered" — drift gate can legitimately return 0 (section updated) or 1 (drift)
+# but never 2 (missing-scope).
+#
+# Mutation-verified: removing the fleet-gui src: globs from the doc-scope
+# annotation in USER_MANUAL.md makes this test FAIL (exit 2 instead of 0/1).
+
+@test "fleet scripts diff (skills/autospec-fleet/scripts/**) does NOT return exit 2 (#851)" {
+    cat > "$WORK/diff.txt" <<'DIFF'
+diff --git a/skills/autospec-fleet/scripts/fleet-gui-server.py b/skills/autospec-fleet/scripts/fleet-gui-server.py
+index 0000000..1111111 100644
+--- a/skills/autospec-fleet/scripts/fleet-gui-server.py
++++ b/skills/autospec-fleet/scripts/fleet-gui-server.py
+@@ -1,3 +1,4 @@
+ #!/usr/bin/env python3
++# new comment
+ import sys
+DIFF
+
+    run_drift "$WORK/diff.txt"
+
+    # Must NOT be exit 2.
+    [ "$status" -ne 2 ]
+}
+
+@test "fleet GUI diff (skills/autospec-fleet/gui/**) does NOT return exit 2 (#851)" {
+    cat > "$WORK/diff.txt" <<'DIFF'
+diff --git a/skills/autospec-fleet/gui/index.html b/skills/autospec-fleet/gui/index.html
+index 0000000..1111111 100644
+--- a/skills/autospec-fleet/gui/index.html
++++ b/skills/autospec-fleet/gui/index.html
+@@ -1,3 +1,4 @@
+ <!DOCTYPE html>
++<!-- updated -->
+ <html>
+DIFF
+
+    run_drift "$WORK/diff.txt"
+
+    # Must NOT be exit 2.
+    [ "$status" -ne 2 ]
+}
+
+# ── Sanity: non-fleet non-test source file still trips correctly ──────────────
+#
+# Verify the exclusion didn't swallow ALL source files. A diff touching a
+# source file that genuinely has no doc-scope should still return exit 2.
+# This guards against an overly broad exclusion that mutes the gate entirely.
+
+@test "genuinely uncovered source file still returns exit 2 (gate still works) (#851)" {
+    cat > "$WORK/diff.txt" <<'DIFF'
+diff --git a/some/totally/new/uncovered-script.sh b/some/totally/new/uncovered-script.sh
+index 0000000..1111111 100644
+--- /dev/null
++++ b/some/totally/new/uncovered-script.sh
+@@ -0,0 +1,3 @@
++#!/usr/bin/env bash
++# brand new script not covered by any scope
++echo hello
+DIFF
+
+    run_drift "$WORK/diff.txt"
+
+    # This path matches no doc-scope → exit 2 (missing-scope still fires).
+    [ "$status" -eq 2 ]
+    echo "$output" | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+ms = d.get('missing_scope', [])
+assert len(ms) > 0, f'expected non-empty missing_scope for genuinely uncovered file'
+"
+}


### PR DESCRIPTION
Closes #851

## Summary

Two-part fix for the docs-drift gate false-tripping (exit 2) on fleet PRs:

- **`check-doc-drift.sh`**: Exclude `tests/**` from `changed_source.txt` so test-only diffs never trigger missing-scope entries. Tests are internal QA artifacts with no user-facing surface to document.

- **`docs/USER_MANUAL.md`**: Expand the `/autospec-fleet` doc-scope annotation's `src:` globs from `["skills/autospec-fleet/SKILL.md", "skills/autospec-fleet/README.md", "scripts/fleet-run.sh", ...]` to `["skills/autospec-fleet/SKILL.md", "skills/autospec-fleet/README.md", "skills/autospec-fleet/scripts/**", "skills/autospec-fleet/gui/**"]`, covering the fleet GUI server, frontend, and all support scripts.

**Regression test** in `tests/unit/test_doc_drift_fleet_scope.bats` asserts:
- `tests/fleet/**`-only diff → exit 0 (not exit 2)
- `tests/**`-only diff → exit 0 with empty `missing_scope`
- `skills/autospec-fleet/scripts/**` diff → not exit 2 (returns exit 1 = drift, covered by scope)
- `skills/autospec-fleet/gui/**` diff → not exit 2
- Genuinely uncovered source still returns exit 2 (gate still fires correctly)

Mutation-verified: removing the `tests/` exclusion fails tests 1-2; removing the `scripts/**` and `gui/**` globs fails tests 3-4.

## Test plan

- [x] `bats tests/unit/test_doc_drift_fleet_scope.bats` — 5/5 pass
- [x] `bats tests/unit/test_doc_drift_mismatch_action.bats` — 7/7 pass (no regression)
- [x] Mutation-verified as described above
- [x] `bash -n check-doc-drift.sh` — syntax clean