### PR TITLE
feat(autospec-run): watchdog orphaned-worktree GC

### DIFF
--- a/scripts/autospec-watchdog.sh
+++ b/scripts/autospec-watchdog.sh
@@ -24,6 +24,14 @@ WATCHDOG_CLAIMED_TIMEOUT_SECS="${AUTOSPEC_WATCHDOG_CLAIMED_TIMEOUT_SECS:-300}"
 WATCHDOG_NUDGE_COOLDOWN_SECS="${AUTOSPEC_WATCHDOG_NUDGE_COOLDOWN_SECS:-900}"
 STATE_FILE="${AUTOSPEC_WATCHDOG_STATE_FILE:-$HOME/.autospec/watchdog-state.tsv}"
 
+# Orphaned-worktree GC (crash-resume design, Child 3). The GC pass scans this
+# root for `wt-*` worktree directories and prunes only those that are provably
+# safe to remove (no un-pushed commits, issue closed/unlabeled, no live
+# heartbeat). Default root is /tmp where autospec runners create `/tmp/wt-*`.
+WATCHDOG_GC_DIR="${AUTOSPEC_WATCHDOG_GC_DIR:-/tmp}"
+# Heartbeat is considered "live" if its ts is within this many seconds of now.
+WATCHDOG_GC_HEARTBEAT_FRESH_SECS="${AUTOSPEC_WATCHDOG_GC_HEARTBEAT_FRESH_SECS:-${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}}"
+
 WATCHDOG_LOG_PREFIX="[autospec-watchdog]"
 
 if ! command -v gh >/dev/null 2>&1; then
@@ -254,6 +262,98 @@ normalize_heartbeat() {
         && mv "$tmp" "$file"
 }
 
+# ── Orphaned-worktree GC (crash-resume design, Child 3) ───────────────────────
+#
+# Prune a `wt-*` worktree via `git worktree remove --force` ONLY when ALL three
+# data-integrity guards hold:
+#   (1) NO un-pushed commits   — `git -C <wt> log --not --remotes` is empty
+#   (2) issue closed/unlabeled — gh shows the issue not (OPEN AND still labeled
+#                                auto-implement/in-progress-by-bot)
+#   (3) NO live heartbeat      — no heartbeat for that issue has a fresh `ts`
+#                                (within WATCHDOG_GC_HEARTBEAT_FRESH_SECS)
+#
+# This is a destructive, data-integrity-load-bearing pass: it NEVER recursively
+# force-deletes a path and NEVER removes a worktree with un-pushed work or a
+# live heartbeat. It
+# only ever invokes `git worktree remove --force` after all three guards pass.
+# The pass is bounded (it only globs WATCHDOG_GC_DIR/wt-*) and must not block or
+# slow the reclaim loop; every guard short-circuits on the cheap local checks
+# (rev-parse, log) before the single per-candidate `gh` call.
+
+# True (0) if a heartbeat for $issue is live (fresh ts within the freshness
+# window). Conservative: any parse failure is treated as "not live" so it does
+# not by itself save a worktree — the un-pushed and issue-state guards remain.
+_gc_heartbeat_is_live() {
+    issue="$1"
+    hb="${WATCHDOG_DIR}/${issue}.json"
+    [ -f "$hb" ] || return 1
+    hb_ts="$(json_value ts "$hb")"
+    case "$hb_ts" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    hb_age=$(( now_ts - hb_ts ))
+    [ "$hb_age" -lt 0 ] && hb_age=0
+    [ "$hb_age" -lt "$WATCHDOG_GC_HEARTBEAT_FRESH_SECS" ]
+}
+
+gc_orphaned_worktrees() {
+    command -v git >/dev/null 2>&1 || return 0
+    for wt in "$WATCHDOG_GC_DIR"/wt-*; do
+        [ -d "$wt" ] || continue
+        # Must be a real git worktree before we touch it.
+        git -C "$wt" rev-parse --is-inside-work-tree >/dev/null 2>&1 || continue
+
+        branch="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+        case "$branch" in
+            ''|HEAD) continue ;;
+        esac
+
+        # Derive the issue number from the branch (e.g. feat/...-issue-700 or a
+        # trailing numeric segment). Skip if we cannot identify an issue.
+        issue="$(printf '%s' "$branch" | grep -oE '[0-9]+' | tail -1 || true)"
+        case "$issue" in
+            ''|*[!0-9]*) continue ;;
+        esac
+
+        # GUARD 1 — un-pushed commits. NEVER prune if any local commit is not on
+        # a remote. This is the load-bearing data-integrity check.
+        unpushed="$(git -C "$wt" log --not --remotes --oneline 2>/dev/null || echo "x")"
+        [ -z "$unpushed" ] || continue
+
+        # GUARD 3 — live heartbeat (cheap local file check; do it before gh).
+        if _gc_heartbeat_is_live "$issue"; then
+            continue
+        fi
+
+        # GUARD 2 — issue closed or unlabeled. Skip if the issue is still OPEN
+        # AND still carries an in-flight label. issue_meta is "STATE labels".
+        meta="$(issue_meta "$issue")"
+        gc_state="${meta%% *}"
+        gc_labels="${meta#* }"
+        [ "$gc_state" = "$meta" ] && gc_labels=""
+        if [ "$gc_state" = "OPEN" ]; then
+            if printf '%s' ",${gc_labels}," | grep -qE ',(auto-implement|in-progress-by-bot),'; then
+                continue
+            fi
+        fi
+
+        # All three guards passed → safe to prune via git's own worktree removal.
+        if git worktree remove --force "$wt" >/dev/null 2>&1; then
+            garbage_collected=$((garbage_collected + 1))
+            echo "$WATCHDOG_LOG_PREFIX gc: removed orphaned worktree $wt (issue #$issue, branch $branch)" >&2
+        fi
+    done
+}
+
+# GC-only mode: run just the orphaned-worktree GC pass and exit. Used by the
+# watchdog GC bats fixture to exercise the real pass in isolation.
+if [ "${AUTOSPEC_WATCHDOG_GC_ONLY:-}" = "1" ]; then
+    gc_orphaned_worktrees
+    printf 'service-watch: nudged=0 reclaimed=0 claimed_released=0 garbage_collected=%s invalid_schema=0 skipped=0\n' \
+        "$garbage_collected"
+    exit 0
+fi
+
 load_state
 
 for hb in "$WATCHDOG_DIR"/*.json; do
@@ -416,6 +516,9 @@ reconcile_run_state_comments() {
 }
 
 reconcile_run_state_comments
+
+# Orphaned-worktree GC: once per watchdog cycle, after reclaim, before summary.
+gc_orphaned_worktrees
 
 save_state
 printf 'service-watch: nudged=%s reclaimed=%s claimed_released=%s garbage_collected=%s invalid_schema=%s skipped=%s\n' \

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1722,6 +1722,39 @@ check_claim_cas_guard() {
     done
 }
 
+# Watchdog orphaned-worktree GC (crash-resume design, Child 3 / issue #883).
+# Enforces the data-integrity contract structurally:
+#   - gc_orphaned_worktrees is defined and invoked once per cycle.
+#   - Pruning uses `git worktree remove --force`, never `rm -rf` of a worktree.
+#   - The script passes `bash -n`.
+#   - A bats fixture under tests/resume/ covers the three GC outcomes.
+check_watchdog_worktree_gc() {
+    info "watchdog orphaned-worktree GC (issue #883)"
+    local wd="scripts/autospec-watchdog.sh"
+    [ -f "$wd" ] || fail "$wd: missing"
+    bash -n "$wd" || fail "$wd: bash syntax error (issue #883)"
+    grep -q 'gc_orphaned_worktrees()' "$wd" \
+        || fail "$wd must define gc_orphaned_worktrees() (issue #883)"
+    grep -q '^gc_orphaned_worktrees$\|^    gc_orphaned_worktrees$' "$wd" \
+        || fail "$wd must invoke gc_orphaned_worktrees once per cycle (issue #883)"
+    grep -q 'git worktree remove --force' "$wd" \
+        || fail "$wd GC must prune via 'git worktree remove --force' (issue #883)"
+    # Data-integrity guard: the GC must never rm -rf a worktree path. Allow no
+    # `rm -rf` anywhere in the watchdog (it has never needed one).
+    if grep -vE '^[[:space:]]*#' "$wd" | grep -qE 'rm[[:space:]]+-rf'; then
+        fail "$wd must never 'rm -rf' a worktree path; use 'git worktree remove --force' (issue #883)"
+    fi
+    grep -q 'log --not --remotes' "$wd" \
+        || fail "$wd GC must gate on 'git -C <wt> log --not --remotes' for un-pushed commits (issue #883)"
+    [ -f tests/resume/test_watchdog_gc.bats ] \
+        || fail "tests/resume/test_watchdog_gc.bats: GC bats fixture missing (issue #883)"
+    if command -v bats >/dev/null 2>&1; then
+        info "  running: tests/resume/test_watchdog_gc.bats"
+        bats tests/resume/test_watchdog_gc.bats >/tmp/validate-watchdog-gc.log 2>&1 \
+            || { cat /tmp/validate-watchdog-gc.log >&2; fail "tests/resume/test_watchdog_gc.bats: failed (issue #883)"; }
+    fi
+}
+
 main() {
     info "scanning multi-harness skills under skills/ ..."
     skills="$(discover_skills)"
@@ -1813,6 +1846,7 @@ main() {
     check_autospec_qa_cluster_contract
     check_autospec_qa_bug_class_contract
     check_autospec_resume_contract
+    check_watchdog_worktree_gc
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.

--- a/tests/resume/test_watchdog_gc.bats
+++ b/tests/resume/test_watchdog_gc.bats
@@ -1,0 +1,203 @@
+#!/usr/bin/env bats
+# tests/resume/test_watchdog_gc.bats — watchdog orphaned-worktree GC pass.
+#
+# Covers (docs/specs/2026-06-03-crash-resume-design.md §Error handling "GC
+# safety", §Decomposition Child 3): a /tmp/wt-* worktree is pruned via
+# `git worktree remove --force` ONLY when ALL THREE hold:
+#   (1) no un-pushed commits   — `git -C <wt> log --not --remotes` is empty
+#   (2) issue closed/unlabeled — gh shows it not OPEN+labeled auto-implement
+#   (3) no live heartbeat      — no fresh heartbeat references the branch
+#
+# Data-integrity contract (load-bearing): the GC must NEVER remove a worktree
+# with un-pushed commits, and NEVER remove an in-progress-this-host worktree
+# with a fresh heartbeat. Pruning is `git worktree remove --force` only — never
+# `rm -rf`.
+#
+# All gh / git / hostname access is via PATH-shadow mocks driven by env vars,
+# mirroring tests/resume/test_resume_scan.bats. The real watchdog script runs
+# in GC-only mode (AUTOSPEC_WATCHDOG_GC_ONLY=1).
+
+ROOT="${BATS_TEST_DIRNAME}/../.."
+WATCHDOG="$ROOT/scripts/autospec-watchdog.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+
+    export AUTOSPEC_WATCHDOG_DIR="$TEST_TMP/heartbeats"
+    export AUTOSPEC_WATCHDOG_REPO="o/n"
+    export AUTOSPEC_WATCHDOG_GC_ONLY="1"
+    export AUTOSPEC_WATCHDOG_GC_DIR="$TEST_TMP/wt"   # scan root for /tmp/wt-* analogues
+    export AUTOSPEC_HOST="host-A"
+
+    mkdir -p "$AUTOSPEC_WATCHDOG_DIR/o_n"
+    mkdir -p "$AUTOSPEC_WATCHDOG_GC_DIR"
+
+    # Records of git worktree remove invocations.
+    export REMOVE_LOG="$TEST_TMP/removed.log"
+    : > "$REMOVE_LOG"
+
+    # gh mock state.
+    export GH_ISSUE_STATE="CLOSED"   # state of the issue
+    export GH_ISSUE_LABELS=""        # comma-joined labels
+
+    # git mock state.
+    export GIT_UNPUSHED=""           # non-empty => un-pushed commits present
+    export GIT_BRANCH="feat/autospec-issue-700"
+
+    export MOCK_DIR="$TEST_TMP/bin"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+
+    write_hostname_mock
+    write_gh_mock
+    write_git_mock
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+now_ts() { date -u +%s; }
+
+write_hostname_mock() {
+    cat > "$MOCK_DIR/hostname" <<EOF
+#!/usr/bin/env bash
+echo "${AUTOSPEC_HOST}"
+EOF
+    chmod +x "$MOCK_DIR/hostname"
+}
+
+write_gh_mock() {
+    cat > "$MOCK_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+# PATH-shadow gh mock. Only supports `gh issue view <n> --json state,labels`.
+case "$1 $2" in
+  "issue view")
+    printf '%s %s\n' "$GH_ISSUE_STATE" "$GH_ISSUE_LABELS"
+    ;;
+  "repo view")
+    echo "o/n"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+    chmod +x "$MOCK_DIR/gh"
+}
+
+# git mock: shadows the real git so we can observe `worktree remove` and drive
+# log/rev-parse outputs. Anything we do not special-case falls through to the
+# real git so the watchdog's own logic still works.
+write_git_mock() {
+    REAL_GIT="$(command -v git)"
+    export REAL_GIT
+    cat > "$MOCK_DIR/git" <<EOF
+#!/usr/bin/env bash
+REAL_GIT="$REAL_GIT"
+REMOVE_LOG="$REMOVE_LOG"
+EOF
+    cat >> "$MOCK_DIR/git" <<'EOF'
+# Find a -C <dir> target if present (we ignore the dir; mock is global state).
+args=("$@")
+
+# git worktree ...
+if [ "${args[0]}" = "worktree" ] || { [ "${args[0]}" = "-C" ] && [ "${args[2]}" = "worktree" ]; }; then
+  # locate subcommand after 'worktree'
+  sub=""
+  for ((i=0;i<${#args[@]};i++)); do
+    if [ "${args[$i]}" = "worktree" ]; then sub="${args[$((i+1))]}"; fi
+  done
+  case "$sub" in
+    remove)
+      # last arg is the path
+      path="${args[$((${#args[@]}-1))]}"
+      printf '%s\n' "$path" >> "$REMOVE_LOG"
+      exit 0
+      ;;
+    *)
+      exit 0
+      ;;
+  esac
+fi
+
+# git -C <dir> rev-parse --abbrev-ref HEAD  -> branch
+# git -C <dir> rev-parse --is-inside-work-tree -> true
+if printf '%s ' "${args[@]}" | grep -q 'rev-parse'; then
+  if printf '%s ' "${args[@]}" | grep -q 'is-inside-work-tree'; then
+    echo "true"; exit 0
+  fi
+  if printf '%s ' "${args[@]}" | grep -q 'abbrev-ref'; then
+    echo "$GIT_BRANCH"; exit 0
+  fi
+  exit 0
+fi
+
+# git -C <dir> log --not --remotes  -> emit un-pushed commits when GIT_UNPUSHED set
+if printf '%s ' "${args[@]}" | grep -q 'log'; then
+  if [ -n "$GIT_UNPUSHED" ]; then
+    echo "deadbeef un-pushed work"
+  fi
+  exit 0
+fi
+
+# fallthrough to real git (never reached for our cases)
+exec "$REAL_GIT" "$@"
+EOF
+    chmod +x "$MOCK_DIR/git"
+}
+
+# Create a fake /tmp/wt-* worktree directory under the GC scan root.
+make_worktree() {
+    local name="$1"
+    mkdir -p "$AUTOSPEC_WATCHDOG_GC_DIR/$name"
+    printf '%s' "$AUTOSPEC_WATCHDOG_GC_DIR/$name"
+}
+
+# Write a heartbeat referencing a branch with a given ts and host.
+write_heartbeat() {
+    local issue="$1" branch="$2" ts="$3" host="$4"
+    printf '{"issue":"%s","branch":"%s","step":"tests_started","ts":%s,"pr":"","repo":"o/n","host":"%s"}\n' \
+        "$issue" "$branch" "$ts" "$host" \
+        > "$AUTOSPEC_WATCHDOG_DIR/o_n/${issue}.json"
+}
+
+run_gc() { run bash "$WATCHDOG"; }
+
+was_removed() { grep -qF "$1" "$REMOVE_LOG"; }
+
+@test "gc_unpushed_not_pruned: a worktree with un-pushed commits is NOT removed" {
+    wt="$(make_worktree wt-700)"
+    export GIT_BRANCH="feat/autospec-issue-700"
+    export GIT_UNPUSHED="yes"        # un-pushed commits present
+    export GH_ISSUE_STATE="CLOSED"   # issue closed
+    # no heartbeat
+
+    run_gc
+    [ "$status" -eq 0 ]
+    ! was_removed "$wt"
+}
+
+@test "gc_in_progress_not_pruned: an in-progress-this-host worktree with a fresh heartbeat is NOT removed" {
+    wt="$(make_worktree wt-701)"
+    export GIT_BRANCH="feat/autospec-issue-701"
+    export GIT_UNPUSHED=""           # clean
+    export GH_ISSUE_STATE="OPEN"
+    export GH_ISSUE_LABELS="auto-implement,in-progress-by-bot"
+    write_heartbeat 701 "feat/autospec-issue-701" "$(now_ts)" "host-A"  # fresh, this host
+
+    run_gc
+    [ "$status" -eq 0 ]
+    ! was_removed "$wt"
+}
+
+@test "gc_clean_closed_pruned: clean + closed/unlabeled issue + no live heartbeat IS removed via git worktree remove --force" {
+    wt="$(make_worktree wt-702)"
+    export GIT_BRANCH="feat/autospec-issue-702"
+    export GIT_UNPUSHED=""           # clean, all pushed
+    export GH_ISSUE_STATE="CLOSED"   # closed
+    export GH_ISSUE_LABELS=""        # unlabeled
+    # no heartbeat referencing the branch
+
+    run_gc
+    [ "$status" -eq 0 ]
+    was_removed "$wt"
+}


### PR DESCRIPTION
Closes #883

Adds a `gc_orphaned_worktrees` pass to `scripts/autospec-watchdog.sh`, invoked once per watchdog cycle. It prunes a `/tmp/wt-*` worktree via `git worktree remove --force` ONLY when all three data-integrity guards hold: (1) no un-pushed commits (`git -C <wt> log --not --remotes` empty), (2) issue closed or unlabeled, (3) no live heartbeat references it. Never `rm -rf`. Cheap-first guard ordering keeps the reclaim loop fast.

Tests: `tests/resume/test_watchdog_gc.bats` (PATH-shadow gh/git/hostname mocks, GC-only mode) covers un-pushed-not-pruned, in-progress-this-host-not-pruned, clean-closed-pruned. `scripts/validate.sh` gains `check_watchdog_worktree_gc` (function defined+invoked, force-remove not rm -rf, un-pushed gate, bash -n, bats green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)