### PR TITLE
fix: keep autospec-run draining after deep batches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,7 +396,7 @@ Exit codes from `ci-wait-poll.sh`: 0=pass, 1=fail/stalled, 2=pending, 3=no senti
 
 ## Batch size policy
 
-Default `AUTOSPEC_BATCH_SIZE=3`; force batch=1 when the next ready issue is `reasoning:deep` (high blast-radius work runs one-at-a-time per monitor session).
+Default `AUTOSPEC_BATCH_SIZE=3`; force batch=1 when the next ready issue is `reasoning:deep` (high blast-radius work runs one-at-a-time per monitor session). This only ends the current monitor batch: `autospec-run` must automatically relaunch fresh monitor batches until the queue is `ALL_DONE`.
 
 ## Memory inventory
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -684,6 +684,27 @@ check_phase4_immediate_next_issue_pickup() {
     done
 }
 
+# autospec-run queue-drain contract: `reasoning:deep` may shorten one monitor
+# batch for fresh context, but it must not end the user-invoked run.
+check_autospec_run_continuation_contract() {
+    info "autospec-run continuation contract: BATCH_COMPLETE relaunches until ALL_DONE"
+    for f in \
+        skills/autospec-run/SKILL.md \
+        skills/autospec-run/codex/prompt.md \
+        skills/autospec-run/opencode/agent.md
+    do
+        [ -f "$f" ] || fail "$f: required file missing"
+        grep -F 'BATCH_COMPLETE is a continuation signal, not a terminal state' "$f" >/dev/null \
+            || fail "$f missing BATCH_COMPLETE continuation contract"
+        grep -F 'reasoning:deep may reduce a single monitor batch to one issue' "$f" >/dev/null \
+            || fail "$f missing reasoning:deep single-monitor-batch wording"
+        grep -F 'the orchestrator MUST relaunch automatically until ALL_DONE' "$f" >/dev/null \
+            || fail "$f missing automatic relaunch-until-ALL_DONE directive"
+        grep -F 'Never tell the operator to rerun `/autospec-run` after BATCH_COMPLETE' "$f" >/dev/null \
+            || fail "$f missing no-manual-rerun directive"
+    done
+}
+
 # Phase 4 single-agent absorbed-discipline (issue #648): the autospec-run trio
 # must (1) carry the canonical constraint sentence stating that subagents spawned
 # by background `Agent` calls do NOT inherit the `Agent` tool, (2) reference the
@@ -1850,6 +1871,7 @@ main() {
     check_phase1_bounded_context_contract
     check_phase4_issue_start_summary
     check_phase4_immediate_next_issue_pickup
+    check_autospec_run_continuation_contract
     check_phase4_single_agent_discipline
     check_phase4_adaptive_retry
     check_phase4_full_test_suite_gate

--- a/skills/autospec-run/README.md
+++ b/skills/autospec-run/README.md
@@ -82,6 +82,9 @@ reclaims stale GitHub run-state in addition to same-host heartbeat files.
   a foreground subagent to implement it (worktree → TDD → push → PR → self-review
   → admin-squash-merge), then loops without sleeping so a freshly-merged PR can
   unblock the next issue immediately.
+  `reasoning:deep` issues may reduce one monitor batch to a single issue for
+  fresh context, but `BATCH_COMPLETE` still auto-relaunches; only `ALL_DONE`
+  ends the `/autospec-run` invocation.
 - **Phase 5** — Periodic status updates posted to the user every ~25 min (slows
   to ~50 min when quiet).
 - **Phase 6** — Final report on monitor termination: every issue processed, every

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -326,6 +326,8 @@ while true:
   # continue immediately, no sleep
 ```
 
+**Continuation contract:** BATCH_COMPLETE is a continuation signal, not a terminal state. reasoning:deep may reduce a single monitor batch to one issue, but the orchestrator MUST relaunch automatically until ALL_DONE. Never tell the operator to rerun `/autospec-run` after BATCH_COMPLETE; the current invocation owns the relaunch loop until the queue is empty or a hard blocker stops it.
+
 Pass the following prompt verbatim to each background subagent:
 
 > You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
@@ -340,7 +342,7 @@ Pass the following prompt verbatim to each background subagent:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. BATCH_COMPLETE is a continuation signal, not a terminal state; the orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Profile load (run-start, once).** If `--profile <name>` was passed, look it up in `~/.autospec/model-profiles.yml`; if `<name>` is not a key under `profiles:`, exit non-zero and print the available names. If no flag was passed, load the file's `default:` profile. If the file is missing, run auto-init and exit (per the Invocation section).
@@ -505,7 +507,8 @@ inline label-swap path below.
 >     fi
 >   fi
 >   # effective_batch_size probe — recomputed each outer-loop tick (not cached).
->   # Force batch=1 when the next ready issue is reasoning:deep (high blast-radius).
+>   # reasoning:deep may reduce a single monitor batch to one issue for fresh context.
+>   # This is not a run stop: the orchestrator MUST relaunch automatically until ALL_DONE.
 >   _next_reasoning=$(gh issue view "${ready[0]}" --json labels \
 >     --jq '[.labels[].name | select(startswith("reasoning:"))] | first // "reasoning:medium"' \
 >     2>/dev/null || echo "reasoning:medium")

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -321,6 +321,8 @@ while true:
   # continue immediately, no sleep
 ```
 
+**Continuation contract:** BATCH_COMPLETE is a continuation signal, not a terminal state. reasoning:deep may reduce a single monitor batch to one issue, but the orchestrator MUST relaunch automatically until ALL_DONE. Never tell the operator to rerun `/autospec-run` after BATCH_COMPLETE; the current invocation owns the relaunch loop until the queue is empty or a hard blocker stops it.
+
 Pass the following prompt verbatim to each background subagent:
 
 > You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
@@ -335,7 +337,7 @@ Pass the following prompt verbatim to each background subagent:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. BATCH_COMPLETE is a continuation signal, not a terminal state; the orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Profile load (run-start, once).** If `--profile <name>` was passed, look it up in `~/.autospec/model-profiles.yml`; if `<name>` is not a key under `profiles:`, exit non-zero and print the available names. If no flag was passed, load the file's `default:` profile. If the file is missing, run auto-init and exit (per the Invocation section).
@@ -500,7 +502,8 @@ inline label-swap path below.
 >     fi
 >   fi
 >   # effective_batch_size probe — recomputed each outer-loop tick (not cached).
->   # Force batch=1 when the next ready issue is reasoning:deep (high blast-radius).
+>   # reasoning:deep may reduce a single monitor batch to one issue for fresh context.
+>   # This is not a run stop: the orchestrator MUST relaunch automatically until ALL_DONE.
 >   _next_reasoning=$(gh issue view "${ready[0]}" --json labels \
 >     --jq '[.labels[].name | select(startswith("reasoning:"))] | first // "reasoning:medium"' \
 >     2>/dev/null || echo "reasoning:medium")

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -325,6 +325,8 @@ while true:
   # continue immediately, no sleep
 ```
 
+**Continuation contract:** BATCH_COMPLETE is a continuation signal, not a terminal state. reasoning:deep may reduce a single monitor batch to one issue, but the orchestrator MUST relaunch automatically until ALL_DONE. Never tell the operator to rerun `/autospec-run` after BATCH_COMPLETE; the current invocation owns the relaunch loop until the queue is empty or a hard blocker stops it.
+
 Pass the following prompt verbatim to each background subagent:
 
 > You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
@@ -339,7 +341,7 @@ Pass the following prompt verbatim to each background subagent:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. BATCH_COMPLETE is a continuation signal, not a terminal state; the orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Profile load (run-start, once).** If `--profile <name>` was passed, look it up in `~/.autospec/model-profiles.yml`; if `<name>` is not a key under `profiles:`, exit non-zero and print the available names. If no flag was passed, load the file's `default:` profile. If the file is missing, run auto-init and exit (per the Invocation section).
@@ -504,7 +506,8 @@ inline label-swap path below.
 >     fi
 >   fi
 >   # effective_batch_size probe — recomputed each outer-loop tick (not cached).
->   # Force batch=1 when the next ready issue is reasoning:deep (high blast-radius).
+>   # reasoning:deep may reduce a single monitor batch to one issue for fresh context.
+>   # This is not a run stop: the orchestrator MUST relaunch automatically until ALL_DONE.
 >   _next_reasoning=$(gh issue view "${ready[0]}" --json labels \
 >     --jq '[.labels[].name | select(startswith("reasoning:"))] | first // "reasoning:medium"' \
 >     2>/dev/null || echo "reasoning:medium")

--- a/tests/batch-size-gating.bats
+++ b/tests/batch-size-gating.bats
@@ -82,3 +82,25 @@ setup() {
   opencode_md="${BATS_TEST_DIRNAME}/../skills/autospec-run/opencode/agent.md"
   grep -q 'effective_batch_size:-\$BATCH_SIZE' "$opencode_md"
 }
+
+@test "autospec-run documents BATCH_COMPLETE as continuation rather than manual rerun" {
+  for f in \
+    "${BATS_TEST_DIRNAME}/../skills/autospec-run/SKILL.md" \
+    "${BATS_TEST_DIRNAME}/../skills/autospec-run/codex/prompt.md" \
+    "${BATS_TEST_DIRNAME}/../skills/autospec-run/opencode/agent.md"
+  do
+    grep -F 'BATCH_COMPLETE is a continuation signal, not a terminal state' "$f"
+    grep -F 'Never tell the operator to rerun `/autospec-run` after BATCH_COMPLETE' "$f"
+  done
+}
+
+@test "reasoning:deep gate is scoped to one monitor batch, not the full autospec-run invocation" {
+  for f in \
+    "${BATS_TEST_DIRNAME}/../skills/autospec-run/SKILL.md" \
+    "${BATS_TEST_DIRNAME}/../skills/autospec-run/codex/prompt.md" \
+    "${BATS_TEST_DIRNAME}/../skills/autospec-run/opencode/agent.md"
+  do
+    grep -F 'reasoning:deep may reduce a single monitor batch to one issue' "$f"
+    grep -F 'the orchestrator MUST relaunch automatically until ALL_DONE' "$f"
+  done
+}


### PR DESCRIPTION
## Summary
- Clarifies autospec-run's continuation contract: BATCH_COMPLETE is a relaunch signal, not a terminal state.
- Keeps reasoning:deep one-item monitor batches for fresh context while requiring automatic relaunch until ALL_DONE.
- Adds validate.sh and Bats coverage so future skill edits cannot reintroduce a manual rerun handoff.

## Validation
- bats tests/batch-size-gating.bats
- bash scripts/validate.sh

## Not tested
- Live GitHub queue drain with real auto-implement issues