### PR TITLE
feat(listener): explore/discover D3 classifier branch + D4 suppression + bats tables

### DIFF
--- a/scripts/listener-match.sh
+++ b/scripts/listener-match.sh
@@ -237,6 +237,20 @@ is_imperative() {
         esac
     done
 
+    # Suppressor 5: explore/discover read-and-understand idioms (D4, issue #909).
+    # Reinforces the question/negation/past groups for the explore verb. These
+    # are narrow read-intent phrasings — NOT a blanket "explore the" suppressor,
+    # which would wrongly kill "explore the repo for improvements" (a CLAIM
+    # phrase). The build/ship co-occurrence gate in classify_phrase() is the
+    # primary guard; this is belt-and-suspenders for descriptive explore use.
+    for rd in "explore the codebase" "explore this" "explore the data" \
+              "explore the file" "explore the files" "explore options" \
+              "let me explore" "exploratory" "the exploration"; do
+        case "$text" in
+            *"$rd"*) return 1 ;;
+        esac
+    done
+
     return 0
 }
 
@@ -357,6 +371,52 @@ EOF
             return 0
         fi
         # Gerund ("running"): fall through to remaining verbs.
+    fi
+
+    # ── Explore / discover — research-and-ship intent (D3, issue #909) ───────
+    # Route to /autospec-explore ONLY when an explore/discover verb co-occurs
+    # with a COORDINATED build/ship/feature action ("explore and ship",
+    # "discover features to build", "explore the repo for improvements"). A bare
+    # "explore <noun>" — including "explore the feature flags" / "explore the
+    # build dir", where the build/feature word is an incidental noun with no
+    # coordinating action connector — must NOT route. That is the critical
+    # safety property guarding against auto-launching a perpetual PR-shipping
+    # loop.
+    # Placed BEFORE implement/build/ship so the more-specific explore semantics
+    # win over the embedded build/ship/implement verb. Emitted explicitly (like
+    # the bare-run gate exemplar above) so it carries gate=explore-confirm,
+    # consumed byte-for-byte by the autospec-listen trio (issue #910).
+    # `discover` is an alias verb routing identically (same skill/trigger/gate).
+    _has_explore=0
+    if has_word "$text_lc" "explore" || has_word "$text_lc" "discover" \
+        || has_word "$text_lc" "exploring" || has_word "$text_lc" "discovering"; then
+        _has_explore=1
+    fi
+    # Build intent requires an explicit ACTION CONNECTOR ("and/to/for") joined
+    # to a build/ship/feature word — NOT mere co-occurrence. This is the safety
+    # discriminator: "explore the feature flags" / "explore the build dir" are
+    # read requests (a build/feature noun, no coordinating action) and must NOT
+    # route; "explore and ship", "discover features to build", "explore the repo
+    # for improvements" carry a coordinated build action and DO route.
+    _has_build_intent=0
+    if [ "$_has_explore" -eq 1 ]; then
+        for _bi in "and ship" "to ship" "for ship" \
+                   "and build" "to build" "for build" \
+                   "and implement" "to implement" "for implement" \
+                   "and improve" "to improve" "for improvement" "for improvements" \
+                   "and enhance" "to enhance" "for enhancement" "for enhancements"; do
+            case "$text_lc" in
+                *"$_bi"*) _has_build_intent=1; break ;;
+            esac
+        done
+    fi
+    if [ "$_has_explore" -eq 1 ] && [ "$_has_build_intent" -eq 1 ]; then
+        if is_imperative "$text_lc"; then
+            emit_classify_json true autospec-explore explore imperative 0.7 "$is_auto" "" explore-confirm
+        else
+            emit_classify_json false autospec-explore explore incidental 0.2 false "" ""
+        fi
+        return 0
     fi
 
     # Existing branches (preserved in order).

--- a/tests/unit/test_listener_classify.bats
+++ b/tests/unit/test_listener_classify.bats
@@ -226,3 +226,179 @@ setup() {
     [ "$status" -eq 0 ]
     [ "$(printf '%s' "$output" | jq -r .chain)" = "null" ]
 }
+
+# ── Explore/discover intent → autospec-explore, gate=explore-confirm (#909) ──
+#
+# CLAIM table: explore/discover co-occurring with build/ship/feature intent
+# routes to autospec-explore carrying the explore-confirm gate. The gate value
+# is consumed byte-for-byte by the autospec-listen trio (#910), so trigger,
+# intent, and gate are all asserted.
+
+@test "classify: 'explore and ship new features' → autospec-explore, gate=explore-confirm" {
+    run "$MATCH" --classify "explore and ship new features"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-explore" ]
+    [ "$(printf '%s' "$output" | jq -r .trigger)" = "explore" ]
+    [ "$(printf '%s' "$output" | jq -r .intent)" = "imperative" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "explore-confirm" ]
+}
+
+@test "classify: 'discover features to build' → autospec-explore, gate=explore-confirm" {
+    run "$MATCH" --classify "discover features to build"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-explore" ]
+    [ "$(printf '%s' "$output" | jq -r .trigger)" = "explore" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "explore-confirm" ]
+}
+
+@test "classify: 'autonomously explore the repo for improvements' → autospec-explore, gate=explore-confirm" {
+    run "$MATCH" --classify "autonomously explore the repo for improvements"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-explore" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "explore-confirm" ]
+}
+
+@test "classify: 'go explore and build improvements' → autospec-explore, gate=explore-confirm" {
+    run "$MATCH" --classify "go explore and build improvements"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-explore" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "explore-confirm" ]
+}
+
+@test "classify: 'discover and implement enhancements' → autospec-explore, gate=explore-confirm" {
+    run "$MATCH" --classify "discover and implement enhancements"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-explore" ]
+    [ "$(printf '%s' "$output" | jq -r .trigger)" = "explore" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "explore-confirm" ]
+}
+
+@test "classify: 'start exploring features to ship' → autospec-explore, gate=explore-confirm" {
+    run "$MATCH" --classify "start exploring features to ship"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-explore" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "explore-confirm" ]
+}
+
+# ── Explore/discover SUPPRESS table — THE CRITICAL SAFETY GUARD (#909) ───────
+#
+# Every read/understand/conversational/interrogative/negated/past-tense explore
+# phrasing MUST yield match:false (no route). A false positive here would
+# auto-launch a perpetual PR-shipping loop on an isolated sandbox branch. Do
+# NOT weaken these assertions.
+
+@test "classify: 'explore the codebase' → match:false (read intent, no route)" {
+    run "$MATCH" --classify "explore the codebase"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'explore this file' → match:false (read intent, no route)" {
+    run "$MATCH" --classify "explore this file"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'explore the data' → match:false (read intent, no route)" {
+    run "$MATCH" --classify "explore the data"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'explore options' → match:false (no build intent, no route)" {
+    run "$MATCH" --classify "explore options"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'let me explore' → match:false (no build intent, no route)" {
+    run "$MATCH" --classify "let me explore"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: \"I'll explore later\" → match:false (no build intent, no route)" {
+    run "$MATCH" --classify "I'll explore later"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'exploratory test' → match:false (not the explore verb, no route)" {
+    run "$MATCH" --classify "exploratory test"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: \"let's do exploratory testing\" → match:false (no route)" {
+    run "$MATCH" --classify "let's do exploratory testing"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'the exploration is done' → match:false (past/descriptive)" {
+    run "$MATCH" --classify "the exploration is done"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'should we explore?' → match:false (interrogative)" {
+    run "$MATCH" --classify "should we explore?"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: \"don't explore yet\" → match:false (negated)" {
+    run "$MATCH" --classify "don't explore yet"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'should we explore and ship?' → match:false (interrogative beats build intent)" {
+    run "$MATCH" --classify "should we explore and ship?"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: \"don't explore and build yet\" → match:false (negation beats build intent)" {
+    run "$MATCH" --classify "don't explore and build yet"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+# Incidental build/feature NOUN after explore (no coordinating action) must NOT
+# route — these slipped past a naive co-occurrence gate and are the real-world
+# misfire risk the connector requirement closes.
+
+@test "classify: 'explore the feature flags' → match:false (feature is an incidental noun)" {
+    run "$MATCH" --classify "explore the feature flags"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'explore the build directory' → match:false (build is an incidental noun)" {
+    run "$MATCH" --classify "explore the build directory"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+# "explore the test build output" contains the bare verb 'build', which the
+# PRE-EXISTING build→autospec-run branch claims (out of #909's scope). The
+# safety property #909 owns is narrower and absolute: it must NOT route to
+# autospec-explore (no perpetual ship-loop launch).
+@test "classify: 'explore the test build output' → NOT autospec-explore" {
+    run "$MATCH" --classify "explore the test build output"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" != "autospec-explore" ]
+}
+
+@test "classify: \"let's explore how the build works\" → match:false (read intent)" {
+    run "$MATCH" --classify "let's explore how the build works"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}


### PR DESCRIPTION
Closes #909

## Summary

Adds the explore/discover D3 routing branch to `scripts/listener-match.sh`'s `classify_phrase()` plus D4 read/understand suppression, guarded by positive + negative bats tables. Implements the design spec `docs/specs/2026-06-03-explore-discover-intent-routing-design.md` (§Design D3/D4 + §"The routing contract").

## What changed

- **D3 explore/discover branch** (placed BEFORE implement/build/ship so the more-specific explore semantics win over an embedded build verb). On a match it emits explicitly, mirroring the bare-run gate exemplar at line 353:
  `emit_classify_json true autospec-explore explore imperative 0.7 "$is_auto" "" explore-confirm`
  carrying the `explore-confirm` gate consumed byte-for-byte by the autospec-listen trio (#910). `discover` is an alias verb routing identically.
- **Safety discriminator** — routes ONLY when an explore/discover verb co-occurs with a **coordinated** build action (an `and/to/for <build-word>` connector), not mere word co-occurrence. This closes a real misfire class found in self-review: `explore the feature flags` / `explore the build directory` carry a build/feature **noun** with no coordinating action and correctly do NOT route.
- **D4 suppression** — narrow explore read-idioms added to `is_imperative()`'s descriptive group ("let me explore", "exploratory", "the exploration"); deliberately NOT a blanket "explore the" suppressor, which would kill the CLAIM phrase "explore the repo for improvements".
- **bats tables** (TDD — written first, watched fail, then implemented).

## Contract emitted (consumed by #910)

```json
{"match":true,"skill":"autospec-explore","trigger":"explore","intent":"imperative","gate":"explore-confirm"}
```

## Critical safety property (negative table — all yield match:false / no route)

`explore the codebase`, `explore this file`, `explore the data`, `explore options`, `let me explore`, `I'll explore later`, `exploratory test`, `let's do exploratory testing`, `the exploration is done`, `should we explore?`, `don't explore yet`, plus connector-aware guards: `should we explore and ship?` (interrogative beats build intent), `don't explore and build yet` (negation beats build intent), `explore the feature flags` / `explore the build directory` (incidental build/feature noun, no coordinating action).

## Pattern survey

No reuse — extends the existing `classify_phrase()` verb chain and `is_imperative()` suppressor groups in place, following their established conventions (the bare-run gate emit exemplar, the suppressor `for` loops).

## Verification

- `bats tests/unit/test_listener_classify.bats` — 50/50 green (positive + negative tables)
- `bash scripts/validate.sh` — exit 0 (all checks pass)
- `bash -n scripts/listener-match.sh` — clean

## Scope

Touches only the two files #909 owns: `scripts/listener-match.sh`, `tests/unit/test_listener_classify.bats`. Trio prose, gate honor, `autospec-explore` description, and `validate.sh` extension belong to #910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)