### PR TITLE
fix(autospec-run): distinguish claim exit 1 usage error from exit 2 lost

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -482,8 +482,17 @@ inline label-swap path below.
 >   # label swap. Multiple monitors can race the same candidate; exactly one
 >   # wins (exit 0), the rest lose (non-zero) and skip to the next candidate.
 >   claim_json="$("$COORD_CLAIM" --issue "$ISSUE" --repo {repo} --worker-id "${AUTOSPEC_WORKER_ID:-$(hostname):${USER:-unknown}:monitor:$$}" --branch "${BRANCH:-}")" && claim_rc=0 || claim_rc=$?
->   if [ "$claim_rc" -ne 0 ]; then
+>   # exit 1 = hard usage error (never a race signal); exit 2 = lost race.
+>   # Split them: a misconfigured claim (rc 1 or any other non-2 non-zero) must
+>   # surface an operator-visible WARN, not masquerade as a silently-dropped
+>   # lost race (rc 2). rc 0 falls through to ownership below.
+>   if [ "$claim_rc" -eq 2 ]; then
 >     echo "[monitor] claim lost for #$ISSUE (rc=$claim_rc); refreshing queue"
+>     READY_REMOVE=$(printf "%s\n%s" "$READY_REMOVE" "$ISSUE" | grep -v "^${ISSUE}$" || true)
+>     ready=($READY_REMOVE)
+>     continue
+>   elif [ "$claim_rc" -ne 0 ]; then
+>     echo "[monitor] WARN: claim hard error for #$ISSUE (rc=$claim_rc) — usage/config error, NOT a lost race; skipping. Check claim-issue.sh invocation." >&2
 >     READY_REMOVE=$(printf "%s\n%s" "$READY_REMOVE" "$ISSUE" | grep -v "^${ISSUE}$" || true)
 >     ready=($READY_REMOVE)
 >     continue

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -477,8 +477,17 @@ inline label-swap path below.
 >   # label swap. Multiple monitors can race the same candidate; exactly one
 >   # wins (exit 0), the rest lose (non-zero) and skip to the next candidate.
 >   claim_json="$("$COORD_CLAIM" --issue "$ISSUE" --repo {repo} --worker-id "${AUTOSPEC_WORKER_ID:-$(hostname):${USER:-unknown}:monitor:$$}" --branch "${BRANCH:-}")" && claim_rc=0 || claim_rc=$?
->   if [ "$claim_rc" -ne 0 ]; then
+>   # exit 1 = hard usage error (never a race signal); exit 2 = lost race.
+>   # Split them: a misconfigured claim (rc 1 or any other non-2 non-zero) must
+>   # surface an operator-visible WARN, not masquerade as a silently-dropped
+>   # lost race (rc 2). rc 0 falls through to ownership below.
+>   if [ "$claim_rc" -eq 2 ]; then
 >     echo "[monitor] claim lost for #$ISSUE (rc=$claim_rc); refreshing queue"
+>     READY_REMOVE=$(printf "%s\n%s" "$READY_REMOVE" "$ISSUE" | grep -v "^${ISSUE}$" || true)
+>     ready=($READY_REMOVE)
+>     continue
+>   elif [ "$claim_rc" -ne 0 ]; then
+>     echo "[monitor] WARN: claim hard error for #$ISSUE (rc=$claim_rc) — usage/config error, NOT a lost race; skipping. Check claim-issue.sh invocation." >&2
 >     READY_REMOVE=$(printf "%s\n%s" "$READY_REMOVE" "$ISSUE" | grep -v "^${ISSUE}$" || true)
 >     ready=($READY_REMOVE)
 >     continue

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -481,8 +481,17 @@ inline label-swap path below.
 >   # label swap. Multiple monitors can race the same candidate; exactly one
 >   # wins (exit 0), the rest lose (non-zero) and skip to the next candidate.
 >   claim_json="$("$COORD_CLAIM" --issue "$ISSUE" --repo {repo} --worker-id "${AUTOSPEC_WORKER_ID:-$(hostname):${USER:-unknown}:monitor:$$}" --branch "${BRANCH:-}")" && claim_rc=0 || claim_rc=$?
->   if [ "$claim_rc" -ne 0 ]; then
+>   # exit 1 = hard usage error (never a race signal); exit 2 = lost race.
+>   # Split them: a misconfigured claim (rc 1 or any other non-2 non-zero) must
+>   # surface an operator-visible WARN, not masquerade as a silently-dropped
+>   # lost race (rc 2). rc 0 falls through to ownership below.
+>   if [ "$claim_rc" -eq 2 ]; then
 >     echo "[monitor] claim lost for #$ISSUE (rc=$claim_rc); refreshing queue"
+>     READY_REMOVE=$(printf "%s\n%s" "$READY_REMOVE" "$ISSUE" | grep -v "^${ISSUE}$" || true)
+>     ready=($READY_REMOVE)
+>     continue
+>   elif [ "$claim_rc" -ne 0 ]; then
+>     echo "[monitor] WARN: claim hard error for #$ISSUE (rc=$claim_rc) — usage/config error, NOT a lost race; skipping. Check claim-issue.sh invocation." >&2
 >     READY_REMOVE=$(printf "%s\n%s" "$READY_REMOVE" "$ISSUE" | grep -v "^${ISSUE}$" || true)
 >     ready=($READY_REMOVE)
 >     continue


### PR DESCRIPTION
Closes #877

The autospec-run hot monitor loop collapsed every non-zero claim-issue.sh exit into the lost-race `continue`, silently dropping a usable issue when the claim failed on a usage/config error (exit 1) instead of a lost race (exit 2).

This splits the claim branch: `claim_rc -eq 2` logs `claim lost` and refreshes the queue as before; any other non-zero (including exit 1) emits an operator-visible WARN to stderr identifying it as a usage/config error, not a race, then skips; `claim_rc -eq 0` falls through to ownership. The edit is byte-identical across the SKILL.md / opencode/agent.md / codex/prompt.md trio (check_lockstep stays green) and claim-issue.sh remains the sole claim path (check_claim_cas_guard stays green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)