### PR TITLE
docs: fix-routing/docs-gating + worktree-guard design specs

### DIFF
--- a/docs/specs/2026-06-03-fix-routing-docs-gating-design.md
+++ b/docs/specs/2026-06-03-fix-routing-docs-gating-design.md
@@ -1,0 +1,135 @@
+# 'fix' intent routing + docs-generation gating (off-by-default in runs, always in QA)
+
+- **Date:** 2026-06-03
+- **Status:** Design (Phase 2)
+- **Author:** berlinguyinca (refined via /autospec-refine)
+- **Tracker target:** `berlinguyinca/autospec`
+- **Builds on:** explore/discover routing (`2026-06-03-explore-discover-intent-routing-design.md`), autospec-doc core (`2026-06-03-autospec-doc-core-design.md` §D6), cost-efficiency (`2026-06-03-autospec-cost-efficiency-design.md`)
+
+## Problem statement
+
+Three operator-decided changes:
+
+1. **`fix` is not a routed verb.** Imperative "fix the login flow" should enter
+   the pipeline like implement/build/ship do — but routing to **`/autospec`
+   end-to-end** (spec → issues → run), since a fix needs scoping before
+   implementation. `new feature` already routes to `autospec-define`
+   (plan-only) and **stays unchanged** (explicit decision).
+2. **Doc generation currently fires unconditionally during runs.** The merged
+   Phase-4 `regenerate` self-heal (PR #935) regenerates docs on every
+   drift/missing_scope/example_stale finding; the only escape is per-issue
+   `docs: skip`. Generation is expensive (audience × feature fan-out) — it
+   must be **off by default during autospec runs** unless explicitly enabled.
+   Drift **detection** stays on (cheap, informative labels).
+3. **QA must always do docs.** `autospec-qa` becomes the guaranteed
+   documentation sync point: it ALWAYS invokes `/autospec-doc --full`
+   (generation + completeness audit + example verification), ignoring the
+   off-by-default switch.
+
+## Goals / non-goals
+
+**Goals**
+- G1: `fix` → `/autospec` via the autospec-listen deterministic classifier,
+  intent-gated, with the standard one-line opt-out (`plain`/`no`) — no confirm
+  gate (`/autospec` is not a perpetual loop) — plus **trivial-fix suppressors**.
+- G2: `documentation.auto_regenerate: false` schema default; three opt-ins:
+  (a) config `true`, (b) per-issue body line `docs: generate` (mirror of the
+  existing `docs: skip`), (c) per-run flag `--with-docs`. Detection unchanged.
+- G3: autospec-qa gains a mandatory **Documentation gate**: `/autospec-doc
+  --full` + `verify-examples` always run; failures are QA findings (never
+  silently skipped).
+
+**Non-goals**
+- Changing `new feature` routing (stays → autospec-define).
+- Touching drift detection, labels, or `docs: skip` semantics.
+- Weakening the docs-as-tests engine (QA runs it in full).
+
+## Design
+
+### D1 — `fix` routing (listener-match + listen trio)
+
+- **D3 branch** in `scripts/listener-match.sh`: imperative `fix` (whole-word)
+  → `emit_classify_json true autospec fix imperative 0.7 "$is_auto" "" ""`
+  (no gate — standard opt-out applies; `/autospec` itself brainstorms scope).
+  Place alongside the implement/build/ship branch; `fix` must NOT shadow the
+  more specific explore/refine/run branches (evaluate after them).
+- **Trivial-fix suppressors** (the negative table — false-negative biased):
+  "fix this typo", "fix the typo", "fix the comment", "fix the indentation",
+  "fix the formatting", "quick fix", "fix the spelling" → `match:false`, stay
+  plain. Plus the existing D4 question/negation/past suppression ("did you fix
+  it?", "don't fix that yet", "I fixed it").
+- **Listen trio**: add the `fix → /autospec` row to the verb-map table
+  (lock-step, byte-identical bodies).
+- bats: positive table ("fix the login flow", "fix the race condition in the
+  watchdog", "please fix the broken pagination") → `skill=autospec`,
+  `intent=imperative`; negative table (all suppressors above) → `match:false`.
+
+### D2 — docs off-by-default in runs
+
+- **Config**: `documentation.auto_regenerate` (boolean, default **false**) in
+  `skills/autospec-doc/scripts/doc-config.mjs` (#917's loader) + the schema
+  docs + README migration note. `init` writes it explicitly with a comment.
+- **Gate conditional**: the run trio's `docs-drift-gate` block (the #935
+  self-heal) wraps the regenerate path in the resolved switch:
+  `auto_regenerate==true` ∨ issue body matches `^docs:\s*generate\s*$`
+  (case-insensitive, same matcher shape as `docs: skip`) ∨ run launched with
+  `--with-docs` (plumbed as `AUTOSPEC_WITH_DOCS=1`). When OFF: detection runs,
+  labels/comments still applied, classifier verdict logged, **no generation,
+  no docs commit** — log line `docs: regeneration skipped (auto_regenerate=false)`.
+  Precedence: `docs: skip` > `docs: generate` > config/flag.
+- Phase 5.5 docs-completeness (#923) and sweep `--full` (#924) honor the same
+  switch for *generation* but always *report* gaps (report-only when off).
+
+### D3 — QA documentation gate (autospec-qa trio)
+
+New top-level section **`## Documentation gate`** in the autospec-qa trio
+(slotting with the existing proof/freshness gates): every QA run invokes
+`/autospec-doc --full` (via `doc-orchestrator.mjs`), then `verify-examples.mjs`
+across regenerated pages, then `check-doc-drift.sh --working-tree` — expecting
+clean. Failures (generation error, failing example, residual drift, missing
+audience page) are **QA findings** in the standard QA report format, with the
+same severity discipline as the no-mock smoke rule. The `auto_regenerate`
+switch is explicitly documented as NOT consulted here.
+
+## Sequencing constraint
+
+D2's gate conditional edits the **autospec-run trio** — the same surface as the
+cost-efficiency epic's serialized chain (#938→#939→#941→#942). The D2 child
+MUST depend on the cost epic's audit (#944). D1 (listen trio) and D3 (qa trio)
+are independent surfaces and dep-free (config child first for D2/D3 consumers).
+
+## Testing & validation
+
+- bats: classifier positive/negative `fix` tables; config-key default +
+  3-opt-in resolution matrix (incl. precedence with `docs: skip`); gate-block
+  extraction `bash -n` (existing tests/phase4 pattern) asserting the
+  conditional wraps ONLY the regenerate path.
+- QA trio: named-content check in `validate.sh` for the `## Documentation
+  gate` section across the qa trio; lock-step byte-identity for every trio
+  edit (listen, run, qa — each authored in SKILL.md, mirrors regenerated).
+- Regression guard: existing explore/discover + implement/build/ship routing
+  tests stay green ('fix' must not cannibalize them).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| 'fix' over-triggers on chatter | D4 gates + trivial suppressors + opt-out; negative bats table is the permanent guard |
+| Docs silently rot with generation off | detection/labels stay on; QA always regenerates; Phase 5.5/sweep report gaps |
+| Trio conflict with cost epic | D2 child depends on #944; trio edits serialized |
+| Switch confusion (`docs: skip` vs `generate`) | documented precedence; resolution matrix test |
+
+## Decomposition hint for /autospec-define
+
+1. **Config key + resolution** (D2a): `auto_regenerate` default false +
+   3-opt-in resolution helper + precedence tests. Dep-free.
+2. **`fix` routing** (D1): classifier branch + suppressors + listen trio row +
+   bats. Dep-free (listen trio quiet).
+3. **Run-trio gate conditional** (D2b): wrap the #935 regenerate path; log
+   line; Phase 5.5/sweep report-only mode. Depends on child 1 AND **#944**.
+4. **QA documentation gate** (D3): qa trio section + validate named-content +
+   QA-finding wiring. Depends on child 1.
+5. Standard Phase 5.5 audit issue depending on all.
+
+> Decomposer notes: three different trios are touched (listen/run/qa) — one
+> trio per child, lock-step checkbox each; do NOT apply needs-autospec-template.

--- a/docs/specs/2026-06-03-worktree-guard-design.md
+++ b/docs/specs/2026-06-03-worktree-guard-design.md
@@ -1,0 +1,161 @@
+# worktree guard — never work on dirty branches; fresh worktrees enforced
+
+- **Date:** 2026-06-03
+- **Status:** Design (Phase 2)
+- **Author:** berlinguyinca (refined via /autospec-refine)
+- **Tracker target:** `berlinguyinca/autospec`
+
+## Problem statement
+
+The worktree rule exists only as prose (`skills/autospec-run/SKILL.md:609,729`)
+— nothing enforces it. Verified gaps (2026-06-03):
+
+- `scripts/dispatch-implementer.sh:78-82` **silently reuses an existing
+  worktree** with no clean-check — a dirty-worktree hazard by design.
+- **No script anywhere** checks "am I in the primary checkout"
+  (`git-common-dir` vs `git-dir`) or "does this branch already exist on the
+  remote" (`ls-remote --heads`).
+- Live failure classes this session: the **#882/#886 collision** (a prior
+  worker's branch + open PR existed; a new worker re-claimed and would have
+  pushed a conflicting branch), recovery agents inheriting half-done worktrees
+  (#917), stray `/tmp/ws-*` worktrees, and a perpetually-dirty primary
+  checkout that every agent had to tip-toe around.
+
+The watchdog GC (#887) covers orphaned-worktree *cleanup*; the missing piece
+is the deterministic *preflight*.
+
+## Goals (operator-decided)
+
+- **G1:** A shared deterministic guard: agents NEVER work in the primary
+  checkout or on a dirty/stale worktree — always a fresh (or verified-clean
+  adopted) worktree off just-fetched `origin/main`.
+- **G2 (PR-aware recovery ladder):** when the target branch already exists
+  remotely: open PR → **validate + merge, no re-implementation** (the #886
+  recovery); branch-only → **adopt in a fresh worktree and continue** (the
+  #917 recovery); neither → create fresh.
+- **G3 (scope: ALL git-mutating autospec flows):** run implementers first,
+  then define spec-PRs, doc regenerate commits, explore sandbox, release.
+  The primary checkout becomes **read-only territory for agents**; operator
+  dirt in it never matters and is never touched.
+- **G4:** Git best practices codified in AGENTS.md: fetch-before-branch,
+  cleanup only after merge confirmed, `git worktree prune` in cleanup, no
+  reuse of dirty worktrees (no force-push/amend already covered).
+
+**Non-goals:** changing the watchdog GC; touching operator-driven git flows
+outside autospec skills; rebase/merge-strategy changes.
+
+## Design
+
+### D1 — `scripts/worktree-guard.sh` (shared, repo-root scripts/, installed to `~/.autospec/scripts/`)
+
+```
+worktree-guard.sh assert                         # preflight in cwd
+worktree-guard.sh resolve-branch --branch B --repo O/R   # the G2 ladder, JSON verdict
+worktree-guard.sh create --branch B [--base origin/main] [--path /tmp/wt-B]
+```
+
+- **`assert`** (MUST pass before any file edit/commit; exit codes):
+  - `3 in_primary_checkout` — `git rev-parse --git-dir` == `--git-common-dir`
+    (cwd is the main checkout, not a linked worktree).
+  - `4 dirty` — `git status --porcelain` non-empty (untracked included).
+  - `5 stale_base` — after `git fetch origin <base>`: for a new branch, HEAD
+    != `origin/main`; for an adopted branch, `merge-base HEAD origin/main`
+    != `origin/main` tip is reported (warn-level by default, fail with
+    `--strict-base`).
+  - `2` usage / not a git dir. `0` ok.
+- **`resolve-branch`** — deterministic ladder, no LLM:
+  `gh pr list --head B --state open` → `{"state":"open-pr","pr":N}`;
+  else `git ls-remote --heads origin B` non-empty →
+  `{"state":"branch-only"}`; else `{"state":"fresh"}`. Exit 0 always; the
+  caller branches on `state`.
+- **`create`** — `git fetch origin` then `git worktree add -b B <path>
+  origin/main` (or `add <path> origin/B` for adopt). If the worktree path
+  already exists: reuse ONLY if clean AND on the same branch
+  (else exit `4` with `code_health:worktree_dirty_reuse_refused`). Never
+  silent-reuse a dirty tree (replaces dispatch-implementer's current
+  behavior).
+
+### D2 — dispatch-implementer.sh integration
+
+`dispatch-implementer.sh` delegates worktree creation to `worktree-guard.sh
+create` and calls `resolve-branch` first, surfacing the ladder verdict to the
+orchestrator in its output contract. The silent-reuse path
+(`dispatch-implementer.sh:78-82`) is removed. Existing
+`tests/autospec-run/test_parallel_dispatch.bats` updated; new bats for the
+refusal path.
+
+### D3 — run trio + phase4-implementer.md wiring
+
+`process(ISSUE)` step 1 becomes:
+1. `resolve-branch` → on `open-pr`: skip implementation; check out the PR in
+   a fresh worktree, run the issue's verification (tests + validate.sh) and
+   the standard review loop against the EXISTING PR, then merge if green
+   (#886 path). On `branch-only`: adopt the branch in a fresh worktree;
+   continue remaining work (#917 path). On `fresh`: `create`.
+2. `worktree-guard.sh assert` — MUST exit 0 before any edit; non-zero →
+   comment + restore `auto-implement` + stop the issue (never "work around").
+3. Prose hard rules added: implementers NEVER `cd` into the primary checkout,
+   never `git checkout`/`commit` there; cleanup = `git worktree remove` after
+   merge confirmed + `git worktree prune`.
+
+Same assert instruction lands in `skills/autospec-run/prompts/phase4-implementer.md`.
+
+### D4 — other git-mutating flows (phased)
+
+Each flow gains the same pattern (resolve → create/adopt → assert):
+- **autospec-define** spec-PR flow: the spec commit happens in a temp
+  worktree (`/tmp/wt-spec-<slug>`), never in the primary checkout.
+- **autospec-doc** regenerate commits: already on the PR branch in the
+  implementer's worktree — add the `assert` call before committing.
+- **autospec-explore** sandbox + **autospec-release**: assert before any
+  commit step.
+
+### D5 — AGENTS.md git best practices
+
+New `## Git hygiene (agents)` section: fetch-before-branch; primary checkout
+is read-only for agents; fresh-or-verified-clean worktrees only; cleanup after
+merge + prune; the PR-aware ladder as the standard branch-exists behavior;
+pointer to `worktree-guard.sh` as the enforcement tool.
+
+## Sequencing constraint
+
+D3 edits the autospec-run trio — serialize behind the cost-efficiency chain
+(`#938→#939→#941→#942`, audit `#944`) AND any run-trio child of the
+fix-routing spec if it has been decomposed by then. D4's define/doc/explore/
+release edits serialize per-trio as usual. D1/D2 are dep-free.
+
+## Testing & validation
+
+- bats `tests/worktree-guard/`: every exit code; primary-checkout detection
+  (fixture repo + linked worktree); dirty-reuse refusal; ladder verdicts with
+  PATH-shadowed `gh`/`git ls-remote` mocks (per the repo's established mock
+  pattern); adopt-path base check; idempotent `create`.
+- dispatch-implementer bats updated (no silent reuse; verdict surfaced).
+- Trio named-content checks in `validate.sh`: the assert step present in run
+  trio + phase4-implementer.md; `## Git hygiene (agents)` present in
+  AGENTS.md.
+- Regression: existing parallel-dispatch + watchdog-GC tests stay green.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| open-PR validate+merge path merges a bad stale PR | full verification (tests + validate.sh + review loop) runs against the PR before merge — same bar as fresh work |
+| guard false-positives block work (e.g. transient fetch failure) | distinct exit codes + clear `code_health:*` identifiers; fetch failure = retry once then surface, never silently pass |
+| adopted branch diverged badly from main | `assert` stale-base warn + the rebase-and-retest pre-merge gate already covers final state |
+| trio conflicts with queued epics | D3 child gated on #944 (+ fix-routing run-trio child when filed) |
+
+## Decomposition hint for /autospec-define
+
+1. **`worktree-guard.sh`** (assert/resolve-branch/create + full bats). Dep-free.
+2. **dispatch-implementer.sh integration** (remove silent-reuse; surface
+   verdict; bats). Depends on 1.
+3. **Run trio + phase4-implementer.md wiring** (ladder + assert + prose hard
+   rules). Depends on 1, 2, **#944**, and the fix-routing spec's run-trio
+   child if filed by then.
+4. **Define spec-PR worktree + AGENTS.md git-hygiene section.** Depends on 1.
+5. **Doc/explore/release asserts.** Depends on 1; split per-trio if caps require.
+6. Standard Phase 5.5 audit issue depending on all.
+
+> Decomposer notes: one trio per child; lock-step checkbox each; do NOT apply
+> needs-autospec-template.


### PR DESCRIPTION
Two operator-approved specs: (1) 'fix' intent routing + docs-generation gating (off-by-default in runs, always in QA); (2) deterministic worktree guard with PR-aware recovery ladder. Run-trio children sequence behind the cost epic (#944).

🤖 Generated with [Claude Code](https://claude.com/claude-code)