### PR TITLE
docs(memory): land session learnings + ignore transient artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ batch-donel.json
 # Allow .autospec/ inside autospec-e2e-clone synthetic integration targets (C10)
 !skills/autospec-e2e-clone/tests/targets/**/.autospec/
 !skills/autospec-e2e-clone/tests/targets/**/.autospec/**
+
+# agent worktrees (transient) and python build artifacts
+.claude/worktrees/
+*.egg-info/

--- a/docs/memory/MEMORY.md
+++ b/docs/memory/MEMORY.md
@@ -1,34 +1,79 @@
-- [User role - autospec author](user_role.md) — berlinguyinca authors and maintains the multi-harness autospec skill family
-- [Sync repo before /autospec design phases](feedback_pre_pipeline_sync.md) — check git fetch/status before brainstorming; stale local edits often duplicate landed upstream work
-- [Autospec design preferences](feedback_autospec_design_prefs.md) — small-LLM target (60-120k ctx), correctness>>speed, tight imperative triggers, conservative guardrails, lock-step rule sacred
-- [Autospec monitor exit modes + recovery](feedback_monitor_silent_exit.md) — Phase 4 monitor exits via two known modes: silent-exit (stale worktree + stuck label) and "Prompt is too long" overflow at ~185 tool calls; relaunch is part of the workflow
-- [Autospec decomposer + lockstep gotchas](feedback_autospec_decomposer_gotchas.md) — first new-skill issue MUST include structural sections (Self-update + Model tier + adapter row) or auto-discovery breaks downstream; codex/prompt.md needs leading blank line for lockstep
-- [Admin-merge denial during autospec](feedback_admin_merge_denial.md) — `gh pr merge --admin` blocked by harness hook; AskUserQuestion approval doesn't count, needs settings.json permission rule for Phase 4 to flow
-- [/autospec autonomy scope](feedback_autospec_autonomy_scope.md) — auto-merge spec PRs, collapse low-stakes brainstorm to default-locks, surface only run/defer/refine + destructive-remote actions
-- [OMC autopilot magic-keyword misfire](feedback_omc_autopilot_misfire.md) — system reminders containing "AUTOPILOT" auto-activate OMC autopilot mid-session; recover via state_write(active=false) + state_clear(skill-active)
-- [LLM validator + adaptive retry](feedback_llm_validator_adaptive_retry.md) — pair every LLM-output validator with a 5-attempt retry loop that feeds findings back as directives; one-shot gates leave quality unimproved
-- [Skill per capability](feedback_autospec_skill_per_capability.md) — operator-facing autospec capabilities ship as top-level /autospec-<verb> skills; inline sub-modes are convenience-only shortcuts to the same helper
-- [Autospec mode-dispatch must not shell out user text](feedback_autospec_no_shell_user_text.md) — Self-update / Stop mode sections must be pure prose; no bash heredocs of `{FEATURE_DESCRIPTION}` (placeholder is never substituted) — caused `Shell command failed for pattern "!\` | "` parse errors
-- [validate.sh has named-content checks](feedback_validate_sh_lockstep_checks.md) — renaming SKILL.md prose sections requires updating validate.sh checks too
-- [validate.sh lockstep duo gap](feedback_validate_sh_lockstep_duo_gap.md) — check_lockstep() guards on all 3 trio files; SKILL.md+codex/prompt.md duos fall through silently (now fixed in #415 / PR #425)
-- [ROI-check new components](feedback_roi_check_new_components.md) — every new skill/fork/schema needs a named consumer that benefits today; default to invoking upstream over forking
-- [Bash RETURN trap leaks](feedback_bash_return_trap_leak.md) — RETURN traps in bash functions leak into caller frames; never use for local cleanup under set -u. Use inline cleanup instead.
-- [Bash set -e short-circuit aborts](feedback_bash_set_e_short_circuit.md) — `[ test ] && action` aborts under set -e when test fails; use if/then/fi for one-sided conditionals in install.sh.
-- [Mempalace miner flat-form gap](feedback_mempalace_miner_flat_form.md) — M3 miner only matched spec-style nested `metadata.type:`; real CC files use flat `type:`. Always fixture both real-world variants
-- [Heartbeat cross-repo collision](feedback_heartbeat_cross_repo_collision.md) — ~/.autospec/process-heartbeats/ shared across repos; filter by .repo field (now path-scoped via #416 / PR #426)
-- [E2E coverage gate skill — autospec-test family](project_e2e_coverage_gate_design.md) — v1+v2+hardening+caching+docs-amendment ALL SHIPPED 2026-05-22; 47+ PRs across the session
-- [Autospec Phase 2 roadmap](project_autospec_phase2_roadmap.md) — 6 non-tracker fixes SHIPPED 2026-05-22 (#415-#419, #422); 4 tracker stubs queued (#420 mutation, #421 tooling, #423 Skill C, #424 distribution)
-- [Autospec tooling optimization — queued](project_autospec_tooling_optimization.md) — convert LLM-driven steps to deterministic tools; tracker #421
-- [Autospec init skill — queued](project_autospec_init_skill.md) — was folded into docs amendment (drift gate + reverse-engineer); residual init UX work tracked under Phase 2 distribution (#424)
-- [Autospec mutation testing — queued](project_autospec_mutation_testing.md) — test-of-tests layer: mutation testing gate + assertion-density floor + negative-path-pair lint; tracker #420
-- [Cross-tool memory — SHIPPED](project_cross_tool_memory_brainstorm.md) — M1-M5 all merged PRs #503-#507; CC↔Codex↔OpenCode share docs/memory/ via symlink+AGENTS.md inventory; mempalace MCP indexes (2026-05-23)
-- [Session close 2026-05-22→23](project_2026_05_22_23_session_close.md) — ~105 PRs shipped across 11 feature families; queue drained; CI disabled; cross-tool memory live
-- [Gap-remediation + keyword-routing SHIPPED](project_gap_remediation_keyword_routing.md) — 2026-05-24: end-of-run gap-remediation loop (Phase 5.5) + autospec-listen keyword auto-routing; built via parallel-wave opus single-issue monitors on disjoint files (watchdog off, no shared batch-done)
+<!--
+ACTIVE USE PROTOCOL (this file is auto-loaded every session — read this header)
 
-<!-- Archived entries (shipped work; kept in dir for git history but not indexed):
-- project_autospec_review_status.md (autospec-review shipped 2026-05-07)
-- project_harness_aware_model_tier.md (harness-aware tier shipped 2026-05-07)
-- project_monitor_session_reset.md (monitor session-reset + guardian fusion shipped)
-- project_turbo_integration_design.md (turbo/autospec integration shipped)
-- project_cross_session_ci_rot.md (cross-session CI rot shipped 2026-05-18)
+Before each significant decision, do a 5-second mental check:
+  "Is there a memory below that applies to what I'm about to do?"
+
+Major decision triggers (consult memory BEFORE):
+  - dispatching a subagent (esp. for autospec/long-running work)
+  - recovering from a failure (silent-exit, stalled batch, label conflict)
+  - filing new issues (sizing caps, lockstep, decomposer gotchas)
+  - design choices (skill-per-capability, ROI check, autonomy scope)
+  - bash / shell scripting (set -e, return traps, heredoc gotchas)
+  - validation / lockstep (validate.sh checks, trio/duo gaps)
+
+If a memory applies and you didn't reference it, that's a miss. Call it out
+to the user when you catch yourself. Memory works only if you actually use it.
+
+Adding new memories: when you'd otherwise re-learn the same lesson, save it.
+Removing old ones: when a memory cites a closed issue or "SHIPPED" status
+older than 7 days AND the lesson is no longer load-bearing, archive it.
+-->
+
+# Always-relevant
+
+- [User role - autospec author](user_role.md) — berlinguyinca authors and maintains the multi-harness autospec skill family
+- [Proactively query memory before major decisions](feedback_proactively_query_memory.md) — meta-rule: passive auto-load isn't enough; explicit "what memory applies here?" check before each dispatch/recovery/design choice
+
+# Autospec workflow
+
+- [Sync repo before /autospec design phases](feedback_pre_pipeline_sync.md) — check git fetch/status before brainstorming; stale local edits often duplicate landed upstream work
+- [autospec-split origin/main gate](feedback_autospec_split_origin_main_gate.md) — /autospec-split halts if spec not on origin/main; land spec first to avoid mid-pipeline PR detour
+- [Per-PR LGTM misses integration](feedback_per_pr_lgtm_misses_integration.md) — Phase 5.5 broad-audit caught 7 high-sev integration bugs that 19 per-PR LGTMs missed; never skip 5.5
+- [Autospec design preferences](feedback_autospec_design_prefs.md) — small-LLM target (60-120k ctx), correctness>>speed, tight imperative triggers, conservative guardrails, lock-step rule sacred
+- [Autospec monitor exit modes + recovery](feedback_monitor_silent_exit.md) — Phase 4 monitor silent-exits on complex integration work; relaunch is part of the workflow; subprocess mocks for tmux/osascript prevent test stalls
+- [Autospec decomposer + lockstep gotchas](feedback_autospec_decomposer_gotchas.md) — first new-skill issue MUST include structural sections (Self-update + Model tier + adapter row); codex/prompt.md needs leading blank line for lockstep; decomposer should NOT apply needs-autospec-template
+- [Admin-merge denial during autospec](feedback_admin_merge_denial.md) — `gh pr merge --admin` blocked by harness hook; needs settings.json permission rule for Phase 4 to flow
+- [/autospec autonomy scope](feedback_autospec_autonomy_scope.md) — auto-merge spec PRs, collapse low-stakes brainstorm to default-locks, surface only run/defer/refine + destructive-remote actions
+- [Skill per capability](feedback_autospec_skill_per_capability.md) — operator-facing capabilities ship as top-level /autospec-<verb> skills; inline sub-modes are convenience shortcuts only
+- [Autospec mode-dispatch must not shell out user text](feedback_autospec_no_shell_user_text.md) — Self-update/Stop mode sections must be pure prose; no bash heredocs of `{FEATURE_DESCRIPTION}`
+
+# Quality / framework discipline
+
+- [ROI-check new components](feedback_roi_check_new_components.md) — every new skill/fork/schema needs a named consumer that benefits today; default to invoking upstream over forking
+- [LLM validator + adaptive retry](feedback_llm_validator_adaptive_retry.md) — pair every LLM-output validator with a 5-attempt retry loop that feeds findings back as directives
+- [validate.sh has named-content checks](feedback_validate_sh_lockstep_checks.md) — renaming SKILL.md prose sections requires updating validate.sh checks too
+- [validate.sh lockstep duo gap](feedback_validate_sh_lockstep_duo_gap.md) — check_lockstep() must guard SKILL.md+codex/prompt.md duos, not just full trios
+- [jq test() regex metachar injection](feedback_jq_test_regex_metachar_injection.md) — interpolating host/user-derived values into jq test() is regex injection; dotted hostnames made claim self-clean delete the wrong worker's lock comment; use capture()+==
+- [Self-consistent test fixtures mask bugs](feedback_self_consistent_test_fixtures_mask_bugs.md) — tests that build fixtures with the SUT's own derivation expression can't catch a bug in it; the Claude transcript-slug `lstrip` bug shipped green for months. Pin against the real convention / live values; reproduce end-to-end
+
+# Infrastructure gotchas
+
+- [Heartbeat cross-repo collision](feedback_heartbeat_cross_repo_collision.md) — ~/.autospec/process-heartbeats/ is shared across repos; use path-scoped slug subdirs
+- [Bash RETURN trap leaks](feedback_bash_return_trap_leak.md) — RETURN traps leak into caller frames under set -u; use inline cleanup
+- [Bash set -e short-circuit aborts](feedback_bash_set_e_short_circuit.md) — `[ test ] && action` aborts under set -e when test fails; use if/then/fi for one-sided conditionals
+- [OMC autopilot magic-keyword misfire](feedback_omc_autopilot_misfire.md) — system reminders containing "AUTOPILOT" auto-activate OMC autopilot mid-session; recover via state_write(active=false) + state_clear(skill-active)
+- [Mempalace miner flat-form gap](feedback_mempalace_miner_flat_form.md) — M3 miner matches both `metadata.type:` (spec) and `type:` (real CC files); fixture both variants
+- [Harness session-id env vars](reference_harness_session_id_envs.md) — `CLAUDE_CODE_SESSION_ID` is the stable per-session id (ps -o sess=0, no tty under tool calls); fallback chain for harness-neutral per-session locks; PPID fallback is unreliable
+
+# Active project state (review weekly; archive when shipped)
+
+- [Autospec tooling optimization — tracker #421](project_autospec_tooling_optimization.md) — convert LLM-driven steps to deterministic tools
+- [Autospec mutation testing — tracker #420](project_autospec_mutation_testing.md) — test-of-tests layer: mutation gate + assertion-density floor + negative-path-pair lint
+
+<!-- Archived (shipped or session-historical; files kept on disk, removed from index):
+- project_2026_05_22_23_session_close.md — historical session close 2026-05-22→23
+- project_e2e_coverage_gate_design.md — autospec-test family SHIPPED 2026-05-22
+- project_autospec_phase2_roadmap.md — Phase 2 fixes shipped May 2026; trackers folded into items above
+- project_autospec_init_skill.md — folded into docs amendment; residual under #424
+- project_autospec_review_status.md — autospec-review shipped 2026-05-07
+- project_harness_aware_model_tier.md — harness-aware tier shipped 2026-05-07
+- project_monitor_session_reset.md — monitor session-reset + guardian fusion shipped
+- project_turbo_integration_design.md — turbo/autospec integration shipped
+- project_cross_session_ci_rot.md — cross-session CI rot shipped 2026-05-18
+- project_cross_tool_memory_brainstorm.md — cross-tool memory M1-M5 shipped 2026-05-23 (PRs #503-#507)
+- project_gap_remediation_keyword_routing.md — gap-remediation + keyword-routing shipped 2026-05-24
+- feedback_mempalace_integration_boundary.md — mempalace-specific, archived to keep index focused
+- project_memory_consumers_epic.md — superseded by current session's framework improvements (#820-#824)
+- Auto-context-rollover feature SHIPPED 2026-06-01 — see .turbo/handoff/2026-06-01-auto-context-rollover-shipped.md for the full PR list (43 PRs incl. framework #820-#824)
 -->

--- a/docs/memory/diary/2026-06-03.md
+++ b/docs/memory/diary/2026-06-03.md
@@ -1,0 +1,10 @@
+---
+wing: episodic
+drawer_class: diary
+date: 2026-06-03
+ts: 2026-06-03T04:22:35Z
+phase: 1
+event: brainstorm-locked
+---
+
+Spec locked: docs/specs/2026-06-02-autospec-loop-design.md. Gate answer: defer. Issues filed: 7 (EPIC #889, children #890-895, audit #896).

--- a/docs/memory/feedback_autospec_split_origin_main_gate.md
+++ b/docs/memory/feedback_autospec_split_origin_main_gate.md
@@ -1,0 +1,20 @@
+---
+name: autospec-split-origin-main-gate
+description: "/autospec-split halts at Phase 0.5 if the selected spec isn't on origin/main; check git status vs origin before invoking to avoid a mid-pipeline PR detour"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 37f5bea4-90df-4cf3-8298-d8158b15d2ca
+---
+
+`/autospec-split` requires the selected `docs/specs/*.md` file to exist on `origin/main` before Phase 3 dispatches — it verifies via `git cat-file -e origin/main:<path>` and stops with the "Selected spec is not on origin/main yet" message if missing.
+
+**Why:** Phase 3 child issues cite the spec by stable GitHub URL (`https://github.com/{repo}/blob/main/<path>`). A local-only spec produces a 404 link that downstream Phase 4 implementers can't follow. The gate is deliberate.
+
+**How to apply:** Before invoking `/autospec-split <path>`, run `git fetch origin && git cat-file -e origin/main:<spec-path> 2>&1` (or just `git log --oneline origin/main..HEAD` to see what's unpushed). If the spec is local-only, decide in advance:
+- **Solo repo + low-risk spec:** `git push origin main` directly.
+- **Shared repo or admin-merge available:** branch + PR + `gh pr merge --admin --squash --delete-branch`.
+
+This avoids the mid-pipeline detour observed 2026-05-31 (umbrella #740 work) where /autospec-split bounced out, requiring a manual PR #739 + admin-merge + re-invocation. The Phase 2 protocol inside `/autospec` and `/autospec-define` handles spec-landing automatically; only `/autospec-split` assumes pre-landed specs.
+
+Related: [[admin-merge-denial]] — admin-merge requires settings.json permission rule, not just AskUserQuestion approval.

--- a/docs/memory/feedback_jq_test_regex_metachar_injection.md
+++ b/docs/memory/feedback_jq_test_regex_metachar_injection.md
@@ -1,0 +1,14 @@
+---
+name: feedback-jq-test-regex-metachar-injection
+description: "Interpolating host/user-derived values into a jq test() regex is a metachar-injection bug; autospec claim self-clean matched worker_id this way and deleted the wrong worker's lock comment for dotted hostnames"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 28ec6f0b-02b3-4a16-ac53-f4d2d5c2bc46
+---
+
+In autospec-run's cross-machine claim path (`skills/autospec-run/scripts/claim-issue.sh`), `own_marked_comment_id()` matched this worker's lock comment by interpolating `worker_id` into a jq `test("...worker_id...:\""+$wid+"\"")` **regex**. Worker ids are `host:user:monitor:pid`, and real hostnames contain `.` (`mac.lan`, `*.local`, FQDNs) — a regex metachar — so `mac.lan:...` false-matched `macXlan:...` and a losing worker DELETED THE WRONG worker's lock comment, reintroducing the duplicate-claim bug the whole feature fixes. Fixed in PR #879 (#876) by extracting the field via jq `capture()` and comparing with `==` literal equality.
+
+**Why:** any value derived from hostnames/usernames/paths injected into `test()`/`match()` is regex-interpreted — dots, `+`, `*`, `[]`, `()` all break exact matching. The owner-arbitration path was already safe because it used `capture()`+fixed pattern; only the self-clean targeting used `test()`.
+
+**How to apply:** in autospec claim/run-state code (and any jq), never put externally-derived strings inside `test()`/`match()` for equality — use `capture()` to pull the field, then `==`. The Phase 5.5 integration audit MUST keep checking worker_id/identity matching for this. Confirms [[feedback_per_pr_lgtm_misses_integration]] — per-PR LGTM passed all 4 PRs; only the broad audit caught it.

--- a/docs/memory/feedback_per_pr_lgtm_misses_integration.md
+++ b/docs/memory/feedback_per_pr_lgtm_misses_integration.md
@@ -1,0 +1,30 @@
+---
+name: per-pr-lgtm-misses-integration
+description: Per-PR self-review LGTM caught zero integration bugs across 19 PRs; Phase 5.5 broad audit caught 7 highs. Always run Phase 5.5; per-PR review is necessary but not sufficient.
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 37f5bea4-90df-4cf3-8298-d8158b15d2ca
+---
+
+Per-PR self-review LGTM (the autospec Phase 4 inline reviewer) caught **0 of 7** high-severity integration bugs across the 19-PR context-monitor batch shipped 2026-06-01. Phase 5.5 broad-audit caught them after the fact:
+
+- g-001: PreCompact hook argparse crashes immediately (`--hook-event` wasn't a flag).
+- g-002: `install.sh` never `pip install`s the package (silent post-install failure).
+- g-003: handoff dir mismatch (`~/.turbo` vs `<cwd>/.turbo`) — validation gate vacuously passed.
+- g-004: `wait_for_handoff` was dead code; daemon never waited.
+- g-005: engine skipped compact when context jumped >50% direct to >80%.
+- g-006: daemon dispatched literal `/clear` instead of calling `adapter.command()`.
+- g-007: `validate.sh` failing on new skill's lockstep duo.
+
+**Why per-PR review missed everything:** each PR looked fine in isolation. The bugs lived at integration boundaries (daemon ↔ adapter, daemon ↔ install.sh, daemon ↔ handoff). Per-PR reviewer only sees the diff for one PR.
+
+**How to apply:**
+
+1. **Never skip Phase 5.5** — even when the queue is fully merged and all per-PR LGTMs passed, Phase 5.5 is what catches integration. `~/.autospec/no-review.flag` should rarely if ever exist.
+2. **Smoke tests must be executable, not descriptive.** Issue templates have `### Primary smoke test (inner loop)` — make it an actual shell command that hits the binary, not prose. Framework issue #821 codifies this as a Phase 4 merge gate.
+3. **Pattern survey before code** — implementer should always know what already exists. Framework issue #820 codifies a `## Pattern survey` step before code generation.
+4. **Subprocess mocks ARE allowed** — `tmux`/`osascript`/`notify-send` are EXTERNAL boundaries (not internal services). The "no mocks" rule applies to internal services only. A batch-11 monitor stalled this session because it tried to run real tmux in tests; batch 12 succeeded after explicit "mock external subprocesses" guidance.
+5. **For multi-bug integration fixes, use opus**. Sonnet silent-exited twice on #779 (6 interconnected bugs); opus completed in one shot. Hard cases: `priority:high` + integration-shaped + >2 files touched.
+
+Related: [[autospec-split-origin-main-gate]], [[autospec-decomposer-gotchas]], [[monitor-silent-exit]].

--- a/docs/memory/feedback_proactively_query_memory.md
+++ b/docs/memory/feedback_proactively_query_memory.md
@@ -1,0 +1,33 @@
+---
+name: proactively-query-memory
+description: "Meta-rule. Passive auto-load isn't enough; do a 5-second \"what memory applies here?\" check before each significant decision (dispatch, recovery, filing, design choice, bash code)."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 37f5bea4-90df-4cf3-8298-d8158b15d2ca
+---
+
+Auto-memory is loaded into context at session start, but loading != using. Honest audit after the 2026-06-01 session: only ~4 of 25 memories were actively referenced before decisions, despite at least 8 being applicable. Memory only works if I do the consult step.
+
+**The rule:** before each significant action, run a one-sentence mental check: "Is there a memory in MEMORY.md that applies to what I'm about to do?" If yes, open it (Read tool) and let it shape the decision. If no, proceed.
+
+**Significant actions that warrant the check:**
+- Dispatching a subagent (esp. autospec / long-running monitors) → `feedback_monitor_silent_exit.md`, `feedback_admin_merge_denial.md`, `feedback_autospec_autonomy_scope.md`
+- Recovering from a stall / silent-exit → `feedback_monitor_silent_exit.md`, `feedback_heartbeat_cross_repo_collision.md`
+- Filing GitHub issues → `feedback_autospec_decomposer_gotchas.md`, `feedback_autospec_skill_per_capability.md`, `feedback_roi_check_new_components.md`
+- Writing bash / shell → `feedback_bash_return_trap_leak.md`, `feedback_bash_set_e_short_circuit.md`, `feedback_autospec_no_shell_user_text.md`
+- Editing validate.sh / lockstep files → `feedback_validate_sh_lockstep_checks.md`, `feedback_validate_sh_lockstep_duo_gap.md`
+- Before invoking `/autospec-split` or `/autospec-define` → `feedback_pre_pipeline_sync.md`, `feedback_autospec_split_origin_main_gate.md`
+- Before declaring a feature "done" → `feedback_per_pr_lgtm_misses_integration.md` (never skip Phase 5.5)
+- Designing a new component or skill → `feedback_roi_check_new_components.md` (named consumer? upstream invocation possible?)
+
+**When you catch yourself NOT having checked:**
+- Surface it to the user briefly (one sentence — "should have checked memory for X")
+- Save a new memory if it's a recurring miss
+
+**When a memory turns out to be wrong:**
+- Update or remove it immediately (memory rot is worse than no memory)
+
+**The discipline:** the 5-second check feels expensive but compounds. Each correctly-applied memory saves minutes of re-discovery later. Treat unchecked memory as technical debt against future sessions.
+
+Related: [[per-pr-lgtm-misses-integration]] (concrete example of a memory that would have saved a Phase 5.5 round if proactively used).

--- a/docs/memory/feedback_self_consistent_test_fixtures_mask_bugs.md
+++ b/docs/memory/feedback_self_consistent_test_fixtures_mask_bugs.md
@@ -1,0 +1,39 @@
+---
+name: feedback_self_consistent_test_fixtures_mask_bugs
+description: "Tests that build fixtures with the same expression as the code-under-test can't catch a bug in that expression; pin against the real external convention"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: d039abad-07c8-4595-980c-99dc83e9788b
+---
+
+When a function derives a value from an external convention (a filesystem path,
+an API slug, a third-party encoding), do NOT build the test fixture by reusing
+the same derivation expression — the test becomes self-consistent with the bug
+and passes regardless of correctness.
+
+**Concrete case (2026-06-02, context-monitor):** `ClaudeAdapter.find_transcript`
+computed the Claude project-dir slug as `cwd.replace("/","-").lstrip("-")`. The
+`.lstrip("-")` was wrong — Claude Code's real `~/.claude/projects/<slug>` keeps
+the leading dash (`/Users/x/repo` → `-Users-x-repo`) and maps EVERY
+non-alphanumeric char to `-` (verified: `.../m_/...` → `...-m--...`). Correct:
+`re.sub(r"[^a-zA-Z0-9]", "-", cwd)`. The unit tests had constructed their fixture
+dirs with the same buggy expression, so they were green while the deployed
+PreCompact hook hit `TranscriptNotFoundError` on every compaction and the
+auto-context-rollover silently no-opped for months.
+
+**Why:** the bug was in the cwd→slug mapping; the test encoded the same mapping,
+so both agreed on the wrong answer.
+
+**How to apply:**
+- Pin against ground truth: assert known real values (an actual live
+  `~/.claude/projects` slug), or a hand-written golden, NEVER the SUT's own formula.
+- For "did it actually run end-to-end" bugs, reproduce against the real
+  environment (run the real hook against the real cwd and read the log) — that
+  is what surfaced this, not the unit tests.
+- Pair every external-convention mapping with one test that would fail if the
+  formula drifts from the real convention (here: leading-dash, dots, underscores/
+  specials cases).
+
+Related: [[feedback_llm_validator_adaptive_retry]] (validators need independent
+ground truth too), [[feedback_monitor_silent_exit]] (context-monitor quirks).

--- a/docs/memory/reference_harness_session_id_envs.md
+++ b/docs/memory/reference_harness_session_id_envs.md
@@ -1,0 +1,33 @@
+---
+name: reference_harness_session_id_envs
+description: Env vars that expose a stable per-session id for harness-neutral per-session locks/scoping
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: d039abad-07c8-4595-980c-99dc83e9788b
+---
+
+For a **stable per-session identifier** that survives across many separate shell
+invocations within one harness session (each `$$`/`$PPID` differs per tool call,
+and `ps -o sess=` returns 0 with no controlling tty under Claude Code tool
+calls), use this fallback chain — first non-empty wins:
+
+1. `AUTOSPEC_SESSION_ID` (explicit override)
+2. `CLAUDE_CODE_SESSION_ID` — **confirmed present** in Claude Code (e.g.
+   `d039abad-07c8-4595-980c-99dc83e9788b`); matches the session UUID in
+   `~/.claude/projects/<slug>/` and `/tmp/claude-*/.../<uuid>/` paths.
+3. `CODEX_SESSION_ID` / `CODEX_THREAD_ID` (Codex; best-effort)
+4. `OPENCODE_SESSION_ID` / `OPENCODE_SESSION` (OpenCode; best-effort)
+5. `TERM_SESSION_ID` (Apple Terminal / multiplexer)
+6. POSIX session id `ps -o sess= -p $$` (only non-zero with a controlling tty)
+7. `PPID` — last resort; **unreliable**: a `env`/wrapper layer or a re-parented
+   monitor changes it, so two calls in one session can yield different tokens
+   (under-scope) — do NOT write a test asserting the PPID fallback collides.
+
+Other confirmed Claude Code env: `CLAUDECODE=1`, `AI_AGENT=claude-code_<ver>_agent`,
+`CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_TMPDIR`.
+
+Used by `skills/autospec-run/scripts/autospec-run-session-lock.sh` (per-session
+single-instance monitor guard, PR #899). Related: [[feedback_heartbeat_cross_repo_collision]]
+(path-scope shared state), [[feedback_self_consistent_test_fixtures_mask_bugs]]
+(don't assert intentionally-degraded fallbacks).


### PR DESCRIPTION
Lands the `docs/memory/` cross-tool memory accumulated this session (feedback + reference entries, MEMORY.md index pointers, 2026-06-03 diary) and adds `.gitignore` rules for `.claude/worktrees/` and `*.egg-info/` so transient agent worktrees and Python build artifacts stay out of the tree.

Docs/ignore-only — no code or skill changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)