### PR TITLE
fix(install): ship schemas/ to ~/.autospec/schemas so installed validate-qa-artifacts.sh resolves them

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -879,10 +879,39 @@ copy_repo_scripts() {
     info "copy_repo_scripts: copied repo-root scripts to $autospec_scripts_dir/"
 }
 
+copy_schemas() {
+    # Copy repo-root schemas/*.json into $AUTOSPEC_SCHEMAS_DIR (default ~/.autospec/schemas/).
+    # Mirrors copy_repo_scripts for the schemas/ directory. Runs on every install
+    # (fresh + --update) so validate-qa-artifacts.sh can resolve schemas from the
+    # installed location without requiring a repo checkout alongside the scripts.
+    # Issue #856: install.sh never shipped schemas/, causing the installed validator
+    # to fail with "missing ~/.autospec/schemas/*.json" for all non-checkout users.
+    schemas_src="$REPO_ROOT/schemas"
+    if [ ! -d "$schemas_src" ]; then
+        warn "copy_schemas: $schemas_src not found; skipping"
+        return 0
+    fi
+
+    autospec_schemas_dir="${AUTOSPEC_SCHEMAS_DIR:-$HOME/.autospec/schemas}"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        info "[dry-run] copy_schemas: would copy $schemas_src/*.json to $autospec_schemas_dir/"
+        return 0
+    fi
+
+    mkdir -p "$autospec_schemas_dir"
+    for f in "$schemas_src"/*.json; do
+        [ -e "$f" ] || continue
+        cp "$f" "$autospec_schemas_dir/"
+    done
+    info "copy_schemas: copied $(ls "$autospec_schemas_dir"/*.json 2>/dev/null | wc -l | tr -d ' ') schemas to $autospec_schemas_dir/"
+}
+
 # Integration bootstrap: pull autospec (if --update) + turbo, before per-skill installers run.
 pull_autospec
 copy_shared_scripts
 copy_repo_scripts
+copy_schemas
 ensure_system_tools
 bootstrap_peer_ecosystems
 bootstrap_turbo

--- a/scripts/validate-qa-artifacts.sh
+++ b/scripts/validate-qa-artifacts.sh
@@ -21,7 +21,15 @@ EOF
 }
 
 repo="."
-schema_dir="$(cd "$(dirname "$0")/.." && pwd)/schemas"
+# Schema directory resolution (issue #856):
+#   1. AUTOSPEC_SCHEMAS_DIR env override (set by operators or tests).
+#   2. --schema-dir CLI flag (explicit override, takes precedence over env).
+#   3. Default: ~/.autospec/schemas/ (the installed location populated by install.sh).
+# When running from a repo checkout, scripts/validate-qa-artifacts.sh resolves
+# to repo/schemas/ via the relative "$(dirname $0)/.." path; from the installed
+# copy (~/.autospec/scripts/), the env/default resolves correctly without a
+# checkout alongside the scripts.
+schema_dir="${AUTOSPEC_SCHEMAS_DIR:-$HOME/.autospec/schemas}"
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -44,6 +52,32 @@ while [ "$#" -gt 0 ]; do
             ;;
     esac
 done
+
+# Guard: verify the schema directory exists and contains the required schemas.
+# Print an actionable error and exit non-zero instead of silently skipping QA
+# validation, so operators know exactly how to recover (run install.sh --update).
+_required_schemas="
+autospec-proof-matrix.schema.json
+autospec-control-intent-ledger.schema.json
+autospec-mutation-proof.schema.json
+autospec-canary-results.schema.json
+autospec-reliability.schema.json
+"
+_missing_schemas=""
+for _schema in $_required_schemas; do
+    [ -z "$_schema" ] && continue
+    if [ ! -f "$schema_dir/$_schema" ]; then
+        _missing_schemas="$_missing_schemas $_schema"
+    fi
+done
+if [ -n "$_missing_schemas" ]; then
+    echo "validate-qa-artifacts: schemas directory is missing required files: $_missing_schemas" >&2
+    echo "  Looked in: $schema_dir" >&2
+    echo "  Recovery:  run 'bash install.sh --update' to install schemas to \$AUTOSPEC_SCHEMAS_DIR (default ~/.autospec/schemas/)" >&2
+    echo "  Override:  set AUTOSPEC_SCHEMAS_DIR or pass --schema-dir to point at the correct location" >&2
+    exit 3
+fi
+unset _required_schemas _missing_schemas _schema
 
 command -v ajv >/dev/null 2>&1 || {
     echo "validate-qa-artifacts: ajv is required" >&2

--- a/tests/install/test_install_schemas.sh
+++ b/tests/install/test_install_schemas.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Regression guard: install.sh must copy schemas/*.json into
+# $AUTOSPEC_SCHEMAS_DIR (default ~/.autospec/schemas/) on install and --update.
+# Also verifies that validate-qa-artifacts.sh honors AUTOSPEC_SCHEMAS_DIR and
+# fails with a non-zero exit + actionable message when a schema is missing.
+#
+# Mutation-verify: if install.sh does NOT copy schemas/, the first assertion
+# fails because the schema file will be absent from the temp install prefix.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# --- helper: create a temp install prefix --------------------------------
+tmpdir="$(mktemp -d /tmp/autospec-test-schemas-XXXXXX)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+export AUTOSPEC_SCRIPTS_DIR="$tmpdir/scripts"
+export AUTOSPEC_SCHEMAS_DIR="$tmpdir/schemas"
+# Ensure no prompt / interactive steps are triggered.
+export AUTOSPEC_AUTO_YES=1
+export AUTOSPEC_NO_STAR_PROMPT=1
+export AUTOSPEC_SKIP_SYSTEM_TOOLS=1
+export AUTOSPEC_SKIP_ECOSYSTEM_BOOTSTRAP=1
+export AUTOSPEC_SKIP_SUPERPOWERS=1
+export CI=true
+
+# --------------------------------------------------------------------------
+# Part 1: fresh install places schemas in AUTOSPEC_SCHEMAS_DIR
+# --------------------------------------------------------------------------
+
+# Run install in dry-run first to ensure the dry-run path also emits the right
+# message (and does NOT write any files).
+dry_run_output=$(bash "$SCRIPT_DIR/install.sh" \
+    --dry-run --skill autospec --harness claude 2>&1 || true)
+
+case "$dry_run_output" in
+    *"copy_schemas"*)
+        ;;
+    *)
+        echo "FAIL: dry-run did not mention copy_schemas step"
+        echo "--- output ---"
+        echo "$dry_run_output"
+        exit 1
+        ;;
+esac
+
+# Dry-run must NOT have created the schemas dir.
+if [ -d "$AUTOSPEC_SCHEMAS_DIR" ] && [ -n "$(ls -A "$AUTOSPEC_SCHEMAS_DIR" 2>/dev/null)" ]; then
+    echo "FAIL: dry-run created files in AUTOSPEC_SCHEMAS_DIR"
+    exit 1
+fi
+
+# Now do a real (non-dry-run) install.
+bash "$SCRIPT_DIR/install.sh" \
+    --skill autospec --harness claude 2>&1 | grep -v "^$" || true
+
+# Every schema in the repo's schemas/ dir must now exist in the install prefix.
+missing=""
+for schema_file in "$SCRIPT_DIR/schemas/"*.json; do
+    [ -e "$schema_file" ] || continue
+    schema_name="$(basename "$schema_file")"
+    if [ ! -f "$AUTOSPEC_SCHEMAS_DIR/$schema_name" ]; then
+        missing="$missing $schema_name"
+    fi
+done
+
+if [ -n "$missing" ]; then
+    echo "FAIL: after install, the following schemas are missing from $AUTOSPEC_SCHEMAS_DIR:"
+    echo "  $missing"
+    echo "Root cause: install.sh does not copy schemas/ (issue #856)"
+    exit 1
+fi
+echo "PASS (part 1): all $(ls "$AUTOSPEC_SCHEMAS_DIR" | wc -l | tr -d ' ') schemas present in $AUTOSPEC_SCHEMAS_DIR after install"
+
+# --------------------------------------------------------------------------
+# Part 2: --update also re-copies schemas (idempotent)
+# --------------------------------------------------------------------------
+
+# Remove one schema to simulate an out-of-date install.
+first_schema="$(ls "$AUTOSPEC_SCHEMAS_DIR"/*.json | head -1)"
+rm "$first_schema"
+
+bash "$SCRIPT_DIR/install.sh" \
+    --update --skill autospec --harness claude 2>&1 | grep -v "^$" || true
+
+if [ ! -f "$first_schema" ]; then
+    echo "FAIL: --update did not restore the missing schema $first_schema"
+    exit 1
+fi
+echo "PASS (part 2): --update re-installs a deleted schema"
+
+# --------------------------------------------------------------------------
+# Part 3: validate-qa-artifacts.sh honors AUTOSPEC_SCHEMAS_DIR and fails with
+# an actionable message when a schema is missing.
+# --------------------------------------------------------------------------
+
+# Create a schemas dir that is empty (no schemas inside).
+bad_schema_dir="$(mktemp -d /tmp/autospec-test-bad-schemas-XXXXXX)"
+trap 'rm -rf "$bad_schema_dir"' EXIT
+
+repo_dir="$(mktemp -d /tmp/autospec-test-repo-XXXXXX)"
+trap 'rm -rf "$repo_dir"' EXIT
+
+# Run the validator pointing at the empty schema dir; expect non-zero exit and
+# an actionable error message.
+validator_out=$(
+    AUTOSPEC_SCHEMAS_DIR="$bad_schema_dir" \
+    bash "$SCRIPT_DIR/scripts/validate-qa-artifacts.sh" \
+        --repo "$repo_dir" 2>&1 \
+    ; true
+)
+validator_rc=$(
+    AUTOSPEC_SCHEMAS_DIR="$bad_schema_dir" \
+    bash "$SCRIPT_DIR/scripts/validate-qa-artifacts.sh" \
+        --repo "$repo_dir" 2>&1 >/dev/null; echo $?
+) || true
+
+# Capture actual exit code
+set +e
+AUTOSPEC_SCHEMAS_DIR="$bad_schema_dir" \
+    bash "$SCRIPT_DIR/scripts/validate-qa-artifacts.sh" \
+        --repo "$repo_dir" >/dev/null 2>&1
+actual_rc=$?
+set -e
+
+if [ "$actual_rc" -eq 0 ]; then
+    echo "FAIL: validate-qa-artifacts.sh exited 0 when schemas are missing (should be non-zero)"
+    exit 1
+fi
+
+case "$validator_out" in
+    *install.sh*|*install*|*AUTOSPEC_SCHEMAS_DIR*|*schemas*missing*|*missing*schema*)
+        ;;
+    *)
+        echo "FAIL: validate-qa-artifacts.sh missing-schema message is not actionable"
+        echo "--- output ---"
+        echo "$validator_out"
+        exit 1
+        ;;
+esac
+echo "PASS (part 3): validate-qa-artifacts.sh exits non-zero with actionable message when schemas are missing"
+
+echo "PASS"


### PR DESCRIPTION
Closes #856

## Root cause

`install.sh` copied helper scripts to `~/.autospec/scripts/` but never copied `schemas/`. The installed `validate-qa-artifacts.sh` resolves its schema directory relative to the script (`$(dirname $0)/../schemas`), which works from a repo checkout but resolves to the non-existent `~/.autospec/schemas/` from the installed copy.

## Changes

### `install.sh`
- Adds `copy_schemas()` function (mirrors `copy_repo_scripts`) that copies all `schemas/*.json` into `$AUTOSPEC_SCHEMAS_DIR` (default `~/.autospec/schemas/`) on every fresh install and `--update`.
- Dry-run path emits `[dry-run] copy_schemas:` message (verified by test).
- Called in the integration bootstrap section alongside `copy_shared_scripts` and `copy_repo_scripts`.

### `scripts/validate-qa-artifacts.sh`
- Honors `AUTOSPEC_SCHEMAS_DIR` env override (default `~/.autospec/schemas/`) instead of the hardcoded relative path that resolves incorrectly from the installed copy.
- Adds a guard block that checks all five required schemas before running `ajv`; exits non-zero (code 3) with an actionable "run `install.sh --update` to install schemas" message when any are missing.

### `tests/install/test_install_schemas.sh` (new)
- Three-part regression guard:
  1. Fresh install places all 15 schemas in `AUTOSPEC_SCHEMAS_DIR`
  2. `--update` re-installs a deleted schema (idempotent)
  3. Validator exits non-zero with actionable message when schemas dir is empty
- Mutation-verify: without the `copy_schemas()` call, part 1 fails immediately.

## Verification

- `bash tests/install/test_install_schemas.sh` → PASS (all 3 parts)
- `bash tests/install/test_install_dry_run.sh` → PASS
- `bash tests/install/test_update_flag.sh` → PASS
- `bash scripts/validate.sh` → OK — all validation checks passed