### PR TITLE
feat(autospec-run): fresh-subagent-per-issue canonical + batch default 1 (D2, #939)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,7 +396,7 @@ Exit codes from `ci-wait-poll.sh`: 0=pass, 1=fail/stalled, 2=pending, 3=no senti
 
 ## Batch size policy
 
-Default `AUTOSPEC_BATCH_SIZE=3`; force batch=1 when the next ready issue is `reasoning:deep` (high blast-radius work runs one-at-a-time per monitor session). This only ends the current monitor batch: `autospec-run` must automatically relaunch fresh monitor batches until the queue is `ALL_DONE`.
+Default `AUTOSPEC_BATCH_SIZE=1`; force batch=1 when the next ready issue is `reasoning:deep` (high blast-radius work runs one-at-a-time per monitor session). This only ends the current monitor batch: `autospec-run` must automatically relaunch fresh monitor batches until the queue is `ALL_DONE`.
 
 ## Memory inventory
 

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -262,7 +262,7 @@ same session id (a fresh session gets a new id), and `--force` overrides it.
 
 ## Phase 4 — Background autonomous monitor
 
-**Single-agent absorbed-discipline (canonical Phase 4 path).** The monitor agent IS the implementer for the issue it claims — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — all in one agent's context. The main session orchestrator relaunches the monitor between issues so each one gets a fresh top-level `Agent` call with full tool access. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch its own inner implementer. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "the monitor agent now does the implementation work itself in this same context", NOT a nested subagent dispatch. `AUTOSPEC_BATCH_SIZE` semantics are preserved: a single agent can still process up to N issues sequentially within its 40-tool-call budget, exiting with `BATCH_COMPLETE` when the budget is approaching or after N issues, whichever comes first.
+**Fresh-subagent-per-issue (canonical Phase 4 path, formerly single-agent absorbed-discipline).** Each issue is processed by a FRESH top-level subagent dispatched by the orchestrator — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — in that subagent's own context. The orchestrator NEVER implements in its own context; it only claims, dispatches, and waits. Each subagent receives full tool access because it is a top-level `Agent` call launched directly by the main session orchestrator. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so nested monitors cannot dispatch inner implementers. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "dispatch a fresh top-level subagent to do this work", NOT in-context implementation by the orchestrator. Batch>1 is an explicit operator opt-in via `AUTOSPEC_BATCH_SIZE=N`; the default is 1 (one issue per subagent). The `reasoning:deep` force-to-1 rule is retained: deep issues stay batch=1 even under an operator `AUTOSPEC_BATCH_SIZE=N` override.
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
 
@@ -301,12 +301,12 @@ fi
 
 The helper writes `~/.autospec/usage-limits/<run-id>.json`, starts a background daemon, polls every 300 seconds by default, and relaunches the recorded command after the reset time. This is intentionally shell-only so recovery does not require an LLM turn after the usage limit has already been hit.
 
-Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
+Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 1). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
 ```
 batch_num=1
 while true:
-  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3})
+  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-1})
   wait for task-notification (monitor agent completes)
 
   # Read and consume the batch-done signal.
@@ -330,7 +330,7 @@ while true:
 
 Pass the following prompt verbatim to each background subagent:
 
-> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
+> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 1) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
 
 > **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
 > 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
@@ -342,7 +342,7 @@ Pass the following prompt verbatim to each background subagent:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. BATCH_COMPLETE is a continuation signal, not a terminal state; the orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 1) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. BATCH_COMPLETE is a continuation signal, not a terminal state; the orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Profile load (run-start, once).** If `--profile <name>` was passed, look it up in `~/.autospec/model-profiles.yml`; if `<name>` is not a key under `profiles:`, exit non-zero and print the available names. If no flag was passed, load the file's `default:` profile. If the file is missing, run auto-init and exit (per the Invocation section).
@@ -355,8 +355,8 @@ Pass the following prompt verbatim to each background subagent:
 > ```
 > # Before the loop (run-once init):
 > #   batch_issue_count=0
-> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
-> #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3   # guard against 0 or negative
+> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-1}"
+> #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=1   # guard against 0 or negative
 > #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
 >
 > while true:
@@ -406,7 +406,7 @@ COORD_RELEASE="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/release-issue.sh
 ```
 
 If `--coordination-status` is active, run `list-ready-issues.sh --repo {repo}
---batch-size "${AUTOSPEC_BATCH_SIZE:-3}"`, print the JSON, and exit. If
+--batch-size "${AUTOSPEC_BATCH_SIZE:-1}"`, print the JSON, and exit. If
 `--max-parallel-safe` is active, print only the `.batch` array and exit.
 
 During the normal monitor loop:
@@ -515,8 +515,8 @@ inline label-swap path below.
 >   if [ "$_next_reasoning" = "reasoning:deep" ]; then
 >     effective_batch_size=1
 >   else
->     effective_batch_size="${AUTOSPEC_BATCH_SIZE:-3}"
->     [ "$effective_batch_size" -gt 0 ] 2>/dev/null || effective_batch_size=3
+>     effective_batch_size="${AUTOSPEC_BATCH_SIZE:-1}"
+>     [ "$effective_batch_size" -gt 0 ] 2>/dev/null || effective_batch_size=1
 >   fi
 >   echo "[monitor] effective_batch_size=$effective_batch_size (next issue reasoning: $_next_reasoning)"
 >   ISSUE = ready[0]

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -257,7 +257,7 @@ same session id (a fresh session gets a new id), and `--force` overrides it.
 
 ## Phase 4 — Background autonomous monitor
 
-**Single-agent absorbed-discipline (canonical Phase 4 path).** The monitor agent IS the implementer for the issue it claims — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — all in one agent's context. The main session orchestrator relaunches the monitor between issues so each one gets a fresh top-level `Agent` call with full tool access. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch its own inner implementer. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "the monitor agent now does the implementation work itself in this same context", NOT a nested subagent dispatch. `AUTOSPEC_BATCH_SIZE` semantics are preserved: a single agent can still process up to N issues sequentially within its 40-tool-call budget, exiting with `BATCH_COMPLETE` when the budget is approaching or after N issues, whichever comes first.
+**Fresh-subagent-per-issue (canonical Phase 4 path, formerly single-agent absorbed-discipline).** Each issue is processed by a FRESH top-level subagent dispatched by the orchestrator — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — in that subagent's own context. The orchestrator NEVER implements in its own context; it only claims, dispatches, and waits. Each subagent receives full tool access because it is a top-level `Agent` call launched directly by the main session orchestrator. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so nested monitors cannot dispatch inner implementers. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "dispatch a fresh top-level subagent to do this work", NOT in-context implementation by the orchestrator. Batch>1 is an explicit operator opt-in via `AUTOSPEC_BATCH_SIZE=N`; the default is 1 (one issue per subagent). The `reasoning:deep` force-to-1 rule is retained: deep issues stay batch=1 even under an operator `AUTOSPEC_BATCH_SIZE=N` override.
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
 
@@ -296,12 +296,12 @@ fi
 
 The helper writes `~/.autospec/usage-limits/<run-id>.json`, starts a background daemon, polls every 300 seconds by default, and relaunches the recorded command after the reset time. This is intentionally shell-only so recovery does not require an LLM turn after the usage limit has already been hit.
 
-Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
+Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 1). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
 ```
 batch_num=1
 while true:
-  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3})
+  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-1})
   wait for task-notification (monitor agent completes)
 
   # Read and consume the batch-done signal.
@@ -325,7 +325,7 @@ while true:
 
 Pass the following prompt verbatim to each background subagent:
 
-> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
+> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 1) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
 
 > **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
 > 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
@@ -337,7 +337,7 @@ Pass the following prompt verbatim to each background subagent:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. BATCH_COMPLETE is a continuation signal, not a terminal state; the orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 1) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. BATCH_COMPLETE is a continuation signal, not a terminal state; the orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Profile load (run-start, once).** If `--profile <name>` was passed, look it up in `~/.autospec/model-profiles.yml`; if `<name>` is not a key under `profiles:`, exit non-zero and print the available names. If no flag was passed, load the file's `default:` profile. If the file is missing, run auto-init and exit (per the Invocation section).
@@ -350,8 +350,8 @@ Pass the following prompt verbatim to each background subagent:
 > ```
 > # Before the loop (run-once init):
 > #   batch_issue_count=0
-> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
-> #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3   # guard against 0 or negative
+> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-1}"
+> #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=1   # guard against 0 or negative
 > #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
 >
 > while true:
@@ -401,7 +401,7 @@ COORD_RELEASE="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/release-issue.sh
 ```
 
 If `--coordination-status` is active, run `list-ready-issues.sh --repo {repo}
---batch-size "${AUTOSPEC_BATCH_SIZE:-3}"`, print the JSON, and exit. If
+--batch-size "${AUTOSPEC_BATCH_SIZE:-1}"`, print the JSON, and exit. If
 `--max-parallel-safe` is active, print only the `.batch` array and exit.
 
 During the normal monitor loop:
@@ -510,8 +510,8 @@ inline label-swap path below.
 >   if [ "$_next_reasoning" = "reasoning:deep" ]; then
 >     effective_batch_size=1
 >   else
->     effective_batch_size="${AUTOSPEC_BATCH_SIZE:-3}"
->     [ "$effective_batch_size" -gt 0 ] 2>/dev/null || effective_batch_size=3
+>     effective_batch_size="${AUTOSPEC_BATCH_SIZE:-1}"
+>     [ "$effective_batch_size" -gt 0 ] 2>/dev/null || effective_batch_size=1
 >   fi
 >   echo "[monitor] effective_batch_size=$effective_batch_size (next issue reasoning: $_next_reasoning)"
 >   ISSUE = ready[0]

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -261,7 +261,7 @@ same session id (a fresh session gets a new id), and `--force` overrides it.
 
 ## Phase 4 — Background autonomous monitor
 
-**Single-agent absorbed-discipline (canonical Phase 4 path).** The monitor agent IS the implementer for the issue it claims — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — all in one agent's context. The main session orchestrator relaunches the monitor between issues so each one gets a fresh top-level `Agent` call with full tool access. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch its own inner implementer. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "the monitor agent now does the implementation work itself in this same context", NOT a nested subagent dispatch. `AUTOSPEC_BATCH_SIZE` semantics are preserved: a single agent can still process up to N issues sequentially within its 40-tool-call budget, exiting with `BATCH_COMPLETE` when the budget is approaching or after N issues, whichever comes first.
+**Fresh-subagent-per-issue (canonical Phase 4 path, formerly single-agent absorbed-discipline).** Each issue is processed by a FRESH top-level subagent dispatched by the orchestrator — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — in that subagent's own context. The orchestrator NEVER implements in its own context; it only claims, dispatches, and waits. Each subagent receives full tool access because it is a top-level `Agent` call launched directly by the main session orchestrator. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so nested monitors cannot dispatch inner implementers. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "dispatch a fresh top-level subagent to do this work", NOT in-context implementation by the orchestrator. Batch>1 is an explicit operator opt-in via `AUTOSPEC_BATCH_SIZE=N`; the default is 1 (one issue per subagent). The `reasoning:deep` force-to-1 rule is retained: deep issues stay batch=1 even under an operator `AUTOSPEC_BATCH_SIZE=N` override.
 
 Record this durable preference in `AGENTS.md` (idempotent — skip if already present):
 
@@ -300,12 +300,12 @@ fi
 
 The helper writes `~/.autospec/usage-limits/<run-id>.json`, starts a background daemon, polls every 300 seconds by default, and relaunches the recorded command after the reset time. This is intentionally shell-only so recovery does not require an LLM turn after the usage limit has already been hit.
 
-Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
+Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 1). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
 ```
 batch_num=1
 while true:
-  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3})
+  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-1})
   wait for task-notification (monitor agent completes)
 
   # Read and consume the batch-done signal.
@@ -329,7 +329,7 @@ while true:
 
 Pass the following prompt verbatim to each background subagent:
 
-> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
+> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 1) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
 
 > **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
 > 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
@@ -341,7 +341,7 @@ Pass the following prompt verbatim to each background subagent:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. BATCH_COMPLETE is a continuation signal, not a terminal state; the orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 1) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. BATCH_COMPLETE is a continuation signal, not a terminal state; the orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Profile load (run-start, once).** If `--profile <name>` was passed, look it up in `~/.autospec/model-profiles.yml`; if `<name>` is not a key under `profiles:`, exit non-zero and print the available names. If no flag was passed, load the file's `default:` profile. If the file is missing, run auto-init and exit (per the Invocation section).
@@ -354,8 +354,8 @@ Pass the following prompt verbatim to each background subagent:
 > ```
 > # Before the loop (run-once init):
 > #   batch_issue_count=0
-> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
-> #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3   # guard against 0 or negative
+> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-1}"
+> #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=1   # guard against 0 or negative
 > #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
 >
 > while true:
@@ -405,7 +405,7 @@ COORD_RELEASE="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/release-issue.sh
 ```
 
 If `--coordination-status` is active, run `list-ready-issues.sh --repo {repo}
---batch-size "${AUTOSPEC_BATCH_SIZE:-3}"`, print the JSON, and exit. If
+--batch-size "${AUTOSPEC_BATCH_SIZE:-1}"`, print the JSON, and exit. If
 `--max-parallel-safe` is active, print only the `.batch` array and exit.
 
 During the normal monitor loop:
@@ -514,8 +514,8 @@ inline label-swap path below.
 >   if [ "$_next_reasoning" = "reasoning:deep" ]; then
 >     effective_batch_size=1
 >   else
->     effective_batch_size="${AUTOSPEC_BATCH_SIZE:-3}"
->     [ "$effective_batch_size" -gt 0 ] 2>/dev/null || effective_batch_size=3
+>     effective_batch_size="${AUTOSPEC_BATCH_SIZE:-1}"
+>     [ "$effective_batch_size" -gt 0 ] 2>/dev/null || effective_batch_size=1
 >   fi
 >   echo "[monitor] effective_batch_size=$effective_batch_size (next issue reasoning: $_next_reasoning)"
 >   ISSUE = ready[0]

--- a/skills/autospec-run/scripts/list-ready-issues.sh
+++ b/skills/autospec-run/scripts/list-ready-issues.sh
@@ -17,7 +17,7 @@ die() {
 }
 
 repo=""
-batch_size=3
+batch_size=1
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -29,7 +29,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 case "$batch_size" in *[!0-9]*|'') die "--batch-size must be an integer" ;; esac
-[ "$batch_size" -gt 0 ] || batch_size=3
+[ "$batch_size" -gt 0 ] || batch_size=1
 
 if [ -z "$repo" ]; then
     repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"

--- a/tests/batch-size-gating.bats
+++ b/tests/batch-size-gating.bats
@@ -6,9 +6,9 @@ setup() {
   # We define the function inline here as it will appear in SKILL.md pseudocode.
   compute_effective_batch_size() {
     local reasoning_lbl="${1:-reasoning:medium}"
-    local batch_size="${AUTOSPEC_BATCH_SIZE:-3}"
+    local batch_size="${AUTOSPEC_BATCH_SIZE:-1}"
     # Guard against 0 or negative
-    [[ "$batch_size" -gt 0 ]] 2>/dev/null || batch_size=3
+    [[ "$batch_size" -gt 0 ]] 2>/dev/null || batch_size=1
     if [ "$reasoning_lbl" = "reasoning:deep" ]; then
       echo 1
     else
@@ -32,9 +32,9 @@ setup() {
   [ "$result" = "7" ]
 }
 
-@test "unlabeled issue defaults to reasoning:medium behavior (batch size 3)" {
-  AUTOSPEC_BATCH_SIZE=3 result=$(compute_effective_batch_size "reasoning:medium")
-  [ "$result" = "3" ]
+@test "unlabeled issue defaults to reasoning:medium behavior (batch size 1)" {
+  result=$(compute_effective_batch_size "reasoning:medium")
+  [ "$result" = "1" ]
 }
 
 @test "reasoning:deep overrides even large AUTOSPEC_BATCH_SIZE" {
@@ -48,10 +48,10 @@ setup() {
   grep -q "effective_batch_size" "$skill_md"
 }
 
-@test "SKILL.md default AUTOSPEC_BATCH_SIZE is 3" {
+@test "SKILL.md default AUTOSPEC_BATCH_SIZE is 1" {
   skill_md="${BATS_TEST_DIRNAME}/../skills/autospec-run/SKILL.md"
-  # Should contain AUTOSPEC_BATCH_SIZE:-3 (the default)
-  grep -q 'AUTOSPEC_BATCH_SIZE:-3' "$skill_md"
+  # Should contain AUTOSPEC_BATCH_SIZE:-1 (the default)
+  grep -q 'AUTOSPEC_BATCH_SIZE:-1' "$skill_md"
 }
 
 @test "AGENTS.md documents batch default and reasoning:deep gating" {

--- a/tests/unit/test_monitor_batch_exit.bats
+++ b/tests/unit/test_monitor_batch_exit.bats
@@ -45,7 +45,7 @@ version: 1.0.0
 
 ## Phase 4 — Background autonomous monitor
 
-> batch_issue_count=0; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3}
+> batch_issue_count=0; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-1}
 >
 > Write "$HOME/.autospec/batch-done.json" with status BATCH_COMPLETE after batch limit.
 > When queue drained write status ALL_DONE instead.
@@ -143,8 +143,8 @@ version: 1.0.0
 
 ## Phase 4 — Background autonomous monitor
 
-> batch_issue_count=0; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3}
-> [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3
+> batch_issue_count=0; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-1}
+> [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=1
 >
 > Write "$HOME/.autospec/batch-done.json" with status BATCH_COMPLETE after batch limit.
 > When queue drained write status ALL_DONE instead.


### PR DESCRIPTION
Closes #939

## Summary

- **AGENTS.md**: default `AUTOSPEC_BATCH_SIZE` literal `3`→`1`
- **Run trio** (SKILL.md + codex/prompt.md + opencode/agent.md): all seven `${AUTOSPEC_BATCH_SIZE:-3}` sites changed to `:-1`; guard fallbacks `3→1`; prose "default: 3"/"default 3" updated to match
- **Absorbed-discipline paragraph rewritten**: orchestrator NEVER implements in its own context; each issue dispatched to a FRESH top-level subagent; batch>1 is explicit operator opt-in via `AUTOSPEC_BATCH_SIZE=N`; `reasoning:deep` force-to-1 rule retained unchanged
- **list-ready-issues.sh**: default `batch_size` `3→1` (guard fallback `3→1`)
- **tests/batch-size-gating.bats**: assert default=1; update inline helper and SKILL.md default check
- **tests/unit/test_monitor_batch_exit.bats**: update fixtures to `:-1`

## Verification

- `bats tests/batch-size-gating.bats tests/unit/test_monitor_batch_exit.bats` — 20/20 pass
- `bash scripts/validate.sh` — exit 0
- `grep -rn ':-3' skills/autospec-run/` — zero batch-size hits (completeness proof)
- Lock-step: all trio files carry identical absorbed-discipline paragraph