### PR TITLE
feat(autospec-loop): scaffold skill trio + packaging

### DIFF
--- a/skills/autospec-loop/README.md
+++ b/skills/autospec-loop/README.md
@@ -1,0 +1,109 @@
+# autospec-loop
+
+Harness-neutral, autospec-family **refine-then-goal-conditioned execution
+loop**. Turns an operator request to "run something in a loop until a goal is
+reached" into (1) an interactive **refine-until-`go`** gate that freezes a
+testable contract, then (2) a **goal-conditioned loop** that re-dispatches the
+refined prompt with carried state each iteration until a deterministic CHECK —
+or, failing that, an independent verifier — confirms the goal is met.
+
+It stops on the **goal**, not a clock, and ships conservative guardrails
+(max-iters cap, no-progress halt, shared `stop.flag`, pre-loop short-circuit)
+so it never spins unbounded on small-context local models.
+
+Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
+
+> **Status:** scaffold. This issue ships the lock-step trio with the 7 required
+> structural sections plus packaging. Phase 1 gate logic, Phase 2 loop logic,
+> trigger wording, the `scripts/loop-state.sh` / `loop-check.sh` helpers, and
+> `validate-autospec-loop.sh` land in follow-up child issues.
+
+## autospec-loop vs native `/loop`
+
+| Intent | Skill |
+| --- | --- |
+| "loop until the build passes", "keep going until done", "run X in a loop until Y" | **autospec-loop** (goal-conditioned) |
+| "loop every 5m", "/loop 5m /foo", "poll every N minutes" | native `/loop` (interval) |
+
+Ambiguous bare "do a loop" with no interval and no goal is claimed by
+autospec-loop; the refine gate's first question is goal-or-interval, and an
+interval answer redirects to native `/loop`.
+
+## Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-loop/install.sh | sh -s -- --harness all
+```
+
+Per-harness:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-loop/install.sh | sh -s -- --harness claude
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-loop/install.sh | sh -s -- --harness opencode
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-loop/install.sh | sh -s -- --harness codex
+```
+
+From a clone:
+
+```bash
+cd skills/autospec-loop
+./install.sh --harness all
+```
+
+## Invocation
+
+```
+/autospec-loop "<request>" [--goal '<criterion>'] [--check '<cmd>'] \
+               [--max-iters N] [--no-progress K] [--yes]
+```
+
+- `--goal '<criterion>'` — supply the testable GOAL explicitly; skip inference.
+- `--check '<cmd>'` — supply the deterministic CHECK (shell command); skip
+  inference. Exit 0 = met, non-zero = not-met.
+- `--max-iters N` — override the iteration cap (default 25).
+- `--no-progress K` — override the consecutive-no-progress halt (default 3).
+- `--yes` — skip the show-and-explain gate (autonomous; off by default, since
+  the gate is the core requested behaviour).
+
+## Required structural sections
+
+Every harness body (`SKILL.md` / `codex/prompt.md` / `opencode/agent.md`)
+carries these 7 sections in order, so the decomposer and the repo validator
+recognise it as a conformant autospec skill:
+
+1. **Startup self-update** — canonical self-update block, `SKILL_NAME=autospec-loop`.
+2. **Self-update mode** — pure-prose dispatch on `^\s*update\s*$`.
+3. **Model tier** — AGENTS.md Tier A/B + harness-detection + adapter row.
+4. **Trigger disambiguation** — goal-intent vs interval (`/loop`) split.
+5. **Phase 1 — refine-until-go gate**.
+6. **Phase 2 — goal-conditioned loop**.
+7. **Guardrails** — max-iters, no-progress, stop.flag, pre-loop short-circuit.
+
+## State file
+
+`~/.autospec/loop/<repo-slug>/loop-state.json` (path-scoped slug avoids
+cross-repo collision; atomic `tmp`+`mv` writes). Schema: 1.
+
+## Self-update
+
+```
+/autospec-loop update
+```
+
+Or re-run the installer with `--update`:
+
+```bash
+./install.sh --harness all --update
+```
+
+## Related skills
+
+| Skill | Purpose |
+| --- | --- |
+| [`autospec-refine`](../autospec-refine/README.md) | The refinement rounds reused by Phase 1's gate. |
+| [`autospec-stop`](../autospec-stop/README.md) | Writes the shared `~/.autospec/stop.flag` the loop honours. |
+| [`autospec`](../autospec/README.md) | Full plan-and-ship pipeline. |
+
+## License
+
+MIT — see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autospec-loop/SKILL.md
+++ b/skills/autospec-loop/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: autospec-loop
+description: Use when the user wants to run a single task repeatedly in a loop until a goal is reached — "loop until the build passes", "keep going until done", "run X in a loop until Y". Interactively refines the request into a frozen contract, then runs a goal-conditioned loop with conservative guardrails. Claims goal/completion loop phrasings; defers bare interval polling ("loop every 5m") to the native /loop.
+---
+
+# autospec-loop workflow (harness-neutral)
+
+Take an operator request to "run something in a loop until a goal is reached"
+and turn it into (1) an interactive **refine-until-"go"** gate that freezes a
+testable contract, then (2) a **goal-conditioned loop** that re-dispatches the
+refined prompt with carried state each iteration until a deterministic check —
+or, failing that, an independent verifier — confirms the goal is met, with
+conservative guardrails so it never spins unbounded.
+
+Goal: a harness-neutral, autospec-family way to "keep doing X until Y" that
+stops on the *goal* (not a clock), prefers a deterministic CHECK over LLM
+self-assessment, and is safe to run on small-context local models.
+
+Manage your own context — never exceed 60%. Delegate per-iteration work to
+subagents whenever your harness supports it (Codex runs iterations inline); do
+not carry raw iteration transcripts in the orchestrator context.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-loop   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-loop
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the argument matches the regex `^\s*update\s*$` (case-insensitive,
+whitespace-padded), this skill enters self-update mode and does not run the
+normal pipeline. This section is pure prose: never interpolate or shell out the
+operator's argument text.
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-loop/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-loop.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-loop.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter the loop pipeline. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-loop found; run install.sh first.` and exit.
+
+## Model tier
+
+Tier A/B model resolution and the harness-detection protocol are inherited
+verbatim from `AGENTS.md` (`## Subagent model selection (two-tier, cost-aware)`
+and `## Subagent vs inline decision matrix`). Refinement-gate reasoning runs at
+Tier A (spec work); per-iteration loop work and the independent verifier run at
+Tier B (implementation work), escalating to Tier A for high-stakes goals.
+
+> **Model tier:** Phase 1 refine-gate dispatches at Tier A (spec work); Phase 2
+> per-iteration worker and verifier dispatch at TIER_B (implementation work),
+> resolved at startup per the harness detection below.
+
+### Required capabilities & harness adapter
+
+This workflow assumes the following capabilities. Map each to your harness's
+actual tool; if a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                                | Fallback if missing                              |
+|-----------------------------|-----------------------------------------|---------------------------------------|------------------------------------------|--------------------------------------------------|
+| Per-iteration worker        | `Agent` (subagent_type=general-purpose) | `task` agent, await output            | run the iteration inline (no subagents)  | Run the iteration in-thread (more context cost)  |
+| Independent verifier        | a **separate** `Agent` dispatch         | a **separate** `task` agent           | a separate inline judging pass           | Judge in-thread, but never reuse the worker pass |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                            | Ask in the response and wait for the next turn   |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+| Subagent dispatch policy    | per AGENTS.md decision matrix           | per AGENTS.md decision matrix         | per AGENTS.md decision matrix            | inline with main-session token cost              |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in
+the repo root — recognized by Claude Code, OpenCode, and Codex.
+
+## Harness detection (run once at skill start, before the gate begins)
+
+Detect your harness by checking available tools before any dispatch:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; iterations run inline.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness, silently retry
+the same subagent dispatch with `TIER_A`. Preserve parent context on retry.
+Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run.
+
+## Trigger disambiguation
+
+`autospec-loop` and the native `/loop` cover different intents; route by
+goal-vs-interval:
+
+- **autospec-loop claims** goal/completion phrasings: *"loop until …"*, *"in a
+  loop until …"*, *"keep going until done"*, *"do a loop"*, *"execute a loop"*,
+  *"run X in a loop until Y"*, *"keep doing X until Y"*.
+- **Native `/loop` keeps** bare interval phrasings: *"loop every 5m"*,
+  *"/loop 5m /foo"*, *"poll every N minutes"*, *"keep running … on an interval"*.
+- **Ambiguous** bare *"do a loop"* / *"execute a loop"* with no interval and no
+  explicit goal → autospec-loop claims it, and the refine gate's **first
+  question** is goal-or-interval. If the operator wants interval polling, the
+  skill **redirects to native `/loop`** and exits without starting its own loop.
+
+> Stub: the full trigger wording lives in the frontmatter `description` and is
+> finalized in the trigger-disambiguation child issue.
+
+## Phase 1 — refine-until-go gate
+
+The interactive gate that freezes a contract before any loop iteration runs:
+
+1. **Trigger disambiguation** (above). If interval intent → redirect to native
+   `/loop`, stop.
+2. **Refinement rounds** — invoke `autospec-refine --interactive` to run the
+   repo-grounded prompt-improvement rounds on the raw request (reuse upstream;
+   do not fork the lens logic).
+3. **Contract extraction** — extract GOAL (testable success criterion), CHECK
+   (a deterministic verifier command, or `null`), and MODE (`cumulative`
+   default vs `polling`).
+4. **Show & explain** — present the refined prompt verbatim, restate what was
+   understood (GOAL, CHECK or "an independent verifier will judge", MODE,
+   guardrails), and the per-iteration plan.
+5. **Clarify loop** — re-run steps 2–4 until the operator types the literal
+   unlock token **`go`** (case-insensitive; also accepts "go ahead"/"start").
+   `--yes` skips the gate (off by default).
+6. **Freeze** the contract into the loop-state file.
+
+> Stub: the contract-extraction and show-and-explain logic is filled in by the
+> Phase 1 refine-until-go gate child issue.
+
+## Phase 2 — goal-conditioned loop
+
+State lives at `~/.autospec/loop/<repo-slug>/loop-state.json` (path-scoped slug
+to avoid cross-repo collision; atomic `tmp`+`mv` writes via `loop-state.sh`).
+
+**Pre-loop short-circuit:** if CHECK is non-null, run it once before iterating;
+if already satisfied → `exit_reason="already-satisfied"`, report, stop.
+
+**Each iteration** (stop-gates evaluated *before* doing work):
+
+1. **Halt gate** — see Guardrails.
+2. **Work** — dispatch a worker subagent (Tier B; inline on Codex) with the
+   refined prompt + GOAL + carried `progress[]` (cumulative) or just the prompt
+   + `last_result` (polling). Instruct it to make forward progress and report.
+3. **Persist** — append the outcome to `progress[]`, set `last_result`, via
+   `loop-state.sh`.
+4. **Goal eval** — if CHECK non-null, run `loop-check.sh` (deterministic,
+   preferred). If CHECK is `null`, dispatch a **separate** verifier subagent —
+   **never the worker subagent** (no self-approval) — to judge against GOAL.
+5. **No-progress detection** — measurable change this iteration? No →
+   `no_progress_count++`; yes → reset to 0.
+6. **Converge** — goal met → `done=true`, `exit_reason="goal-met"`, break.
+   Else `iter++`, continue.
+
+> Stub: the iteration body and exit report are filled in by the Phase 2
+> goal-conditioned loop child issue; `loop-state.sh` / `loop-check.sh` ship in
+> the scripts child issue.
+
+## Guardrails
+
+Conservative caps so the loop never spins unbounded (small-model target):
+
+- **stop.flag** — `~/.autospec/stop.flag` exists (shared with `/autospec-stop`)
+  → halt with `exit_reason="stopped-by-flag"`.
+- **max-iters** — `iter >= max_iters` (default 25, `--max-iters N`) →
+  `exit_reason="max-iters"`.
+- **no-progress** — `no_progress_count >= no_progress_K` (default 3,
+  `--no-progress K`) → `exit_reason="no-progress"`.
+- **pre-loop short-circuit** — CHECK already satisfied before iterating →
+  `exit_reason="already-satisfied"`, no wasted iteration.
+- **no self-approval** — when CHECK is `null`, goal judgement is always done by
+  a **separate** verifier subagent, never the worker that produced the result.
+
+The halt gate is evaluated *before* each iteration's work, so a set flag or an
+exhausted cap stops the loop without dispatching another worker.

--- a/skills/autospec-loop/codex/prompt.md
+++ b/skills/autospec-loop/codex/prompt.md
@@ -1,0 +1,217 @@
+
+# autospec-loop workflow (harness-neutral)
+
+Take an operator request to "run something in a loop until a goal is reached"
+and turn it into (1) an interactive **refine-until-"go"** gate that freezes a
+testable contract, then (2) a **goal-conditioned loop** that re-dispatches the
+refined prompt with carried state each iteration until a deterministic check —
+or, failing that, an independent verifier — confirms the goal is met, with
+conservative guardrails so it never spins unbounded.
+
+Goal: a harness-neutral, autospec-family way to "keep doing X until Y" that
+stops on the *goal* (not a clock), prefers a deterministic CHECK over LLM
+self-assessment, and is safe to run on small-context local models.
+
+Manage your own context — never exceed 60%. Delegate per-iteration work to
+subagents whenever your harness supports it (Codex runs iterations inline); do
+not carry raw iteration transcripts in the orchestrator context.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-loop   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-loop
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the argument matches the regex `^\s*update\s*$` (case-insensitive,
+whitespace-padded), this skill enters self-update mode and does not run the
+normal pipeline. This section is pure prose: never interpolate or shell out the
+operator's argument text.
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-loop/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-loop.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-loop.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter the loop pipeline. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-loop found; run install.sh first.` and exit.
+
+## Model tier
+
+Tier A/B model resolution and the harness-detection protocol are inherited
+verbatim from `AGENTS.md` (`## Subagent model selection (two-tier, cost-aware)`
+and `## Subagent vs inline decision matrix`). Refinement-gate reasoning runs at
+Tier A (spec work); per-iteration loop work and the independent verifier run at
+Tier B (implementation work), escalating to Tier A for high-stakes goals.
+
+> **Model tier:** Phase 1 refine-gate dispatches at Tier A (spec work); Phase 2
+> per-iteration worker and verifier dispatch at TIER_B (implementation work),
+> resolved at startup per the harness detection below.
+
+### Required capabilities & harness adapter
+
+This workflow assumes the following capabilities. Map each to your harness's
+actual tool; if a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                                | Fallback if missing                              |
+|-----------------------------|-----------------------------------------|---------------------------------------|------------------------------------------|--------------------------------------------------|
+| Per-iteration worker        | `Agent` (subagent_type=general-purpose) | `task` agent, await output            | run the iteration inline (no subagents)  | Run the iteration in-thread (more context cost)  |
+| Independent verifier        | a **separate** `Agent` dispatch         | a **separate** `task` agent           | a separate inline judging pass           | Judge in-thread, but never reuse the worker pass |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                            | Ask in the response and wait for the next turn   |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+| Subagent dispatch policy    | per AGENTS.md decision matrix           | per AGENTS.md decision matrix         | per AGENTS.md decision matrix            | inline with main-session token cost              |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in
+the repo root — recognized by Claude Code, OpenCode, and Codex.
+
+## Harness detection (run once at skill start, before the gate begins)
+
+Detect your harness by checking available tools before any dispatch:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; iterations run inline.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness, silently retry
+the same subagent dispatch with `TIER_A`. Preserve parent context on retry.
+Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run.
+
+## Trigger disambiguation
+
+`autospec-loop` and the native `/loop` cover different intents; route by
+goal-vs-interval:
+
+- **autospec-loop claims** goal/completion phrasings: *"loop until …"*, *"in a
+  loop until …"*, *"keep going until done"*, *"do a loop"*, *"execute a loop"*,
+  *"run X in a loop until Y"*, *"keep doing X until Y"*.
+- **Native `/loop` keeps** bare interval phrasings: *"loop every 5m"*,
+  *"/loop 5m /foo"*, *"poll every N minutes"*, *"keep running … on an interval"*.
+- **Ambiguous** bare *"do a loop"* / *"execute a loop"* with no interval and no
+  explicit goal → autospec-loop claims it, and the refine gate's **first
+  question** is goal-or-interval. If the operator wants interval polling, the
+  skill **redirects to native `/loop`** and exits without starting its own loop.
+
+> Stub: the full trigger wording lives in the frontmatter `description` and is
+> finalized in the trigger-disambiguation child issue.
+
+## Phase 1 — refine-until-go gate
+
+The interactive gate that freezes a contract before any loop iteration runs:
+
+1. **Trigger disambiguation** (above). If interval intent → redirect to native
+   `/loop`, stop.
+2. **Refinement rounds** — invoke `autospec-refine --interactive` to run the
+   repo-grounded prompt-improvement rounds on the raw request (reuse upstream;
+   do not fork the lens logic).
+3. **Contract extraction** — extract GOAL (testable success criterion), CHECK
+   (a deterministic verifier command, or `null`), and MODE (`cumulative`
+   default vs `polling`).
+4. **Show & explain** — present the refined prompt verbatim, restate what was
+   understood (GOAL, CHECK or "an independent verifier will judge", MODE,
+   guardrails), and the per-iteration plan.
+5. **Clarify loop** — re-run steps 2–4 until the operator types the literal
+   unlock token **`go`** (case-insensitive; also accepts "go ahead"/"start").
+   `--yes` skips the gate (off by default).
+6. **Freeze** the contract into the loop-state file.
+
+> Stub: the contract-extraction and show-and-explain logic is filled in by the
+> Phase 1 refine-until-go gate child issue.
+
+## Phase 2 — goal-conditioned loop
+
+State lives at `~/.autospec/loop/<repo-slug>/loop-state.json` (path-scoped slug
+to avoid cross-repo collision; atomic `tmp`+`mv` writes via `loop-state.sh`).
+
+**Pre-loop short-circuit:** if CHECK is non-null, run it once before iterating;
+if already satisfied → `exit_reason="already-satisfied"`, report, stop.
+
+**Each iteration** (stop-gates evaluated *before* doing work):
+
+1. **Halt gate** — see Guardrails.
+2. **Work** — dispatch a worker subagent (Tier B; inline on Codex) with the
+   refined prompt + GOAL + carried `progress[]` (cumulative) or just the prompt
+   + `last_result` (polling). Instruct it to make forward progress and report.
+3. **Persist** — append the outcome to `progress[]`, set `last_result`, via
+   `loop-state.sh`.
+4. **Goal eval** — if CHECK non-null, run `loop-check.sh` (deterministic,
+   preferred). If CHECK is `null`, dispatch a **separate** verifier subagent —
+   **never the worker subagent** (no self-approval) — to judge against GOAL.
+5. **No-progress detection** — measurable change this iteration? No →
+   `no_progress_count++`; yes → reset to 0.
+6. **Converge** — goal met → `done=true`, `exit_reason="goal-met"`, break.
+   Else `iter++`, continue.
+
+> Stub: the iteration body and exit report are filled in by the Phase 2
+> goal-conditioned loop child issue; `loop-state.sh` / `loop-check.sh` ship in
+> the scripts child issue.
+
+## Guardrails
+
+Conservative caps so the loop never spins unbounded (small-model target):
+
+- **stop.flag** — `~/.autospec/stop.flag` exists (shared with `/autospec-stop`)
+  → halt with `exit_reason="stopped-by-flag"`.
+- **max-iters** — `iter >= max_iters` (default 25, `--max-iters N`) →
+  `exit_reason="max-iters"`.
+- **no-progress** — `no_progress_count >= no_progress_K` (default 3,
+  `--no-progress K`) → `exit_reason="no-progress"`.
+- **pre-loop short-circuit** — CHECK already satisfied before iterating →
+  `exit_reason="already-satisfied"`, no wasted iteration.
+- **no self-approval** — when CHECK is `null`, goal judgement is always done by
+  a **separate** verifier subagent, never the worker that produced the result.
+
+The halt gate is evaluated *before* each iteration's work, so a set flag or an
+exhausted cap stops the loop without dispatching another worker.

--- a/skills/autospec-loop/install.sh
+++ b/skills/autospec-loop/install.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --symlink           # symlink instead of copy (updates propagate)
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-loop/install.sh \
+#     | sh -s -- --harness all
+# When piped, the script auto-downloads the skill files from the same branch.
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPEC_LOOP_REF         (default: main) — git ref to fetch from when piped
+#   AUTOSPEC_LOOP_RAW_BASE    (override the raw URL base entirely)
+#
+# Idempotent: re-running upgrades the install. Exits non-zero on hard failure;
+# exits zero with warnings on missing optional deps.
+
+set -eu
+
+SKILL_NAME="autospec-loop"
+SKILL_RAW_BASE="${AUTOSPEC_LOOP_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_LOOP_REF:-main}/skills/autospec-loop}"
+
+# Resolve the directory containing this script. When piped through stdin (e.g.
+# `curl ... | sh`), $0 will not be a real file — detect that and fall back to
+# downloading the source files from the raw GitHub URL.
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+UPDATE_MODE=0
+TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+
+# ---------- helpers --------------------------------------------------------
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
+
+Installs the ${SKILL_NAME} skill into the chosen harness's standard
+skill/agent/prompt directory.
+
+Examples:
+  $0                          # interactive
+  $0 --harness all            # install everywhere
+  $0 --harness claude         # Claude Code only
+  $0 --harness opencode       # OpenCode only
+  $0 --harness codex          # Codex CLI only
+  $0 --harness all --symlink  # symlink instead of copy
+  $0 --dry-run --harness all  # print plan, change nothing
+  $0 --harness claude --update  # idempotent re-install (overwrite existing)
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    # Download the files we need into a temp dir and set SKILL_DIR to it.
+    if ! command -v curl >/dev/null 2>&1; then
+        err "curl is required when running from stdin (e.g. piped via 'curl | sh')."
+        exit 1
+    fi
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/$rel"
+            exit 1
+        fi
+    done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autospec helper scripts"
+        return 1
+    fi
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    dest_dir="$(dirname "$dest")"
+
+    if [ ! -f "$src" ]; then
+        err "missing source file: $src"
+        return 1
+    fi
+
+    run "mkdir -p \"$dest_dir\""
+
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --symlink)
+            USE_SYMLINK=1
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        --update)
+            UPDATE_MODE=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# ---------- harness prompt -------------------------------------------------
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- ensure source files are available ------------------------------
+
+# If we couldn't resolve a local SKILL_DIR (piped from curl) OR the local dir
+# doesn't actually contain the skill files, fall back to remote fetch.
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+
+if [ "$need_fetch" -eq 1 ]; then
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        err "--symlink requires running from a checkout of the codex-skills repo (no local files to symlink to)."
+        exit 2
+    fi
+    fetch_source_files
+fi
+
+# ---------- dependency checks ---------------------------------------------
+
+dep_warnings=0
+
+check_dep() {
+    name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        warn "$name not found on PATH (required by the skill at runtime)"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+}
+
+check_dep git
+check_dep gh
+check_dep jq
+
+if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+        warn "gh is installed but not authenticated. Run: gh auth login"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+fi
+
+if [ "$dep_warnings" -gt 0 ]; then
+    warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
+fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+CLAUDE_SRC="$SKILL_DIR/SKILL.md"
+OPENCODE_SRC="$SKILL_DIR/opencode/agent.md"
+CODEX_SRC="$SKILL_DIR/codex/prompt.md"
+
+# ---------- install --------------------------------------------------------
+
+installed_paths=""
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_SRC" "$CLAUDE_DEST"
+    installed_paths="${installed_paths}  Claude Code: ${CLAUDE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_SRC" "$OPENCODE_DEST"
+    installed_paths="${installed_paths}  OpenCode:    ${OPENCODE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+    installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
+fi
+
+# ---------- final summary --------------------------------------------------
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    if [ "$UPDATE_MODE" -eq 1 ]; then
+        info "Updated (idempotent overwrite):"
+    else
+        info "Installed:"
+    fi
+    printf '%b' "$installed_paths"
+    info ""
+    info "Invoke with:"
+    info "  Claude Code:  /${SKILL_NAME} <feature description>"
+    info "  OpenCode:     @${SKILL_NAME} <feature description>"
+    info "  Codex CLI:    /${SKILL_NAME} <feature description>"
+fi
+
+exit 0

--- a/skills/autospec-loop/opencode/agent.md
+++ b/skills/autospec-loop/opencode/agent.md
@@ -1,0 +1,221 @@
+---
+description: Use when the user wants to run a single task repeatedly in a loop until a goal is reached — "loop until the build passes", "keep going until done", "run X in a loop until Y". Interactively refines the request into a frozen contract, then runs a goal-conditioned loop with conservative guardrails. Claims goal/completion loop phrasings; defers bare interval polling ("loop every 5m") to the native /loop.
+mode: primary
+---
+
+# autospec-loop workflow (harness-neutral)
+
+Take an operator request to "run something in a loop until a goal is reached"
+and turn it into (1) an interactive **refine-until-"go"** gate that freezes a
+testable contract, then (2) a **goal-conditioned loop** that re-dispatches the
+refined prompt with carried state each iteration until a deterministic check —
+or, failing that, an independent verifier — confirms the goal is met, with
+conservative guardrails so it never spins unbounded.
+
+Goal: a harness-neutral, autospec-family way to "keep doing X until Y" that
+stops on the *goal* (not a clock), prefers a deterministic CHECK over LLM
+self-assessment, and is safe to run on small-context local models.
+
+Manage your own context — never exceed 60%. Delegate per-iteration work to
+subagents whenever your harness supports it (Codex runs iterations inline); do
+not carry raw iteration transcripts in the orchestrator context.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-loop   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-loop
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the argument matches the regex `^\s*update\s*$` (case-insensitive,
+whitespace-padded), this skill enters self-update mode and does not run the
+normal pipeline. This section is pure prose: never interpolate or shell out the
+operator's argument text.
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-loop/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-loop.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-loop.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter the loop pipeline. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-loop found; run install.sh first.` and exit.
+
+## Model tier
+
+Tier A/B model resolution and the harness-detection protocol are inherited
+verbatim from `AGENTS.md` (`## Subagent model selection (two-tier, cost-aware)`
+and `## Subagent vs inline decision matrix`). Refinement-gate reasoning runs at
+Tier A (spec work); per-iteration loop work and the independent verifier run at
+Tier B (implementation work), escalating to Tier A for high-stakes goals.
+
+> **Model tier:** Phase 1 refine-gate dispatches at Tier A (spec work); Phase 2
+> per-iteration worker and verifier dispatch at TIER_B (implementation work),
+> resolved at startup per the harness detection below.
+
+### Required capabilities & harness adapter
+
+This workflow assumes the following capabilities. Map each to your harness's
+actual tool; if a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                                | Fallback if missing                              |
+|-----------------------------|-----------------------------------------|---------------------------------------|------------------------------------------|--------------------------------------------------|
+| Per-iteration worker        | `Agent` (subagent_type=general-purpose) | `task` agent, await output            | run the iteration inline (no subagents)  | Run the iteration in-thread (more context cost)  |
+| Independent verifier        | a **separate** `Agent` dispatch         | a **separate** `task` agent           | a separate inline judging pass           | Judge in-thread, but never reuse the worker pass |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                            | Ask in the response and wait for the next turn   |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+| Subagent dispatch policy    | per AGENTS.md decision matrix           | per AGENTS.md decision matrix         | per AGENTS.md decision matrix            | inline with main-session token cost              |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in
+the repo root — recognized by Claude Code, OpenCode, and Codex.
+
+## Harness detection (run once at skill start, before the gate begins)
+
+Detect your harness by checking available tools before any dispatch:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; iterations run inline.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness, silently retry
+the same subagent dispatch with `TIER_A`. Preserve parent context on retry.
+Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run.
+
+## Trigger disambiguation
+
+`autospec-loop` and the native `/loop` cover different intents; route by
+goal-vs-interval:
+
+- **autospec-loop claims** goal/completion phrasings: *"loop until …"*, *"in a
+  loop until …"*, *"keep going until done"*, *"do a loop"*, *"execute a loop"*,
+  *"run X in a loop until Y"*, *"keep doing X until Y"*.
+- **Native `/loop` keeps** bare interval phrasings: *"loop every 5m"*,
+  *"/loop 5m /foo"*, *"poll every N minutes"*, *"keep running … on an interval"*.
+- **Ambiguous** bare *"do a loop"* / *"execute a loop"* with no interval and no
+  explicit goal → autospec-loop claims it, and the refine gate's **first
+  question** is goal-or-interval. If the operator wants interval polling, the
+  skill **redirects to native `/loop`** and exits without starting its own loop.
+
+> Stub: the full trigger wording lives in the frontmatter `description` and is
+> finalized in the trigger-disambiguation child issue.
+
+## Phase 1 — refine-until-go gate
+
+The interactive gate that freezes a contract before any loop iteration runs:
+
+1. **Trigger disambiguation** (above). If interval intent → redirect to native
+   `/loop`, stop.
+2. **Refinement rounds** — invoke `autospec-refine --interactive` to run the
+   repo-grounded prompt-improvement rounds on the raw request (reuse upstream;
+   do not fork the lens logic).
+3. **Contract extraction** — extract GOAL (testable success criterion), CHECK
+   (a deterministic verifier command, or `null`), and MODE (`cumulative`
+   default vs `polling`).
+4. **Show & explain** — present the refined prompt verbatim, restate what was
+   understood (GOAL, CHECK or "an independent verifier will judge", MODE,
+   guardrails), and the per-iteration plan.
+5. **Clarify loop** — re-run steps 2–4 until the operator types the literal
+   unlock token **`go`** (case-insensitive; also accepts "go ahead"/"start").
+   `--yes` skips the gate (off by default).
+6. **Freeze** the contract into the loop-state file.
+
+> Stub: the contract-extraction and show-and-explain logic is filled in by the
+> Phase 1 refine-until-go gate child issue.
+
+## Phase 2 — goal-conditioned loop
+
+State lives at `~/.autospec/loop/<repo-slug>/loop-state.json` (path-scoped slug
+to avoid cross-repo collision; atomic `tmp`+`mv` writes via `loop-state.sh`).
+
+**Pre-loop short-circuit:** if CHECK is non-null, run it once before iterating;
+if already satisfied → `exit_reason="already-satisfied"`, report, stop.
+
+**Each iteration** (stop-gates evaluated *before* doing work):
+
+1. **Halt gate** — see Guardrails.
+2. **Work** — dispatch a worker subagent (Tier B; inline on Codex) with the
+   refined prompt + GOAL + carried `progress[]` (cumulative) or just the prompt
+   + `last_result` (polling). Instruct it to make forward progress and report.
+3. **Persist** — append the outcome to `progress[]`, set `last_result`, via
+   `loop-state.sh`.
+4. **Goal eval** — if CHECK non-null, run `loop-check.sh` (deterministic,
+   preferred). If CHECK is `null`, dispatch a **separate** verifier subagent —
+   **never the worker subagent** (no self-approval) — to judge against GOAL.
+5. **No-progress detection** — measurable change this iteration? No →
+   `no_progress_count++`; yes → reset to 0.
+6. **Converge** — goal met → `done=true`, `exit_reason="goal-met"`, break.
+   Else `iter++`, continue.
+
+> Stub: the iteration body and exit report are filled in by the Phase 2
+> goal-conditioned loop child issue; `loop-state.sh` / `loop-check.sh` ship in
+> the scripts child issue.
+
+## Guardrails
+
+Conservative caps so the loop never spins unbounded (small-model target):
+
+- **stop.flag** — `~/.autospec/stop.flag` exists (shared with `/autospec-stop`)
+  → halt with `exit_reason="stopped-by-flag"`.
+- **max-iters** — `iter >= max_iters` (default 25, `--max-iters N`) →
+  `exit_reason="max-iters"`.
+- **no-progress** — `no_progress_count >= no_progress_K` (default 3,
+  `--no-progress K`) → `exit_reason="no-progress"`.
+- **pre-loop short-circuit** — CHECK already satisfied before iterating →
+  `exit_reason="already-satisfied"`, no wasted iteration.
+- **no self-approval** — when CHECK is `null`, goal judgement is always done by
+  a **separate** verifier subagent, never the worker that produced the result.
+
+The halt gate is evaluated *before* each iteration's work, so a set flag or an
+exhausted cap stops the loop without dispatching another worker.

--- a/skills/autospec-loop/uninstall.sh
+++ b/skills/autospec-loop/uninstall.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autospec-loop"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        # Try to remove an empty parent skill directory (Claude only — its layout
+        # has a per-skill subdir).
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+# ---------- remove ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0


### PR DESCRIPTION
Closes #890

## Summary
Scaffolds the new harness-neutral `autospec-loop` skill: the lock-step trio (`SKILL.md`, `codex/prompt.md`, `opencode/agent.md`) with byte-identical bodies, plus `README.md` and `install.sh`/`uninstall.sh` mirrored from `autospec-refine`.

All 7 required structural sections are present in order in every body:
1. Startup self-update (`SKILL_NAME=autospec-loop`, canonical block)
2. Self-update mode (pure-prose `^\s*update\s*$` dispatch, no shelling of operator text)
3. Model tier (AGENTS.md Tier A/B + harness-detection + adapter row incl. `Subagent dispatch policy`)
4. Trigger disambiguation (stub)
5. Phase 1 — refine-until-go gate (stub)
6. Phase 2 — goal-conditioned loop (stub)
7. Guardrails (max-iters, no-progress, stop.flag, pre-loop short-circuit, no-self-approval)

Sections 4/5/6 are header + stub by design; scripts (`loop-state.sh`/`loop-check.sh`) and `validate-autospec-loop.sh` are out of scope (child issues #891–#895).

## Reuse
Reusing the `autospec-refine` trio + install/uninstall shape as the scaffold template (per the issue's "mirror an existing skill" directive); the startup self-update block is byte-identical to the canonical block modulo the `SKILL_NAME=` line.

## Lock-step
- Frontmatter-stripped diff of the three bodies is empty (verified manually and by `scripts/validate.sh`).
- `codex/prompt.md` first byte is a newline (leading blank line).

## Tests / verification
- Primary smoke test: `bash -n install.sh && bash -n uninstall.sh && head -c1 codex/prompt.md | od -An -c | grep -q '\n'` — passes.
- `bash scripts/validate.sh` exits 0 (lock-step, frontmatter, self-update, model-tier, harness-detection for the new trio).

Peer-review: codex not on PATH, skipping.