### PR TITLE
feat(autospec-resume): external boot supervisor for crash-resume

### DIFF
--- a/scripts/autospec-supervisor-install.sh
+++ b/scripts/autospec-supervisor-install.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# autospec-supervisor-install.sh — install/uninstall/status the boot unit that
+# runs autospec-supervisor.sh once per boot (child 2 of
+# docs/specs/2026-06-03-crash-resume-design.md §Interactivity / API shape).
+#
+# Platform selection (spec "AUTONOMOUS ASSUMPTION"):
+#   darwin -> launchd user LaunchAgent (~/Library/LaunchAgents)
+#   linux  -> systemd user unit         (~/.config/systemd/user)
+#   else   -> `@reboot` crontab fallback
+#
+# All three install paths are IDEMPOTENT: a second `install` overwrites in place
+# and leaves exactly one entry; `uninstall` removes it; `status` reports presence.
+#
+# Usage:
+#   autospec-supervisor-install.sh install
+#   autospec-supervisor-install.sh uninstall
+#   autospec-supervisor-install.sh status
+#
+# Environment:
+#   AUTOSPEC_SUPERVISOR_SH        path to autospec-supervisor.sh (auto-resolved)
+#   AUTOSPEC_PLATFORM             override platform detection: darwin|linux|cron
+#   AUTOSPEC_LAUNCH_AGENTS_DIR    override launchd dir (tests)
+#   AUTOSPEC_SYSTEMD_USER_DIR     override systemd user dir (tests)
+
+set -eu
+
+LABEL="com.berlinguyinca.autospec.supervisor"
+UNIT="autospec-supervisor"           # systemd unit base name
+CRON_TAG="# autospec-supervisor"     # crontab marker line
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STATE_DIR="${AUTOSPEC_STATE_DIR:-$HOME/.autospec}"
+
+LAUNCH_AGENTS_DIR="${AUTOSPEC_LAUNCH_AGENTS_DIR:-$HOME/Library/LaunchAgents}"
+SYSTEMD_USER_DIR="${AUTOSPEC_SYSTEMD_USER_DIR:-$HOME/.config/systemd/user}"
+PLIST_PATH="$LAUNCH_AGENTS_DIR/$LABEL.plist"
+SERVICE_PATH="$SYSTEMD_USER_DIR/$UNIT.service"
+
+err()  { printf 'autospec-supervisor-install: %s\n' "$1" >&2; }
+die()  { err "$1"; exit 1; }
+say()  { printf '%s\n' "$1"; }
+
+usage() {
+    cat <<'EOF'
+Usage:
+  autospec-supervisor-install.sh install
+  autospec-supervisor-install.sh uninstall
+  autospec-supervisor-install.sh status
+EOF
+}
+
+# ── Resolve the supervisor entrypoint we install a boot unit for. ──────────────
+resolve_supervisor() {
+    if [ -n "${AUTOSPEC_SUPERVISOR_SH:-}" ] && [ -f "$AUTOSPEC_SUPERVISOR_SH" ]; then
+        printf '%s' "$AUTOSPEC_SUPERVISOR_SH"; return
+    fi
+    for c in "$SCRIPT_DIR/autospec-supervisor.sh" "$STATE_DIR/scripts/autospec-supervisor.sh"; do
+        [ -f "$c" ] && { printf '%s' "$c"; return; }
+    done
+    printf ''
+}
+
+detect_platform() {
+    if [ -n "${AUTOSPEC_PLATFORM:-}" ]; then printf '%s' "$AUTOSPEC_PLATFORM"; return; fi
+    case "$(uname -s 2>/dev/null || echo unknown)" in
+        Darwin) printf 'darwin' ;;
+        Linux)  printf 'linux' ;;
+        *)      printf 'cron' ;;
+    esac
+}
+
+# ── launchd (macOS) ────────────────────────────────────────────────────────────
+launchd_install() {
+    sup="$1"
+    mkdir -p "$LAUNCH_AGENTS_DIR"
+    tmp="$(mktemp "${PLIST_PATH}.XXXXXX")"
+    cat > "$tmp" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>$sup</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+EOF
+    mv "$tmp" "$PLIST_PATH"       # atomic overwrite -> idempotent (single entry)
+    if command -v launchctl >/dev/null 2>&1; then
+        launchctl unload "$PLIST_PATH" >/dev/null 2>&1 || true
+        launchctl load "$PLIST_PATH"  >/dev/null 2>&1 || true
+    fi
+    say "installed launchd agent: $PLIST_PATH"
+}
+launchd_uninstall() {
+    if command -v launchctl >/dev/null 2>&1 && [ -f "$PLIST_PATH" ]; then
+        launchctl unload "$PLIST_PATH" >/dev/null 2>&1 || true
+    fi
+    rm -f "$PLIST_PATH"
+    say "uninstalled launchd agent: $PLIST_PATH"
+}
+launchd_status() {
+    if [ -f "$PLIST_PATH" ]; then say "installed (launchd): $PLIST_PATH"; return 0; fi
+    say "not installed (launchd)"; return 1
+}
+
+# ── systemd (Linux, user unit) ─────────────────────────────────────────────────
+systemd_install() {
+    sup="$1"
+    mkdir -p "$SYSTEMD_USER_DIR"
+    tmp="$(mktemp "${SERVICE_PATH}.XXXXXX")"
+    cat > "$tmp" <<EOF
+[Unit]
+Description=autospec crash-resume boot supervisor
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash $sup
+
+[Install]
+WantedBy=default.target
+EOF
+    mv "$tmp" "$SERVICE_PATH"     # atomic overwrite -> idempotent (single entry)
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl --user daemon-reload >/dev/null 2>&1 || true
+        systemctl --user enable "$UNIT.service" >/dev/null 2>&1 || true
+    fi
+    say "installed systemd user unit: $SERVICE_PATH"
+}
+systemd_uninstall() {
+    if command -v systemctl >/dev/null 2>&1 && [ -f "$SERVICE_PATH" ]; then
+        systemctl --user disable "$UNIT.service" >/dev/null 2>&1 || true
+        systemctl --user daemon-reload >/dev/null 2>&1 || true
+    fi
+    rm -f "$SERVICE_PATH"
+    say "uninstalled systemd user unit: $SERVICE_PATH"
+}
+systemd_status() {
+    if [ -f "$SERVICE_PATH" ]; then say "installed (systemd): $SERVICE_PATH"; return 0; fi
+    say "not installed (systemd)"; return 1
+}
+
+# ── @reboot crontab fallback ───────────────────────────────────────────────────
+cron_line() {
+    sup="$1"
+    printf '@reboot /bin/bash %s >/dev/null 2>&1 %s\n' "$sup" "$CRON_TAG"
+}
+cron_current() { crontab -l 2>/dev/null || true; }
+cron_without_ours() {
+    # Drop any prior autospec-supervisor line so re-install stays idempotent.
+    cron_current | grep -vF "$CRON_TAG" || true
+}
+cron_install() {
+    sup="$1"
+    command -v crontab >/dev/null 2>&1 || die "crontab not available for @reboot fallback"
+    { cron_without_ours; cron_line "$sup"; } | crontab -
+    say "installed @reboot cron entry for $sup"
+}
+cron_uninstall() {
+    command -v crontab >/dev/null 2>&1 || { say "uninstalled (cron): crontab absent"; return 0; }
+    remaining="$(cron_without_ours)"
+    if [ -n "$remaining" ]; then
+        printf '%s\n' "$remaining" | crontab -
+    else
+        crontab -r >/dev/null 2>&1 || true
+    fi
+    say "uninstalled @reboot cron entry"
+}
+cron_status() {
+    if command -v crontab >/dev/null 2>&1 && cron_current | grep -qF "$CRON_TAG"; then
+        say "installed (cron): @reboot entry present"; return 0
+    fi
+    say "not installed (cron)"; return 1
+}
+
+# ── Dispatch ───────────────────────────────────────────────────────────────────
+action="${1:-}"
+[ -n "$action" ] || { usage >&2; exit 1; }
+
+platform="$(detect_platform)"
+
+case "$action" in
+    install)
+        sup="$(resolve_supervisor)"
+        [ -n "$sup" ] || die "autospec-supervisor.sh not found (set AUTOSPEC_SUPERVISOR_SH)"
+        case "$platform" in
+            darwin) launchd_install "$sup" ;;
+            linux)  systemd_install "$sup" ;;
+            *)      cron_install "$sup" ;;
+        esac
+        ;;
+    uninstall)
+        case "$platform" in
+            darwin) launchd_uninstall ;;
+            linux)  systemd_uninstall ;;
+            *)      cron_uninstall ;;
+        esac
+        ;;
+    status)
+        case "$platform" in
+            darwin) launchd_status ;;
+            linux)  systemd_status ;;
+            *)      cron_status ;;
+        esac
+        ;;
+    --help|-h) usage ;;
+    *) usage >&2; exit 1 ;;
+esac

--- a/scripts/autospec-supervisor.sh
+++ b/scripts/autospec-supervisor.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# autospec-supervisor.sh — external boot supervisor for crash-resume (child 2 of
+# docs/specs/2026-06-03-crash-resume-design.md).
+#
+# Runs once at boot (launchd / systemd / @reboot cron — installed by
+# autospec-supervisor-install.sh). For each entry in the durable active-runs
+# registry (~/.autospec/active-runs/<repo-slug>.json), it:
+#   1. reads the registry entry's repo,
+#   2. INDEPENDENTLY confirms via GitHub that the repo has >=1 OPEN issue
+#      labeled `in-progress-by-bot` (a confirmed open in-progress run-state),
+#   3. only then invokes `/autospec-resume --repo <repo>` (resume-scan.sh),
+#      which re-confirms crash-vs-live and resolves the durable resume_command.
+#
+# SECURITY (spec §Error handling "Supervisor safety"): the supervisor NEVER
+# execs the registry's raw `resume_command` directly. It only ever delegates to
+# /autospec-resume for a repo it has *independently confirmed* has an open
+# in-progress run on GitHub. A poisoned/attacker-edited `resume_command` in the
+# registry is therefore never executed by the supervisor — resume-scan.sh owns
+# the relaunch, and only after its own GitHub crash-vs-live confirmation.
+#
+# BOOT-THRASH SAFETY: when NO registry entry has a confirmed open run, the
+# supervisor prints one line, exits 0, and does NOT re-arm / reschedule itself.
+# The boot unit fires once per boot; the supervisor never loops or re-arms.
+#
+# Usage:
+#   autospec-supervisor.sh [--dry-run]
+#
+# Exit codes:
+#   0  ran the boot pass (resumed 0..N confirmed-open repos, or nothing to do)
+#   1  hard error (no gh)
+#
+# Environment:
+#   AUTOSPEC_ACTIVE_RUNS_DIR     registry base dir (default ~/.autospec/active-runs)
+#   AUTOSPEC_RUN_REGISTRY_SH     path to autospec-run-registry.sh (auto-resolved)
+#   AUTOSPEC_RESUME_SCAN_SH      path to resume-scan.sh (auto-resolved); this is
+#                                what `/autospec-resume --repo <r>` dispatches to
+#   AUTOSPEC_SUPERVISOR_DRY_RUN  set to 1 to force --dry-run (no relaunch)
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STATE_DIR="${AUTOSPEC_STATE_DIR:-$HOME/.autospec}"
+
+err()  { printf 'autospec-supervisor: %s\n' "$1" >&2; }
+die()  { err "$1"; exit 1; }
+say()  { printf '%s\n' "$1"; }
+
+DRY_RUN=0
+[ "${AUTOSPEC_SUPERVISOR_DRY_RUN:-0}" = "1" ] && DRY_RUN=1
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        --help|-h) sed -n '2,30p' "$0"; exit 0 ;;
+        *) die "unknown option: $1" ;;
+    esac
+done
+
+command -v gh >/dev/null 2>&1 || die "gh CLI not found"
+
+# ── Resolve sibling helpers (checkout layout or installed ~/.autospec/scripts). ─
+resolve_helper() {
+    override="$1"; shift
+    if [ -n "$override" ] && [ -f "$override" ]; then printf '%s' "$override"; return; fi
+    for c in "$@"; do
+        [ -f "$c" ] && { printf '%s' "$c"; return; }
+    done
+    printf ''
+}
+
+RUN_REGISTRY_SH="$(resolve_helper "${AUTOSPEC_RUN_REGISTRY_SH:-}" \
+    "$SCRIPT_DIR/autospec-run-registry.sh" \
+    "$STATE_DIR/scripts/autospec-run-registry.sh")"
+[ -n "$RUN_REGISTRY_SH" ] || die "autospec-run-registry.sh not found"
+
+RESUME_SCAN_SH="$(resolve_helper "${AUTOSPEC_RESUME_SCAN_SH:-}" \
+    "$SCRIPT_DIR/../skills/autospec-resume/scripts/resume-scan.sh" \
+    "$STATE_DIR/scripts/resume-scan.sh")"
+[ -n "$RESUME_SCAN_SH" ] || die "resume-scan.sh (/autospec-resume) not found"
+
+# ── Independent GitHub confirmation: does <repo> have an OPEN in-progress run? ──
+# This is the supervisor's own least-privilege gate. It does NOT trust the
+# registry's resume_command — it asks GitHub directly. Only a confirmed-open run
+# is handed to /autospec-resume.
+confirm_open_run() {
+    repo="$1"
+    count="$(gh issue list --repo "$repo" --label in-progress-by-bot \
+        --state open --json number --jq 'length' 2>/dev/null || echo 0)"
+    case "$count" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    [ "$count" -ge 1 ]
+}
+
+# ── Iterate the registry. ──────────────────────────────────────────────────────
+resumed=0
+confirmed=0
+registry_files="$(bash "$RUN_REGISTRY_SH" list 2>/dev/null || true)"
+
+if [ -n "$registry_files" ]; then
+    while IFS= read -r reg_file; do
+        [ -n "$reg_file" ] || continue
+        [ -f "$reg_file" ] || continue
+        repo="$(jq -r '.repo // empty' "$reg_file" 2>/dev/null || true)"
+        [ -n "$repo" ] || continue
+
+        if ! confirm_open_run "$repo"; then
+            # No independently-confirmed open run for this entry: do NOT relaunch.
+            continue
+        fi
+        confirmed=$((confirmed + 1))
+
+        if [ "$DRY_RUN" -eq 1 ]; then
+            say "[dry-run] would resume $repo (confirmed open in-progress run)"
+            resumed=$((resumed + 1))
+            continue
+        fi
+
+        say "supervisor: resuming $repo (confirmed open in-progress run)"
+        # Delegate to /autospec-resume (resume-scan.sh). It re-confirms
+        # crash-vs-live via GitHub server updated_at and resolves the durable
+        # resume_command itself; the supervisor never execs that command.
+        bash "$RESUME_SCAN_SH" --repo "$repo" || \
+            err "resume for $repo exited non-zero (continuing)"
+        resumed=$((resumed + 1))
+    done <<EOF
+$registry_files
+EOF
+fi
+
+# ── No confirmed open run anywhere -> exit 0, back off, do NOT re-arm. ─────────
+if [ "$confirmed" -eq 0 ]; then
+    say "no open run; nothing to resume (exit 0, backing off)"
+    exit 0
+fi
+
+exit 0

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -2177,12 +2177,45 @@ check_autospec_resume_structure() {
     done
 }
 
+# External boot supervisor (issue #882, child 2 of the crash-resume spec): the
+# boot entrypoint + cross-platform install surface must exist, be executable,
+# and pass `bash -n`. The supervisor must delegate relaunch to /autospec-resume
+# (resume-scan.sh) and never eval the registry's raw resume_command directly,
+# and the installer must select launchd / systemd / @reboot cron by platform.
+check_autospec_supervisor_structure() {
+    info "autospec-supervisor boot supervisor + install surface (issue #882)"
+    for s in scripts/autospec-supervisor.sh scripts/autospec-supervisor-install.sh; do
+        [ -f "$s" ] || fail "$s: required script missing (issue #882)"
+        [ -x "$s" ] || fail "$s: file not executable (issue #882)"
+        bash -n "$s" || fail "$s: bash syntax error (issue #882)"
+    done
+    # Security: the supervisor relaunches only via /autospec-resume (resume-scan),
+    # never by eval'ing the registry's raw resume_command.
+    grep -q 'resume-scan.sh' scripts/autospec-supervisor.sh \
+        || fail "scripts/autospec-supervisor.sh must delegate relaunch to resume-scan.sh (/autospec-resume)"
+    if grep -Eq 'eval[[:space:]]+"\$(resume_command|reg)' scripts/autospec-supervisor.sh; then
+        fail "scripts/autospec-supervisor.sh must NOT eval the registry's raw resume_command directly (supervisor safety)"
+    fi
+    grep -q 'confirm_open_run\|in-progress-by-bot' scripts/autospec-supervisor.sh \
+        || fail "scripts/autospec-supervisor.sh must independently confirm an open in-progress run via gh"
+    # Installer must cover all three platform surfaces.
+    for needle in launchd systemd '@reboot'; do
+        grep -q "$needle" scripts/autospec-supervisor-install.sh \
+            || fail "scripts/autospec-supervisor-install.sh missing $needle platform surface (issue #882)"
+    done
+    for action in install uninstall status; do
+        grep -q "^[[:space:]]*$action)" scripts/autospec-supervisor-install.sh \
+            || fail "scripts/autospec-supervisor-install.sh missing '$action' action (issue #882)"
+    done
+}
+
 # Crash-resume invariants: no second lock, server updated_at, host field,
 # registry wiring, per-skill lint, and bats coverage.
 check_autospec_resume_contract() {
     info "autospec-resume crash-resume skill + durable run registry (issue #881)"
     local skill="skills/autospec-resume"
     check_autospec_resume_structure
+    check_autospec_supervisor_structure
 
     # Idempotency / no-second-lock: resume-scan reads run-state but never
     # upserts/clears it and never writes a run-state comment.

--- a/tests/resume/test_supervisor.bats
+++ b/tests/resume/test_supervisor.bats
@@ -1,0 +1,284 @@
+#!/usr/bin/env bats
+# tests/resume/test_supervisor.bats — external boot supervisor (issue #882,
+# child 2 of docs/specs/2026-06-03-crash-resume-design.md §Supervisor safety).
+#
+# Covers:
+#   - supervisor_thrash: no open run in registry -> supervisor exits 0 and the
+#     relaunch (/autospec-resume) path is NOT called.
+#   - supervisor_two_repo: a two-repo registry resumes exactly the repos with a
+#     confirmed open in-progress run-state and skips the other.
+#   - supervisor security: never execs the registry's raw resume_command; only
+#     delegates to /autospec-resume for an independently-confirmed open run.
+#   - install_idempotent: install twice -> one launchd/systemd/cron entry;
+#     uninstall removes it; status reports correctly on each mocked platform.
+#
+# All GitHub / launchctl / systemctl / crontab access is via PATH-shadow mocks.
+
+ROOT="${BATS_TEST_DIRNAME}/../.."
+SUPERVISOR="$ROOT/scripts/autospec-supervisor.sh"
+INSTALL="$ROOT/scripts/autospec-supervisor-install.sh"
+REGISTRY="$ROOT/scripts/autospec-run-registry.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    export AUTOSPEC_STATE_DIR="$TEST_TMP/state"
+    export AUTOSPEC_ACTIVE_RUNS_DIR="$TEST_TMP/active-runs"
+    export AUTOSPEC_RUN_REGISTRY_SH="$REGISTRY"
+    mkdir -p "$AUTOSPEC_STATE_DIR"
+
+    export MOCK_DIR="$TEST_TMP/bin"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+
+    # Repos that GitHub will report as having an OPEN in-progress run (space-sep).
+    export GH_OPEN_REPOS=""
+    # Log of which repos /autospec-resume (the mock resume-scan) was invoked for.
+    export RESUME_LOG="$TEST_TMP/resume.log"
+    : > "$RESUME_LOG"
+    # Log of any attempt to exec a raw registry resume_command (security probe).
+    export POISON_LOG="$TEST_TMP/poison.log"
+    : > "$POISON_LOG"
+
+    write_gh_mock
+    write_resume_scan_mock
+    export AUTOSPEC_RESUME_SCAN_SH="$MOCK_DIR/resume-scan-mock.sh"
+}
+teardown() { rm -rf "$TEST_TMP"; }
+
+# gh mock: `gh issue list --repo R --label in-progress-by-bot ... --jq length`
+# returns 1 when R is in GH_OPEN_REPOS, else 0.
+write_gh_mock() {
+    cat > "$MOCK_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+args="$*"
+repo=""
+prev=""
+for a in "$@"; do
+    [ "$prev" = "--repo" ] && repo="$a"
+    prev="$a"
+done
+case "$args" in
+    *"issue list"*"--label in-progress-by-bot"*)
+        for r in $GH_OPEN_REPOS; do
+            if [ "$r" = "$repo" ]; then echo "1"; exit 0; fi
+        done
+        echo "0"; exit 0 ;;
+esac
+exit 0
+EOF
+    chmod +x "$MOCK_DIR/gh"
+}
+
+# resume-scan mock: stands in for `/autospec-resume --repo R`. Records the repo
+# and (security) records if it was ever asked to exec a raw poisoned command.
+write_resume_scan_mock() {
+    cat > "$MOCK_DIR/resume-scan-mock.sh" <<'EOF'
+#!/usr/bin/env bash
+repo=""
+prev=""
+for a in "$@"; do
+    [ "$prev" = "--repo" ] && repo="$a"
+    prev="$a"
+done
+printf '%s\n' "$repo" >> "$RESUME_LOG"
+echo "resuming $repo: 1 issue(s)"
+exit 0
+EOF
+    chmod +x "$MOCK_DIR/resume-scan-mock.sh"
+}
+
+register() {
+    # register --repo R --command C
+    bash "$REGISTRY" write --repo "$1" --repo-dir /tmp/x --harness claude \
+        --command "${2:-echo RELAUNCHED}" --host h >/dev/null
+}
+
+# ── supervisor_thrash ──────────────────────────────────────────────────────────
+
+@test "supervisor_thrash: no open run -> exit 0, resume path NOT called" {
+    register o/n "echo SHOULD-NOT-RUN"
+    export GH_OPEN_REPOS=""    # GitHub confirms NO open in-progress run
+    run bash "$SUPERVISOR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no open run"* ]]
+    [[ "$output" == *"backing off"* ]]
+    # resume-scan must never have been invoked.
+    [ ! -s "$RESUME_LOG" ]
+}
+
+@test "supervisor_thrash: empty registry -> exit 0, nothing resumed" {
+    export GH_OPEN_REPOS=""
+    run bash "$SUPERVISOR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no open run"* ]]
+    [ ! -s "$RESUME_LOG" ]
+}
+
+# ── supervisor_two_repo ────────────────────────────────────────────────────────
+
+@test "supervisor_two_repo: resumes only the confirmed-open repo, skips the other" {
+    register a/one "echo A"
+    register b/two "echo B"
+    export GH_OPEN_REPOS="a/one"          # only a/one has an open in-progress run
+    run bash "$SUPERVISOR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"resuming a/one"* ]]
+    [[ "$output" != *"resuming b/two"* ]]
+    grep -qx "a/one" "$RESUME_LOG"
+    ! grep -qx "b/two" "$RESUME_LOG"
+}
+
+@test "supervisor_two_repo: both confirmed -> both resumed" {
+    register a/one "echo A"
+    register b/two "echo B"
+    export GH_OPEN_REPOS="a/one b/two"
+    run bash "$SUPERVISOR"
+    [ "$status" -eq 0 ]
+    grep -qx "a/one" "$RESUME_LOG"
+    grep -qx "b/two" "$RESUME_LOG"
+}
+
+# ── security: never exec a poisoned registry command ───────────────────────────
+
+@test "security: supervisor delegates to /autospec-resume, never execs raw registry command" {
+    # A poisoned resume_command that would touch POISON_LOG if ever eval'd.
+    register a/one "touch $POISON_LOG.hit"
+    export GH_OPEN_REPOS="a/one"
+    run bash "$SUPERVISOR"
+    [ "$status" -eq 0 ]
+    # The supervisor handed the repo to /autospec-resume (the confirmer/relauncher).
+    grep -qx "a/one" "$RESUME_LOG"
+    # It must NOT have eval'd the raw registry command itself.
+    [ ! -e "$POISON_LOG.hit" ]
+}
+
+@test "security: unconfirmed repo with poisoned command is never relaunched" {
+    register evil/repo "touch $POISON_LOG.hit"
+    export GH_OPEN_REPOS=""    # GitHub does NOT confirm an open run
+    run bash "$SUPERVISOR"
+    [ "$status" -eq 0 ]
+    [ ! -s "$RESUME_LOG" ]
+    [ ! -e "$POISON_LOG.hit" ]
+}
+
+# ── install_idempotent: launchd ────────────────────────────────────────────────
+
+@test "install_idempotent (launchd): install twice -> one plist; uninstall removes; status reports" {
+    export AUTOSPEC_PLATFORM="darwin"
+    export AUTOSPEC_LAUNCH_AGENTS_DIR="$TEST_TMP/LaunchAgents"
+    export AUTOSPEC_SUPERVISOR_SH="$SUPERVISOR"
+    # launchctl mock (no-op success).
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$MOCK_DIR/launchctl"; chmod +x "$MOCK_DIR/launchctl"
+
+    run bash "$INSTALL" status
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not installed"* ]]
+
+    bash "$INSTALL" install
+    bash "$INSTALL" install            # idempotent second install
+    count="$(ls "$AUTOSPEC_LAUNCH_AGENTS_DIR"/*.plist 2>/dev/null | wc -l | tr -d ' ')"
+    [ "$count" = "1" ]
+
+    run bash "$INSTALL" status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"installed (launchd)"* ]]
+
+    bash "$INSTALL" uninstall
+    count="$(ls "$AUTOSPEC_LAUNCH_AGENTS_DIR"/*.plist 2>/dev/null | wc -l | tr -d ' ')"
+    [ "$count" = "0" ]
+    run bash "$INSTALL" status
+    [ "$status" -ne 0 ]
+}
+
+# ── install_idempotent: systemd ────────────────────────────────────────────────
+
+@test "install_idempotent (systemd): install twice -> one unit; uninstall removes; status reports" {
+    export AUTOSPEC_PLATFORM="linux"
+    export AUTOSPEC_SYSTEMD_USER_DIR="$TEST_TMP/systemd"
+    export AUTOSPEC_SUPERVISOR_SH="$SUPERVISOR"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$MOCK_DIR/systemctl"; chmod +x "$MOCK_DIR/systemctl"
+
+    bash "$INSTALL" install
+    bash "$INSTALL" install
+    count="$(ls "$AUTOSPEC_SYSTEMD_USER_DIR"/*.service 2>/dev/null | wc -l | tr -d ' ')"
+    [ "$count" = "1" ]
+
+    run bash "$INSTALL" status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"installed (systemd)"* ]]
+
+    bash "$INSTALL" uninstall
+    count="$(ls "$AUTOSPEC_SYSTEMD_USER_DIR"/*.service 2>/dev/null | wc -l | tr -d ' ')"
+    [ "$count" = "0" ]
+    run bash "$INSTALL" status
+    [ "$status" -ne 0 ]
+}
+
+# ── install_idempotent: @reboot cron fallback ──────────────────────────────────
+
+@test "install_idempotent (cron): install twice -> one @reboot entry; uninstall removes; status reports" {
+    export AUTOSPEC_PLATFORM="cron"
+    export AUTOSPEC_SUPERVISOR_SH="$SUPERVISOR"
+    # crontab mock backed by a file.
+    export CRON_FILE="$TEST_TMP/crontab.txt"
+    : > "$CRON_FILE"
+    cat > "$MOCK_DIR/crontab" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+    -l) [ -s "$CRON_FILE" ] && cat "$CRON_FILE"; [ -s "$CRON_FILE" ] || exit 1; exit 0 ;;
+    -r) : > "$CRON_FILE"; exit 0 ;;
+    -)  cat > "$CRON_FILE"; exit 0 ;;
+    *)  cat > "$CRON_FILE"; exit 0 ;;
+esac
+EOF
+    chmod +x "$MOCK_DIR/crontab"
+
+    run bash "$INSTALL" status
+    [ "$status" -ne 0 ]
+
+    bash "$INSTALL" install
+    bash "$INSTALL" install
+    count="$(grep -F 'autospec-supervisor' "$CRON_FILE" 2>/dev/null | wc -l | tr -d ' ')"
+    [ "$count" = "1" ]
+
+    run bash "$INSTALL" status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"installed (cron)"* ]]
+
+    bash "$INSTALL" uninstall
+    count="$(grep -F 'autospec-supervisor' "$CRON_FILE" 2>/dev/null | wc -l | tr -d ' ')"
+    [ "$count" = "0" ]
+    run bash "$INSTALL" status
+    [ "$status" -ne 0 ]
+}
+
+# ── platform selection ─────────────────────────────────────────────────────────
+
+@test "platform selection: darwin->launchd, linux->systemd, else->cron" {
+    export AUTOSPEC_SUPERVISOR_SH="$SUPERVISOR"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$MOCK_DIR/launchctl"; chmod +x "$MOCK_DIR/launchctl"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$MOCK_DIR/systemctl"; chmod +x "$MOCK_DIR/systemctl"
+
+    export AUTOSPEC_PLATFORM="darwin"
+    export AUTOSPEC_LAUNCH_AGENTS_DIR="$TEST_TMP/la"
+    run bash "$INSTALL" install
+    [[ "$output" == *"launchd"* ]]
+
+    export AUTOSPEC_PLATFORM="linux"
+    export AUTOSPEC_SYSTEMD_USER_DIR="$TEST_TMP/sd"
+    run bash "$INSTALL" install
+    [[ "$output" == *"systemd"* ]]
+
+    export AUTOSPEC_PLATFORM="cron"
+    export CRON_FILE="$TEST_TMP/cron.txt"; : > "$CRON_FILE"
+    cat > "$MOCK_DIR/crontab" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+    -l) [ -s "$CRON_FILE" ] && cat "$CRON_FILE"; exit 0 ;;
+    *)  cat > "$CRON_FILE"; exit 0 ;;
+esac
+EOF
+    chmod +x "$MOCK_DIR/crontab"
+    run bash "$INSTALL" install
+    [[ "$output" == *"cron"* ]]
+}


### PR DESCRIPTION
Closes #882

External boot supervisor (child 2 of `docs/specs/2026-06-03-crash-resume-design.md`).

- `scripts/autospec-supervisor.sh` — boot entrypoint. Iterates the durable active-runs registry; for each entry it **independently confirms via GitHub** that the repo has an open in-progress run (≥1 issue labeled `in-progress-by-bot`) before invoking `/autospec-resume --repo <r>` (resume-scan.sh). It never eval's the registry's raw `resume_command`, so a poisoned/attacker-edited registry command is never executed by the supervisor. With no confirmed open run it prints one line, exits 0, and does **not** re-arm (no boot thrash).
- `scripts/autospec-supervisor-install.sh` `{install|uninstall|status}` — selects launchd (macOS) / systemd user unit (Linux) / `@reboot` cron (fallback) by platform; all three paths idempotent (atomic plist/unit overwrite; tag-scoped crontab rewrite).
- `tests/resume/test_supervisor.bats` — PATH-shadow `gh`/`launchctl`/`systemctl`/`crontab` mocks: no-open-run thrash, two-repo selective resume, never-exec-raw-command security gate, idempotent install/uninstall/status on all three platforms (10 tests).
- `scripts/validate.sh` — `check_autospec_supervisor_structure` (exists + executable + `bash -n` + delegation/confirmation/platform invariants).

`bash scripts/validate.sh` → exit 0 (runs all 3 `tests/resume/` bats suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)