### PR TITLE
feat(autospec-doc): config schema + folder contract + working init (D2)

### DIFF
--- a/skills/autospec-doc/README.md
+++ b/skills/autospec-doc/README.md
@@ -15,10 +15,11 @@ Works on **Claude Code**, **OpenCode**, and **Codex CLI**.
 
 > **Status:** scaffold (issue #916). This issue ships the lock-step trio with
 > the required structural sections, packaging, and the `doc-orchestrator.mjs`
-> router stub. The generators (`gen-audience-docs.mjs`, `verify-examples.mjs`,
-> `doc-style.mjs`, `gen-llms-full.mjs`), the config schema + folder contract,
-> and the Phase 4 / Phase 5.5 / sweep / define wiring land in follow-up child
-> issues #917-#924.
+> router stub. The config schema + folder contract (`scripts/doc-config.mjs`)
+> and the working `init` scaffolder landed in #917. The generators
+> (`gen-audience-docs.mjs`, `verify-examples.mjs`, `doc-style.mjs`,
+> `gen-llms-full.mjs`) and the Phase 4 / Phase 5.5 / sweep / define wiring land
+> in follow-up child issues #918-#924.
 
 ## Subcommands
 
@@ -73,10 +74,43 @@ a conformant autospec skill:
 
 ## Config
 
-`.autospec/autospec.yml` `documentation:` block. `init` seeds the four default
-audiences (user → `docs/user`, developer → `docs/developer`, admin →
-`docs/admin`, general → `docs/general`) only when `audiences:` is empty.
-*(Schema + folder-contract path constants land in #917.)*
+`.autospec/autospec.yml` `documentation:` block, parsed by
+`scripts/doc-config.mjs`. `init` seeds the four default audiences (user →
+`docs/user`, developer → `docs/developer`, admin → `docs/admin`, general →
+`docs/general`) only when `audiences:` is empty.
+
+```yaml
+documentation:
+  audiences:
+    - {name: user,      path: docs/user,      focus: "tasks, workflows, how to use features"}
+    - {name: developer, path: docs/developer, focus: "architecture, APIs, extending"}
+    - {name: admin,     path: docs/admin,     focus: "install, configure, operate, troubleshoot"}
+    - {name: general,   path: docs/general,   focus: "what it is, why it matters, plain language"}
+  style:
+    palette: light-blue        # named preset (default: light-blue)
+  examples:
+    verify: true               # docs-as-tests on/off (default: true)
+    sandbox: worktree          # example execution isolation (default: worktree)
+```
+
+**Folder contract** per audience: `index.md`, `getting-started.md`,
+`tutorials/<feature>.md`, `features/<feature>.md`; **developer** additionally
+gets `architecture/` + `api/`; **admin** links `docs/runbooks/`; shared assets
+live under `docs/assets/{screenshots,diagrams,transcripts}/`. The path constants
+are exported from `scripts/doc-config.mjs` as `FOLDER_CONTRACT`.
+
+### Migration note
+
+The `style` and `examples` keys are **new and optional** — existing
+`documentation:` configs keep working unchanged. If your repo already declares
+`audiences:` (including custom audiences such as `operators` or
+`security-reviewers`, or legacy entries keyed by `id`/`label`), those entries
+are preserved **verbatim**: the loader never rewrites their
+`name`/`path`/`focus`/`require_scope` fields and does **not** inject the four
+defaults when any audience is already declared. To adopt the new behavior, add a
+`style:` and/or `examples:` block; omit them to accept the defaults
+(`palette: light-blue`, `examples.verify: true`, `examples.sandbox: worktree`).
+No action is required to upgrade.
 
 ## Self-update
 

--- a/skills/autospec-doc/scripts/doc-config.mjs
+++ b/skills/autospec-doc/scripts/doc-config.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+// doc-config.mjs — config loader for /autospec-doc (issue #917)
+//
+// Parses the `documentation:` block from .autospec/autospec.yml, applies
+// defaults for the new optional `style` and `examples` keys, and seeds the
+// four default audiences (user/developer/admin/general) when `audiences:` is
+// absent or empty.
+//
+// Existing `audiences:` entries (with any key shape — name/id/label/path/focus/
+// require_scope) are preserved verbatim; this module never mutates or replaces
+// them. The issue's shared-contracts block is the single source of truth for
+// default audience strings; any change there must propagate here.
+//
+// Exports:
+//   loadConfig(configPath) → { audiences, style, examples }
+//   DEFAULT_AUDIENCES — the four canonical defaults (array, read-only)
+//   FOLDER_CONTRACT   — the approved folder-contract constants (object, read-only)
+
+import fs from 'node:fs';
+
+// ── Default audiences (spec §D2; shared-contracts block pinned 2026-06-03) ────
+
+export const DEFAULT_AUDIENCES = Object.freeze([
+  Object.freeze({
+    name: 'user',
+    path: 'docs/user',
+    focus: 'tasks, workflows, how to use features',
+    require_scope: true,
+  }),
+  Object.freeze({
+    name: 'developer',
+    path: 'docs/developer',
+    focus: 'architecture, APIs, extending',
+    require_scope: true,
+  }),
+  Object.freeze({
+    name: 'admin',
+    path: 'docs/admin',
+    focus: 'install, configure, operate, troubleshoot',
+    require_scope: true,
+  }),
+  Object.freeze({
+    name: 'general',
+    path: 'docs/general',
+    focus: 'what it is, why it matters, plain language',
+    require_scope: true,
+  }),
+]);
+
+// ── Folder contract (spec §D2) ────────────────────────────────────────────────
+
+export const FOLDER_CONTRACT = Object.freeze({
+  baseFiles: Object.freeze(['index.md', 'getting-started.md']),
+  tutorialPattern: 'tutorials/<feature>.md',
+  featurePattern:  'features/<feature>.md',
+  developerExtras: Object.freeze(['architecture/', 'api/']),
+  adminRunbooksLink: 'docs/runbooks/',
+  sharedAssets: Object.freeze([
+    'docs/assets/screenshots',
+    'docs/assets/diagrams',
+    'docs/assets/transcripts',
+  ]),
+});
+
+// ── Minimal YAML subset parser ────────────────────────────────────────────────
+//
+// Parses the subset of YAML used in .autospec/autospec.yml documentation blocks:
+// - nested mappings (key: value or key:\n  subkey: value)
+// - block sequences (  - key: value\n    key2: value2)
+// - scalar values: strings (bare, single/double quoted), booleans, integers, null
+//
+// No external dependency — keeps the script self-contained.
+
+// Split a flow-mapping/sequence body on top-level commas, respecting single and
+// double quotes (so a quoted value containing a comma is not split).
+function splitTopLevel(body) {
+  const parts = [];
+  let cur = '';
+  let quote = null;
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (quote) {
+      cur += ch;
+      if (ch === quote) quote = null;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+      cur += ch;
+    } else if (ch === ',') {
+      parts.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  if (cur.trim() !== '') parts.push(cur);
+  return parts;
+}
+
+// Parse a flow mapping body (the text between { and }) into a plain object.
+function parseFlowMapping(body) {
+  const obj = {};
+  for (const pair of splitTopLevel(body)) {
+    const colonIdx = pair.indexOf(':');
+    if (colonIdx === -1) continue;
+    const k = pair.slice(0, colonIdx).trim();
+    const v = pair.slice(colonIdx + 1).trim();
+    if (k) obj[k] = parseYamlValue(v);
+  }
+  return obj;
+}
+
+function parseYamlValue(raw) {
+  const s = raw.trim();
+  if (s === '' || s === '~' || s === 'null') return null;
+  if (s === 'true')  return true;
+  if (s === 'false') return false;
+  if (s.startsWith('"') && s.endsWith('"')) return s.slice(1, -1);
+  if (s.startsWith("'") && s.endsWith("'")) return s.slice(1, -1);
+  if (/^-?\d+$/.test(s)) return parseInt(s, 10);
+  return s;
+}
+
+/**
+ * parseYamlDoc — parse a YAML document (or sub-document) from an array of
+ * lines.  Returns a plain JS object.
+ *
+ * Algorithm: recursive descent using a shared line-index pointer.
+ * parseMapping(minIndent) reads key:value pairs while indentation >= minIndent.
+ * parseSequence(indent) reads list items at exactly `indent`.
+ */
+function parseYamlDoc(lines) {
+  // Filter out comment and blank lines, attach indent.
+  const tokens = lines
+    .map((line, i) => ({ line, i, indent: line.match(/^( *)/)[1].length, content: line.trim() }))
+    .filter(t => t.content !== '' && !t.content.startsWith('#'));
+
+  let pos = 0; // index into tokens
+
+  function peek() { return pos < tokens.length ? tokens[pos] : null; }
+  function consume() { return tokens[pos++]; }
+
+  function parseValue(content, childIndent) {
+    // Inline sequence: "[]" or "[ ... ]"
+    if (content === '[]') return [];
+    if (content.startsWith('[') && content.endsWith(']')) {
+      const inner = content.slice(1, -1).trim();
+      if (!inner) return [];
+      return splitTopLevel(inner).map(s => parseYamlValue(s.trim()));
+    }
+    if (content === '' || content === null) {
+      // Value is on subsequent lines — peek to see if it's a mapping or sequence.
+      const next = peek();
+      if (!next || next.indent < childIndent) return null;
+      if (next.content.startsWith('- ')) {
+        return parseSequence(next.indent);
+      }
+      return parseMapping(next.indent);
+    }
+    return parseYamlValue(content);
+  }
+
+  function parseMapping(minIndent) {
+    const obj = {};
+    while (true) {
+      const t = peek();
+      if (!t || t.indent < minIndent) break;
+      // A sequence item at this level means we were called from the wrong place.
+      if (t.content.startsWith('- ')) break;
+      consume();
+      const colonIdx = t.content.indexOf(':');
+      if (colonIdx === -1) continue; // malformed line — skip
+      const k = t.content.slice(0, colonIdx).trim();
+      const rest = t.content.slice(colonIdx + 1).trim();
+      obj[k] = parseValue(rest, t.indent + 1);
+    }
+    return obj;
+  }
+
+  function parseSequence(seqIndent) {
+    const arr = [];
+    while (true) {
+      const t = peek();
+      if (!t || t.indent !== seqIndent || !t.content.startsWith('- ')) break;
+      consume();
+      const itemContent = t.content.slice(2).trim();
+      // Inline flow mapping item: "- {name: user, path: docs/user, focus: \"...\"}"
+      if (itemContent.startsWith('{') && itemContent.endsWith('}')) {
+        arr.push(parseFlowMapping(itemContent.slice(1, -1)));
+        continue;
+      }
+      // Inline mapping item: "- key: value"
+      if (/^[A-Za-z_][A-Za-z0-9_-]*\s*:/.test(itemContent)) {
+        const itemObj = {};
+        // Parse the first k:v pair from this line.
+        const colonIdx = itemContent.indexOf(':');
+        const k = itemContent.slice(0, colonIdx).trim();
+        const rest = itemContent.slice(colonIdx + 1).trim();
+        itemObj[k] = parseValue(rest, t.indent + 1);
+        // Collect subsequent indented keys for this item.
+        while (true) {
+          const next = peek();
+          if (!next || next.indent <= seqIndent || next.content.startsWith('- ')) break;
+          consume();
+          const ci = next.content.indexOf(':');
+          if (ci === -1) continue;
+          const ik = next.content.slice(0, ci).trim();
+          const iv = next.content.slice(ci + 1).trim();
+          itemObj[ik] = parseValue(iv, next.indent + 1);
+        }
+        arr.push(itemObj);
+      } else if (itemContent === '') {
+        // Multi-line item — next lines at deeper indent form a mapping.
+        const next = peek();
+        if (next && next.indent > seqIndent) {
+          arr.push(parseMapping(next.indent));
+        } else {
+          arr.push(null);
+        }
+      } else {
+        arr.push(parseYamlValue(itemContent));
+      }
+    }
+    return arr;
+  }
+
+  return parseMapping(0);
+}
+
+// extractDocumentationBlock — return the lines of the `documentation:` sub-doc.
+function extractDocumentationBlock(text) {
+  const lines = text.split('\n');
+  let inDoc = false;
+  let baseIndent = -1;
+  const block = [];
+
+  for (const line of lines) {
+    if (!inDoc) {
+      if (/^documentation:\s*$/.test(line) || /^documentation:\s*\S/.test(line)) {
+        inDoc = true;
+        const inline = line.replace(/^documentation:\s*/, '');
+        if (inline.trim()) block.push(inline);
+      }
+      continue;
+    }
+    // A non-empty line at column 0 that isn't a comment ends the block.
+    if (/^\S/.test(line) && !/^\s*#/.test(line)) break;
+
+    if (baseIndent === -1 && line.trim() !== '') {
+      baseIndent = line.match(/^( *)/)[1].length;
+    }
+    block.push(baseIndent > 0 ? line.slice(baseIndent) : line);
+  }
+  return block;
+}
+
+// ── loadConfig ─────────────────────────────────────────────────────────────────
+
+/**
+ * loadConfig(configPath) → { audiences, style, examples }
+ *
+ * Reads the `documentation:` block from .autospec/autospec.yml at `configPath`
+ * and returns a normalised config object with defaults applied.
+ *
+ * Rules:
+ *  - audiences: existing entries are preserved verbatim. Default audiences are
+ *    injected ONLY when the list is absent or empty.
+ *  - style.palette: defaults to 'light-blue'.
+ *  - examples.verify: defaults to true.
+ *  - examples.sandbox: defaults to 'worktree'.
+ *
+ * @param {string} configPath  Absolute or CWD-relative path to autospec.yml.
+ * @returns {{ audiences: object[], style: { palette: string }, examples: { verify: boolean, sandbox: string } }}
+ */
+export function loadConfig(configPath) {
+  let raw = '';
+  try {
+    raw = fs.readFileSync(configPath, 'utf8');
+  } catch {
+    return {
+      audiences: DEFAULT_AUDIENCES.map(a => ({ ...a })),
+      style:    { palette: 'light-blue' },
+      examples: { verify: true, sandbox: 'worktree' },
+    };
+  }
+
+  const blockLines = extractDocumentationBlock(raw);
+  const doc = parseYamlDoc(blockLines);
+
+  // ── audiences ──────────────────────────────────────────────────────────────
+  let audiences;
+  if (Array.isArray(doc.audiences) && doc.audiences.length > 0) {
+    audiences = doc.audiences;
+  } else {
+    audiences = DEFAULT_AUDIENCES.map(a => ({ ...a }));
+  }
+
+  // ── style ─────────────────────────────────────────────────────────────────
+  const styleRaw = (typeof doc.style === 'object' && doc.style !== null && !Array.isArray(doc.style))
+    ? doc.style : {};
+  const style = {
+    palette: (styleRaw.palette != null) ? String(styleRaw.palette) : 'light-blue',
+  };
+
+  // ── examples ──────────────────────────────────────────────────────────────
+  const exRaw = (typeof doc.examples === 'object' && doc.examples !== null && !Array.isArray(doc.examples))
+    ? doc.examples : {};
+  const examples = {
+    verify:  (exRaw.verify  != null) ? Boolean(exRaw.verify)  : true,
+    sandbox: (exRaw.sandbox != null) ? String(exRaw.sandbox)  : 'worktree',
+  };
+
+  return { audiences, style, examples };
+}

--- a/skills/autospec-doc/scripts/doc-orchestrator.mjs
+++ b/skills/autospec-doc/scripts/doc-orchestrator.mjs
@@ -22,11 +22,15 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadConfig, DEFAULT_AUDIENCES, FOLDER_CONTRACT } from './doc-config.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // ── Config detection ──────────────────────────────────────────────────────────
-// The real config loader lands in #917. For the scaffold we only need to answer
-// one question: does a `documentation:` block exist in `.autospec/autospec.yml`?
-// Non-`init` subcommands require it; `init` is what creates it.
+// The config loader (doc-config.mjs, #917) parses the `documentation:` block.
+// Non-`init` subcommands require the block to exist; `init` is what creates it.
 const CONFIG_PATH = process.env.AUTOSPEC_DOC_CONFIG
   || path.join('.autospec', 'autospec.yml');
 
@@ -40,20 +44,29 @@ function hasDocumentationConfig(configPath) {
   }
 }
 
-// ── Handlers (no-op stubs; filled by downstream issues) ───────────────────────
+// ── Config-backed handlers ────────────────────────────────────────────────────
+// The generator logic (scope-diff, AI-review, verify) is filled in by downstream
+// issues #918-#923. Here each non-init handler loads the real config via
+// doc-config.mjs (#917) so the audience list it reports is the resolved one
+// (declared entries verbatim, or the four seeded defaults).
 
 function handleIncremental(_opts) {
-  console.log('[autospec-doc] incremental: plan scopes affected since last generation (stub — #918/#919).');
+  const cfg = loadConfig(CONFIG_PATH);
+  const names = cfg.audiences.map(a => a.name || a.id).join(', ');
+  console.log(`[autospec-doc] incremental: plan scopes affected since last generation for audiences [${names}] (generation stub — #918/#919).`);
   return 0;
 }
 
 function handleFull(_opts) {
-  console.log('[autospec-doc] full: regenerate every audience + run completeness audit (stub — #918/#923).');
+  const cfg = loadConfig(CONFIG_PATH);
+  const names = cfg.audiences.map(a => a.name || a.id).join(', ');
+  console.log(`[autospec-doc] full: regenerate every audience [${names}] + run completeness audit (generation stub — #918/#923).`);
   return 0;
 }
 
 function handleAudit(_opts) {
-  console.log('[autospec-doc] audit: read-only completeness/drift report (stub — #919/#923).');
+  const cfg = loadConfig(CONFIG_PATH);
+  console.log(`[autospec-doc] audit: read-only completeness/drift report across ${cfg.audiences.length} audiences (generation stub — #919/#923).`);
   return 0;
 }
 
@@ -62,19 +75,118 @@ function handleAudience(opts) {
     console.error('[autospec-doc] --audience requires a <name> argument.');
     return 2;
   }
-  console.log(`[autospec-doc] audience: regenerate "${opts.audience}" only (stub — #918).`);
+  // The router dispatches by form; audience-membership resolution (and the
+  // unknown-audience error) is the generator's concern (#918). Here we load the
+  // config only to surface whether the requested name is already configured.
+  const cfg = loadConfig(CONFIG_PATH);
+  const known = cfg.audiences.some(a => (a.name || a.id) === opts.audience);
+  const note = known ? '' : ' [not in current config — generator will resolve]';
+  console.log(`[autospec-doc] audience: regenerate "${opts.audience}" only${note} (generation stub — #918).`);
   return 0;
 }
 
-function handleInit(_opts) {
-  // init is the bootstrap: it scans the repo and scaffolds the documentation:
-  // config block + starter doc scopes. The real scaffolding logic lands in #917
-  // (config schema + folder contract). The scaffold prints the plan.
+// ── init scaffolding (#917) ───────────────────────────────────────────────────
+//
+// init is the bootstrap. It writes a `documentation:` block to
+// .autospec/autospec.yml (seeding the four default audiences) and creates the
+// per-audience starter folder contract under docs/<audience>/. It is idempotent:
+// an existing `documentation:` block is left untouched, and existing doc files
+// are never overwritten. With --dry-run it prints the plan and writes nothing.
+
+// Render the canonical `documentation:` YAML block from the default audiences
+// and the style/examples defaults. Kept in lock-step with spec §D2 and
+// doc-config.mjs's defaults.
+function renderDocumentationBlock() {
+  const lines = ['documentation:', '  audiences:'];
+  for (const a of DEFAULT_AUDIENCES) {
+    lines.push(`    - {name: ${a.name}, path: ${a.path}, focus: "${a.focus}"}`);
+  }
+  lines.push('  style:');
+  lines.push('    palette: light-blue');
+  lines.push('  examples:');
+  lines.push('    verify: true');
+  lines.push('    sandbox: worktree');
+  return lines.join('\n') + '\n';
+}
+
+// Per-audience starter files per the folder contract (spec §D2): index.md +
+// getting-started.md for every audience; developer also gets architecture/ and
+// api/ directory placeholders.
+function plannedScopeFiles() {
+  const files = [];
+  for (const a of DEFAULT_AUDIENCES) {
+    for (const base of FOLDER_CONTRACT.baseFiles) {
+      files.push(path.join(a.path, base));
+    }
+    if (a.name === 'developer') {
+      for (const extra of FOLDER_CONTRACT.developerExtras) {
+        // Directory placeholder — keep the tree present with a .gitkeep.
+        files.push(path.join(a.path, extra, '.gitkeep'));
+      }
+    }
+  }
+  return files;
+}
+
+function starterContent(audience, relfile) {
+  if (path.basename(relfile) === '.gitkeep') return '';
+  const title = path.basename(relfile, '.md');
+  return `<!-- autospec-doc-scope: audience=${audience.name} generated: false -->\n`
+    + `# ${audience.name} — ${title}\n\n`
+    + `_Starter scope for the **${audience.name}** audience (${audience.focus})._\n\n`
+    + `Run \`/autospec-doc --audience ${audience.name}\` to generate this content.\n`;
+}
+
+function handleInit(opts) {
+  // The "init: scaffold plan" line is part of the stable output contract.
   console.log('[autospec-doc] init: scaffold plan');
-  console.log('  - scan the repo for features, entry points, and existing docs/');
-  console.log('  - write a `documentation:` block to .autospec/autospec.yml (default audiences: user, developer, admin, general)');
-  console.log('  - create starter doc scopes under docs/<audience>/ per the folder contract');
-  console.log('  (scaffolding logic filled in by #917)');
+
+  const configExists = hasDocumentationConfig(CONFIG_PATH);
+  const scopeFiles = plannedScopeFiles();
+
+  if (configExists) {
+    console.log(`  - documentation: block already present in ${CONFIG_PATH} (left untouched)`);
+  } else {
+    console.log(`  - write a \`documentation:\` block to ${CONFIG_PATH} (default audiences: user, developer, admin, general)`);
+  }
+  console.log('  - create starter doc scopes under docs/<audience>/ per the folder contract:');
+  for (const f of scopeFiles) console.log(`      ${f}`);
+
+  if (opts.dryRun) {
+    console.log('  (--dry-run: no files written)');
+    return 0;
+  }
+
+  // 1. Write/extend the config block.
+  if (!configExists) {
+    const dir = path.dirname(CONFIG_PATH);
+    if (dir && dir !== '.') fs.mkdirSync(dir, { recursive: true });
+    const block = renderDocumentationBlock();
+    if (fs.existsSync(CONFIG_PATH)) {
+      const existing = fs.readFileSync(CONFIG_PATH, 'utf8');
+      const sep = existing.endsWith('\n') || existing === '' ? '' : '\n';
+      fs.writeFileSync(CONFIG_PATH, existing + sep + block, 'utf8');
+    } else {
+      fs.writeFileSync(CONFIG_PATH, block, 'utf8');
+    }
+    console.log(`  ✓ wrote documentation: block to ${CONFIG_PATH}`);
+  }
+
+  // 2. Create starter scopes (never overwrite human-owned files).
+  const byPath = new Map(DEFAULT_AUDIENCES.map(a => [a.path, a]));
+  let created = 0;
+  for (const rel of scopeFiles) {
+    if (fs.existsSync(rel)) continue;
+    fs.mkdirSync(path.dirname(rel), { recursive: true });
+    // Resolve which audience owns this file by longest matching path prefix.
+    let owner = null;
+    for (const [p, a] of byPath) {
+      if (rel === p || rel.startsWith(p + path.sep)) { owner = a; break; }
+    }
+    fs.writeFileSync(rel, owner ? starterContent(owner, rel) : '', 'utf8');
+    created++;
+  }
+  console.log(`  ✓ created ${created} starter doc file(s)`);
   return 0;
 }
 
@@ -83,12 +195,15 @@ function handleInit(_opts) {
 function parseArgs(argv) {
   // Returns { subcommand, audience } where subcommand is one of:
   //   incremental | full | audit | audience | init | usage
-  const opts = { subcommand: 'incremental', audience: null };
+  const opts = { subcommand: 'incremental', audience: null, dryRun: false };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     switch (arg) {
       case 'init':
         opts.subcommand = 'init';
+        break;
+      case '--dry-run':
+        opts.dryRun = true;
         break;
       case '--full':
         opts.subcommand = 'full';
@@ -130,6 +245,7 @@ function usage() {
   console.log('  --audit             read-only completeness/drift report');
   console.log('  --audience <name>   regenerate one audience only');
   console.log('  init                scaffold documentation: config + starter scopes');
+  console.log('  --dry-run           (with init) print the scaffold plan; write nothing');
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────

--- a/skills/autospec-doc/tests/doc-config.test.mjs
+++ b/skills/autospec-doc/tests/doc-config.test.mjs
@@ -1,0 +1,239 @@
+// doc-config.test.mjs — unit tests for skills/autospec-doc/scripts/doc-config.mjs (issue #917)
+//
+// Tests:
+//   1. style.palette defaults to 'light-blue' when absent
+//   2. examples.verify defaults to true when absent
+//   3. examples.sandbox defaults to 'worktree' when absent
+//   4. default audiences seeded only when audiences list is empty
+//   5. existing audience entries preserved verbatim (name/path/focus/require_scope)
+//   6. existing audience entries preserved verbatim (id-keyed legacy entries)
+//   7. all four default audience names are user/developer/admin/general
+//   8. default audience paths match spec §D2 exactly
+//   9. default audience focus strings match spec §D2 exactly
+//  10. folder-contract constants exported and match §D2 exactly
+//  11. loadConfig returns structured object with audiences/style/examples
+//  12. explicit style/examples values are honoured over defaults
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIG_MOD = path.resolve(__dirname, '../scripts/doc-config.mjs');
+
+const { loadConfig, FOLDER_CONTRACT, DEFAULT_AUDIENCES } = await import(CONFIG_MOD);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'doc-config-test-'));
+}
+
+function writeYml(dir, content) {
+  fs.mkdirSync(path.join(dir, '.autospec'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.autospec', 'autospec.yml'), content, 'utf8');
+}
+
+function configPath(dir) {
+  return path.join(dir, '.autospec', 'autospec.yml');
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test('style.palette defaults to light-blue when absent', () => {
+  const dir = makeTmpDir();
+  writeYml(dir, 'documentation:\n  audiences:\n    - name: user\n      path: docs/user\n      focus: "tasks"\n      require_scope: true\n');
+  const cfg = loadConfig(configPath(dir));
+  assert.strictEqual(cfg.style.palette, 'light-blue');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('examples.verify defaults to true when absent', () => {
+  const dir = makeTmpDir();
+  writeYml(dir, 'documentation:\n  audiences:\n    - name: user\n      path: docs/user\n      focus: "tasks"\n      require_scope: true\n');
+  const cfg = loadConfig(configPath(dir));
+  assert.strictEqual(cfg.examples.verify, true);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('examples.sandbox defaults to worktree when absent', () => {
+  const dir = makeTmpDir();
+  writeYml(dir, 'documentation:\n  audiences:\n    - name: user\n      path: docs/user\n      focus: "tasks"\n      require_scope: true\n');
+  const cfg = loadConfig(configPath(dir));
+  assert.strictEqual(cfg.examples.sandbox, 'worktree');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('default audiences seeded only when audiences list is empty', () => {
+  const dir = makeTmpDir();
+  writeYml(dir, 'documentation:\n  audiences: []\n');
+  const cfg = loadConfig(configPath(dir));
+  assert.strictEqual(cfg.audiences.length, 4);
+  assert.deepEqual(cfg.audiences.map(a => a.name), ['user', 'developer', 'admin', 'general']);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('default audiences NOT seeded when audiences list is non-empty', () => {
+  const dir = makeTmpDir();
+  writeYml(dir, 'documentation:\n  audiences:\n    - name: user\n      path: docs/user\n      focus: "tasks"\n      require_scope: true\n');
+  const cfg = loadConfig(configPath(dir));
+  assert.strictEqual(cfg.audiences.length, 1);
+  assert.strictEqual(cfg.audiences[0].name, 'user');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('default audiences seeded when audiences key is absent entirely', () => {
+  const dir = makeTmpDir();
+  writeYml(dir, 'documentation:\n  style:\n    palette: light-blue\n');
+  const cfg = loadConfig(configPath(dir));
+  assert.strictEqual(cfg.audiences.length, 4);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('existing audience name/path/focus/require_scope preserved verbatim', () => {
+  const dir = makeTmpDir();
+  writeYml(dir, [
+    'documentation:',
+    '  audiences:',
+    '    - name: user',
+    '      path: docs/user',
+    '      focus: "tasks, workflows, how to use features"',
+    '      require_scope: true',
+    '    - name: developer',
+    '      path: docs/developer',
+    '      focus: "architecture, APIs, extending"',
+    '      require_scope: false',
+    '',
+  ].join('\n'));
+  const cfg = loadConfig(configPath(dir));
+  assert.strictEqual(cfg.audiences[0].name, 'user');
+  assert.strictEqual(cfg.audiences[0].path, 'docs/user');
+  assert.strictEqual(cfg.audiences[0].focus, 'tasks, workflows, how to use features');
+  assert.strictEqual(cfg.audiences[0].require_scope, true);
+  assert.strictEqual(cfg.audiences[1].name, 'developer');
+  assert.strictEqual(cfg.audiences[1].require_scope, false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('legacy id-keyed audiences preserved verbatim (not overwritten)', () => {
+  const dir = makeTmpDir();
+  writeYml(dir, [
+    'documentation:',
+    '  audiences:',
+    '    - id: users',
+    '      label: End users',
+    '      path: docs/USER_MANUAL.md',
+    '      focus: "Installation and workflows"',
+    '      require_scope: true',
+    '',
+  ].join('\n'));
+  const cfg = loadConfig(configPath(dir));
+  // One entry — not replaced with defaults (list is non-empty).
+  assert.strictEqual(cfg.audiences.length, 1);
+  assert.strictEqual(cfg.audiences[0].id, 'users');
+  assert.strictEqual(cfg.audiences[0].path, 'docs/USER_MANUAL.md');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('all four default audience names are user/developer/admin/general', () => {
+  assert.deepEqual(DEFAULT_AUDIENCES.map(a => a.name), ['user', 'developer', 'admin', 'general']);
+});
+
+test('default audience paths match spec §D2 exactly', () => {
+  const paths = DEFAULT_AUDIENCES.reduce((acc, a) => { acc[a.name] = a.path; return acc; }, {});
+  assert.strictEqual(paths.user,      'docs/user');
+  assert.strictEqual(paths.developer, 'docs/developer');
+  assert.strictEqual(paths.admin,     'docs/admin');
+  assert.strictEqual(paths.general,   'docs/general');
+});
+
+test('default audience focus strings match spec §D2 exactly', () => {
+  const focus = DEFAULT_AUDIENCES.reduce((acc, a) => { acc[a.name] = a.focus; return acc; }, {});
+  assert.strictEqual(focus.user,      'tasks, workflows, how to use features');
+  assert.strictEqual(focus.developer, 'architecture, APIs, extending');
+  assert.strictEqual(focus.admin,     'install, configure, operate, troubleshoot');
+  assert.strictEqual(focus.general,   'what it is, why it matters, plain language');
+});
+
+test('folder-contract constants exported and match spec §D2', () => {
+  assert.ok(Array.isArray(FOLDER_CONTRACT.baseFiles), 'FOLDER_CONTRACT.baseFiles must be an array');
+  assert.ok(FOLDER_CONTRACT.baseFiles.includes('index.md'));
+  assert.ok(FOLDER_CONTRACT.baseFiles.includes('getting-started.md'));
+  // Tutorial and feature patterns
+  assert.ok(typeof FOLDER_CONTRACT.tutorialPattern === 'string');
+  assert.ok(FOLDER_CONTRACT.tutorialPattern.includes('tutorials/'));
+  assert.ok(typeof FOLDER_CONTRACT.featurePattern === 'string');
+  assert.ok(FOLDER_CONTRACT.featurePattern.includes('features/'));
+  // Developer-specific extras
+  assert.ok(Array.isArray(FOLDER_CONTRACT.developerExtras));
+  assert.ok(FOLDER_CONTRACT.developerExtras.includes('architecture/'));
+  assert.ok(FOLDER_CONTRACT.developerExtras.includes('api/'));
+  // Admin link
+  assert.strictEqual(FOLDER_CONTRACT.adminRunbooksLink, 'docs/runbooks/');
+  // Shared assets
+  assert.ok(FOLDER_CONTRACT.sharedAssets.includes('docs/assets/screenshots'));
+  assert.ok(FOLDER_CONTRACT.sharedAssets.includes('docs/assets/diagrams'));
+  assert.ok(FOLDER_CONTRACT.sharedAssets.includes('docs/assets/transcripts'));
+});
+
+test('loadConfig returns structured object with audiences/style/examples', () => {
+  const dir = makeTmpDir();
+  writeYml(dir, 'documentation:\n  audiences: []\n');
+  const cfg = loadConfig(configPath(dir));
+  assert.ok(typeof cfg === 'object');
+  assert.ok(Array.isArray(cfg.audiences));
+  assert.ok(typeof cfg.style === 'object');
+  assert.ok(typeof cfg.examples === 'object');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('inline-mapping audience entries (init output form) parse to all four defaults', () => {
+  // The init scaffolder writes audiences as inline flow mappings:
+  //   - {name: user, path: docs/user, focus: "..."}
+  // loadConfig must parse these back to the canonical four with exact strings.
+  const dir = makeTmpDir();
+  writeYml(dir, [
+    'documentation:',
+    '  audiences:',
+    '    - {name: user, path: docs/user, focus: "tasks, workflows, how to use features"}',
+    '    - {name: developer, path: docs/developer, focus: "architecture, APIs, extending"}',
+    '    - {name: admin, path: docs/admin, focus: "install, configure, operate, troubleshoot"}',
+    '    - {name: general, path: docs/general, focus: "what it is, why it matters, plain language"}',
+    '  style:',
+    '    palette: light-blue',
+    '  examples:',
+    '    verify: true',
+    '    sandbox: worktree',
+    '',
+  ].join('\n'));
+  const cfg = loadConfig(configPath(dir));
+  assert.deepEqual(cfg.audiences.map(a => a.name), ['user', 'developer', 'admin', 'general']);
+  assert.strictEqual(cfg.audiences[0].path, 'docs/user');
+  assert.strictEqual(cfg.audiences[1].focus, 'architecture, APIs, extending');
+  assert.strictEqual(cfg.style.palette, 'light-blue');
+  assert.strictEqual(cfg.examples.verify, true);
+  assert.strictEqual(cfg.examples.sandbox, 'worktree');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('explicit style.palette and examples values are honoured over defaults', () => {
+  const dir = makeTmpDir();
+  writeYml(dir, [
+    'documentation:',
+    '  audiences: []',
+    '  style:',
+    '    palette: dark-blue',
+    '  examples:',
+    '    verify: false',
+    '    sandbox: docker',
+    '',
+  ].join('\n'));
+  const cfg = loadConfig(configPath(dir));
+  assert.strictEqual(cfg.style.palette, 'dark-blue');
+  assert.strictEqual(cfg.examples.verify, false);
+  assert.strictEqual(cfg.examples.sandbox, 'docker');
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/skills/autospec-doc/tests/doc-orchestrator.bats
+++ b/skills/autospec-doc/tests/doc-orchestrator.bats
@@ -113,3 +113,87 @@ EOF
   [ "$status" -eq 2 ]
   [[ "$output" == *"Usage:"* ]]
 }
+
+# ── init scaffolding (issue #917) ─────────────────────────────────────────────
+
+@test "init writes the documentation: block with style and examples keys" {
+  run node "$ORCH" init
+  [ "$status" -eq 0 ]
+  [ -f .autospec/autospec.yml ]
+  grep -q '^documentation:' .autospec/autospec.yml
+  grep -q 'palette: light-blue' .autospec/autospec.yml
+  grep -q 'verify: true' .autospec/autospec.yml
+  grep -q 'sandbox: worktree' .autospec/autospec.yml
+}
+
+@test "init seeds the four default audiences in the written block" {
+  run node "$ORCH" init
+  [ "$status" -eq 0 ]
+  grep -q 'name: user' .autospec/autospec.yml
+  grep -q 'name: developer' .autospec/autospec.yml
+  grep -q 'name: admin' .autospec/autospec.yml
+  grep -q 'name: general' .autospec/autospec.yml
+}
+
+@test "init creates per-audience starter scopes per the folder contract" {
+  run node "$ORCH" init
+  [ "$status" -eq 0 ]
+  [ -f docs/user/index.md ]
+  [ -f docs/user/getting-started.md ]
+  [ -f docs/developer/architecture/.gitkeep ]
+  [ -f docs/developer/api/.gitkeep ]
+  [ -f docs/admin/getting-started.md ]
+  [ -f docs/general/index.md ]
+  grep -q 'autospec-doc-scope: audience=user' docs/user/index.md
+}
+
+@test "init --dry-run writes nothing" {
+  run node "$ORCH" init --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no files written"* ]]
+  [ ! -f .autospec/autospec.yml ]
+  [ ! -d docs ]
+}
+
+@test "init is idempotent: existing documentation: block left untouched" {
+  seed_config
+  before="$(cat .autospec/autospec.yml)"
+  run node "$ORCH" init
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already present"* ]]
+  after="$(cat .autospec/autospec.yml)"
+  [ "$before" == "$after" ]
+}
+
+@test "init does not overwrite an existing human-owned doc file" {
+  mkdir -p docs/user
+  echo "HUMAN OWNED" > docs/user/index.md
+  run node "$ORCH" init
+  [ "$status" -eq 0 ]
+  grep -q 'HUMAN OWNED' docs/user/index.md
+}
+
+@test "after init, a non-init subcommand passes the config gate" {
+  node "$ORCH" init >/dev/null
+  run node "$ORCH" --full
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"full:"* ]]
+}
+
+@test "init output round-trips: loadConfig parses the written block to four defaults" {
+  node "$ORCH" init >/dev/null
+  export CFG="$PWD/.autospec/autospec.yml"
+  export CONFMOD="${BATS_TEST_DIRNAME}/../scripts/doc-config.mjs"
+  run node -e '
+    import(process.env.CONFMOD).then(m => {
+      const c = m.loadConfig(process.env.CFG);
+      const names = c.audiences.map(a => a.name).join(",");
+      if (names !== "user,developer,admin,general") { console.error("names=" + names); process.exit(1); }
+      if (c.style.palette !== "light-blue") process.exit(1);
+      if (c.examples.verify !== true || c.examples.sandbox !== "worktree") process.exit(1);
+      console.log("roundtrip-ok");
+    }).catch(e => { console.error(e); process.exit(1); });
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"roundtrip-ok"* ]]
+}


### PR DESCRIPTION
Closes #917

Implements the `documentation:` config schema (§D2), folder-contract path constants, and upgrades `init` from a plan-printing stub to a working scaffolder.

## What landed
- **`scripts/doc-config.mjs`** — `loadConfig()` parses the `documentation:` block; defaults `style.palette=light-blue`, `examples.verify=true`, `examples.sandbox=worktree`; seeds the four default audiences (user/developer/admin/general with exact §D2 paths/focus) only when `audiences:` is empty; preserves existing entries (including legacy `id`/`label`-keyed) verbatim. Exports `DEFAULT_AUDIENCES` + `FOLDER_CONTRACT`.
- Self-contained YAML subset parser gained quote-aware inline flow-mapping support so init's written block round-trips through `loadConfig`.
- **`doc-orchestrator.mjs`** — non-init handlers load the resolved config; `init` writes the block + per-audience starter scopes (developer adds `architecture/`+`api/`). Idempotent; honors `init --dry-run`.
- **README** — schema example, folder contract, and operator/security migration note.

## Shared-contracts adherence
Config keys, default audience name/path/focus strings, and the folder contract match the issue's pinned `## Shared contracts` block byte-for-byte (consumed by #918-#925).

## Tests
- 15 `doc-config` unit tests + 8 new `init` bats (write/seed/folder-contract/dry-run/idempotency/no-overwrite/gate/round-trip). Existing 12 router bats still green.
- `bash scripts/validate.sh` exits 0; `node --check` clean; primary smoke test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)