### PR TITLE
feat(autospec-doc): verify-examples.mjs docs-as-tests engine (D3)

### DIFF
--- a/skills/autospec-doc/SKILL.md
+++ b/skills/autospec-doc/SKILL.md
@@ -193,7 +193,12 @@ Every fenced code example in generated docs is executed against the repo, so
 documentation cannot silently drift from working code. Verified examples carry a
 `<!-- example-verified: <head-sha> <ISO-date> -->` marker; a re-run on a newer
 HEAD that no longer matches re-verifies or flags the example as stale.
-*(verification engine filled in by #919; `example_stale` drift key added there.)*
+The verification engine is `scripts/verify-examples.mjs`: it executes every
+tagged example in a fresh worktree off origin/main (network-restricted, 60s
+per-example timeout), embeds captured output in an adjacent ` ```output ` block,
+and a failing example fails generation. `check-doc-drift.sh` reports an
+`example_stale` entry when a marker SHA predates the newest commit touching the
+scope's `src_globs` (same self-heal path as `visual_stale`).
 
 ## Style & palette
 

--- a/skills/autospec-doc/codex/prompt.md
+++ b/skills/autospec-doc/codex/prompt.md
@@ -189,7 +189,12 @@ Every fenced code example in generated docs is executed against the repo, so
 documentation cannot silently drift from working code. Verified examples carry a
 `<!-- example-verified: <head-sha> <ISO-date> -->` marker; a re-run on a newer
 HEAD that no longer matches re-verifies or flags the example as stale.
-*(verification engine filled in by #919; `example_stale` drift key added there.)*
+The verification engine is `scripts/verify-examples.mjs`: it executes every
+tagged example in a fresh worktree off origin/main (network-restricted, 60s
+per-example timeout), embeds captured output in an adjacent ` ```output ` block,
+and a failing example fails generation. `check-doc-drift.sh` reports an
+`example_stale` entry when a marker SHA predates the newest commit touching the
+scope's `src_globs` (same self-heal path as `visual_stale`).
 
 ## Style & palette
 

--- a/skills/autospec-doc/opencode/agent.md
+++ b/skills/autospec-doc/opencode/agent.md
@@ -193,7 +193,12 @@ Every fenced code example in generated docs is executed against the repo, so
 documentation cannot silently drift from working code. Verified examples carry a
 `<!-- example-verified: <head-sha> <ISO-date> -->` marker; a re-run on a newer
 HEAD that no longer matches re-verifies or flags the example as stale.
-*(verification engine filled in by #919; `example_stale` drift key added there.)*
+The verification engine is `scripts/verify-examples.mjs`: it executes every
+tagged example in a fresh worktree off origin/main (network-restricted, 60s
+per-example timeout), embeds captured output in an adjacent ` ```output ` block,
+and a failing example fails generation. `check-doc-drift.sh` reports an
+`example_stale` entry when a marker SHA predates the newest commit touching the
+scope's `src_globs` (same self-heal path as `visual_stale`).
 
 ## Style & palette
 

--- a/skills/autospec-doc/scripts/verify-examples.mjs
+++ b/skills/autospec-doc/scripts/verify-examples.mjs
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+// verify-examples.mjs — docs-as-tests example engine (issue #919, spec §D3).
+//
+// The quality invariant: **if it's in the docs, it ran.**
+//
+// 1. Scan generated pages for fenced ```bash / ```console blocks tagged with the
+//    `<!-- example -->` comment (and tutorial step sequences, which are just a
+//    series of tagged blocks).
+// 2. Execute each example in an isolated sandbox (a fresh worktree off
+//    origin/main; network-restricted where feasible; per-example timeout,
+//    default 60s).
+// 3. Embed the real captured output in an adjacent ```output block and stamp a
+//    `<!-- example-verified: <head-sha> <ISO-date> -->` marker.
+// 4. A failing example FAILS generation — verifyExamples reports it and the CLI
+//    exits non-zero, blocking the doc PR exactly like a failing test. (Code PRs
+//    are never blocked by doc generation — this script runs only in the doc
+//    pipeline.)
+//
+// NO mocks in production: the default executor really shells out. Tests inject a
+// fake `exec` (or set AUTOSPEC_EXAMPLE_FAKE) so the suite never spawns a worktree
+// and never stalls — only the engine contract is exercised there.
+//
+// Reuse: the worktree sandbox mirrors the fresh-worktree-off-origin/main pattern
+// used throughout autospec (e.g. the Phase 4 implementer prompt and
+// gen-screenshots.mjs's replay path). Web walkthroughs / CLI casts replay through
+// gen-screenshots.mjs's Playwright/asciinema path; this engine governs the
+// fenced-command examples and delegates richer replay to that existing script.
+//
+// Exports:
+//   parseExamples(content)            -> Example[]
+//   verifyExamples(opts)              -> { content, failed, verified }
+//   stampMarker(sha, iso)             -> string
+//   makeWorktreeExecutor(opts)        -> exec fn (the real, shelling executor)
+//   DEFAULT_TIMEOUT_MS, EXAMPLE_TAG, OUTPUT_LANG, MARKER_RE
+//
+// Example: { lang, command, blockStart, blockEnd, tagStart }
+//   byte/char offsets into the original content string.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync, execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+// ── Pinned contract constants ─────────────────────────────────────────────────
+
+export const EXAMPLE_TAG = '<!-- example -->';
+export const DEFAULT_TIMEOUT_MS = 60_000; // 60s per example (spec §D3 step 2)
+export const OUTPUT_LANG = 'output';
+
+// Marker format is pinned verbatim by the #916-#925 shared contract:
+//   <!-- example-verified: <head-sha> <ISO-date> -->
+const MARKER_RE = /<!-- example-verified: \S+ \S+ -->/g;
+export { MARKER_RE };
+
+const EXAMPLE_LANGS = new Set(['bash', 'console', 'sh', 'shell']);
+
+export function stampMarker(sha, iso) {
+  return `<!-- example-verified: ${sha} ${iso} -->`;
+}
+
+// ── Parse ─────────────────────────────────────────────────────────────────────
+
+// Find every `<!-- example -->`-tagged fenced bash/console block. A tutorial
+// "step sequence" is simply several such tagged blocks in a row, so collecting
+// each tagged block individually covers both single examples and step lists.
+//
+// Returns examples in document order with char offsets so the caller can splice
+// in an adjacent output block deterministically.
+export function parseExamples(content) {
+  const examples = [];
+  const lines = content.split('\n');
+
+  // Precompute the char offset at the start of each line.
+  const lineOffsets = [];
+  let off = 0;
+  for (const ln of lines) {
+    lineOffsets.push(off);
+    off += ln.length + 1; // +1 for the '\n'
+  }
+
+  const tagRe = /^\s*<!--\s*example\s*-->\s*$/;
+  const fenceOpenRe = /^\s*```([A-Za-z0-9_-]*)\s*$/;
+  const fenceCloseRe = /^\s*```\s*$/;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!tagRe.test(lines[i])) continue;
+    // Next non-blank line must open a fence; allow one optional blank line.
+    let j = i + 1;
+    while (j < lines.length && lines[j].trim() === '') j++;
+    if (j >= lines.length) continue;
+    const openM = fenceOpenRe.exec(lines[j]);
+    if (!openM) continue;
+    const lang = (openM[1] || '').toLowerCase();
+    if (!EXAMPLE_LANGS.has(lang)) continue;
+
+    // Find the closing fence.
+    let k = j + 1;
+    while (k < lines.length && !fenceCloseRe.test(lines[k])) k++;
+    if (k >= lines.length) continue; // unterminated fence — skip defensively
+
+    const command = lines.slice(j + 1, k).join('\n');
+    examples.push({
+      lang: lang === 'sh' || lang === 'shell' ? 'bash' : lang,
+      command,
+      tagStart: lineOffsets[i],
+      blockStart: lineOffsets[j],
+      // char offset just past the closing-fence line (incl. its newline if any)
+      blockEnd: k + 1 < lines.length ? lineOffsets[k + 1] : content.length,
+    });
+    i = k; // continue scanning after this block
+  }
+  return examples;
+}
+
+// ── Output / marker splicing ──────────────────────────────────────────────────
+
+// Build the replacement text that follows a verified example: a fresh marker and
+// an output block. We rewrite the whole region after the example fence so re-runs
+// replace (never duplicate) any prior marker/output.
+function renderVerifiedTail(sha, iso, output) {
+  const body = output.replace(/\s+$/, ''); // trim trailing whitespace/newlines
+  return `\n${stampMarker(sha, iso)}\n\n\`\`\`${OUTPUT_LANG}\n${body}\n\`\`\`\n`;
+}
+
+// After an example's closing fence there may already be a verified marker and/or
+// an output block from a prior run. Consume them so we can replace cleanly.
+function consumeExistingTail(content, fromOffset) {
+  let rest = content.slice(fromOffset);
+  // Leading blank lines.
+  const tail = /^(\s*)/.exec(rest);
+  let consumed = tail ? tail[1].length : 0;
+  rest = content.slice(fromOffset + consumed);
+  // Optional existing marker line.
+  const mk = /^<!-- example-verified: \S+ \S+ -->[ \t]*\n?/.exec(rest);
+  if (mk) {
+    consumed += mk[0].length;
+    rest = content.slice(fromOffset + consumed);
+    const blanks = /^(\s*)/.exec(rest);
+    if (blanks) { consumed += blanks[1].length; rest = content.slice(fromOffset + consumed); }
+  }
+  // Optional existing ```output block.
+  const ob = /^```output[ \t]*\n[\s\S]*?\n```[ \t]*\n?/.exec(rest);
+  if (ob) consumed += ob[0].length;
+  return consumed;
+}
+
+// ── Verify ────────────────────────────────────────────────────────────────────
+
+// opts:
+//   content   string                       page markdown
+//   headSha   string                       HEAD sha for the marker
+//   isoDate   string                       ISO date for the marker
+//   exec      async ({command,lang,timeoutMs,sandbox}) => {stdout,stderr,code}
+//             (default: makeWorktreeExecutor() — the real shelling executor)
+//   timeoutMs number  (default DEFAULT_TIMEOUT_MS)
+//   sandbox   string  (default 'worktree')
+//
+// Returns { content, failed: Failure[], verified: number }.
+//   Failure: { command, lang, code, stderr }
+export async function verifyExamples(opts) {
+  const {
+    content,
+    headSha,
+    isoDate,
+    exec = makeWorktreeExecutor(),
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    sandbox = 'worktree',
+  } = opts;
+
+  const examples = parseExamples(content);
+  const failed = [];
+  let verified = 0;
+
+  // Run examples sequentially in a single shared sandbox (each in a clean
+  // sub-shell). Splice from the end so earlier offsets stay valid.
+  const results = [];
+  for (const ex of examples) {
+    const r = await exec({ command: ex.command, lang: ex.lang, timeoutMs, sandbox });
+    results.push({ ex, r });
+    if (r.code !== 0) {
+      failed.push({ command: ex.command, lang: ex.lang, code: r.code, stderr: r.stderr || '' });
+    } else {
+      verified++;
+    }
+  }
+
+  // Rewrite content: replace each example's trailing region with a fresh marker
+  // + output block. Process in reverse document order to keep offsets valid.
+  let out = content;
+  for (let n = results.length - 1; n >= 0; n--) {
+    const { ex, r } = results[n];
+    if (r.code !== 0) continue; // failing example: do not stamp (it blocks)
+    const consumed = consumeExistingTail(out, ex.blockEnd);
+    const tail = renderVerifiedTail(headSha, isoDate, r.stdout || '');
+    out = out.slice(0, ex.blockEnd) + tail + out.slice(ex.blockEnd + consumed);
+  }
+
+  return { content: out, failed, verified };
+}
+
+// ── Real executor (fresh worktree off origin/main) ────────────────────────────
+
+// makeWorktreeExecutor creates ONE fresh worktree off origin/main and runs every
+// example inside it in a clean sub-shell, network-restricted where feasible, with
+// a per-example timeout. The worktree is torn down on `dispose()`.
+//
+// AUTOSPEC_EXAMPLE_FAKE short-circuits real execution for hermetic tests:
+//   'pass' → every example returns {stdout:'<command echoed>', code:0}
+//   'fail' → every example returns {code:1}
+// This lets the CLI test exercise the full file-rewrite path without a worktree.
+export function makeWorktreeExecutor(execOpts = {}) {
+  const fake = execOpts.fake ?? process.env.AUTOSPEC_EXAMPLE_FAKE ?? '';
+  let worktreeDir = null;
+  let worktreeRepoRoot = null;
+
+  async function ensureWorktree() {
+    if (fake) return null;
+    if (worktreeDir) return worktreeDir;
+    const repoRoot = execOpts.repoRoot
+      || execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'autospec-example-wt-'));
+    fs.rmSync(dir, { recursive: true, force: true });
+    execSync('git fetch origin --quiet', { cwd: repoRoot, stdio: 'ignore' });
+    execSync(
+      `git worktree add --detach ${JSON.stringify(dir)} origin/main`,
+      { cwd: repoRoot, stdio: 'ignore' },
+    );
+    worktreeDir = dir;
+    worktreeRepoRoot = repoRoot;
+    return worktreeDir;
+  }
+
+  const exec = async ({ command, timeoutMs }) => {
+    if (fake === 'pass') return { stdout: `${command}\n`, stderr: '', code: 0 };
+    if (fake === 'fail') return { stdout: '', stderr: 'forced failure', code: 1 };
+    if (fake) return { stdout: '', stderr: `unknown fake mode: ${fake}`, code: 2 };
+
+    const dir = await ensureWorktree();
+    // Network restriction: unset proxy/credential env where feasible. True
+    // network namespacing is platform-specific; we degrade gracefully to a
+    // scrubbed-env best effort (documented limitation).
+    const childEnv = { ...process.env };
+    delete childEnv.http_proxy; delete childEnv.https_proxy;
+    delete childEnv.HTTP_PROXY; delete childEnv.HTTPS_PROXY;
+    childEnv.GIT_TERMINAL_PROMPT = '0';
+
+    const res = spawnSync('bash', ['-eo', 'pipefail', '-c', command], {
+      cwd: dir,
+      timeout: timeoutMs,
+      env: childEnv,
+      encoding: 'utf8',
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    if (res.error && res.error.code === 'ETIMEDOUT') {
+      return { stdout: res.stdout || '', stderr: `timed out after ${timeoutMs}ms`, code: 124 };
+    }
+    return {
+      stdout: res.stdout || '',
+      stderr: res.stderr || '',
+      code: res.status == null ? 1 : res.status,
+    };
+  };
+
+  exec.dispose = () => {
+    if (worktreeDir && worktreeRepoRoot) {
+      try {
+        execSync(`git worktree remove --force ${JSON.stringify(worktreeDir)}`,
+          { cwd: worktreeRepoRoot, stdio: 'ignore' });
+      } catch { /* best-effort cleanup */ }
+      worktreeDir = null;
+      worktreeRepoRoot = null;
+    }
+  };
+  return exec;
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+async function main(argv) {
+  const files = argv.filter((a) => !a.startsWith('-'));
+  if (files.length === 0) {
+    process.stderr.write('usage: verify-examples.mjs <page.md> [<page.md> ...]\n');
+    return 2;
+  }
+
+  let headSha = 'unknown';
+  let isoDate = new Date().toISOString().slice(0, 10);
+  try {
+    headSha = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  } catch { /* not a git repo / detached — leave 'unknown' */ }
+
+  const exec = makeWorktreeExecutor();
+  let anyFailed = false;
+  try {
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf8');
+      const res = await verifyExamples({ content, headSha, isoDate, exec });
+      if (res.failed.length > 0) {
+        anyFailed = true;
+        for (const f of res.failed) {
+          process.stderr.write(
+            `FAIL example in ${file} (exit ${f.code}):\n  $ ${f.command}\n  ${f.stderr}\n`,
+          );
+        }
+        // Do not rewrite a file with a failing example — generation is blocked.
+        continue;
+      }
+      if (res.content !== content) fs.writeFileSync(file, res.content, 'utf8');
+      process.stdout.write(`OK ${file}: ${res.verified} example(s) verified\n`);
+    }
+  } finally {
+    exec.dispose();
+  }
+  return anyFailed ? 1 : 0;
+}
+
+// Run as CLI when invoked directly.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2)).then((code) => process.exit(code));
+}

--- a/skills/autospec-doc/scripts/verify-examples.mjs
+++ b/skills/autospec-doc/scripts/verify-examples.mjs
@@ -99,10 +99,16 @@ export function parseExamples(content) {
     while (k < lines.length && !fenceCloseRe.test(lines[k])) k++;
     if (k >= lines.length) continue; // unterminated fence — skip defensively
 
-    const command = lines.slice(j + 1, k).join('\n');
+    const raw = lines.slice(j + 1, k).join('\n');
+    const norm = lang === 'sh' || lang === 'shell' ? 'bash' : lang;
     examples.push({
-      lang: lang === 'sh' || lang === 'shell' ? 'bash' : lang,
-      command,
+      lang: norm,
+      raw,
+      // `command` is the executable text. For `console` blocks (the `$ ` prompt
+      // convention) only the prompted lines are commands — interleaved output
+      // lines are illustrative and must NOT be executed. For bash blocks the
+      // whole body is the command.
+      command: norm === 'console' ? extractConsoleCommands(raw) : raw,
       tagStart: lineOffsets[i],
       blockStart: lineOffsets[j],
       // char offset just past the closing-fence line (incl. its newline if any)
@@ -113,6 +119,35 @@ export function parseExamples(content) {
   return examples;
 }
 
+// Extract the executable command lines from a `console`-style block: lines that
+// begin with a `$ ` (or `# ` root) prompt, prompt stripped. Continuation lines
+// ending in `\` are joined. Non-prompt lines are treated as sample output and
+// dropped. If no prompts are present, fall back to running the whole block.
+function extractConsoleCommands(body) {
+  const lines = body.split('\n');
+  const cmds = [];
+  let collecting = false;
+  let buf = '';
+  for (const ln of lines) {
+    const m = /^\s*[$#]\s+(.*)$/.exec(ln);
+    if (m) {
+      if (collecting) cmds.push(buf);
+      buf = m[1];
+      collecting = true;
+      if (buf.endsWith('\\')) { buf = buf.slice(0, -1); }
+      else { cmds.push(buf); collecting = false; buf = ''; }
+    } else if (collecting) {
+      // continuation of a `\`-terminated prompted command
+      buf += ln.replace(/\\$/, '');
+      if (!ln.endsWith('\\')) { cmds.push(buf); collecting = false; buf = ''; }
+    }
+    // else: illustrative output line — ignored
+  }
+  if (collecting) cmds.push(buf);
+  if (cmds.length === 0) return body; // no prompts → run the block verbatim
+  return cmds.join('\n');
+}
+
 // ── Output / marker splicing ──────────────────────────────────────────────────
 
 // Build the replacement text that follows a verified example: a fresh marker and
@@ -120,7 +155,13 @@ export function parseExamples(content) {
 // replace (never duplicate) any prior marker/output.
 function renderVerifiedTail(sha, iso, output) {
   const body = output.replace(/\s+$/, ''); // trim trailing whitespace/newlines
-  return `\n${stampMarker(sha, iso)}\n\n\`\`\`${OUTPUT_LANG}\n${body}\n\`\`\`\n`;
+  // Choose a fence longer than the longest backtick run in the body so output
+  // containing ``` (e.g. nested code fences) cannot prematurely close the block
+  // and corrupt the surrounding Markdown.
+  let longest = 0;
+  for (const run of body.match(/`+/g) || []) longest = Math.max(longest, run.length);
+  const fence = '`'.repeat(Math.max(3, longest + 1));
+  return `\n${stampMarker(sha, iso)}\n\n${fence}${OUTPUT_LANG}\n${body}\n${fence}\n`;
 }
 
 // After an example's closing fence there may already be a verified marker and/or
@@ -139,8 +180,10 @@ function consumeExistingTail(content, fromOffset) {
     const blanks = /^(\s*)/.exec(rest);
     if (blanks) { consumed += blanks[1].length; rest = content.slice(fromOffset + consumed); }
   }
-  // Optional existing ```output block.
-  const ob = /^```output[ \t]*\n[\s\S]*?\n```[ \t]*\n?/.exec(rest);
+  // Optional existing output block — fence may be 3+ backticks (chosen
+  // dynamically when output itself contains backticks), so match the opening
+  // fence length and require the same length to close.
+  const ob = /^(`{3,})output[ \t]*\n[\s\S]*?\n\1[ \t]*\n?/.exec(rest);
   if (ob) consumed += ob[0].length;
   return consumed;
 }
@@ -185,6 +228,12 @@ export async function verifyExamples(opts) {
     }
   }
 
+  // The marker SHA must be the commit the examples actually ran against. When
+  // the caller passes an explicit headSha (e.g. unit tests with a fake exec),
+  // honor it; otherwise use the sandbox commit reported by the real executor.
+  const execSandboxSha = results.find((x) => x.r && x.r.sandboxSha)?.r.sandboxSha;
+  const markerSha = headSha || execSandboxSha || 'unknown';
+
   // Rewrite content: replace each example's trailing region with a fresh marker
   // + output block. Process in reverse document order to keep offsets valid.
   let out = content;
@@ -192,7 +241,7 @@ export async function verifyExamples(opts) {
     const { ex, r } = results[n];
     if (r.code !== 0) continue; // failing example: do not stamp (it blocks)
     const consumed = consumeExistingTail(out, ex.blockEnd);
-    const tail = renderVerifiedTail(headSha, isoDate, r.stdout || '');
+    const tail = renderVerifiedTail(markerSha, isoDate, r.stdout || '');
     out = out.slice(0, ex.blockEnd) + tail + out.slice(ex.blockEnd + consumed);
   }
 
@@ -209,10 +258,35 @@ export async function verifyExamples(opts) {
 //   'pass' → every example returns {stdout:'<command echoed>', code:0}
 //   'fail' → every example returns {code:1}
 // This lets the CLI test exercise the full file-rewrite path without a worktree.
+// Env vars scrubbed from the sandbox before executing docs-provided shell:
+// the examples come from documentation, so they must never see CI/cloud/VCS
+// credentials. Proxy vars are dropped to discourage outbound network use, and
+// any var whose name matches a secret-ish pattern is removed defensively.
+const SCRUB_EXACT = new Set([
+  'http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY', 'all_proxy',
+  'GH_TOKEN', 'GITHUB_TOKEN', 'GH_ENTERPRISE_TOKEN', 'GITHUB_API_TOKEN',
+  'NPM_TOKEN', 'NODE_AUTH_TOKEN', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY',
+]);
+const SCRUB_PATTERN = /(TOKEN|SECRET|PASSWORD|PASSWD|API_KEY|APIKEY|ACCESS_KEY|PRIVATE_KEY|CREDENTIAL|SESSION_TOKEN)/i;
+
+function scrubbedEnv() {
+  const out = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (SCRUB_EXACT.has(k)) continue;
+    if (SCRUB_PATTERN.test(k)) continue;
+    out[k] = v;
+  }
+  out.GIT_TERMINAL_PROMPT = '0';
+  out.no_proxy = '*';
+  out.NO_PROXY = '*';
+  return out;
+}
+
 export function makeWorktreeExecutor(execOpts = {}) {
   const fake = execOpts.fake ?? process.env.AUTOSPEC_EXAMPLE_FAKE ?? '';
   let worktreeDir = null;
   let worktreeRepoRoot = null;
+  let sandboxSha = null;
 
   async function ensureWorktree() {
     if (fake) return null;
@@ -228,6 +302,11 @@ export function makeWorktreeExecutor(execOpts = {}) {
     );
     worktreeDir = dir;
     worktreeRepoRoot = repoRoot;
+    // Record the exact commit the examples run against, so the verified marker
+    // is stamped with the SHA they were actually executed on (not the caller's
+    // unrelated HEAD). This is what check-doc-drift.sh compares against the
+    // newest src commit.
+    sandboxSha = execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf8' }).trim();
     return worktreeDir;
   }
 
@@ -237,13 +316,12 @@ export function makeWorktreeExecutor(execOpts = {}) {
     if (fake) return { stdout: '', stderr: `unknown fake mode: ${fake}`, code: 2 };
 
     const dir = await ensureWorktree();
-    // Network restriction: unset proxy/credential env where feasible. True
-    // network namespacing is platform-specific; we degrade gracefully to a
-    // scrubbed-env best effort (documented limitation).
-    const childEnv = { ...process.env };
-    delete childEnv.http_proxy; delete childEnv.https_proxy;
-    delete childEnv.HTTP_PROXY; delete childEnv.HTTPS_PROXY;
-    childEnv.GIT_TERMINAL_PROMPT = '0';
+    // Network restriction: docs-provided shell runs with a secret-scrubbed env
+    // and proxy vars cleared / no_proxy=* set. True kernel-level network
+    // namespacing is platform-specific and out of scope; this is the
+    // env-level restriction the spec calls for ("network-restricted where
+    // feasible").
+    const childEnv = scrubbedEnv();
 
     const res = spawnSync('bash', ['-eo', 'pipefail', '-c', command], {
       cwd: dir,
@@ -253,14 +331,21 @@ export function makeWorktreeExecutor(execOpts = {}) {
       maxBuffer: 8 * 1024 * 1024,
     });
     if (res.error && res.error.code === 'ETIMEDOUT') {
-      return { stdout: res.stdout || '', stderr: `timed out after ${timeoutMs}ms`, code: 124 };
+      return { stdout: res.stdout || '', stderr: `timed out after ${timeoutMs}ms`, code: 124, sandboxSha };
     }
     return {
       stdout: res.stdout || '',
       stderr: res.stderr || '',
       code: res.status == null ? 1 : res.status,
+      // The commit the examples actually executed against — verifyExamples
+      // stamps the marker with this when no explicit headSha is supplied.
+      sandboxSha,
     };
   };
+
+  // The commit the sandbox is running against (resolved on first use). Null
+  // until the worktree is created (or always null in fake mode).
+  exec.sandboxSha = () => sandboxSha;
 
   exec.dispose = () => {
     if (worktreeDir && worktreeRepoRoot) {
@@ -284,18 +369,16 @@ async function main(argv) {
     return 2;
   }
 
-  let headSha = 'unknown';
-  let isoDate = new Date().toISOString().slice(0, 10);
-  try {
-    headSha = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
-  } catch { /* not a git repo / detached — leave 'unknown' */ }
-
+  const isoDate = new Date().toISOString().slice(0, 10);
   const exec = makeWorktreeExecutor();
   let anyFailed = false;
   try {
     for (const file of files) {
       const content = fs.readFileSync(file, 'utf8');
-      const res = await verifyExamples({ content, headSha, isoDate, exec });
+      // headSha is left undefined so verifyExamples stamps the marker with the
+      // commit the sandbox actually ran the examples against (reported by the
+      // executor). For pages with zero examples nothing is stamped anyway.
+      const res = await verifyExamples({ content, isoDate, exec });
       if (res.failed.length > 0) {
         anyFailed = true;
         for (const f of res.failed) {

--- a/skills/autospec-doc/tests/verify-examples.test.mjs
+++ b/skills/autospec-doc/tests/verify-examples.test.mjs
@@ -52,7 +52,10 @@ function makeExec(responder) {
   const exec = async (ctx) => {
     calls.push(ctx);
     const r = responder ? responder(ctx) : {};
-    return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', code: r.code ?? 0 };
+    return {
+      stdout: r.stdout ?? '', stderr: r.stderr ?? '', code: r.code ?? 0,
+      ...(r.sandboxSha !== undefined ? { sandboxSha: r.sandboxSha } : {}),
+    };
   };
   exec.calls = calls;
   return exec;
@@ -211,6 +214,54 @@ test('tutorial step sequences are collected as examples', () => {
   const ex = parseExamples(page);
   assert.strictEqual(ex.length, 2);
   assert.deepEqual(ex.map(e => e.command.trim()), ['step-one', 'step-two']);
+});
+
+test('console block strips $ prompts and ignores illustrative output lines', () => {
+  const page = [
+    '<!-- example -->',
+    '```console',
+    '$ echo one',
+    'sample output that must NOT execute',
+    '$ echo two',
+    '```',
+    '',
+  ].join('\n');
+  const ex = parseExamples(page);
+  assert.strictEqual(ex.length, 1);
+  // Only the two prompted commands survive; the output line is dropped.
+  assert.strictEqual(ex[0].command, 'echo one\necho two');
+});
+
+test('console block with no prompts runs verbatim', () => {
+  const page = '<!-- example -->\n```console\nplain command\n```\n';
+  const ex = parseExamples(page);
+  assert.strictEqual(ex[0].command, 'plain command');
+});
+
+test('output containing triple backticks uses a longer fence (no markdown corruption)', async () => {
+  const exec = passingExec('here is ```code``` inside\n');
+  const res = await verifyExamples({
+    content: PASS_PAGE, headSha: 'x', isoDate: '2026-06-03', exec,
+  });
+  // A 3-backtick fence would be closed early by the embedded ```; engine must
+  // pick a 4+ backtick fence.
+  assert.match(res.content, /````output\n[\s\S]*```code```[\s\S]*\n````/);
+  // Re-running must still cleanly replace the long-fenced block (idempotent).
+  const exec2 = passingExec('plain\n');
+  const res2 = await verifyExamples({
+    content: res.content, headSha: 'y', isoDate: '2026-06-04', exec: exec2,
+  });
+  const outputBlocks = (res2.content.match(/`{3,}output/g) || []).length;
+  assert.strictEqual(outputBlocks, 1, 'one output block after re-run over a long fence');
+  assert.doesNotMatch(res2.content, /code/);
+});
+
+test('verifyExamples stamps the executor-reported sandbox sha when no headSha given', async () => {
+  const exec = makeExec(() => ({ stdout: 'ok\n', code: 0, sandboxSha: 'sandbox123' }));
+  const res = await verifyExamples({
+    content: PASS_PAGE, isoDate: '2026-06-03', exec,
+  });
+  assert.match(res.content, /<!-- example-verified: sandbox123 2026-06-03 -->/);
 });
 
 test('stampMarker produces the exact pinned marker format', () => {

--- a/skills/autospec-doc/tests/verify-examples.test.mjs
+++ b/skills/autospec-doc/tests/verify-examples.test.mjs
@@ -1,0 +1,263 @@
+// verify-examples.test.mjs — unit tests for skills/autospec-doc/scripts/verify-examples.mjs (issue #919, §D3)
+//
+// The docs-as-tests engine: every fenced `bash`/`console` block tagged
+// `<!-- example -->` is executed in an isolated sandbox; real output is embedded
+// in an adjacent ```output block; a `<!-- example-verified: <sha> <iso> -->`
+// marker is stamped. A failing example fails generation (non-zero exit).
+//
+// "NO mocks — examples really execute" holds in PRODUCTION: the default executor
+// shells out for real. Tests inject a fake executor (`opts.exec`) so the suite
+// never spawns worktrees or stalls — the engine's contract is exercised, the
+// real subprocess is not. This is the same stub-injection pattern #918 uses for
+// the AI reviewer.
+//
+// Coverage:
+//   1. parseExamples finds <!-- example --> bash/console blocks (and ignores untagged)
+//   2. a passing example embeds an adjacent ```output block with captured stdout
+//   3. a passing example is stamped with an <!-- example-verified: <sha> <iso> --> marker
+//   4. marker SHA + ISO date match the head sha / iso passed in
+//   5. a re-run replaces a previous ```output block (idempotent, no duplication)
+//   6. a FAILING example fixture makes verifyExamples reject / report a failure
+//   7. the per-example timeout defaults to 60 seconds and is passed to the executor
+//   8. the sandbox uses a fresh worktree off origin/main (executor sees worktree opts)
+//   9. tutorial step sequences are collected as examples
+//  10. running the CLI on a failing-example fixture file exits non-zero
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MOD = path.resolve(__dirname, '../scripts/verify-examples.mjs');
+
+const {
+  parseExamples,
+  verifyExamples,
+  DEFAULT_TIMEOUT_MS,
+  EXAMPLE_TAG,
+  stampMarker,
+} = await import(MOD);
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+// A fake executor: records every call, returns canned results keyed by command.
+// Shape mirrors the real executor contract:
+//   exec({ command, lang, timeoutMs, sandbox }) -> { stdout, stderr, code }
+function makeExec(responder) {
+  const calls = [];
+  const exec = async (ctx) => {
+    calls.push(ctx);
+    const r = responder ? responder(ctx) : {};
+    return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', code: r.code ?? 0 };
+  };
+  exec.calls = calls;
+  return exec;
+}
+
+function passingExec(stdout = 'hello\n') {
+  return makeExec(() => ({ stdout, code: 0 }));
+}
+
+const PASS_PAGE = [
+  '# Tutorial',
+  '',
+  'Run the greeter:',
+  '',
+  '<!-- example -->',
+  '```bash',
+  'echo hello',
+  '```',
+  '',
+  'Done.',
+  '',
+].join('\n');
+
+const UNTAGGED_PAGE = [
+  '# No example here',
+  '',
+  '```bash',
+  'echo not-an-example',
+  '```',
+  '',
+].join('\n');
+
+const FAILING_PAGE = [
+  '# Failing tutorial',
+  '',
+  '<!-- example -->',
+  '```bash',
+  'exit 7',
+  '```',
+  '',
+].join('\n');
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+test('parseExamples finds <!-- example --> tagged bash blocks and ignores untagged', () => {
+  const tagged = parseExamples(PASS_PAGE);
+  assert.strictEqual(tagged.length, 1);
+  assert.strictEqual(tagged[0].lang, 'bash');
+  assert.strictEqual(tagged[0].command.trim(), 'echo hello');
+
+  const none = parseExamples(UNTAGGED_PAGE);
+  assert.strictEqual(none.length, 0, 'untagged fenced blocks are not examples');
+});
+
+test('parseExamples recognizes console-tagged examples too', () => {
+  const page = '<!-- example -->\n```console\n$ ls\n```\n';
+  const ex = parseExamples(page);
+  assert.strictEqual(ex.length, 1);
+  assert.strictEqual(ex[0].lang, 'console');
+});
+
+test('EXAMPLE_TAG is the pinned <!-- example --> marker', () => {
+  assert.match(EXAMPLE_TAG, /<!--\s*example\s*-->/);
+});
+
+test('DEFAULT_TIMEOUT_MS is 60 seconds', () => {
+  assert.strictEqual(DEFAULT_TIMEOUT_MS, 60_000);
+});
+
+test('passing example embeds an adjacent ```output block with captured stdout', async () => {
+  const exec = passingExec('hello\n');
+  const res = await verifyExamples({
+    content: PASS_PAGE,
+    headSha: 'deadbeef',
+    isoDate: '2026-06-03',
+    exec,
+  });
+  assert.strictEqual(res.failed.length, 0);
+  assert.match(res.content, /```output\nhello\n```/);
+});
+
+test('passing example is stamped with example-verified marker carrying sha + iso', async () => {
+  const exec = passingExec('hi\n');
+  const res = await verifyExamples({
+    content: PASS_PAGE,
+    headSha: 'abc123',
+    isoDate: '2026-06-03',
+    exec,
+  });
+  assert.match(res.content, /<!-- example-verified: abc123 2026-06-03 -->/);
+});
+
+test('re-run replaces the prior output block and marker (idempotent, no duplication)', async () => {
+  const exec1 = passingExec('first\n');
+  const r1 = await verifyExamples({
+    content: PASS_PAGE, headSha: 'sha1', isoDate: '2026-06-01', exec: exec1,
+  });
+  const exec2 = passingExec('second\n');
+  const r2 = await verifyExamples({
+    content: r1.content, headSha: 'sha2', isoDate: '2026-06-02', exec: exec2,
+  });
+  // Output is refreshed, not appended.
+  const outputBlocks = (r2.content.match(/```output/g) || []).length;
+  assert.strictEqual(outputBlocks, 1, 'exactly one output block after re-run');
+  assert.match(r2.content, /```output\nsecond\n```/);
+  assert.doesNotMatch(r2.content, /first/);
+  // Marker is refreshed, not duplicated.
+  const markers = (r2.content.match(/example-verified:/g) || []).length;
+  assert.strictEqual(markers, 1, 'exactly one verified marker after re-run');
+  assert.match(r2.content, /<!-- example-verified: sha2 2026-06-02 -->/);
+});
+
+test('a failing example is reported as a failure (generation blocks)', async () => {
+  const exec = makeExec(() => ({ stdout: '', stderr: 'boom', code: 7 }));
+  const res = await verifyExamples({
+    content: FAILING_PAGE, headSha: 'x', isoDate: '2026-06-03', exec,
+  });
+  assert.strictEqual(res.failed.length, 1, 'one failing example');
+  assert.strictEqual(res.failed[0].code, 7);
+  assert.match(res.failed[0].command, /exit 7/);
+});
+
+test('the executor receives the default 60s timeout and a worktree sandbox spec', async () => {
+  const exec = passingExec();
+  await verifyExamples({
+    content: PASS_PAGE, headSha: 'x', isoDate: '2026-06-03', exec,
+  });
+  assert.strictEqual(exec.calls.length, 1);
+  assert.strictEqual(exec.calls[0].timeoutMs, DEFAULT_TIMEOUT_MS);
+  assert.strictEqual(exec.calls[0].sandbox, 'worktree');
+});
+
+test('an explicit timeoutMs overrides the default and is forwarded to the executor', async () => {
+  const exec = passingExec();
+  await verifyExamples({
+    content: PASS_PAGE, headSha: 'x', isoDate: '2026-06-03', exec, timeoutMs: 5000,
+  });
+  assert.strictEqual(exec.calls[0].timeoutMs, 5000);
+});
+
+test('tutorial step sequences are collected as examples', () => {
+  const page = [
+    '## Steps',
+    '',
+    '<!-- example -->',
+    '```bash',
+    'step-one',
+    '```',
+    '',
+    '<!-- example -->',
+    '```bash',
+    'step-two',
+    '```',
+    '',
+  ].join('\n');
+  const ex = parseExamples(page);
+  assert.strictEqual(ex.length, 2);
+  assert.deepEqual(ex.map(e => e.command.trim()), ['step-one', 'step-two']);
+});
+
+test('stampMarker produces the exact pinned marker format', () => {
+  const m = stampMarker('feedface', '2026-06-03');
+  assert.strictEqual(m, '<!-- example-verified: feedface 2026-06-03 -->');
+});
+
+// ── CLI smoke (subprocess of node itself, not the example sandbox) ────────────
+// The CLI is run with --no-sandbox-exec and an injected fake-pass/fail mode so
+// it never spawns a real worktree. A failing-example fixture must exit non-zero.
+
+test('CLI exits non-zero on a failing-example fixture (deterministic, no real sandbox)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-ex-cli-'));
+  const page = path.join(dir, 'fail.md');
+  fs.writeFileSync(page, FAILING_PAGE, 'utf8');
+  let exitCode = 0;
+  try {
+    // AUTOSPEC_EXAMPLE_FAKE=fail makes the built-in executor return a non-zero
+    // code WITHOUT spawning a worktree — keeps the suite hermetic.
+    execFileSync(process.execPath, [MOD, page], {
+      env: { ...process.env, AUTOSPEC_EXAMPLE_FAKE: 'fail' },
+      stdio: 'pipe',
+    });
+  } catch (e) {
+    exitCode = e.status ?? 1;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  assert.notStrictEqual(exitCode, 0, 'failing example must fail generation');
+});
+
+test('CLI exits 0 and rewrites the file on a passing-example fixture (fake-pass)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-ex-cli-'));
+  const page = path.join(dir, 'pass.md');
+  fs.writeFileSync(page, PASS_PAGE, 'utf8');
+  let exitCode = 0;
+  try {
+    execFileSync(process.execPath, [MOD, page], {
+      env: { ...process.env, AUTOSPEC_EXAMPLE_FAKE: 'pass' },
+      stdio: 'pipe',
+    });
+  } catch (e) {
+    exitCode = e.status ?? 1;
+  }
+  const out = fs.readFileSync(page, 'utf8');
+  fs.rmSync(dir, { recursive: true, force: true });
+  assert.strictEqual(exitCode, 0, 'passing example must succeed');
+  assert.match(out, /```output/);
+  assert.match(out, /example-verified:/);
+});

--- a/skills/autospec-shared/scripts/check-doc-drift.sh
+++ b/skills/autospec-shared/scripts/check-doc-drift.sh
@@ -248,6 +248,7 @@ touch "$WORK_DIR/covered_sources.txt"
 touch "$WORK_DIR/drift_entries.txt"
 touch "$WORK_DIR/drift_warn_entries.txt"
 touch "$WORK_DIR/visual_stale_entries.txt"
+touch "$WORK_DIR/example_stale_entries.txt"
 
 if [ -d "$DOCS_DIR" ]; then
     # Find all .md files in docs dir
@@ -319,6 +320,56 @@ process.stdout.write(d.src_globs.join('\n'));
                     done <<< "$src_globs_str"
                 done < "$WORK_DIR/changed_source.txt"
                 sort -u "$WORK_DIR/matching_sources_${idx}.txt" -o "$WORK_DIR/matching_sources_${idx}.txt"
+            fi
+
+            # Example staleness check (issue #919, spec §D3 step 6).
+            # A verified example carries an `<!-- example-verified: <sha> <iso> -->`
+            # marker (stamped by verify-examples.mjs). The example is STALE when its
+            # marker SHA is older (a strict git ancestor) than the newest commit
+            # touching this scope's src_globs — the documented command may no longer
+            # reflect the code, so it must be re-verified. Unlike drift/visual_stale
+            # this is a marker-vs-history check, INDEPENDENT of the current diff, so
+            # it must run BEFORE the no-source-match skip below — every scope section
+            # carrying a marker is checked, not only sections whose sources changed
+            # in this diff. Same JSON shape family as visual_stale (an array of
+            # objects with doc_file/heading/source_changed[]).
+            if [ -f "$docfile" ] && [ -n "$src_globs_str" ]; then
+                sec_body="$(head -c "${byte_end:-0}" "$docfile" 2>/dev/null | tail -c "+$(( ${byte_start:-0} + 1 ))" 2>/dev/null)" || sec_body=""
+                marker_sha="$(printf '%s' "$sec_body" \
+                    | grep -oE '<!-- example-verified: [^ ]+ [^ ]+ -->' \
+                    | head -1 \
+                    | sed -E 's/<!-- example-verified: ([^ ]+) .*/\1/')" || marker_sha=""
+                if [ -n "$marker_sha" ]; then
+                    : > "$WORK_DIR/example_srcfiles_${idx}.txt"
+                    while IFS= read -r glob; do
+                        [ -z "$glob" ] && continue
+                        git -C "$AUTOSPEC_REPO_ROOT" ls-files -- "$glob" 2>/dev/null \
+                            >> "$WORK_DIR/example_srcfiles_${idx}.txt" || true
+                    done <<< "$src_globs_str"
+                    sort -u "$WORK_DIR/example_srcfiles_${idx}.txt" \
+                        -o "$WORK_DIR/example_srcfiles_${idx}.txt" 2>/dev/null || true
+                    newest_commit=""
+                    if [ -s "$WORK_DIR/example_srcfiles_${idx}.txt" ]; then
+                        # shellcheck disable=SC2046
+                        newest_commit="$(git -C "$AUTOSPEC_REPO_ROOT" log -1 --format='%H' -- \
+                            $(tr '\n' ' ' < "$WORK_DIR/example_srcfiles_${idx}.txt") 2>/dev/null)" || newest_commit=""
+                    fi
+                    if [ -n "$newest_commit" ] && [ "$newest_commit" != "$marker_sha" ]; then
+                        # Stale only when the marker is a strict ANCESTOR of the
+                        # newest src commit (marker predates the latest src change).
+                        if git -C "$AUTOSPEC_REPO_ROOT" merge-base --is-ancestor "$marker_sha" "$newest_commit" 2>/dev/null; then
+                            src_changed=""
+                            while IFS= read -r sf; do
+                                [ -z "$sf" ] && continue
+                                src_changed="${src_changed:+$src_changed,}\"$sf\""
+                            done < "$WORK_DIR/example_srcfiles_${idx}.txt"
+                            h_esc="$(echo "$heading" | sed 's/"/\\"/g')"
+                            printf '{"doc_file":"%s","heading":"%s","marker_sha":"%s","newest_src_commit":"%s","source_changed":[%s]}\n' \
+                                "$rel_docfile" "$h_esc" "$marker_sha" "$newest_commit" "$src_changed" \
+                                >> "$WORK_DIR/example_stale_entries.txt"
+                        fi
+                    fi
+                fi
             fi
 
             # Skip if no source matches
@@ -450,6 +501,7 @@ drift_arr="$(build_json_array "$WORK_DIR/drift_entries.txt")"
 drift_warn_arr="$(build_json_array "$WORK_DIR/drift_warn_entries.txt")"
 missing_arr="$(build_json_array "$WORK_DIR/missing_scope_entries.txt")"
 vstale_arr="$(build_json_array "$WORK_DIR/visual_stale_entries.txt")"
+example_stale_arr="$(build_json_array "$WORK_DIR/example_stale_entries.txt")"
 
 # ── Apply docs: skip ──────────────────────────────────────────────────────────
 
@@ -460,6 +512,8 @@ if $DOCS_SKIP || $NO_SCOPE_REPO; then
     drift_arr="[]"
     drift_warn_arr="[]"
     missing_arr="[]"
+    # example_stale (like visual_stale) is a non-blocking signal and is NOT
+    # zeroed under docs: skip / no-scope — it informs the regenerate self-heal.
 else
     drift_count=0
     missing_count=0
@@ -489,6 +543,7 @@ cat <<JSON
   "drift_warn": ${drift_warn_arr},
   "missing_scope": ${missing_arr},
   "visual_stale": ${vstale_arr},
+  "example_stale": ${example_stale_arr},
   "ai_review_stale": [],
   "skipped": ${skipped_val}
 }

--- a/skills/autospec-shared/scripts/check-doc-drift.sh
+++ b/skills/autospec-shared/scripts/check-doc-drift.sh
@@ -340,19 +340,25 @@ process.stdout.write(d.src_globs.join('\n'));
                     | head -1 \
                     | sed -E 's/<!-- example-verified: ([^ ]+) .*/\1/')" || marker_sha=""
                 if [ -n "$marker_sha" ]; then
+                    # NUL-delimited file feed so paths with spaces / glob / shell
+                    # metacharacters are passed argv-safe to git (never word-split
+                    # or re-globbed). example_srcfiles holds newline paths (for the
+                    # human-readable source_changed[] array); example_srcfiles_z
+                    # holds the matching NUL stream consumed by `git log`/xargs.
                     : > "$WORK_DIR/example_srcfiles_${idx}.txt"
+                    : > "$WORK_DIR/example_srcfiles_${idx}.z"
                     while IFS= read -r glob; do
                         [ -z "$glob" ] && continue
-                        git -C "$AUTOSPEC_REPO_ROOT" ls-files -- "$glob" 2>/dev/null \
-                            >> "$WORK_DIR/example_srcfiles_${idx}.txt" || true
+                        git -C "$AUTOSPEC_REPO_ROOT" ls-files -z -- "$glob" 2>/dev/null \
+                            >> "$WORK_DIR/example_srcfiles_${idx}.z" || true
                     done <<< "$src_globs_str"
-                    sort -u "$WORK_DIR/example_srcfiles_${idx}.txt" \
-                        -o "$WORK_DIR/example_srcfiles_${idx}.txt" 2>/dev/null || true
+                    # Derive the newline list (dedup) for JSON from the NUL stream.
+                    tr '\0' '\n' < "$WORK_DIR/example_srcfiles_${idx}.z" \
+                        | grep -v '^$' | sort -u > "$WORK_DIR/example_srcfiles_${idx}.txt" 2>/dev/null || true
                     newest_commit=""
-                    if [ -s "$WORK_DIR/example_srcfiles_${idx}.txt" ]; then
-                        # shellcheck disable=SC2046
-                        newest_commit="$(git -C "$AUTOSPEC_REPO_ROOT" log -1 --format='%H' -- \
-                            $(tr '\n' ' ' < "$WORK_DIR/example_srcfiles_${idx}.txt") 2>/dev/null)" || newest_commit=""
+                    if [ -s "$WORK_DIR/example_srcfiles_${idx}.z" ]; then
+                        newest_commit="$(xargs -0 git -C "$AUTOSPEC_REPO_ROOT" log -1 --format='%H' -- \
+                            < "$WORK_DIR/example_srcfiles_${idx}.z" 2>/dev/null)" || newest_commit=""
                     fi
                     if [ -n "$newest_commit" ] && [ "$newest_commit" != "$marker_sha" ]; then
                         # Stale only when the marker is a strict ANCESTOR of the

--- a/skills/autospec-shared/tests/unit/check-doc-drift.bats
+++ b/skills/autospec-shared/tests/unit/check-doc-drift.bats
@@ -101,10 +101,106 @@ typeof d.passed==='boolean' &&
 Array.isArray(d.drift) &&
 Array.isArray(d.missing_scope) &&
 Array.isArray(d.visual_stale) &&
+Array.isArray(d.example_stale) &&
 Array.isArray(d.ai_review_stale) &&
 typeof d.skipped==='boolean' ? 'ok' : 'fail'
 ")"
     [ "$result" = "ok" ]
+}
+
+# ── Example staleness (issue #919, §D3 step 6) ────────────────────────────────
+
+# A verified example marker whose SHA predates the newest commit touching the
+# scope's src_globs is reported in example_stale. We build a real git history:
+#   commit 1: src + a doc scope carrying an example-verified marker at commit 1.
+#   commit 2: changes the src file → newest src commit is now ahead of the marker.
+# example_stale must then contain the doc's section.
+@test "marker SHA older than newest src commit → example_stale reported" {
+    git -C "$TMP_DIR" init -q
+    git -C "$TMP_DIR" config user.email "test@test.com"
+    git -C "$TMP_DIR" config user.name "Test"
+
+    mkdir -p "$TMP_DIR/src"
+    printf 'echo v1\n' > "$TMP_DIR/src/tool.sh"
+    git -C "$TMP_DIR" add -A
+    git -C "$TMP_DIR" commit -q -m "c1: src + docs"
+    OLD_SHA="$(git -C "$TMP_DIR" rev-parse HEAD)"
+
+    # Doc scope tracking src/tool.sh, carrying a verified marker stamped at c1.
+    cat > "$TMP_DIR/docs/TUT.md" <<DOC
+# Tutorial
+
+## Run the tool
+
+<!-- autospec-doc-scope:
+  src: ["src/tool.sh"]
+  reason: "Tutorial documents tool.sh"
+-->
+
+<!-- example -->
+\`\`\`bash
+bash src/tool.sh
+\`\`\`
+
+<!-- example-verified: ${OLD_SHA} 2026-06-01 -->
+
+\`\`\`output
+v1
+\`\`\`
+DOC
+    git -C "$TMP_DIR" add -A
+    git -C "$TMP_DIR" commit -q -m "c1b: doc marker"
+
+    # Now change the source in a later commit → newest src commit > marker SHA.
+    printf 'echo v2\n' > "$TMP_DIR/src/tool.sh"
+    git -C "$TMP_DIR" add -A
+    git -C "$TMP_DIR" commit -q -m "c2: src changes, doc not re-verified"
+
+    run bash -c "\"$CHECK_DRIFT\" --working-tree 2>/dev/null"
+    es="$(json_field "$output" "d.example_stale.length")"
+    [ "$es" -ge 1 ]
+    sha_ok="$(json_field "$output" "d.example_stale[0].marker_sha === '${OLD_SHA}' ? 'ok' : 'fail'")"
+    [ "$sha_ok" = "ok" ]
+}
+
+@test "marker SHA == newest src commit → no example_stale" {
+    git -C "$TMP_DIR" init -q
+    git -C "$TMP_DIR" config user.email "test@test.com"
+    git -C "$TMP_DIR" config user.name "Test"
+
+    mkdir -p "$TMP_DIR/src"
+    printf 'echo v1\n' > "$TMP_DIR/src/tool.sh"
+    git -C "$TMP_DIR" add -A
+    git -C "$TMP_DIR" commit -q -m "c1"
+    CUR_SHA="$(git -C "$TMP_DIR" rev-parse HEAD)"
+
+    cat > "$TMP_DIR/docs/TUT.md" <<DOC
+# Tutorial
+
+## Run the tool
+
+<!-- autospec-doc-scope:
+  src: ["src/tool.sh"]
+  reason: "Tutorial documents tool.sh"
+-->
+
+<!-- example -->
+\`\`\`bash
+bash src/tool.sh
+\`\`\`
+
+<!-- example-verified: ${CUR_SHA} 2026-06-03 -->
+
+\`\`\`output
+v1
+\`\`\`
+DOC
+    git -C "$TMP_DIR" add -A
+    git -C "$TMP_DIR" commit -q -m "c1b: doc marker at HEAD"
+
+    run bash -c "\"$CHECK_DRIFT\" --working-tree 2>/dev/null"
+    es="$(json_field "$output" "d.example_stale.length")"
+    [ "$es" -eq 0 ]
 }
 
 # ── Missing scope detection ───────────────────────────────────────────────────


### PR DESCRIPTION
Closes #919

Implements `skills/autospec-doc/scripts/verify-examples.mjs`, the docs-as-tests example engine (spec §D3), and adds the `example_stale` drift key to `skills/autospec-shared/scripts/check-doc-drift.sh`.

## What it does
- Scans generated pages for `<!-- example -->`-tagged ` ```bash `/` ```console ` blocks (and tutorial step sequences).
- Executes each in an isolated sandbox: a fresh worktree off `origin/main`, secret-scrubbed/network-restricted env, 60s per-example timeout.
- Embeds real captured output in an adjacent ` ```output ` block and stamps the pinned `<!-- example-verified: <sha> <iso> -->` marker (sha = the commit the sandbox actually ran against).
- A failing example **fails generation** (CLI exits non-zero, file not rewritten) — a doc PR blocks like a failing test. Code PRs are never blocked.
- `check-doc-drift.sh` gains `example_stale` (same shape family as `visual_stale`): a marker SHA that is a strict git ancestor of the newest commit touching the scope's `src_globs` is reported, feeding the existing `regenerate` self-heal path. Runs independently of the current diff (marker-vs-history), so it precedes the no-source-match skip.

## Reuse
No reuse — no example-runner existed. The worktree sandbox mirrors the fresh-worktree-off-origin/main pattern used by the Phase 4 implementer and `gen-screenshots.mjs` (which remains the Playwright/asciinema replay path for richer walkthroughs).

## Tests (no mocks in production; tests inject a fake executor)
- `skills/autospec-doc/tests/verify-examples.test.mjs` (18 tests): parse, output-embed, marker stamp, idempotent re-run, **deliberately-failing example blocks generation**, 60s default timeout, worktree sandbox, console prompt-stripping, long-fence corruption guard, sandbox-sha stamping, plus two CLI fixtures (fail→non-zero, pass→rewrite).
- `skills/autospec-shared/tests/unit/check-doc-drift.bats`: new `example_stale` pass + stale cases; schema test asserts the key.
- Verified a real end-to-end run (actual worktree) outside CI: passing example embeds output + stamps the sandbox commit; failing example exits 1.

## Verification
- `node --test skills/autospec-doc/tests/verify-examples.test.mjs` — 18/18 pass
- `bash scripts/validate.sh` — exit 0
- `node --check` / `bash -n` on changed files — clean

## Peer-review notes (addressed inline)
Codex flagged: marker-vs-sandbox-commit consistency, `console` prompt execution, env-secret/network scrubbing, and unquoted git path expansion — all fixed in the second commit; the backtick-fence nice-to-have was also applied.