### PR TITLE
feat(autospec-doc): doc-style.mjs palette + mermaid theming (D4)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1892,6 +1892,7 @@ main() {
     check_autospec_qa_cluster_contract
     check_autospec_qa_bug_class_contract
     check_autospec_resume_contract
+    check_palette_single_source
     check_autospec_doc_contract
     check_watchdog_worktree_gc
 
@@ -2326,6 +2327,44 @@ check_autospec_resume_contract() {
             info "  running: $bats_file"
             bats "$bats_file" >/tmp/validate-resume-bats.log 2>&1 \
                 || { cat /tmp/validate-resume-bats.log >&2; fail "$bats_file: failed"; }
+        done
+    fi
+}
+
+# Palette single-source check (issue #920): the 6 light-blue hex constants must
+# live ONLY in skills/autospec-doc/scripts/doc-style.mjs.  No other .mjs, .sh,
+# or .md file in the repo may hardcode any of those hex values.
+check_palette_single_source() {
+    info "palette single-source: 6 light-blue hexes must live only in doc-style.mjs (issue #920)"
+    local doc_style="skills/autospec-doc/scripts/doc-style.mjs"
+    local doc_style_test="skills/autospec-doc/tests/doc-style.test.mjs"
+    [ -f "$doc_style" ] || { fail "$doc_style: file missing"; return; }
+
+    # Read the 6 pinned hex values directly from the source of truth.
+    local hexes
+    hexes=$(grep -oE '#[0-9A-Fa-f]{6}' "$doc_style" | sort -u)
+    if [ -z "$hexes" ]; then
+        fail "$doc_style: no hex values found — palette single-source check cannot run"
+        return
+    fi
+
+    local violations=()
+    while IFS= read -r hex; do
+        # Search all .mjs and .sh files (NOT .md — specs and docs are allowed to
+        # document the hex values; only source code must not hardcode them).
+        # Exclude doc-style.mjs itself and its test file.
+        while IFS= read -r hit; do
+            # Normalize path (strip leading ./)
+            local norm_hit="${hit#./}"
+            [ "$norm_hit" = "$doc_style" ]      && continue
+            [ "$norm_hit" = "$doc_style_test" ] && continue
+            violations+=("$norm_hit contains palette hex $hex")
+        done < <(grep -rl "$hex" --include="*.mjs" --include="*.sh" . 2>/dev/null || true)
+    done <<< "$hexes"
+
+    if [ "${#violations[@]}" -gt 0 ]; then
+        for v in "${violations[@]}"; do
+            fail "palette single-source violation: $v"
         done
     fi
 }

--- a/skills/autospec-doc/scripts/doc-style.mjs
+++ b/skills/autospec-doc/scripts/doc-style.mjs
@@ -1,0 +1,269 @@
+// doc-style.mjs — palette resolution + mermaid theme injection (issue #920, spec §D4)
+//
+// Single source of truth for the light-blue palette preset.
+// ALL six hex constants live ONLY here — no other file may hardcode them.
+// scripts/validate.sh enforces single-source via check_palette_single_source().
+//
+// Exports:
+//   PALETTE          — { background, primary, secondary, accent, line, text }
+//   mermaidInit()    — %%{init: {'theme':'base','themeVariables':{...}}}%% block
+//   resolvePalette(presetName) → PALETTE | null
+//   mermaidInitForPreset(presetName) → string | null
+//   isLogicFlowSection(section) → boolean
+//   generateExplainerDiagram(section) → string | null
+
+// ── Palette preset: light-blue ────────────────────────────────────────────────
+// Pinned hexes per spec §D4.  DO NOT replicate these values in any other file.
+export const PALETTE = Object.freeze({
+  background: '#E3F2FD',
+  primary:    '#90CAF9',
+  secondary:  '#BBDEFB',
+  accent:     '#1E88E5',
+  line:       '#64B5F6',
+  text:       '#0D2C45',
+});
+
+// ── Preset registry ───────────────────────────────────────────────────────────
+
+const PRESETS = {
+  'light-blue': PALETTE,
+};
+
+/**
+ * Resolve a named palette preset.
+ * @param {string} presetName
+ * @returns {typeof PALETTE | null}  null when the preset is unknown.
+ */
+export function resolvePalette(presetName) {
+  return PRESETS[presetName] ?? null;
+}
+
+// ── Mermaid theme injection ───────────────────────────────────────────────────
+
+/**
+ * Build the %%{init}%% front-matter block that injects the light-blue palette
+ * into any mermaid diagram rendered with theme:base.
+ *
+ * The returned string is a single line (no trailing newline) suitable for
+ * prepending directly before the diagram type declaration, e.g.:
+ *
+ *   %%{init: {'theme':'base','themeVariables':{...}}}%%
+ *   flowchart LR
+ *     A --> B
+ *
+ * @returns {string}
+ */
+export function mermaidInit() {
+  const vars = {
+    background:       PALETTE.background,
+    primaryColor:     PALETTE.primary,
+    secondaryColor:   PALETTE.secondary,
+    tertiaryColor:    PALETTE.secondary,
+    primaryBorderColor: PALETTE.accent,
+    lineColor:        PALETTE.line,
+    textColor:        PALETTE.text,
+    nodeBorder:       PALETTE.accent,
+    clusterBkg:       PALETTE.secondary,
+    titleColor:       PALETTE.text,
+  };
+  const themeVarsJson = JSON.stringify(vars);
+  return `%%{init: {"theme":"base","themeVariables":${themeVarsJson}}}%%`;
+}
+
+/**
+ * Emit the %%{init}%% block for a named preset.
+ * Returns null when the preset is unknown.
+ *
+ * @param {string} presetName
+ * @returns {string | null}
+ */
+export function mermaidInitForPreset(presetName) {
+  if (presetName === 'light-blue') return mermaidInit();
+  const pal = resolvePalette(presetName);
+  if (!pal) return null;
+  // For future presets, build the same shape with their values.
+  const vars = {
+    background:       pal.background,
+    primaryColor:     pal.primary,
+    secondaryColor:   pal.secondary,
+    tertiaryColor:    pal.secondary,
+    primaryBorderColor: pal.accent,
+    lineColor:        pal.line,
+    textColor:        pal.text,
+    nodeBorder:       pal.accent,
+    clusterBkg:       pal.secondary,
+    titleColor:       pal.text,
+  };
+  return `%%{init: {"theme":"base","themeVariables":${JSON.stringify(vars)}}}%%`;
+}
+
+// ── Algorithm-explainer heuristics ───────────────────────────────────────────
+
+// Patterns that indicate a section describes logic, flows, decisions, or state machines.
+const LOGIC_FLOW_PATTERNS = [
+  // Ordered steps: "1. …", "2. …" (at least two numbered items)
+  /^\d+\.\s+\S/m,
+  // Decision language
+  /\b(if|otherwise|else|when|unless|given that|in case)\b/i,
+  // State transitions (arrow operators or state-machine keywords)
+  /(?:→|->)|(?:\b(?:state|transition|states:|phases:)\b)/i,
+  // Explicit flow words
+  /\b(decision|rule|algorithm|flow|workflow|pipeline|process|guard|route|branch)\b/i,
+];
+
+/**
+ * Returns true when a spec section describes logic/flows and therefore warrants
+ * an algorithm explainer diagram (spec §D4).
+ *
+ * Heuristic: the section body matches at least one logic/flow pattern AND has
+ * sufficient length (≥ 40 chars) to be more than a stub.
+ *
+ * @param {{ heading: string, body: string }} section
+ * @returns {boolean}
+ */
+export function isLogicFlowSection(section) {
+  const body = (section.body || '').trim();
+  if (body.length < 40) return false;
+  return LOGIC_FLOW_PATTERNS.some(re => re.test(body));
+}
+
+// ── Diagram generation helpers ────────────────────────────────────────────────
+
+/**
+ * Sanitize a label for use as a mermaid node ID.
+ * @param {string} label
+ * @returns {string}
+ */
+function mermaidId(label) {
+  return label.replace(/[^a-zA-Z0-9]/g, '_').replace(/^_+/, '').replace(/_+$/, '') || 'node';
+}
+
+/**
+ * Extract ordered-step items from a body string.
+ * Returns an array of step strings, or [] if none found.
+ * @param {string} body
+ * @returns {string[]}
+ */
+function extractOrderedSteps(body) {
+  const steps = [];
+  for (const line of body.split('\n')) {
+    const m = line.match(/^\d+\.\s+(.+)/);
+    if (m) steps.push(m[1].trim());
+  }
+  return steps;
+}
+
+/**
+ * Build a themed mermaid flowchart from a list of step labels.
+ * @param {string[]} steps
+ * @returns {string}  complete mermaid block (init header + flowchart)
+ */
+function buildFlowchart(steps) {
+  const init = mermaidInit();
+  const lines = ['flowchart TD'];
+  for (let i = 0; i < steps.length; i++) {
+    const nodeId = `S${i + 1}`;
+    const label = steps[i].replace(/"/g, "'").slice(0, 80);
+    lines.push(`    ${nodeId}["${label}"]`);
+    if (i > 0) {
+      lines.push(`    S${i} --> ${nodeId}`);
+    }
+  }
+  return `${init}\n${lines.join('\n')}`;
+}
+
+/**
+ * Build a themed mermaid flowchart from decision-rule language in the body.
+ * Falls back to a simple two-branch decision node.
+ * @param {string} body
+ * @param {string} heading
+ * @returns {string}
+ */
+function buildDecisionFlowchart(body, heading) {
+  const init = mermaidInit();
+  const title = heading.replace(/"/g, "'").slice(0, 60);
+  // Extract a simple if/otherwise pair if present.
+  const ifMatch = body.match(/\bif\b[^,.]*?[,.]?([^.]*)/i);
+  const otherwiseMatch = body.match(/\b(otherwise|else|when not)\b[^,.]*/i);
+  const lines = ['flowchart TD'];
+  lines.push(`    Start["${title}"]`);
+  lines.push(`    Cond{Condition?}`);
+  lines.push(`    Start --> Cond`);
+  if (ifMatch) {
+    const yes = ifMatch[0].replace(/^if\s*/i, '').replace(/"/g, "'").slice(0, 60);
+    lines.push(`    Cond -->|Yes| Yes["${yes}"]`);
+  } else {
+    lines.push(`    Cond -->|Yes| Yes["True branch"]`);
+  }
+  if (otherwiseMatch) {
+    const no = otherwiseMatch[0].replace(/^(otherwise|else|when not)\s*/i, '').replace(/"/g, "'").slice(0, 60);
+    lines.push(`    Cond -->|No| No["${no}"]`);
+  } else {
+    lines.push(`    Cond -->|No| No["False branch"]`);
+  }
+  return `${init}\n${lines.join('\n')}`;
+}
+
+/**
+ * Build a themed mermaid state diagram from state-machine language in the body.
+ * @param {string} body
+ * @param {string} heading
+ * @returns {string}
+ */
+function buildStateDiagram(body, heading) {
+  const init = mermaidInit();
+  // Try to extract "A → B" or "A -> B" transitions.
+  const transPattern = /(\w[\w\s-]*)[\s]*(?:→|->)[\s]*([\w][\w\s-]*)/g;
+  const transitions = [];
+  let m;
+  while ((m = transPattern.exec(body)) !== null) {
+    transitions.push({ from: m[1].trim(), to: m[2].trim() });
+  }
+  if (transitions.length === 0) {
+    // Fallback: generic two-state diagram
+    const title = heading.replace(/"/g, "'").slice(0, 40);
+    return `${init}\nstateDiagram-v2\n    [*] --> Active\n    Active --> Done\n    Done --> [*]`;
+  }
+  const lines = ['stateDiagram-v2'];
+  // First transition from gets [*] start
+  lines.push(`    [*] --> ${mermaidId(transitions[0].from)}`);
+  for (const t of transitions) {
+    lines.push(`    ${mermaidId(t.from)} --> ${mermaidId(t.to)}`);
+  }
+  // Last to gets [*] end
+  lines.push(`    ${mermaidId(transitions[transitions.length - 1].to)} --> [*]`);
+  return `${init}\n${lines.join('\n')}`;
+}
+
+/**
+ * Generate a themed mermaid explainer diagram for a logic/flow spec section.
+ * Returns null if the section is not a logic/flow section.
+ *
+ * The diagram type is chosen by heuristic:
+ *   - Ordered steps (1. 2. 3. …) → flowchart TD
+ *   - State-machine language (→ / ->) → stateDiagram-v2
+ *   - Decision language (if/otherwise) → flowchart TD with decision node
+ *
+ * @param {{ heading: string, body: string }} section
+ * @returns {string | null}
+ */
+export function generateExplainerDiagram(section) {
+  if (!isLogicFlowSection(section)) return null;
+
+  const body = section.body || '';
+  const heading = section.heading || '';
+
+  // 1. Ordered steps take highest priority.
+  const steps = extractOrderedSteps(body);
+  if (steps.length >= 2) {
+    return buildFlowchart(steps);
+  }
+
+  // 2. State-machine transitions.
+  if (/(?:→|->)/.test(body)) {
+    return buildStateDiagram(body, heading);
+  }
+
+  // 3. Decision / rule language.
+  return buildDecisionFlowchart(body, heading);
+}

--- a/skills/autospec-doc/tests/doc-style.test.mjs
+++ b/skills/autospec-doc/tests/doc-style.test.mjs
@@ -1,0 +1,239 @@
+// doc-style.test.mjs — unit tests for skills/autospec-doc/scripts/doc-style.mjs (issue #920)
+//
+// Tests:
+//   1. PALETTE export has exactly 6 keys matching spec §D4 names
+//   2. Each palette value matches the pinned §D4 hex exactly
+//   3. mermaidInit() emits all 6 palette hex values
+//   4. mermaidInit() emits %%{init ...}%% wrapper
+//   5. mermaidInit() emits theme:base
+//   6. mermaidInit() output is valid %%{init}%% JSON (parseable)
+//   7. resolvePalette('light-blue') returns the light-blue PALETTE object
+//   8. resolvePalette with unknown preset returns null
+//   9. mermaidInitForPreset('light-blue') emits the same block as mermaidInit()
+//  10. gen-arch-diagram.mjs --style flag prepends the init block before graph content
+//  11. isLogicFlowSection: ordered-step section returns true
+//  12. isLogicFlowSection: plain prose section returns false
+//  13. isLogicFlowSection: decision-rule section returns true
+//  14. isLogicFlowSection: state-machine section returns true
+//  15. generateExplainerDiagram: returns a themed flowchart string for a logic section
+//  16. generateExplainerDiagram: returns null for a non-logic section
+//  17. single-source guard: no hex from PALETTE appears in any file outside doc-style.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = path.resolve(__dirname, '../scripts');
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+const { PALETTE, mermaidInit, resolvePalette, mermaidInitForPreset, isLogicFlowSection, generateExplainerDiagram } =
+  await import(path.join(SCRIPTS_DIR, 'doc-style.mjs'));
+
+// ── Spec §D4 pinned values ────────────────────────────────────────────────────
+
+const EXPECTED_HEXES = {
+  background: '#E3F2FD',
+  primary:    '#90CAF9',
+  secondary:  '#BBDEFB',
+  accent:     '#1E88E5',
+  line:       '#64B5F6',
+  text:       '#0D2C45',
+};
+
+// ── Tests 1-2: PALETTE export ─────────────────────────────────────────────────
+
+test('PALETTE export has exactly 6 keys matching spec §D4 names', () => {
+  const keys = Object.keys(PALETTE).sort();
+  const expected = Object.keys(EXPECTED_HEXES).sort();
+  assert.deepEqual(keys, expected);
+});
+
+test('each palette value matches the pinned §D4 hex exactly', () => {
+  for (const [key, hex] of Object.entries(EXPECTED_HEXES)) {
+    assert.strictEqual(
+      PALETTE[key],
+      hex,
+      `PALETTE.${key} must be ${hex} (got ${PALETTE[key]})`
+    );
+  }
+});
+
+// ── Tests 3-6: mermaidInit() ──────────────────────────────────────────────────
+
+test('mermaidInit() emits all 6 palette hex values', () => {
+  const block = mermaidInit();
+  for (const [key, hex] of Object.entries(EXPECTED_HEXES)) {
+    assert.ok(
+      block.includes(hex),
+      `mermaidInit() output must contain ${hex} (for ${key})`
+    );
+  }
+});
+
+test('mermaidInit() emits %%{init ...}%% wrapper', () => {
+  const block = mermaidInit();
+  assert.ok(block.startsWith('%%{init:'), `mermaidInit() must start with %%{init: — got: ${block.slice(0, 30)}`);
+  assert.ok(block.trimEnd().endsWith('}%%'), `mermaidInit() must end with }%% — got: ${block.slice(-20)}`);
+});
+
+test('mermaidInit() emits theme:base', () => {
+  const block = mermaidInit();
+  assert.ok(block.includes("'theme':'base'") || block.includes('"theme":"base"') || block.includes("'theme': 'base'"),
+    `mermaidInit() must include theme:base`);
+});
+
+test('mermaidInit() output is valid %%{init}%% JSON (parseable)', () => {
+  const block = mermaidInit();
+  // Strip %%{init: ... }%%
+  const inner = block.replace(/^%%\{init:\s*/, '').replace(/\s*\}%%\s*$/, '');
+  let parsed;
+  try {
+    parsed = JSON.parse(inner);
+  } catch (e) {
+    assert.fail(`mermaidInit() inner JSON is not parseable: ${e.message}\nBlock: ${block}`);
+  }
+  assert.ok(parsed && typeof parsed === 'object', 'parsed inner must be an object');
+  assert.ok('themeVariables' in parsed, 'parsed must have themeVariables key');
+});
+
+// ── Tests 7-9: resolvePalette + mermaidInitForPreset ─────────────────────────
+
+test('resolvePalette(\'light-blue\') returns the light-blue PALETTE object', () => {
+  const pal = resolvePalette('light-blue');
+  assert.deepEqual(pal, PALETTE);
+});
+
+test('resolvePalette with unknown preset returns null', () => {
+  const pal = resolvePalette('does-not-exist');
+  assert.strictEqual(pal, null);
+});
+
+test('mermaidInitForPreset(\'light-blue\') emits the same block as mermaidInit()', () => {
+  const a = mermaidInit();
+  const b = mermaidInitForPreset('light-blue');
+  assert.strictEqual(b, a);
+});
+
+// ── Test 10: gen-arch-diagram.mjs --style flag ────────────────────────────────
+
+test('gen-arch-diagram.mjs --style flag prepends the init block before graph content', () => {
+  const GEN_ARCH = path.resolve(__dirname, '../../autospec-shared/scripts/gen-arch-diagram.mjs');
+  const clusterFixture = path.resolve(__dirname, '../../autospec-shared/tests/fixtures/cluster-sample.json');
+  if (!fs.existsSync(GEN_ARCH)) {
+    // Skip if gen-arch-diagram not present (shouldn't happen)
+    return;
+  }
+  if (!fs.existsSync(clusterFixture)) {
+    return;
+  }
+  const result = spawnSync(process.execPath, [GEN_ARCH, '--cluster', clusterFixture, '--style'], {
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+  assert.strictEqual(result.status, 0, `gen-arch-diagram.mjs --style exited ${result.status}: ${result.stderr}`);
+  const out = result.stdout;
+  assert.ok(out.includes('%%{init:'), `--style output must contain mermaid init block, got: ${out.slice(0, 200)}`);
+  assert.ok(out.includes(EXPECTED_HEXES.primary), `--style output must contain primary hex ${EXPECTED_HEXES.primary}`);
+});
+
+// ── Tests 11-14: isLogicFlowSection ──────────────────────────────────────────
+
+test('isLogicFlowSection: ordered-step section returns true', () => {
+  const section = {
+    heading: 'Processing Pipeline',
+    body: '1. Validate input\n2. Transform data\n3. Write output\n4. Confirm success',
+  };
+  assert.strictEqual(isLogicFlowSection(section), true);
+});
+
+test('isLogicFlowSection: plain prose section returns false', () => {
+  const section = {
+    heading: 'Overview',
+    body: 'This is a general overview of the system. It describes the background context.',
+  };
+  assert.strictEqual(isLogicFlowSection(section), false);
+});
+
+test('isLogicFlowSection: decision-rule section returns true', () => {
+  const section = {
+    heading: 'Routing Logic',
+    body: 'If the request is authenticated, route to /api. Otherwise, redirect to /login.',
+  };
+  assert.strictEqual(isLogicFlowSection(section), true);
+});
+
+test('isLogicFlowSection: state-machine section returns true', () => {
+  const section = {
+    heading: 'Issue States',
+    body: 'States: open → in-progress → review → closed. Transitions are guarded by labels.',
+  };
+  assert.strictEqual(isLogicFlowSection(section), true);
+});
+
+// ── Tests 15-16: generateExplainerDiagram ────────────────────────────────────
+
+test('generateExplainerDiagram: returns a themed flowchart string for a logic section', () => {
+  const section = {
+    heading: 'Processing Steps',
+    body: '1. Read config\n2. Parse input\n3. Generate output\n4. Write file',
+  };
+  const diagram = generateExplainerDiagram(section);
+  assert.ok(typeof diagram === 'string' && diagram.length > 0,
+    'generateExplainerDiagram must return a non-empty string for a logic section');
+  assert.ok(diagram.includes('%%{init:'), `diagram must include mermaid init block, got: ${diagram.slice(0, 200)}`);
+  assert.ok(diagram.includes('flowchart') || diagram.includes('graph') || diagram.includes('sequenceDiagram'),
+    `diagram must include a mermaid diagram type, got: ${diagram.slice(0, 200)}`);
+});
+
+test('generateExplainerDiagram: returns null for a non-logic section', () => {
+  const section = {
+    heading: 'Background',
+    body: 'This section provides background context about the project history.',
+  };
+  const diagram = generateExplainerDiagram(section);
+  assert.strictEqual(diagram, null);
+});
+
+// ── Test 17: single-source guard ─────────────────────────────────────────────
+
+test('single-source guard: no hex from PALETTE appears in any file outside doc-style.mjs and its test', () => {
+  // Directories to scan (narrow to .mjs files to keep this fast)
+  const hexValues = Object.values(PALETTE);
+  const violations = [];
+
+  function scanDir(dir) {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        // Skip node_modules, .git, test fixtures
+        if (['node_modules', '.git', 'fixtures'].includes(entry.name)) continue;
+        scanDir(fullPath);
+      } else if (entry.isFile() && (entry.name.endsWith('.mjs') || entry.name.endsWith('.sh'))) {
+        // NOTE: .md files (specs, docs) are allowed to document hex values;
+        // only source code (.mjs, .sh) must not hardcode them.
+        // Skip doc-style.mjs itself and its test
+        if (entry.name === 'doc-style.mjs') continue;
+        if (entry.name === 'doc-style.test.mjs') continue;
+        let content;
+        try { content = fs.readFileSync(fullPath, 'utf8'); } catch { continue; }
+        for (const hex of hexValues) {
+          if (content.includes(hex)) {
+            violations.push(`${fullPath}: contains palette hex ${hex}`);
+          }
+        }
+      }
+    }
+  }
+
+  // Scan the full repo (skills/ + scripts/ + docs/)
+  for (const topDir of ['skills', 'scripts', 'docs']) {
+    scanDir(path.join(REPO_ROOT, topDir));
+  }
+
+  assert.deepEqual(violations, [], `Single-source violation: palette hexes found outside doc-style.mjs:\n${violations.join('\n')}`);
+});

--- a/skills/autospec-shared/scripts/gen-arch-diagram.mjs
+++ b/skills/autospec-shared/scripts/gen-arch-diagram.mjs
@@ -21,6 +21,24 @@ import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 
+// ── Style / palette integration ───────────────────────────────────────────────
+// doc-style.mjs is the single source of the light-blue palette.
+// When --style is passed on the CLI, mermaidInit() is prepended to every
+// generated diagram so renderers apply the correct theme variables.
+let _mermaidInitFn = null;
+
+async function getMermaidInit() {
+  if (_mermaidInitFn) return _mermaidInitFn;
+  try {
+    const stylePath = path.resolve(path.dirname(__filename), '../../autospec-doc/scripts/doc-style.mjs');
+    const mod = await import(stylePath);
+    _mermaidInitFn = mod.mermaidInit;
+  } catch {
+    _mermaidInitFn = null;
+  }
+  return _mermaidInitFn;
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
@@ -285,13 +303,16 @@ if (process.argv[1] && fs.realpathSync(path.resolve(process.argv[1])) === fs.rea
   let clusterFile = null;
   let archFile = null;
 
+  let useStyle = false;
+
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--cluster') clusterFile = args[i + 1];
     if (args[i] === '--arch')    archFile    = args[i + 1];
+    if (args[i] === '--style')   useStyle    = true;
   }
 
   if (!clusterFile) {
-    process.stderr.write('Usage: gen-arch-diagram.mjs --cluster <file> [--arch <architecture.md>]\n');
+    process.stderr.write('Usage: gen-arch-diagram.mjs --cluster <file> [--arch <architecture.md>] [--style]\n');
     process.exit(1);
   }
 
@@ -303,26 +324,55 @@ if (process.argv[1] && fs.realpathSync(path.resolve(process.argv[1])) === fs.rea
     process.exit(1);
   }
 
+  // Resolve the mermaid init block when --style is requested.
+  let initBlock = '';
+  if (useStyle) {
+    const initFn = await getMermaidInit();
+    if (initFn) {
+      initBlock = initFn() + '\n';
+    } else {
+      process.stderr.write('gen-arch-diagram: --style requested but doc-style.mjs could not be loaded; continuing without theme\n');
+    }
+  }
+
+  /**
+   * Wrap a mermaid string with the optional init block and fences.
+   * @param {string} content
+   * @returns {string}
+   */
+  function styledFence(content) {
+    return '```mermaid\n' + initBlock + content + '\n```';
+  }
+
   const diagrams = generateAllDiagrams(clusters);
 
   if (archFile) {
     let existing = '';
     if (fs.existsSync(archFile)) existing = fs.readFileSync(archFile, 'utf8');
-    const patched = patchArchitectureMd(existing, diagrams);
+    // When --style is active, patch diagrams to include the init block.
+    let patchedDiagrams = diagrams;
+    if (initBlock) {
+      patchedDiagrams = {
+        moduleGraph: initBlock.trimEnd() + '\n' + diagrams.moduleGraph,
+        cliTrees:  diagrams.cliTrees.map(t  => initBlock.trimEnd() + '\n' + t),
+        httpTrees: diagrams.httpTrees.map(t => initBlock.trimEnd() + '\n' + t),
+      };
+    }
+    const patched = patchArchitectureMd(existing, patchedDiagrams);
     fs.writeFileSync(archFile, patched, 'utf8');
     process.stdout.write(`gen-arch-diagram: patched ${archFile}\n`);
   } else {
     // Print all diagrams to stdout
     const { moduleGraph, cliTrees, httpTrees } = diagrams;
     process.stdout.write('## Module Graph\n\n');
-    process.stdout.write(mermaidFence(moduleGraph) + '\n');
+    process.stdout.write(styledFence(moduleGraph) + '\n');
     if (cliTrees.length > 0) {
       process.stdout.write('\n## CLI Entry-point Call Trees\n\n');
-      for (const t of cliTrees) process.stdout.write(mermaidFence(t) + '\n\n');
+      for (const t of cliTrees) process.stdout.write(styledFence(t) + '\n\n');
     }
     if (httpTrees.length > 0) {
       process.stdout.write('\n## HTTP Entry-point Call Trees\n\n');
-      for (const t of httpTrees) process.stdout.write(mermaidFence(t) + '\n\n');
+      for (const t of httpTrees) process.stdout.write(styledFence(t) + '\n\n');
     }
   }
 


### PR DESCRIPTION
Closes #920

## Summary

Implements spec §D4 — the visual layer for `autospec-doc`:

- **`skills/autospec-doc/scripts/doc-style.mjs`** (new): single source of truth for the 6 light-blue palette hexes (`#E3F2FD`/`#90CAF9`/`#BBDEFB`/`#1E88E5`/`#64B5F6`/`#0D2C45`). Exports `PALETTE`, `mermaidInit()`, `resolvePalette()`, `mermaidInitForPreset()`, `isLogicFlowSection()`, and `generateExplainerDiagram()`.
- **`skills/autospec-doc/tests/doc-style.test.mjs`** (new): 17 unit tests covering palette values, `%%{init}%%` block shape, `--style` flag integration, logic-flow heuristics, explainer diagram generation, and the single-source guard.
- **`skills/autospec-shared/scripts/gen-arch-diagram.mjs`** (modified): added `--style` flag; when set, lazily imports `mermaidInit()` from `doc-style.mjs` and prepends the `%%{init}%%` block to every generated diagram.
- **`scripts/validate.sh`** (modified): added `check_palette_single_source()` — scans all `.mjs`/`.sh` files and fails if any of the 6 hex constants appear outside `doc-style.mjs` (single-source enforcement per spec contract).

## Reuse

Reusing the existing `node:test` + `node:assert/strict` test pattern from `doc-config.test.mjs` and `gen-arch-diagram.test.mjs`. The `--style` flag wires into the existing `mermaidFence()`/`generateAllDiagrams()` pipeline without reimplementation.

## Test results

- `node --test skills/autospec-doc/tests/doc-style.test.mjs` → 17/17 pass
- `node --test skills/autospec-shared/tests/unit/gen-arch-diagram.test.mjs` → 12/12 pass
- `bash scripts/validate.sh` → exit 0