### PR TITLE
feat(autospec-run): per-issue token reporting (D1, #938)

### DIFF
--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -1005,6 +1005,16 @@ inline label-swap path below.
 >      exit 0
 >    fi
 >    ```
+>    <!-- token-report:begin -->
+>    Post the per-issue token report (best-effort; never fails the run):
+>    ```bash
+>    # Orchestrator writes .autospec/tokens-<ISSUE>.json from Agent-result usage
+>    # (harness-dependent, best-effort; absent fields → null, never blocking).
+>    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/post-token-report.sh" \
+>      --issue "<ISSUE>" --repo "<REPO>" \
+>      --tokens-json ".autospec/tokens-<ISSUE>.json" || true
+>    ```
+>    <!-- token-report:end -->
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
 > 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
 > 11. Report: PR number, outcome, one-paragraph summary.

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -1000,6 +1000,16 @@ inline label-swap path below.
 >      exit 0
 >    fi
 >    ```
+>    <!-- token-report:begin -->
+>    Post the per-issue token report (best-effort; never fails the run):
+>    ```bash
+>    # Orchestrator writes .autospec/tokens-<ISSUE>.json from Agent-result usage
+>    # (harness-dependent, best-effort; absent fields → null, never blocking).
+>    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/post-token-report.sh" \
+>      --issue "<ISSUE>" --repo "<REPO>" \
+>      --tokens-json ".autospec/tokens-<ISSUE>.json" || true
+>    ```
+>    <!-- token-report:end -->
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
 > 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
 > 11. Report: PR number, outcome, one-paragraph summary.

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -1004,6 +1004,16 @@ inline label-swap path below.
 >      exit 0
 >    fi
 >    ```
+>    <!-- token-report:begin -->
+>    Post the per-issue token report (best-effort; never fails the run):
+>    ```bash
+>    # Orchestrator writes .autospec/tokens-<ISSUE>.json from Agent-result usage
+>    # (harness-dependent, best-effort; absent fields → null, never blocking).
+>    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/post-token-report.sh" \
+>      --issue "<ISSUE>" --repo "<REPO>" \
+>      --tokens-json ".autospec/tokens-<ISSUE>.json" || true
+>    ```
+>    <!-- token-report:end -->
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
 > 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
 > 11. Report: PR number, outcome, one-paragraph summary.

--- a/skills/autospec-run/scripts/post-token-report.sh
+++ b/skills/autospec-run/scripts/post-token-report.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# skills/autospec-run/scripts/post-token-report.sh — Post one idempotent token-usage comment.
+#
+# Usage:
+#   post-token-report.sh --issue N --repo OWNER/REPO [--tokens-json FILE]
+#
+# Reads token counts from FILE (JSON with per-role sub-objects for
+# implementer/reviewer/recovery, each with: input_tokens, output_tokens,
+# cache_creation_input_tokens, cache_read_input_tokens, model; plus top-level
+# "pr" field). Composes a ## Token usage comment and posts it to the issue.
+#
+# Idempotency: if a comment with the marker block
+#   <!-- autospec-tokens:begin --> … <!-- autospec-tokens:end -->
+# already exists on the issue, the script edits it in place rather than
+# creating a new comment.
+#
+# Fallback: when --tokens-json is not provided, the file does not exist, or
+# parsing fails, the script posts "tokens: unavailable on <harness>" ONCE and
+# exits 0. The run NEVER fails due to missing token data.
+#
+# Exit codes:
+#   0  Success (or best-effort fallback)
+#   1  Usage error (missing required --issue or --repo argument)
+#
+# Compatible with bash 3.2+
+
+set -eu
+
+ISSUE=""
+REPO=""
+TOKENS_JSON=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --issue)
+      if [ $# -lt 2 ]; then
+        printf 'post-token-report.sh: --issue requires an argument\n' >&2
+        exit 1
+      fi
+      ISSUE="$2"; shift 2 ;;
+    --repo)
+      if [ $# -lt 2 ]; then
+        printf 'post-token-report.sh: --repo requires an argument\n' >&2
+        exit 1
+      fi
+      REPO="$2"; shift 2 ;;
+    --tokens-json)
+      if [ $# -lt 2 ]; then
+        printf 'post-token-report.sh: --tokens-json requires an argument\n' >&2
+        exit 1
+      fi
+      TOKENS_JSON="$2"; shift 2 ;;
+    -*)
+      printf 'post-token-report.sh: unknown option: %s\n' "$1" >&2
+      exit 1 ;;
+    *)
+      printf 'post-token-report.sh: unexpected argument: %s\n' "$1" >&2
+      exit 1 ;;
+  esac
+done
+
+if [ -z "$ISSUE" ] || [ -z "$REPO" ]; then
+  printf 'Usage: post-token-report.sh --issue N --repo OWNER/REPO [--tokens-json FILE]\n' >&2
+  exit 1
+fi
+
+MARKER_BEGIN="<!-- autospec-tokens:begin -->"
+MARKER_END="<!-- autospec-tokens:end -->"
+
+# ── Compose comment body ──────────────────────────────────────────────────────
+
+compose_comment() {
+  local tokens_json="$1"
+  local harness="${AUTOSPEC_HARNESS:-unknown}"
+
+  # If no tokens file or it doesn't exist, post fallback
+  if [ -z "$tokens_json" ] || [ ! -f "$tokens_json" ]; then
+    printf '%s\n' "## Token usage"
+    printf '%s\n' "tokens: unavailable on ${harness}"
+    printf '%s\n' "$MARKER_BEGIN"
+    printf '%s\n' "$MARKER_END"
+    return
+  fi
+
+  # Extract per-role totals (best-effort — absent fields default to 0/null)
+  local impl_input impl_output impl_cache_c impl_cache_r impl_model
+  local rev_input rev_output rev_model
+  local rec_input rec_output
+  local pr_num total_input total_output
+
+  impl_input=$(jq '.implementer.input_tokens // 0' "$tokens_json" 2>/dev/null || printf '0')
+  impl_output=$(jq '.implementer.output_tokens // 0' "$tokens_json" 2>/dev/null || printf '0')
+  impl_model=$(jq -r '.implementer.model // ""' "$tokens_json" 2>/dev/null || printf '')
+  rev_input=$(jq '.reviewer.input_tokens // 0' "$tokens_json" 2>/dev/null || printf '0')
+  rev_output=$(jq '.reviewer.output_tokens // 0' "$tokens_json" 2>/dev/null || printf '0')
+  rev_model=$(jq -r '.reviewer.model // ""' "$tokens_json" 2>/dev/null || printf '')
+  rec_input=$(jq '.recovery.input_tokens // 0' "$tokens_json" 2>/dev/null || printf '0')
+  rec_output=$(jq '.recovery.output_tokens // 0' "$tokens_json" 2>/dev/null || printf '0')
+  pr_num=$(jq '.pr // empty' "$tokens_json" 2>/dev/null || printf '')
+
+  # Compute per-role totals and grand total
+  local impl_total rev_total rec_total
+  impl_total=$(( impl_input + impl_output ))
+  rev_total=$(( rev_input + rev_output ))
+  rec_total=$(( rec_input + rec_output ))
+  total_input=$(( impl_input + rev_input + rec_input ))
+  total_output=$(( impl_output + rev_output + rec_output ))
+  local grand_total=$(( total_input + total_output ))
+
+  # Format numbers with commas (portable awk)
+  fmt_num() {
+    printf '%s' "$1" | awk '{
+      n = $0 + 0
+      s = sprintf("%d", n)
+      result = ""
+      len = length(s)
+      for (i = 1; i <= len; i++) {
+        if (i > 1 && (len - i + 1) % 3 == 0) result = result ","
+        result = result substr(s, i, 1)
+      }
+      print result
+    }'
+  }
+
+  local impl_fmt rev_fmt grand_fmt
+  impl_fmt=$(fmt_num "$impl_total")
+  rev_fmt=$(fmt_num "$rev_total")
+  grand_fmt=$(fmt_num "$grand_total")
+
+  # Build model suffix for implementer
+  local impl_model_sfx=""
+  if [ -n "$impl_model" ]; then
+    impl_model_sfx=" ($impl_model)"
+  fi
+
+  # Build PR suffix
+  local pr_sfx=""
+  if [ -n "$pr_num" ]; then
+    pr_sfx=" — PR #${pr_num}"
+  fi
+
+  # Build reviewer model suffix
+  local rev_model_sfx=""
+  if [ -n "$rev_model" ]; then
+    rev_model_sfx=" ($rev_model)"
+  fi
+
+  # Build recovery line
+  local rec_line="- recovery: —"
+  if [ "$rec_total" -gt 0 ] 2>/dev/null; then
+    rec_line="- recovery: $(fmt_num "$rec_total")"
+  fi
+
+  local impl_line rev_line total_line
+  impl_line="- implementer: ${impl_fmt}${impl_model_sfx}${pr_sfx}"
+  rev_line="- reviewer: ${rev_fmt}${rev_model_sfx}"
+  total_line="- total: ${grand_fmt}"
+  printf '%s\n' "## Token usage"
+  printf '%s\n' "$impl_line"
+  printf '%s\n' "$rev_line"
+  printf '%s\n' "$rec_line"
+  printf '%s\n' "$total_line"
+  printf '%s\n' "$MARKER_BEGIN"
+  printf '%s\n' "$MARKER_END"
+}
+
+# ── Check for existing marker comment ────────────────────────────────────────
+
+find_existing_comment_id() {
+  # Returns the numeric comment ID if a comment with our marker exists, else empty
+  gh api "repos/${REPO}/issues/${ISSUE}/comments" --method GET \
+    --paginate 2>/dev/null \
+    | jq -r --arg marker "$MARKER_BEGIN" \
+      '.[] | select(.body | contains($marker)) | .id' 2>/dev/null \
+    | head -1 || true
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+# Compose the comment body (best-effort; never fails)
+comment_body=$(compose_comment "${TOKENS_JSON:-}") || {
+  comment_body="$(printf '%s\n%s\n%s\n%s\n' \
+    "## Token usage" \
+    "tokens: unavailable on ${AUTOSPEC_HARNESS:-unknown}" \
+    "$MARKER_BEGIN" \
+    "$MARKER_END")"
+}
+
+# Print the composed body to stdout for visibility/testing
+printf '%s\n' "$comment_body"
+
+# Find existing comment to edit in place
+existing_id=$(find_existing_comment_id 2>/dev/null || true)
+
+if [ -n "$existing_id" ]; then
+  # Edit in place
+  gh api "repos/${REPO}/issues/comments/${existing_id}" \
+    --method PATCH \
+    --field "body=${comment_body}" >/dev/null 2>&1 || true
+else
+  # Post new comment
+  gh issue comment "$ISSUE" --repo "$REPO" --body "$comment_body" >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/skills/autospec-run/tests/post-token-report.bats
+++ b/skills/autospec-run/tests/post-token-report.bats
@@ -1,0 +1,244 @@
+#!/usr/bin/env bats
+# skills/autospec-run/tests/post-token-report.bats — TDD for post-token-report.sh (issue #938)
+#
+# Uses PATH-shadowed `gh` mock so no real GitHub API is called.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/post-token-report.sh"
+FIXTURES_DIR="${BATS_TEST_DIRNAME}/fixtures/post-token-report"
+
+setup() {
+  mkdir -p "$FIXTURES_DIR/bin"
+
+  # Write a full tokens JSON fixture
+  cat > "$FIXTURES_DIR/tokens-938.json" << 'FIXTURE'
+{
+  "implementer": {
+    "input_tokens": 121643,
+    "cache_creation_input_tokens": 8000,
+    "cache_read_input_tokens": 4000,
+    "output_tokens": 3500,
+    "model": "claude-opus-4-5"
+  },
+  "reviewer": {
+    "input_tokens": 41200,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 3000,
+    "output_tokens": 1800,
+    "model": "claude-sonnet-4-5"
+  },
+  "recovery": null,
+  "pr": 930
+}
+FIXTURE
+
+  # Write a minimal/partial tokens JSON (some fields missing)
+  cat > "$FIXTURES_DIR/tokens-partial.json" << 'FIXTURE'
+{
+  "implementer": {
+    "input_tokens": 50000
+  },
+  "pr": 930
+}
+FIXTURE
+
+  # PATH-shadowed gh mock — records call args and returns canned responses
+  cat > "$FIXTURES_DIR/bin/gh" << 'STUB'
+#!/usr/bin/env bash
+# Minimal gh stub for post-token-report tests
+GH_LOG="${GH_MOCK_LOG:-/tmp/gh-mock-$$.log}"
+printf '%s\n' "$*" >> "$GH_LOG"
+
+case "$*" in
+  "issue list-comments"*|"api repos"*/comments*)
+    # First call: no existing comment (no marker)
+    printf '[]\n'
+    exit 0
+    ;;
+  "issue comment"*)
+    # Post new comment — echo back the body arg
+    printf 'comment created\n'
+    exit 0
+    ;;
+  "issue edit-comment"*|*"--edit-last"*)
+    printf 'comment updated\n'
+    exit 0
+    ;;
+  *)
+    # For any other gh call, succeed silently
+    exit 0
+    ;;
+esac
+STUB
+  chmod 0755 "$FIXTURES_DIR/bin/gh"
+
+  export PATH="$FIXTURES_DIR/bin:$PATH"
+  export GH_MOCK_LOG="$FIXTURES_DIR/gh-calls.log"
+  rm -f "$GH_MOCK_LOG"
+}
+
+teardown() {
+  rm -rf "$FIXTURES_DIR"
+}
+
+# ── Existence / executability ─────────────────────────────────────────────────
+
+@test "post-token-report.sh exists and is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "post-token-report.sh exits 1 on missing required args" {
+  run "$SCRIPT"
+  [ "$status" -eq 1 ]
+}
+
+@test "post-token-report.sh exits 1 when --issue missing value" {
+  run "$SCRIPT" --repo berlinguyinca/autospec
+  [ "$status" -eq 1 ]
+}
+
+@test "post-token-report.sh exits 1 when --repo missing value" {
+  run "$SCRIPT" --issue 938
+  [ "$status" -eq 1 ]
+}
+
+# ── Compose comment body ──────────────────────────────────────────────────────
+
+@test "post-token-report.sh composes comment with implementer tokens" {
+  run "$SCRIPT" --issue 938 --repo berlinguyinca/autospec \
+    --tokens-json "$FIXTURES_DIR/tokens-938.json"
+  [ "$status" -eq 0 ]
+  # implementer total = input(121643) + output(3500) = 125,143
+  printf '%s\n' "$output" | grep -qiE "implementer.*125[,.]?143|125[,.]?143.*implementer"
+}
+
+@test "post-token-report.sh composes comment with reviewer tokens" {
+  run "$SCRIPT" --issue 938 --repo berlinguyinca/autospec \
+    --tokens-json "$FIXTURES_DIR/tokens-938.json"
+  [ "$status" -eq 0 ]
+  # reviewer total = input(41200) + output(1800) = 43,000
+  printf '%s\n' "$output" | grep -qiE "reviewer.*43[,.]?000|43[,.]?000.*reviewer"
+}
+
+@test "post-token-report.sh composes comment with PR number" {
+  run "$SCRIPT" --issue 938 --repo berlinguyinca/autospec \
+    --tokens-json "$FIXTURES_DIR/tokens-938.json"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qE "#930|PR.*930|930.*PR"
+}
+
+@test "post-token-report.sh includes marker begin/end in output" {
+  run "$SCRIPT" --issue 938 --repo berlinguyinca/autospec \
+    --tokens-json "$FIXTURES_DIR/tokens-938.json"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qF "autospec-tokens:begin"
+  printf '%s\n' "$output" | grep -qF "autospec-tokens:end"
+}
+
+@test "post-token-report.sh includes Token usage heading" {
+  run "$SCRIPT" --issue 938 --repo berlinguyinca/autospec \
+    --tokens-json "$FIXTURES_DIR/tokens-938.json"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qiE "token.usage|## Token"
+}
+
+# ── Missing / partial tokens-json fallback ────────────────────────────────────
+
+@test "post-token-report.sh exits 0 when tokens-json is absent (fallback)" {
+  run "$SCRIPT" --issue 938 --repo berlinguyinca/autospec \
+    --tokens-json "$FIXTURES_DIR/nonexistent.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "post-token-report.sh posts unavailable message when tokens-json absent" {
+  run "$SCRIPT" --issue 938 --repo berlinguyinca/autospec \
+    --tokens-json "$FIXTURES_DIR/nonexistent.json"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qi "unavailable"
+}
+
+@test "post-token-report.sh exits 0 when --tokens-json not provided at all" {
+  run "$SCRIPT" --issue 938 --repo berlinguyinca/autospec
+  [ "$status" -eq 0 ]
+}
+
+@test "post-token-report.sh exits 0 on partial tokens-json (missing reviewer)" {
+  run "$SCRIPT" --issue 938 --repo berlinguyinca/autospec \
+    --tokens-json "$FIXTURES_DIR/tokens-partial.json"
+  [ "$status" -eq 0 ]
+}
+
+# ── Idempotent edit-in-place ──────────────────────────────────────────────────
+
+@test "post-token-report.sh is idempotent: second run edits existing comment" {
+  # First run — gh returns no existing comment, should create
+  run "$SCRIPT" --issue 938 --repo berlinguyinca/autospec \
+    --tokens-json "$FIXTURES_DIR/tokens-938.json"
+  [ "$status" -eq 0 ]
+
+  # Create a stub that mimics an existing marker comment
+  cat > "$FIXTURES_DIR/bin/gh" << 'STUB2'
+#!/usr/bin/env bash
+GH_MOCK_LOG="${GH_MOCK_LOG:-/tmp/gh-mock-$$.log}"
+printf '%s\n' "$*" >> "$GH_MOCK_LOG"
+case "$*" in
+  "api repos"*"/issues/938/comments"*"--method GET"*)
+    # Return a comment with the marker
+    printf '[{"id":99001,"body":"<!-- autospec-tokens:begin -->old tokens<!-- autospec-tokens:end -->"}]\n'
+    exit 0
+    ;;
+  "api repos"*"/issues/comments/99001"*"--method PATCH"*)
+    printf '{"id":99001}\n'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+STUB2
+  chmod 0755 "$FIXTURES_DIR/bin/gh"
+
+  # Second run — should detect existing marker and edit in place (exit 0)
+  run "$SCRIPT" --issue 938 --repo berlinguyinca/autospec \
+    --tokens-json "$FIXTURES_DIR/tokens-938.json"
+  [ "$status" -eq 0 ]
+  # The edit-in-place call must appear in the log
+  grep -qE "PATCH|edit|99001" "$GH_MOCK_LOG" || \
+    grep -qE "issues/comments" "$GH_MOCK_LOG"
+}
+
+# ── Telemetry e2e: tokens-json → telemetry row golden ─────────────────────────
+
+@test "record-telemetry.sh accepts the tokens-json implementer sub-object shape" {
+  TELEMETRY_FILE="$FIXTURES_DIR/telemetry.jsonl"
+  # Extract implementer object into a flat file (the recorder role='implementer')
+  FLAT_JSON="$FIXTURES_DIR/flat-implementer.json"
+  jq '.implementer // {}' "$FIXTURES_DIR/tokens-938.json" > "$FLAT_JSON"
+
+  RECORD_SCRIPT="${BATS_TEST_DIRNAME}/../../autospec-shared/scripts/record-telemetry.sh"
+  AUTOSPEC_TELEMETRY_FILE="$TELEMETRY_FILE" run bash "$RECORD_SCRIPT" \
+    --dispatch-id "test-d1" \
+    --role implementer \
+    --issue 938 \
+    --tokens-json "$FLAT_JSON"
+  [ "$status" -eq 0 ]
+  [ -f "$TELEMETRY_FILE" ]
+  grep -q '"role":"implementer"' "$TELEMETRY_FILE"
+  grep -q '"input_tokens":121643' "$TELEMETRY_FILE"
+}
+
+# ── Trio presence checks ──────────────────────────────────────────────────────
+
+@test "SKILL.md includes post-token-report.sh step after admin-merge" {
+  skill_md="${BATS_TEST_DIRNAME}/../SKILL.md"
+  grep -qF "post-token-report.sh" "$skill_md"
+}
+
+@test "codex/prompt.md includes post-token-report.sh step (lock-step)" {
+  codex_md="${BATS_TEST_DIRNAME}/../codex/prompt.md"
+  grep -qF "post-token-report.sh" "$codex_md"
+}
+
+@test "opencode/agent.md includes post-token-report.sh step (lock-step)" {
+  opencode_md="${BATS_TEST_DIRNAME}/../opencode/agent.md"
+  grep -qF "post-token-report.sh" "$opencode_md"
+}


### PR DESCRIPTION
Closes #938

## Summary

- New `skills/autospec-run/scripts/post-token-report.sh`: posts one idempotent `## Token usage` comment per issue with implementer/reviewer/recovery token breakdown, model, PR#. Uses `<!-- autospec-tokens:begin/end -->` markers for edit-in-place idempotency on re-run. Never fails the run — missing/partial tokens-json falls back to `tokens: unavailable on <harness>` (exit 0 always).
- Run-trio prose updated: adds the token-report step at the pinned slot (after admin-merge + stop-sentinel, before batch-done.json). SKILL.md + codex/prompt.md + opencode/agent.md are byte-identical lock-step (validate.sh exit 0 confirmed).
- 18 bats tests covering: compose output, idempotent edit-in-place, missing/partial tokens-json fallback, telemetry e2e golden row via record-telemetry.sh, and lock-step trio presence checks.