### PR TITLE
feat(autospec-run): per-session single-instance monitor lock

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -231,6 +231,35 @@ bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/run-batch-start.sh" --wri
 
 This writes the UTC ISO 8601 timestamp to `~/.autospec/.run-batch-start` (idempotent within a run; pass `--force` only when intentionally starting a fresh batch window). Phase 5.5 reads it back via `run-batch-start.sh --read`, which yields `BATCH_START_DATE`.
 
+## Single-instance session lock (run-start, once)
+
+Acquire a per-session lock BEFORE launching the Phase 4 monitor so a single
+harness session never runs two concurrent monitors (which collide on the queue
+and on git branches). The lock is keyed by the harness session id, so separate
+sessions still run independently by design.
+
+```bash
+LOCK="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-run-session-lock.sh"
+if ! bash "$LOCK" acquire --repo "{repo}"; then
+    # exit 3 = a monitor is already active in THIS session.
+    echo "autospec-run: refusing to start a second monitor in this session." >&2
+    bash "$LOCK" status
+    # STOP — do NOT launch Phase 4. Halt the active monitor with /autospec-stop,
+    # or re-run the lock helper with --force to override a stale lock.
+    exit 0
+fi
+```
+
+Release the lock on EVERY terminal exit of this run — the Phase 6 final report,
+the `ALL_DONE` shutdown, and stop mode:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-run-session-lock.sh" release
+```
+
+The lock is advisory and self-scoped: a crashed session's lock only blocks that
+same session id (a fresh session gets a new id), and `--force` overrides it.
+
 ## Phase 4 — Background autonomous monitor
 
 **Single-agent absorbed-discipline (canonical Phase 4 path).** The monitor agent IS the implementer for the issue it claims — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — all in one agent's context. The main session orchestrator relaunches the monitor between issues so each one gets a fresh top-level `Agent` call with full tool access. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch its own inner implementer. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "the monitor agent now does the implementation work itself in this same context", NOT a nested subagent dispatch. `AUTOSPEC_BATCH_SIZE` semantics are preserved: a single agent can still process up to N issues sequentially within its 40-tool-call budget, exiting with `BATCH_COMPLETE` when the budget is approaching or after N issues, whichever comes first.

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -226,6 +226,35 @@ bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/run-batch-start.sh" --wri
 
 This writes the UTC ISO 8601 timestamp to `~/.autospec/.run-batch-start` (idempotent within a run; pass `--force` only when intentionally starting a fresh batch window). Phase 5.5 reads it back via `run-batch-start.sh --read`, which yields `BATCH_START_DATE`.
 
+## Single-instance session lock (run-start, once)
+
+Acquire a per-session lock BEFORE launching the Phase 4 monitor so a single
+harness session never runs two concurrent monitors (which collide on the queue
+and on git branches). The lock is keyed by the harness session id, so separate
+sessions still run independently by design.
+
+```bash
+LOCK="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-run-session-lock.sh"
+if ! bash "$LOCK" acquire --repo "{repo}"; then
+    # exit 3 = a monitor is already active in THIS session.
+    echo "autospec-run: refusing to start a second monitor in this session." >&2
+    bash "$LOCK" status
+    # STOP — do NOT launch Phase 4. Halt the active monitor with /autospec-stop,
+    # or re-run the lock helper with --force to override a stale lock.
+    exit 0
+fi
+```
+
+Release the lock on EVERY terminal exit of this run — the Phase 6 final report,
+the `ALL_DONE` shutdown, and stop mode:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-run-session-lock.sh" release
+```
+
+The lock is advisory and self-scoped: a crashed session's lock only blocks that
+same session id (a fresh session gets a new id), and `--force` overrides it.
+
 ## Phase 4 — Background autonomous monitor
 
 **Single-agent absorbed-discipline (canonical Phase 4 path).** The monitor agent IS the implementer for the issue it claims — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — all in one agent's context. The main session orchestrator relaunches the monitor between issues so each one gets a fresh top-level `Agent` call with full tool access. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch its own inner implementer. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "the monitor agent now does the implementation work itself in this same context", NOT a nested subagent dispatch. `AUTOSPEC_BATCH_SIZE` semantics are preserved: a single agent can still process up to N issues sequentially within its 40-tool-call budget, exiting with `BATCH_COMPLETE` when the budget is approaching or after N issues, whichever comes first.

--- a/skills/autospec-run/install.sh
+++ b/skills/autospec-run/install.sh
@@ -275,7 +275,7 @@ install_shared_scripts
 
 info ""
 info "autospec-run skill helper scripts:"
-SKILL_SCRIPT_FILES="heartbeat-write.sh heartbeat-read.sh run-state.sh list-ready-issues.sh claim-issue.sh release-issue.sh"
+SKILL_SCRIPT_FILES="heartbeat-write.sh heartbeat-read.sh run-state.sh list-ready-issues.sh claim-issue.sh release-issue.sh autospec-run-session-lock.sh"
 for rel in $SKILL_SCRIPT_FILES; do
     skill_scripts_src=""
     if [ -d "$SKILL_DIR/scripts" ]; then

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -230,6 +230,35 @@ bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/run-batch-start.sh" --wri
 
 This writes the UTC ISO 8601 timestamp to `~/.autospec/.run-batch-start` (idempotent within a run; pass `--force` only when intentionally starting a fresh batch window). Phase 5.5 reads it back via `run-batch-start.sh --read`, which yields `BATCH_START_DATE`.
 
+## Single-instance session lock (run-start, once)
+
+Acquire a per-session lock BEFORE launching the Phase 4 monitor so a single
+harness session never runs two concurrent monitors (which collide on the queue
+and on git branches). The lock is keyed by the harness session id, so separate
+sessions still run independently by design.
+
+```bash
+LOCK="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-run-session-lock.sh"
+if ! bash "$LOCK" acquire --repo "{repo}"; then
+    # exit 3 = a monitor is already active in THIS session.
+    echo "autospec-run: refusing to start a second monitor in this session." >&2
+    bash "$LOCK" status
+    # STOP — do NOT launch Phase 4. Halt the active monitor with /autospec-stop,
+    # or re-run the lock helper with --force to override a stale lock.
+    exit 0
+fi
+```
+
+Release the lock on EVERY terminal exit of this run — the Phase 6 final report,
+the `ALL_DONE` shutdown, and stop mode:
+
+```bash
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/autospec-run-session-lock.sh" release
+```
+
+The lock is advisory and self-scoped: a crashed session's lock only blocks that
+same session id (a fresh session gets a new id), and `--force` overrides it.
+
 ## Phase 4 — Background autonomous monitor
 
 **Single-agent absorbed-discipline (canonical Phase 4 path).** The monitor agent IS the implementer for the issue it claims — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — all in one agent's context. The main session orchestrator relaunches the monitor between issues so each one gets a fresh top-level `Agent` call with full tool access. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch its own inner implementer. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "the monitor agent now does the implementation work itself in this same context", NOT a nested subagent dispatch. `AUTOSPEC_BATCH_SIZE` semantics are preserved: a single agent can still process up to N issues sequentially within its 40-tool-call budget, exiting with `BATCH_COMPLETE` when the budget is approaching or after N issues, whichever comes first.

--- a/skills/autospec-run/scripts/autospec-run-session-lock.sh
+++ b/skills/autospec-run/scripts/autospec-run-session-lock.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# autospec-run-session-lock.sh — per-session single-instance guard for /autospec-run.
+#
+# Ensures only ONE autospec-run monitor runs per harness session. The lock is
+# keyed by a stable per-session token, so two separate harness sessions still run
+# independently (by design); a second invocation WITHIN the same session is
+# refused with a status report.
+#
+#   acquire [--repo <owner/repo>] [--force]   exit 0 acquired | 3 busy (same session)
+#   release                                   exit 0
+#   status                                    exit 0 (prints lock JSON or active:false)
+#
+# Session token resolution (first non-empty wins): AUTOSPEC_SESSION_ID,
+# CLAUDE_CODE_SESSION_ID, CODEX_SESSION_ID, CODEX_THREAD_ID, OPENCODE_SESSION_ID,
+# OPENCODE_SESSION, TERM_SESSION_ID, POSIX session id, then PPID.
+set -u
+
+LOCK_DIR="${AUTOSPEC_LOCK_DIR:-$HOME/.autospec/locks}"
+
+session_token() {
+    local v
+    for v in "${AUTOSPEC_SESSION_ID:-}" "${CLAUDE_CODE_SESSION_ID:-}" \
+             "${CODEX_SESSION_ID:-}" "${CODEX_THREAD_ID:-}" \
+             "${OPENCODE_SESSION_ID:-}" "${OPENCODE_SESSION:-}" \
+             "${TERM_SESSION_ID:-}"; do
+        if [ -n "$v" ]; then printf '%s' "$v"; return 0; fi
+    done
+    local sid
+    sid="$(ps -o sess= -p "$$" 2>/dev/null | tr -d ' ')"
+    if [ -n "$sid" ] && [ "$sid" != "0" ]; then printf 'sid-%s' "$sid"; return 0; fi
+    printf 'ppid-%s' "${PPID:-unknown}"
+}
+
+slugify() { printf '%s' "$1" | tr -c 'A-Za-z0-9_.-' '-'; }
+
+TOKEN="$(session_token)"
+LOCK_FILE="$LOCK_DIR/autospec-run-session-$(slugify "$TOKEN").lock"
+
+cmd="${1:-status}"
+shift 2>/dev/null || true
+REPO=""
+FORCE=0
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --repo) REPO="${2:-}"; shift 2 ;;
+        --force) FORCE=1; shift ;;
+        *) shift ;;
+    esac
+done
+
+case "$cmd" in
+    acquire)
+        mkdir -p "$LOCK_DIR"
+        [ "$FORCE" = "1" ] && rm -f "$LOCK_FILE"
+        # Atomic create: noclobber redirection fails if the file already exists.
+        if ( set -o noclobber; : > "$LOCK_FILE" ) 2>/dev/null; then
+            printf '{"session":"%s","pid":%s,"repo":"%s","host":"%s","started_at":"%s"}\n' \
+                "$TOKEN" "$$" "$REPO" "$(hostname 2>/dev/null || echo unknown)" \
+                "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$LOCK_FILE"
+            printf 'autospec-run: session lock acquired (session=%s)\n' "$TOKEN"
+            exit 0
+        fi
+        # Held for THIS session already -> refuse + report (per-session single instance).
+        existing="$(cat "$LOCK_FILE" 2>/dev/null || true)"
+        pid="$(printf '%s' "$existing" | sed -n 's/.*"pid":\([0-9]*\).*/\1/p')"
+        alive="dead"
+        { [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; } && alive="alive"
+        {
+            printf 'autospec-run: a monitor is already active for this session (session=%s).\n' "$TOKEN"
+            printf '  %s\n' "$existing"
+            printf '  holder pid=%s (%s). Run /autospec-stop to halt it, or re-run with --force to override.\n' "${pid:-?}" "$alive"
+        } >&2
+        exit 3
+        ;;
+    release)
+        rm -f "$LOCK_FILE"
+        printf 'autospec-run: session lock released (session=%s)\n' "$TOKEN"
+        exit 0
+        ;;
+    status)
+        if [ -f "$LOCK_FILE" ]; then
+            cat "$LOCK_FILE"
+        else
+            printf '{"session":"%s","active":false}\n' "$TOKEN"
+        fi
+        exit 0
+        ;;
+    *)
+        printf 'usage: autospec-run-session-lock.sh {acquire|release|status} [--repo owner/repo] [--force]\n' >&2
+        exit 2
+        ;;
+esac

--- a/skills/autospec-run/scripts/autospec-run-session-lock.sh
+++ b/skills/autospec-run/scripts/autospec-run-session-lock.sh
@@ -51,26 +51,30 @@ done
 case "$cmd" in
     acquire)
         mkdir -p "$LOCK_DIR"
-        [ "$FORCE" = "1" ] && rm -f "$LOCK_FILE"
-        # Atomic create: noclobber redirection fails if the file already exists.
-        if ( set -o noclobber; : > "$LOCK_FILE" ) 2>/dev/null; then
-            printf '{"session":"%s","pid":%s,"repo":"%s","host":"%s","started_at":"%s"}\n' \
-                "$TOKEN" "$$" "$REPO" "$(hostname 2>/dev/null || echo unknown)" \
-                "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$LOCK_FILE"
-            printf 'autospec-run: session lock acquired (session=%s)\n' "$TOKEN"
-            exit 0
+        if [ "$FORCE" != "1" ]; then
+            # Atomic guard: noclobber redirection fails if the file already exists.
+            # (--force skips this entirely → deterministic last-writer-wins, no
+            #  rm+recreate window that a concurrent acquire could slip through.)
+            if ! ( set -o noclobber; : > "$LOCK_FILE" ) 2>/dev/null; then
+                # Held for THIS session already -> refuse + report (single instance).
+                existing="$(cat "$LOCK_FILE" 2>/dev/null || true)"
+                pid="$(printf '%s' "$existing" | sed -n 's/.*"pid":\([0-9]*\).*/\1/p')"
+                alive="dead"
+                { [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; } && alive="alive"
+                {
+                    printf 'autospec-run: a monitor is already active for this session (session=%s).\n' "$TOKEN"
+                    printf '  %s\n' "$existing"
+                    printf '  holder pid=%s (%s). Run /autospec-stop to halt it, or re-run with --force to override.\n' "${pid:-?}" "$alive"
+                } >&2
+                exit 3
+            fi
         fi
-        # Held for THIS session already -> refuse + report (per-session single instance).
-        existing="$(cat "$LOCK_FILE" 2>/dev/null || true)"
-        pid="$(printf '%s' "$existing" | sed -n 's/.*"pid":\([0-9]*\).*/\1/p')"
-        alive="dead"
-        { [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; } && alive="alive"
-        {
-            printf 'autospec-run: a monitor is already active for this session (session=%s).\n' "$TOKEN"
-            printf '  %s\n' "$existing"
-            printf '  holder pid=%s (%s). Run /autospec-stop to halt it, or re-run with --force to override.\n' "${pid:-?}" "$alive"
-        } >&2
-        exit 3
+        # Acquired a fresh noclobber sentinel, or --force override: write the body.
+        printf '{"session":"%s","pid":%s,"repo":"%s","host":"%s","started_at":"%s"}\n' \
+            "$TOKEN" "$$" "$REPO" "$(hostname 2>/dev/null || echo unknown)" \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$LOCK_FILE"
+        printf 'autospec-run: session lock acquired (session=%s)\n' "$TOKEN"
+        exit 0
         ;;
     release)
         rm -f "$LOCK_FILE"

--- a/tests/autospec-run/test_session_lock.bats
+++ b/tests/autospec-run/test_session_lock.bats
@@ -62,3 +62,17 @@ teardown() {
     CLAUDE_CODE_SESSION_ID=ccB run bash "$LOCK" acquire --repo o/r
     [ "$status" -eq 0 ]
 }
+
+@test "release is idempotent (releasing when no lock is held still exits 0)" {
+    AUTOSPEC_SESSION_ID=sessA run bash "$LOCK" release
+    [ "$status" -eq 0 ]
+}
+
+@test "--force is a clean override even when the file is mid-write empty" {
+    # Simulate a partially-written (empty) lock body; --force must still acquire
+    # deterministically (no rm+recreate race).
+    : > "$AUTOSPEC_LOCK_DIR/autospec-run-session-sessF.lock"
+    AUTOSPEC_SESSION_ID=sessF run bash "$LOCK" acquire --repo o/r --force
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$AUTOSPEC_LOCK_DIR/autospec-run-session-sessF.lock")" == *"sessF"* ]]
+}

--- a/tests/autospec-run/test_session_lock.bats
+++ b/tests/autospec-run/test_session_lock.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+# tests/autospec-run/test_session_lock.bats — per-session single-instance guard
+# for /autospec-run. Scope: harness session id. On contention: refuse + report.
+
+setup() {
+    REPO_ROOT="$(git rev-parse --show-toplevel)"
+    LOCK="$REPO_ROOT/skills/autospec-run/scripts/autospec-run-session-lock.sh"
+    AUTOSPEC_LOCK_DIR="$(mktemp -d)"
+    export AUTOSPEC_LOCK_DIR
+}
+
+teardown() {
+    rm -rf "$AUTOSPEC_LOCK_DIR"
+}
+
+@test "acquire succeeds on first call and writes a lock file" {
+    AUTOSPEC_SESSION_ID=sessA run bash "$LOCK" acquire --repo o/r
+    [ "$status" -eq 0 ]
+    [ -n "$(ls -A "$AUTOSPEC_LOCK_DIR")" ]
+}
+
+@test "second acquire in the SAME session is refused (exit 3) and reports status" {
+    AUTOSPEC_SESSION_ID=sessA bash "$LOCK" acquire --repo o/r
+    AUTOSPEC_SESSION_ID=sessA run bash "$LOCK" acquire --repo o/r
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"already active"* ]]
+}
+
+@test "a DIFFERENT session acquires independently while the first is held" {
+    AUTOSPEC_SESSION_ID=sessA bash "$LOCK" acquire --repo o/r
+    AUTOSPEC_SESSION_ID=sessB run bash "$LOCK" acquire --repo o/r
+    [ "$status" -eq 0 ]
+}
+
+@test "release frees the lock so the same session can re-acquire" {
+    AUTOSPEC_SESSION_ID=sessA bash "$LOCK" acquire --repo o/r
+    AUTOSPEC_SESSION_ID=sessA run bash "$LOCK" release
+    [ "$status" -eq 0 ]
+    AUTOSPEC_SESSION_ID=sessA run bash "$LOCK" acquire --repo o/r
+    [ "$status" -eq 0 ]
+}
+
+@test "--force overrides an existing lock in the same session" {
+    AUTOSPEC_SESSION_ID=sessA bash "$LOCK" acquire --repo o/r
+    AUTOSPEC_SESSION_ID=sessA run bash "$LOCK" acquire --repo o/r --force
+    [ "$status" -eq 0 ]
+}
+
+@test "status reports inactive when free and active when held" {
+    AUTOSPEC_SESSION_ID=sessC run bash "$LOCK" status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"false"* ]]
+    AUTOSPEC_SESSION_ID=sessC bash "$LOCK" acquire --repo o/r
+    AUTOSPEC_SESSION_ID=sessC run bash "$LOCK" status
+    [[ "$output" == *"sessC"* ]]
+}
+
+@test "session token falls back to CLAUDE_CODE_SESSION_ID when AUTOSPEC_SESSION_ID unset" {
+    CLAUDE_CODE_SESSION_ID=ccA bash "$LOCK" acquire --repo o/r
+    CLAUDE_CODE_SESSION_ID=ccA run bash "$LOCK" acquire --repo o/r
+    [ "$status" -eq 3 ]
+    CLAUDE_CODE_SESSION_ID=ccB run bash "$LOCK" acquire --repo o/r
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Problem

Re-invoking `/autospec-run` (or running it next to another monitor in the same harness session) spawned a **second concurrent monitor** that collided on the `auto-implement` queue and on git branches. Observed live this session: a redundant monitor re-claimed an issue that already had an open PR.

## What this adds

A **per-session single-instance guard** (scope confirmed with the operator: per harness session, *not* per repo).

- **`scripts/autospec-run-session-lock.sh`** — `acquire | release | status`, plus `--force`. The lock is keyed by a stable per-session token resolved harness-neutrally: `AUTOSPEC_SESSION_ID` → `CLAUDE_CODE_SESSION_ID` → Codex/OpenCode ids → `TERM_SESSION_ID` → POSIX sid → `PPID`. Atomic acquire via `noclobber`; `--force` is a deterministic last-writer-wins write (no rm+recreate race).
- **Contention = refuse + report**: a second `acquire` in the *same* session exits **3** and prints the active holder (pid, repo, started_at) + how to recover (`/autospec-stop` or `--force`). Separate sessions acquire independently by design.
- **Lock-step trio** (`SKILL.md` / `codex/prompt.md` / `opencode/agent.md`) gains a *"Single-instance session lock (run-start, once)"* section: acquire before Phase 4, refuse-and-stop on contention, release on every terminal exit.
- **install.sh** installs the helper via `SKILL_SCRIPT_FILES`.
- **tests/autospec-run/test_session_lock.bats** — 9 cases.

## Scope notes

- **Per-session, not per-repo** (operator's choice). This does *not* stop two *separate* sessions from both running on the same repo — cross-machine/-session coordination remains the existing GitHub run-state per-issue claims. It does stop one session from launching a redundant monitor.
- Strict refuse (no auto-reclaim). A crashed session's lock only ever blocks that *same* session id (a fresh session gets a new id), so there's no cross-session deadlock; `--force` recovers a stranded lock within a surviving session.

## Verification

- `bats tests/autospec-run/test_session_lock.bats` → 9/9.
- `scripts/validate.sh` → exit 0 (lock-step trio byte-identical, frontmatter, `bash -n`, structural sections).
- Independent code review pass; its two MEDIUM findings (the `--force` race and test coverage) are incorporated in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)