### PR TITLE
feat(autospec-resume): detect-and-continue skill + durable run registry

### DIFF
--- a/scripts/autospec-run-registry.sh
+++ b/scripts/autospec-run-registry.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# autospec-run-registry.sh — durable registry of active autospec runs.
+#
+# Closes root-cause #3 of docs/specs/2026-06-03-crash-resume-design.md: the
+# relaunch command (`AUTOSPEC_RESUME_COMMAND`, computed at
+# skills/autospec-run/SKILL.md:244) only survives in a session env var, so a
+# bare host/session crash loses it. /autospec-run writes this registry at
+# monitor launch so the command is DURABLE across reboot. The supervisor (child
+# 2) and `/autospec-resume` read it on a fresh start.
+#
+# Registry file (path-scoped by repo-slug, mirroring the heartbeat collision
+# lesson — ~/.autospec/process-heartbeats collides across repos otherwise):
+#   ~/.autospec/active-runs/<repo-slug>.json
+#   {
+#     "schema": 1,
+#     "repo": "owner/name",
+#     "repo_dir": "/abs/path/to/checkout",
+#     "harness": "claude|codex|opencode",
+#     "resume_command": "<exact non-interactive relaunch command>",
+#     "host": "<hostname that registered this run>",
+#     "registered_at": "<iso8601>",
+#     "updated_at": "<iso8601>"
+#   }
+#
+# Subcommands:
+#   write  --repo <o/n> --repo-dir <dir> --harness <h> --command <cmd> [--host <h>]
+#   read   --repo <o/n>          # print the registry JSON (empty if absent)
+#   list                         # print every registry file path, one per line
+#   prune  [--repo <o/n>]        # drop entries older than 24h
+#   path   --repo <o/n>          # print the resolved registry file path
+#
+# Writes are two-line atomic (build temp, then mv). Entries older than 24h are
+# treated as stale by `read`/`list` consumers; `prune` removes them.
+#
+# Environment:
+#   AUTOSPEC_ACTIVE_RUNS_DIR   base dir (default: ~/.autospec/active-runs)
+
+set -eu
+
+REGISTRY_BASE="${AUTOSPEC_ACTIVE_RUNS_DIR:-$HOME/.autospec/active-runs}"
+STALE_SECS="${AUTOSPEC_REGISTRY_STALE_SECS:-86400}"   # 24h
+
+err() { printf 'autospec-run-registry: %s\n' "$1" >&2; }
+die() { err "$1"; exit 1; }
+
+usage() {
+    cat <<'EOF'
+Usage:
+  autospec-run-registry.sh write --repo <owner/name> --repo-dir <dir> --harness <h> --command <cmd> [--host <h>]
+  autospec-run-registry.sh read  --repo <owner/name>
+  autospec-run-registry.sh list
+  autospec-run-registry.sh prune [--repo <owner/name>]
+  autospec-run-registry.sh path  --repo <owner/name>
+EOF
+}
+
+repo_slug() {
+    repo="${1:-}"
+    [ -n "$repo" ] || die "repo is required"
+    printf '%s' "$repo" | tr '/' '_'
+}
+
+registry_path() {
+    slug="$(repo_slug "$1")"
+    printf '%s/%s.json' "$REGISTRY_BASE" "$slug"
+}
+
+now_iso() { date -u +'%Y-%m-%dT%H:%M:%SZ'; }
+
+iso_to_epoch() {
+    ts="$1"
+    [ -n "$ts" ] || { echo 0; return; }
+    date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$ts" +%s 2>/dev/null \
+        || date -u -d "$ts" +%s 2>/dev/null \
+        || echo 0
+}
+
+# entry_is_stale FILE -> exit 0 (true) when file's updated_at is older than
+# STALE_SECS. A missing/unparseable updated_at counts as stale.
+entry_is_stale() {
+    file="$1"
+    [ -f "$file" ] || return 0
+    updated="$(jq -r '.updated_at // empty' "$file" 2>/dev/null || true)"
+    epoch="$(iso_to_epoch "$updated")"
+    [ "$epoch" -gt 0 ] || return 0
+    now="$(date -u +%s)"
+    age=$((now - epoch))
+    [ "$age" -ge "$STALE_SECS" ]
+}
+
+cmd_write() {
+    repo="" repo_dir="" harness="" command="" host=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --repo)     repo="${2:-}";     shift 2 ;;
+            --repo-dir) repo_dir="${2:-}"; shift 2 ;;
+            --harness)  harness="${2:-}";  shift 2 ;;
+            --command)  command="${2:-}";  shift 2 ;;
+            --host)     host="${2:-}";     shift 2 ;;
+            *) die "write: unknown option: $1" ;;
+        esac
+    done
+    [ -n "$repo" ]     || die "write: --repo is required"
+    [ -n "$repo_dir" ] || die "write: --repo-dir is required"
+    [ -n "$harness" ]  || die "write: --harness is required"
+    [ -n "$command" ]  || die "write: --command is required"
+    [ -n "$host" ]     || host="${AUTOSPEC_HOST:-$(hostname 2>/dev/null || echo "")}"
+
+    path="$(registry_path "$repo")"
+    mkdir -p "$REGISTRY_BASE"
+    now="$(now_iso)"
+    registered_at="$now"
+    if [ -f "$path" ]; then
+        prev="$(jq -r '.registered_at // empty' "$path" 2>/dev/null || true)"
+        [ -n "$prev" ] && registered_at="$prev"
+    fi
+
+    tmp="$(mktemp "${path}.XXXXXX")"
+    if ! jq -n \
+        --arg repo "$repo" \
+        --arg repo_dir "$repo_dir" \
+        --arg harness "$harness" \
+        --arg resume_command "$command" \
+        --arg host "$host" \
+        --arg registered_at "$registered_at" \
+        --arg updated_at "$now" \
+        '{schema:1, repo:$repo, repo_dir:$repo_dir, harness:$harness, resume_command:$resume_command, host:$host, registered_at:$registered_at, updated_at:$updated_at}' \
+        > "$tmp"; then
+        rm -f "$tmp"
+        die "write: failed to build registry JSON"
+    fi
+    mv "$tmp" "$path"
+    printf '%s\n' "$path"
+}
+
+cmd_read() {
+    repo=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --repo) repo="${2:-}"; shift 2 ;;
+            *) die "read: unknown option: $1" ;;
+        esac
+    done
+    [ -n "$repo" ] || die "read: --repo is required"
+    path="$(registry_path "$repo")"
+    [ -f "$path" ] || exit 0
+    if entry_is_stale "$path"; then
+        # Stale entries are not surfaced to consumers.
+        exit 0
+    fi
+    cat "$path"
+}
+
+cmd_list() {
+    [ -d "$REGISTRY_BASE" ] || exit 0
+    for f in "$REGISTRY_BASE"/*.json; do
+        [ -f "$f" ] || continue
+        entry_is_stale "$f" && continue
+        printf '%s\n' "$f"
+    done
+}
+
+cmd_prune() {
+    repo=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --repo) repo="${2:-}"; shift 2 ;;
+            *) die "prune: unknown option: $1" ;;
+        esac
+    done
+    if [ -n "$repo" ]; then
+        path="$(registry_path "$repo")"
+        if [ -f "$path" ] && entry_is_stale "$path"; then
+            rm -f "$path"
+        fi
+        exit 0
+    fi
+    [ -d "$REGISTRY_BASE" ] || exit 0
+    for f in "$REGISTRY_BASE"/*.json; do
+        [ -f "$f" ] || continue
+        entry_is_stale "$f" && rm -f "$f"
+    done
+}
+
+cmd_path() {
+    repo=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --repo) repo="${2:-}"; shift 2 ;;
+            *) die "path: unknown option: $1" ;;
+        esac
+    done
+    [ -n "$repo" ] || die "path: --repo is required"
+    registry_path "$repo"
+}
+
+subcommand="${1:-}"
+[ -n "$subcommand" ] || { usage >&2; exit 1; }
+shift || true
+
+case "$subcommand" in
+    write) cmd_write "$@" ;;
+    read)  cmd_read "$@" ;;
+    list)  cmd_list "$@" ;;
+    prune) cmd_prune "$@" ;;
+    path)  cmd_path "$@" ;;
+    --help|-h) usage ;;
+    *) usage >&2; exit 1 ;;
+esac

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -211,7 +211,7 @@ check_startup_preflight() {
         || printf '%s\n' "$canonical" | grep -F 'raw.githubusercontent.com/berlinguyinca/autospec/main/skills/' >/dev/null; then
         fail "startup preflight must not call a raw installer directly"
     fi
-    for s in autospec autospec-release autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa; do
+    for s in autospec autospec-release autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa autospec-resume; do
         for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
             body=$(extract_block "$f")
             [ -n "$body" ] || fail "$f missing ## Startup self-update section"
@@ -1812,6 +1812,7 @@ main() {
     check_autospec_sweep_area_contract
     check_autospec_qa_cluster_contract
     check_autospec_qa_bug_class_contract
+    check_autospec_resume_contract
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.
@@ -2138,6 +2139,85 @@ check_autospec_release_area_contract() {
         bats tests/release/test_release_area_dispatch.bats \
             >/tmp/validate-release-area-dispatch.log 2>&1 \
             || { cat /tmp/validate-release-area-dispatch.log >&2; fail "tests/release/test_release_area_dispatch.bats: failed"; }
+    fi
+}
+
+# Crash-resume skill + durable run registry contract (issue #881):
+# the new autospec-resume skill ships the trio + scaffolding + per-skill
+# validate.sh; resume-scan.sh / resume-attempts.sh / autospec-run-registry.sh
+# exist, are executable, and bash -n clean; the heartbeat schema carries a
+# backward-compatible `host` field; and /autospec-run wires the registry write
+# in lockstep across its trio. Runs the per-skill validate.sh and the
+# tests/resume bats fixtures when bats is on PATH.
+check_autospec_resume_contract() {
+    info "autospec-resume crash-resume skill + durable run registry (issue #881)"
+    local skill="skills/autospec-resume"
+    [ -d "$skill" ] || fail "$skill: skill directory missing (issue #881)"
+    for f in SKILL.md README.md install.sh uninstall.sh validate.sh \
+             opencode/agent.md codex/prompt.md \
+             scripts/resume-scan.sh scripts/resume-attempts.sh; do
+        [ -f "$skill/$f" ] || fail "$skill/$f: required file missing (issue #881)"
+    done
+
+    # Standard new-skill structural sections in SKILL.md.
+    grep -q '^## Startup self-update' "$skill/SKILL.md" \
+        || fail "$skill/SKILL.md missing ## Startup self-update section"
+    grep -q 'SKILL_NAME=autospec-resume' "$skill/SKILL.md" \
+        || fail "$skill/SKILL.md Startup self-update missing SKILL_NAME=autospec-resume"
+    grep -q '^## Harness detection' "$skill/SKILL.md" \
+        || fail "$skill/SKILL.md missing harness-detection section"
+    grep -q '^## Required capabilities & harness adapter' "$skill/SKILL.md" \
+        || fail "$skill/SKILL.md missing ## Required capabilities & harness adapter row"
+    grep -q 'Subagent model tier' "$skill/SKILL.md" \
+        || fail "$skill/SKILL.md adapter table missing 'Subagent model tier' row"
+
+    # New scripts exist, executable, bash -n clean.
+    for s in "$skill/scripts/resume-scan.sh" \
+             "$skill/scripts/resume-attempts.sh" \
+             "scripts/autospec-run-registry.sh"; do
+        [ -f "$s" ] || fail "$s: required script missing (issue #881)"
+        [ -x "$s" ] || fail "$s: file not executable (issue #881)"
+        bash -n "$s" || fail "$s: bash syntax error (issue #881)"
+    done
+
+    # Idempotency / no-second-lock invariant: resume-scan reads run-state but
+    # never upserts/clears it and never writes a run-state comment.
+    if grep -E 'run-state\.sh[^[:alnum:]]*upsert|run-state\.sh[^[:alnum:]]*clear|gh issue comment' \
+            "$skill/scripts/resume-scan.sh" >/dev/null; then
+        fail "$skill/scripts/resume-scan.sh must add no second lock (found a run-state mutation)"
+    fi
+
+    # Crash-vs-live must key on server updated_at (mirrors watchdog windows).
+    grep -q 'updated_at' "$skill/scripts/resume-scan.sh" \
+        || fail "$skill/scripts/resume-scan.sh must use run-state server updated_at"
+
+    # Heartbeat schema gained a backward-compatible host field.
+    grep -q '"host"' "skills/autospec-run/scripts/heartbeat-write.sh" \
+        || fail "heartbeat-write.sh must write a backward-compatible host field (issue #881)"
+
+    # /autospec-run wires the registry write in lockstep across its trio.
+    for trio in skills/autospec-run/SKILL.md \
+                skills/autospec-run/codex/prompt.md \
+                skills/autospec-run/opencode/agent.md; do
+        grep -q 'autospec-run-registry.sh' "$trio" \
+            || fail "$trio missing autospec-run-registry.sh registry-write wiring (issue #881)"
+    done
+
+    # Per-skill structural lint.
+    info "  running: $skill/validate.sh"
+    bash "$skill/validate.sh" >/tmp/validate-resume-skill.log 2>&1 \
+        || { cat /tmp/validate-resume-skill.log >&2; fail "$skill/validate.sh: failed"; }
+
+    # bats coverage.
+    local bats_dir="tests/resume"
+    [ -d "$bats_dir" ] || fail "$bats_dir: bats coverage directory missing (issue #881)"
+    if command -v bats >/dev/null 2>&1; then
+        for bats_file in "$bats_dir"/*.bats; do
+            [ -f "$bats_file" ] || continue
+            info "  running: $bats_file"
+            bats "$bats_file" >/tmp/validate-resume-bats.log 2>&1 \
+                || { cat /tmp/validate-resume-bats.log >&2; fail "$bats_file: failed"; }
+        done
     fi
 }
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -2149,8 +2149,8 @@ check_autospec_release_area_contract() {
 # backward-compatible `host` field; and /autospec-run wires the registry write
 # in lockstep across its trio. Runs the per-skill validate.sh and the
 # tests/resume bats fixtures when bats is on PATH.
-check_autospec_resume_contract() {
-    info "autospec-resume crash-resume skill + durable run registry (issue #881)"
+# Files + structural sections + script syntax for the autospec-resume skill.
+check_autospec_resume_structure() {
     local skill="skills/autospec-resume"
     [ -d "$skill" ] || fail "$skill: skill directory missing (issue #881)"
     for f in SKILL.md README.md install.sh uninstall.sh validate.sh \
@@ -2158,8 +2158,6 @@ check_autospec_resume_contract() {
              scripts/resume-scan.sh scripts/resume-attempts.sh; do
         [ -f "$skill/$f" ] || fail "$skill/$f: required file missing (issue #881)"
     done
-
-    # Standard new-skill structural sections in SKILL.md.
     grep -q '^## Startup self-update' "$skill/SKILL.md" \
         || fail "$skill/SKILL.md missing ## Startup self-update section"
     grep -q 'SKILL_NAME=autospec-resume' "$skill/SKILL.md" \
@@ -2170,8 +2168,6 @@ check_autospec_resume_contract() {
         || fail "$skill/SKILL.md missing ## Required capabilities & harness adapter row"
     grep -q 'Subagent model tier' "$skill/SKILL.md" \
         || fail "$skill/SKILL.md adapter table missing 'Subagent model tier' row"
-
-    # New scripts exist, executable, bash -n clean.
     for s in "$skill/scripts/resume-scan.sh" \
              "$skill/scripts/resume-attempts.sh" \
              "scripts/autospec-run-registry.sh"; do
@@ -2179,23 +2175,25 @@ check_autospec_resume_contract() {
         [ -x "$s" ] || fail "$s: file not executable (issue #881)"
         bash -n "$s" || fail "$s: bash syntax error (issue #881)"
     done
+}
 
-    # Idempotency / no-second-lock invariant: resume-scan reads run-state but
-    # never upserts/clears it and never writes a run-state comment.
+# Crash-resume invariants: no second lock, server updated_at, host field,
+# registry wiring, per-skill lint, and bats coverage.
+check_autospec_resume_contract() {
+    info "autospec-resume crash-resume skill + durable run registry (issue #881)"
+    local skill="skills/autospec-resume"
+    check_autospec_resume_structure
+
+    # Idempotency / no-second-lock: resume-scan reads run-state but never
+    # upserts/clears it and never writes a run-state comment.
     if grep -E 'run-state\.sh[^[:alnum:]]*upsert|run-state\.sh[^[:alnum:]]*clear|gh issue comment' \
             "$skill/scripts/resume-scan.sh" >/dev/null; then
         fail "$skill/scripts/resume-scan.sh must add no second lock (found a run-state mutation)"
     fi
-
-    # Crash-vs-live must key on server updated_at (mirrors watchdog windows).
     grep -q 'updated_at' "$skill/scripts/resume-scan.sh" \
         || fail "$skill/scripts/resume-scan.sh must use run-state server updated_at"
-
-    # Heartbeat schema gained a backward-compatible host field.
     grep -q '"host"' "skills/autospec-run/scripts/heartbeat-write.sh" \
         || fail "heartbeat-write.sh must write a backward-compatible host field (issue #881)"
-
-    # /autospec-run wires the registry write in lockstep across its trio.
     for trio in skills/autospec-run/SKILL.md \
                 skills/autospec-run/codex/prompt.md \
                 skills/autospec-run/opencode/agent.md; do
@@ -2203,16 +2201,13 @@ check_autospec_resume_contract() {
             || fail "$trio missing autospec-run-registry.sh registry-write wiring (issue #881)"
     done
 
-    # Per-skill structural lint.
     info "  running: $skill/validate.sh"
     bash "$skill/validate.sh" >/tmp/validate-resume-skill.log 2>&1 \
         || { cat /tmp/validate-resume-skill.log >&2; fail "$skill/validate.sh: failed"; }
 
-    # bats coverage.
-    local bats_dir="tests/resume"
-    [ -d "$bats_dir" ] || fail "$bats_dir: bats coverage directory missing (issue #881)"
+    [ -d tests/resume ] || fail "tests/resume: bats coverage directory missing (issue #881)"
     if command -v bats >/dev/null 2>&1; then
-        for bats_file in "$bats_dir"/*.bats; do
+        for bats_file in tests/resume/*.bats; do
             [ -f "$bats_file" ] || continue
             info "  running: $bats_file"
             bats "$bats_file" >/tmp/validate-resume-bats.log 2>&1 \

--- a/skills/autospec-resume/README.md
+++ b/skills/autospec-resume/README.md
@@ -1,0 +1,68 @@
+# autospec-resume
+
+Detect an interrupted **autospec** run from durable run-state + heartbeats on a
+*fresh* start (host crash, session crash, terminal death) and **auto-continue**
+it — without adding a second lock, without stealing a genuinely-live worker on
+another host, without deleting un-pushed work, and capped at
+`AUTOSPEC_RESUME_MAX_ATTEMPTS` (default 3) consecutive attempts.
+
+Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
+
+## Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-resume/install.sh | sh -s -- --harness all
+```
+
+Per-harness:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-resume/install.sh | sh -s -- --harness claude
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-resume/install.sh | sh -s -- --harness opencode
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-resume/install.sh | sh -s -- --harness codex
+```
+
+From a clone:
+
+```bash
+cd skills/autospec-resume
+./install.sh --harness all
+```
+
+## Flags
+
+| Flag | Behaviour |
+|---|---|
+| (none) | Scan the current repo's durable run-state + heartbeats; if the pre-conditions pass, relaunch via the durably-captured command (clean-restart off `origin/main`). |
+| `--resume-partial` | Additionally re-attach `/tmp/wt-<branch>` only when `heartbeat.host == $(hostname)`; cross-host or missing host clean-restarts. |
+| `--repo <owner/name>` | Target a specific repo (used by the boot supervisor iterating the registry). |
+| `--dry-run` | Print the decision and the command that would run; change nothing; exit 0. |
+
+## How it stays safe
+
+- **No second lock.** Resume relaunches the *run*; the relaunched monitor claims
+  each issue through the **existing** GitHub CAS run-state lock. Two concurrent
+  resumes converge to exactly one claim.
+- **Crash-vs-live.** Eligibility is computed from run-state **server**
+  `updated_at` (never a local clock): `step=claimed && age>=300` OR `age>=10800`.
+  A fresh claimed issue is never stolen.
+- **Cross-host.** `--resume-partial` only re-attaches a worktree whose heartbeat
+  `host` matches `$(hostname)`; otherwise it clean-restarts off `origin/main`.
+- **Durable relaunch command.** `/autospec-run` records the relaunch command in
+  `~/.autospec/active-runs/<repo-slug>.json` at monitor launch, so it survives a
+  reboot even though the session env var does not.
+- **Attempt cap.** Bounded at `AUTOSPEC_RESUME_MAX_ATTEMPTS` (default 3); the
+  counter resets when any issue reaches `merged`.
+
+## Components
+
+- `scripts/resume-scan.sh` — the decision engine (pre-conditions, crash-vs-live,
+  cross-host gate, attempt cap; relaunches via the registry command).
+- `scripts/resume-attempts.sh` — durable consecutive-attempt counter
+  (`~/.autospec/resume-attempts/<repo-slug>.json`).
+- `../../scripts/autospec-run-registry.sh` — durable run registry
+  (`~/.autospec/active-runs/<repo-slug>.json`), written by `/autospec-run`.
+
+## Spec
+
+`docs/specs/2026-06-03-crash-resume-design.md`

--- a/skills/autospec-resume/SKILL.md
+++ b/skills/autospec-resume/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: autospec-resume
+description: Use when a fresh process must detect an interrupted autospec run from durable run-state plus heartbeats and auto-continue it after a host, session, or terminal crash — without adding a second lock, without stealing a genuinely-live worker on another host, without deleting un-pushed work, and capped at AUTOSPEC_RESUME_MAX_ATTEMPTS (default 3) consecutive attempts. Supports --resume-partial, --repo <owner/name>, and --dry-run.
+---
+
+# autospec-resume (harness-neutral)
+
+Detect an interrupted autospec run from durable run-state + heartbeats on a
+*fresh* start and auto-continue it. All decision logic routes through
+`bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh" "$@"`.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-resume   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-stop / autospec-resume
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-resume/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-resume.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-resume.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-resume found; run install.sh first.` and exit.
+
+## Harness detection
+
+This skill is a thin dispatch wrapper — the relaunch happens through the durably-captured command, so it runs at the implementation tier. Detect your harness and pick the matching subagent tier:
+
+- **TIER_A** (architecture / deep reasoning): not used here; this skill never plans.
+- **TIER_B** (implementation work): the default — run the scan helper, print its one-line decision.
+
+If your harness lacks a subagent primitive, run the helper inline and **silently** fall back to the in-context path rather than erroring. Never escalate a missing capability into a hard failure.
+
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
+(case-insensitive), defer to `/autospec-stop`: dispatch to
+`bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`,
+print its stdout, and do not enter any resume pipeline. Resume never halts a
+running monitor — that is `/autospec-stop`'s job.
+
+## Invocation
+
+```
+/autospec-resume [--resume-partial] [--repo <owner/name>] [--dry-run]
+```
+
+Dispatches directly to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh" "$@"`. All decision logic lives in the helper script.
+
+| Flag | Behaviour |
+|---|---|
+| (none) | Scan the current repo's durable run-state + heartbeats, apply the auto-resume pre-conditions, and if all pass relaunch via the durably-captured command (clean-restart off `origin/main`). |
+| `--resume-partial` | Additionally re-attach `/tmp/wt-<branch>` **only when** `heartbeat.host == $(hostname)`; cross-host or missing host silently clean-restarts off `origin/main`. |
+| `--repo <owner/name>` | Target a specific repo (used by the boot supervisor, which iterates the registry). |
+| `--dry-run` | Print the decision and the command that *would* run; change nothing; exit 0. |
+
+**Exit codes:** `0` = nothing to resume / `--dry-run` / resumed (one-line reason printed); `1` = hard error (bad args, no `gh`).
+
+## Auto-resume contract (enforced by the helper)
+
+- **No second lock / idempotency.** Resume relaunches the *run*; the relaunched monitor claims issues through the **existing** GitHub CAS lock-comment (`run-state.sh`, lowest-comment-id wins, loser self-cleans). Resume itself never writes a run-state comment and never adds any new lock. Two concurrent resumes (supervisor + human, or two hosts) converge to exactly one claim per issue at the existing CAS boundary.
+- **Pre-conditions (ALL required, else exit 0, no relaunch):** (a) ≥1 issue with run-state labeled `in-progress-by-bot` whose heartbeat step ∉ {`merged`,`failed`}; (b) no `~/.autospec/stop.flag`; (c) no issue labeled `paused-by-user`; (d) not all issues closed.
+- **Crash-vs-live.** Treat an issue as crashed (eligible) only when its age, computed from run-state **server** `updated_at` (never a local clock — mirrors `scripts/autospec-watchdog.sh:386-405`), satisfies `step=claimed && age>=300` OR `age>=10800`. Otherwise assume a live/slow worker elsewhere and do **not** steal.
+- **Cross-host.** `--resume-partial` re-attaches `/tmp/wt-<branch>` only when `heartbeat.host == $(hostname)`; cross-host or missing `host` MUST clean-restart off `origin/main` (the crashed worktree is on a dead machine's local `/tmp`).
+- **Durable relaunch command.** The command comes from the registry `~/.autospec/active-runs/<repo-slug>.json` written by `/autospec-run` at monitor launch — never an attacker-supplied path. After a reboot (env cleared) the registry alone yields a runnable command.
+- **Attempt cap.** Capped at `AUTOSPEC_RESUME_MAX_ATTEMPTS` (default 3) consecutive attempts without forward progress. At the cap, halt, print the cap-reached reason, and surface. The counter resets on forward progress (any issue `merged`).
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Run shell command            | `Bash`                               | `bash` tool                              | `shell` / `apply_patch`                  | Ask user to run manually                           |
+| Ask the user a question      | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Subagent model tier          | Tier B: `sonnet` + medium thinking   | Tier B: smaller-tier `task` + medium reasoning | Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Fall back UP on unavailability |
+| Subagent dispatch policy   | per AGENTS.md decision matrix        | per AGENTS.md decision matrix            | per AGENTS.md decision matrix            | inline with main-session token cost                |
+
+**Model tier:** Tier B (implementation work) — this skill is a thin dispatch wrapper.
+
+## Procedure
+
+1. Run startup self-update block above.
+2. Parse the user's invocation arguments.
+3. Execute: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh" "$@"`
+4. Print the helper's one-line decision to the user and exit.
+
+If `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh` is not found, print:
+```
+autospec-resume: helper not found at ${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh.
+Reinstall autospec-resume from the autospec repo, then retry.
+```
+and exit non-zero.
+
+## Hard rules
+
+- Never write a run-state comment from this skill and never add a new lock. The relaunched monitor claims through the existing GitHub CAS lock only.
+- Never re-attach a cross-host or missing-host worktree under `--resume-partial`; clean-restart off `origin/main`.
+- Never exceed `AUTOSPEC_RESUME_MAX_ATTEMPTS` consecutive auto-resume attempts; halt and surface at the cap.
+- This skill is a thin wrapper. All behaviour is in the helper script.

--- a/skills/autospec-resume/codex/prompt.md
+++ b/skills/autospec-resume/codex/prompt.md
@@ -1,0 +1,147 @@
+
+# autospec-resume (harness-neutral)
+
+Detect an interrupted autospec run from durable run-state + heartbeats on a
+*fresh* start and auto-continue it. All decision logic routes through
+`bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh" "$@"`.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-resume   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-stop / autospec-resume
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-resume/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-resume.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-resume.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-resume found; run install.sh first.` and exit.
+
+## Harness detection
+
+This skill is a thin dispatch wrapper — the relaunch happens through the durably-captured command, so it runs at the implementation tier. Detect your harness and pick the matching subagent tier:
+
+- **TIER_A** (architecture / deep reasoning): not used here; this skill never plans.
+- **TIER_B** (implementation work): the default — run the scan helper, print its one-line decision.
+
+If your harness lacks a subagent primitive, run the helper inline and **silently** fall back to the in-context path rather than erroring. Never escalate a missing capability into a hard failure.
+
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
+(case-insensitive), defer to `/autospec-stop`: dispatch to
+`bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`,
+print its stdout, and do not enter any resume pipeline. Resume never halts a
+running monitor — that is `/autospec-stop`'s job.
+
+## Invocation
+
+```
+/autospec-resume [--resume-partial] [--repo <owner/name>] [--dry-run]
+```
+
+Dispatches directly to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh" "$@"`. All decision logic lives in the helper script.
+
+| Flag | Behaviour |
+|---|---|
+| (none) | Scan the current repo's durable run-state + heartbeats, apply the auto-resume pre-conditions, and if all pass relaunch via the durably-captured command (clean-restart off `origin/main`). |
+| `--resume-partial` | Additionally re-attach `/tmp/wt-<branch>` **only when** `heartbeat.host == $(hostname)`; cross-host or missing host silently clean-restarts off `origin/main`. |
+| `--repo <owner/name>` | Target a specific repo (used by the boot supervisor, which iterates the registry). |
+| `--dry-run` | Print the decision and the command that *would* run; change nothing; exit 0. |
+
+**Exit codes:** `0` = nothing to resume / `--dry-run` / resumed (one-line reason printed); `1` = hard error (bad args, no `gh`).
+
+## Auto-resume contract (enforced by the helper)
+
+- **No second lock / idempotency.** Resume relaunches the *run*; the relaunched monitor claims issues through the **existing** GitHub CAS lock-comment (`run-state.sh`, lowest-comment-id wins, loser self-cleans). Resume itself never writes a run-state comment and never adds any new lock. Two concurrent resumes (supervisor + human, or two hosts) converge to exactly one claim per issue at the existing CAS boundary.
+- **Pre-conditions (ALL required, else exit 0, no relaunch):** (a) ≥1 issue with run-state labeled `in-progress-by-bot` whose heartbeat step ∉ {`merged`,`failed`}; (b) no `~/.autospec/stop.flag`; (c) no issue labeled `paused-by-user`; (d) not all issues closed.
+- **Crash-vs-live.** Treat an issue as crashed (eligible) only when its age, computed from run-state **server** `updated_at` (never a local clock — mirrors `scripts/autospec-watchdog.sh:386-405`), satisfies `step=claimed && age>=300` OR `age>=10800`. Otherwise assume a live/slow worker elsewhere and do **not** steal.
+- **Cross-host.** `--resume-partial` re-attaches `/tmp/wt-<branch>` only when `heartbeat.host == $(hostname)`; cross-host or missing `host` MUST clean-restart off `origin/main` (the crashed worktree is on a dead machine's local `/tmp`).
+- **Durable relaunch command.** The command comes from the registry `~/.autospec/active-runs/<repo-slug>.json` written by `/autospec-run` at monitor launch — never an attacker-supplied path. After a reboot (env cleared) the registry alone yields a runnable command.
+- **Attempt cap.** Capped at `AUTOSPEC_RESUME_MAX_ATTEMPTS` (default 3) consecutive attempts without forward progress. At the cap, halt, print the cap-reached reason, and surface. The counter resets on forward progress (any issue `merged`).
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Run shell command            | `Bash`                               | `bash` tool                              | `shell` / `apply_patch`                  | Ask user to run manually                           |
+| Ask the user a question      | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Subagent model tier          | Tier B: `sonnet` + medium thinking   | Tier B: smaller-tier `task` + medium reasoning | Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Fall back UP on unavailability |
+| Subagent dispatch policy   | per AGENTS.md decision matrix        | per AGENTS.md decision matrix            | per AGENTS.md decision matrix            | inline with main-session token cost                |
+
+**Model tier:** Tier B (implementation work) — this skill is a thin dispatch wrapper.
+
+## Procedure
+
+1. Run startup self-update block above.
+2. Parse the user's invocation arguments.
+3. Execute: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh" "$@"`
+4. Print the helper's one-line decision to the user and exit.
+
+If `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh` is not found, print:
+```
+autospec-resume: helper not found at ${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh.
+Reinstall autospec-resume from the autospec repo, then retry.
+```
+and exit non-zero.
+
+## Hard rules
+
+- Never write a run-state comment from this skill and never add a new lock. The relaunched monitor claims through the existing GitHub CAS lock only.
+- Never re-attach a cross-host or missing-host worktree under `--resume-partial`; clean-restart off `origin/main`.
+- Never exceed `AUTOSPEC_RESUME_MAX_ATTEMPTS` consecutive auto-resume attempts; halt and surface at the cap.
+- This skill is a thin wrapper. All behaviour is in the helper script.

--- a/skills/autospec-resume/install.sh
+++ b/skills/autospec-resume/install.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec-resume skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --symlink           # symlink instead of copy (updates propagate)
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#   ./install.sh --update            # idempotent re-install (overwrite existing)
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-resume/install.sh \
+#     | sh -s -- --harness all
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPEC_RESUME_REF         (default: main)
+#   AUTOSPEC_RESUME_RAW_BASE    (override raw URL base entirely)
+
+set -eu
+
+SKILL_NAME="autospec-resume"
+SKILL_RAW_BASE="${AUTOSPEC_RESUME_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_RESUME_REF:-main}/skills/autospec-resume}"
+
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+UPDATE_MODE=0
+TMP_FETCH_DIR=""
+# Repo-root scripts/ helpers this skill needs at runtime.
+SHARED_SCRIPT_FILES="autospec-run-registry.sh run-state.sh heartbeat-read.sh heartbeat-write.sh autospec-stop.sh"
+# Per-skill scripts/ helpers (skills/autospec-resume/scripts/).
+SKILL_SCRIPT_FILES="resume-scan.sh resume-attempts.sh"
+
+# ---------- helpers --------------------------------------------------------
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
+
+Installs the ${SKILL_NAME} skill into the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    if ! command -v curl >/dev/null 2>&1; then
+        err "curl is required when running from stdin."
+        exit 1
+    fi
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/$rel"
+            exit 1
+        fi
+    done
+    for rel in $SKILL_SCRIPT_FILES; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
+    mkdir -p "$TMP_FETCH_DIR/repo-scripts"
+    for rel in $SHARED_SCRIPT_FILES; do
+        # run-state.sh / heartbeat-*.sh live under skills/autospec-run/scripts/.
+        case "$rel" in
+            run-state.sh|heartbeat-read.sh|heartbeat-write.sh)
+                src_url="$RAW_REPO_BASE/skills/autospec-run/scripts/$rel" ;;
+            *)
+                src_url="$RAW_REPO_BASE/scripts/$rel" ;;
+        esac
+        if ! curl -fsSL "$src_url" -o "$TMP_FETCH_DIR/repo-scripts/$rel"; then
+            err "failed to download $src_url"
+            exit 1
+        fi
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+# resolve_repo_scripts_dir — locate the repo-root scripts/ in a full checkout,
+# or the fetched repo-scripts/ dir when running from stdin.
+resolve_repo_root() {
+    cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true
+}
+
+install_runtime_scripts() {
+    checkout_root="$(resolve_repo_root)"
+    # Per-skill scripts.
+    if [ -n "$checkout_root" ] && [ -d "$SKILL_DIR/scripts" ]; then
+        per_skill_dir="$SKILL_DIR/scripts"
+    else
+        per_skill_dir="$SKILL_DIR/scripts"
+    fi
+    for rel in $SKILL_SCRIPT_FILES; do
+        install_one "$per_skill_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        run "chmod +x \"$HOME/.autospec/scripts/$rel\""
+    done
+    # Shared repo-root scripts (and autospec-run scripts).
+    for rel in $SHARED_SCRIPT_FILES; do
+        src=""
+        if [ -n "$checkout_root" ]; then
+            case "$rel" in
+                run-state.sh|heartbeat-read.sh|heartbeat-write.sh)
+                    src="$checkout_root/skills/autospec-run/scripts/$rel" ;;
+                *)
+                    src="$checkout_root/scripts/$rel" ;;
+            esac
+        fi
+        if [ -z "$src" ] || [ ! -f "$src" ]; then
+            src="$SKILL_DIR/repo-scripts/$rel"
+        fi
+        install_one "$src" "$HOME/.autospec/scripts/$rel" || return 1
+        run "chmod +x \"$HOME/.autospec/scripts/$rel\""
+    done
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    dest_dir="$(dirname "$dest")"
+
+    if [ ! -f "$src" ]; then
+        err "missing source file: $src"
+        return 1
+    fi
+
+    run "mkdir -p \"$dest_dir\""
+
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --symlink)
+            USE_SYMLINK=1
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        --update)
+            UPDATE_MODE=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# ---------- harness prompt -------------------------------------------------
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- ensure source files are available ------------------------------
+
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+
+if [ "$need_fetch" -eq 1 ]; then
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        err "--symlink requires running from a checkout (no local files to symlink to)."
+        exit 2
+    fi
+    fetch_source_files
+fi
+
+# ---------- install runtime helper scripts ---------------------------------
+
+info ""
+info "autospec-resume runtime helper scripts:"
+install_runtime_scripts
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+CLAUDE_SRC="$SKILL_DIR/SKILL.md"
+OPENCODE_SRC="$SKILL_DIR/opencode/agent.md"
+CODEX_SRC="$SKILL_DIR/codex/prompt.md"
+
+# ---------- install --------------------------------------------------------
+
+installed_paths=""
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_SRC" "$CLAUDE_DEST"
+    installed_paths="${installed_paths}  Claude Code: ${CLAUDE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_SRC" "$OPENCODE_DEST"
+    installed_paths="${installed_paths}  OpenCode:    ${OPENCODE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+    installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
+fi
+
+# ---------- final summary --------------------------------------------------
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    if [ "$UPDATE_MODE" -eq 1 ]; then
+        info "Updated (idempotent overwrite):"
+    else
+        info "Installed:"
+    fi
+    printf '%b' "$installed_paths"
+    info ""
+    info "Invoke with:"
+    info "  Claude Code:  /${SKILL_NAME}"
+    info "  OpenCode:     @${SKILL_NAME} --dry-run"
+    info "  Codex CLI:    /${SKILL_NAME} --resume-partial"
+fi
+
+exit 0

--- a/skills/autospec-resume/opencode/agent.md
+++ b/skills/autospec-resume/opencode/agent.md
@@ -1,0 +1,151 @@
+---
+description: Use when a fresh process must detect an interrupted autospec run from durable run-state plus heartbeats and auto-continue it after a host, session, or terminal crash — without adding a second lock, without stealing a genuinely-live worker on another host, without deleting un-pushed work, and capped at AUTOSPEC_RESUME_MAX_ATTEMPTS (default 3) consecutive attempts. Supports --resume-partial, --repo <owner/name>, and --dry-run.
+mode: primary
+---
+
+# autospec-resume (harness-neutral)
+
+Detect an interrupted autospec run from durable run-state + heartbeats on a
+*fresh* start and auto-continue it. All decision logic routes through
+`bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh" "$@"`.
+
+Manage your own context — never exceed 60%. Delegate to subagents whenever your harness supports it.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-resume   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-stop / autospec-resume
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the feature-request argument matches the regex `^\s*update\s*$` (case-insensitive, whitespace-padded), this skill enters self-update mode and does not run the normal pipeline:
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-resume/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-resume.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-resume.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-resume found; run install.sh first.` and exit.
+
+## Harness detection
+
+This skill is a thin dispatch wrapper — the relaunch happens through the durably-captured command, so it runs at the implementation tier. Detect your harness and pick the matching subagent tier:
+
+- **TIER_A** (architecture / deep reasoning): not used here; this skill never plans.
+- **TIER_B** (implementation work): the default — run the scan helper, print its one-line decision.
+
+If your harness lacks a subagent primitive, run the helper inline and **silently** fall back to the in-context path rather than erroring. Never escalate a missing capability into a hard failure.
+
+## Stop mode
+
+If the feature-request argument matches the regex `^\s*stop(\s+--\w+)*\s*$`
+(case-insensitive), defer to `/autospec-stop`: dispatch to
+`bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-stop.sh" <args>`,
+print its stdout, and do not enter any resume pipeline. Resume never halts a
+running monitor — that is `/autospec-stop`'s job.
+
+## Invocation
+
+```
+/autospec-resume [--resume-partial] [--repo <owner/name>] [--dry-run]
+```
+
+Dispatches directly to `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh" "$@"`. All decision logic lives in the helper script.
+
+| Flag | Behaviour |
+|---|---|
+| (none) | Scan the current repo's durable run-state + heartbeats, apply the auto-resume pre-conditions, and if all pass relaunch via the durably-captured command (clean-restart off `origin/main`). |
+| `--resume-partial` | Additionally re-attach `/tmp/wt-<branch>` **only when** `heartbeat.host == $(hostname)`; cross-host or missing host silently clean-restarts off `origin/main`. |
+| `--repo <owner/name>` | Target a specific repo (used by the boot supervisor, which iterates the registry). |
+| `--dry-run` | Print the decision and the command that *would* run; change nothing; exit 0. |
+
+**Exit codes:** `0` = nothing to resume / `--dry-run` / resumed (one-line reason printed); `1` = hard error (bad args, no `gh`).
+
+## Auto-resume contract (enforced by the helper)
+
+- **No second lock / idempotency.** Resume relaunches the *run*; the relaunched monitor claims issues through the **existing** GitHub CAS lock-comment (`run-state.sh`, lowest-comment-id wins, loser self-cleans). Resume itself never writes a run-state comment and never adds any new lock. Two concurrent resumes (supervisor + human, or two hosts) converge to exactly one claim per issue at the existing CAS boundary.
+- **Pre-conditions (ALL required, else exit 0, no relaunch):** (a) ≥1 issue with run-state labeled `in-progress-by-bot` whose heartbeat step ∉ {`merged`,`failed`}; (b) no `~/.autospec/stop.flag`; (c) no issue labeled `paused-by-user`; (d) not all issues closed.
+- **Crash-vs-live.** Treat an issue as crashed (eligible) only when its age, computed from run-state **server** `updated_at` (never a local clock — mirrors `scripts/autospec-watchdog.sh:386-405`), satisfies `step=claimed && age>=300` OR `age>=10800`. Otherwise assume a live/slow worker elsewhere and do **not** steal.
+- **Cross-host.** `--resume-partial` re-attaches `/tmp/wt-<branch>` only when `heartbeat.host == $(hostname)`; cross-host or missing `host` MUST clean-restart off `origin/main` (the crashed worktree is on a dead machine's local `/tmp`).
+- **Durable relaunch command.** The command comes from the registry `~/.autospec/active-runs/<repo-slug>.json` written by `/autospec-run` at monitor launch — never an attacker-supplied path. After a reboot (env cleared) the registry alone yields a runnable command.
+- **Attempt cap.** Capped at `AUTOSPEC_RESUME_MAX_ATTEMPTS` (default 3) consecutive attempts without forward progress. At the cap, halt, print the cap-reached reason, and surface. The counter resets on forward progress (any issue `merged`).
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Run shell command            | `Bash`                               | `bash` tool                              | `shell` / `apply_patch`                  | Ask user to run manually                           |
+| Ask the user a question      | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Subagent model tier          | Tier B: `sonnet` + medium thinking   | Tier B: smaller-tier `task` + medium reasoning | Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Fall back UP on unavailability |
+| Subagent dispatch policy   | per AGENTS.md decision matrix        | per AGENTS.md decision matrix            | per AGENTS.md decision matrix            | inline with main-session token cost                |
+
+**Model tier:** Tier B (implementation work) — this skill is a thin dispatch wrapper.
+
+## Procedure
+
+1. Run startup self-update block above.
+2. Parse the user's invocation arguments.
+3. Execute: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh" "$@"`
+4. Print the helper's one-line decision to the user and exit.
+
+If `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh` is not found, print:
+```
+autospec-resume: helper not found at ${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/resume-scan.sh.
+Reinstall autospec-resume from the autospec repo, then retry.
+```
+and exit non-zero.
+
+## Hard rules
+
+- Never write a run-state comment from this skill and never add a new lock. The relaunched monitor claims through the existing GitHub CAS lock only.
+- Never re-attach a cross-host or missing-host worktree under `--resume-partial`; clean-restart off `origin/main`.
+- Never exceed `AUTOSPEC_RESUME_MAX_ATTEMPTS` consecutive auto-resume attempts; halt and surface at the cap.
+- This skill is a thin wrapper. All behaviour is in the helper script.

--- a/skills/autospec-resume/scripts/resume-attempts.sh
+++ b/skills/autospec-resume/scripts/resume-attempts.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# resume-attempts.sh — durable consecutive-auto-resume-attempt counter.
+#
+# Per docs/specs/2026-06-03-crash-resume-design.md (§Data model, §Error
+# handling): a bounded number of consecutive auto-resume attempts without
+# forward progress (any issue reaching `merged`) before resume halts and
+# surfaces to the operator — never an infinite boot-thrash loop.
+#
+# Counter file (path-scoped by repo-slug):
+#   ~/.autospec/resume-attempts/<repo-slug>.json
+#   { "schema": 1, "repo": "owner/name", "count": 0,
+#     "first_at": "<iso8601>", "updated_at": "<iso8601>" }
+#
+# Two-line atomic temp+mv write. A counter whose updated_at is older than 24h is
+# considered stale and treated as count=0 (sentinel convention) — a crash days
+# ago must not permanently cap recovery.
+#
+# Subcommands:
+#   get    --repo <o/n>    # print current effective count (0 if absent/stale)
+#   inc    --repo <o/n>    # increment and print the new count
+#   reset  --repo <o/n>    # reset to 0 (forward progress; any issue merged)
+#   cap                    # print the configured cap (AUTOSPEC_RESUME_MAX_ATTEMPTS, default 3)
+#   at-cap --repo <o/n>    # exit 0 when effective count >= cap, else exit 1
+#   path   --repo <o/n>    # print the resolved counter file path
+#
+# Environment:
+#   AUTOSPEC_RESUME_ATTEMPTS_DIR   base dir (default: ~/.autospec/resume-attempts)
+#   AUTOSPEC_RESUME_MAX_ATTEMPTS   cap (default: 3)
+
+set -eu
+
+ATTEMPTS_BASE="${AUTOSPEC_RESUME_ATTEMPTS_DIR:-$HOME/.autospec/resume-attempts}"
+STALE_SECS="${AUTOSPEC_RESUME_ATTEMPTS_STALE_SECS:-86400}"   # 24h
+
+err() { printf 'resume-attempts: %s\n' "$1" >&2; }
+die() { err "$1"; exit 1; }
+
+usage() {
+    cat <<'EOF'
+Usage:
+  resume-attempts.sh get    --repo <owner/name>
+  resume-attempts.sh inc    --repo <owner/name>
+  resume-attempts.sh reset  --repo <owner/name>
+  resume-attempts.sh cap
+  resume-attempts.sh at-cap --repo <owner/name>
+  resume-attempts.sh path   --repo <owner/name>
+EOF
+}
+
+repo_slug() {
+    repo="${1:-}"
+    [ -n "$repo" ] || die "repo is required"
+    printf '%s' "$repo" | tr '/' '_'
+}
+
+attempts_path() {
+    slug="$(repo_slug "$1")"
+    printf '%s/%s.json' "$ATTEMPTS_BASE" "$slug"
+}
+
+now_iso() { date -u +'%Y-%m-%dT%H:%M:%SZ'; }
+
+iso_to_epoch() {
+    ts="$1"
+    [ -n "$ts" ] || { echo 0; return; }
+    date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$ts" +%s 2>/dev/null \
+        || date -u -d "$ts" +%s 2>/dev/null \
+        || echo 0
+}
+
+cap_value() {
+    cap="${AUTOSPEC_RESUME_MAX_ATTEMPTS:-3}"
+    case "$cap" in ''|*[!0-9]*) cap=3 ;; esac
+    printf '%s' "$cap"
+}
+
+# effective_count FILE -> echo the count, treating stale (>24h) or
+# missing/unparseable files as 0.
+effective_count() {
+    file="$1"
+    [ -f "$file" ] || { echo 0; return; }
+    updated="$(jq -r '.updated_at // empty' "$file" 2>/dev/null || true)"
+    epoch="$(iso_to_epoch "$updated")"
+    if [ "$epoch" -gt 0 ]; then
+        now="$(date -u +%s)"
+        age=$((now - epoch))
+        if [ "$age" -ge "$STALE_SECS" ]; then
+            echo 0; return
+        fi
+    fi
+    count="$(jq -r '.count // 0' "$file" 2>/dev/null || echo 0)"
+    case "$count" in ''|*[!0-9]*) count=0 ;; esac
+    printf '%s' "$count"
+}
+
+write_counter() {
+    repo="$1"; count="$2"
+    path="$(attempts_path "$repo")"
+    mkdir -p "$ATTEMPTS_BASE"
+    now="$(now_iso)"
+    first_at="$now"
+    if [ -f "$path" ]; then
+        prev="$(jq -r '.first_at // empty' "$path" 2>/dev/null || true)"
+        [ -n "$prev" ] && first_at="$prev"
+    fi
+    tmp="$(mktemp "${path}.XXXXXX")"
+    if ! jq -n \
+        --arg repo "$repo" \
+        --argjson count "$count" \
+        --arg first_at "$first_at" \
+        --arg updated_at "$now" \
+        '{schema:1, repo:$repo, count:$count, first_at:$first_at, updated_at:$updated_at}' \
+        > "$tmp"; then
+        rm -f "$tmp"
+        die "failed to build counter JSON"
+    fi
+    mv "$tmp" "$path"
+}
+
+require_repo() {
+    repo=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --repo) repo="${2:-}"; shift 2 ;;
+            *) die "unknown option: $1" ;;
+        esac
+    done
+    [ -n "$repo" ] || die "--repo is required"
+    printf '%s' "$repo"
+}
+
+subcommand="${1:-}"
+[ -n "$subcommand" ] || { usage >&2; exit 1; }
+shift || true
+
+case "$subcommand" in
+    get)
+        repo="$(require_repo "$@")"
+        printf '%s\n' "$(effective_count "$(attempts_path "$repo")")"
+        ;;
+    inc)
+        repo="$(require_repo "$@")"
+        cur="$(effective_count "$(attempts_path "$repo")")"
+        new=$((cur + 1))
+        write_counter "$repo" "$new"
+        printf '%s\n' "$new"
+        ;;
+    reset)
+        repo="$(require_repo "$@")"
+        write_counter "$repo" 0
+        printf '0\n'
+        ;;
+    cap)
+        printf '%s\n' "$(cap_value)"
+        ;;
+    at-cap)
+        repo="$(require_repo "$@")"
+        cur="$(effective_count "$(attempts_path "$repo")")"
+        cap="$(cap_value)"
+        if [ "$cur" -ge "$cap" ]; then exit 0; else exit 1; fi
+        ;;
+    path)
+        repo="$(require_repo "$@")"
+        attempts_path "$repo"
+        ;;
+    --help|-h) usage ;;
+    *) usage >&2; exit 1 ;;
+esac

--- a/skills/autospec-resume/scripts/resume-scan.sh
+++ b/skills/autospec-resume/scripts/resume-scan.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# resume-scan.sh — scan durable run-state + heartbeats on a FRESH start and
+# decide whether to auto-continue an interrupted autospec run.
+#
+# Implements docs/specs/2026-06-03-crash-resume-design.md §Error handling:
+#   - Auto-resume pre-conditions (ALL required, else exit 0, no relaunch):
+#       (a) >=1 issue with run-state labeled in-progress-by-bot whose heartbeat
+#           step is not in {merged,failed}
+#       (b) no ~/.autospec/stop.flag
+#       (c) no issue labeled paused-by-user
+#       (d) not all issues closed
+#   - Crash-vs-live: an issue is eligible (crashed) only when its age, computed
+#     from run-state SERVER updated_at (never a local clock — mirrors
+#     scripts/autospec-watchdog.sh:386-405), satisfies
+#       step=claimed && age>=CLAIMED_TIMEOUT (300)  OR  age>=RECLAIM (10800).
+#     Otherwise assume a live/slow worker elsewhere and do NOT steal.
+#   - Idempotency / NO second lock: this script NEVER writes a run-state comment
+#     and adds NO new lock. The relaunched monitor claims through the EXISTING
+#     GitHub CAS lock (run-state.sh, lowest-comment-id wins). Two concurrent
+#     resumes therefore converge to exactly one claim at the existing CAS.
+#   - Cross-host: --resume-partial re-attaches /tmp/wt-<branch> only when the
+#     heartbeat host == $(hostname). Cross-host or missing host MUST
+#     clean-restart off origin/main.
+#   - Attempt cap: capped at AUTOSPEC_RESUME_MAX_ATTEMPTS (default 3) consecutive
+#     attempts without forward progress (any issue merged). Counter resets on a
+#     merged issue.
+#
+# Usage:
+#   resume-scan.sh [--repo <owner/name>] [--resume-partial] [--dry-run]
+#
+# Exit codes / output (mirrors the skill table):
+#   0  nothing to resume / --dry-run    -> one-line reason on stdout
+#   0  resumed                          -> "resuming <repo>: <N> issue(s); command=<...>"
+#   1  hard error (bad args, no gh)     -> error to stderr
+#
+# Environment:
+#   AUTOSPEC_STATE_DIR              base for stop.flag (default: ~/.autospec)
+#   AUTOSPEC_RUN_STATE_SH          path to run-state.sh (auto-resolved)
+#   AUTOSPEC_HEARTBEAT_READ_SH     path to heartbeat-read.sh (auto-resolved)
+#   AUTOSPEC_RUN_REGISTRY_SH       path to autospec-run-registry.sh (auto-resolved)
+#   AUTOSPEC_RESUME_ATTEMPTS_SH    path to resume-attempts.sh (auto-resolved)
+#   AUTOSPEC_HOST                  hostname override (tests)
+#   WATCHDOG_CLAIMED_TIMEOUT_SECS  default 300
+#   WATCHDOG_RECLAIM_SECS          default 10800
+
+set -eu
+
+STATE_DIR="${AUTOSPEC_STATE_DIR:-$HOME/.autospec}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+CLAIMED_TIMEOUT="${WATCHDOG_CLAIMED_TIMEOUT_SECS:-300}"
+RECLAIM_SECS="${WATCHDOG_RECLAIM_SECS:-10800}"
+
+err() { printf 'resume-scan: %s\n' "$1" >&2; }
+die() { err "$1"; exit 1; }
+say() { printf '%s\n' "$1"; }   # one-line decision/reason on stdout
+
+# ── Resolve sibling helper scripts (checkout layout or installed layout). ──────
+resolve_helper() {
+    # $1 env override, $2..$N candidate paths
+    override="$1"; shift
+    if [ -n "$override" ] && [ -f "$override" ]; then printf '%s' "$override"; return; fi
+    for c in "$@"; do
+        [ -f "$c" ] && { printf '%s' "$c"; return; }
+    done
+    printf ''
+}
+
+RUN_STATE_SH="$(resolve_helper "${AUTOSPEC_RUN_STATE_SH:-}" \
+    "$SCRIPT_DIR/../../autospec-run/scripts/run-state.sh" \
+    "$STATE_DIR/scripts/run-state.sh")"
+HEARTBEAT_READ_SH="$(resolve_helper "${AUTOSPEC_HEARTBEAT_READ_SH:-}" \
+    "$SCRIPT_DIR/../../autospec-run/scripts/heartbeat-read.sh" \
+    "$STATE_DIR/scripts/heartbeat-read.sh")"
+RUN_REGISTRY_SH="$(resolve_helper "${AUTOSPEC_RUN_REGISTRY_SH:-}" \
+    "$SCRIPT_DIR/../../../scripts/autospec-run-registry.sh" \
+    "$STATE_DIR/scripts/autospec-run-registry.sh")"
+RESUME_ATTEMPTS_SH="$(resolve_helper "${AUTOSPEC_RESUME_ATTEMPTS_SH:-}" \
+    "$SCRIPT_DIR/resume-attempts.sh" \
+    "$STATE_DIR/scripts/resume-attempts.sh")"
+
+# ── Arg parse ─────────────────────────────────────────────────────────────────
+REPO=""
+RESUME_PARTIAL=0
+DRY_RUN=0
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --repo)           REPO="${2:-}"; shift 2 ;;
+        --resume-partial) RESUME_PARTIAL=1; shift ;;
+        --dry-run)        DRY_RUN=1; shift ;;
+        --help|-h)
+            sed -n '2,40p' "$0"; exit 0 ;;
+        *) die "unknown option: $1" ;;
+    esac
+done
+
+command -v gh >/dev/null 2>&1 || die "gh CLI not found"
+command -v jq >/dev/null 2>&1 || die "jq not found"
+
+if [ -z "$REPO" ]; then
+    REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+fi
+[ -n "$REPO" ] || die "--repo is required when gh cannot infer it"
+
+HOST="${AUTOSPEC_HOST:-$(hostname 2>/dev/null || echo "")}"
+
+now_epoch() { date -u +%s; }
+iso_to_epoch() {
+    ts="$1"
+    [ -n "$ts" ] || { echo 0; return; }
+    date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$ts" +%s 2>/dev/null \
+        || date -u -d "$ts" +%s 2>/dev/null \
+        || echo 0
+}
+
+# ── Pre-condition (b): stop.flag present -> exit 0, no relaunch. ───────────────
+if [ -f "$STATE_DIR/stop.flag" ]; then
+    say "stop.flag present"
+    exit 0
+fi
+
+# ── Gather issues by label. We query GitHub once per label set. ───────────────
+# in-progress-by-bot issues (candidates for resume):
+in_progress="$(gh issue list --repo "$REPO" --label in-progress-by-bot \
+    --state open --json number --jq '.[].number' 2>/dev/null || true)"
+# paused-by-user issues (pre-condition c):
+paused="$(gh issue list --repo "$REPO" --label paused-by-user \
+    --state all --json number --jq '.[].number' 2>/dev/null || true)"
+# any open auto-implement OR in-progress issues (pre-condition d):
+open_any="$(gh issue list --repo "$REPO" --state open \
+    --label auto-implement --json number --jq '.[].number' 2>/dev/null || true)"
+open_any="$(printf '%s\n%s\n' "$open_any" "$in_progress" | sed '/^$/d' | sort -u)"
+
+# ── Pre-condition (c): any paused-by-user -> exit 0. ──────────────────────────
+if [ -n "$paused" ]; then
+    say "paused-by-user present"
+    exit 0
+fi
+
+# ── Pre-condition (d): not all issues closed. If neither auto-implement nor ───
+# in-progress issues are open, there is nothing to resume.
+if [ -z "$(printf '%s' "$open_any" | sed '/^$/d')" ]; then
+    say "all issues closed"
+    exit 0
+fi
+
+# ── Pre-condition (a) + crash-vs-live + cross-host: walk in-progress issues. ──
+# An issue is eligible only when run-state is present, its heartbeat step is not
+# terminal, AND server-updated_at age crosses the crash threshold.
+eligible_count=0
+eligible_issues=""
+partial_branch=""
+saw_in_progress_nonterminal=0
+
+for issue in $in_progress; do
+    [ -n "$issue" ] || continue
+
+    # Heartbeat (machine-local): determine terminal step + host.
+    hb=""
+    if [ -n "$HEARTBEAT_READ_SH" ]; then
+        hb="$(bash "$HEARTBEAT_READ_SH" --issue "$issue" --repo "$REPO" 2>/dev/null || true)"
+    fi
+    hb_step=""
+    hb_host=""
+    hb_branch=""
+    if [ -n "$hb" ]; then
+        hb_step="$(printf '%s' "$hb" | jq -r '.step // empty' 2>/dev/null || true)"
+        # Missing host -> empty -> treated as unknown (never partial-eligible).
+        hb_host="$(printf '%s' "$hb" | jq -r '.host // empty' 2>/dev/null || true)"
+        hb_branch="$(printf '%s' "$hb" | jq -r '.branch // empty' 2>/dev/null || true)"
+    fi
+    case "$hb_step" in
+        merged|failed) continue ;;   # terminal heartbeat -> not a crash to resume
+    esac
+
+    # Run-state (durable, cross-machine): must exist; gives SERVER updated_at.
+    rs=""
+    if [ -n "$RUN_STATE_SH" ]; then
+        rs="$(bash "$RUN_STATE_SH" read --issue "$issue" --repo "$REPO" 2>/dev/null || true)"
+    fi
+    [ -n "$rs" ] || continue   # no durable run-state -> not a resumable claim
+
+    saw_in_progress_nonterminal=1
+
+    rs_step="$(printf '%s' "$rs" | jq -r '.step // .state // empty' 2>/dev/null || true)"
+    rs_updated="$(printf '%s' "$rs" | jq -r '.updated_at // empty' 2>/dev/null || true)"
+    rs_branch="$(printf '%s' "$rs" | jq -r '.branch // empty' 2>/dev/null || true)"
+    [ -n "$rs_branch" ] || rs_branch="$hb_branch"
+
+    # Crash-vs-live off SERVER updated_at (never local clock).
+    updated_epoch="$(iso_to_epoch "$rs_updated")"
+    [ "$updated_epoch" -gt 0 ] || continue
+    age=$(( $(now_epoch) - updated_epoch ))
+    [ "$age" -ge 0 ] || age=0
+
+    crashed=0
+    if [ "$rs_step" = "claimed" ] && [ "$age" -ge "$CLAIMED_TIMEOUT" ]; then
+        crashed=1
+    elif [ "$age" -ge "$RECLAIM_SECS" ]; then
+        crashed=1
+    fi
+    if [ "$crashed" -eq 0 ]; then
+        # Fresh server heartbeat: assume a live/slow worker elsewhere; do NOT steal.
+        continue
+    fi
+
+    eligible_count=$((eligible_count + 1))
+    eligible_issues="$eligible_issues $issue"
+
+    # Cross-host gate for --resume-partial: only re-attach /tmp/wt-<branch> when
+    # the heartbeat host matches THIS host. Cross-host / missing host -> clean.
+    if [ "$RESUME_PARTIAL" -eq 1 ] && [ -z "$partial_branch" ]; then
+        if [ -n "$hb_host" ] && [ "$hb_host" = "$HOST" ]; then
+            partial_branch="$rs_branch"
+        fi
+    fi
+done
+
+# ── Pre-condition (a): need >=1 eligible (non-terminal, crashed) issue. ───────
+if [ "$eligible_count" -eq 0 ]; then
+    if [ "$saw_in_progress_nonterminal" -eq 1 ]; then
+        say "no crashed in-progress run-state (live/slow worker not stolen)"
+    else
+        say "no open in-progress run-state"
+    fi
+    exit 0
+fi
+
+# ── Attempt cap (checked before incrementing / relaunching). ──────────────────
+if [ -n "$RESUME_ATTEMPTS_SH" ]; then
+    if bash "$RESUME_ATTEMPTS_SH" at-cap --repo "$REPO" 2>/dev/null; then
+        cap="$(bash "$RESUME_ATTEMPTS_SH" cap 2>/dev/null || echo 3)"
+        say "attempt cap reached (${cap})"
+        exit 0
+    fi
+fi
+
+# ── Resolve the durable relaunch command from the registry. ───────────────────
+resume_command=""
+if [ -n "$RUN_REGISTRY_SH" ]; then
+    reg="$(bash "$RUN_REGISTRY_SH" read --repo "$REPO" 2>/dev/null || true)"
+    [ -n "$reg" ] && resume_command="$(printf '%s' "$reg" | jq -r '.resume_command // empty' 2>/dev/null || true)"
+fi
+if [ -z "$resume_command" ]; then
+    say "no durable resume_command in registry"
+    exit 0
+fi
+
+restart_mode="clean-restart off origin/main"
+if [ -n "$partial_branch" ]; then
+    restart_mode="resume-partial /tmp/wt-${partial_branch} (host match)"
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    say "[dry-run] would resume $REPO: ${eligible_count} issue(s) [${eligible_issues# }]; mode=${restart_mode}; command=${resume_command}"
+    exit 0
+fi
+
+# Count this attempt (durable, capped). Resume itself writes NO run-state
+# comment and adds NO lock — the relaunched monitor claims via the existing CAS.
+if [ -n "$RESUME_ATTEMPTS_SH" ]; then
+    bash "$RESUME_ATTEMPTS_SH" inc --repo "$REPO" >/dev/null 2>&1 || true
+fi
+
+say "resuming $REPO: ${eligible_count} issue(s); mode=${restart_mode}; command=${resume_command}"
+# Execute the durably-captured relaunch command. It is the command /autospec-run
+# itself captured for this repo (registry write), so it is not attacker-supplied
+# from an arbitrary /tmp path.
+# shellcheck disable=SC2086
+eval "$resume_command"

--- a/skills/autospec-resume/uninstall.sh
+++ b/skills/autospec-resume/uninstall.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec-resume skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autospec-resume"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+CODEX_SKILL_DEST="$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+
+# ---------- remove ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+    remove_one "$CODEX_SKILL_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0

--- a/skills/autospec-resume/validate.sh
+++ b/skills/autospec-resume/validate.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# skills/autospec-resume/validate.sh — per-skill structural lint for autospec-resume.
+#
+# Checks:
+#   1. Required files exist (trio + install/uninstall/README + scripts).
+#   2. SKILL.md carries the standard new-skill structural sections:
+#      ## Startup self-update (with SKILL_NAME=autospec-resume), the
+#      harness-detection / Subagent-model-tier section, and the
+#      ## Required capabilities & harness adapter row.
+#   3. SKILL.md frontmatter is valid YAML with a `name: autospec-resume` field.
+#   4. codex/prompt.md starts with a leading blank line (byte-precise).
+#   5. resume-scan.sh writes NO run-state comment and adds NO new lock.
+#   6. All scripts pass `bash -n`.
+#
+# Usage:
+#   bash skills/autospec-resume/validate.sh [--skill-dir <path>]
+#
+# Exit 0 = all checks pass. Exit 1 = at least one check failed.
+
+set -eu
+
+fail() { printf 'autospec-resume/validate: FAIL — %s\n' "$*" >&2; exit 1; }
+info() { printf 'autospec-resume/validate: %s\n' "$*"; }
+
+SKILL_DIR=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --skill-dir) SKILL_DIR="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+[ -n "$SKILL_DIR" ] || SKILL_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+SKILL_MD="$SKILL_DIR/SKILL.md"
+CODEX_PROMPT="$SKILL_DIR/codex/prompt.md"
+OPENCODE_AGENT="$SKILL_DIR/opencode/agent.md"
+REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd)"
+
+# ── 1. Required files exist ───────────────────────────────────────────────────
+info "checking required files exist"
+for f in SKILL.md README.md install.sh uninstall.sh validate.sh \
+         opencode/agent.md codex/prompt.md \
+         scripts/resume-scan.sh scripts/resume-attempts.sh; do
+    [ -f "$SKILL_DIR/$f" ] || fail "missing required file: $f"
+done
+[ -f "$REPO_ROOT/scripts/autospec-run-registry.sh" ] \
+    || fail "missing required file: scripts/autospec-run-registry.sh"
+
+# ── 2. Standard new-skill structural sections ─────────────────────────────────
+info "checking standard structural sections in SKILL.md"
+grep -q '^## Startup self-update' "$SKILL_MD" \
+    || fail "SKILL.md missing '## Startup self-update' section"
+grep -q 'SKILL_NAME=autospec-resume' "$SKILL_MD" \
+    || fail "SKILL.md Startup self-update missing 'SKILL_NAME=autospec-resume'"
+grep -q '^## Harness detection' "$SKILL_MD" \
+    || fail "SKILL.md missing harness-detection section"
+grep -q 'TIER_A' "$SKILL_MD" \
+    || fail "SKILL.md harness-detection missing TIER_A reference"
+grep -q 'TIER_B' "$SKILL_MD" \
+    || fail "SKILL.md harness-detection missing TIER_B reference"
+grep -q '^## Required capabilities & harness adapter' "$SKILL_MD" \
+    || fail "SKILL.md missing '## Required capabilities & harness adapter' section"
+grep -q 'Subagent model tier' "$SKILL_MD" \
+    || fail "SKILL.md adapter table missing 'Subagent model tier' row"
+
+# ── 3. Frontmatter ────────────────────────────────────────────────────────────
+info "checking SKILL.md frontmatter"
+fm="$(awk 'BEGIN{in_fm=0} /^---$/{in_fm++; if(in_fm==1) next; if(in_fm==2) exit} in_fm==1{print}' "$SKILL_MD")"
+[ -n "$fm" ] || fail "SKILL.md missing or empty YAML frontmatter"
+printf '%s\n' "$fm" | grep -q '^name: autospec-resume' \
+    || fail "SKILL.md frontmatter missing 'name: autospec-resume'"
+if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" 2>/dev/null; then
+    printf '%s\n' "$fm" | python3 -c "import sys, yaml; yaml.safe_load(sys.stdin.read())" \
+        || fail "SKILL.md frontmatter is not valid YAML"
+fi
+
+# ── 4. codex/prompt.md leading blank line ─────────────────────────────────────
+info "checking codex/prompt.md leading blank line"
+first_char="$(od -An -tx1 -N1 "$CODEX_PROMPT" | tr -d ' \n')"
+[ "$first_char" = "0a" ] \
+    || fail "codex/prompt.md does not start with a leading blank line (first byte: $first_char, expected 0a)"
+
+# ── 5. resume-scan.sh writes no run-state comment / adds no new lock ──────────
+info "checking resume-scan.sh adds no second lock"
+if grep -E 'run-state\.sh[^[:alnum:]]*upsert|run-state\.sh[^[:alnum:]]*clear|gh issue comment' \
+        "$SKILL_DIR/scripts/resume-scan.sh"; then
+    fail "resume-scan.sh must NOT write a run-state comment or add a lock (found a mutation call)"
+fi
+grep -q 'run-state.sh read\|run-state.sh" read\|RUN_STATE_SH" read' "$SKILL_DIR/scripts/resume-scan.sh" \
+    || fail "resume-scan.sh must READ run-state (reuse the existing CAS), never re-implement it"
+
+# ── 6. bash -n on all scripts ─────────────────────────────────────────────────
+info "checking bash -n on all scripts"
+for s in "$SKILL_DIR/scripts/resume-scan.sh" \
+         "$SKILL_DIR/scripts/resume-attempts.sh" \
+         "$REPO_ROOT/scripts/autospec-run-registry.sh"; do
+    bash -n "$s" || fail "$s: bash syntax error"
+    [ -x "$s" ] || fail "$s: not executable"
+done
+
+info "OK — all autospec-resume structural checks passed."

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -243,6 +243,18 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 **Usage-limit recovery guard.** Before launching the monitor, determine the exact non-interactive command that can relaunch this same `/autospec-run` invocation in the current repo and store it in `AUTOSPEC_RESUME_COMMAND` if the harness has not already set one. This must be a real shell command, for example the same Claude Code, Codex CLI, OpenCode, tmux, or wrapper command the operator used to start the run with the same `--profile` and repo path. Do not ask the user for it during a running monitor.
 
+**Durable run registry (crash-resume).** At monitor launch, also persist that same relaunch command to the durable run registry so it survives a host/session crash and reboot — the session env var `AUTOSPEC_RESUME_COMMAND` does not. Write it once per launch with the identical command:
+
+```bash
+REGISTRY="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-run-registry.sh"
+if [ -f "$REGISTRY" ] && [ -n "${AUTOSPEC_RESUME_COMMAND:-}" ]; then
+  bash "$REGISTRY" write --repo "$(gh repo view --json nameWithOwner --jq .nameWithOwner)" \
+    --repo-dir "$(pwd)" --harness "<claude|codex|opencode>" --command "$AUTOSPEC_RESUME_COMMAND"
+fi
+```
+
+`/autospec-resume` reads `~/.autospec/active-runs/<repo-slug>.json` on a fresh start to relaunch this run. The registry is the only durable carrier of the relaunch command across reboot.
+
 When a harness reports a deterministic usage-limit/quota/capacity pause with a known reset time or wait duration, do not spend tokens diagnosing the message. Immediately arm the shell supervisor and exit:
 
 ```bash

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -238,6 +238,18 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 **Usage-limit recovery guard.** Before launching the monitor, determine the exact non-interactive command that can relaunch this same `/autospec-run` invocation in the current repo and store it in `AUTOSPEC_RESUME_COMMAND` if the harness has not already set one. This must be a real shell command, for example the same Claude Code, Codex CLI, OpenCode, tmux, or wrapper command the operator used to start the run with the same `--profile` and repo path. Do not ask the user for it during a running monitor.
 
+**Durable run registry (crash-resume).** At monitor launch, also persist that same relaunch command to the durable run registry so it survives a host/session crash and reboot — the session env var `AUTOSPEC_RESUME_COMMAND` does not. Write it once per launch with the identical command:
+
+```bash
+REGISTRY="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-run-registry.sh"
+if [ -f "$REGISTRY" ] && [ -n "${AUTOSPEC_RESUME_COMMAND:-}" ]; then
+  bash "$REGISTRY" write --repo "$(gh repo view --json nameWithOwner --jq .nameWithOwner)" \
+    --repo-dir "$(pwd)" --harness "<claude|codex|opencode>" --command "$AUTOSPEC_RESUME_COMMAND"
+fi
+```
+
+`/autospec-resume` reads `~/.autospec/active-runs/<repo-slug>.json` on a fresh start to relaunch this run. The registry is the only durable carrier of the relaunch command across reboot.
+
 When a harness reports a deterministic usage-limit/quota/capacity pause with a known reset time or wait duration, do not spend tokens diagnosing the message. Immediately arm the shell supervisor and exit:
 
 ```bash

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -242,6 +242,18 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 **Usage-limit recovery guard.** Before launching the monitor, determine the exact non-interactive command that can relaunch this same `/autospec-run` invocation in the current repo and store it in `AUTOSPEC_RESUME_COMMAND` if the harness has not already set one. This must be a real shell command, for example the same Claude Code, Codex CLI, OpenCode, tmux, or wrapper command the operator used to start the run with the same `--profile` and repo path. Do not ask the user for it during a running monitor.
 
+**Durable run registry (crash-resume).** At monitor launch, also persist that same relaunch command to the durable run registry so it survives a host/session crash and reboot — the session env var `AUTOSPEC_RESUME_COMMAND` does not. Write it once per launch with the identical command:
+
+```bash
+REGISTRY="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-run-registry.sh"
+if [ -f "$REGISTRY" ] && [ -n "${AUTOSPEC_RESUME_COMMAND:-}" ]; then
+  bash "$REGISTRY" write --repo "$(gh repo view --json nameWithOwner --jq .nameWithOwner)" \
+    --repo-dir "$(pwd)" --harness "<claude|codex|opencode>" --command "$AUTOSPEC_RESUME_COMMAND"
+fi
+```
+
+`/autospec-resume` reads `~/.autospec/active-runs/<repo-slug>.json` on a fresh start to relaunch this run. The registry is the only durable carrier of the relaunch command across reboot.
+
 When a harness reports a deterministic usage-limit/quota/capacity pause with a known reset time or wait duration, do not spend tokens diagnosing the message. Immediately arm the shell supervisor and exit:
 
 ```bash

--- a/skills/autospec-run/scripts/heartbeat-write.sh
+++ b/skills/autospec-run/scripts/heartbeat-write.sh
@@ -77,11 +77,19 @@ mkdir -p "$TARGET_DIR"
 
 NOW_TS="$(date -u +%s)"
 
-printf '{"issue":"%s","branch":"%s","step":"%s","ts":%s,"pr":"%s","repo":"%s"}\n' \
+# host: the machine that owns this heartbeat. Added backward-compatibly for the
+# cross-host partial-resume gate (resume-scan.sh). Readers that predate this
+# field, or any heartbeat written before it existed, simply see a missing
+# "host" key and MUST treat it as an unknown host → never eligible for
+# --resume-partial (always clean-restart). Override via AUTOSPEC_HOST for tests.
+HOST_VAL="${AUTOSPEC_HOST:-$(hostname 2>/dev/null || echo "")}"
+
+printf '{"issue":"%s","branch":"%s","step":"%s","ts":%s,"pr":"%s","repo":"%s","host":"%s"}\n' \
     "$ISSUE" \
     "${BRANCH:-}" \
     "$STEP" \
     "$NOW_TS" \
     "${PR_VAL:-}" \
     "$REPO_FULL" \
+    "$HOST_VAL" \
     > "${TARGET_DIR}/${ISSUE}.json"

--- a/tests/resume/test_resume_scan.bats
+++ b/tests/resume/test_resume_scan.bats
@@ -1,0 +1,340 @@
+#!/usr/bin/env bats
+# tests/resume/test_resume_scan.bats — crash-resume decision engine.
+#
+# Covers (docs/specs/2026-06-03-crash-resume-design.md §Error handling):
+#   - idempotency: resume writes NO run-state comment / adds NO lock
+#   - pre-conditions: stop.flag / paused-by-user / all-closed / no-in-progress
+#   - crash-vs-live: server updated_at age<300 not stolen; age>=threshold eligible
+#   - cross-host: host != hostname / missing host under --resume-partial -> clean
+#   - attempt cap: counter at max -> exit 0 cap-reached; resets on merged
+#
+# All GitHub/hostname access is via PATH-shadow mocks driven by env vars.
+
+ROOT="${BATS_TEST_DIRNAME}/../.."
+SCAN="$ROOT/skills/autospec-resume/scripts/resume-scan.sh"
+ATTEMPTS="$ROOT/skills/autospec-resume/scripts/resume-attempts.sh"
+REGISTRY="$ROOT/scripts/autospec-run-registry.sh"
+RUN_STATE_REAL="$ROOT/skills/autospec-run/scripts/run-state.sh"
+HB_READ_REAL="$ROOT/skills/autospec-run/scripts/heartbeat-read.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    export AUTOSPEC_STATE_DIR="$TEST_TMP/state"
+    export AUTOSPEC_ACTIVE_RUNS_DIR="$TEST_TMP/active-runs"
+    export AUTOSPEC_RESUME_ATTEMPTS_DIR="$TEST_TMP/resume-attempts"
+    export AUTOSPEC_HEARTBEAT_DIR="$TEST_TMP/heartbeats"
+    mkdir -p "$AUTOSPEC_STATE_DIR"
+    export AUTOSPEC_HOST="host-A"
+
+    # Point resume-scan at the real helpers (run-state read + heartbeat read),
+    # the real attempts + registry scripts (no re-implementation).
+    export AUTOSPEC_HEARTBEAT_READ_SH="$HB_READ_REAL"
+    export AUTOSPEC_RUN_REGISTRY_SH="$REGISTRY"
+    export AUTOSPEC_RESUME_ATTEMPTS_SH="$ATTEMPTS"
+
+    # Mock dir on PATH (shadows gh, hostname; and run-state.sh via a wrapper).
+    export MOCK_DIR="$TEST_TMP/bin"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+
+    # Defaults driving the gh mock. Tests override these.
+    export GH_IN_PROGRESS="42"     # newline-separated issue numbers
+    export GH_PAUSED=""            # newline-separated
+    export GH_OPEN_AUTO="42"       # open auto-implement issues
+    export GH_REPO="o/n"
+
+    # run-state mock: we shadow run-state.sh by exporting a fake that returns
+    # controlled JSON via AUTOSPEC_RUN_STATE_SH pointing to a generated script.
+    export RS_STEP="claimed"
+    export RS_UPDATED_AGE="600"    # seconds ago (server updated_at)
+    export RS_BRANCH="feat/x"
+
+    write_gh_mock
+    write_hostname_mock
+    write_run_state_mock
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+write_hostname_mock() {
+    cat > "$MOCK_DIR/hostname" <<EOF
+#!/usr/bin/env bash
+echo "${AUTOSPEC_HOST}"
+EOF
+    chmod +x "$MOCK_DIR/hostname"
+}
+
+write_gh_mock() {
+    cat > "$MOCK_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+# PATH-shadow gh mock driven by env vars.
+args="$*"
+case "$args" in
+    *"repo view"*) echo "${GH_REPO}"; exit 0 ;;
+esac
+case "$args" in
+    *"issue list"*"--label in-progress-by-bot"*) printf '%s\n' $GH_IN_PROGRESS; exit 0 ;;
+    *"issue list"*"--label paused-by-user"*)     printf '%s\n' $GH_PAUSED;      exit 0 ;;
+    *"issue list"*"--label auto-implement"*)     printf '%s\n' $GH_OPEN_AUTO;   exit 0 ;;
+    *"issue list"*)                              printf '%s\n' $GH_OPEN_AUTO;   exit 0 ;;
+esac
+# Any run-state comment write would land here -> record it as a violation.
+case "$args" in
+    *"issue comment"*) echo "VIOLATION: gh issue comment called" >>"${VIOLATION_LOG:-/dev/null}"; exit 0 ;;
+    *"api"*) exit 0 ;;
+esac
+exit 0
+EOF
+    chmod +x "$MOCK_DIR/gh"
+}
+
+# run-state mock script: resume-scan calls it as `run-state.sh read --issue N --repo r`.
+write_run_state_mock() {
+    local rs="$MOCK_DIR/run-state-mock.sh"
+    cat > "$rs" <<'EOF'
+#!/usr/bin/env bash
+# Mocked run-state read: emits a JSON object with a server updated_at computed
+# from RS_UPDATED_AGE seconds ago. `clear`/`upsert` would be a lock mutation —
+# emit a violation if ever invoked.
+cmd="${1:-}"
+case "$cmd" in
+    read)
+        updated="$(date -u -v-"${RS_UPDATED_AGE:-600}"S +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+            || date -u -d "-${RS_UPDATED_AGE:-600} seconds" +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)"
+        printf '{"schema":1,"repo":"%s","issue":%s,"step":"%s","state":"%s","branch":"%s","updated_at":"%s"}\n' \
+            "${GH_REPO}" "42" "${RS_STEP}" "${RS_STEP}" "${RS_BRANCH}" "$updated"
+        ;;
+    upsert|clear)
+        echo "VIOLATION: run-state ${cmd} (lock mutation) called" >>"${VIOLATION_LOG:-/dev/null}"
+        ;;
+esac
+exit 0
+EOF
+    chmod +x "$rs"
+    export AUTOSPEC_RUN_STATE_SH="$rs"
+}
+
+# Write a heartbeat for issue 42 with a given step + host.
+write_heartbeat() {
+    local issue="$1" step="$2" host="$3"
+    local dir="$AUTOSPEC_HEARTBEAT_DIR/o_n"
+    mkdir -p "$dir"
+    printf '{"issue":"%s","branch":"feat/x","step":"%s","ts":%s,"pr":"","repo":"o/n","host":"%s"}\n' \
+        "$issue" "$step" "$(date -u +%s)" "$host" > "$dir/$issue.json"
+}
+
+# Heartbeat WITHOUT a host field (backward-compat / legacy).
+write_heartbeat_nohost() {
+    local issue="$1" step="$2"
+    local dir="$AUTOSPEC_HEARTBEAT_DIR/o_n"
+    mkdir -p "$dir"
+    printf '{"issue":"%s","branch":"feat/x","step":"%s","ts":%s,"pr":"","repo":"o/n"}\n' \
+        "$issue" "$step" "$(date -u +%s)" > "$dir/$issue.json"
+}
+
+# Register a durable resume command so a relaunch is possible.
+register_command() {
+    bash "$REGISTRY" write --repo o/n --repo-dir /tmp/x --harness claude \
+        --command "${1:-echo RELAUNCHED}" --host host-A >/dev/null
+}
+
+# ── Pre-conditions ────────────────────────────────────────────────────────────
+
+@test "stop.flag present -> exit 0, no relaunch" {
+    touch "$AUTOSPEC_STATE_DIR/stop.flag"
+    write_heartbeat 42 claimed host-A
+    register_command
+    run bash "$SCAN" --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stop.flag present"* ]]
+    [[ "$output" != *"resuming"* ]]
+}
+
+@test "paused-by-user present -> exit 0, no relaunch" {
+    export GH_PAUSED="7"
+    write_heartbeat 42 claimed host-A
+    register_command
+    run bash "$SCAN" --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"paused-by-user present"* ]]
+    [[ "$output" != *"resuming"* ]]
+}
+
+@test "all issues closed -> exit 0, no relaunch" {
+    export GH_IN_PROGRESS=""
+    export GH_OPEN_AUTO=""
+    register_command
+    run bash "$SCAN" --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"all issues closed"* ]]
+    [[ "$output" != *"resuming"* ]]
+}
+
+@test "no in-progress run-state -> exit 0, no relaunch" {
+    export GH_IN_PROGRESS=""
+    export GH_OPEN_AUTO="99"   # open issues exist but none in-progress
+    register_command
+    run bash "$SCAN" --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no open in-progress run-state"* ]]
+    [[ "$output" != *"resuming"* ]]
+}
+
+# ── Crash-vs-live (server updated_at) ─────────────────────────────────────────
+
+@test "claimed age < 300 -> not stolen (live/slow worker)" {
+    export RS_STEP="claimed"
+    export RS_UPDATED_AGE="120"   # < 300
+    write_heartbeat 42 claimed host-A
+    register_command
+    run bash "$SCAN" --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not stolen"* ]] || [[ "$output" == *"live/slow"* ]]
+    [[ "$output" != *"resuming"* ]]
+}
+
+@test "claimed age >= 300 -> eligible, resumes" {
+    export RS_STEP="claimed"
+    export RS_UPDATED_AGE="600"   # >= 300
+    write_heartbeat 42 claimed host-A
+    register_command "echo RELAUNCHED"
+    run bash "$SCAN" --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"resuming o/n"* ]]
+    [[ "$output" == *"RELAUNCHED"* ]]
+}
+
+@test "non-claimed age >= 10800 -> eligible, resumes" {
+    export RS_STEP="implementing"
+    export RS_UPDATED_AGE="11000"   # >= 10800
+    write_heartbeat 42 implementing host-A
+    register_command "echo RELAUNCHED"
+    run bash "$SCAN" --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"resuming o/n"* ]]
+}
+
+@test "non-claimed age < 10800 -> not stolen" {
+    export RS_STEP="implementing"
+    export RS_UPDATED_AGE="500"   # < 10800 and step != claimed
+    write_heartbeat 42 implementing host-A
+    register_command
+    run bash "$SCAN" --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"resuming"* ]]
+}
+
+@test "terminal heartbeat step merged -> not resumed" {
+    export RS_UPDATED_AGE="600"
+    write_heartbeat 42 merged host-A
+    register_command
+    run bash "$SCAN" --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"resuming"* ]]
+}
+
+# ── Idempotency / no second lock ──────────────────────────────────────────────
+
+@test "idempotency: resume writes NO run-state comment / no lock mutation" {
+    export VIOLATION_LOG="$TEST_TMP/violations.log"
+    : > "$VIOLATION_LOG"
+    export RS_UPDATED_AGE="600"
+    write_heartbeat 42 claimed host-A
+    register_command "echo RELAUNCHED"
+    # Two concurrent resumes.
+    bash "$SCAN" --repo o/n >/dev/null 2>&1 &
+    bash "$SCAN" --repo o/n >/dev/null 2>&1 &
+    wait
+    # Neither resume may have written a run-state comment or mutated the lock.
+    [ ! -s "$VIOLATION_LOG" ]
+}
+
+# ── Cross-host gate (--resume-partial) ────────────────────────────────────────
+
+@test "cross-host: heartbeat host != hostname -> clean-restart, not partial" {
+    export RS_UPDATED_AGE="600"
+    write_heartbeat 42 claimed host-B   # different host than AUTOSPEC_HOST=host-A
+    register_command "echo RELAUNCHED"
+    run bash "$SCAN" --repo o/n --resume-partial
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"resuming o/n"* ]]
+    [[ "$output" == *"clean-restart off origin/main"* ]]
+    [[ "$output" != *"resume-partial"* ]]
+}
+
+@test "cross-host: missing host -> clean-restart, not partial" {
+    export RS_UPDATED_AGE="600"
+    write_heartbeat_nohost 42 claimed
+    register_command "echo RELAUNCHED"
+    run bash "$SCAN" --repo o/n --resume-partial
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"clean-restart off origin/main"* ]]
+    [[ "$output" != *"resume-partial"* ]]
+}
+
+@test "same-host --resume-partial -> partial re-attach" {
+    export RS_UPDATED_AGE="600"
+    write_heartbeat 42 claimed host-A
+    register_command "echo RELAUNCHED"
+    run bash "$SCAN" --repo o/n --resume-partial
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"resume-partial /tmp/wt-feat/x"* ]]
+}
+
+# ── Attempt cap ───────────────────────────────────────────────────────────────
+
+@test "attempt cap reached -> exit 0 cap-reached, no relaunch" {
+    export AUTOSPEC_RESUME_MAX_ATTEMPTS=3
+    export RS_UPDATED_AGE="600"
+    write_heartbeat 42 claimed host-A
+    register_command "echo RELAUNCHED"
+    # Drive the counter to the cap.
+    bash "$ATTEMPTS" inc --repo o/n >/dev/null
+    bash "$ATTEMPTS" inc --repo o/n >/dev/null
+    bash "$ATTEMPTS" inc --repo o/n >/dev/null
+    run bash "$SCAN" --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"attempt cap reached"* ]]
+    [[ "$output" != *"resuming"* ]]
+}
+
+@test "attempt counter resets on merged (forward progress)" {
+    export AUTOSPEC_RESUME_MAX_ATTEMPTS=3
+    bash "$ATTEMPTS" inc --repo o/n >/dev/null
+    bash "$ATTEMPTS" inc --repo o/n >/dev/null
+    bash "$ATTEMPTS" inc --repo o/n >/dev/null
+    run bash "$ATTEMPTS" at-cap --repo o/n
+    [ "$status" -eq 0 ]   # at cap
+    # A merged issue resets the counter.
+    bash "$ATTEMPTS" reset --repo o/n >/dev/null
+    run bash "$ATTEMPTS" at-cap --repo o/n
+    [ "$status" -eq 1 ]   # no longer at cap
+    run bash "$ATTEMPTS" get --repo o/n
+    [ "$output" = "0" ]
+}
+
+@test "resume increments the attempt counter on relaunch" {
+    export RS_UPDATED_AGE="600"
+    write_heartbeat 42 claimed host-A
+    register_command "echo RELAUNCHED"
+    run bash "$ATTEMPTS" get --repo o/n
+    [ "$output" = "0" ]
+    bash "$SCAN" --repo o/n >/dev/null 2>&1
+    run bash "$ATTEMPTS" get --repo o/n
+    [ "$output" = "1" ]
+}
+
+# ── --dry-run ─────────────────────────────────────────────────────────────────
+
+@test "--dry-run prints decision, changes nothing, exit 0" {
+    export RS_UPDATED_AGE="600"
+    write_heartbeat 42 claimed host-A
+    register_command "echo RELAUNCHED"
+    run bash "$SCAN" --repo o/n --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[dry-run]"* ]]
+    [[ "$output" == *"command=echo RELAUNCHED"* ]]
+    # No attempt increment under dry-run.
+    run bash "$ATTEMPTS" get --repo o/n
+    [ "$output" = "0" ]
+}

--- a/tests/resume/test_run_registry.bats
+++ b/tests/resume/test_run_registry.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# tests/resume/test_run_registry.bats — durable run registry + attempts counter.
+#
+# Covers (docs/specs/2026-06-03-crash-resume-design.md §Data model):
+#   - registry write/read/list/prune two-line atomic temp+mv
+#   - registry-durable: after a simulated reboot (env cleared except the base
+#     dir on disk) the registry ALONE yields a runnable resume_command
+#   - attempts counter get/inc/reset, cap, stale>24h ignored
+
+ROOT="${BATS_TEST_DIRNAME}/../.."
+REGISTRY="$ROOT/scripts/autospec-run-registry.sh"
+ATTEMPTS="$ROOT/skills/autospec-resume/scripts/resume-attempts.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    export AUTOSPEC_ACTIVE_RUNS_DIR="$TEST_TMP/active-runs"
+    export AUTOSPEC_RESUME_ATTEMPTS_DIR="$TEST_TMP/resume-attempts"
+}
+teardown() { rm -rf "$TEST_TMP"; }
+
+# ── registry ──────────────────────────────────────────────────────────────────
+
+@test "registry write then read returns the resume_command" {
+    bash "$REGISTRY" write --repo o/n --repo-dir /abs/checkout --harness claude \
+        --command "claude /autospec-run" --host host-A
+    run bash "$REGISTRY" read --repo o/n
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.resume_command')" = "claude /autospec-run" ]
+    [ "$(echo "$output" | jq -r '.repo')" = "o/n" ]
+    [ "$(echo "$output" | jq -r '.harness')" = "claude" ]
+    [ "$(echo "$output" | jq -r '.host')" = "host-A" ]
+}
+
+@test "registry path is scoped by repo-slug" {
+    run bash "$REGISTRY" path --repo owner/name
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"/owner_name.json" ]]
+}
+
+@test "registry-durable: reboot (env cleared) still yields a runnable command" {
+    # /autospec-run writes the registry at monitor launch.
+    AUTOSPEC_RESUME_COMMAND="echo REBOOT-OK" \
+        bash "$REGISTRY" write --repo o/n --repo-dir /abs/checkout --harness codex \
+            --command "echo REBOOT-OK" --host host-A
+    # Simulate a reboot: env var is GONE, only the on-disk registry survives.
+    unset AUTOSPEC_RESUME_COMMAND
+    cmd="$(bash "$REGISTRY" read --repo o/n | jq -r '.resume_command')"
+    [ "$cmd" = "echo REBOOT-OK" ]
+    # The command derived from the registry alone is runnable.
+    run bash -c "$cmd"
+    [ "$status" -eq 0 ]
+    [ "$output" = "REBOOT-OK" ]
+}
+
+@test "registry list shows fresh entries, prune drops stale" {
+    bash "$REGISTRY" write --repo a/one --repo-dir /x --harness claude --command "c1" --host h
+    bash "$REGISTRY" write --repo b/two --repo-dir /y --harness claude --command "c2" --host h
+    run bash "$REGISTRY" list
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"a_one.json"* ]]
+    [[ "$output" == *"b_two.json"* ]]
+}
+
+@test "registry stale (>24h) entry is not surfaced by read" {
+    bash "$REGISTRY" write --repo o/n --repo-dir /x --harness claude --command "c" --host h
+    # Backdate updated_at to 25h ago.
+    f="$(bash "$REGISTRY" path --repo o/n)"
+    old="$(date -u -v-25H +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '-25 hours' +'%Y-%m-%dT%H:%M:%SZ')"
+    jq --arg u "$old" '.updated_at=$u' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+    run bash "$REGISTRY" read --repo o/n
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    # prune removes it from disk.
+    bash "$REGISTRY" prune
+    [ ! -f "$f" ]
+}
+
+@test "registry write preserves registered_at across re-write" {
+    bash "$REGISTRY" write --repo o/n --repo-dir /x --harness claude --command "c1" --host h
+    first="$(bash "$REGISTRY" read --repo o/n | jq -r '.registered_at')"
+    sleep 1
+    bash "$REGISTRY" write --repo o/n --repo-dir /x --harness claude --command "c2" --host h
+    again="$(bash "$REGISTRY" read --repo o/n | jq -r '.registered_at')"
+    [ "$first" = "$again" ]
+}
+
+# ── attempts counter ──────────────────────────────────────────────────────────
+
+@test "attempts get is 0 when absent" {
+    run bash "$ATTEMPTS" get --repo o/n
+    [ "$status" -eq 0 ]
+    [ "$output" = "0" ]
+}
+
+@test "attempts inc increments and persists" {
+    bash "$ATTEMPTS" inc --repo o/n
+    bash "$ATTEMPTS" inc --repo o/n
+    run bash "$ATTEMPTS" get --repo o/n
+    [ "$output" = "2" ]
+}
+
+@test "attempts cap default is 3, override via env" {
+    run bash "$ATTEMPTS" cap
+    [ "$output" = "3" ]
+    AUTOSPEC_RESUME_MAX_ATTEMPTS=5 run bash "$ATTEMPTS" cap
+    [ "$output" = "5" ]
+}
+
+@test "attempts stale (>24h) counter ignored -> effective 0" {
+    bash "$ATTEMPTS" inc --repo o/n
+    bash "$ATTEMPTS" inc --repo o/n
+    f="$(bash "$ATTEMPTS" path --repo o/n)"
+    old="$(date -u -v-25H +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '-25 hours' +'%Y-%m-%dT%H:%M:%SZ')"
+    jq --arg u "$old" '.updated_at=$u' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+    run bash "$ATTEMPTS" get --repo o/n
+    [ "$output" = "0" ]
+}


### PR DESCRIPTION
Closes #881

Adds the `/autospec-resume` lock-step trio plus the durable crash-resume machinery (child 1 of the crash-resume design spec): a fresh process now detects an interrupted run from durable run-state + heartbeats and auto-continues it.

- **No second lock / idempotency:** `resume-scan.sh` reads run-state but never upserts/clears it and writes no comment; the relaunched monitor claims through the existing GitHub CAS. Two concurrent resumes converge to one claim.
- **Crash-vs-live** keyed on run-state SERVER `updated_at` (never local clock): `step=claimed && age>=300` OR `age>=10800`. Fresh claimed issues are never stolen.
- **Cross-host gate:** `--resume-partial` re-attaches `/tmp/wt-<branch>` only when `heartbeat.host == hostname`; missing/foreign host clean-restarts off `origin/main`. Heartbeat schema gains a backward-compatible `host` field.
- **Durable relaunch command:** `/autospec-run` writes `~/.autospec/active-runs/<slug>.json` at monitor launch, so the command survives reboot (env var does not).
- **Attempt cap** at `AUTOSPEC_RESUME_MAX_ATTEMPTS` (default 3); resets on any merged issue.

Validation: full `bash scripts/validate.sh` passes (exit 0) including trio lockstep, the new `check_autospec_resume_contract`, per-skill `validate.sh`, and 27 `tests/resume/` bats with PATH-shadow gh/hostname/run-state mocks. Out of scope: supervisor (#882) and watchdog GC (#883).

🤖 Generated with [Claude Code](https://claude.com/claude-code)