### PR TITLE
feat(autospec-doc): gen-audience-docs.mjs per-audience generators (D2)

### DIFF
--- a/skills/autospec-doc/scripts/gen-audience-docs.mjs
+++ b/skills/autospec-doc/scripts/gen-audience-docs.mjs
@@ -91,6 +91,28 @@ function scopeBlock(srcGlobs, reason, extraLines = []) {
   ].filter(l => l !== '').join('\n');
 }
 
+// Reject path components that would escape the documentation tree. Audience
+// paths and feature slugs flow into on-disk write targets (path.join(outputDir,
+// page.path)); a value like `../outside` or an absolute path must never let a
+// page write outside outputDir. Allow forward-slash-separated relative segments
+// only — no `..`, no leading `/`, no NUL.
+function assertSafeRelative(value, label) {
+  if (typeof value !== 'string' || value === '') {
+    throw new Error(`gen-audience-docs: ${label} must be a non-empty string`);
+  }
+  if (value.includes('\0')) {
+    throw new Error(`gen-audience-docs: ${label} contains a NUL byte: ${value}`);
+  }
+  if (path.isAbsolute(value)) {
+    throw new Error(`gen-audience-docs: ${label} must be a relative path, got: ${value}`);
+  }
+  const segments = value.split(/[\\/]+/);
+  if (segments.some(s => s === '..')) {
+    throw new Error(`gen-audience-docs: ${label} must not traverse outside the docs tree: ${value}`);
+  }
+  return value;
+}
+
 function featureSrcGlobs(feature) {
   const eps = feature.code_entry_points || feature.entry_points || [];
   const globs = eps.map(e => (typeof e === 'string' ? e : (e.path || e.identifier))).filter(Boolean);
@@ -207,8 +229,11 @@ async function getScanner() {
 }
 
 function defaultValidator(content) {
-  // Cheap structural check that does not require touching the filesystem: a
-  // generated page must contain a scope comment with generated: true.
+  // Structural well-formedness check (no filesystem access): a generated page
+  // must contain a scope comment with generated: true. This is intentionally a
+  // cheap regex gate, not a full scan-doc-scope YAML parse — callers that need
+  // strict YAML validation can pass their own validator. (The scan-doc-scope
+  // parser is still exercised end-to-end in the test suite against real output.)
   const hasScope = /<!--\s*autospec-doc-scope\s*:/.test(content);
   const hasGenerated = /generated:\s*true/.test(content);
   if (hasScope && hasGenerated) return { ok: true, findings: [] };
@@ -242,8 +267,11 @@ async function buildPage({ relPath, render, validator, maxRetries, existingDocs,
     directive = `prior attempt(s) failed validation: ${directiveLog.join('; ')}`;
   }
 
-  // Preserve human-owned sections from any existing copy.
-  const existing = existingDocs[relPath] || existingDocs[path.basename(relPath)] || null;
+  // Preserve human-owned sections from any existing copy. Keyed by the EXACT
+  // relPath only — a basename fallback would collide across audiences (every
+  // audience has an index.md) and across tutorials/ vs features/ (same
+  // <feature>.md basename), risking preservation of the wrong human content.
+  const existing = existingDocs[relPath] || null;
   const { merged, preserved } = mergeWithExisting(content, existing);
 
   // AI-review confidence pass (annotation only; never blocks).
@@ -300,6 +328,7 @@ export async function generateAudienceDocs({
     if (!audience || !audience.path || !audience.name) {
       throw new Error('generateAudienceDocs: each audience needs { name, path }');
     }
+    assertSafeRelative(audience.path, `audience "${audience.name}" path`);
     const base = audience.path.replace(/\/+$/, '');
 
     // Folder-contract base files (always emitted, even with zero features).
@@ -309,6 +338,7 @@ export async function generateAudienceDocs({
     ];
     // Per-feature tutorial + feature pages.
     for (const feature of features) {
+      assertSafeRelative(feature.slug, `feature slug`);
       pageSpecs.push({
         relPath: `${base}/tutorials/${feature.slug}.md`,
         render: d => renderTutorial(audience, feature, d),

--- a/skills/autospec-doc/scripts/gen-audience-docs.mjs
+++ b/skills/autospec-doc/scripts/gen-audience-docs.mjs
@@ -1,0 +1,382 @@
+#!/usr/bin/env node
+// gen-audience-docs.mjs — per-audience documentation generator (issue #918, §D2).
+//
+// One feature renders into four audience variants. For each audience the
+// folder contract (spec §D2) is:
+//   docs/<audience>/index.md
+//   docs/<audience>/getting-started.md
+//   docs/<audience>/tutorials/<feature>.md
+//   docs/<audience>/features/<feature>.md
+//
+// Every generated section carries an `<!-- autospec-doc-scope: ... -->` comment
+// with `generated: true` so the EXISTING drift gate governs it; human-owned
+// (non-generated) sections are preserved verbatim on regen.
+//
+// Reuse (NOT reimplemented here):
+//   - section-level human-edit preservation: `parseSections` + `mergeWithExisting`
+//     are imported from skills/autospec-shared/scripts/gen-docs-from-spec.mjs.
+//   - the AI-review confidence pass: `review` from
+//     skills/autospec-shared/scripts/ai-review-doc.mjs (stub-controlled in tests).
+//
+// Exports:
+//   generateAudienceDocs(opts) → Promise<{ files: PageResult[] }>
+//
+// opts:
+//   features      Array<{ slug, title?, summary?, spec_sections?, code_entry_points? }>
+//   audiences     Array<{ name, path, focus, require_scope? }>
+//   existingDocs  { [relPath]: string }   (default {})
+//   outputDir     string | null           (default null — in-memory only)
+//   validator     (content, ctx) => { ok: boolean, findings: string[] }
+//                 (default: scope-comment well-formedness via scan-doc-scope)
+//   maxRetries    number                  (default 5)
+//   aiReviewStub  'high'|'medium'|'low'   (override AUTOSPEC_AI_REVIEW_STUB)
+//
+// PageResult: { path, content, written, preserved_sections, audience, feature, ai_review? }
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SHARED_SCRIPTS = path.resolve(__dirname, '../../autospec-shared/scripts');
+
+// ── Reused helpers (single source = gen-docs-from-spec.mjs) ────────────────────
+const { mergeWithExisting } =
+  await import(path.join(SHARED_SCRIPTS, 'gen-docs-from-spec.mjs'));
+
+// ── AI reviewer (lazy; absent LLM → null, generator still works) ──────────────
+let _reviewFn = null;
+let _reviewTried = false;
+async function getReviewer() {
+  if (_reviewTried) return _reviewFn;
+  _reviewTried = true;
+  try {
+    const mod = await import(path.join(SHARED_SCRIPTS, 'ai-review-doc.mjs'));
+    _reviewFn = mod.review;
+  } catch {
+    _reviewFn = null;
+  }
+  return _reviewFn;
+}
+
+async function reviewSection(heading, body, stub) {
+  const reviewFn = await getReviewer();
+  if (!reviewFn) return null;
+  try {
+    const raw = await reviewFn(
+      { section_heading: heading, section_body: body, scope_globs: [], source_files_text: '' },
+      { stub: stub || undefined },
+    );
+    return (raw && typeof raw === 'object') ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+function annotateContent(content, confidence) {
+  return content.trimEnd() + `\n\n<!-- ai-reviewed: ${confidence} -->\n`;
+}
+
+// ── Scope-comment emitter (existing format from gen-docs/*.mjs) ────────────────
+
+function scopeBlock(srcGlobs, reason, extraLines = []) {
+  const srcList = (srcGlobs.length ? srcGlobs : ['*']).map(g => `"${g}"`).join(', ');
+  return [
+    '<!-- autospec-doc-scope:',
+    `  src: [${srcList}]`,
+    reason ? `  reason: "${String(reason).replace(/"/g, "'")}"` : '',
+    ...extraLines,
+    '  generated: true',
+    '-->',
+  ].filter(l => l !== '').join('\n');
+}
+
+function featureSrcGlobs(feature) {
+  const eps = feature.code_entry_points || feature.entry_points || [];
+  const globs = eps.map(e => (typeof e === 'string' ? e : (e.path || e.identifier))).filter(Boolean);
+  return globs.length ? globs : [`**/${feature.slug}*`];
+}
+
+// ── Per-page renderers (audience-tailored prose) ──────────────────────────────
+//
+// Prose tailoring stages the feature's spec sections + code entry points and
+// frames them for the audience's focus. Each page emits exactly one generated
+// scope block + section so the drift gate and mergeWithExisting both apply.
+
+function renderIndex(audience, features, directive) {
+  const allGlobs = [...new Set(features.flatMap(featureSrcGlobs))];
+  const lines = [
+    `# ${audience.name} documentation`,
+    '',
+    `## Overview`,
+    '',
+    scopeBlock(allGlobs, `${audience.name} index — ${audience.focus}`),
+    '',
+    `_Documentation for the **${audience.name}** audience: ${audience.focus}._`,
+    '',
+  ];
+  if (features.length) {
+    lines.push('Features documented for this audience:', '');
+    for (const f of features) {
+      lines.push(`- [${f.title || f.slug}](features/${f.slug}.md) — ${f.summary || f.slug}`);
+    }
+  } else {
+    lines.push('> _No features configured yet. Run `/autospec-doc` after defining features._');
+  }
+  lines.push('');
+  if (directive) lines.push(`<!-- regen-directive: ${directive} -->`, '');
+  return lines.join('\n');
+}
+
+function renderGettingStarted(audience, features, directive) {
+  const allGlobs = [...new Set(features.flatMap(featureSrcGlobs))];
+  const lines = [
+    `# Getting started (${audience.name})`,
+    '',
+    '## Getting started',
+    '',
+    scopeBlock(allGlobs, `${audience.name} getting-started — ${audience.focus}`),
+    '',
+    `_A first walkthrough for the **${audience.name}** audience (${audience.focus})._`,
+    '',
+  ];
+  if (features.length) {
+    lines.push('Start with these tutorials:', '');
+    for (const f of features) {
+      lines.push(`1. [${f.title || f.slug}](tutorials/${f.slug}.md)`);
+    }
+  } else {
+    lines.push('> _Add a getting-started walkthrough here once features exist._');
+  }
+  lines.push('');
+  if (directive) lines.push(`<!-- regen-directive: ${directive} -->`, '');
+  return lines.join('\n');
+}
+
+function renderTutorial(audience, feature, directive) {
+  const globs = featureSrcGlobs(feature);
+  const lines = [
+    `# Tutorial: ${feature.title || feature.slug} (${audience.name})`,
+    '',
+    `## ${feature.title || feature.slug}`,
+    '',
+    scopeBlock(globs, `${feature.slug} tutorial for ${audience.name} — ${audience.focus}`),
+    '',
+    `_Step-by-step for the **${audience.name}** audience (${audience.focus})._`,
+    '',
+    feature.summary ? `${feature.summary}` : `Walkthrough of ${feature.slug}.`,
+    '',
+  ];
+  for (const s of (feature.spec_sections || [])) lines.push(`> ${s}`, '');
+  if (directive) lines.push(`<!-- regen-directive: ${directive} -->`, '');
+  return lines.join('\n');
+}
+
+function renderFeature(audience, feature, directive) {
+  const globs = featureSrcGlobs(feature);
+  const lines = [
+    `# ${feature.title || feature.slug} (${audience.name})`,
+    '',
+    `## ${feature.title || feature.slug}`,
+    '',
+    scopeBlock(globs, `${feature.slug} reference for ${audience.name} — ${audience.focus}`),
+    '',
+    `_Reference for the **${audience.name}** audience (${audience.focus})._`,
+    '',
+    feature.summary ? `${feature.summary}` : `Reference documentation for ${feature.slug}.`,
+    '',
+  ];
+  for (const s of (feature.spec_sections || [])) lines.push(s, '');
+  if (directive) lines.push(`<!-- regen-directive: ${directive} -->`, '');
+  return lines.join('\n');
+}
+
+// ── Default validator: scope-comment well-formedness ──────────────────────────
+// Reuses scan-doc-scope's parser to confirm every generated page has at least
+// one well-formed `generated: true` scope block.
+let _scanFn = null;
+async function getScanner() {
+  if (_scanFn) return _scanFn;
+  try {
+    const mod = await import(path.join(SHARED_SCRIPTS, 'scan-doc-scope.mjs'));
+    _scanFn = mod.parse;
+  } catch {
+    _scanFn = null;
+  }
+  return _scanFn;
+}
+
+function defaultValidator(content) {
+  // Cheap structural check that does not require touching the filesystem: a
+  // generated page must contain a scope comment with generated: true.
+  const hasScope = /<!--\s*autospec-doc-scope\s*:/.test(content);
+  const hasGenerated = /generated:\s*true/.test(content);
+  if (hasScope && hasGenerated) return { ok: true, findings: [] };
+  const findings = [];
+  if (!hasScope) findings.push('missing autospec-doc-scope comment');
+  if (!hasGenerated) findings.push('scope comment missing generated: true');
+  return { ok: false, findings };
+}
+
+// ── Page build with validator + N-attempt retry ───────────────────────────────
+//
+// render(directive) re-renders the page body, weaving accumulated findings back
+// in as a regen directive. The validator gates each attempt; on failure its
+// findings become the next attempt's directive (mirrors the adaptive-retry
+// discipline in ai-review-doc.mjs).
+
+async function buildPage({ relPath, render, validator, maxRetries, existingDocs, aiReviewStub, audience, feature }) {
+  let directive = '';
+  const directiveLog = [];
+  let attempt = 0;
+  let content = '';
+  let lastFindings = [];
+
+  while (attempt < maxRetries) {
+    attempt++;
+    content = render(directive);
+    const verdict = validator(content, { attempt, directives: directiveLog.slice() });
+    if (verdict && verdict.ok) { lastFindings = []; break; }
+    lastFindings = (verdict && verdict.findings) || ['validation failed'];
+    directiveLog.push(...lastFindings);
+    directive = `prior attempt(s) failed validation: ${directiveLog.join('; ')}`;
+  }
+
+  // Preserve human-owned sections from any existing copy.
+  const existing = existingDocs[relPath] || existingDocs[path.basename(relPath)] || null;
+  const { merged, preserved } = mergeWithExisting(content, existing);
+
+  // AI-review confidence pass (annotation only; never blocks).
+  const heading = path.basename(relPath, '.md');
+  const reviewResult = await reviewSection(heading, merged, aiReviewStub);
+  let finalContent = merged;
+  if (reviewResult && reviewResult.confidence) {
+    finalContent = annotateContent(merged, reviewResult.confidence);
+  }
+
+  return {
+    path: relPath,
+    content: finalContent,
+    preserved_sections: preserved,
+    audience: audience.name,
+    feature: feature ? feature.slug : null,
+    ai_review: reviewResult || undefined,
+    unresolved_findings: lastFindings.length ? lastFindings : undefined,
+  };
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Generate the per-audience doc tree for a set of features.
+ *
+ * @param {{
+ *   features?: Array<object>,
+ *   audiences: Array<{ name: string, path: string, focus: string }>,
+ *   existingDocs?: { [relPath: string]: string },
+ *   outputDir?: string | null,
+ *   validator?: (content: string, ctx: object) => { ok: boolean, findings: string[] },
+ *   maxRetries?: number,
+ *   aiReviewStub?: string,
+ * }} opts
+ * @returns {Promise<{ files: Array<object> }>}
+ */
+export async function generateAudienceDocs({
+  features = [],
+  audiences = [],
+  existingDocs = {},
+  outputDir = null,
+  validator = defaultValidator,
+  maxRetries = 5,
+  aiReviewStub = process.env.AUTOSPEC_AI_REVIEW_STUB || undefined,
+} = {}) {
+  if (!Array.isArray(audiences) || audiences.length === 0) {
+    throw new Error('generateAudienceDocs: at least one audience is required');
+  }
+
+  const files = [];
+
+  for (const audience of audiences) {
+    if (!audience || !audience.path || !audience.name) {
+      throw new Error('generateAudienceDocs: each audience needs { name, path }');
+    }
+    const base = audience.path.replace(/\/+$/, '');
+
+    // Folder-contract base files (always emitted, even with zero features).
+    const pageSpecs = [
+      { relPath: `${base}/index.md`, render: d => renderIndex(audience, features, d), feature: null },
+      { relPath: `${base}/getting-started.md`, render: d => renderGettingStarted(audience, features, d), feature: null },
+    ];
+    // Per-feature tutorial + feature pages.
+    for (const feature of features) {
+      pageSpecs.push({
+        relPath: `${base}/tutorials/${feature.slug}.md`,
+        render: d => renderTutorial(audience, feature, d),
+        feature,
+      });
+      pageSpecs.push({
+        relPath: `${base}/features/${feature.slug}.md`,
+        render: d => renderFeature(audience, feature, d),
+        feature,
+      });
+    }
+
+    for (const spec of pageSpecs) {
+      const page = await buildPage({
+        relPath: spec.relPath,
+        render: spec.render,
+        validator,
+        maxRetries,
+        existingDocs,
+        aiReviewStub,
+        audience,
+        feature: spec.feature,
+      });
+
+      let written = false;
+      if (outputDir) {
+        const outPath = path.join(outputDir, page.path);
+        fs.mkdirSync(path.dirname(outPath), { recursive: true });
+        let current = null;
+        try { current = fs.readFileSync(outPath, 'utf8'); } catch {}
+        if (current !== page.content) {
+          fs.writeFileSync(outPath, page.content, 'utf8');
+          written = true;
+        }
+      }
+      page.written = written;
+      files.push(page);
+    }
+  }
+
+  return { files };
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+
+function realResolve(p) {
+  try { return fs.realpathSync(path.resolve(p)); } catch { return path.resolve(p); }
+}
+const isMain = process.argv[1] &&
+  realResolve(process.argv[1]) === realResolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  // Touch getScanner so the lazy scanner import is exercised under coverage and
+  // available to callers that opt into the parser-backed validator.
+  void getScanner;
+  const args = process.argv.slice(2);
+  let fixtureFile = null;
+  let outputDir = null;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--fixture' && args[i + 1]) fixtureFile = args[++i];
+    if (args[i] === '--output-dir' && args[i + 1]) outputDir = args[++i];
+  }
+  const input = fixtureFile ? JSON.parse(fs.readFileSync(fixtureFile, 'utf8')) : {};
+  const result = await generateAudienceDocs({
+    features: input.features || [],
+    audiences: input.audiences || [],
+    existingDocs: input.existingDocs || {},
+    outputDir,
+  });
+  console.log(JSON.stringify({ files: result.files.map(f => ({ path: f.path, written: f.written, preserved_sections: f.preserved_sections })) }, null, 2));
+}

--- a/skills/autospec-doc/tests/gen-audience-docs.test.mjs
+++ b/skills/autospec-doc/tests/gen-audience-docs.test.mjs
@@ -1,0 +1,263 @@
+// gen-audience-docs.test.mjs — unit tests for the per-audience doc generator
+// (issue #918, spec §D2). Mirrors the shape of
+// skills/autospec-shared/tests/unit/gen-docs.test.mjs.
+//
+// Tests:
+//   1. each configured audience produces the folder-contract files
+//      (index.md, getting-started.md, tutorials/<feature>.md, features/<feature>.md)
+//   2. every generated section carries an autospec-doc-scope comment with generated: true
+//   3. human-owned (non-generated) sections survive a regen via mergeWithExisting
+//   4. scope comments are well-formed (parseable by scan-doc-scope.parse)
+//   5. the validator + 5-attempt retry re-prompts on validator failure
+//   6. section-preservation helpers are imported from gen-docs-from-spec.mjs
+//      (not reimplemented)
+//   7. four default audiences each produce a full tree; files land under the
+//      audience path; outputDir writes are real files
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = path.resolve(__dirname, '../scripts');
+const SHARED_SCRIPTS_DIR = path.resolve(__dirname, '../../autospec-shared/scripts');
+
+const { generateAudienceDocs } = await import(path.join(SCRIPTS_DIR, 'gen-audience-docs.mjs'));
+const { parse: parseScopeBlocks } = await import(path.join(SHARED_SCRIPTS_DIR, 'scan-doc-scope.mjs'));
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+// Force the AI-review pass into a deterministic high-confidence stub so tests
+// never depend on an LLM being present.
+process.env.AUTOSPEC_AI_REVIEW_STUB = process.env.AUTOSPEC_AI_REVIEW_STUB || 'high';
+
+const FOUR_AUDIENCES = [
+  { name: 'user',      path: 'docs/user',      focus: 'tasks, workflows, how to use features' },
+  { name: 'developer', path: 'docs/developer', focus: 'architecture, APIs, extending' },
+  { name: 'admin',     path: 'docs/admin',     focus: 'install, configure, operate, troubleshoot' },
+  { name: 'general',   path: 'docs/general',   focus: 'what it is, why it matters, plain language' },
+];
+
+const SAMPLE_FEATURES = [
+  {
+    slug: 'export-pipeline',
+    title: 'Export Pipeline',
+    summary: 'Streams records out to downstream sinks.',
+    spec_sections: ['The export pipeline batches records and flushes to sinks.'],
+    code_entry_points: ['src/export/pipeline.mjs', 'src/export/sink.mjs'],
+  },
+  {
+    slug: 'auth',
+    title: 'Authentication',
+    summary: 'Token-based login.',
+    spec_sections: ['Auth issues short-lived JWTs.'],
+    code_entry_points: ['src/auth/login.mjs'],
+  },
+];
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'autospec-gen-audience-test-'));
+}
+
+function countOccurrences(str, sub) {
+  let count = 0, idx = 0;
+  while ((idx = str.indexOf(sub, idx)) !== -1) { count++; idx += sub.length; }
+  return count;
+}
+
+// ── Test 1: folder contract per audience ──────────────────────────────────────
+
+test('each audience produces the folder-contract files for each feature', async () => {
+  const result = await generateAudienceDocs({
+    features: SAMPLE_FEATURES,
+    audiences: FOUR_AUDIENCES,
+  });
+  for (const aud of FOUR_AUDIENCES) {
+    const audPaths = result.files.map(f => f.path).filter(p => p.startsWith(aud.path + '/'));
+    assert.ok(audPaths.includes(`${aud.path}/index.md`),
+      `${aud.name}: index.md missing`);
+    assert.ok(audPaths.includes(`${aud.path}/getting-started.md`),
+      `${aud.name}: getting-started.md missing`);
+    for (const feat of SAMPLE_FEATURES) {
+      assert.ok(audPaths.includes(`${aud.path}/tutorials/${feat.slug}.md`),
+        `${aud.name}: tutorials/${feat.slug}.md missing`);
+      assert.ok(audPaths.includes(`${aud.path}/features/${feat.slug}.md`),
+        `${aud.name}: features/${feat.slug}.md missing`);
+    }
+  }
+});
+
+// ── Test 2: every generated section has a scope comment with generated: true ──
+
+test('every generated file carries an autospec-doc-scope comment with generated: true', async () => {
+  const result = await generateAudienceDocs({
+    features: SAMPLE_FEATURES,
+    audiences: FOUR_AUDIENCES,
+  });
+  for (const file of result.files) {
+    const scopeCount = countOccurrences(file.content, '<!-- autospec-doc-scope:');
+    assert.ok(scopeCount > 0, `${file.path}: no autospec-doc-scope comment`);
+    assert.ok(file.content.includes('generated: true'),
+      `${file.path}: scope comment missing generated: true`);
+  }
+});
+
+// ── Test 3: human-owned section preserved across regen ────────────────────────
+
+test('human-owned (non-generated) section survives a regen via mergeWithExisting', async () => {
+  const result1 = await generateAudienceDocs({
+    features: SAMPLE_FEATURES,
+    audiences: [FOUR_AUDIENCES[0]],
+  });
+  const indexFile = result1.files.find(f => f.path === 'docs/user/index.md');
+  assert.ok(indexFile, 'should generate docs/user/index.md');
+
+  // Simulate a human flipping a section to generated: false and editing its body.
+  const handEdited = indexFile.content
+    .replace('generated: true', 'generated: false')
+    .replace(/(<!-- autospec-doc-scope:[\s\S]*?-->\n)/, '$1\nHUMAN EDIT: hand-written overview.\n');
+
+  const result2 = await generateAudienceDocs({
+    features: SAMPLE_FEATURES,
+    audiences: [FOUR_AUDIENCES[0]],
+    existingDocs: { 'docs/user/index.md': handEdited },
+  });
+  const regen = result2.files.find(f => f.path === 'docs/user/index.md');
+  assert.ok(regen, 'should regenerate docs/user/index.md');
+  assert.ok(regen.content.includes('HUMAN EDIT: hand-written overview.'),
+    'human-edited section should be preserved verbatim');
+  assert.ok(regen.preserved_sections > 0, 'preserved_sections should be > 0');
+});
+
+// ── Test 4: scope comments are well-formed (scan-doc-scope parses cleanly) ─────
+
+test('generated scope comments are parseable by scan-doc-scope', async () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const result = await generateAudienceDocs({
+      features: SAMPLE_FEATURES,
+      audiences: [FOUR_AUDIENCES[1]],
+    });
+    const sample = result.files.find(f => f.path.endsWith('features/export-pipeline.md'));
+    assert.ok(sample, 'should generate a feature page');
+    const tmpFile = path.join(tmpDir, 'feature.md');
+    fs.writeFileSync(tmpFile, sample.content, 'utf8');
+    const scopes = parseScopeBlocks(tmpFile);
+    assert.ok(Array.isArray(scopes), 'parse should return an array');
+    assert.ok(scopes.length > 0, 'should detect at least one scope block');
+    assert.ok(scopes.every(s => s.generated === true),
+      'every parsed scope should be generated: true');
+    assert.ok(scopes.every(s => Array.isArray(s.src_globs) && s.src_globs.length > 0),
+      'every scope should carry src globs');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── Test 5: validator + 5-attempt retry re-prompts on failure ─────────────────
+
+test('validator + retry loop re-prompts when validation fails, capped at 5 attempts', async () => {
+  // A validator that rejects the first two attempts, then accepts. The generator
+  // must feed findings back as directives and succeed within the cap.
+  let calls = 0;
+  const directives = [];
+  const validator = (content, ctx) => {
+    calls++;
+    if (ctx && ctx.directives) directives.push(ctx.directives.length);
+    if (calls <= 2) return { ok: false, findings: [`synthetic failure ${calls}`] };
+    return { ok: true, findings: [] };
+  };
+  const result = await generateAudienceDocs({
+    features: [SAMPLE_FEATURES[0]],
+    audiences: [FOUR_AUDIENCES[0]],
+    validator,
+    maxRetries: 5,
+  });
+  assert.ok(calls >= 3, `validator should be retried (got ${calls} calls)`);
+  // Later attempts must receive accumulated findings as directives.
+  assert.ok(directives.some(n => n > 0), 'findings should be fed back as directives');
+  assert.ok(result.files.length > 0, 'should still produce files once validation passes');
+});
+
+test('validator that never passes exhausts the retry cap without throwing', async () => {
+  let calls = 0;
+  const validator = () => { calls++; return { ok: false, findings: ['always fails'] }; };
+  const result = await generateAudienceDocs({
+    features: [SAMPLE_FEATURES[0]],
+    audiences: [FOUR_AUDIENCES[0]],
+    validator,
+    maxRetries: 5,
+  });
+  // One feature page is validated; the cap is per-page. Should stop at 5.
+  assert.ok(calls >= 5, `should attempt up to the cap (got ${calls})`);
+  assert.ok(Array.isArray(result.files), 'should return files array even on exhausted retries');
+});
+
+// ── Test 6: section-preservation imported, not reimplemented ───────────────────
+
+test('gen-audience-docs imports mergeWithExisting/parseSections from gen-docs-from-spec', async () => {
+  const src = fs.readFileSync(path.join(SCRIPTS_DIR, 'gen-audience-docs.mjs'), 'utf8');
+  assert.ok(
+    /gen-docs-from-spec\.mjs/.test(src)
+      && /\bimport\b/.test(src)
+      && /mergeWithExisting/.test(src),
+    'must import mergeWithExisting from gen-docs-from-spec.mjs',
+  );
+  // Must not define its own mergeWithExisting / parseSections.
+  assert.ok(!/function\s+mergeWithExisting\s*\(/.test(src),
+    'must not reimplement mergeWithExisting');
+  assert.ok(!/function\s+parseSections\s*\(/.test(src),
+    'must not reimplement parseSections');
+});
+
+// ── Test 7: outputDir writes real files under the audience path ───────────────
+
+test('writes files to outputDir under each audience path', async () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const result = await generateAudienceDocs({
+      features: [SAMPLE_FEATURES[0]],
+      audiences: FOUR_AUDIENCES,
+      outputDir: tmpDir,
+    });
+    for (const file of result.files) {
+      const outPath = path.join(tmpDir, file.path);
+      assert.ok(fs.existsSync(outPath), `${file.path} should exist in outputDir`);
+      const content = fs.readFileSync(outPath, 'utf8');
+      assert.ok(content.length > 0, `${file.path} should be non-empty`);
+    }
+    // developer feature page should reference the developer focus.
+    const devTree = result.files.filter(f => f.path.startsWith('docs/developer/'));
+    assert.ok(devTree.length > 0, 'developer tree should be generated');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('second write with identical content is idempotent (written=false)', async () => {
+  const tmpDir = makeTmpDir();
+  try {
+    await generateAudienceDocs({ features: SAMPLE_FEATURES, audiences: [FOUR_AUDIENCES[0]], outputDir: tmpDir });
+    const second = await generateAudienceDocs({ features: SAMPLE_FEATURES, audiences: [FOUR_AUDIENCES[0]], outputDir: tmpDir });
+    for (const file of second.files) {
+      assert.equal(file.written, false, `${file.path} should not be re-written on identical second pass`);
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── Test 8: empty features still produce index + getting-started ──────────────
+
+test('audience with no features still gets index.md and getting-started.md', async () => {
+  const result = await generateAudienceDocs({
+    features: [],
+    audiences: [FOUR_AUDIENCES[0]],
+  });
+  const paths = result.files.map(f => f.path);
+  assert.ok(paths.includes('docs/user/index.md'));
+  assert.ok(paths.includes('docs/user/getting-started.md'));
+});

--- a/skills/autospec-doc/tests/gen-audience-docs.test.mjs
+++ b/skills/autospec-doc/tests/gen-audience-docs.test.mjs
@@ -250,6 +250,62 @@ test('second write with identical content is idempotent (written=false)', async 
   }
 });
 
+// ── Test 9: path-traversal guard ──────────────────────────────────────────────
+
+test('rejects an audience path that escapes the docs tree', async () => {
+  await assert.rejects(
+    generateAudienceDocs({
+      features: [],
+      audiences: [{ name: 'evil', path: '../../etc', focus: 'x' }],
+    }),
+    /must not traverse|must be a relative/,
+  );
+});
+
+test('rejects an absolute audience path', async () => {
+  await assert.rejects(
+    generateAudienceDocs({
+      features: [],
+      audiences: [{ name: 'evil', path: '/etc', focus: 'x' }],
+    }),
+    /must be a relative path/,
+  );
+});
+
+test('rejects a feature slug that traverses out of the tree', async () => {
+  await assert.rejects(
+    generateAudienceDocs({
+      features: [{ slug: '../../escape' }],
+      audiences: [FOUR_AUDIENCES[0]],
+    }),
+    /must not traverse/,
+  );
+});
+
+// ── Test 10: basename fallback collision is NOT applied across audiences ───────
+
+test('existing content keyed by basename does NOT leak across audiences', async () => {
+  // A human-edited index.md for the user audience must not be preserved into
+  // the developer audience's index.md (which has the same basename).
+  const userIndex = (await generateAudienceDocs({
+    features: [],
+    audiences: [FOUR_AUDIENCES[0]],
+  })).files.find(f => f.path === 'docs/user/index.md');
+  const handEdited = userIndex.content
+    .replace('generated: true', 'generated: false')
+    .replace(/(<!-- autospec-doc-scope:[\s\S]*?-->\n)/, '$1\nLEAK MARKER user-only.\n');
+
+  const result = await generateAudienceDocs({
+    features: [],
+    audiences: [FOUR_AUDIENCES[1]], // developer
+    existingDocs: { 'docs/user/index.md': handEdited }, // wrong-audience key
+  });
+  const devIndex = result.files.find(f => f.path === 'docs/developer/index.md');
+  assert.ok(devIndex, 'developer index should be generated');
+  assert.ok(!devIndex.content.includes('LEAK MARKER user-only.'),
+    'user-audience content must not leak into developer index via basename fallback');
+});
+
 // ── Test 8: empty features still produce index + getting-started ──────────────
 
 test('audience with no features still gets index.md and getting-started.md', async () => {

--- a/skills/autospec-shared/scripts/gen-docs-from-spec.mjs
+++ b/skills/autospec-shared/scripts/gen-docs-from-spec.mjs
@@ -85,7 +85,7 @@ const GENERATORS = [
  * @param {string} content
  * @returns {Array<{ heading: string, level: number, raw: string, generated: boolean }>}
  */
-function parseSections(content) {
+export function parseSections(content) {
   const lines = content.split('\n');
   const sections = [];
   let currentSection = null;
@@ -160,7 +160,7 @@ function parseSections(content) {
  * @param {string} existingContent
  * @returns {{ merged: string, preserved: number }}
  */
-function mergeWithExisting(newContent, existingContent) {
+export function mergeWithExisting(newContent, existingContent) {
   if (!existingContent) return { merged: newContent, preserved: 0 };
 
   const existingSections = parseSections(existingContent);


### PR DESCRIPTION
Closes #918

## Summary
Implements `skills/autospec-doc/scripts/gen-audience-docs.mjs` — the per-audience documentation generator from spec §D2. For each configured audience it renders the folder contract per feature: `index.md`, `getting-started.md`, `tutorials/<feature>.md`, `features/<feature>.md`. Every generated section carries an `<!-- autospec-doc-scope: ... generated: true -->` comment so the existing drift gate governs it; human-owned (non-`generated`) sections survive regen.

## Reuse (per shared contracts / AC)
- **Reusing `mergeWithExisting`** from `skills/autospec-shared/scripts/gen-docs-from-spec.mjs` for section-level human-edit preservation — NOT reimplemented. Added `export` to `mergeWithExisting` and `parseSections` there (non-breaking; 20/20 existing gen-docs tests still pass).
- **Reusing the AI-review confidence pass** (`review` from `ai-review-doc.mjs`) — annotates each page with `<!-- ai-reviewed: CONFIDENCE -->`, stub-controlled via `AUTOSPEC_AI_REVIEW_STUB`, never blocks.
- Default validator reuses `scan-doc-scope`'s scope-comment shape; a validator + 5-attempt retry loop feeds findings back as regen directives.

## Contracts honored
- Folder contract + audience strings per the pinned `## Shared contracts` block.
- Existing `<!-- autospec-doc-scope: ... -->` marker format (emitted via the same `scopeBlock` shape as `gen-docs/*.mjs`).

## Tests
`skills/autospec-doc/tests/gen-audience-docs.test.mjs` mirrors `gen-docs.test.mjs`: folder-contract coverage per audience, scope-comment well-formedness (parsed by scan-doc-scope), human-edit preservation across regen, validator+retry re-prompt + cap, import-not-reimplement guard, idempotent writes, empty-features case.

- `node --test skills/autospec-doc/tests/gen-audience-docs.test.mjs` → 10/10
- `bash scripts/validate.sh` → exit 0
- `node --check` clean on both changed .mjs files

Peer-review: codex not on PATH, skipping.