### PR TITLE
fix: require full-suite proof before autospec merges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,8 @@ top GPT" at call time so the skill survives model-family churn.
 ## Auto-merge authority for auto-implement PRs
 
 Admin-merge `auto-implement` PRs (`gh pr merge <#> --admin --squash --delete-branch`) when:
-- All required CI checks pass (slow optional checks pending is acceptable).
+- The full target-repo validation/test suite has passed locally after the branch is current with `main`.
+- All required CI checks pass (slow optional checks pending is acceptable only after the full local suite is green).
 - The self-review subagent returned `LGTM`.
 - PR closes an `auto-implement` issue from a `feat/*` branch.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It gives you:
 - Model-fit metadata on each issue with `ctx:*` and `reasoning:*` labels.
 - Implementation queues that can be filtered by model profile.
 - Quality gates for issue shape and implementation scope.
-- Autonomous PR creation, counter-team review, CI checks, and admin squash-merge.
+- Autonomous PR creation, counter-team review, full-suite validation, CI checks, and admin squash-merge.
 - Stop/resume controls for long-running monitors.
 - A read-only story mode that explains the current application state from local
   docs plus GitHub issues and PRs.
@@ -352,8 +352,8 @@ The monitor:
 - Claims one ready issue at a time.
 - Opens a branch and PR for each issue.
 - Runs self-review and implementation guardian checks.
-- Admin squash-merges `auto-implement` PRs when required checks pass and review
-  is `LGTM`.
+- Admin squash-merges `auto-implement` PRs when the full target-repo test suite
+  passes, required checks pass, and review is `LGTM`.
 
 ## Stop and Resume
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -73,7 +73,7 @@ Turns a feature description into a spec PR and a GitHub issue tree.
 
 Background monitor that claims `auto-implement`-labelled issues one at a time, dispatches a
 TIER_B implementer subagent, runs the fused guardian+LGTM gate, rebase-and-retests, and
-admin-squash-merges the PR.
+admin-squash-merges the PR only after the full target-repo test suite passes.
 
 **Triggers:** `autospec-run`, `run the queue`, `implement issues`, `start the monitor`
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -103,7 +103,8 @@ Phase 3 complete. Run /autospec-run --profile <name> to begin implementation.
 `/autospec-run` is the implementation half: it consumes any open
 `auto-implement` issues whose `Depends-on` graph is satisfied,
 processes them one at a time through a TDD inner loop, opens a PR per
-issue, self-reviews, and admin-merges on `LGTM`.
+issue, self-reviews, runs the full target-repo test suite, and admin-merges only
+after the suite and required checks pass.
 
 ### When to use it
 

--- a/scripts/validate-qa-artifacts.sh
+++ b/scripts/validate-qa-artifacts.sh
@@ -104,6 +104,16 @@ validate_json() {
     echo "OK: $artifact"
 }
 
+yaml_to_json() {
+    src="$1"
+    dest="$2"
+    if yq -o=json '.' "$src" > "$dest" 2>/dev/null; then
+        return 0
+    fi
+    # Python yq transcodes YAML to JSON by default and forwards -o to jq.
+    yq '.' "$src" > "$dest"
+}
+
 validate_json \
     "$autospec_dir/proof-matrix.json" \
     "$schema_dir/autospec-proof-matrix.schema.json"
@@ -126,7 +136,7 @@ elif [ -f "$autospec_dir/reliability.yml" ]; then
         echo "validate-qa-artifacts: yq is required for $autospec_dir/reliability.yml" >&2
         exit 2
     }
-    yq -o=json '.' "$autospec_dir/reliability.yml" > "$tmpdir/reliability.json"
+    yaml_to_json "$autospec_dir/reliability.yml" "$tmpdir/reliability.json"
     ajv validate \
         -s "$schema_dir/autospec-reliability.schema.json" \
         --spec=draft2020 \

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -754,6 +754,39 @@ check_phase4_adaptive_retry() {
     done
 }
 
+# Phase 4 full-suite verification: autospec must never merge a PR just because
+# review and required CI are green. Every Phase 4 adapter must require the
+# target repo's full local validation/test suite before LGTM review and again
+# after branch update/rebase immediately before admin-merge. Failures must
+# return to the fix/recommit/retry loop; no merge is allowed while the suite
+# fails.
+check_phase4_full_test_suite_gate() {
+    info "phase4 full test suite gate: autospec + autospec-run trio"
+    for f in \
+        skills/autospec/SKILL.md \
+        skills/autospec/codex/prompt.md \
+        skills/autospec/opencode/agent.md \
+        skills/autospec-run/SKILL.md \
+        skills/autospec-run/codex/prompt.md \
+        skills/autospec-run/opencode/agent.md
+    do
+        grep -q 'Full test suite gate' "$f" \
+            || fail "$f missing Full test suite gate section"
+        grep -q 'AUTOSPEC_FULL_TEST_COMMAND' "$f" \
+            || fail "$f missing AUTOSPEC_FULL_TEST_COMMAND override"
+        grep -q 'scripts/validate.sh' "$f" \
+            || fail "$f missing scripts/validate.sh fallback command"
+        grep -q 'If the full suite fails, fix the failure, recommit, rerun the full suite, and repeat' "$f" \
+            || fail "$f missing fix/recommit/rerun failure loop"
+        grep -q 'Do NOT dispatch LGTM review' "$f" \
+            || fail "$f missing pre-review block on failing full suite"
+        grep -q 'Do NOT run `gh pr merge`' "$f" \
+            || fail "$f missing pre-merge block on failing full suite"
+        grep -q 'Record the exact full-suite command and passing output summary' "$f" \
+            || fail "$f missing verification evidence requirement"
+    done
+}
+
 # Team-personality contract: autospec should infer the right solving team from
 # the request, repository evidence, memories, and prior specs. If confidence is
 # low, it must ask explicitly with five concrete starter combinations, carry
@@ -1819,6 +1852,7 @@ main() {
     check_phase4_immediate_next_issue_pickup
     check_phase4_single_agent_discipline
     check_phase4_adaptive_retry
+    check_phase4_full_test_suite_gate
     check_autospec_sweep_config_contract
     check_autospec_fleet_scripts
     check_fleet_gui_subcommand_lockstep

--- a/skills/autospec-fleet/scripts/fleet-config-lint.sh
+++ b/skills/autospec-fleet/scripts/fleet-config-lint.sh
@@ -33,13 +33,23 @@ need_cmd() {
     command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
 }
 
+yaml_to_json() {
+    local src="$1"
+    local dest="$2"
+    if yq -o=json '.' "$src" > "$dest" 2>/dev/null; then
+        return 0
+    fi
+    # Python yq transcodes YAML to JSON by default and forwards -o to jq.
+    yq '.' "$src" > "$dest"
+}
+
 schema_validate() {
     local schema="$1"
     local src="$2"
     local json_file
     json_file="$(mktemp -t fleet-config.XXXXXX).json"
     tmp_files="$tmp_files $json_file"
-    yq -o=json '.' "$src" > "$json_file"
+    yaml_to_json "$src" "$json_file"
     ajv validate -s "$schema" --spec=draft2020 -d "$json_file" >/dev/null \
         || fail "$src failed schema validation"
 }

--- a/skills/autospec-run/README.md
+++ b/skills/autospec-run/README.md
@@ -2,7 +2,7 @@
 
 Implementation half of the **autospec** suite. Picks up where `/autospec-define`
 stops: takes the populated `auto-implement` queue on the current GitHub repo and
-runs Phases 4–6 of autospec — autonomous monitor + admin-squash-merge of each PR
+runs Phases 4–6 of autospec — autonomous monitor + full-suite-gated admin-squash-merge of each PR
 + periodic status updates + final report.
 
 Works on **Claude Code**, **OpenCode**, and **Codex CLI**.

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -266,7 +266,7 @@ same session id (a fresh session gets a new id), and `--force` overrides it.
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
 
-> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
+> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) the full target-repo validation/test suite has passed locally after the branch is current with `main`, (b) all required CI checks pass — slow optional checks like TeamCity may be pending only after the full local suite is green, (c) the self-review subagent returned `LGTM`, (d) PR closes an `auto-implement` issue from a `feat/*` branch.
 
 **Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
 
@@ -725,7 +725,11 @@ inline label-swap path below.
 >    cd {repo_root} && git fetch origin
 >    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
 > 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
-> 3. Build + test green (use the project's test runner; for Go: `go build ./... && go test ./... -count=1`; for Node: `npm test`; for Python: `pytest`). 80%+ coverage on changed files.
+> 3. **Full test suite gate.** Run the target repo's full validation/test suite, not only the Primary smoke test. Command resolution order:
+>    1. If `AUTOSPEC_FULL_TEST_COMMAND` is set, run `bash -lc "$AUTOSPEC_FULL_TEST_COMMAND"`.
+>    2. Else run every command listed under the issue's **Operator/full verification** section.
+>    3. Else run the repo-standard full suite: `bash scripts/validate.sh` when present; otherwise use the ecosystem default (`npm test`, `pytest`, `go test ./...`, `cargo test`, `mvn test`, etc.).
+>    If the full suite fails, fix the failure, recommit, rerun the full suite, and repeat. Do NOT dispatch LGTM review while the full suite is failing. Do NOT run `gh pr merge` while the full suite is failing. Record the exact full-suite command and passing output summary in the PR comment or final report.
 > 3a. **autospec-test gate** (run when `skills/autospec-test/scripts/run-gate.sh` exists in the repo): invoke the gate against the PR's target repo root. Handle exit codes per spec §7a/§7b:
 >    ```bash
 >    GATE_SCRIPT="skills/autospec-test/scripts/run-gate.sh"
@@ -830,6 +834,7 @@ inline label-swap path below.
 >    fi
 >    ```
 >    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - Run the **Full test suite gate** before fused guardian + LGTM review. If it fails, fix and recommit, rerun the full suite, and do not dispatch review until the full suite passes.
 >    - **Fused guardian + LGTM review** (one subagent does both — saves one dispatch per inner-loop iteration):
 >      <!-- guardian-block:begin -->
 >      Run deterministic lint first (no subagent cost):
@@ -886,7 +891,7 @@ inline label-swap path below.
 >
 >      If `LGTM` && det_exit == 0:
 >        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
->        run **Operator/full verification**
+>        run **Full test suite gate** and record the exact full-suite command and passing output summary
 >        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/ci-wait.sh" <PR>  # fire-and-forget sentinel
 >        if [ -f ".autospec/tokens-<ISSUE>-reviewer.json" ]; then
 >          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
@@ -895,7 +900,7 @@ inline label-swap path below.
 >        fi
 >        # monitor exits to parking state HERE — orchestrator relaunches when ~/.autospec/ci-state/<PR>.signal settles
 >        # On relaunch: run ci-wait-poll.sh <PR>; break SUCCESS if exit 0 (pass)
->        break SUCCESS if required checks pass.
+>        break SUCCESS only if the full suite passed and required checks pass.
 >      If `LGTM` but det_exit != 0:
 >        Treat deterministic findings as blocking. Comment, fix, recommit, push. Continue inner loop.
 >      If findings list:
@@ -959,6 +964,10 @@ inline label-swap path below.
 >        gh issue comment <ISSUE> --body "PR #<PR>: rebase-and-retest stalled after $max_attempts attempts; main is moving faster than CI completes. Pausing for operator review."
 >        exit 1
 >    fi
+>    # Mandatory final local proof after the branch is current with main.
+>    # Run the **Full test suite gate** here using the same command resolution order
+>    # (`AUTOSPEC_FULL_TEST_COMMAND`, Operator/full verification, then `bash scripts/validate.sh` fallback).
+>    # If it fails, fix the failure, recommit, push, rerun the full suite and review, and do NOT run `gh pr merge`.
 >    gh pr merge <PR> --admin --squash --delete-branch
 >    ```
 >    The block ends with the admin-merge; merge auto-closes the issue.

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -261,7 +261,7 @@ same session id (a fresh session gets a new id), and `--force` overrides it.
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
 
-> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
+> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) the full target-repo validation/test suite has passed locally after the branch is current with `main`, (b) all required CI checks pass — slow optional checks like TeamCity may be pending only after the full local suite is green, (c) the self-review subagent returned `LGTM`, (d) PR closes an `auto-implement` issue from a `feat/*` branch.
 
 **Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
 
@@ -720,7 +720,11 @@ inline label-swap path below.
 >    cd {repo_root} && git fetch origin
 >    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
 > 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
-> 3. Build + test green (use the project's test runner; for Go: `go build ./... && go test ./... -count=1`; for Node: `npm test`; for Python: `pytest`). 80%+ coverage on changed files.
+> 3. **Full test suite gate.** Run the target repo's full validation/test suite, not only the Primary smoke test. Command resolution order:
+>    1. If `AUTOSPEC_FULL_TEST_COMMAND` is set, run `bash -lc "$AUTOSPEC_FULL_TEST_COMMAND"`.
+>    2. Else run every command listed under the issue's **Operator/full verification** section.
+>    3. Else run the repo-standard full suite: `bash scripts/validate.sh` when present; otherwise use the ecosystem default (`npm test`, `pytest`, `go test ./...`, `cargo test`, `mvn test`, etc.).
+>    If the full suite fails, fix the failure, recommit, rerun the full suite, and repeat. Do NOT dispatch LGTM review while the full suite is failing. Do NOT run `gh pr merge` while the full suite is failing. Record the exact full-suite command and passing output summary in the PR comment or final report.
 > 3a. **autospec-test gate** (run when `skills/autospec-test/scripts/run-gate.sh` exists in the repo): invoke the gate against the PR's target repo root. Handle exit codes per spec §7a/§7b:
 >    ```bash
 >    GATE_SCRIPT="skills/autospec-test/scripts/run-gate.sh"
@@ -825,6 +829,7 @@ inline label-swap path below.
 >    fi
 >    ```
 >    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - Run the **Full test suite gate** before fused guardian + LGTM review. If it fails, fix and recommit, rerun the full suite, and do not dispatch review until the full suite passes.
 >    - **Fused guardian + LGTM review** (one subagent does both — saves one dispatch per inner-loop iteration):
 >      <!-- guardian-block:begin -->
 >      Run deterministic lint first (no subagent cost):
@@ -881,7 +886,7 @@ inline label-swap path below.
 >
 >      If `LGTM` && det_exit == 0:
 >        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
->        run **Operator/full verification**
+>        run **Full test suite gate** and record the exact full-suite command and passing output summary
 >        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/ci-wait.sh" <PR>  # fire-and-forget sentinel
 >        if [ -f ".autospec/tokens-<ISSUE>-reviewer.json" ]; then
 >          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
@@ -890,7 +895,7 @@ inline label-swap path below.
 >        fi
 >        # monitor exits to parking state HERE — orchestrator relaunches when ~/.autospec/ci-state/<PR>.signal settles
 >        # On relaunch: run ci-wait-poll.sh <PR>; break SUCCESS if exit 0 (pass)
->        break SUCCESS if required checks pass.
+>        break SUCCESS only if the full suite passed and required checks pass.
 >      If `LGTM` but det_exit != 0:
 >        Treat deterministic findings as blocking. Comment, fix, recommit, push. Continue inner loop.
 >      If findings list:
@@ -954,6 +959,10 @@ inline label-swap path below.
 >        gh issue comment <ISSUE> --body "PR #<PR>: rebase-and-retest stalled after $max_attempts attempts; main is moving faster than CI completes. Pausing for operator review."
 >        exit 1
 >    fi
+>    # Mandatory final local proof after the branch is current with main.
+>    # Run the **Full test suite gate** here using the same command resolution order
+>    # (`AUTOSPEC_FULL_TEST_COMMAND`, Operator/full verification, then `bash scripts/validate.sh` fallback).
+>    # If it fails, fix the failure, recommit, push, rerun the full suite and review, and do NOT run `gh pr merge`.
 >    gh pr merge <PR> --admin --squash --delete-branch
 >    ```
 >    The block ends with the admin-merge; merge auto-closes the issue.

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -265,7 +265,7 @@ same session id (a fresh session gets a new id), and `--force` overrides it.
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
 
-> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
+> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) the full target-repo validation/test suite has passed locally after the branch is current with `main`, (b) all required CI checks pass — slow optional checks like TeamCity may be pending only after the full local suite is green, (c) the self-review subagent returned `LGTM`, (d) PR closes an `auto-implement` issue from a `feat/*` branch.
 
 **Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
 
@@ -724,7 +724,11 @@ inline label-swap path below.
 >    cd {repo_root} && git fetch origin
 >    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
 > 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
-> 3. Build + test green (use the project's test runner; for Go: `go build ./... && go test ./... -count=1`; for Node: `npm test`; for Python: `pytest`). 80%+ coverage on changed files.
+> 3. **Full test suite gate.** Run the target repo's full validation/test suite, not only the Primary smoke test. Command resolution order:
+>    1. If `AUTOSPEC_FULL_TEST_COMMAND` is set, run `bash -lc "$AUTOSPEC_FULL_TEST_COMMAND"`.
+>    2. Else run every command listed under the issue's **Operator/full verification** section.
+>    3. Else run the repo-standard full suite: `bash scripts/validate.sh` when present; otherwise use the ecosystem default (`npm test`, `pytest`, `go test ./...`, `cargo test`, `mvn test`, etc.).
+>    If the full suite fails, fix the failure, recommit, rerun the full suite, and repeat. Do NOT dispatch LGTM review while the full suite is failing. Do NOT run `gh pr merge` while the full suite is failing. Record the exact full-suite command and passing output summary in the PR comment or final report.
 > 3a. **autospec-test gate** (run when `skills/autospec-test/scripts/run-gate.sh` exists in the repo): invoke the gate against the PR's target repo root. Handle exit codes per spec §7a/§7b:
 >    ```bash
 >    GATE_SCRIPT="skills/autospec-test/scripts/run-gate.sh"
@@ -829,6 +833,7 @@ inline label-swap path below.
 >    fi
 >    ```
 >    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - Run the **Full test suite gate** before fused guardian + LGTM review. If it fails, fix and recommit, rerun the full suite, and do not dispatch review until the full suite passes.
 >    - **Fused guardian + LGTM review** (one subagent does both — saves one dispatch per inner-loop iteration):
 >      <!-- guardian-block:begin -->
 >      Run deterministic lint first (no subagent cost):
@@ -885,7 +890,7 @@ inline label-swap path below.
 >
 >      If `LGTM` && det_exit == 0:
 >        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
->        run **Operator/full verification**
+>        run **Full test suite gate** and record the exact full-suite command and passing output summary
 >        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/ci-wait.sh" <PR>  # fire-and-forget sentinel
 >        if [ -f ".autospec/tokens-<ISSUE>-reviewer.json" ]; then
 >          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
@@ -894,7 +899,7 @@ inline label-swap path below.
 >        fi
 >        # monitor exits to parking state HERE — orchestrator relaunches when ~/.autospec/ci-state/<PR>.signal settles
 >        # On relaunch: run ci-wait-poll.sh <PR>; break SUCCESS if exit 0 (pass)
->        break SUCCESS if required checks pass.
+>        break SUCCESS only if the full suite passed and required checks pass.
 >      If `LGTM` but det_exit != 0:
 >        Treat deterministic findings as blocking. Comment, fix, recommit, push. Continue inner loop.
 >      If findings list:
@@ -958,6 +963,10 @@ inline label-swap path below.
 >        gh issue comment <ISSUE> --body "PR #<PR>: rebase-and-retest stalled after $max_attempts attempts; main is moving faster than CI completes. Pausing for operator review."
 >        exit 1
 >    fi
+>    # Mandatory final local proof after the branch is current with main.
+>    # Run the **Full test suite gate** here using the same command resolution order
+>    # (`AUTOSPEC_FULL_TEST_COMMAND`, Operator/full verification, then `bash scripts/validate.sh` fallback).
+>    # If it fails, fix the failure, recommit, push, rerun the full suite and review, and do NOT run `gh pr merge`.
 >    gh pr merge <PR> --admin --squash --delete-branch
 >    ```
 >    The block ends with the admin-merge; merge auto-closes the issue.

--- a/skills/autospec/README.md
+++ b/skills/autospec/README.md
@@ -104,7 +104,7 @@ Reach for this skill when:
 | **2** | Brainstorm + design | Selects a `Team personality` plus independent `Review counter-team`, then runs the structured 5-section brainstorm (architecture / API / data / errors / testing) with explicit per-section approval, written to `docs/specs/YYYY-MM-DD-<topic>-design.md`. |
 | **3** | Decompose into linked GitHub issues (delegate) | Foreground subagent creates labels, an EPIC umbrella, and N self-contained mini-specs sized for 32B-class local LLMs: team lens, review counter-team, file pointers, section anchors, checkbox AC, primary smoke test. |
 | **3.5** | Review and label (delegate) | Foreground subagent applies the `ctx:*` / `reasoning:*` rubric to each child, writes a `## Model fit` block into the body (idempotent), runs sibling-normalization across split children, and validates dep edges (closed-dep / child-less-tracker warnings; circular sibling-dep hard fail). Optional board assignment via `~/.autospec/project-map.yml` (full reader lands in PR B3 / #16). |
-| **4** | Background autonomous monitor | Background subagent loops: pick next ready issue → worktree → TDD → push → PR → self-review → admin-squash-merge → repeat until drained. |
+| **4** | Background autonomous monitor | Background subagent loops: pick next ready issue → worktree → TDD → full-suite validation → push → PR → self-review → revalidate → admin-squash-merge → repeat until drained. |
 | **5** | Periodic status updates | Self-paced ~25 min wakeups posting deltas (closed issues, merged PRs, failures, blockers); slows to ~50 min when quiet. |
 | **6** | Final report | When the monitor terminates, summarize every issue processed, PR merged, wall time, and any human-attention failures. |
 

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -674,7 +674,7 @@ Once `run` is selected and `/autospec-run` starts, do not ask operator questions
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
 
-> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
+> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) the full target-repo validation/test suite has passed locally after the branch is current with `main`, (b) all required CI checks pass — slow optional checks like TeamCity may be pending only after the full local suite is green, (c) the self-review subagent returned `LGTM`, (d) PR closes an `auto-implement` issue from a `feat/*` branch.
 
 **Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
 
@@ -900,7 +900,11 @@ Pass the following prompt verbatim to each background subagent:
 >    cd {repo_root} && git fetch origin
 >    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
 > 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
-> 3. Build + test green (use the project's test runner; for Go: `go build ./... && go test ./... -count=1`; for Node: `npm test`; for Python: `pytest`). 80%+ coverage on changed files.
+> 3. **Full test suite gate.** Run the target repo's full validation/test suite, not only the Primary smoke test. Command resolution order:
+>    1. If `AUTOSPEC_FULL_TEST_COMMAND` is set, run `bash -lc "$AUTOSPEC_FULL_TEST_COMMAND"`.
+>    2. Else run every command listed under the issue's **Operator/full verification** section.
+>    3. Else run the repo-standard full suite: `bash scripts/validate.sh` when present; otherwise use the ecosystem default (`npm test`, `pytest`, `go test ./...`, `cargo test`, `mvn test`, etc.).
+>    If the full suite fails, fix the failure, recommit, rerun the full suite, and repeat. Do NOT dispatch LGTM review while the full suite is failing. Do NOT run `gh pr merge` while the full suite is failing. Record the exact full-suite command and passing output summary in the PR comment or final report.
 > 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
 > 5. Push: git push -u origin <BRANCH>
 >    ```bash
@@ -920,6 +924,7 @@ Pass the following prompt verbatim to each background subagent:
 >    fi
 >    ```
 >    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - Run the **Full test suite gate** before fused guardian + LGTM review. If it fails, fix and recommit, rerun the full suite, and do not dispatch review until the full suite passes.
 >    - **Fused guardian + LGTM review** (one subagent does both — saves one dispatch per inner-loop iteration):
 >      <!-- guardian-block:begin -->
 >      Run deterministic lint first (no subagent cost):
@@ -976,7 +981,7 @@ Pass the following prompt verbatim to each background subagent:
 >
 >      If `LGTM` && det_exit == 0:
 >        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
->        run **Operator/full verification**
+>        run **Full test suite gate** and record the exact full-suite command and passing output summary
 >        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/ci-wait.sh" <PR>  # fire-and-forget sentinel
 >        if [ -f ".autospec/tokens-<ISSUE>-reviewer.json" ]; then
 >          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
@@ -985,7 +990,7 @@ Pass the following prompt verbatim to each background subagent:
 >        fi
 >        # monitor exits to parking state HERE — orchestrator relaunches when ~/.autospec/ci-state/<PR>.signal settles
 >        # On relaunch: run ci-wait-poll.sh <PR>; break SUCCESS if exit 0 (pass)
->        break SUCCESS if required checks pass.
+>        break SUCCESS only if the full suite passed and required checks pass.
 >      If `LGTM` but det_exit != 0:
 >        Treat deterministic findings as blocking. Comment, fix, recommit, push. Continue inner loop.
 >      If findings list:
@@ -1006,7 +1011,7 @@ Pass the following prompt verbatim to each background subagent:
 >      exit 0
 >    fi
 >    ```
-> 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
+> 8. SUCCESS: Run the **Full test suite gate** one final time after the PR branch is current with `main`; if it fails, fix the failure, recommit, push, rerun the full suite and review, and do NOT run `gh pr merge`. Then run `gh pr merge <PR> --admin --squash --delete-branch`. Merge auto-closes the issue.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -668,7 +668,7 @@ Once `run` is selected and `/autospec-run` starts, do not ask operator questions
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
 
-> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
+> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) the full target-repo validation/test suite has passed locally after the branch is current with `main`, (b) all required CI checks pass — slow optional checks like TeamCity may be pending only after the full local suite is green, (c) the self-review subagent returned `LGTM`, (d) PR closes an `auto-implement` issue from a `feat/*` branch.
 
 **Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
 
@@ -894,7 +894,11 @@ Pass the following prompt verbatim to each background subagent:
 >    cd {repo_root} && git fetch origin
 >    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
 > 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
-> 3. Build + test green (use the project's test runner; for Go: `go build ./... && go test ./... -count=1`; for Node: `npm test`; for Python: `pytest`). 80%+ coverage on changed files.
+> 3. **Full test suite gate.** Run the target repo's full validation/test suite, not only the Primary smoke test. Command resolution order:
+>    1. If `AUTOSPEC_FULL_TEST_COMMAND` is set, run `bash -lc "$AUTOSPEC_FULL_TEST_COMMAND"`.
+>    2. Else run every command listed under the issue's **Operator/full verification** section.
+>    3. Else run the repo-standard full suite: `bash scripts/validate.sh` when present; otherwise use the ecosystem default (`npm test`, `pytest`, `go test ./...`, `cargo test`, `mvn test`, etc.).
+>    If the full suite fails, fix the failure, recommit, rerun the full suite, and repeat. Do NOT dispatch LGTM review while the full suite is failing. Do NOT run `gh pr merge` while the full suite is failing. Record the exact full-suite command and passing output summary in the PR comment or final report.
 > 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
 > 5. Push: git push -u origin <BRANCH>
 >    ```bash
@@ -914,6 +918,7 @@ Pass the following prompt verbatim to each background subagent:
 >    fi
 >    ```
 >    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - Run the **Full test suite gate** before fused guardian + LGTM review. If it fails, fix and recommit, rerun the full suite, and do not dispatch review until the full suite passes.
 >    - **Fused guardian + LGTM review** (one subagent does both — saves one dispatch per inner-loop iteration):
 >      <!-- guardian-block:begin -->
 >      Run deterministic lint first (no subagent cost):
@@ -970,7 +975,7 @@ Pass the following prompt verbatim to each background subagent:
 >
 >      If `LGTM` && det_exit == 0:
 >        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
->        run **Operator/full verification**
+>        run **Full test suite gate** and record the exact full-suite command and passing output summary
 >        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/ci-wait.sh" <PR>  # fire-and-forget sentinel
 >        if [ -f ".autospec/tokens-<ISSUE>-reviewer.json" ]; then
 >          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
@@ -979,7 +984,7 @@ Pass the following prompt verbatim to each background subagent:
 >        fi
 >        # monitor exits to parking state HERE — orchestrator relaunches when ~/.autospec/ci-state/<PR>.signal settles
 >        # On relaunch: run ci-wait-poll.sh <PR>; break SUCCESS if exit 0 (pass)
->        break SUCCESS if required checks pass.
+>        break SUCCESS only if the full suite passed and required checks pass.
 >      If `LGTM` but det_exit != 0:
 >        Treat deterministic findings as blocking. Comment, fix, recommit, push. Continue inner loop.
 >      If findings list:
@@ -1000,7 +1005,7 @@ Pass the following prompt verbatim to each background subagent:
 >      exit 0
 >    fi
 >    ```
-> 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
+> 8. SUCCESS: Run the **Full test suite gate** one final time after the PR branch is current with `main`; if it fails, fix the failure, recommit, push, rerun the full suite and review, and do NOT run `gh pr merge`. Then run `gh pr merge <PR> --admin --squash --delete-branch`. Merge auto-closes the issue.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -672,7 +672,7 @@ Once `run` is selected and `/autospec-run` starts, do not ask operator questions
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
 
-> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) all required CI checks pass — slow optional checks like TeamCity may be pending and that's acceptable, (b) the self-review subagent returned `LGTM`, (c) PR closes an `auto-implement` issue from a `feat/*` branch.
+> **Auto-merge authority for auto-implement PRs.** Admin-merge auto-implement PRs (`gh pr merge <#> --admin --squash --delete-branch`) when (a) the full target-repo validation/test suite has passed locally after the branch is current with `main`, (b) all required CI checks pass — slow optional checks like TeamCity may be pending only after the full local suite is green, (c) the self-review subagent returned `LGTM`, (d) PR closes an `auto-implement` issue from a `feat/*` branch.
 
 **Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
 
@@ -898,7 +898,11 @@ Pass the following prompt verbatim to each background subagent:
 >    cd {repo_root} && git fetch origin
 >    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
 > 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
-> 3. Build + test green (use the project's test runner; for Go: `go build ./... && go test ./... -count=1`; for Node: `npm test`; for Python: `pytest`). 80%+ coverage on changed files.
+> 3. **Full test suite gate.** Run the target repo's full validation/test suite, not only the Primary smoke test. Command resolution order:
+>    1. If `AUTOSPEC_FULL_TEST_COMMAND` is set, run `bash -lc "$AUTOSPEC_FULL_TEST_COMMAND"`.
+>    2. Else run every command listed under the issue's **Operator/full verification** section.
+>    3. Else run the repo-standard full suite: `bash scripts/validate.sh` when present; otherwise use the ecosystem default (`npm test`, `pytest`, `go test ./...`, `cargo test`, `mvn test`, etc.).
+>    If the full suite fails, fix the failure, recommit, rerun the full suite, and repeat. Do NOT dispatch LGTM review while the full suite is failing. Do NOT run `gh pr merge` while the full suite is failing. Record the exact full-suite command and passing output summary in the PR comment or final report.
 > 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
 > 5. Push: git push -u origin <BRANCH>
 >    ```bash
@@ -918,6 +922,7 @@ Pass the following prompt verbatim to each background subagent:
 >    fi
 >    ```
 >    - Run the **Primary smoke test** from the issue body. If it fails, fix and recommit before review.
+>    - Run the **Full test suite gate** before fused guardian + LGTM review. If it fails, fix and recommit, rerun the full suite, and do not dispatch review until the full suite passes.
 >    - **Fused guardian + LGTM review** (one subagent does both — saves one dispatch per inner-loop iteration):
 >      <!-- guardian-block:begin -->
 >      Run deterministic lint first (no subagent cost):
@@ -974,7 +979,7 @@ Pass the following prompt verbatim to each background subagent:
 >
 >      If `LGTM` && det_exit == 0:
 >        gh pr comment <PR> --body "<!-- guardian-block --> Review: clean. <!-- /-->"
->        run **Operator/full verification**
+>        run **Full test suite gate** and record the exact full-suite command and passing output summary
 >        bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/ci-wait.sh" <PR>  # fire-and-forget sentinel
 >        if [ -f ".autospec/tokens-<ISSUE>-reviewer.json" ]; then
 >          bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/record-telemetry.sh" \
@@ -983,7 +988,7 @@ Pass the following prompt verbatim to each background subagent:
 >        fi
 >        # monitor exits to parking state HERE — orchestrator relaunches when ~/.autospec/ci-state/<PR>.signal settles
 >        # On relaunch: run ci-wait-poll.sh <PR>; break SUCCESS if exit 0 (pass)
->        break SUCCESS if required checks pass.
+>        break SUCCESS only if the full suite passed and required checks pass.
 >      If `LGTM` but det_exit != 0:
 >        Treat deterministic findings as blocking. Comment, fix, recommit, push. Continue inner loop.
 >      If findings list:
@@ -1004,7 +1009,7 @@ Pass the following prompt verbatim to each background subagent:
 >      exit 0
 >    fi
 >    ```
-> 8. SUCCESS: gh pr merge <PR> --admin --squash --delete-branch. Merge auto-closes the issue.
+> 8. SUCCESS: Run the **Full test suite gate** one final time after the PR branch is current with `main`; if it fails, fix the failure, recommit, push, rerun the full suite and review, and do NOT run `gh pr merge`. Then run `gh pr merge <PR> --admin --squash --delete-branch`. Merge auto-closes the issue.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then


### PR DESCRIPTION
## Summary
- Require the autospec/autospec-run Phase 4 skill trios to run the full target-repo validation/test suite before fused guardian + LGTM review and again immediately before admin-merge.
- Add a validate.sh invariant so future prompt drift cannot remove the full-suite gate across adapters.
- Fix YAML-to-JSON validation for Python yq as well as Mike Farah yq, which was blocking the repo validation suite in this environment.
- Update current user-facing docs to describe the full-suite merge gate.

## Validation
- bash scripts/validate.sh

## Notes
- Not tested against a live external target repo; this changes the skill contract and validates the repository harness.