### PR TITLE
feat(autospec-run): slim implementer prefix to implementer-contract.md + cache-boundary fix (D3, #940)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -559,6 +559,76 @@ check_lint_implementation_helpers() {
     done
 }
 
+# Implementer-contract named-content invariants (issue #940, spec §D3): the
+# curated implementer-contract.md replaces the 70KB SKILL.md in the implementer
+# prefix. The contract MUST exist, stay <=24KB (size budget so the cached prefix
+# is small), carry exactly one RULE_ID table header (single copy, no dup), and
+# must not drift from AGENTS.md's canonical RULE_ID set. The bundler MUST NOT
+# inject the autospec-run SKILL.md into the implementer role any more.
+check_implementer_contract() {
+    info "implementer-contract: skills/autospec-run/prompts/implementer-contract.md"
+    local contract="skills/autospec-run/prompts/implementer-contract.md"
+    [ -f "$contract" ] \
+        || fail "$contract: file missing"
+
+    # Size guard: <=24576 bytes.
+    local size
+    size="$(wc -c < "$contract" | tr -d ' ')"
+    [ "$size" -le 24576 ] \
+        || fail "$contract: $size bytes exceeds 24576-byte (24KB) budget"
+
+    # Single RULE_ID table header (no duplicate re-extraction).
+    local header_count
+    header_count="$(grep -c '^### RULE_ID table' "$contract" || true)"
+    [ "$header_count" = "1" ] \
+        || fail "$contract: expected exactly 1 '### RULE_ID table' header, found $header_count"
+
+    # Drift gate: every RULE_ID named in AGENTS.md's canonical table must also be
+    # present in the contract (curated digest must not silently drop a rule).
+    [ -f AGENTS.md ] || fail "AGENTS.md missing at repo root"
+    # Extract only the FIRST-column backticked token from each table data row so
+    # backticked regex fragments in later columns (e.g. `URL`) are never mistaken
+    # for RULE_IDs.
+    local agents_rule_ids
+    agents_rule_ids="$(awk '
+        /^### RULE_ID table/ { in_table=1; next }
+        /^### / && in_table { exit }
+        /^## / && in_table { exit }
+        in_table && /^\| `[A-Z_]+`/ {
+            line=$0; sub(/^\| `/,"",line); sub(/`.*/,"",line); print line
+        }
+    ' AGENTS.md | sort -u)"
+    [ -n "$agents_rule_ids" ] || fail "AGENTS.md RULE_ID table yielded no RULE_IDs (parse drift)"
+    local rid
+    for rid in $agents_rule_ids; do
+        grep -q "$rid" "$contract" \
+            || fail "$contract: drift — AGENTS.md RULE_ID '$rid' missing from contract"
+    done
+
+    # The bundler must inject the contract for the implementer role and must NOT
+    # inject the autospec-run SKILL.md for that role any more.
+    local bundler="skills/autospec-shared/scripts/bundle-static-context.sh"
+    [ -f "$bundler" ] || fail "$bundler: file missing"
+    grep -q 'implementer-contract.md' "$bundler" \
+        || fail "$bundler: implementer role no longer references implementer-contract.md"
+    grep -q 'IMPLEMENTER_CONTRACT' "$bundler" \
+        || fail "$bundler: missing IMPLEMENTER_CONTRACT injection variable"
+
+    # Behavioral negative: actual implementer-role output must NOT carry the
+    # verbose 'SKILL.md (implementer role)' injection header. This catches a
+    # future regression where the bundler emits BOTH the contract and the 70KB
+    # SKILL.md (the named-content presence checks above would not).
+    local impl_out
+    impl_out="$(AUTOSPEC_REPO_ROOT="$REPO_ROOT" \
+        AUTOSPEC_MEMORY_DIR=/nonexistent-memory-dir \
+        AUTOSPEC_MANIFEST=/nonexistent-manifest.yml \
+        bash "$bundler" --role implementer --issue-labels 'ctx:120k' 2>/dev/null)" \
+        || fail "$bundler: --role implementer failed to run"
+    if printf '%s\n' "$impl_out" | grep -q 'SKILL.md (implementer role)'; then
+        fail "$bundler: implementer output still injects the SKILL.md (implementer role) prefix"
+    fi
+}
+
 # Usage-limit recovery helper invariants: autospec-run's quota recovery path
 # depends on this shell-only supervisor being installed and executable.
 check_usage_limit_helper() {
@@ -1864,6 +1934,7 @@ main() {
     check_existing_spec_mode
     check_lint_issue_helpers
     check_lint_implementation_helpers
+    check_implementer_contract
     check_lint_heredoc_handling
     check_usage_limit_helper
     check_supersession_contract

--- a/skills/autospec-run/prompts/implementer-contract.md
+++ b/skills/autospec-run/prompts/implementer-contract.md
@@ -1,0 +1,192 @@
+# Implementer contract (autospec:v2-flow)
+
+This is the **implementer-relevant extract** of the autospec project rules. It is
+the curated subset an implementer ACTS on — project rules, the RULE_ID table,
+lock-step discipline, heartbeat schema, worktree/branch rules, the retry/review
+loop contract, and the merge-gate summary. The full 70KB `autospec-run/SKILL.md`
+monitor-loop machinery is intentionally NOT here: as a single-agent
+absorbed-discipline implementer you own one issue end-to-end and do not run the
+orchestrator's monitor phases, profile machinery, or invocation flags.
+
+Treat this contract as authoritative for HOW to take one issue from "open" to
+"PR merged". When a rule here references a deeper procedure (e.g. the full
+`phase4-implementer.md` step body), follow that procedure; this file is the
+acting digest, not a replacement for the per-step prompt.
+
+## Engineering standards
+
+- **No mock databases.** Tests run against a real database (or the repo's
+  established test-DB harness). Mocks/stubs of DB symbols are a blocking finding.
+- **TDD is non-negotiable** for any non-docs change: write the failing test
+  first, implement, make it pass. Pure prose/docs changes skip TDD.
+- **Conventional commits** (`feat:` / `fix:` / `test:` / `docs:` / `refactor:`).
+  Small commits as you go; the PR squashes.
+- **NEVER** push to `main`, force-push, bypass hooks (`--no-verify`), or `amend`
+  an already-pushed commit.
+- **Small-LLM target.** Keep changes self-contained and within the context /
+  reasoning budget implied by the issue's `ctx:*` / `reasoning:*` labels. If you
+  hit budget pressure, stop and comment on the issue rather than rushing.
+- **Reuse before re-implementing.** Run the mandatory pattern survey, then state
+  either `Reusing <X> because <Y>` or `No reuse — <reason>` in the PR body.
+
+## Implementation-quality contract
+
+Every PR produced by an `auto-implement` agent must satisfy the rules below
+before the LGTM reviewer is dispatched. The enforcer is
+`scripts/lint-implementation.sh` (exits 0 on pass, N on fail where N = number of
+blocking findings, capped at 200).
+
+### RULE_ID table
+
+| RULE_ID | Detector | Tier | Threshold / regex |
+|---|---|---|---|
+| `OUT_OF_SCOPE` | det | path-list compare | files touched ∉ issue body `## Implementation outline` paths |
+| `MISSING_TEST` | det | path-prefix scan | required test type from issue body `## Tests required` not present in diff under `tests/{unit,integration,smoke,e2e}/` |
+| `COMPLEXITY` | det | line/regex scan | function >50 LOC, file >500 LOC, nesting >4 |
+| `SECURITY` | det | regex match | `eval\(`, `exec\(`, `--no-verify`, `git reset --hard`, `rm -rf /`, AWS-key shape `AKIA[0-9A-Z]{16}`, GitHub-token shape `gh[pousr]_[A-Za-z0-9]{36,}`, private-key markers `-----BEGIN [A-Z ]*PRIVATE KEY-----` |
+| `TODO_LEFT` | det | regex on non-test diff | `\b(TODO\|XXX\|FIXME)\b` |
+| `MOCK_DB` | det | regex on test diff | `\b(mock\|stub)\b` near DB-symbol heuristics (`db\.`, `database`, `DataSource`, `pg`, `mysql`, `sqlite`) |
+| `HALLUCINATED_API` | LLM | semantic | symbol referenced in diff not defined in diff, not in pre-PR repo (verifiable via repo search), not in dependency manifests |
+| `DUPLICATE_CODE` | LLM | semantic | new code mirrors an existing helper (must cite `<path>:<line>`) |
+| `STRING_MATCH_DOMAIN_LOGIC` | LLM | semantic | code uses substring checks against free-form text to encode domain meaning, AND a proper-representation library is imported in the file |
+| `REPEATED_STRUCTURE_AS_CODE` | LLM | semantic | ≥5 branches in the same function/method sharing identical structural shape (same return shape, predicate signature, side-effect line) |
+| `DOC_OUT_OF_SYNC` | hybrid | det+LLM | det: any change to public surface (CLI flag, env var, exported function, config key) WITHOUT a touched doc file (`README*`, `AGENTS.md`, `docs/**`, `SKILL.md`); LLM: judges semantic accuracy when a doc IS touched |
+| `INVENTED_CONFIG` | LLM | semantic | flag/env-var/config-key introduced in diff not present in issue body or referenced spec |
+
+### Corrective directive map
+
+Each RULE_ID maps to a single-line corrective directive that is injected into the
+implementer's retry prompt as cumulative context:
+
+| RULE_ID | Directive |
+|---|---|
+| `OUT_OF_SCOPE` | "Restrict diff to files listed in issue's ## Implementation outline. Revert other changes or amend the issue body." |
+| `MISSING_TEST` | "Add a test under tests/<TIER>/ for the listed required test type before re-pushing." |
+| `COMPLEXITY` | "Split functions >50 LOC, files >500 LOC, nesting >4. No copy-paste branches." |
+| `SECURITY` | "Remove the flagged pattern. NEVER hardcode secrets, NEVER use --no-verify or git reset --hard, validate input at boundaries." |
+| `TODO_LEFT` | "Remove TODO/XXX/FIXME from non-test code. File a follow-up issue if the work is genuinely deferred." |
+| `MOCK_DB` | "Remove DB mock/stub. Use the real DB per AGENTS.md ## Engineering standards." |
+| `HALLUCINATED_API` | "The flagged symbol does not exist. Verify identifier names against the pre-PR repo and dependency manifests." |
+| `DUPLICATE_CODE` | "Reuse the existing helper at <path>:<line> instead of re-implementing." |
+| `STRING_MATCH_DOMAIN_LOGIC` | "Replace substring checks with the proper domain primitive (AST/parsed URL/IP/date/schema)." |
+| `REPEATED_STRUCTURE_AS_CODE` | "Extract the N branches into a table + single dispatcher loop." |
+| `DOC_OUT_OF_SYNC` | "Update the doc file(s) covering the changed public surface in this same PR." |
+| `INVENTED_CONFIG` | "Remove the invented flag/env/key, or amend the issue body to introduce it as scope." |
+
+### Enforcement and opt-out
+
+- `TDD non-negotiable`, `No DB mocks/stubs`, and `No hardcoded secrets / unsafe
+  git ops` are enforced deterministically by `scripts/lint-implementation.sh`.
+- **Inline escape hatch:** `# linter:allow-RULE_ID <reason>` on the same line as,
+  or the line immediately before, the offending pattern. A bare
+  `# linter:allow-X` with no reason is rejected and the rule stays active.
+- **Per-issue opt-out** (issue body): `Guardian: skip-RULE_ID # <mandatory
+  justification>`. Bare `Guardian: skip-X` is rejected. Skips are emitted as
+  `INFO:RULE_ID...` (audit trail) but do NOT block the merge, and apply only to
+  the PR derived from that issue.
+- `AUTOSPEC_NO_GUARDIAN=1` short-circuits the guardian to the LGTM-only path
+  (logged as `WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN`).
+
+## Lock-step discipline
+
+Many autospec skills ship as a multi-harness trio: `SKILL.md`,
+`codex/prompt.md`, and `opencode/agent.md`. The trio bodies MUST stay
+byte-identical (after frontmatter is stripped per the repo convention
+`awk '/^---$/{c++; next} c>=2'`).
+
+- **Author `SKILL.md` only**, then regenerate `codex/prompt.md` and
+  `opencode/agent.md` so the bodies are byte-identical. Never hand-edit the
+  three copies independently.
+- A SKILL.md + codex/prompt.md **duo** (no opencode/agent.md) must also stay
+  byte-identical.
+- Renaming any prose section heading in a trio SKILL.md requires updating
+  `scripts/validate.sh` named-content checks in the same PR.
+- `scripts/validate.sh` is the authoritative lock-step gate. Run it before every
+  push; a non-zero exit means the trio (or a named-content check) diverged.
+
+## Heartbeat schema
+
+Liveness is tracked per-issue, per-repo via
+`skills/autospec-run/scripts/heartbeat-write.sh`:
+
+```
+heartbeat-write.sh --issue <N> --step <step> [--branch <b>] [--pr <p>] --repo <owner/repo>
+```
+
+- Writes `~/.autospec/process-heartbeats/<repo-slug>/<issue>.json`, where
+  `<repo-slug>` is `<owner/repo>` with `/` replaced by `_` (path-scoped so the
+  shared heartbeat dir never collides across repos).
+- Update the heartbeat at each major step:
+  `claimed → worktree_ready → tests_started → tests_passed → pr_created →
+  reviewed → merged`.
+- Delete the heartbeat on any terminal outcome (merged, failed, or returned to
+  queue).
+
+## Worktree / branch rules
+
+- Branch name: `feat/<slug>` derived from the issue.
+- Create an isolated worktree off freshly-fetched `origin/main`:
+
+  ```bash
+  git fetch origin
+  git worktree add -b feat/<slug> /tmp/wt-feat-<slug> origin/main
+  cd /tmp/wt-feat-<slug>
+  ```
+
+- Do all work in the worktree. Clean the worktree up on every terminal outcome.
+- A post-merge branch-switch error in the original checkout is harmless.
+
+## Retry / review loop contract
+
+1. **Pattern survey** (mandatory, before any code): search for analogous
+   utilities; document the reuse decision in the PR body.
+2. **Expand:** read the issue body in full; verify every referenced file path
+   exists. If a path is wrong or the contract is ambiguous in a way that changes
+   implementation, comment on the issue and exit — do NOT guess.
+3. **Implement + TDD:** failing test first (for functional changes), then code,
+   then green.
+4. **Finalize:** run the project's full test/lint command; if the diff touches a
+   migration path, run the migration-replay hook before opening the PR; run the
+   docs-drift gate.
+5. **Peer-review (Codex):** if `codex` is on PATH, get a second opinion on the
+   diff; apply must-fix findings as additional commits and re-run tests; append
+   nice-to-have findings verbatim to the PR body under
+   `## Peer-review notes (not addressed)`. If `codex` is absent, log
+   `Peer-review: codex not on PATH, skipping` and proceed.
+6. **Adaptive retry:** on a blocking finding, re-run the implement step with the
+   corrective directive(s) accumulated as cumulative context, up to
+   `MAX_IMPL_RETRIES`. On exhaustion, comment
+   `Implementer hit max retries; manual intervention needed`, release the
+   lock-label, and stop.
+
+## Merge-gate summary
+
+Immediately before `gh pr create`, then before `gh pr merge`:
+
+1. **Lock-step deps:** re-check every `Depends on issue #N` line — each must
+   return `CLOSED` via `gh issue view <N> --json state --jq .state`. If any dep
+   is not merged, do NOT open the PR; comment which dep blocks and exit.
+2. **Full test suite gate:** the repo's full validation/test suite (default
+   `bash scripts/validate.sh`, override `AUTOSPEC_FULL_TEST_COMMAND`) MUST pass
+   before LGTM review and again immediately before admin-merge. A failing suite
+   blocks both review and merge — fix, recommit, rerun, repeat. Record the exact
+   command and passing summary as merge evidence.
+3. **Smoke gate:** run the issue body's **Primary smoke test** command. If it is
+   not an executable single-command fence, comment and exit (missing AC).
+4. **Rebase-and-retest:** if `mergeStateStatus` is `BEHIND`, `gh pr update-branch`
+   and wait for CI green (cap `AUTOSPEC_REBASE_MAX_ATTEMPTS`, default 3). `DIRTY`
+   (merge conflict) → comment and exit for human resolution.
+5. **Sandbox guard:** if `.autospec/explore-mode.json` exists, target its
+   `branch` as PR base and REFUSE any merge to `main`
+   (`code_health:explore_main_merge_refused`).
+6. **Merge:** when the merge-state is `CLEAN`/`HAS_HOOKS`/`UNSTABLE` and all
+   gates pass: `gh pr merge <PR> --admin --squash --delete-branch`.
+
+## Exit conditions
+
+- **Success** — PR opened, CI green, admin auto-merge complete; heartbeat removed.
+- **Soft fail (return to queue)** — clarification needed, lock-step blocked, or
+  budget exhausted. Comment on the issue; do NOT open a PR; restore the
+  `auto-implement` label; remove the heartbeat.
+- **Hard fail (escalate)** — broken test infra, inconsistent repo state, or
+  conflicting changes. Comment on the issue and add the `escalate:human` label.

--- a/skills/autospec-shared/scripts/bundle-static-context.sh
+++ b/skills/autospec-shared/scripts/bundle-static-context.sh
@@ -6,13 +6,28 @@
 #                            [--issue-labels "label1,label2,..."]
 #
 # Output (stdout): static blob framed by <!-- CACHE BOUNDARY --> markers.
-# Composition order (implementer role):
-#   1. SKILL.md (autospec-run, verbatim)
+#
+# Composition order (implementer role — D3 prefix slim):
+#   --- inside the CACHE BOUNDARY (byte-stable prefix, safe to cache) ---
+#   1. implementer-contract.md (curated <=24KB extract — NOT the 70KB SKILL.md)
+#   2. AGENTS.md ## Implementation-quality contract section (canonical RULE_ID)
+#   --- below the closing CACHE BOUNDARY (per-issue, NOT cached) ---
+#   3. Tag-filtered saved-memory files
+#   4. Lockstep paragraph
+#   5. Role-specific implementer scaffolding
+#
+# Composition order (reviewer/decomposer/classifier roles — unchanged):
+#   1. SKILL.md (role's skill, verbatim)
 #   2. AGENTS.md (verbatim)
 #   3. RULE_ID table (extracted from AGENTS.md)
 #   4. Tag-filtered saved-memory files
 #   5. Lockstep paragraph
-#   6. Role-specific implementer scaffolding
+#   6. Role-specific scaffolding
+#
+# Implementer prefix caching: the launch path SHOULD pass everything ABOVE the
+# closing <!-- CACHE BOUNDARY --> with cache_control: {type: ephemeral} where the
+# harness supports it. The prefix is byte-stable across issues because all
+# per-issue material (memory, scaffolding, dynamic suffix) lives below the marker.
 #
 # Environment overrides (for testing):
 #   AUTOSPEC_REPO_ROOT    — repo root (default: dirname of this script / 3 levels up)
@@ -93,10 +108,14 @@ SCRIPTS_DIR="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}"
 # Allow explicit override for testing; fall back to scripts dir
 MANIFEST="${AUTOSPEC_MANIFEST:-$SCRIPTS_DIR/memory-tags.yml}"
 AGENTS_MD="$REPO_ROOT/AGENTS.md"
+# D3: the implementer role injects this curated contract instead of the 70KB SKILL.md.
+IMPLEMENTER_CONTRACT="$REPO_ROOT/skills/autospec-run/prompts/implementer-contract.md"
 
-# Role-to-skill mapping
+# Role-to-skill mapping. The implementer role no longer injects a SKILL.md
+# (D3 prefix slim) — it injects implementer-contract.md instead.
+SKILL_MD=""
 case "$ROLE" in
-  implementer) SKILL_MD="$REPO_ROOT/skills/autospec-run/SKILL.md" ;;
+  implementer) SKILL_MD="" ;;
   reviewer)    SKILL_MD="$REPO_ROOT/skills/autospec-run/SKILL.md" ;;
   decomposer)  SKILL_MD="$REPO_ROOT/skills/autospec-define/SKILL.md" ;;
   classifier)  SKILL_MD="$REPO_ROOT/skills/autospec-classify/SKILL.md" ;;
@@ -107,7 +126,12 @@ if [ ! -f "$AGENTS_MD" ]; then
   printf 'bundle-static-context.sh: AGENTS.md not found: %s\n' "$AGENTS_MD" >&2
   exit 1
 fi
-if [ ! -f "$SKILL_MD" ]; then
+if [ "$ROLE" = "implementer" ]; then
+  if [ ! -f "$IMPLEMENTER_CONTRACT" ]; then
+    printf 'bundle-static-context.sh: implementer-contract.md not found: %s\n' "$IMPLEMENTER_CONTRACT" >&2
+    exit 1
+  fi
+elif [ ! -f "$SKILL_MD" ]; then
   printf 'bundle-static-context.sh: SKILL.md not found for role %s: %s\n' "$ROLE" "$SKILL_MD" >&2
   exit 1
 fi
@@ -151,86 +175,137 @@ if [ -f "$MANIFEST" ] && [ -d "$MEMORY_DIR" ]; then
   done < "$MANIFEST"
 fi
 
+# ── emit helpers ──────────────────────────────────────────────────────────────
+
+# Emit tag-filtered saved-memory files (per-issue; must live BELOW the closing
+# CACHE BOUNDARY so the implementer prefix stays byte-stable across issues).
+emit_memory() {
+  printf '## Project rules (saved memory)\n\n'
+  if [ -z "$matched_memory" ]; then
+    printf '(No memory files matched the issue labels.)\n\n'
+  else
+    printf '%s' "$matched_memory" | while IFS= read -r mem_file; do
+      [ -n "$mem_file" ] || continue
+      [ -f "$mem_file" ] || continue
+      # Strip YAML frontmatter (---...---) if present
+      awk '
+        BEGIN { in_front=0; done_front=0 }
+        /^---$/ && !done_front && NR==1 { in_front=1; next }
+        /^---$/ && in_front { in_front=0; done_front=1; next }
+        !in_front { print }
+      ' "$mem_file"
+      printf '\n'
+    done
+  fi
+}
+
+# Emit the lockstep paragraph (static, but kept below the boundary alongside the
+# other per-role scaffolding for the implementer role).
+emit_lockstep() {
+  printf '## Lockstep rules\n\n'
+  printf 'All SKILL.md edits must be byte-identically mirrored to codex/prompt.md and opencode/agent.md.\n'
+  printf 'Run scripts/validate.sh to confirm lockstep compliance before every push.\n'
+  printf 'Renaming any prose section heading in SKILL.md requires updating scripts/validate.sh named-content checks.\n'
+  printf '\n'
+}
+
+# Emit role-specific scaffolding (per-issue acting instructions).
+emit_scaffolding() {
+  case "$ROLE" in
+    implementer)
+      printf '## Implementer scaffolding\n\n'
+      printf 'You are implementing a GitHub issue in a git worktree off origin/main.\n'
+      printf 'TDD discipline: write failing tests first, then implement, then make tests pass.\n'
+      printf 'Use conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.\n'
+      printf 'Keep heartbeat updated at each major step: claimed → worktree_ready → tests_started → tests_passed → pr_created → reviewed → merged.\n'
+      printf '\n'
+      ;;
+    reviewer)
+      printf '## Reviewer scaffolding\n\n'
+      printf 'You are performing fused guardian + LGTM review of a GitHub PR.\n'
+      printf 'Part 1 — Guardian: apply RULE_ID table to the diff. Collect findings as RULE_ID:<path>:<line>: <desc>.\n'
+      printf 'Part 2 — LGTM: check correctness, edge cases, missing tests, AGENTS.md compliance.\n'
+      printf 'Verdict: if zero blocking findings → return only the token LGTM. Otherwise return numbered findings list.\n'
+      printf '\n'
+      ;;
+    decomposer)
+      printf '## Decomposer scaffolding\n\n'
+      printf 'You are decomposing a feature spec into GitHub issues for autonomous implementation.\n'
+      printf 'Each issue must be self-contained, sized for 32B-class local LLMs (48 GB Macs), with one primary smoke test.\n'
+      printf '\n'
+      ;;
+    classifier)
+      printf '## Classifier scaffolding\n\n'
+      printf 'You are classifying GitHub issues with model-fit labels (ctx:* and reasoning:*).\n'
+      printf 'Ordinals: ctx: 32k < 64k < 120k; reasoning: shallow < medium < deep.\n'
+      printf '\n'
+      ;;
+  esac
+}
+
 # ── emit output ───────────────────────────────────────────────────────────────
 
-printf '<!-- CACHE BOUNDARY -->\n'
+if [ "$ROLE" = "implementer" ]; then
+  # D3 prefix slim: the implementer prefix is byte-stable across issues. Only
+  # the curated contract + AGENTS.md quality-contract section live inside the
+  # cache boundary; per-issue memory + scaffolding go BELOW the closing marker.
 
-# 1. SKILL.md verbatim
-printf '## SKILL.md (%s role)\n\n' "$ROLE"
-cat "$SKILL_MD"
-printf '\n'
+  printf '<!-- CACHE BOUNDARY -->\n'
 
-# 2. AGENTS.md verbatim
-printf '## AGENTS.md\n\n'
-cat "$AGENTS_MD"
-printf '\n'
+  # 1. Curated implementer contract (NOT the 70KB SKILL.md).
+  printf '## Implementer contract\n\n'
+  cat "$IMPLEMENTER_CONTRACT"
+  printf '\n'
 
-# 3. RULE_ID table extracted from AGENTS.md
-printf '## RULE_ID table\n\n'
-awk '
-  /^### RULE_ID table/ { in_table=1; next }
-  /^### / && in_table { exit }
-  /^## / && in_table { exit }
-  in_table { print }
-' "$AGENTS_MD"
-printf '\n'
+  # 2. AGENTS.md ## Implementation-quality contract section (canonical source of
+  #    the RULE_ID table). The contract above mirrors it; validate.sh flags drift.
+  printf '## AGENTS.md — Implementation-quality contract\n\n'
+  awk '
+    /^## Implementation-quality contract/ { in_sec=1; print; next }
+    /^## / && in_sec { exit }
+    in_sec { print }
+  ' "$AGENTS_MD"
+  printf '\n'
 
-# 4. Tag-filtered saved-memory files
-printf '## Project rules (saved memory)\n\n'
-if [ -z "$matched_memory" ]; then
-  printf '(No memory files matched the issue labels.)\n\n'
+  printf '<!-- CACHE BOUNDARY -->\n'
+
+  # Below the boundary: per-issue, NOT part of the cached prefix.
+  emit_memory
+  emit_lockstep
+  emit_scaffolding
 else
-  printf '%s' "$matched_memory" | while IFS= read -r mem_file; do
-    [ -n "$mem_file" ] || continue
-    [ -f "$mem_file" ] || continue
-    # Strip YAML frontmatter (---...---) if present
-    awk '
-      BEGIN { in_front=0; done_front=0 }
-      /^---$/ && !done_front && NR==1 { in_front=1; next }
-      /^---$/ && in_front { in_front=0; done_front=1; next }
-      !in_front { print }
-    ' "$mem_file"
-    printf '\n'
-  done
+  # reviewer / decomposer / classifier: unchanged composition (everything inside
+  # the boundary; these roles do not yet use the byte-stable-prefix split).
+  printf '<!-- CACHE BOUNDARY -->\n'
+
+  # 1. SKILL.md verbatim
+  printf '## SKILL.md (%s role)\n\n' "$ROLE"
+  cat "$SKILL_MD"
+  printf '\n'
+
+  # 2. AGENTS.md verbatim
+  printf '## AGENTS.md\n\n'
+  cat "$AGENTS_MD"
+  printf '\n'
+
+  # 3. RULE_ID table extracted from AGENTS.md
+  printf '## RULE_ID table\n\n'
+  awk '
+    /^### RULE_ID table/ { in_table=1; next }
+    /^### / && in_table { exit }
+    /^## / && in_table { exit }
+    in_table { print }
+  ' "$AGENTS_MD"
+  printf '\n'
+
+  # 4. Tag-filtered saved-memory files
+  emit_memory
+
+  # 5. Lockstep paragraph
+  emit_lockstep
+
+  # 6. Role-specific scaffolding
+  emit_scaffolding
+
+  printf '<!-- CACHE BOUNDARY -->\n'
 fi
-
-# 5. Lockstep paragraph
-printf '## Lockstep rules\n\n'
-printf 'All SKILL.md edits must be byte-identically mirrored to codex/prompt.md and opencode/agent.md.\n'
-printf 'Run scripts/validate.sh to confirm lockstep compliance before every push.\n'
-printf 'Renaming any prose section heading in SKILL.md requires updating scripts/validate.sh named-content checks.\n'
-printf '\n'
-
-# 6. Role-specific scaffolding
-case "$ROLE" in
-  implementer)
-    printf '## Implementer scaffolding\n\n'
-    printf 'You are implementing a GitHub issue in a git worktree off origin/main.\n'
-    printf 'TDD discipline: write failing tests first, then implement, then make tests pass.\n'
-    printf 'Use conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.\n'
-    printf 'Keep heartbeat updated at each major step: claimed → worktree_ready → tests_started → tests_passed → pr_created → reviewed → merged.\n'
-    printf '\n'
-    ;;
-  reviewer)
-    printf '## Reviewer scaffolding\n\n'
-    printf 'You are performing fused guardian + LGTM review of a GitHub PR.\n'
-    printf 'Part 1 — Guardian: apply RULE_ID table to the diff. Collect findings as RULE_ID:<path>:<line>: <desc>.\n'
-    printf 'Part 2 — LGTM: check correctness, edge cases, missing tests, AGENTS.md compliance.\n'
-    printf 'Verdict: if zero blocking findings → return only the token LGTM. Otherwise return numbered findings list.\n'
-    printf '\n'
-    ;;
-  decomposer)
-    printf '## Decomposer scaffolding\n\n'
-    printf 'You are decomposing a feature spec into GitHub issues for autonomous implementation.\n'
-    printf 'Each issue must be self-contained, sized for 32B-class local LLMs (48 GB Macs), with one primary smoke test.\n'
-    printf '\n'
-    ;;
-  classifier)
-    printf '## Classifier scaffolding\n\n'
-    printf 'You are classifying GitHub issues with model-fit labels (ctx:* and reasoning:*).\n'
-    printf 'Ordinals: ctx: 32k < 64k < 120k; reasoning: shallow < medium < deep.\n'
-    printf '\n'
-    ;;
-esac
-
-printf '<!-- CACHE BOUNDARY -->\n'

--- a/tests/bundle-and-dispatch.bats
+++ b/tests/bundle-and-dispatch.bats
@@ -7,7 +7,7 @@ FIXTURES_DIR="${BATS_TEST_DIRNAME}/fixtures/bundle-and-dispatch"
 
 setup() {
   mkdir -p "$FIXTURES_DIR/memory"
-  mkdir -p "$FIXTURES_DIR/skills/autospec-run"
+  mkdir -p "$FIXTURES_DIR/skills/autospec-run/prompts"
   mkdir -p "$FIXTURES_DIR/skills/autospec-shared/scripts"
 
   # Fixture SKILL.md for implementer role
@@ -20,6 +20,19 @@ description: test fixture
 # autospec-run workflow
 
 This is the SKILL.md content for testing.
+EOF
+
+  # Fixture implementer-contract.md (D3: implementer role injects this, not SKILL.md)
+  cat > "$FIXTURES_DIR/skills/autospec-run/prompts/implementer-contract.md" <<'EOF'
+# Implementer contract (test fixture)
+
+## Implementation-quality contract
+
+### RULE_ID table
+
+| RULE_ID | Detector |
+|---|---|
+| `OUT_OF_SCOPE` | det |
 EOF
 
   # Fixture AGENTS.md with RULE_ID table
@@ -106,8 +119,9 @@ teardown() {
     "$SCRIPT" --role implementer --issue-labels "ctx:64k" \
     --dynamic-suffix-file "$FIXTURES_DIR/dynamic-suffix.txt"
   [ "$status" -eq 0 ]
-  # Spot-check: a distinctive line from the prefix appears in combined output
-  printf '%s\n' "$output" | grep -q "SKILL.md (implementer role)"
+  # Spot-check: a distinctive line from the implementer prefix (the injected
+  # contract section header) appears in the combined output.
+  printf '%s\n' "$output" | grep -q "Implementer contract"
 }
 
 @test "bundle-and-dispatch.sh output appends dynamic suffix after cache boundary" {

--- a/tests/bundle-static-context.bats
+++ b/tests/bundle-static-context.bats
@@ -6,7 +6,7 @@ FIXTURES_DIR="${BATS_TEST_DIRNAME}/fixtures/bundle-static-context"
 
 setup() {
   mkdir -p "$FIXTURES_DIR/memory"
-  mkdir -p "$FIXTURES_DIR/skills/autospec-run"
+  mkdir -p "$FIXTURES_DIR/skills/autospec-run/prompts"
   mkdir -p "$FIXTURES_DIR/skills/autospec-shared/scripts"
 
   # Fixture SKILL.md for implementer role
@@ -19,6 +19,19 @@ description: test fixture
 # autospec-run workflow
 
 This is the SKILL.md content for testing.
+EOF
+
+  # Fixture implementer-contract.md (D3: implementer role injects this, not SKILL.md)
+  cat > "$FIXTURES_DIR/skills/autospec-run/prompts/implementer-contract.md" <<'EOF'
+# Implementer contract (test fixture)
+
+## Implementation-quality contract
+
+### RULE_ID table
+
+| RULE_ID | Detector |
+|---|---|
+| `OUT_OF_SCOPE` | det |
 EOF
 
   # Fixture AGENTS.md with RULE_ID table
@@ -84,14 +97,71 @@ teardown() {
   printf '%s\n' "$output" | head -1 | grep -q "CACHE BOUNDARY"
 }
 
-@test "bundle-static-context.sh --role implementer emits closing CACHE BOUNDARY marker" {
+@test "bundle-static-context.sh --role implementer emits two CACHE BOUNDARY markers (prefix is framed; memory/scaffolding below the second)" {
   run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
     AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
     AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
     AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
     "$SCRIPT" --role implementer --issue-labels "skill:autospec-run"
   [ "$status" -eq 0 ]
-  printf '%s\n' "$output" | tail -1 | grep -q "CACHE BOUNDARY"
+  boundary_count=$(printf '%s\n' "$output" | grep -c "CACHE BOUNDARY")
+  [ "$boundary_count" -eq 2 ]
+}
+
+@test "bundle-static-context.sh --role implementer injects implementer-contract.md, NOT the SKILL.md" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run"
+  [ "$status" -eq 0 ]
+  # The contract section header is injected for the implementer role...
+  printf '%s\n' "$output" | grep -q "Implementer contract"
+  # ...and the verbose SKILL.md prefix header is gone for the implementer role.
+  ! printf '%s\n' "$output" | grep -q "SKILL.md (implementer role)"
+}
+
+@test "bundle-static-context.sh --role implementer keeps memory BELOW the closing CACHE BOUNDARY (byte-stable prefix)" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run"
+  [ "$status" -eq 0 ]
+  # Second (closing) CACHE BOUNDARY line number vs the matched memory content.
+  last_boundary=$(printf '%s\n' "$output" | grep -n "CACHE BOUNDARY" | tail -1 | cut -d: -f1)
+  mem_line=$(printf '%s\n' "$output" | grep -n "ascending issue order" | head -1 | cut -d: -f1)
+  [ -n "$last_boundary" ]
+  [ -n "$mem_line" ]
+  [ "$mem_line" -gt "$last_boundary" ]
+}
+
+@test "bundle-static-context.sh --role implementer prefix is byte-stable across two different issue-label inputs" {
+  pfx() {
+    env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+      AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+      AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+      AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+      "$SCRIPT" --role implementer --issue-labels "$1" \
+      | awk '/<!-- CACHE BOUNDARY -->/{c++} {print} c==2{exit}'
+  }
+  p1=$(pfx "skill:autospec-run")
+  p2=$(pfx "bash,scripting")
+  [ "$p1" = "$p2" ]
+}
+
+@test "implementer-contract.md exists and is at most 24576 bytes (size guard)" {
+  contract="${BATS_TEST_DIRNAME}/../skills/autospec-run/prompts/implementer-contract.md"
+  [ -f "$contract" ]
+  size=$(wc -c < "$contract" | tr -d ' ')
+  [ "$size" -le 24576 ]
+}
+
+@test "implementer-contract.md contains the single RULE_ID table header" {
+  contract="${BATS_TEST_DIRNAME}/../skills/autospec-run/prompts/implementer-contract.md"
+  [ -f "$contract" ]
+  count=$(grep -c '^### RULE_ID table' "$contract")
+  [ "$count" -eq 1 ]
 }
 
 @test "bundle-static-context.sh --role implementer output is idempotent" {


### PR DESCRIPTION
## Summary

Implements spec §D3 (cost-efficiency): replace the 70KB `autospec-run/SKILL.md`
injection in the **implementer** prompt prefix with a curated
`implementer-contract.md`, move per-issue memory + scaffolding below the closing
`<!-- CACHE BOUNDARY -->` so the implementer prefix is byte-stable across issues,
and drop the duplicate RULE_ID re-extraction for the implementer role.

Closes #940.

## What changed

- **New `skills/autospec-run/prompts/implementer-contract.md`** (11519 bytes,
  well under the 24KB budget): the implementer-relevant extract only — project
  rules digest, single RULE_ID table, lock-step discipline, heartbeat schema,
  worktree/branch rules, retry/review loop contract, merge-gate summary.
  Curated from the 76KB SKILL.md + AGENTS.md; excludes monitor-loop bash,
  orchestrator phases, profile machinery, and invocation flags.
- **`skills/autospec-shared/scripts/bundle-static-context.sh`**: the implementer
  role now emits the contract + AGENTS.md `## Implementation-quality contract`
  section **inside** the boundary, closes the boundary, then emits tag-filtered
  memory + lockstep + scaffolding **below** it. The 70KB SKILL.md is no longer
  injected for the implementer role; no separate RULE_ID re-extraction for it.
  Reviewer / decomposer / classifier composition is unchanged.
- **`scripts/validate.sh`** — `check_implementer_contract`: contract exists,
  ≤24576 bytes, exactly one `### RULE_ID table` header, no AGENTS.md RULE_ID
  drift (every canonical first-column RULE_ID must appear in the contract),
  bundler injects the contract, and the implementer output no longer carries the
  `SKILL.md (implementer role)` header (behavioral negative).
- **Tests** (`tests/bundle-static-context.bats`, `tests/bundle-and-dispatch.bats`):
  size guard (≤24576 bytes), single-RULE_ID-header, byte-stable-prefix across two
  issue-label inputs, memory-below-boundary, contract-not-SKILL.md; updated the
  boundary + verbatim assertions and added a fixture `implementer-contract.md`.

## Demonstrated savings (the big cost win)

Implementer dispatch, `ctx:120k,skill:autospec-run` fixture, old (`origin/main`
bundler) vs new:

| | bytes |
|---|---|
| OLD implementer bundle | 137965 |
| NEW implementer bundle | 51272 |
| **Savings** | **86693 bytes (62.8% smaller)** |

Cacheable prefix (inside the boundary): **18959 bytes**, byte-identical across
two different issue-label inputs (`ctx:120k,skill:autospec-run` vs
`ctx:64k,reasoning:deep,bash`).

## Size guard (proof)

```
$ wc -c skills/autospec-run/prompts/implementer-contract.md
11519 skills/autospec-run/prompts/implementer-contract.md
```

Negative tests confirmed: oversizing to 31519 bytes → size guard FAILs;
deleting a RULE_ID from the contract → drift gate FAILs.

## Verification

- `bash scripts/validate.sh` → exit 0 (includes `implementer-contract:` check).
- `bats tests/bundle-static-context.bats tests/bundle-static-context-reviewer.bats tests/bundle-and-dispatch.bats` → 37/37 green.
- `bash -n` clean on both changed shell files.

Cross-checked the contract against `phase4-implementer.md` references — nothing
an implementer acts on (RULE_ID table, lock-step, heartbeat, worktree/branch,
retry/review loop, merge gate, smoke/rebase/sandbox guards) was cut.

## Peer-review notes (not addressed)

Codex found no must-fix findings. One nice-to-have (strengthen the validate
check so a future bundler can't emit BOTH the contract and the SKILL.md) was
**addressed** in this PR via the behavioral negative assertion in
`check_implementer_contract`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)