### PR TITLE
feat(autospec-doc): scaffold skill trio + packaging + init (D1)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -223,7 +223,7 @@ check_startup_preflight() {
         || printf '%s\n' "$canonical" | grep -F 'raw.githubusercontent.com/berlinguyinca/autospec/main/skills/' >/dev/null; then
         fail "startup preflight must not call a raw installer directly"
     fi
-    for s in autospec autospec-release autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa autospec-resume; do
+    for s in autospec autospec-release autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa autospec-resume autospec-doc; do
         for f in "skills/$s/SKILL.md" "skills/$s/opencode/agent.md" "skills/$s/codex/prompt.md"; do
             body=$(extract_block "$f")
             [ -n "$body" ] || fail "$f missing ## Startup self-update section"
@@ -240,7 +240,7 @@ check_startup_preflight() {
 # prompts/ path AND the new skills/ slash-command registry path.
 check_codex_skills_install() {
     info "codex skills-dir install: all skills"
-    for s in autospec autospec-release autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa; do
+    for s in autospec autospec-release autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa autospec-doc; do
         f="skills/$s/install.sh"
         grep -q 'skills/\$SKILL_NAME/SKILL\.md' "$f" \
             || fail "$f missing Codex skills-dir install (skills/\$SKILL_NAME/SKILL.md)"
@@ -255,7 +255,7 @@ check_codex_skills_install() {
 check_shared_script_install() {
     info "shared helper install: all skills"
     helpers="autospec-stop.sh autospec-usage-limit.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
-    for s in autospec autospec-release autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa; do
+    for s in autospec autospec-release autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa autospec-doc; do
         f="skills/$s/install.sh"
         grep -q 'install_shared_scripts' "$f" \
             || fail "$f missing install_shared_scripts function/call"
@@ -1892,6 +1892,7 @@ main() {
     check_autospec_qa_cluster_contract
     check_autospec_qa_bug_class_contract
     check_autospec_resume_contract
+    check_autospec_doc_contract
     check_watchdog_worktree_gc
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
@@ -2326,6 +2327,54 @@ check_autospec_resume_contract() {
             bats "$bats_file" >/tmp/validate-resume-bats.log 2>&1 \
                 || { cat /tmp/validate-resume-bats.log >&2; fail "$bats_file: failed"; }
         done
+    fi
+}
+
+# autospec-doc scaffold contract (issue #916): the per-audience documentation
+# generator trio + subcommand router stub. Enforces:
+#   - all three trio files carry a `## Subcommand contract` section documenting
+#     the five §D1 forms (bare incremental, --full, --audit, --audience <name>,
+#     init), so the contract stays in lock-step across harnesses;
+#   - scripts/doc-orchestrator.mjs exists, node --check clean, and exits 2 on a
+#     non-init subcommand with no `documentation:` config;
+#   - the bats suite exists and passes.
+# Generic trio checks (lock-step, frontmatter, self-update, model-tier,
+# harness-detection, required-files) run via the discover_skills loop in main().
+check_autospec_doc_contract() {
+    info "autospec-doc scaffold contract (issue #916)"
+    local skill="skills/autospec-doc"
+    [ -d "$skill" ] || fail "$skill: directory missing"
+    for trio in SKILL.md codex/prompt.md opencode/agent.md; do
+        f="$skill/$trio"
+        [ -f "$f" ] || fail "$f: required file missing"
+        grep -q '^## Subcommand contract' "$f" \
+            || fail "$f missing '## Subcommand contract' section"
+        # The five §D1 subcommand forms must all be documented in every trio file.
+        grep -q -- '--full' "$f"     || fail "$f missing --full subcommand"
+        grep -q -- '--audit' "$f"    || fail "$f missing --audit subcommand"
+        grep -q -- '--audience' "$f" || fail "$f missing --audience subcommand"
+        grep -qE '/autospec-doc init|`init`' "$f" \
+            || fail "$f missing init subcommand"
+    done
+    orch="$skill/scripts/doc-orchestrator.mjs"
+    [ -f "$orch" ] || fail "$orch: orchestrator stub missing"
+    if command -v node >/dev/null 2>&1; then
+        node --check "$orch" || fail "$orch: node --check failed"
+        # Config gate: a non-init subcommand with no documentation config exits 2.
+        # Capture the exit without tripping `set -e` (the non-zero exit is expected).
+        gate_dir="$(mktemp -d)"
+        rc=0
+        ( cd "$gate_dir" && node "$REPO_ROOT/$orch" --full ) >/dev/null 2>&1 || rc=$?
+        rm -rf "$gate_dir"
+        [ "$rc" -eq 2 ] \
+            || fail "$orch: non-init subcommand with no documentation config must exit 2 (got $rc)"
+    fi
+    bats_file="$skill/tests/doc-orchestrator.bats"
+    [ -f "$bats_file" ] || fail "$bats_file: bats coverage missing"
+    if command -v bats >/dev/null 2>&1; then
+        info "  running: $bats_file"
+        bats "$bats_file" >/tmp/validate-autospec-doc-bats.log 2>&1 \
+            || { cat /tmp/validate-autospec-doc-bats.log >&2; fail "$bats_file: failed"; }
     fi
 }
 

--- a/skills/autospec-doc/README.md
+++ b/skills/autospec-doc/README.md
@@ -1,0 +1,103 @@
+# autospec-doc
+
+Harness-neutral, autospec-family **per-audience documentation generator**.
+Generates and maintains project documentation for four audiences — **user**,
+**developer**, **admin**, and **general** — as a verifiable, docs-as-tests
+artifact: every code example is executed against the repo, the visual palette
+is single-sourced, and the whole corpus is concatenated into an `llms-full.txt`
+for downstream LLM consumption.
+
+Incremental by default (cheap, scoped to what changed), with `--full`,
+`--audit`, `--audience <name>`, and an `init` scaffolder. Every operation routes
+through `scripts/doc-orchestrator.mjs`.
+
+Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
+
+> **Status:** scaffold (issue #916). This issue ships the lock-step trio with
+> the required structural sections, packaging, and the `doc-orchestrator.mjs`
+> router stub. The generators (`gen-audience-docs.mjs`, `verify-examples.mjs`,
+> `doc-style.mjs`, `gen-llms-full.mjs`), the config schema + folder contract,
+> and the Phase 4 / Phase 5.5 / sweep / define wiring land in follow-up child
+> issues #917-#924.
+
+## Subcommands
+
+| Form | Behavior |
+| --- | --- |
+| `/autospec-doc` | Incremental — regenerate scopes affected since last generation. The cheap default. |
+| `/autospec-doc --full` | Regenerate everything + run the completeness audit. |
+| `/autospec-doc --audit` | Read-only completeness/drift report; writes nothing. |
+| `/autospec-doc --audience <name>` | Regenerate one audience only. |
+| `/autospec-doc init` | Scaffold the `documentation:` config + starter doc scopes. |
+
+Every non-`init` subcommand exits `2` when no `documentation:` config exists in
+`.autospec/autospec.yml`: run `/autospec-doc init` first to scaffold it.
+
+## Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-doc/install.sh | sh -s -- --harness all
+```
+
+Per-harness:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-doc/install.sh | sh -s -- --harness claude
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-doc/install.sh | sh -s -- --harness opencode
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-doc/install.sh | sh -s -- --harness codex
+```
+
+From a clone:
+
+```bash
+cd skills/autospec-doc
+./install.sh --harness all
+```
+
+## Invocation
+
+```
+/autospec-doc [--full | --audit | --audience <name> | init]
+```
+
+## Required structural sections
+
+Every harness body (`SKILL.md` / `codex/prompt.md` / `opencode/agent.md`)
+carries these sections, so the decomposer and the repo validator recognise it as
+a conformant autospec skill:
+
+1. **Startup self-update** — canonical self-update block, `SKILL_NAME=autospec-doc`.
+2. **Self-update mode** — pure-prose dispatch on `^\s*update\s*$`.
+3. **Model tier** — AGENTS.md Tier A/B + harness-detection + adapter row.
+4. **Subcommand contract** — the five-form `/autospec-doc` routing table.
+
+## Config
+
+`.autospec/autospec.yml` `documentation:` block. `init` seeds the four default
+audiences (user → `docs/user`, developer → `docs/developer`, admin →
+`docs/admin`, general → `docs/general`) only when `audiences:` is empty.
+*(Schema + folder-contract path constants land in #917.)*
+
+## Self-update
+
+```
+/autospec-doc update
+```
+
+Or re-run the installer with `--update`:
+
+```bash
+./install.sh --harness all --update
+```
+
+## Related skills
+
+| Skill | Purpose |
+| --- | --- |
+| [`autospec-define`](../autospec-define/README.md) | Plans features; its auto-docs step redirects here (#924). |
+| [`autospec-run`](../autospec-run/README.md) | Phase 4 gains a `regenerate` self-heal action calling this skill (#922). |
+| [`autospec-sweep`](../autospec-sweep/README.md) | Its docs-drift check redirects to `/autospec-doc --full` (#924). |
+
+## License
+
+MIT — see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autospec-doc/SKILL.md
+++ b/skills/autospec-doc/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: autospec-doc
+description: Use when the user wants to generate, regenerate, or audit per-audience project documentation (user, developer, admin, general) as docs-as-tests — incremental by default, with --full, --audit, --audience <name>, and an init scaffolder. Single-source palette, verified examples, and llms-full.txt output. Hands generation to scripts/doc-orchestrator.mjs.
+---
+
+# autospec-doc workflow (harness-neutral)
+
+Generate and maintain **per-audience project documentation** as a first-class,
+verifiable artifact. The product is documentation infrastructure: every page is
+audience-targeted (user / developer / admin / general), every code example is
+executed (docs-as-tests), the visual palette is single-sourced, and the whole
+corpus is concatenated into an `llms-full.txt` for downstream LLM consumption.
+
+Goal: documentation that a non-author can actually follow, that never silently
+drifts from the code, whose examples are proven to run, and whose token cost
+stays bounded through incremental regeneration. This skill is the operator
+entry point; the heavy lifting lives in `scripts/doc-orchestrator.mjs` and the
+per-capability generators it dispatches.
+
+This SKILL.md is the **scaffold contract** (issue #916). The subcommand router
+exists as a stub; the generator scripts (`gen-audience-docs.mjs`,
+`verify-examples.mjs`, `doc-style.mjs`, `gen-llms-full.mjs`) are header+stub
+here and filled in by downstream issues #917-#921. Sections below marked
+*(filled in by #NNN)* are intentional stubs.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-doc   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-loop
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the argument matches the regex `^\s*update\s*$` (case-insensitive,
+whitespace-padded), this skill enters self-update mode and does not run the
+normal pipeline. This section is pure prose: never interpolate or shell out the
+operator's argument text.
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-doc/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-doc.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-doc.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter the documentation pipeline. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-doc found; run install.sh first.` and exit.
+
+## Model tier
+
+Tier A/B model resolution and the harness-detection protocol are inherited
+verbatim from `AGENTS.md` (`## Subagent model selection (two-tier, cost-aware)`
+and `## Subagent vs inline decision matrix`). Audience-content authoring and the
+completeness audit run at Tier A (spec work — fresh-eyes reasoning produces
+better prose and catches gaps); deterministic generation, example verification,
+and palette resolution run at Tier B (implementation work).
+
+> **Model tier:** TIER_A (spec work) for the per-audience content pass and the completeness audit; TIER_B (implementation work) for deterministic generation, example verification, and style — resolved at startup per the harness detection below.
+
+### Required capabilities & harness adapter
+
+This workflow assumes the following capabilities. Map each to your harness's
+actual tool; if a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                                | Fallback if missing                              |
+|-----------------------------|-----------------------------------------|---------------------------------------|------------------------------------------|--------------------------------------------------|
+| Audience content authoring  | `Agent` (subagent_type=general-purpose) | `task` agent, await output            | run the authoring pass inline            | Author in-thread (more context cost)             |
+| Completeness / gap audit    | a **separate** `Agent` dispatch         | a **separate** `task` agent           | a separate inline judging pass           | Audit in-thread, never reuse the authoring pass  |
+| Read-only repo research     | `Agent` (subagent_type=Explore)         | `task` agent in read-only mode        | shell `grep`/`rg` read-only              | Search in-thread with `rg`/`grep`                |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                            | Ask in the response and wait for the next turn   |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+| Subagent dispatch policy    | per AGENTS.md decision matrix           | per AGENTS.md decision matrix         | per AGENTS.md decision matrix            | inline with main-session token cost              |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in
+the repo root — recognized by Claude Code, OpenCode, and Codex.
+
+## Harness detection (run once at skill start, before generation begins)
+
+Detect your harness by checking available tools before any dispatch:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; passes run inline.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness, silently retry
+the same subagent dispatch with `TIER_A`. Preserve parent context on retry.
+Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run.
+
+## Subcommand contract
+
+`/autospec-doc` routes every operation through `scripts/doc-orchestrator.mjs`.
+There are five forms; resolve the active repo's `<owner/name>` once and reuse it.
+
+```
+/autospec-doc                     # incremental — regenerate scopes affected since last generation
+/autospec-doc --full              # regenerate everything + run the completeness audit
+/autospec-doc --audit             # read-only completeness/drift report; writes nothing
+/autospec-doc --audience <name>   # regenerate one audience only (user|developer|admin|general|custom)
+/autospec-doc init                # scaffold the documentation: config + starter doc scopes
+```
+
+- **(bare) incremental** — the default and the cheap path. Scopes only the docs
+  affected since the last generation (changed features, drifted examples). Keeps
+  per-run token cost bounded; never regenerates the whole corpus. Requires a
+  `documentation:` config. *(scope-diff + generation filled in by #918/#919.)*
+- **`--full`** — regenerate every audience's pages from scratch and then run the
+  completeness audit. The expensive, exhaustive path. Requires config.
+  *(filled in by #918/#923.)*
+- **`--audit`** — read-only. Reports missing scopes, stale verified examples,
+  and audience coverage gaps without writing any file. Requires config.
+  *(filled in by #919/#923.)*
+- **`--audience <name>`** — regenerate exactly one audience's docs. Requires
+  config; `<name>` must resolve to a configured (or default) audience.
+  *(filled in by #918.)*
+- **`init`** — the bootstrap. Scans the repo (features, entry points, existing
+  `docs/`) and scaffolds a `documentation:` block in `.autospec/autospec.yml`
+  plus starter doc scopes under `docs/<audience>/` per the folder contract. This
+  is the ONLY subcommand that runs WITHOUT an existing `documentation:` config —
+  it is what creates that config. *(scaffolding logic filled in by #917.)*
+
+**Config gate.** Every non-`init` subcommand exits `2` when no `documentation:`
+config is present in `.autospec/autospec.yml`: there is nothing to generate
+until `init` has scaffolded the config. The orchestrator enforces this gate
+deterministically; `init` is exempt by design.
+
+## Audience & content model
+
+Four default audiences, seeded by `init` only when `documentation.audiences` is
+empty: **user** (`docs/user`, "tasks, workflows, how to use features"),
+**developer** (`docs/developer`, "architecture, APIs, extending"), **admin**
+(`docs/admin`, "install, configure, operate, troubleshoot"), and **general**
+(`docs/general`, "what it is, why it matters, plain language"). Operators may
+declare custom audiences. *(config schema + folder-contract constants filled in
+by #917; per-audience generators by #918.)*
+
+Folder contract: `docs/<audience>/{index.md,getting-started.md,tutorials/<feature>.md,features/<feature>.md}`;
+developer adds `architecture/` + `api/`; admin links `docs/runbooks/`; shared
+assets live under `docs/assets/{screenshots,diagrams,transcripts}/`.
+
+## Docs-as-tests
+
+Every fenced code example in generated docs is executed against the repo, so
+documentation cannot silently drift from working code. Verified examples carry a
+`<!-- example-verified: <head-sha> <ISO-date> -->` marker; a re-run on a newer
+HEAD that no longer matches re-verifies or flags the example as stale.
+*(verification engine filled in by #919; `example_stale` drift key added there.)*
+
+## Style & palette
+
+The visual palette is **single-sourced** in `scripts/doc-style.mjs` — no other
+file may hardcode the palette hexes, and `scripts/validate.sh` enforces this.
+The palette also themes generated mermaid diagrams. *(palette resolution +
+mermaid theming filled in by #920.)*
+
+## llms-full.txt
+
+`--full` (and the orchestrator's concatenation step) emit an `llms-full.txt` at
+the repo root: the whole verified corpus, delimited per audience/feature with
+`<!-- llms: audience=<a> feature=<f> -->` markers, plus a `.llm-manifest.json`
+index. *(concatenator + manifest fill filled in by #921.)*
+
+## Pipeline wiring (downstream)
+
+Phase 4 of `/autospec-run` gains a `regenerate` self-heal action that calls
+`/autospec-doc` when docs drift is detected; Phase 5.5 gains a
+docs-completeness dimension; `/autospec-sweep --full` and `/autospec-define`'s
+auto-docs step redirect to `/autospec-doc`. *(wiring filled in by
+#922/#923/#924.)*
+
+## Invocation
+
+```
+/autospec-doc [--full | --audit | --audience <name> | init]
+```
+
+> **Model tier:** TIER_A (spec work) for the audience-content authoring pass and the completeness audit; TIER_B (implementation work) for deterministic generation, example verification, and style — resolved at startup per the harness detection above.
+
+The skill resolves the harness and tiers, runs the startup self-update preflight,
+then dispatches the parsed subcommand to `scripts/doc-orchestrator.mjs`. On a
+non-`init` subcommand with no `documentation:` config, it surfaces the orchestrator's
+exit-`2` message instructing the operator to run `/autospec-doc init` first.

--- a/skills/autospec-doc/codex/prompt.md
+++ b/skills/autospec-doc/codex/prompt.md
@@ -1,0 +1,227 @@
+
+# autospec-doc workflow (harness-neutral)
+
+Generate and maintain **per-audience project documentation** as a first-class,
+verifiable artifact. The product is documentation infrastructure: every page is
+audience-targeted (user / developer / admin / general), every code example is
+executed (docs-as-tests), the visual palette is single-sourced, and the whole
+corpus is concatenated into an `llms-full.txt` for downstream LLM consumption.
+
+Goal: documentation that a non-author can actually follow, that never silently
+drifts from the code, whose examples are proven to run, and whose token cost
+stays bounded through incremental regeneration. This skill is the operator
+entry point; the heavy lifting lives in `scripts/doc-orchestrator.mjs` and the
+per-capability generators it dispatches.
+
+This SKILL.md is the **scaffold contract** (issue #916). The subcommand router
+exists as a stub; the generator scripts (`gen-audience-docs.mjs`,
+`verify-examples.mjs`, `doc-style.mjs`, `gen-llms-full.mjs`) are header+stub
+here and filled in by downstream issues #917-#921. Sections below marked
+*(filled in by #NNN)* are intentional stubs.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-doc   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-loop
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the argument matches the regex `^\s*update\s*$` (case-insensitive,
+whitespace-padded), this skill enters self-update mode and does not run the
+normal pipeline. This section is pure prose: never interpolate or shell out the
+operator's argument text.
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-doc/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-doc.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-doc.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter the documentation pipeline. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-doc found; run install.sh first.` and exit.
+
+## Model tier
+
+Tier A/B model resolution and the harness-detection protocol are inherited
+verbatim from `AGENTS.md` (`## Subagent model selection (two-tier, cost-aware)`
+and `## Subagent vs inline decision matrix`). Audience-content authoring and the
+completeness audit run at Tier A (spec work — fresh-eyes reasoning produces
+better prose and catches gaps); deterministic generation, example verification,
+and palette resolution run at Tier B (implementation work).
+
+> **Model tier:** TIER_A (spec work) for the per-audience content pass and the completeness audit; TIER_B (implementation work) for deterministic generation, example verification, and style — resolved at startup per the harness detection below.
+
+### Required capabilities & harness adapter
+
+This workflow assumes the following capabilities. Map each to your harness's
+actual tool; if a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                                | Fallback if missing                              |
+|-----------------------------|-----------------------------------------|---------------------------------------|------------------------------------------|--------------------------------------------------|
+| Audience content authoring  | `Agent` (subagent_type=general-purpose) | `task` agent, await output            | run the authoring pass inline            | Author in-thread (more context cost)             |
+| Completeness / gap audit    | a **separate** `Agent` dispatch         | a **separate** `task` agent           | a separate inline judging pass           | Audit in-thread, never reuse the authoring pass  |
+| Read-only repo research     | `Agent` (subagent_type=Explore)         | `task` agent in read-only mode        | shell `grep`/`rg` read-only              | Search in-thread with `rg`/`grep`                |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                            | Ask in the response and wait for the next turn   |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+| Subagent dispatch policy    | per AGENTS.md decision matrix           | per AGENTS.md decision matrix         | per AGENTS.md decision matrix            | inline with main-session token cost              |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in
+the repo root — recognized by Claude Code, OpenCode, and Codex.
+
+## Harness detection (run once at skill start, before generation begins)
+
+Detect your harness by checking available tools before any dispatch:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; passes run inline.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness, silently retry
+the same subagent dispatch with `TIER_A`. Preserve parent context on retry.
+Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run.
+
+## Subcommand contract
+
+`/autospec-doc` routes every operation through `scripts/doc-orchestrator.mjs`.
+There are five forms; resolve the active repo's `<owner/name>` once and reuse it.
+
+```
+/autospec-doc                     # incremental — regenerate scopes affected since last generation
+/autospec-doc --full              # regenerate everything + run the completeness audit
+/autospec-doc --audit             # read-only completeness/drift report; writes nothing
+/autospec-doc --audience <name>   # regenerate one audience only (user|developer|admin|general|custom)
+/autospec-doc init                # scaffold the documentation: config + starter doc scopes
+```
+
+- **(bare) incremental** — the default and the cheap path. Scopes only the docs
+  affected since the last generation (changed features, drifted examples). Keeps
+  per-run token cost bounded; never regenerates the whole corpus. Requires a
+  `documentation:` config. *(scope-diff + generation filled in by #918/#919.)*
+- **`--full`** — regenerate every audience's pages from scratch and then run the
+  completeness audit. The expensive, exhaustive path. Requires config.
+  *(filled in by #918/#923.)*
+- **`--audit`** — read-only. Reports missing scopes, stale verified examples,
+  and audience coverage gaps without writing any file. Requires config.
+  *(filled in by #919/#923.)*
+- **`--audience <name>`** — regenerate exactly one audience's docs. Requires
+  config; `<name>` must resolve to a configured (or default) audience.
+  *(filled in by #918.)*
+- **`init`** — the bootstrap. Scans the repo (features, entry points, existing
+  `docs/`) and scaffolds a `documentation:` block in `.autospec/autospec.yml`
+  plus starter doc scopes under `docs/<audience>/` per the folder contract. This
+  is the ONLY subcommand that runs WITHOUT an existing `documentation:` config —
+  it is what creates that config. *(scaffolding logic filled in by #917.)*
+
+**Config gate.** Every non-`init` subcommand exits `2` when no `documentation:`
+config is present in `.autospec/autospec.yml`: there is nothing to generate
+until `init` has scaffolded the config. The orchestrator enforces this gate
+deterministically; `init` is exempt by design.
+
+## Audience & content model
+
+Four default audiences, seeded by `init` only when `documentation.audiences` is
+empty: **user** (`docs/user`, "tasks, workflows, how to use features"),
+**developer** (`docs/developer`, "architecture, APIs, extending"), **admin**
+(`docs/admin`, "install, configure, operate, troubleshoot"), and **general**
+(`docs/general`, "what it is, why it matters, plain language"). Operators may
+declare custom audiences. *(config schema + folder-contract constants filled in
+by #917; per-audience generators by #918.)*
+
+Folder contract: `docs/<audience>/{index.md,getting-started.md,tutorials/<feature>.md,features/<feature>.md}`;
+developer adds `architecture/` + `api/`; admin links `docs/runbooks/`; shared
+assets live under `docs/assets/{screenshots,diagrams,transcripts}/`.
+
+## Docs-as-tests
+
+Every fenced code example in generated docs is executed against the repo, so
+documentation cannot silently drift from working code. Verified examples carry a
+`<!-- example-verified: <head-sha> <ISO-date> -->` marker; a re-run on a newer
+HEAD that no longer matches re-verifies or flags the example as stale.
+*(verification engine filled in by #919; `example_stale` drift key added there.)*
+
+## Style & palette
+
+The visual palette is **single-sourced** in `scripts/doc-style.mjs` — no other
+file may hardcode the palette hexes, and `scripts/validate.sh` enforces this.
+The palette also themes generated mermaid diagrams. *(palette resolution +
+mermaid theming filled in by #920.)*
+
+## llms-full.txt
+
+`--full` (and the orchestrator's concatenation step) emit an `llms-full.txt` at
+the repo root: the whole verified corpus, delimited per audience/feature with
+`<!-- llms: audience=<a> feature=<f> -->` markers, plus a `.llm-manifest.json`
+index. *(concatenator + manifest fill filled in by #921.)*
+
+## Pipeline wiring (downstream)
+
+Phase 4 of `/autospec-run` gains a `regenerate` self-heal action that calls
+`/autospec-doc` when docs drift is detected; Phase 5.5 gains a
+docs-completeness dimension; `/autospec-sweep --full` and `/autospec-define`'s
+auto-docs step redirect to `/autospec-doc`. *(wiring filled in by
+#922/#923/#924.)*
+
+## Invocation
+
+```
+/autospec-doc [--full | --audit | --audience <name> | init]
+```
+
+> **Model tier:** TIER_A (spec work) for the audience-content authoring pass and the completeness audit; TIER_B (implementation work) for deterministic generation, example verification, and style — resolved at startup per the harness detection above.
+
+The skill resolves the harness and tiers, runs the startup self-update preflight,
+then dispatches the parsed subcommand to `scripts/doc-orchestrator.mjs`. On a
+non-`init` subcommand with no `documentation:` config, it surfaces the orchestrator's
+exit-`2` message instructing the operator to run `/autospec-doc init` first.

--- a/skills/autospec-doc/install.sh
+++ b/skills/autospec-doc/install.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --symlink           # symlink instead of copy (updates propagate)
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-doc/install.sh \
+#     | sh -s -- --harness all
+# When piped, the script auto-downloads the skill files from the same branch.
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPEC_DOC_REF         (default: main) — git ref to fetch from when piped
+#   AUTOSPEC_DOC_RAW_BASE    (override the raw URL base entirely)
+#
+# Idempotent: re-running upgrades the install. Exits non-zero on hard failure;
+# exits zero with warnings on missing optional deps.
+
+set -eu
+
+SKILL_NAME="autospec-doc"
+SKILL_RAW_BASE="${AUTOSPEC_DOC_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_DOC_REF:-main}/skills/autospec-doc}"
+
+# Resolve the directory containing this script. When piped through stdin (e.g.
+# `curl ... | sh`), $0 will not be a real file — detect that and fall back to
+# downloading the source files from the raw GitHub URL.
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+USE_SYMLINK=0
+DRY_RUN=0
+UPDATE_MODE=0
+TMP_FETCH_DIR=""
+SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+
+# ---------- helpers --------------------------------------------------------
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+warn() { printf 'warn:  %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--symlink] [--dry-run] [--update]
+
+Installs the ${SKILL_NAME} skill into the chosen harness's standard
+skill/agent/prompt directory.
+
+Examples:
+  $0                          # interactive
+  $0 --harness all            # install everywhere
+  $0 --harness claude         # Claude Code only
+  $0 --harness opencode       # OpenCode only
+  $0 --harness codex          # Codex CLI only
+  $0 --harness all --symlink  # symlink instead of copy
+  $0 --dry-run --harness all  # print plan, change nothing
+  $0 --harness claude --update  # idempotent re-install (overwrite existing)
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+cleanup() {
+    if [ -n "${TMP_FETCH_DIR:-}" ] && [ -d "$TMP_FETCH_DIR" ]; then
+        rm -rf "$TMP_FETCH_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+fetch_source_files() {
+    # Download the files we need into a temp dir and set SKILL_DIR to it.
+    if ! command -v curl >/dev/null 2>&1; then
+        err "curl is required when running from stdin (e.g. piped via 'curl | sh')."
+        exit 1
+    fi
+    TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
+    info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
+    for rel in SKILL.md opencode/agent.md codex/prompt.md; do
+        if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
+            err "failed to download $SKILL_RAW_BASE/$rel"
+            exit 1
+        fi
+    done
+    for rel in $SHARED_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
+    SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+resolve_shared_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/scripts" ]; then
+        printf '%s\n' "$checkout_root/scripts"
+    elif [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_shared_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autospec helper scripts"
+        return 1
+    fi
+    for rel in $SHARED_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
+}
+
+install_one() {
+    src="$1"
+    dest="$2"
+    dest_dir="$(dirname "$dest")"
+
+    if [ ! -f "$src" ]; then
+        err "missing source file: $src"
+        return 1
+    fi
+
+    run "mkdir -p \"$dest_dir\""
+
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        run "rm -f \"$dest\""
+        run "ln -s \"$src\" \"$dest\""
+        info "  symlinked: $dest -> $src"
+    else
+        run "cp \"$src\" \"$dest\""
+        info "  installed: $dest"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --symlink)
+            USE_SYMLINK=1
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        --update)
+            UPDATE_MODE=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# ---------- harness prompt -------------------------------------------------
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install for?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- ensure source files are available ------------------------------
+
+# If we couldn't resolve a local SKILL_DIR (piped from curl) OR the local dir
+# doesn't actually contain the skill files, fall back to remote fetch.
+need_fetch=0
+if [ -z "$SKILL_DIR" ]; then
+    need_fetch=1
+elif [ ! -f "$SKILL_DIR/SKILL.md" ] || [ ! -f "$SKILL_DIR/opencode/agent.md" ] || [ ! -f "$SKILL_DIR/codex/prompt.md" ]; then
+    need_fetch=1
+fi
+
+if [ "$need_fetch" -eq 1 ]; then
+    if [ "$USE_SYMLINK" -eq 1 ]; then
+        err "--symlink requires running from a checkout of the codex-skills repo (no local files to symlink to)."
+        exit 2
+    fi
+    fetch_source_files
+fi
+
+# ---------- dependency checks ---------------------------------------------
+
+dep_warnings=0
+
+check_dep() {
+    name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        warn "$name not found on PATH (required by the skill at runtime)"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+}
+
+check_dep git
+check_dep gh
+check_dep jq
+
+if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+        warn "gh is installed but not authenticated. Run: gh auth login"
+        dep_warnings=$((dep_warnings + 1))
+    fi
+fi
+
+if [ "$dep_warnings" -gt 0 ]; then
+    warn "${dep_warnings} dependency warning(s) above. The skill files will still install."
+fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+CLAUDE_SRC="$SKILL_DIR/SKILL.md"
+OPENCODE_SRC="$SKILL_DIR/opencode/agent.md"
+CODEX_SRC="$SKILL_DIR/codex/prompt.md"
+
+# ---------- install --------------------------------------------------------
+
+installed_paths=""
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_SRC" "$CLAUDE_DEST"
+    installed_paths="${installed_paths}  Claude Code: ${CLAUDE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_SRC" "$OPENCODE_DEST"
+    installed_paths="${installed_paths}  OpenCode:    ${OPENCODE_DEST}\n"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_SRC" "$CODEX_DEST"
+    install_one "$CLAUDE_SRC" "$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+    installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
+    installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
+fi
+
+# ---------- final summary --------------------------------------------------
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    if [ "$UPDATE_MODE" -eq 1 ]; then
+        info "Updated (idempotent overwrite):"
+    else
+        info "Installed:"
+    fi
+    printf '%b' "$installed_paths"
+    info ""
+    info "Invoke with:"
+    info "  Claude Code:  /${SKILL_NAME} <feature description>"
+    info "  OpenCode:     @${SKILL_NAME} <feature description>"
+    info "  Codex CLI:    /${SKILL_NAME} <feature description>"
+fi
+
+exit 0

--- a/skills/autospec-doc/opencode/agent.md
+++ b/skills/autospec-doc/opencode/agent.md
@@ -1,0 +1,231 @@
+---
+description: Use when the user wants to generate, regenerate, or audit per-audience project documentation (user, developer, admin, general) as docs-as-tests — incremental by default, with --full, --audit, --audience <name>, and an init scaffolder. Single-source palette, verified examples, and llms-full.txt output. Hands generation to scripts/doc-orchestrator.mjs.
+mode: primary
+---
+
+# autospec-doc workflow (harness-neutral)
+
+Generate and maintain **per-audience project documentation** as a first-class,
+verifiable artifact. The product is documentation infrastructure: every page is
+audience-targeted (user / developer / admin / general), every code example is
+executed (docs-as-tests), the visual palette is single-sourced, and the whole
+corpus is concatenated into an `llms-full.txt` for downstream LLM consumption.
+
+Goal: documentation that a non-author can actually follow, that never silently
+drifts from the code, whose examples are proven to run, and whose token cost
+stays bounded through incremental regeneration. This skill is the operator
+entry point; the heavy lifting lives in `scripts/doc-orchestrator.mjs` and the
+per-capability generators it dispatches.
+
+This SKILL.md is the **scaffold contract** (issue #916). The subcommand router
+exists as a stub; the generator scripts (`gen-audience-docs.mjs`,
+`verify-examples.mjs`, `doc-style.mjs`, `gen-llms-full.mjs`) are header+stub
+here and filled in by downstream issues #917-#921. Sections below marked
+*(filled in by #NNN)* are intentional stubs.
+
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME=autospec-doc   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify / autospec-loop
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```
+
+## Self-update mode
+
+If the argument matches the regex `^\s*update\s*$` (case-insensitive,
+whitespace-padded), this skill enters self-update mode and does not run the
+normal pipeline. This section is pure prose: never interpolate or shell out the
+operator's argument text.
+
+1. **Detect harness** by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-doc/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-doc.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-doc.md`
+2. **Re-install the full autospec suite from `main`** by piping the canonical installer:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. **Show the diff** between the prior installed file(s) and the freshly fetched copy.
+4. **Stop.** Do not enter the documentation pipeline. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-doc found; run install.sh first.` and exit.
+
+## Model tier
+
+Tier A/B model resolution and the harness-detection protocol are inherited
+verbatim from `AGENTS.md` (`## Subagent model selection (two-tier, cost-aware)`
+and `## Subagent vs inline decision matrix`). Audience-content authoring and the
+completeness audit run at Tier A (spec work — fresh-eyes reasoning produces
+better prose and catches gaps); deterministic generation, example verification,
+and palette resolution run at Tier B (implementation work).
+
+> **Model tier:** TIER_A (spec work) for the per-audience content pass and the completeness audit; TIER_B (implementation work) for deterministic generation, example verification, and style — resolved at startup per the harness detection below.
+
+### Required capabilities & harness adapter
+
+This workflow assumes the following capabilities. Map each to your harness's
+actual tool; if a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                                | Fallback if missing                              |
+|-----------------------------|-----------------------------------------|---------------------------------------|------------------------------------------|--------------------------------------------------|
+| Audience content authoring  | `Agent` (subagent_type=general-purpose) | `task` agent, await output            | run the authoring pass inline            | Author in-thread (more context cost)             |
+| Completeness / gap audit    | a **separate** `Agent` dispatch         | a **separate** `task` agent           | a separate inline judging pass           | Audit in-thread, never reuse the authoring pass  |
+| Read-only repo research     | `Agent` (subagent_type=Explore)         | `task` agent in read-only mode        | shell `grep`/`rg` read-only              | Search in-thread with `rg`/`grep`                |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                            | Ask in the response and wait for the next turn   |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+| Subagent dispatch policy    | per AGENTS.md decision matrix           | per AGENTS.md decision matrix         | per AGENTS.md decision matrix            | inline with main-session token cost              |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in
+the repo root — recognized by Claude Code, OpenCode, and Codex.
+
+## Harness detection (run once at skill start, before generation begins)
+
+Detect your harness by checking available tools before any dispatch:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`  (model ID: claude-opus-4-7)
+   - `TIER_B` = `sonnet`               (model ID: claude-sonnet-4-6)
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available; passes run inline.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available in your harness, silently retry
+the same subagent dispatch with `TIER_A`. Preserve parent context on retry.
+Never ask the user.
+
+Hold `TIER_A` and `TIER_B` for the entire skill run.
+
+## Subcommand contract
+
+`/autospec-doc` routes every operation through `scripts/doc-orchestrator.mjs`.
+There are five forms; resolve the active repo's `<owner/name>` once and reuse it.
+
+```
+/autospec-doc                     # incremental — regenerate scopes affected since last generation
+/autospec-doc --full              # regenerate everything + run the completeness audit
+/autospec-doc --audit             # read-only completeness/drift report; writes nothing
+/autospec-doc --audience <name>   # regenerate one audience only (user|developer|admin|general|custom)
+/autospec-doc init                # scaffold the documentation: config + starter doc scopes
+```
+
+- **(bare) incremental** — the default and the cheap path. Scopes only the docs
+  affected since the last generation (changed features, drifted examples). Keeps
+  per-run token cost bounded; never regenerates the whole corpus. Requires a
+  `documentation:` config. *(scope-diff + generation filled in by #918/#919.)*
+- **`--full`** — regenerate every audience's pages from scratch and then run the
+  completeness audit. The expensive, exhaustive path. Requires config.
+  *(filled in by #918/#923.)*
+- **`--audit`** — read-only. Reports missing scopes, stale verified examples,
+  and audience coverage gaps without writing any file. Requires config.
+  *(filled in by #919/#923.)*
+- **`--audience <name>`** — regenerate exactly one audience's docs. Requires
+  config; `<name>` must resolve to a configured (or default) audience.
+  *(filled in by #918.)*
+- **`init`** — the bootstrap. Scans the repo (features, entry points, existing
+  `docs/`) and scaffolds a `documentation:` block in `.autospec/autospec.yml`
+  plus starter doc scopes under `docs/<audience>/` per the folder contract. This
+  is the ONLY subcommand that runs WITHOUT an existing `documentation:` config —
+  it is what creates that config. *(scaffolding logic filled in by #917.)*
+
+**Config gate.** Every non-`init` subcommand exits `2` when no `documentation:`
+config is present in `.autospec/autospec.yml`: there is nothing to generate
+until `init` has scaffolded the config. The orchestrator enforces this gate
+deterministically; `init` is exempt by design.
+
+## Audience & content model
+
+Four default audiences, seeded by `init` only when `documentation.audiences` is
+empty: **user** (`docs/user`, "tasks, workflows, how to use features"),
+**developer** (`docs/developer`, "architecture, APIs, extending"), **admin**
+(`docs/admin`, "install, configure, operate, troubleshoot"), and **general**
+(`docs/general`, "what it is, why it matters, plain language"). Operators may
+declare custom audiences. *(config schema + folder-contract constants filled in
+by #917; per-audience generators by #918.)*
+
+Folder contract: `docs/<audience>/{index.md,getting-started.md,tutorials/<feature>.md,features/<feature>.md}`;
+developer adds `architecture/` + `api/`; admin links `docs/runbooks/`; shared
+assets live under `docs/assets/{screenshots,diagrams,transcripts}/`.
+
+## Docs-as-tests
+
+Every fenced code example in generated docs is executed against the repo, so
+documentation cannot silently drift from working code. Verified examples carry a
+`<!-- example-verified: <head-sha> <ISO-date> -->` marker; a re-run on a newer
+HEAD that no longer matches re-verifies or flags the example as stale.
+*(verification engine filled in by #919; `example_stale` drift key added there.)*
+
+## Style & palette
+
+The visual palette is **single-sourced** in `scripts/doc-style.mjs` — no other
+file may hardcode the palette hexes, and `scripts/validate.sh` enforces this.
+The palette also themes generated mermaid diagrams. *(palette resolution +
+mermaid theming filled in by #920.)*
+
+## llms-full.txt
+
+`--full` (and the orchestrator's concatenation step) emit an `llms-full.txt` at
+the repo root: the whole verified corpus, delimited per audience/feature with
+`<!-- llms: audience=<a> feature=<f> -->` markers, plus a `.llm-manifest.json`
+index. *(concatenator + manifest fill filled in by #921.)*
+
+## Pipeline wiring (downstream)
+
+Phase 4 of `/autospec-run` gains a `regenerate` self-heal action that calls
+`/autospec-doc` when docs drift is detected; Phase 5.5 gains a
+docs-completeness dimension; `/autospec-sweep --full` and `/autospec-define`'s
+auto-docs step redirect to `/autospec-doc`. *(wiring filled in by
+#922/#923/#924.)*
+
+## Invocation
+
+```
+/autospec-doc [--full | --audit | --audience <name> | init]
+```
+
+> **Model tier:** TIER_A (spec work) for the audience-content authoring pass and the completeness audit; TIER_B (implementation work) for deterministic generation, example verification, and style — resolved at startup per the harness detection above.
+
+The skill resolves the harness and tiers, runs the startup self-update preflight,
+then dispatches the parsed subcommand to `scripts/doc-orchestrator.mjs`. On a
+non-`init` subcommand with no `documentation:` config, it surfaces the orchestrator's
+exit-`2` message instructing the operator to run `/autospec-doc init` first.

--- a/skills/autospec-doc/scripts/doc-orchestrator.mjs
+++ b/skills/autospec-doc/scripts/doc-orchestrator.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// doc-orchestrator.mjs — subcommand router for the /autospec-doc skill.
+//
+// This is the scaffold ROUTER STUB (issue #916). It parses the subcommand
+// contract and dispatches to named no-op handlers. The generator logic
+// (gen-audience-docs, verify-examples, doc-style, gen-llms-full) is filled in
+// by downstream issues #917-#921; here every handler is a planning no-op that
+// prints what it WOULD do.
+//
+// Subcommand contract (spec §D1):
+//   /autospec-doc            incremental — scope docs affected since last gen
+//   --full                   regenerate everything + completeness audit
+//   --audit                  read-only completeness/drift report
+//   --audience <name>        regenerate one audience only
+//   init                     scaffold the documentation: config + starter scopes
+//
+// Exit codes:
+//   0  handler dispatched
+//   2  usage error, OR a non-`init` subcommand was invoked with no
+//      `documentation:` config present (config is required to know what to
+//      generate; `init` is the bootstrap that CREATES that config).
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ── Config detection ──────────────────────────────────────────────────────────
+// The real config loader lands in #917. For the scaffold we only need to answer
+// one question: does a `documentation:` block exist in `.autospec/autospec.yml`?
+// Non-`init` subcommands require it; `init` is what creates it.
+const CONFIG_PATH = process.env.AUTOSPEC_DOC_CONFIG
+  || path.join('.autospec', 'autospec.yml');
+
+function hasDocumentationConfig(configPath) {
+  try {
+    const raw = fs.readFileSync(configPath, 'utf8');
+    // Match a top-level `documentation:` key (start of line, no indentation).
+    return /^documentation:\s*$/m.test(raw) || /^documentation:\s*\S/m.test(raw);
+  } catch {
+    return false;
+  }
+}
+
+// ── Handlers (no-op stubs; filled by downstream issues) ───────────────────────
+
+function handleIncremental(_opts) {
+  console.log('[autospec-doc] incremental: plan scopes affected since last generation (stub — #918/#919).');
+  return 0;
+}
+
+function handleFull(_opts) {
+  console.log('[autospec-doc] full: regenerate every audience + run completeness audit (stub — #918/#923).');
+  return 0;
+}
+
+function handleAudit(_opts) {
+  console.log('[autospec-doc] audit: read-only completeness/drift report (stub — #919/#923).');
+  return 0;
+}
+
+function handleAudience(opts) {
+  if (!opts.audience) {
+    console.error('[autospec-doc] --audience requires a <name> argument.');
+    return 2;
+  }
+  console.log(`[autospec-doc] audience: regenerate "${opts.audience}" only (stub — #918).`);
+  return 0;
+}
+
+function handleInit(_opts) {
+  // init is the bootstrap: it scans the repo and scaffolds the documentation:
+  // config block + starter doc scopes. The real scaffolding logic lands in #917
+  // (config schema + folder contract). The scaffold prints the plan.
+  console.log('[autospec-doc] init: scaffold plan');
+  console.log('  - scan the repo for features, entry points, and existing docs/');
+  console.log('  - write a `documentation:` block to .autospec/autospec.yml (default audiences: user, developer, admin, general)');
+  console.log('  - create starter doc scopes under docs/<audience>/ per the folder contract');
+  console.log('  (scaffolding logic filled in by #917)');
+  return 0;
+}
+
+// ── Argv parsing ──────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  // Returns { subcommand, audience } where subcommand is one of:
+  //   incremental | full | audit | audience | init | usage
+  const opts = { subcommand: 'incremental', audience: null };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case 'init':
+        opts.subcommand = 'init';
+        break;
+      case '--full':
+        opts.subcommand = 'full';
+        break;
+      case '--audit':
+        opts.subcommand = 'audit';
+        break;
+      case '--audience':
+        opts.subcommand = 'audience';
+        opts.audience = argv[i + 1] || null;
+        i++; // consume the value
+        break;
+      case '-h':
+      case '--help':
+        opts.subcommand = 'usage';
+        break;
+      default:
+        console.error(`[autospec-doc] unknown argument: ${arg}`);
+        opts.subcommand = 'usage';
+        return opts;
+    }
+  }
+  return opts;
+}
+
+function usage() {
+  console.log('Usage: doc-orchestrator.mjs [--full | --audit | --audience <name> | init]');
+  console.log('  (no subcommand)     incremental regeneration of affected scopes');
+  console.log('  --full              regenerate everything + completeness audit');
+  console.log('  --audit             read-only completeness/drift report');
+  console.log('  --audience <name>   regenerate one audience only');
+  console.log('  init                scaffold documentation: config + starter scopes');
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  if (opts.subcommand === 'usage') {
+    usage();
+    return 2;
+  }
+
+  // Every subcommand except `init` requires a `documentation:` config: without
+  // it there is nothing to generate. `init` is the bootstrap that creates it.
+  if (opts.subcommand !== 'init' && !hasDocumentationConfig(CONFIG_PATH)) {
+    console.error(
+      `[autospec-doc] no \`documentation:\` config found at ${CONFIG_PATH}. `
+      + 'Run `/autospec-doc init` first to scaffold it.',
+    );
+    return 2;
+  }
+
+  switch (opts.subcommand) {
+    case 'init':        return handleInit(opts);
+    case 'full':        return handleFull(opts);
+    case 'audit':       return handleAudit(opts);
+    case 'audience':    return handleAudience(opts);
+    case 'incremental': return handleIncremental(opts);
+    default:
+      usage();
+      return 2;
+  }
+}
+
+process.exit(main());

--- a/skills/autospec-doc/scripts/doc-orchestrator.mjs
+++ b/skills/autospec-doc/scripts/doc-orchestrator.mjs
@@ -96,11 +96,20 @@ function parseArgs(argv) {
       case '--audit':
         opts.subcommand = 'audit';
         break;
-      case '--audience':
+      case '--audience': {
+        const next = argv[i + 1];
+        // The value must be a real name, not another flag or a missing arg.
+        // `--audience --full` or a trailing `--audience` is a usage error.
+        if (next === undefined || next.startsWith('-')) {
+          console.error('[autospec-doc] --audience requires a <name> argument.');
+          opts.subcommand = 'usage';
+          return opts;
+        }
         opts.subcommand = 'audience';
-        opts.audience = argv[i + 1] || null;
+        opts.audience = next;
         i++; // consume the value
         break;
+      }
       case '-h':
       case '--help':
         opts.subcommand = 'usage';

--- a/skills/autospec-doc/tests/doc-orchestrator.bats
+++ b/skills/autospec-doc/tests/doc-orchestrator.bats
@@ -101,6 +101,12 @@ EOF
   [ "$status" -eq 2 ]
 }
 
+@test "--audience followed by a flag is a usage error, not an audience name" {
+  seed_config
+  run node "$ORCH" --audience --full
+  [ "$status" -eq 2 ]
+}
+
 @test "unknown argument prints usage and exits 2" {
   seed_config
   run node "$ORCH" --bogus

--- a/skills/autospec-doc/tests/doc-orchestrator.bats
+++ b/skills/autospec-doc/tests/doc-orchestrator.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# doc-orchestrator.bats — TDD for skills/autospec-doc/scripts/doc-orchestrator.mjs (issue #916)
+#
+# The orchestrator is a router stub: it parses the §D1 subcommand contract,
+# dispatches to distinct named handlers, and exits 2 when a non-`init`
+# subcommand runs without a `documentation:` config.
+
+ORCH="${BATS_TEST_DIRNAME}/../scripts/doc-orchestrator.mjs"
+
+setup() {
+  TESTDIR="$(mktemp -d)"
+  cd "$TESTDIR"
+}
+
+teardown() {
+  rm -rf "$TESTDIR"
+}
+
+# Seed a minimal .autospec/autospec.yml carrying a documentation: block so the
+# config gate passes for non-init subcommands.
+seed_config() {
+  mkdir -p .autospec
+  cat > .autospec/autospec.yml <<'EOF'
+documentation:
+  audiences:
+    - name: user
+      path: docs/user
+EOF
+}
+
+@test "init prints a scaffold plan and exits 0 (no config required)" {
+  run node "$ORCH" init
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"init: scaffold plan"* ]]
+}
+
+@test "init works even with no documentation config present" {
+  # No seed_config — init is the bootstrap that creates the config.
+  run node "$ORCH" init
+  [ "$status" -eq 0 ]
+}
+
+@test "bare invocation routes to the incremental handler" {
+  seed_config
+  run node "$ORCH"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"incremental:"* ]]
+}
+
+@test "--full routes to the full handler" {
+  seed_config
+  run node "$ORCH" --full
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"full:"* ]]
+}
+
+@test "--audit routes to the audit handler" {
+  seed_config
+  run node "$ORCH" --audit
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"audit:"* ]]
+}
+
+@test "--audience <name> routes to the audience handler with the name" {
+  seed_config
+  run node "$ORCH" --audience developer
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"developer"* ]]
+}
+
+@test "bare, --full, --audit, --audience route to DISTINCT handlers" {
+  seed_config
+  bare="$(node "$ORCH" 2>&1)"
+  full="$(node "$ORCH" --full 2>&1)"
+  audit="$(node "$ORCH" --audit 2>&1)"
+  aud="$(node "$ORCH" --audience admin 2>&1)"
+  # All four outputs must differ from each other.
+  [ "$bare" != "$full" ]
+  [ "$bare" != "$audit" ]
+  [ "$bare" != "$aud" ]
+  [ "$full" != "$audit" ]
+  [ "$full" != "$aud" ]
+  [ "$audit" != "$aud" ]
+}
+
+@test "non-init subcommand with no documentation config exits 2" {
+  # No seed_config.
+  run node "$ORCH" --full
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"init"* ]]
+}
+
+@test "bare incremental with no documentation config exits 2" {
+  run node "$ORCH"
+  [ "$status" -eq 2 ]
+}
+
+@test "--audience without a name exits 2" {
+  seed_config
+  run node "$ORCH" --audience
+  [ "$status" -eq 2 ]
+}
+
+@test "unknown argument prints usage and exits 2" {
+  seed_config
+  run node "$ORCH" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Usage:"* ]]
+}

--- a/skills/autospec-doc/uninstall.sh
+++ b/skills/autospec-doc/uninstall.sh
@@ -125,6 +125,7 @@ CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
 CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
 OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
 CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+CODEX_SKILL_DEST="$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
 
 # ---------- remove ---------------------------------------------------------
 
@@ -144,6 +145,7 @@ if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
     info ""
     info "Codex CLI:"
     remove_one "$CODEX_DEST"
+    remove_one "$CODEX_SKILL_DEST"
 fi
 
 info ""

--- a/skills/autospec-doc/uninstall.sh
+++ b/skills/autospec-doc/uninstall.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autospec-doc"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run "rm -f \"$target\""
+        info "  removed: $target"
+        # Try to remove an empty parent skill directory (Claude only — its layout
+        # has a per-skill subdir).
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse ------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift
+            HARNESS="${1:-}"
+            ;;
+        --harness=*)
+            HARNESS="${1#--harness=}"
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            err "unknown arg: $1"
+            usage
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths ---------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+
+# ---------- remove ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0


### PR DESCRIPTION
Closes #916

## Summary

Scaffolds the new `skills/autospec-doc/` per-audience documentation generator per spec §D1 — the lock-step trio, packaging, and the subcommand router stub. Generator logic, config schema, and pipeline wiring are header+stub here and land in #917-#924.

## What's in

- **Lock-step trio** — `SKILL.md`, `codex/prompt.md`, `opencode/agent.md` with byte-identical bodies (codex first line blank; opencode carries its own frontmatter). Each body carries: canonical Startup self-update (`SKILL_NAME=autospec-doc`), pure-prose Self-update mode, Model tier + harness adapter + harness detection, and the **Subcommand contract** section.
- **`scripts/doc-orchestrator.mjs`** — subcommand router stub. Routes the §D1 contract (`/autospec-doc` incremental | `--full` | `--audit` | `--audience <name>` | `init`) to distinct named no-op handlers. Exits `2` when a non-`init` subcommand runs with no `documentation:` config (`init` is the bootstrap that creates that config). Strict `--audience` value parsing.
- **`README.md`, `install.sh`, `uninstall.sh`** — mirror `skills/autospec-loop` packaging shape.
- **`scripts/validate.sh`** — registers `autospec-doc` in the startup-preflight, codex-skills-install, and shared-script-install lists, plus a new `check_autospec_doc_contract` (subcommand-contract lock-step across the trio, orchestrator `node --check` + config-gate exit-2, bats suite). Generic trio checks run via the `discover_skills` auto-discovery loop.
- **`tests/doc-orchestrator.bats`** — 12 cases: init no-op, distinct-handler routing for bare/--full/--audit/--audience, missing-config exit-2, strict --audience.

## Verification

- `node skills/autospec-doc/scripts/doc-orchestrator.mjs --audit; bash scripts/validate.sh` — both exit 0 (primary smoke).
- `bash scripts/validate.sh` exits 0 (lock-step, frontmatter, self-update, model-tier, harness-detection, install-shape, + new contract all green).
- 12/12 bats pass; `bash -n` clean on install/uninstall; trio bodies byte-identical (frontmatter-stripped diff empty).
- No reuse — new skill scaffold; install/uninstall mirror `autospec-loop`, orchestrator follows the existing `.mjs` argv-router convention without sharing code.

## Peer-review notes (addressed)

Codex peer review flagged and I fixed: uninstall now removes the Codex skills-dir copy install creates; `--audience` rejects missing/option-looking values as a usage error.

## Peer-review notes (not addressed)

- *install.sh does not install `doc-orchestrator.mjs` into harness dirs* — this matches the established `autospec-loop` pattern (skill-specific scripts run from the checkout / `~/.autospec/scripts`, not the harness skill dir); changing it is out of scope for the scaffold and would diverge from every sibling skill.
- *`eval "\$@"` in `run()`* — inherited verbatim from every autospec installer; values are the operator's own env on their own machine. Out of scope for this issue; a fleet-wide installer hardening would be a separate change.