### PR TITLE
feat(autospec-loop): fill Trigger disambiguation decision rule in lock-step trio (#894)

### DIFF
--- a/skills/autospec-loop/SKILL.md
+++ b/skills/autospec-loop/SKILL.md
@@ -148,8 +148,23 @@ goal-vs-interval:
   question** is goal-or-interval. If the operator wants interval polling, the
   skill **redirects to native `/loop`** and exits without starting its own loop.
 
-> Stub: the full trigger wording lives in the frontmatter `description` and is
-> finalized in the trigger-disambiguation child issue.
+Decision rule, applied to the raw request before anything else runs:
+
+1. **Explicit interval, no goal** — the request names a cadence (*"every 5m"*,
+   *"every N minutes"*, *"on an interval"*, or the literal `/loop <interval>`
+   form) and no completion criterion → **defer to native `/loop`**; do not
+   enter this skill's gate.
+2. **Explicit goal / completion** — the request names a stopping condition
+   (*"until …"*, *"until done"*, *"until it passes"*, *"keep doing X until Y"*)
+   → **autospec-loop claims it**; enter the Phase 1 gate.
+3. **Ambiguous** — a bare *"do a loop"* / *"execute a loop"* with neither an
+   interval nor a goal → autospec-loop claims it, and the gate's **first
+   clarifying question is goal-or-interval**: on a goal answer, continue the
+   gate; on an interval answer, **redirect to native `/loop`** and exit without
+   starting a loop here.
+
+The frontmatter `description` encodes this same split so auto-invocation routes
+goal-intent phrasings here and leaves bare interval phrasings to native `/loop`.
 
 ## Phase 1 — refine-until-go gate
 

--- a/skills/autospec-loop/codex/prompt.md
+++ b/skills/autospec-loop/codex/prompt.md
@@ -144,8 +144,23 @@ goal-vs-interval:
   question** is goal-or-interval. If the operator wants interval polling, the
   skill **redirects to native `/loop`** and exits without starting its own loop.
 
-> Stub: the full trigger wording lives in the frontmatter `description` and is
-> finalized in the trigger-disambiguation child issue.
+Decision rule, applied to the raw request before anything else runs:
+
+1. **Explicit interval, no goal** — the request names a cadence (*"every 5m"*,
+   *"every N minutes"*, *"on an interval"*, or the literal `/loop <interval>`
+   form) and no completion criterion → **defer to native `/loop`**; do not
+   enter this skill's gate.
+2. **Explicit goal / completion** — the request names a stopping condition
+   (*"until …"*, *"until done"*, *"until it passes"*, *"keep doing X until Y"*)
+   → **autospec-loop claims it**; enter the Phase 1 gate.
+3. **Ambiguous** — a bare *"do a loop"* / *"execute a loop"* with neither an
+   interval nor a goal → autospec-loop claims it, and the gate's **first
+   clarifying question is goal-or-interval**: on a goal answer, continue the
+   gate; on an interval answer, **redirect to native `/loop`** and exit without
+   starting a loop here.
+
+The frontmatter `description` encodes this same split so auto-invocation routes
+goal-intent phrasings here and leaves bare interval phrasings to native `/loop`.
 
 ## Phase 1 — refine-until-go gate
 

--- a/skills/autospec-loop/opencode/agent.md
+++ b/skills/autospec-loop/opencode/agent.md
@@ -148,8 +148,23 @@ goal-vs-interval:
   question** is goal-or-interval. If the operator wants interval polling, the
   skill **redirects to native `/loop`** and exits without starting its own loop.
 
-> Stub: the full trigger wording lives in the frontmatter `description` and is
-> finalized in the trigger-disambiguation child issue.
+Decision rule, applied to the raw request before anything else runs:
+
+1. **Explicit interval, no goal** — the request names a cadence (*"every 5m"*,
+   *"every N minutes"*, *"on an interval"*, or the literal `/loop <interval>`
+   form) and no completion criterion → **defer to native `/loop`**; do not
+   enter this skill's gate.
+2. **Explicit goal / completion** — the request names a stopping condition
+   (*"until …"*, *"until done"*, *"until it passes"*, *"keep doing X until Y"*)
+   → **autospec-loop claims it**; enter the Phase 1 gate.
+3. **Ambiguous** — a bare *"do a loop"* / *"execute a loop"* with neither an
+   interval nor a goal → autospec-loop claims it, and the gate's **first
+   clarifying question is goal-or-interval**: on a goal answer, continue the
+   gate; on an interval answer, **redirect to native `/loop`** and exit without
+   starting a loop here.
+
+The frontmatter `description` encodes this same split so auto-invocation routes
+goal-intent phrasings here and leaves bare interval phrasings to native `/loop`.
 
 ## Phase 1 — refine-until-go gate
 


### PR DESCRIPTION
Closes #894

Fills the Trigger disambiguation section (previously a #890 stub note) with a concrete three-branch decision rule across the lock-step trio:

1. Explicit interval, no goal -> defer to native `/loop`.
2. Explicit goal/completion -> autospec-loop claims it; enter the Phase 1 gate.
3. Ambiguous bare loop -> claim it, first clarifying question is goal-or-interval; redirect to native `/loop` on an interval answer.

The frontmatter `description` already encoded the goal-intent split and matches between SKILL.md and opencode/agent.md (no change needed there).

## Verification
- `bash scripts/validate.sh` exits 0 (check_lockstep, frontmatter parse, named-content headers, full bats suite).
- Frontmatter-stripped bodies of SKILL.md / codex/prompt.md / opencode/agent.md are byte-identical.
- codex/prompt.md retains its leading blank line.
- 7/7 structural section headers present in all three bodies.
- SKILL.md and opencode/agent.md `description:` match.

The issue body smoke one-liner has a known strip-offset quirk (off-by-one blank line); validate.sh check_lockstep is authoritative and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)