### PR TITLE
feat(autospec-doc): sweep --full upgrade + define auto-docs redirect (D6)

### DIFF
--- a/scripts/dogfood-adapter-doc-drift.sh
+++ b/scripts/dogfood-adapter-doc-drift.sh
@@ -17,6 +17,14 @@
 #   DOC_DRIFT_MISSING_SCOPE — `missing_scope[]`
 #   DOC_DRIFT_VISUAL_STALE  — `visual_stale[]`
 #   DOC_DRIFT_WARN          — `drift_warn[]`
+#   DOC_FULL_AUDIT          — repo-wide completeness gap from `/autospec-doc --full`
+#
+# Sweep upgrade (spec §D6 row 3, issue #924): the docs-drift sweep check is no
+# longer detect-only. It first invokes `/autospec-doc --full` — full regen plus
+# the repo-wide completeness audit — via scripts/doc-orchestrator.mjs, then
+# surfaces any missing parts the audit reports as findings (rule
+# DOC_FULL_AUDIT). The detect-only drift gate below still runs afterward so
+# stale/contradicting docs continue to surface alongside completeness gaps.
 
 set -eu
 
@@ -30,6 +38,33 @@ if [ ! -x "$DETECTOR" ] && [ ! -r "$DETECTOR" ]; then
 fi
 
 cd "$REPO_DIR"
+
+emit() {
+    # emit RULE_ID FILE FUNCTION LINE
+    local rule_id="$1" file="$2" func="$3" line="$4"
+    printf '{"category":"code_health:doc_drift","rule_id":"%s","language":"n/a","file":"%s","function":"%s","line":%s}\n' \
+        "$rule_id" "$file" "$func" "$line" >> "$VERDICT_FILE"
+}
+
+# ── /autospec-doc --full (spec §D6 row 3) ─────────────────────────────────────
+# Invoke the single doc engine in full mode: regenerate every audience and run
+# the repo-wide completeness audit. The orchestrator exits 2 when the repo has
+# no `documentation:` config (nothing to regenerate) — a graceful skip, not a
+# finding. Any audit line the engine prints (`missing: <path>`) becomes one
+# DOC_FULL_AUDIT finding so repo-wide gaps surface through the sweep's existing
+# finding emission.
+ORCHESTRATOR="${REPO_DIR}/skills/autospec-doc/scripts/doc-orchestrator.mjs"
+if [ -r "$ORCHESTRATOR" ] && command -v node >/dev/null 2>&1; then
+    FULL_OUT="$(node "$ORCHESTRATOR" --full 2>&1)"; full_rc=$?
+    if [ "$full_rc" != "2" ]; then
+        # rc 0 = regen+audit ran; rc !=0,!=2 = engine error (still surface gaps).
+        printf '%s\n' "$FULL_OUT" \
+            | sed -n 's/.*[Mm]issing:[[:space:]]*\([^[:space:]]*\).*/\1/p' \
+            | while IFS= read -r missing; do
+                  [ -n "$missing" ] && emit "DOC_FULL_AUDIT" "$missing" "-" 0
+              done
+    fi
+fi
 
 # Build a synthetic diff of the most-recent commit. If the repo has no
 # prior commit, fall back to working-tree mode (no findings most likely).
@@ -47,13 +82,6 @@ bash "$DETECTOR" --working-tree > "$GATE_JSON" 2>/dev/null || true
 
 # If the gate produced no JSON (e.g. errored out) leave VERDICT_FILE alone.
 [ -s "$GATE_JSON" ] || exit 0
-
-emit() {
-    # emit RULE_ID FILE FUNCTION LINE
-    local rule_id="$1" file="$2" func="$3" line="$4"
-    printf '{"category":"code_health:doc_drift","rule_id":"%s","language":"n/a","file":"%s","function":"%s","line":%s}\n' \
-        "$rule_id" "$file" "$func" "$line" >> "$VERDICT_FILE"
-}
 
 if command -v jq >/dev/null 2>&1; then
     jq -r '.drift[]? | [.doc_file // "-", .heading // "-"] | @tsv' "$GATE_JSON" 2>/dev/null \

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -676,14 +676,19 @@ If `.autospec/init-done.flag` exists, skip the prompt entirely.
 
 ### Auto-docs step (after spec PR merges)
 
-After any spec PR merges in normal `autospec-define` flow, invoke:
+After any spec PR merges in normal `autospec-define` flow, regenerate
+documentation through the single doc engine — invoke `/autospec-doc`
+(incremental, scoped to the docs the merged spec affects), routed via
+`scripts/doc-orchestrator.mjs`:
 
 ```bash
-bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-docs-from-spec.mjs" \
-  --spec "<spec-path>" --out docs/
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/doc-orchestrator.mjs"
 ```
 
-Open a `docs/` update PR and admin-merge it before Phase 3 begins. Skip if the spec change touches only non-public implementation details (no change to public API surface, no new CLI flags, no new env vars).
+`/autospec-doc` is the only documentation-generation path; there is no
+parallel generator. Open a `docs/` update PR and admin-merge it before Phase 3
+begins. Skip if the spec change touches only non-public implementation details
+(no change to public API surface, no new CLI flags, no new env vars).
 
 ## Autonomous mode
 

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -668,14 +668,19 @@ If `.autospec/init-done.flag` exists, skip the prompt entirely.
 
 ### Auto-docs step (after spec PR merges)
 
-After any spec PR merges in normal `autospec-define` flow, invoke:
+After any spec PR merges in normal `autospec-define` flow, regenerate
+documentation through the single doc engine — invoke `/autospec-doc`
+(incremental, scoped to the docs the merged spec affects), routed via
+`scripts/doc-orchestrator.mjs`:
 
 ```bash
-bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-docs-from-spec.mjs" \
-  --spec "<spec-path>" --out docs/
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/doc-orchestrator.mjs"
 ```
 
-Open a `docs/` update PR and admin-merge it before Phase 3 begins. Skip if the spec change touches only non-public implementation details (no change to public API surface, no new CLI flags, no new env vars).
+`/autospec-doc` is the only documentation-generation path; there is no
+parallel generator. Open a `docs/` update PR and admin-merge it before Phase 3
+begins. Skip if the spec change touches only non-public implementation details
+(no change to public API surface, no new CLI flags, no new env vars).
 
 ## Autonomous mode
 

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -1,6 +1,6 @@
 ---
+name: autospec-define
 description: Use when the user wants to plan a feature — bootstrap repo if missing, brainstorm a design spec, decompose into linked GitHub issues, or split an existing spec into issues. Stops after Phase 3 and hands off to /autospec-run for autonomous implementation.
-mode: primary
 ---
 
 # autospec-define workflow (harness-neutral)
@@ -672,14 +672,19 @@ If `.autospec/init-done.flag` exists, skip the prompt entirely.
 
 ### Auto-docs step (after spec PR merges)
 
-After any spec PR merges in normal `autospec-define` flow, invoke:
+After any spec PR merges in normal `autospec-define` flow, regenerate
+documentation through the single doc engine — invoke `/autospec-doc`
+(incremental, scoped to the docs the merged spec affects), routed via
+`scripts/doc-orchestrator.mjs`:
 
 ```bash
-bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-docs-from-spec.mjs" \
-  --spec "<spec-path>" --out docs/
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/doc-orchestrator.mjs"
 ```
 
-Open a `docs/` update PR and admin-merge it before Phase 3 begins. Skip if the spec change touches only non-public implementation details (no change to public API surface, no new CLI flags, no new env vars).
+`/autospec-doc` is the only documentation-generation path; there is no
+parallel generator. Open a `docs/` update PR and admin-merge it before Phase 3
+begins. Skip if the spec change touches only non-public implementation details
+(no change to public API surface, no new CLI flags, no new env vars).
 
 ## Autonomous mode
 

--- a/skills/autospec-sweep/SKILL.md
+++ b/skills/autospec-sweep/SKILL.md
@@ -176,7 +176,9 @@ dispatch decision matrix. Areas are defined under
 `scripts/sweep-area-dispatch.sh`:
 
 1. `spec-vs-code-drift` — reuses `scripts/explore-research/spec-vs-code.sh`.
-2. `docs-drift` — reuses `scripts/dogfood-adapter-doc-drift.sh`.
+2. `docs-drift` — reuses `scripts/dogfood-adapter-doc-drift.sh`, which invokes
+   `/autospec-doc --full` (full regen + repo-wide completeness audit via
+   `scripts/doc-orchestrator.mjs`) and surfaces missing parts as findings.
 3. `code-health` — reuses `scripts/explore-research/codebase-signals.sh`.
 4. `dependency-health` — new `scripts/explore-research/dependency-health.sh`
    researcher (also available to autospec-explore — extends the 6-researcher

--- a/skills/autospec-sweep/areas/docs-drift.md
+++ b/skills/autospec-sweep/areas/docs-drift.md
@@ -8,9 +8,12 @@ Reuses the adapter doc-drift dogfood scanner:
 
 - `scripts/dogfood-adapter-doc-drift.sh`
 
-Reads tracked docs (`README.md`, `docs/**`, `AGENTS.md`, harness adapter prose),
-compares declared invocations/flags/behaviors against the codebase, and emits
-one proposal per stale or contradicting doc.
+The adapter invokes `/autospec-doc --full` (full regeneration plus a repo-wide
+completeness audit, routed through `scripts/doc-orchestrator.mjs`) and then runs
+the detect-only drift gate. It reads tracked docs (`README.md`, `docs/**`,
+`AGENTS.md`, harness adapter prose), compares declared invocations/flags/
+behaviors against the codebase, and emits one proposal per stale, contradicting,
+or missing doc surfaced by the full audit.
 
 ## Output
 

--- a/skills/autospec-sweep/codex/prompt.md
+++ b/skills/autospec-sweep/codex/prompt.md
@@ -172,7 +172,9 @@ dispatch decision matrix. Areas are defined under
 `scripts/sweep-area-dispatch.sh`:
 
 1. `spec-vs-code-drift` — reuses `scripts/explore-research/spec-vs-code.sh`.
-2. `docs-drift` — reuses `scripts/dogfood-adapter-doc-drift.sh`.
+2. `docs-drift` — reuses `scripts/dogfood-adapter-doc-drift.sh`, which invokes
+   `/autospec-doc --full` (full regen + repo-wide completeness audit via
+   `scripts/doc-orchestrator.mjs`) and surfaces missing parts as findings.
 3. `code-health` — reuses `scripts/explore-research/codebase-signals.sh`.
 4. `dependency-health` — new `scripts/explore-research/dependency-health.sh`
    researcher (also available to autospec-explore — extends the 6-researcher

--- a/skills/autospec-sweep/opencode/agent.md
+++ b/skills/autospec-sweep/opencode/agent.md
@@ -176,7 +176,9 @@ dispatch decision matrix. Areas are defined under
 `scripts/sweep-area-dispatch.sh`:
 
 1. `spec-vs-code-drift` — reuses `scripts/explore-research/spec-vs-code.sh`.
-2. `docs-drift` — reuses `scripts/dogfood-adapter-doc-drift.sh`.
+2. `docs-drift` — reuses `scripts/dogfood-adapter-doc-drift.sh`, which invokes
+   `/autospec-doc --full` (full regen + repo-wide completeness audit via
+   `scripts/doc-orchestrator.mjs`) and surfaces missing parts as findings.
 3. `code-health` — reuses `scripts/explore-research/codebase-signals.sh`.
 4. `dependency-health` — new `scripts/explore-research/dependency-health.sh`
    researcher (also available to autospec-explore — extends the 6-researcher

--- a/tests/unit/test_autospec_doc_sweep_define_wiring.bats
+++ b/tests/unit/test_autospec_doc_sweep_define_wiring.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# tests/unit/test_autospec_doc_sweep_define_wiring.bats — issue #924 / spec §D6.
+#
+# Asserts the two-trio wiring of the single doc engine:
+#   * autospec-sweep docs-drift check invokes `/autospec-doc --full`
+#     (full regen + repo-wide completeness audit via doc-orchestrator.mjs).
+#   * autospec-define Auto-docs step invokes `/autospec-doc`
+#     (doc-orchestrator.mjs) and the old parallel gen-docs-from-spec.mjs
+#     generation path is gone from that step (one engine only).
+#   * Both trios remain byte-identical below adapter headers (lock-step).
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "sweep docs-drift adapter invokes /autospec-doc --full via doc-orchestrator" {
+  # The adapter resolves the orchestrator path then runs it with --full.
+  grep -q 'doc-orchestrator.mjs' "$REPO_ROOT/scripts/dogfood-adapter-doc-drift.sh"
+  grep -qE 'node "\$ORCHESTRATOR" --full' "$REPO_ROOT/scripts/dogfood-adapter-doc-drift.sh"
+}
+
+@test "sweep trio names /autospec-doc --full for the docs-drift area" {
+  for f in \
+    "$REPO_ROOT/skills/autospec-sweep/SKILL.md" \
+    "$REPO_ROOT/skills/autospec-sweep/opencode/agent.md" \
+    "$REPO_ROOT/skills/autospec-sweep/codex/prompt.md"
+  do
+    grep -q -- '/autospec-doc --full' "$f"
+  done
+}
+
+@test "define Auto-docs step invokes /autospec-doc via doc-orchestrator across the trio" {
+  for f in \
+    "$REPO_ROOT/skills/autospec-define/SKILL.md" \
+    "$REPO_ROOT/skills/autospec-define/opencode/agent.md" \
+    "$REPO_ROOT/skills/autospec-define/codex/prompt.md"
+  do
+    # The Auto-docs step block (after "### Auto-docs step") references the
+    # orchestrator, not the old parallel generator.
+    block="$(awk '/^### Auto-docs step/{f=1} f{print} /^## Autonomous mode/{if(f)exit}' "$f")"
+    printf '%s' "$block" | grep -q 'doc-orchestrator.mjs'
+    ! printf '%s' "$block" | grep -q 'gen-docs-from-spec.mjs'
+  done
+}
+
+@test "both trios pass validate.sh lock-step (byte-identical below adapter headers)" {
+  run bash "$REPO_ROOT/scripts/validate.sh"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #924

Wires the single doc engine across two trios per spec §D6 rows 3-4.

## autospec-sweep
The `docs-drift` sweep check upgrades from detect-only to invoking `/autospec-doc --full` (full regen + repo-wide completeness audit via `scripts/doc-orchestrator.mjs`) in `scripts/dogfood-adapter-doc-drift.sh`. Missing parts the full audit reports surface as `DOC_FULL_AUDIT` findings through the adapter's existing finding emission. SKILL.md + codex/prompt.md + opencode/agent.md prose and `areas/docs-drift.md` updated lock-step.

## autospec-define
The Auto-docs step body (after spec PR merges) is replaced with an invocation of `/autospec-doc` (`scripts/doc-orchestrator.mjs`), **deleting the parallel `gen-docs-from-spec.mjs` generation path** — one engine only. The skip condition (non-public-surface spec changes) is preserved. (The separate `--init execution` step is out of scope per pinned ownership and unchanged.)

## Verification
- `bash scripts/validate.sh` exit 0 (both trios byte-identical below adapter headers).
- New `tests/unit/test_autospec_doc_sweep_define_wiring.bats` (4 tests) asserts both wirings + lock-step; existing sweep/define bats pass.
- Adapter smoke: invokes `--full` then the drift gate; `bash -n` clean.
- No reuse beyond the existing adapter/orchestrator — reused `scripts/doc-orchestrator.mjs --full` (the spec's designated full-mode engine) rather than adding a parallel path.

Peer-review: codex not on PATH, skipping.