### PR TITLE
feat(autospec-loop): loop-state.sh + loop-check.sh with bats tests (#891)

### DIFF
--- a/skills/autospec-loop/scripts/loop-check.sh
+++ b/skills/autospec-loop/scripts/loop-check.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# loop-check.sh — run the deterministic CHECK and normalize exit status.
+#
+# Per docs/specs/2026-06-02-autospec-loop-design.md (§Phase 2):
+# Run the CHECK command; map exit 0 -> "met" (exit 0),
+# any non-zero -> "not-met" (exit 1). Missing, empty, or literal "null"
+# CHECK -> "not-met" (exit 1).
+#
+# Usage:
+#   loop-check.sh [<check-command>]
+#
+# Output:
+#   Prints "met"     to stdout and exits 0 when CHECK succeeds.
+#   Prints "not-met" to stdout and exits 1 otherwise.
+
+set -eu
+
+CHECK_CMD="${1:-}"
+
+# Empty or literal "null" means no deterministic check is available.
+if [ -z "$CHECK_CMD" ] || [ "$CHECK_CMD" = "null" ]; then
+    printf 'not-met\n'
+    exit 1
+fi
+
+# Run the check command. Capture exit status without aborting under set -e.
+check_rc=0
+if eval "$CHECK_CMD" > /dev/null 2>&1; then
+    check_rc=0
+else
+    check_rc=$?
+fi
+
+if [ "$check_rc" -eq 0 ]; then
+    printf 'met\n'
+    exit 0
+else
+    printf 'not-met\n'
+    exit 1
+fi

--- a/skills/autospec-loop/scripts/loop-state.sh
+++ b/skills/autospec-loop/scripts/loop-state.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# loop-state.sh — atomic read/update of loop-state.json.
+#
+# Per docs/specs/2026-06-02-autospec-loop-design.md (§Phase 2):
+# State file at ~/.autospec/loop/<repo-slug>/loop-state.json.
+# Writes via mktemp + mv (atomic). Inline cleanup — no RETURN trap.
+# One-sided conditionals use if/then/fi (no set -e short-circuit footgun).
+#
+# Schema 1:
+#   { "schema": 1, "goal": str, "check": cmd|null, "mode": "cumulative"|"polling",
+#     "max_iters": 25, "no_progress_K": 3, "iter": 0, "no_progress_count": 0,
+#     "progress": [], "last_result": "", "done": false, "exit_reason": null }
+#
+# Subcommands:
+#   init   --repo <o/n> --goal <str> --check <cmd|null> [--mode cumulative|polling]
+#                       [--max-iters N] [--no-progress-k N]
+#   read   --repo <o/n>
+#   update --repo <o/n> --key <field> --value <val>
+#   path   --repo <o/n>
+#
+# Environment:
+#   AUTOSPEC_LOOP_STATE_DIR   base dir (default: ~/.autospec/loop)
+
+set -eu
+
+STATE_BASE="${AUTOSPEC_LOOP_STATE_DIR:-$HOME/.autospec/loop}"
+
+err()  { printf 'loop-state: %s\n' "$1" >&2; }
+die()  { err "$1"; exit 1; }
+
+usage() {
+    cat <<'EOF'
+Usage:
+  loop-state.sh init   --repo <owner/name> --goal <str> --check <cmd|null>
+                       [--mode cumulative|polling] [--max-iters N] [--no-progress-k N]
+  loop-state.sh read   --repo <owner/name>
+  loop-state.sh update --repo <owner/name> --key <field> --value <val>
+  loop-state.sh path   --repo <owner/name>
+EOF
+}
+
+repo_slug() {
+    repo="${1:-}"
+    [ -n "$repo" ] || die "repo is required"
+    printf '%s' "$repo" | tr '/' '_'
+}
+
+state_dir() {
+    slug="$(repo_slug "$1")"
+    printf '%s/%s' "$STATE_BASE" "$slug"
+}
+
+state_path() {
+    printf '%s/loop-state.json' "$(state_dir "$1")"
+}
+
+now_iso() { date -u +'%Y-%m-%dT%H:%M:%SZ'; }
+
+# write_state REPO JSON_STRING — atomic tmp+mv write, inline cleanup.
+write_state() {
+    repo="$1"
+    json="$2"
+    dir="$(state_dir "$repo")"
+    mkdir -p "$dir"
+    dest="$(state_path "$repo")"
+    tmp="$(mktemp "${dest}.XXXXXX")"
+    if ! printf '%s\n' "$json" > "$tmp"; then
+        rm -f "$tmp"
+        die "failed to write state to tmp file"
+    fi
+    if ! mv "$tmp" "$dest"; then
+        rm -f "$tmp"
+        die "failed to atomically rename tmp to state file"
+    fi
+}
+
+# ── subcommand: init ──────────────────────────────────────────────────────────
+
+cmd_init() {
+    repo=""
+    goal=""
+    check_val=""
+    mode="cumulative"
+    max_iters=25
+    no_progress_k=3
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --repo)          repo="${2:-}";          shift 2 ;;
+            --goal)          goal="${2:-}";          shift 2 ;;
+            --check)         check_val="${2:-}";     shift 2 ;;
+            --mode)          mode="${2:-cumulative}"; shift 2 ;;
+            --max-iters)     max_iters="${2:-25}";   shift 2 ;;
+            --no-progress-k) no_progress_k="${2:-3}"; shift 2 ;;
+            *) die "init: unknown option: $1" ;;
+        esac
+    done
+
+    [ -n "$repo" ]     || die "init: --repo is required"
+    [ -n "$goal" ]     || die "init: --goal is required"
+    [ -n "$check_val" ] || die "init: --check is required (use 'null' for no check)"
+
+    # Build check JSON value: bare "null" -> JSON null, else quoted string.
+    if [ "$check_val" = "null" ]; then
+        check_json="null"
+    else
+        check_json="$(printf '%s' "$check_val" | jq -Rs '.')"
+    fi
+
+    now="$(now_iso)"
+    json="$(jq -n \
+        --argjson schema 1 \
+        --arg     goal   "$goal" \
+        --argjson check  "$check_json" \
+        --arg     mode   "$mode" \
+        --argjson max_iters       "$max_iters" \
+        --argjson no_progress_K   "$no_progress_k" \
+        --argjson iter            0 \
+        --argjson no_progress_count 0 \
+        --arg     last_result     "" \
+        --argjson done            false \
+        --arg     created_at      "$now" \
+        --arg     updated_at      "$now" \
+        '{
+            schema: $schema,
+            goal: $goal,
+            check: $check,
+            mode: $mode,
+            max_iters: $max_iters,
+            no_progress_K: $no_progress_K,
+            iter: $iter,
+            no_progress_count: $no_progress_count,
+            progress: [],
+            last_result: $last_result,
+            done: $done,
+            exit_reason: null,
+            created_at: $created_at,
+            updated_at: $updated_at
+        }')"
+
+    write_state "$repo" "$json"
+}
+
+# ── subcommand: read ──────────────────────────────────────────────────────────
+
+cmd_read() {
+    repo=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --repo) repo="${2:-}"; shift 2 ;;
+            *) die "read: unknown option: $1" ;;
+        esac
+    done
+    [ -n "$repo" ] || die "read: --repo is required"
+    path="$(state_path "$repo")"
+    if [ ! -f "$path" ]; then
+        err "read: state file not found: $path"
+        exit 1
+    fi
+    cat "$path"
+}
+
+# ── subcommand: update ────────────────────────────────────────────────────────
+
+cmd_update() {
+    repo=""
+    key=""
+    value=""
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --repo)  repo="${2:-}";  shift 2 ;;
+            --key)   key="${2:-}";   shift 2 ;;
+            --value) value="${2:-}"; shift 2 ;;
+            *) die "update: unknown option: $1" ;;
+        esac
+    done
+
+    [ -n "$repo"  ] || die "update: --repo is required"
+    [ -n "$key"   ] || die "update: --key is required"
+    # value may be empty string — do not gate on it
+
+    path="$(state_path "$repo")"
+    if [ ! -f "$path" ]; then
+        die "update: state file not found: $path"
+    fi
+
+    now="$(now_iso)"
+
+    # Determine the correct jq type for the value.
+    # Booleans and numbers are passed as raw JSON; strings as --arg.
+    case "$value" in
+        true|false)
+            # JSON boolean
+            updated="$(jq --arg key "$key" --argjson val "$value" \
+                --arg now "$now" \
+                '.[$key] = $val | .updated_at = $now' "$path")"
+            ;;
+        ''|*[!0-9]*)
+            # String (including empty string and non-numeric)
+            updated="$(jq --arg key "$key" --arg val "$value" \
+                --arg now "$now" \
+                '.[$key] = $val | .updated_at = $now' "$path")"
+            ;;
+        *)
+            # Numeric
+            updated="$(jq --arg key "$key" --argjson val "$value" \
+                --arg now "$now" \
+                '.[$key] = $val | .updated_at = $now' "$path")"
+            ;;
+    esac
+
+    write_state "$repo" "$updated"
+}
+
+# ── subcommand: path ──────────────────────────────────────────────────────────
+
+cmd_path() {
+    repo=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --repo) repo="${2:-}"; shift 2 ;;
+            *) die "path: unknown option: $1" ;;
+        esac
+    done
+    [ -n "$repo" ] || die "path: --repo is required"
+    state_path "$repo"
+}
+
+# ── dispatch ──────────────────────────────────────────────────────────────────
+
+subcommand="${1:-}"
+if [ -z "$subcommand" ]; then
+    usage >&2
+    exit 1
+fi
+shift
+
+case "$subcommand" in
+    init)   cmd_init   "$@" ;;
+    read)   cmd_read   "$@" ;;
+    update) cmd_update "$@" ;;
+    path)   cmd_path   "$@" ;;
+    --help|-h) usage ;;
+    *) usage >&2; exit 1 ;;
+esac

--- a/tests/loop/test_loop_check.bats
+++ b/tests/loop/test_loop_check.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# tests/loop/test_loop_check.bats — loop-check.sh CHECK exit normalization.
+#
+# Covers (docs/specs/2026-06-02-autospec-loop-design.md §Phase 2):
+#   - exit 0 from CHECK -> echo "met", exit 0
+#   - non-zero from CHECK -> echo "not-met", exit 1
+#   - missing/empty CHECK command -> echo "not-met", exit 1
+#   - CHECK command that does not exist -> echo "not-met", exit 1
+
+ROOT="${BATS_TEST_DIRNAME}/../.."
+LOOP_CHECK="$ROOT/skills/autospec-loop/scripts/loop-check.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    export PATH="$TEST_TMP/bin:$PATH"
+    mkdir -p "$TEST_TMP/bin"
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+# ── exit 0 (met) ──────────────────────────────────────────────────────────────
+
+@test "CHECK exit 0 -> output 'met' and exit 0" {
+    run bash "$LOOP_CHECK" "true"
+    [ "$status" -eq 0 ]
+    [ "$output" = "met" ]
+}
+
+@test "CHECK 'test -e /dev/null' exits 0 -> met" {
+    run bash "$LOOP_CHECK" "test -e /dev/null"
+    [ "$status" -eq 0 ]
+    [ "$output" = "met" ]
+}
+
+@test "CHECK inline shell script exiting 0 -> met" {
+    run bash "$LOOP_CHECK" "bash -c 'exit 0'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "met" ]
+}
+
+# ── non-zero (not-met) ────────────────────────────────────────────────────────
+
+@test "CHECK exit 1 -> output 'not-met' and exit 1" {
+    run bash "$LOOP_CHECK" "false"
+    [ "$status" -eq 1 ]
+    [ "$output" = "not-met" ]
+}
+
+@test "CHECK exit 2 -> output 'not-met' and exit 1 (normalized)" {
+    run bash "$LOOP_CHECK" "bash -c 'exit 2'"
+    [ "$status" -eq 1 ]
+    [ "$output" = "not-met" ]
+}
+
+@test "CHECK exit 42 -> output 'not-met' and exit 1 (normalized)" {
+    run bash "$LOOP_CHECK" "bash -c 'exit 42'"
+    [ "$status" -eq 1 ]
+    [ "$output" = "not-met" ]
+}
+
+# ── missing / empty CHECK ────────────────────────────────────────────────────
+
+@test "no CHECK argument -> not-met and exit 1" {
+    run bash "$LOOP_CHECK"
+    [ "$status" -eq 1 ]
+    [ "$output" = "not-met" ]
+}
+
+@test "empty string CHECK -> not-met and exit 1" {
+    run bash "$LOOP_CHECK" ""
+    [ "$status" -eq 1 ]
+    [ "$output" = "not-met" ]
+}
+
+@test "literal 'null' CHECK -> not-met and exit 1" {
+    run bash "$LOOP_CHECK" "null"
+    [ "$status" -eq 1 ]
+    [ "$output" = "not-met" ]
+}
+
+# ── nonexistent command ───────────────────────────────────────────────────────
+
+@test "CHECK command not on PATH -> not-met and exit 1" {
+    run bash "$LOOP_CHECK" "__no_such_cmd_xyz__"
+    [ "$status" -eq 1 ]
+    [ "$output" = "not-met" ]
+}

--- a/tests/loop/test_loop_state.bats
+++ b/tests/loop/test_loop_state.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+# tests/loop/test_loop_state.bats — loop-state.sh atomic read/update.
+#
+# Covers (docs/specs/2026-06-02-autospec-loop-design.md §Phase 2):
+#   - init writes a valid loop-state.json with schema:1 defaults
+#   - read returns the current state JSON
+#   - update <key> <val> round-trips string and numeric values
+#   - atomic write: tmp+mv (file appears atomically, no partial writes)
+#   - path is scoped by repo-slug (owner/name -> owner_name)
+#   - slug isolation: two repos do not share state
+
+ROOT="${BATS_TEST_DIRNAME}/../.."
+LOOP_STATE="$ROOT/skills/autospec-loop/scripts/loop-state.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    export AUTOSPEC_LOOP_STATE_DIR="$TEST_TMP/loop"
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+# ── init ──────────────────────────────────────────────────────────────────────
+
+@test "init creates loop-state.json with schema 1" {
+    run bash "$LOOP_STATE" init --repo owner/name \
+        --goal "tests pass" --check "make test"
+    [ "$status" -eq 0 ]
+    f="$(bash "$LOOP_STATE" path --repo owner/name)"
+    [ -f "$f" ]
+    [ "$(jq '.schema' "$f")" = "1" ]
+}
+
+@test "init sets goal and check fields" {
+    bash "$LOOP_STATE" init --repo owner/name \
+        --goal "build is green" --check "bash build.sh"
+    f="$(bash "$LOOP_STATE" path --repo owner/name)"
+    [ "$(jq -r '.goal' "$f")" = "build is green" ]
+    [ "$(jq -r '.check' "$f")" = "bash build.sh" ]
+}
+
+@test "init sets default numeric fields" {
+    bash "$LOOP_STATE" init --repo owner/name --goal "done" --check "null"
+    f="$(bash "$LOOP_STATE" path --repo owner/name)"
+    [ "$(jq '.max_iters' "$f")" = "25" ]
+    [ "$(jq '.no_progress_K' "$f")" = "3" ]
+    [ "$(jq '.iter' "$f")" = "0" ]
+    [ "$(jq '.no_progress_count' "$f")" = "0" ]
+    [ "$(jq '.done' "$f")" = "false" ]
+    [ "$(jq -r '.exit_reason' "$f")" = "null" ]
+}
+
+@test "init sets mode to cumulative by default" {
+    bash "$LOOP_STATE" init --repo owner/name --goal "done" --check "null"
+    f="$(bash "$LOOP_STATE" path --repo owner/name)"
+    [ "$(jq -r '.mode' "$f")" = "cumulative" ]
+}
+
+@test "init accepts --mode polling" {
+    bash "$LOOP_STATE" init --repo owner/name --goal "done" --check "null" --mode polling
+    f="$(bash "$LOOP_STATE" path --repo owner/name)"
+    [ "$(jq -r '.mode' "$f")" = "polling" ]
+}
+
+@test "init with --check null stores null (JSON null, not string)" {
+    bash "$LOOP_STATE" init --repo owner/name --goal "done" --check "null"
+    f="$(bash "$LOOP_STATE" path --repo owner/name)"
+    [ "$(jq -r '.check' "$f")" = "null" ]
+}
+
+# ── read ──────────────────────────────────────────────────────────────────────
+
+@test "read returns the full JSON object" {
+    bash "$LOOP_STATE" init --repo owner/name --goal "my goal" --check "true"
+    run bash "$LOOP_STATE" read --repo owner/name
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.goal')" = "my goal" ]
+}
+
+@test "read exits non-zero when state file is missing" {
+    run bash "$LOOP_STATE" read --repo no/such
+    [ "$status" -ne 0 ]
+}
+
+# ── update ────────────────────────────────────────────────────────────────────
+
+@test "update string field round-trips" {
+    bash "$LOOP_STATE" init --repo owner/name --goal "g" --check "c"
+    bash "$LOOP_STATE" update --repo owner/name --key last_result --value "iteration 1 done"
+    f="$(bash "$LOOP_STATE" path --repo owner/name)"
+    [ "$(jq -r '.last_result' "$f")" = "iteration 1 done" ]
+}
+
+@test "update numeric field iter increments" {
+    bash "$LOOP_STATE" init --repo owner/name --goal "g" --check "c"
+    bash "$LOOP_STATE" update --repo owner/name --key iter --value 1
+    f="$(bash "$LOOP_STATE" path --repo owner/name)"
+    [ "$(jq '.iter' "$f")" = "1" ]
+}
+
+@test "update done to true" {
+    bash "$LOOP_STATE" init --repo owner/name --goal "g" --check "c"
+    bash "$LOOP_STATE" update --repo owner/name --key done --value true
+    f="$(bash "$LOOP_STATE" path --repo owner/name)"
+    [ "$(jq '.done' "$f")" = "true" ]
+}
+
+@test "update exit_reason sets string value" {
+    bash "$LOOP_STATE" init --repo owner/name --goal "g" --check "c"
+    bash "$LOOP_STATE" update --repo owner/name --key exit_reason --value "goal-met"
+    f="$(bash "$LOOP_STATE" path --repo owner/name)"
+    [ "$(jq -r '.exit_reason' "$f")" = "goal-met" ]
+}
+
+@test "update preserves other fields" {
+    bash "$LOOP_STATE" init --repo owner/name --goal "my goal" --check "cmd"
+    bash "$LOOP_STATE" update --repo owner/name --key iter --value 5
+    f="$(bash "$LOOP_STATE" path --repo owner/name)"
+    [ "$(jq -r '.goal' "$f")" = "my goal" ]
+    [ "$(jq -r '.check' "$f")" = "cmd" ]
+    [ "$(jq '.iter' "$f")" = "5" ]
+}
+
+# ── atomic write ──────────────────────────────────────────────────────────────
+
+@test "atomic write: final file is valid JSON after update" {
+    bash "$LOOP_STATE" init --repo owner/name --goal "g" --check "c"
+    bash "$LOOP_STATE" update --repo owner/name --key last_result --value "ok"
+    f="$(bash "$LOOP_STATE" path --repo owner/name)"
+    run jq . "$f"
+    [ "$status" -eq 0 ]
+}
+
+@test "atomic write: no tmp file left after init" {
+    bash "$LOOP_STATE" init --repo owner/name --goal "g" --check "c"
+    dir="$(dirname "$(bash "$LOOP_STATE" path --repo owner/name)")"
+    tmp_count="$(find "$dir" -name '*.XXXXXX' -o -name 'loop-state.json.tmp*' 2>/dev/null | wc -l | tr -d ' ')"
+    [ "$tmp_count" = "0" ]
+}
+
+# ── path + slug isolation ─────────────────────────────────────────────────────
+
+@test "path command returns slug-scoped path" {
+    run bash "$LOOP_STATE" path --repo owner/name
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"/owner_name/"* ]]
+    [[ "$output" == *"loop-state.json" ]]
+}
+
+@test "slug isolation: two repos do not share state" {
+    bash "$LOOP_STATE" init --repo repo/alpha --goal "alpha" --check "null"
+    bash "$LOOP_STATE" init --repo repo/beta  --goal "beta"  --check "null"
+    alpha_goal="$(jq -r '.goal' "$(bash "$LOOP_STATE" path --repo repo/alpha)")"
+    beta_goal="$(jq -r '.goal'  "$(bash "$LOOP_STATE" path --repo repo/beta)")"
+    [ "$alpha_goal" = "alpha" ]
+    [ "$beta_goal"  = "beta"  ]
+}


### PR DESCRIPTION
Closes #891

## Summary

- `skills/autospec-loop/scripts/loop-state.sh`: atomic `tmp`+`mv` read/init/update of `~/.autospec/loop/<repo-slug>/loop-state.json` (schema 1). Supports `init`, `read`, `update`, `path` subcommands. Inline cleanup, `if/then/fi` for one-sided conditionals, no RETURN trap.
- `skills/autospec-loop/scripts/loop-check.sh`: runs the deterministic CHECK command; maps exit 0 → `"met"` (exit 0), any non-zero → `"not-met"` (exit 1); treats missing/empty/literal `"null"` CHECK as `not-met`.
- `tests/loop/test_loop_state.bats`: 17 bats tests covering init/read/update round-trip, atomic write safety, slug isolation, and schema defaults.
- `tests/loop/test_loop_check.bats`: 10 bats tests covering met/not-met/missing CHECK exit normalization.

## Reuse decision

No reuse — no existing loop-state or check-runner helpers in this codebase. The atomic `tmp`+`mv` write pattern and slug-scoped path conventions follow `skills/autospec-resume/scripts/resume-attempts.sh`.

## Acceptance criteria

- [x] `skills/autospec-loop/scripts/loop-state.sh` exists and writes atomically via tmp+mv.
- [x] State path is scoped by `<repo-slug>` under `~/.autospec/loop/`.
- [x] `loop-state.sh` supports `init`, `read`, and `update` operations on `loop-state.json`.
- [x] `skills/autospec-loop/scripts/loop-check.sh` exists and normalizes CHECK exit status.
- [x] `tests/loop/test_loop_state.bats` exists and passes (27/27 tests pass).
- [x] `tests/loop/test_loop_check.bats` exists and passes.
- [x] No RETURN trap used; cleanup is inline.
- [x] `bash -n` on both scripts exits 0.
- [x] `bash scripts/validate.sh` exits 0.

## Peer-review

Peer-review: codex not on PATH (stdin not a terminal), skipping.