### PR TITLE
fix(autospec-run): match worker_id by literal equality, not jq regex

### DIFF
--- a/skills/autospec-run/scripts/claim-issue.sh
+++ b/skills/autospec-run/scripts/claim-issue.sh
@@ -12,13 +12,16 @@ begin_marker="<!-- autospec-run-state:begin -->"
 end_marker="<!-- autospec-run-state:end -->"
 
 # own_marked_comment_id REPO ISSUE WORKER — print the highest id among marked
-# lock comments whose body carries this worker's worker_id (its own lock); empty
-# if none. Used on the lost-race path to self-delete only this worker's comment.
+# lock comments whose embedded worker_id LITERALLY equals this worker's id (its
+# own lock); empty if none. The worker_id is extracted via capture() and compared
+# with == so a regex metacharacter in the id (e.g. a `.` from an FQDN/hostname)
+# can never false-match a different worker's comment. Used on the lost-race path
+# to self-delete only this worker's own comment.
 own_marked_comment_id() {
     gh api "repos/$1/issues/$2/comments" --jq '. // []' 2>/dev/null \
         | jq -r --arg b "$begin_marker" --arg e "$end_marker" --arg wid "$3" \
             'map(select((.body//"")|contains($b) and contains($e)))
-             | map(select((.body//"")|test("\"worker_id\"\\s*:\\s*\""+$wid+"\"")))
+             | map(select(((.body//"")|capture("\"worker_id\"\\s*:\\s*\"(?<w>[^\"]*)\"").w // "") == $wid))
              | sort_by(.id) | (.[-1].id // empty)' 2>/dev/null || true
 }
 

--- a/tests/unit/test_autospec_claim_id_tiebreak.bats
+++ b/tests/unit/test_autospec_claim_id_tiebreak.bats
@@ -96,6 +96,44 @@ JSON
     ! grep -q 'api repos/testorg/testrepo/issues/comments/100 -X DELETE' "$CALLS"
 }
 
+@test "dotted worker_id self-cleans only its own comment, never a near-collision" {
+    # Cross-machine correctness: a worker_id with a regex metacharacter must
+    # match by LITERAL equality, not jq test(). winner-a holds the lowest-id
+    # lock (100) and wins via FORCE_OWNER. The loser's worker_id contains a dot
+    # (mac.lan:bob:monitor:1, its own comment is 101). A DIFFERENT worker owns a
+    # near-collision id (macXlan:bob:monitor:1, comment 102) where `.` would
+    # regex-match `X`. The loser must DELETE only its OWN comment (101) and never
+    # the near-collision's (102) nor the winner's (100).
+    cat > "$COMMENTS" <<'JSON'
+[
+  {
+    "id": 100,
+    "body": "<!-- autospec-run-state:begin -->\n{\"schema\":1,\"issue\":42,\"repo\":\"testorg/testrepo\",\"worker_id\":\"winner-a\",\"state\":\"claimed\",\"claimed_at\":\"2026-01-01T00:00:00Z\",\"updated_at\":\"2026-01-01T00:00:00Z\"}\n<!-- autospec-run-state:end -->"
+  },
+  {
+    "id": 101,
+    "body": "<!-- autospec-run-state:begin -->\n{\"schema\":1,\"issue\":42,\"repo\":\"testorg/testrepo\",\"worker_id\":\"mac.lan:bob:monitor:1\",\"state\":\"claimed\",\"claimed_at\":\"2026-01-01T00:00:01Z\",\"updated_at\":\"2026-01-01T00:00:01Z\"}\n<!-- autospec-run-state:end -->"
+  },
+  {
+    "id": 102,
+    "body": "<!-- autospec-run-state:begin -->\n{\"schema\":1,\"issue\":42,\"repo\":\"testorg/testrepo\",\"worker_id\":\"macXlan:bob:monitor:1\",\"state\":\"claimed\",\"claimed_at\":\"2026-01-01T00:00:02Z\",\"updated_at\":\"2026-01-01T00:00:02Z\"}\n<!-- autospec-run-state:end -->"
+  }
+]
+JSON
+    printf 'auto-implement\nctx:32k\n' > "$LABELS"
+
+    AUTOSPEC_TEST_FORCE_OWNER=winner-a run bash "$CLAIM" --issue 42 --repo testorg/testrepo --worker-id 'mac.lan:bob:monitor:1'
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'"claimed": false'* ]]
+    [[ "$output" == *'"reason": "claim_lost"'* ]]
+    # loser self-deletes its OWN comment (101) ...
+    grep -q 'api repos/testorg/testrepo/issues/comments/101 -X DELETE' "$CALLS"
+    # ... and NEVER the near-collision's (102), even though `.` regex-matches `X`
+    ! grep -q 'api repos/testorg/testrepo/issues/comments/102 -X DELETE' "$CALLS"
+    # ... and never the winner's lowest id (100)
+    ! grep -q 'api repos/testorg/testrepo/issues/comments/100 -X DELETE' "$CALLS"
+}
+
 @test "both-create race: two distinct marked comments, lower id wins the read" {
     # No pre-existing lock; both workers CREATE a fresh marked comment, ending
     # with two distinct marked comments (100 then 101). read returns the lower id.


### PR DESCRIPTION
Closes #876

`own_marked_comment_id()` in `claim-issue.sh` matched this worker's lock comment by interpolating `worker_id` into a jq `test()` **regex**. A `worker_id` containing a regex metacharacter — e.g. a `.` from an FQDN / `*.lan` / `*.local` hostname (`mac.lan:bob:monitor:1`) — could false-match a different worker's comment (`macXlan:bob:monitor:1`), letting a losing worker **DELETE the wrong worker's lock comment** and corrupt cross-machine claims.

Fix: extract the embedded `worker_id` via jq `capture()` and compare with `==` for literal equality, mirroring the safe approach already used by `lowest_lock_field()` and the owner check. Exit-0/2 contract and run-state schema unchanged.

Tests: adds a `test_autospec_claim_id_tiebreak.bats` case where a dotted `worker_id` self-cleans only its own comment and never a near-collision id (`macXlan:...`) where `.` would regex-match `X`. Red before fix, green after. `bash scripts/validate.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)