### PR TITLE
feat(listener): explore/discover prose + explore-confirm gate + validate.sh

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -143,7 +143,19 @@ check_keyword_routing_section() {
     for trio in SKILL.md opencode/agent.md codex/prompt.md; do
         grep -q '^## Keyword auto-routing' "$skill_dir/$trio" \
             || fail "autospec-listen: $trio missing '## Keyword auto-routing' section"
+        # Issue #910: the explore/discover build-intent verb-map row must route
+        # to /autospec-explore, and the explore-confirm gate literal (emitted by
+        # the #909 classifier in scripts/listener-match.sh) must be honored in
+        # all three trio files. Keep these byte-identical to the classifier.
+        grep -q '/autospec-explore' "$skill_dir/$trio" \
+            || fail "autospec-listen: $trio missing explore -> /autospec-explore verb-map row"
+        grep -q 'explore-confirm' "$skill_dir/$trio" \
+            || fail "autospec-listen: $trio missing 'explore-confirm' gate literal"
     done
+    # The explore-confirm gate literal honored in the trio MUST exactly match the
+    # one emitted by the classifier (scripts/listener-match.sh, issue #909).
+    grep -q 'explore-confirm' scripts/listener-match.sh \
+        || fail "scripts/listener-match.sh missing 'explore-confirm' gate literal (classifier/trio drift)"
 }
 
 # Gap-remediation invariants (issue #535, deps #533/#534): the autospec-run

--- a/skills/autospec-explore/SKILL.md
+++ b/skills/autospec-explore/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autospec-explore
-description: Use when the user wants /autospec-explore to start a perpetual autonomous research + ship loop on an isolated sandbox branch — 6 researchers propose features from spec/code gaps, prior reports, codebase signals, open issues, repo source analysis, and competitor research, then drain via /autospec-run with PRs targeting the sandbox branch (never main).
+description: Use when the user wants /autospec-explore to start a perpetual autonomous research + ship loop on an isolated sandbox branch — 6 researchers propose features from spec/code gaps, prior reports, codebase signals, open issues, repo source analysis, and competitor research, then drain via /autospec-run with PRs targeting the sandbox branch (never main). Can also be reached via an explore/discover build-intent phrase through autospec-listen (which requires one explicit confirmation first), but is not a bare-keyword trigger on its own.
 ---
 
 # autospec-explore workflow (harness-neutral)

--- a/skills/autospec-listen/SKILL.md
+++ b/skills/autospec-listen/SKILL.md
@@ -105,7 +105,7 @@ It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidenta
 
 The two new trailing fields:
 - `chain` — after the primary skill completes, invoke the chained skill (e.g. `/autospec-run` after `/autospec-refine`). Null when no chain applies.
-- `gate` — before routing, the listener must satisfy the named context gate; `auto-implement-open` means run `gh issue list --repo <repo> --label auto-implement --state open --json number --jq 'length'` and route only if > 0, else stay in plain mode. Null means no gate.
+- `gate` — before routing, the listener must satisfy the named context gate; `auto-implement-open` means run `gh issue list --repo <repo> --label auto-implement --state open --json number --jq 'length'` and route only if > 0, else stay in plain mode. `explore-confirm` means the route launches `/autospec-explore`, which starts a perpetual autonomous research + ship loop on an isolated sandbox branch whose PRs target the sandbox branch, never main; before invoking, print exactly that consequence and require ONE explicit confirmation, routing only on an affirmative reply. Null means no gate.
 
 **Verb → skill map (D3).**
 
@@ -117,6 +117,7 @@ The two new trailing fields:
 | `run` (scoped: "run it", "run the loop", "run autospec"; bare "run" only when open `auto-implement` issues exist) | `/autospec-run` |
 | `refine and run` / `tune up` (combined) | `/autospec-refine` then `/autospec-run` |
 | `review` | `/autospec-review` |
+| `explore` / `discover` (only with an explicit build/ship/improve action connector, e.g. "explore and ship", "discover features to build") | `/autospec-explore` (gate `explore-confirm`) |
 | `autospec …` | the umbrella `/autospec` |
 
 **Auto-route behavior.** When the classifier returns `match:true` with `intent:imperative`, print exactly one line then invoke the mapped skill via the harness skill-invocation primitive:
@@ -125,7 +126,7 @@ The two new trailing fields:
 Routing to /<skill> — say "plain" to opt out.
 ```
 
-If `gate` is non-null, perform the gate check first and skip routing (plain mode) if unmet. If `chain` is non-null, after the mapped skill completes, invoke the chained skill (printing one opt-out line as usual).
+If `gate` is non-null, perform the gate check first and skip routing (plain mode) if unmet. For `gate:explore-confirm` (skill `autospec-explore`), do NOT auto-route on the one-line opt-out alone: first print exactly that `/autospec-explore` starts a perpetual autonomous research + ship loop on an isolated sandbox branch whose PRs target the sandbox branch, never main, then require ONE explicit confirmation and invoke `/autospec-explore` only on an affirmative reply; the existing `plain`/`no` escape still cancels. If `chain` is non-null, after the mapped skill completes, invoke the chained skill (printing one opt-out line as usual).
 
 On a non-match or `intent:incidental`/`none`, do nothing — the session proceeds normally in plain mode.
 

--- a/skills/autospec-listen/codex/prompt.md
+++ b/skills/autospec-listen/codex/prompt.md
@@ -100,7 +100,7 @@ It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidenta
 
 The two new trailing fields:
 - `chain` — after the primary skill completes, invoke the chained skill (e.g. `/autospec-run` after `/autospec-refine`). Null when no chain applies.
-- `gate` — before routing, the listener must satisfy the named context gate; `auto-implement-open` means run `gh issue list --repo <repo> --label auto-implement --state open --json number --jq 'length'` and route only if > 0, else stay in plain mode. Null means no gate.
+- `gate` — before routing, the listener must satisfy the named context gate; `auto-implement-open` means run `gh issue list --repo <repo> --label auto-implement --state open --json number --jq 'length'` and route only if > 0, else stay in plain mode. `explore-confirm` means the route launches `/autospec-explore`, which starts a perpetual autonomous research + ship loop on an isolated sandbox branch whose PRs target the sandbox branch, never main; before invoking, print exactly that consequence and require ONE explicit confirmation, routing only on an affirmative reply. Null means no gate.
 
 **Verb → skill map (D3).**
 
@@ -112,6 +112,7 @@ The two new trailing fields:
 | `run` (scoped: "run it", "run the loop", "run autospec"; bare "run" only when open `auto-implement` issues exist) | `/autospec-run` |
 | `refine and run` / `tune up` (combined) | `/autospec-refine` then `/autospec-run` |
 | `review` | `/autospec-review` |
+| `explore` / `discover` (only with an explicit build/ship/improve action connector, e.g. "explore and ship", "discover features to build") | `/autospec-explore` (gate `explore-confirm`) |
 | `autospec …` | the umbrella `/autospec` |
 
 **Auto-route behavior.** When the classifier returns `match:true` with `intent:imperative`, print exactly one line then invoke the mapped skill via the harness skill-invocation primitive:
@@ -120,7 +121,7 @@ The two new trailing fields:
 Routing to /<skill> — say "plain" to opt out.
 ```
 
-If `gate` is non-null, perform the gate check first and skip routing (plain mode) if unmet. If `chain` is non-null, after the mapped skill completes, invoke the chained skill (printing one opt-out line as usual).
+If `gate` is non-null, perform the gate check first and skip routing (plain mode) if unmet. For `gate:explore-confirm` (skill `autospec-explore`), do NOT auto-route on the one-line opt-out alone: first print exactly that `/autospec-explore` starts a perpetual autonomous research + ship loop on an isolated sandbox branch whose PRs target the sandbox branch, never main, then require ONE explicit confirmation and invoke `/autospec-explore` only on an affirmative reply; the existing `plain`/`no` escape still cancels. If `chain` is non-null, after the mapped skill completes, invoke the chained skill (printing one opt-out line as usual).
 
 On a non-match or `intent:incidental`/`none`, do nothing — the session proceeds normally in plain mode.
 

--- a/skills/autospec-listen/opencode/agent.md
+++ b/skills/autospec-listen/opencode/agent.md
@@ -104,7 +104,7 @@ It emits `{"match":bool,"skill":...,"trigger":...,"intent":"imperative|incidenta
 
 The two new trailing fields:
 - `chain` — after the primary skill completes, invoke the chained skill (e.g. `/autospec-run` after `/autospec-refine`). Null when no chain applies.
-- `gate` — before routing, the listener must satisfy the named context gate; `auto-implement-open` means run `gh issue list --repo <repo> --label auto-implement --state open --json number --jq 'length'` and route only if > 0, else stay in plain mode. Null means no gate.
+- `gate` — before routing, the listener must satisfy the named context gate; `auto-implement-open` means run `gh issue list --repo <repo> --label auto-implement --state open --json number --jq 'length'` and route only if > 0, else stay in plain mode. `explore-confirm` means the route launches `/autospec-explore`, which starts a perpetual autonomous research + ship loop on an isolated sandbox branch whose PRs target the sandbox branch, never main; before invoking, print exactly that consequence and require ONE explicit confirmation, routing only on an affirmative reply. Null means no gate.
 
 **Verb → skill map (D3).**
 
@@ -116,6 +116,7 @@ The two new trailing fields:
 | `run` (scoped: "run it", "run the loop", "run autospec"; bare "run" only when open `auto-implement` issues exist) | `/autospec-run` |
 | `refine and run` / `tune up` (combined) | `/autospec-refine` then `/autospec-run` |
 | `review` | `/autospec-review` |
+| `explore` / `discover` (only with an explicit build/ship/improve action connector, e.g. "explore and ship", "discover features to build") | `/autospec-explore` (gate `explore-confirm`) |
 | `autospec …` | the umbrella `/autospec` |
 
 **Auto-route behavior.** When the classifier returns `match:true` with `intent:imperative`, print exactly one line then invoke the mapped skill via the harness skill-invocation primitive:
@@ -124,7 +125,7 @@ The two new trailing fields:
 Routing to /<skill> — say "plain" to opt out.
 ```
 
-If `gate` is non-null, perform the gate check first and skip routing (plain mode) if unmet. If `chain` is non-null, after the mapped skill completes, invoke the chained skill (printing one opt-out line as usual).
+If `gate` is non-null, perform the gate check first and skip routing (plain mode) if unmet. For `gate:explore-confirm` (skill `autospec-explore`), do NOT auto-route on the one-line opt-out alone: first print exactly that `/autospec-explore` starts a perpetual autonomous research + ship loop on an isolated sandbox branch whose PRs target the sandbox branch, never main, then require ONE explicit confirmation and invoke `/autospec-explore` only on an affirmative reply; the existing `plain`/`no` escape still cancels. If `chain` is non-null, after the mapped skill completes, invoke the chained skill (printing one opt-out line as usual).
 
 On a non-match or `intent:incidental`/`none`, do nothing — the session proceeds normally in plain mode.
 


### PR DESCRIPTION
Closes #910

Adds the explore/discover build-intent verb-map row routing to `/autospec-explore` and defines+honors the `explore-confirm` gate byte-identically across the autospec-listen lock-step trio (SKILL.md / codex/prompt.md / opencode/agent.md).

- **Gate honor**: on `gate=explore-confirm` the listener prints exactly that `/autospec-explore` starts a perpetual autonomous research + ship loop on an isolated sandbox branch (PRs target the sandbox, never main) and requires ONE explicit confirmation before invoking; the existing `plain`/`no` escape still cancels.
- **Literal match**: `explore-confirm` matches the string emitted by the #909 classifier in `scripts/listener-match.sh` (verified by grep, 3 occurrences per trio body).
- **autospec-explore description**: one-line note that it is reachable via explore/discover intent through autospec-listen, without a bare-keyword trigger.
- **validate.sh**: `check_keyword_routing_section` extended to assert the explore row + `explore-confirm` literal in all three trio bodies and in listener-match.sh.

## Verification
- `bash scripts/validate.sh` → rc=0 (lock-step + keyword-routing extension pass)
- `bats tests/unit/test_listener_classify.bats` → rc=0 (50 tests, no regression)
- frontmatter-stripped trio diff is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)