### PR TITLE
fix(autospec-loop): remove Codex skills-dir copy on uninstall

### DIFF
--- a/skills/autospec-loop/uninstall.sh
+++ b/skills/autospec-loop/uninstall.sh
@@ -125,6 +125,7 @@ CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
 CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
 OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
 CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+CODEX_SKILL_DEST="$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
 
 # ---------- remove ---------------------------------------------------------
 
@@ -144,6 +145,7 @@ if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
     info ""
     info "Codex CLI:"
     remove_one "$CODEX_DEST"
+    remove_one "$CODEX_SKILL_DEST"
 fi
 
 info ""


### PR DESCRIPTION
Closes #928

## Summary

- `install.sh` copies `SKILL.md` to both `$CODEX_HOME/prompts/autospec-loop.md` and `$CODEX_HOME/skills/autospec-loop/SKILL.md`
- `uninstall.sh` only removed the `prompts/` copy, leaving the `skills/` copy behind
- Fix mirrors the pattern from `skills/autospec-doc/uninstall.sh` (landed in PR #927): add `CODEX_SKILL_DEST` variable and call `remove_one` on it in the codex branch

## Verification

- `bash -n skills/autospec-loop/uninstall.sh` exits 0
- `bash scripts/validate.sh` exits 0 (all checks pass)
- Temp-HOME round-trip: install then uninstall leaves zero autospec-loop files in any harness dir (only shared `.autospec/scripts/` helpers remain, which are intentionally not removed by skill uninstall)