### PR TITLE
feat(tier): deterministic-first classify + reviewer Tier B + AUTOSPEC_REVIEWER_TIER hatch (D4, #941)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,11 @@ When the workflow dispatches a subagent, choose tier based on the **type of work
 
 ### Tier A — Specification work (top model + extended/maximum thinking)
 
-Used by: research subagents (Phase 1), decomposition subagents (Phase 3 — turning a spec into linked GitHub issues), Phase 3.5 review-and-label subagents (turning issue bodies into model-fit metadata that drives all downstream filtering).
+Used by: research subagents (Phase 1), decomposition subagents (Phase 3 — turning a spec into linked GitHub issues).
 
 Reasoning: spec/issue quality is the bottleneck. A cheap model here costs you N cheap-implementer cycles correcting it downstream. The orchestrator/user is also typically running on a top model in Phase 2 (design + spec writing); subagents in spec-adjacent phases match that quality.
+
+**Tier right-sizing for classification (Phase 3.5 review-and-label + `/autospec-classify`):** classification is now **deterministic-first**. The deterministic rubric (file counts under `## Files to read first`, verb keywords — see `scripts/classify-model-fit.sh`, tracker #421) runs FIRST and gates any LLM call. Only issues the rubric scores as ambiguous (confidence below `LLM_ESCALATION_THRESHOLD`) get an LLM call, and that call runs at **Tier B**, not Tier A. Sibling normalization stays deterministic. This keeps the common case zero-LLM-cost while preserving a cheap LLM tie-breaker for genuinely ambiguous issues.
 
 | Harness     | Preferred model | Thinking budget | Fallback (next-tier UP on unavailability) |
 |-------------|-----------------|-----------------|--------------------------------------------|
@@ -27,7 +29,7 @@ Reasoning: spec/issue quality is the bottleneck. A cheap model here costs you N 
 
 ### Tier B — Implementation work (cheaper model + medium thinking)
 
-Used by: implementer subagents inside Phase 4's `process(ISSUE)` (the one writing code on `feat/*` branches), LGTM-review subagents (the inner-loop self-review of a PR).
+Used by: implementer subagents inside Phase 4's `process(ISSUE)` (the one writing code on `feat/*` branches); the fused guardian + LGTM reviewer subagent (the inner-loop self-review of a PR — Tier B for ALL issues including `regression`/`priority:high`, see the env hatch below); and the Tier-B LLM tie-breaker for ambiguous classification (above).
 
 Reasoning: implementation follows a well-specified contract from Tier A. The work is mechanical relative to the spec. We run this loop many times per spec, so cheaper-tier amortizes well.
 
@@ -81,11 +83,12 @@ top GPT" at call time so the skill survives model-family churn.
 | 1 — Investigate (research) | autospec, autospec-define | A |
 | 2 — Brainstorm + design | autospec, autospec-define | (orchestrator only — no subagent dispatch; user invokes skill on top model) |
 | 3 — Decompose into issues | autospec, autospec-define | A |
-| 3.5 — Review and label | autospec, autospec-define | A |
-| classify (per-issue review) | autospec-classify | A |
+| 3.5 — Review and label | autospec, autospec-define | deterministic-first; **B** on ambiguity |
+| classify (per-issue review) | autospec-classify | deterministic-first; **B** on ambiguity |
 | 4 — Implementer (process(ISSUE) in worktree) | autospec, autospec-run | B |
-| 4 — LGTM self-review | autospec, autospec-run | B |
-| 4 — Implementation guardian | autospec, autospec-run | A |
+| 4 — Fused guardian + LGTM reviewer | autospec, autospec-run | **B** for ALL issues (incl. `regression`/`priority:high`); `AUTOSPEC_REVIEWER_TIER=opus` → A |
+
+**`AUTOSPEC_REVIEWER_TIER` (reviewer escape hatch):** the fused guardian + LGTM reviewer runs at **Tier B for every issue**, including `regression` and `priority:high`. The former second Tier-A regression meta-review pass is folded into the single reviewer brief (the reviewer self-asks "would the reviewer have caught the original gap?" and writes any missing checks to `reports/autospec-review/reviewer-lessons.md`). To restore Tier A for the reviewer, set `AUTOSPEC_REVIEWER_TIER=opus`; unset (or any other value) keeps Tier B (sonnet). This is the one-variable revert if a high-stakes run shows the cheaper reviewer missing real bugs.
 
 ## Auto-merge authority for auto-implement PRs
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1014,13 +1014,27 @@ check_autospec_run_priority_sort_lockstep() {
         || fail "priority sort lockstep (codex)"
 }
 
+# Tier right-sizing (issue #941, spec §D4): the second Tier-A regression
+# meta-review dispatch is FOLDED into the single fused reviewer brief. The
+# run-trio variants must (a) NOT carry a second `TIER_A` meta-review dispatch,
+# (b) keep the regression gap-check + reviewer-lessons write-path inside the
+# single reviewer brief, and (c) document the `AUTOSPEC_REVIEWER_TIER` hatch.
 check_autospec_run_regression_review_lockstep() {
-    info "autospec-run regression review lockstep"
-    for variant in "skills/autospec-run/opencode/agent.md" "skills/autospec-run/codex/prompt.md"; do
-        grep -qE "Regression (review escalation|meta-review)" "$variant" \
-            || fail "regression review block missing in $variant"
-        grep -qE "Tier A \(spec work\)|TIER_A" "$variant" \
-            || fail "Tier A annotation missing in $variant"
+    info "autospec-run regression review folded (D4) lockstep"
+    for variant in \
+        "skills/autospec-run/SKILL.md" \
+        "skills/autospec-run/opencode/agent.md" \
+        "skills/autospec-run/codex/prompt.md"; do
+        ! grep -q 'dispatch a second `TIER_A` subagent' "$variant" \
+            || fail "second TIER_A regression meta-review dispatch still present in $variant (should be folded into reviewer brief)"
+        grep -q 'reviewer-lessons.md' "$variant" \
+            || fail "reviewer-lessons write-path missing in $variant"
+        grep -qi 'would the reviewer have caught the original gap' "$variant" \
+            || fail "folded regression gap-check missing in $variant"
+        grep -q 'AUTOSPEC_REVIEWER_TIER' "$variant" \
+            || fail "AUTOSPEC_REVIEWER_TIER env hatch missing in $variant"
+        grep -q '`TIER_B` for ALL issues' "$variant" \
+            || fail "reviewer Tier-B-for-all-issues directive missing in $variant"
     done
 }
 

--- a/skills/autospec-classify/SKILL.md
+++ b/skills/autospec-classify/SKILL.md
@@ -109,7 +109,7 @@ This workflow assumes a small set of capabilities. Map each one to your harness'
 | Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
 | Subagent dispatch policy   | per AGENTS.md decision matrix        | per AGENTS.md decision matrix            | per AGENTS.md decision matrix            | inline with main-session token cost                |
 
-**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work — including this skill's per-issue review (review/label is spec-adjacent) — and Tier B (cheaper model + medium thinking) for implementation work (not used by this skill). The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work and Tier B (cheaper model + medium thinking) for implementation work. This skill's per-issue classification is **deterministic-first**: the deterministic rubric runs with no LLM call, and only ambiguous issues escalate to a single Tier-B LLM tie-breaker — never Tier A. The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
 
 ---
 
@@ -204,7 +204,15 @@ Default for issues that lack any of these signals: `ctx:64k`, `reasoning:medium`
 
 ## Per-issue procedure
 
-> **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
+> **Model tier:** **deterministic-first; `TIER_B` on ambiguity (never `TIER_A`).**
+> Classification runs the deterministic
+> rubric (`scripts/classify-model-fit.sh` — file counts, verb keywords, per
+> tracker #421) FIRST, with **no LLM dispatch** for issues it can score
+> confidently. Only issues the rubric flags as ambiguous (confidence below
+> `LLM_ESCALATION_THRESHOLD`, default 0.3) escalate to a single `TIER_B` LLM
+> tie-breaker — never `TIER_A`. Sibling normalization stays deterministic. Set
+> `AUTOSPEC_REVIEWER_TIER=opus` only governs the run-trio reviewer, not this
+> classifier; the classifier's LLM tie-breaker is always `TIER_B`.
 
 For each candidate issue:
 
@@ -214,8 +222,14 @@ For each candidate issue:
      once at the top of the run).
    - Skip — do not modify body, do not assign a model-fit class.
 
-2. **Classify.** Apply the rubric to assign one `ctx:*` and one `reasoning:*`
-   label. Print the rationale in the dry-run preview.
+2. **Classify (deterministic-first).** Run the deterministic rubric first
+   (`scripts/classify-model-fit.sh <body-file>`): it assigns one `ctx:*` and one
+   `reasoning:*` label from file counts and verb keywords with **zero LLM cost**.
+   Only when the rubric reports `deterministic:false` (confidence below
+   `LLM_ESCALATION_THRESHOLD`) escalate that single ambiguous issue to one
+   `TIER_B` LLM tie-breaker; otherwise take the deterministic result as final.
+   Print the rationale (and whether it was deterministic or escalated) in the
+   dry-run preview.
 
 3. **Apply labels.**
    - `gh label create ctx:32k --color c5def5 --force` (and ctx:64k, ctx:120k).

--- a/skills/autospec-classify/codex/prompt.md
+++ b/skills/autospec-classify/codex/prompt.md
@@ -105,7 +105,7 @@ This workflow assumes a small set of capabilities. Map each one to your harness'
 | Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
 | Subagent dispatch policy   | per AGENTS.md decision matrix        | per AGENTS.md decision matrix            | per AGENTS.md decision matrix            | inline with main-session token cost                |
 
-**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work — including this skill's per-issue review (review/label is spec-adjacent) — and Tier B (cheaper model + medium thinking) for implementation work (not used by this skill). The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work and Tier B (cheaper model + medium thinking) for implementation work. This skill's per-issue classification is **deterministic-first**: the deterministic rubric runs with no LLM call, and only ambiguous issues escalate to a single Tier-B LLM tie-breaker — never Tier A. The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
 
 
 ## Harness detection (run once at skill start, before Phase 0)
@@ -199,7 +199,15 @@ Default for issues that lack any of these signals: `ctx:64k`, `reasoning:medium`
 
 ## Per-issue procedure
 
-> **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
+> **Model tier:** **deterministic-first; `TIER_B` on ambiguity (never `TIER_A`).**
+> Classification runs the deterministic
+> rubric (`scripts/classify-model-fit.sh` — file counts, verb keywords, per
+> tracker #421) FIRST, with **no LLM dispatch** for issues it can score
+> confidently. Only issues the rubric flags as ambiguous (confidence below
+> `LLM_ESCALATION_THRESHOLD`, default 0.3) escalate to a single `TIER_B` LLM
+> tie-breaker — never `TIER_A`. Sibling normalization stays deterministic. Set
+> `AUTOSPEC_REVIEWER_TIER=opus` only governs the run-trio reviewer, not this
+> classifier; the classifier's LLM tie-breaker is always `TIER_B`.
 
 For each candidate issue:
 
@@ -209,8 +217,14 @@ For each candidate issue:
      once at the top of the run).
    - Skip — do not modify body, do not assign a model-fit class.
 
-2. **Classify.** Apply the rubric to assign one `ctx:*` and one `reasoning:*`
-   label. Print the rationale in the dry-run preview.
+2. **Classify (deterministic-first).** Run the deterministic rubric first
+   (`scripts/classify-model-fit.sh <body-file>`): it assigns one `ctx:*` and one
+   `reasoning:*` label from file counts and verb keywords with **zero LLM cost**.
+   Only when the rubric reports `deterministic:false` (confidence below
+   `LLM_ESCALATION_THRESHOLD`) escalate that single ambiguous issue to one
+   `TIER_B` LLM tie-breaker; otherwise take the deterministic result as final.
+   Print the rationale (and whether it was deterministic or escalated) in the
+   dry-run preview.
 
 3. **Apply labels.**
    - `gh label create ctx:32k --color c5def5 --force` (and ctx:64k, ctx:120k).

--- a/skills/autospec-classify/opencode/agent.md
+++ b/skills/autospec-classify/opencode/agent.md
@@ -109,7 +109,7 @@ This workflow assumes a small set of capabilities. Map each one to your harness'
 | Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
 | Subagent dispatch policy   | per AGENTS.md decision matrix        | per AGENTS.md decision matrix            | per AGENTS.md decision matrix            | inline with main-session token cost                |
 
-**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work — including this skill's per-issue review (review/label is spec-adjacent) — and Tier B (cheaper model + medium thinking) for implementation work (not used by this skill). The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work and Tier B (cheaper model + medium thinking) for implementation work. This skill's per-issue classification is **deterministic-first**: the deterministic rubric runs with no LLM call, and only ambiguous issues escalate to a single Tier-B LLM tie-breaker — never Tier A. The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
 
 
 ## Harness detection (run once at skill start, before Phase 0)
@@ -203,7 +203,15 @@ Default for issues that lack any of these signals: `ctx:64k`, `reasoning:medium`
 
 ## Per-issue procedure
 
-> **Model tier:** `TIER_A` (spec work) — top model with extended thinking; resolved at startup.
+> **Model tier:** **deterministic-first; `TIER_B` on ambiguity (never `TIER_A`).**
+> Classification runs the deterministic
+> rubric (`scripts/classify-model-fit.sh` — file counts, verb keywords, per
+> tracker #421) FIRST, with **no LLM dispatch** for issues it can score
+> confidently. Only issues the rubric flags as ambiguous (confidence below
+> `LLM_ESCALATION_THRESHOLD`, default 0.3) escalate to a single `TIER_B` LLM
+> tie-breaker — never `TIER_A`. Sibling normalization stays deterministic. Set
+> `AUTOSPEC_REVIEWER_TIER=opus` only governs the run-trio reviewer, not this
+> classifier; the classifier's LLM tie-breaker is always `TIER_B`.
 
 For each candidate issue:
 
@@ -213,8 +221,14 @@ For each candidate issue:
      once at the top of the run).
    - Skip — do not modify body, do not assign a model-fit class.
 
-2. **Classify.** Apply the rubric to assign one `ctx:*` and one `reasoning:*`
-   label. Print the rationale in the dry-run preview.
+2. **Classify (deterministic-first).** Run the deterministic rubric first
+   (`scripts/classify-model-fit.sh <body-file>`): it assigns one `ctx:*` and one
+   `reasoning:*` label from file counts and verb keywords with **zero LLM cost**.
+   Only when the rubric reports `deterministic:false` (confidence below
+   `LLM_ESCALATION_THRESHOLD`) escalate that single ambiguous issue to one
+   `TIER_B` LLM tie-breaker; otherwise take the deterministic result as final.
+   Print the rationale (and whether it was deterministic or escalated) in the
+   dry-run preview.
 
 3. **Apply labels.**
    - `gh label create ctx:32k --color c5def5 --force` (and ctx:64k, ctx:120k).

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -871,7 +871,7 @@ inline label-swap path below.
 >        fi
 >        det_exit=$?
 >
->      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
+>      **Model tier:** `TIER_B` for ALL issues — including `regression` and `priority:high`. The single fused reviewer carries the regression gap-check (see brief below), so no second Tier-A pass is dispatched. **Escape hatch:** `AUTOSPEC_REVIEWER_TIER` overrides the reviewer tier — unset (or any value other than `opus`) → `TIER_B` (sonnet); set `AUTOSPEC_REVIEWER_TIER=opus` to restore `TIER_A` for the reviewer. Silently fall back to `TIER_A` if `TIER_B` is unavailable.
 >
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
@@ -911,6 +911,7 @@ inline label-swap path below.
 >        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits), whether every new code unit exists for a concrete issue/spec requirement rather than convenience, and whether deprecated routes, caches, buckets, stores, workers, config keys, UI paths, docs, specs, tests, or fixtures were removed instead of revived to make tests pass.
 >        > 7. Collect findings as a numbered list.
 >        > 8. Critical self-question before LGTM: "What else could still pass here while the real user workflow fails, and how could this be better?" Check especially mocked-vs-deployed behavior, external service assumptions, fallback paths, user-visible outcomes, and missing no-mock smoke coverage. If the answer is actionable inside the issue scope, emit it as a finding or required test.
+>        > 9. **Regression gap-check (MANDATORY for `regression`/`priority:high` issues; skip otherwise):** ask "would the reviewer have caught the original gap?" If the fused review as written would NOT have caught the gap this regression closes, add the missing checklist item(s) to `reports/autospec-review/reviewer-lessons.md` (one entry per item, with parent `gap_id` and date) and apply those new checks to this diff before issuing the verdict. This folds the former second-pass regression meta-review into this single reviewer pass — the reviewer-lessons write-path is preserved here; there is no second Tier-A dispatch.
 >        >
 >        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
 >        >
@@ -939,8 +940,8 @@ inline label-swap path below.
 >        Run failure cleanup (comment, swap label, close PR).
 >        rm -f /tmp/guardian-<PR>.md
 >      <!-- guardian-block:end -->
->    - **Regression meta-review** (only for `regression`/`priority:high` issues, after LGTM passes): dispatch a second `TIER_A` subagent: "Would the fused reviewer have caught the original gap? If yes, add missing checklist items to `reports/autospec-review/reviewer-lessons.md` (entry per item, parent gap_id, date) and re-review. Both passes must approve before merge."
->    - If LGTM (and meta-review passes if applicable): break SUCCESS.
+>    - **Regression coverage** for `regression`/`priority:high` issues is handled inside the single fused reviewer brief (Part 2 item 9 above): the reviewer self-asks "would the reviewer have caught the original gap?", writes any missing checks to `reports/autospec-review/reviewer-lessons.md`, and applies them before its verdict. No second Tier-A dispatch.
+>    - If LGTM: break SUCCESS.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -866,7 +866,7 @@ inline label-swap path below.
 >        fi
 >        det_exit=$?
 >
->      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
+>      **Model tier:** `TIER_B` for ALL issues — including `regression` and `priority:high`. The single fused reviewer carries the regression gap-check (see brief below), so no second Tier-A pass is dispatched. **Escape hatch:** `AUTOSPEC_REVIEWER_TIER` overrides the reviewer tier — unset (or any value other than `opus`) → `TIER_B` (sonnet); set `AUTOSPEC_REVIEWER_TIER=opus` to restore `TIER_A` for the reviewer. Silently fall back to `TIER_A` if `TIER_B` is unavailable.
 >
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
@@ -906,6 +906,7 @@ inline label-swap path below.
 >        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits), whether every new code unit exists for a concrete issue/spec requirement rather than convenience, and whether deprecated routes, caches, buckets, stores, workers, config keys, UI paths, docs, specs, tests, or fixtures were removed instead of revived to make tests pass.
 >        > 7. Collect findings as a numbered list.
 >        > 8. Critical self-question before LGTM: "What else could still pass here while the real user workflow fails, and how could this be better?" Check especially mocked-vs-deployed behavior, external service assumptions, fallback paths, user-visible outcomes, and missing no-mock smoke coverage. If the answer is actionable inside the issue scope, emit it as a finding or required test.
+>        > 9. **Regression gap-check (MANDATORY for `regression`/`priority:high` issues; skip otherwise):** ask "would the reviewer have caught the original gap?" If the fused review as written would NOT have caught the gap this regression closes, add the missing checklist item(s) to `reports/autospec-review/reviewer-lessons.md` (one entry per item, with parent `gap_id` and date) and apply those new checks to this diff before issuing the verdict. This folds the former second-pass regression meta-review into this single reviewer pass — the reviewer-lessons write-path is preserved here; there is no second Tier-A dispatch.
 >        >
 >        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
 >        >
@@ -934,8 +935,8 @@ inline label-swap path below.
 >        Run failure cleanup (comment, swap label, close PR).
 >        rm -f /tmp/guardian-<PR>.md
 >      <!-- guardian-block:end -->
->    - **Regression meta-review** (only for `regression`/`priority:high` issues, after LGTM passes): dispatch a second `TIER_A` subagent: "Would the fused reviewer have caught the original gap? If yes, add missing checklist items to `reports/autospec-review/reviewer-lessons.md` (entry per item, parent gap_id, date) and re-review. Both passes must approve before merge."
->    - If LGTM (and meta-review passes if applicable): break SUCCESS.
+>    - **Regression coverage** for `regression`/`priority:high` issues is handled inside the single fused reviewer brief (Part 2 item 9 above): the reviewer self-asks "would the reviewer have caught the original gap?", writes any missing checks to `reports/autospec-review/reviewer-lessons.md`, and applies them before its verdict. No second Tier-A dispatch.
+>    - If LGTM: break SUCCESS.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -870,7 +870,7 @@ inline label-swap path below.
 >        fi
 >        det_exit=$?
 >
->      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
+>      **Model tier:** `TIER_B` for ALL issues — including `regression` and `priority:high`. The single fused reviewer carries the regression gap-check (see brief below), so no second Tier-A pass is dispatched. **Escape hatch:** `AUTOSPEC_REVIEWER_TIER` overrides the reviewer tier — unset (or any value other than `opus`) → `TIER_B` (sonnet); set `AUTOSPEC_REVIEWER_TIER=opus` to restore `TIER_A` for the reviewer. Silently fall back to `TIER_A` if `TIER_B` is unavailable.
 >
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
@@ -910,6 +910,7 @@ inline label-swap path below.
 >        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits), whether every new code unit exists for a concrete issue/spec requirement rather than convenience, and whether deprecated routes, caches, buckets, stores, workers, config keys, UI paths, docs, specs, tests, or fixtures were removed instead of revived to make tests pass.
 >        > 7. Collect findings as a numbered list.
 >        > 8. Critical self-question before LGTM: "What else could still pass here while the real user workflow fails, and how could this be better?" Check especially mocked-vs-deployed behavior, external service assumptions, fallback paths, user-visible outcomes, and missing no-mock smoke coverage. If the answer is actionable inside the issue scope, emit it as a finding or required test.
+>        > 9. **Regression gap-check (MANDATORY for `regression`/`priority:high` issues; skip otherwise):** ask "would the reviewer have caught the original gap?" If the fused review as written would NOT have caught the gap this regression closes, add the missing checklist item(s) to `reports/autospec-review/reviewer-lessons.md` (one entry per item, with parent `gap_id` and date) and apply those new checks to this diff before issuing the verdict. This folds the former second-pass regression meta-review into this single reviewer pass — the reviewer-lessons write-path is preserved here; there is no second Tier-A dispatch.
 >        >
 >        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
 >        >
@@ -938,8 +939,8 @@ inline label-swap path below.
 >        Run failure cleanup (comment, swap label, close PR).
 >        rm -f /tmp/guardian-<PR>.md
 >      <!-- guardian-block:end -->
->    - **Regression meta-review** (only for `regression`/`priority:high` issues, after LGTM passes): dispatch a second `TIER_A` subagent: "Would the fused reviewer have caught the original gap? If yes, add missing checklist items to `reports/autospec-review/reviewer-lessons.md` (entry per item, parent gap_id, date) and re-review. Both passes must approve before merge."
->    - If LGTM (and meta-review passes if applicable): break SUCCESS.
+>    - **Regression coverage** for `regression`/`priority:high` issues is handled inside the single fused reviewer brief (Part 2 item 9 above): the reviewer self-asks "would the reviewer have caught the original gap?", writes any missing checks to `reports/autospec-review/reviewer-lessons.md`, and applies them before its verdict. No second Tier-A dispatch.
+>    - If LGTM: break SUCCESS.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec-run/tests/reviewer-tier.bats
+++ b/skills/autospec-run/tests/reviewer-tier.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# skills/autospec-run/tests/reviewer-tier.bats — named-content coverage for
+# tier right-sizing (D4, issue #941): the fused guardian+LGTM reviewer runs
+# Tier B for ALL issues, `AUTOSPEC_REVIEWER_TIER=opus` is the documented
+# escape hatch back to Tier A, and the second Tier-A regression meta-review
+# dispatch is folded into the single reviewer brief (no longer a second pass).
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+
+RUN_TRIO=(
+  "$REPO_ROOT/skills/autospec-run/SKILL.md"
+  "$REPO_ROOT/skills/autospec-run/codex/prompt.md"
+  "$REPO_ROOT/skills/autospec-run/opencode/agent.md"
+)
+
+AUTOSPEC_TRIO=(
+  "$REPO_ROOT/skills/autospec/SKILL.md"
+  "$REPO_ROOT/skills/autospec/codex/prompt.md"
+  "$REPO_ROOT/skills/autospec/opencode/agent.md"
+)
+
+# ── Reviewer runs Tier B for all issues; env hatch restores Tier A ───────────
+
+@test "run trio: reviewer Model tier is TIER_B for ALL issues (no per-label TIER_A split)" {
+  for f in "${RUN_TRIO[@]}"; do
+    # The reviewer Model tier line must declare TIER_B for all issues.
+    grep -q '`TIER_B` for ALL issues' "$f" \
+      || { echo "missing 'TIER_B for ALL issues' in $f"; return 1; }
+    # The old per-label split ("TIER_A for regression/priority:high") must be gone
+    # from the reviewer Model tier directive.
+    ! grep -q '`TIER_A` for `regression`/`priority:high` issues' "$f" \
+      || { echo "stale per-label TIER_A reviewer split still present in $f"; return 1; }
+  done
+}
+
+@test "run trio: AUTOSPEC_REVIEWER_TIER env hatch documented (unset->sonnet, opus->Tier A)" {
+  for f in "${RUN_TRIO[@]}"; do
+    grep -q 'AUTOSPEC_REVIEWER_TIER' "$f" \
+      || { echo "missing AUTOSPEC_REVIEWER_TIER in $f"; return 1; }
+    grep -q 'opus' "$f" || { echo "missing opus hatch value in $f"; return 1; }
+  done
+}
+
+@test "AGENTS.md: AUTOSPEC_REVIEWER_TIER env hatch documented" {
+  grep -q 'AUTOSPEC_REVIEWER_TIER' "$REPO_ROOT/AGENTS.md"
+}
+
+# ── Regression meta-review folded into the single reviewer brief ─────────────
+
+@test "run trio: second Tier-A regression meta-review dispatch removed" {
+  for f in "${RUN_TRIO[@]}"; do
+    ! grep -q 'dispatch a second `TIER_A` subagent' "$f" \
+      || { echo "second TIER_A meta-review dispatch still present in $f"; return 1; }
+  done
+}
+
+@test "run trio: regression gap-check folded into the single reviewer brief (reviewer-lessons preserved)" {
+  for f in "${RUN_TRIO[@]}"; do
+    grep -q 'reviewer-lessons.md' "$f" \
+      || { echo "reviewer-lessons write-path lost in $f"; return 1; }
+    grep -q 'would the reviewer have caught the original gap' "$f" \
+      || { echo "folded original-gap check missing in $f"; return 1; }
+  done
+}
+
+# ── The autospec umbrella skill mirrors the same reviewer block ──────────────
+
+@test "autospec umbrella trio: second Tier-A regression meta-review dispatch removed" {
+  for f in "${AUTOSPEC_TRIO[@]}"; do
+    ! grep -q 'dispatch a second `TIER_A` subagent' "$f" \
+      || { echo "second TIER_A meta-review dispatch still present in $f"; return 1; }
+  done
+}

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -934,7 +934,7 @@ Pass the following prompt verbatim to each background subagent:
 >        fi
 >        det_exit=$?
 >
->      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
+>      **Model tier:** `TIER_B` for ALL issues — including `regression` and `priority:high`. The single fused reviewer carries the regression gap-check (see brief below), so no second Tier-A pass is dispatched. **Escape hatch:** `AUTOSPEC_REVIEWER_TIER` overrides the reviewer tier — unset (or any value other than `opus`) → `TIER_B` (sonnet); set `AUTOSPEC_REVIEWER_TIER=opus` to restore `TIER_A` for the reviewer. Silently fall back to `TIER_A` if `TIER_B` is unavailable.
 >
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
@@ -974,6 +974,7 @@ Pass the following prompt verbatim to each background subagent:
 >        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits), whether every new code unit exists for a concrete issue/spec requirement rather than convenience, and whether deprecated routes, caches, buckets, stores, workers, config keys, UI paths, docs, specs, tests, or fixtures were removed instead of revived to make tests pass.
 >        > 7. Collect findings as a numbered list.
 >        > 8. Critical self-question before LGTM: "What else could still pass here while the real user workflow fails, and how could this be better?" Check especially mocked-vs-deployed behavior, external service assumptions, fallback paths, user-visible outcomes, and missing no-mock smoke coverage. If the answer is actionable inside the issue scope, emit it as a finding or required test.
+>        > 9. **Regression gap-check (MANDATORY for `regression`/`priority:high` issues; skip otherwise):** ask "would the reviewer have caught the original gap?" If the fused review as written would NOT have caught the gap this regression closes, add the missing checklist item(s) to `reports/autospec-review/reviewer-lessons.md` (one entry per item, with parent `gap_id` and date) and apply those new checks to this diff before issuing the verdict. This folds the former second-pass regression meta-review into this single reviewer pass — the reviewer-lessons write-path is preserved here; there is no second Tier-A dispatch.
 >        >
 >        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
 >        >
@@ -1002,8 +1003,8 @@ Pass the following prompt verbatim to each background subagent:
 >        Run failure cleanup (comment, swap label, close PR).
 >        rm -f /tmp/guardian-<PR>.md
 >      <!-- guardian-block:end -->
->    - **Regression meta-review** (only for `regression`/`priority:high` issues, after LGTM passes): dispatch a second `TIER_A` subagent: "Would the fused reviewer have caught the original gap? If yes, add missing checklist items to `reports/autospec-review/reviewer-lessons.md` (entry per item, parent gap_id, date) and re-review. Both passes must approve before merge."
->    - If LGTM (and meta-review passes if applicable): break SUCCESS.
+>    - **Regression coverage** for `regression`/`priority:high` issues is handled inside the single fused reviewer brief (Part 2 item 9 above): the reviewer self-asks "would the reviewer have caught the original gap?", writes any missing checks to `reports/autospec-review/reviewer-lessons.md`, and applies them before its verdict. No second Tier-A dispatch.
+>    - If LGTM: break SUCCESS.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -928,7 +928,7 @@ Pass the following prompt verbatim to each background subagent:
 >        fi
 >        det_exit=$?
 >
->      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
+>      **Model tier:** `TIER_B` for ALL issues — including `regression` and `priority:high`. The single fused reviewer carries the regression gap-check (see brief below), so no second Tier-A pass is dispatched. **Escape hatch:** `AUTOSPEC_REVIEWER_TIER` overrides the reviewer tier — unset (or any value other than `opus`) → `TIER_B` (sonnet); set `AUTOSPEC_REVIEWER_TIER=opus` to restore `TIER_A` for the reviewer. Silently fall back to `TIER_A` if `TIER_B` is unavailable.
 >
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
@@ -968,6 +968,7 @@ Pass the following prompt verbatim to each background subagent:
 >        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits), whether every new code unit exists for a concrete issue/spec requirement rather than convenience, and whether deprecated routes, caches, buckets, stores, workers, config keys, UI paths, docs, specs, tests, or fixtures were removed instead of revived to make tests pass.
 >        > 7. Collect findings as a numbered list.
 >        > 8. Critical self-question before LGTM: "What else could still pass here while the real user workflow fails, and how could this be better?" Check especially mocked-vs-deployed behavior, external service assumptions, fallback paths, user-visible outcomes, and missing no-mock smoke coverage. If the answer is actionable inside the issue scope, emit it as a finding or required test.
+>        > 9. **Regression gap-check (MANDATORY for `regression`/`priority:high` issues; skip otherwise):** ask "would the reviewer have caught the original gap?" If the fused review as written would NOT have caught the gap this regression closes, add the missing checklist item(s) to `reports/autospec-review/reviewer-lessons.md` (one entry per item, with parent `gap_id` and date) and apply those new checks to this diff before issuing the verdict. This folds the former second-pass regression meta-review into this single reviewer pass — the reviewer-lessons write-path is preserved here; there is no second Tier-A dispatch.
 >        >
 >        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
 >        >
@@ -996,8 +997,8 @@ Pass the following prompt verbatim to each background subagent:
 >        Run failure cleanup (comment, swap label, close PR).
 >        rm -f /tmp/guardian-<PR>.md
 >      <!-- guardian-block:end -->
->    - **Regression meta-review** (only for `regression`/`priority:high` issues, after LGTM passes): dispatch a second `TIER_A` subagent: "Would the fused reviewer have caught the original gap? If yes, add missing checklist items to `reports/autospec-review/reviewer-lessons.md` (entry per item, parent gap_id, date) and re-review. Both passes must approve before merge."
->    - If LGTM (and meta-review passes if applicable): break SUCCESS.
+>    - **Regression coverage** for `regression`/`priority:high` issues is handled inside the single fused reviewer brief (Part 2 item 9 above): the reviewer self-asks "would the reviewer have caught the original gap?", writes any missing checks to `reports/autospec-review/reviewer-lessons.md`, and applies them before its verdict. No second Tier-A dispatch.
+>    - If LGTM: break SUCCESS.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -932,7 +932,7 @@ Pass the following prompt verbatim to each background subagent:
 >        fi
 >        det_exit=$?
 >
->      **Model tier:** `TIER_B` for normal issues; `TIER_A` for `regression`/`priority:high` issues. Silently fall back to `TIER_A` if `TIER_B` unavailable.
+>      **Model tier:** `TIER_B` for ALL issues — including `regression` and `priority:high`. The single fused reviewer carries the regression gap-check (see brief below), so no second Tier-A pass is dispatched. **Escape hatch:** `AUTOSPEC_REVIEWER_TIER` overrides the reviewer tier — unset (or any value other than `opus`) → `TIER_B` (sonnet); set `AUTOSPEC_REVIEWER_TIER=opus` to restore `TIER_A` for the reviewer. Silently fall back to `TIER_A` if `TIER_B` is unavailable.
 >
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
@@ -972,6 +972,7 @@ Pass the following prompt verbatim to each background subagent:
 >        > 6. Check correctness, edge cases, missing tests, AGENTS.md compliance (TDD, no mocks, conventional commits), whether every new code unit exists for a concrete issue/spec requirement rather than convenience, and whether deprecated routes, caches, buckets, stores, workers, config keys, UI paths, docs, specs, tests, or fixtures were removed instead of revived to make tests pass.
 >        > 7. Collect findings as a numbered list.
 >        > 8. Critical self-question before LGTM: "What else could still pass here while the real user workflow fails, and how could this be better?" Check especially mocked-vs-deployed behavior, external service assumptions, fallback paths, user-visible outcomes, and missing no-mock smoke coverage. If the answer is actionable inside the issue scope, emit it as a finding or required test.
+>        > 9. **Regression gap-check (MANDATORY for `regression`/`priority:high` issues; skip otherwise):** ask "would the reviewer have caught the original gap?" If the fused review as written would NOT have caught the gap this regression closes, add the missing checklist item(s) to `reports/autospec-review/reviewer-lessons.md` (one entry per item, with parent `gap_id` and date) and apply those new checks to this diff before issuing the verdict. This folds the former second-pass regression meta-review into this single reviewer pass — the reviewer-lessons write-path is preserved here; there is no second Tier-A dispatch.
 >        >
 >        > **Hard limit:** max **25 tool calls total** (Parts 1 + 2 combined). If budget exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted; PR needs human review` and proceed to verdict.
 >        >
@@ -1000,8 +1001,8 @@ Pass the following prompt verbatim to each background subagent:
 >        Run failure cleanup (comment, swap label, close PR).
 >        rm -f /tmp/guardian-<PR>.md
 >      <!-- guardian-block:end -->
->    - **Regression meta-review** (only for `regression`/`priority:high` issues, after LGTM passes): dispatch a second `TIER_A` subagent: "Would the fused reviewer have caught the original gap? If yes, add missing checklist items to `reports/autospec-review/reviewer-lessons.md` (entry per item, parent gap_id, date) and re-review. Both passes must approve before merge."
->    - If LGTM (and meta-review passes if applicable): break SUCCESS.
+>    - **Regression coverage** for `regression`/`priority:high` issues is handled inside the single fused reviewer brief (Part 2 item 9 above): the reviewer self-asks "would the reviewer have caught the original gap?", writes any missing checks to `reports/autospec-review/reviewer-lessons.md`, and applies them before its verdict. No second Tier-A dispatch.
+>    - If LGTM: break SUCCESS.
 >    ```bash
 >    # autospec-stop sentinel check — inside process(ISSUE), after each major step
 >    if [ -f "$HOME/.autospec/stop.flag" ] && [ "$(head -1 $HOME/.autospec/stop.flag)" = "immediate" ]; then

--- a/tests/test_autospec_run_regression_review_lockstep.bats
+++ b/tests/test_autospec_run_regression_review_lockstep.bats
@@ -1,12 +1,47 @@
 #!/usr/bin/env bats
-@test "regression review escalation block exists in SKILL.md" {
-  grep -q "Regression review escalation" skills/autospec-run/SKILL.md
+# Tier right-sizing (issue #941, spec §D4): the second Tier-A regression
+# meta-review dispatch is folded into the single fused reviewer brief, the
+# reviewer runs Tier B for ALL issues, and AUTOSPEC_REVIEWER_TIER=opus is the
+# escape hatch back to Tier A. The folded gap-check + reviewer-lessons
+# write-path must stay byte-identical across the run trio.
+
+RUN_TRIO=(
+  skills/autospec-run/SKILL.md
+  skills/autospec-run/opencode/agent.md
+  skills/autospec-run/codex/prompt.md
+)
+
+@test "no second Tier-A regression meta-review dispatch remains in run trio" {
+  for f in "${RUN_TRIO[@]}"; do
+    ! grep -q 'dispatch a second `TIER_A` subagent' "$f"
+  done
 }
-@test "regression review escalation block byte-identical: SKILL.md vs opencode" {
-  diff <(sed -n '/Regression review escalation/,/^---/p' skills/autospec-run/SKILL.md | head -20) \
-       <(sed -n '/Regression review escalation/,/^---/p' skills/autospec-run/opencode/agent.md | head -20)
+
+@test "regression gap-check folded into single reviewer brief (run trio)" {
+  for f in "${RUN_TRIO[@]}"; do
+    grep -qi "would the reviewer have caught the original gap" "$f"
+    grep -q "reviewer-lessons.md" "$f"
+  done
 }
-@test "regression review escalation block byte-identical: SKILL.md vs codex" {
-  diff <(sed -n '/Regression review escalation/,/^---/p' skills/autospec-run/SKILL.md | head -20) \
-       <(sed -n '/Regression review escalation/,/^---/p' skills/autospec-run/codex/prompt.md | head -20)
+
+@test "reviewer Model tier is TIER_B for ALL issues (run trio)" {
+  for f in "${RUN_TRIO[@]}"; do
+    grep -q '`TIER_B` for ALL issues' "$f"
+  done
+}
+
+@test "AUTOSPEC_REVIEWER_TIER env hatch documented in run trio" {
+  for f in "${RUN_TRIO[@]}"; do
+    grep -q "AUTOSPEC_REVIEWER_TIER" "$f"
+  done
+}
+
+@test "folded reviewer item 9 byte-identical: SKILL.md vs opencode" {
+  diff <(grep -n "Regression gap-check" skills/autospec-run/SKILL.md | sed 's/^[0-9]*://') \
+       <(grep -n "Regression gap-check" skills/autospec-run/opencode/agent.md | sed 's/^[0-9]*://')
+}
+
+@test "folded reviewer item 9 byte-identical: SKILL.md vs codex" {
+  diff <(grep -n "Regression gap-check" skills/autospec-run/SKILL.md | sed 's/^[0-9]*://') \
+       <(grep -n "Regression gap-check" skills/autospec-run/codex/prompt.md | sed 's/^[0-9]*://')
 }


### PR DESCRIPTION
Closes #941

Implements spec §D4 (tier right-sizing) from `docs/specs/2026-06-03-autospec-cost-efficiency-design.md`.

## What changed
- **AGENTS.md tier tables:** Phase 3.5 review-and-label and `/autospec-classify` move from Tier A to **deterministic-first + Tier-B-on-ambiguity** — the deterministic rubric (`scripts/classify-model-fit.sh`: file counts, verb keywords, per tracker #421) runs first; only ambiguous issues get a Tier-B LLM tie-breaker (never Tier A). Adds `AUTOSPEC_REVIEWER_TIER` documentation (unset→sonnet/Tier B; `opus`→Tier A).
- **autospec-classify trio:** per-issue procedure + `**Model tier:**` line become deterministic-first; LLM fallback at Tier B.
- **Run trio (autospec-run + autospec umbrella):** fused guardian+LGTM reviewer runs `TIER_B` for **ALL** issues including `regression`/`priority:high`, honoring `AUTOSPEC_REVIEWER_TIER` (`opus` restores Tier A). The second Tier-A regression meta-review dispatch is **removed** and folded into a mandatory bullet (Part 2 item 9) of the single reviewer brief — the `reviewer-lessons.md` write-path is preserved inside that one pass.
- **validate.sh:** `check_autospec_run_regression_review_lockstep` now asserts the folded state (no second `TIER_A` dispatch; gap-check + `reviewer-lessons.md` + `AUTOSPEC_REVIEWER_TIER` + `TIER_B`-for-all present across the run trio).
- **Tests:** new `skills/autospec-run/tests/reviewer-tier.bats`; updated `tests/test_autospec_run_regression_review_lockstep.bats`.

## Reuse
No reuse — this is pure-prose trio + AGENTS.md + validate.sh edits; the deterministic classifier (`scripts/classify-model-fit.sh`) already exists and is referenced, not reimplemented.

## Lock-step
All three trios (autospec, autospec-run, autospec-classify) regenerated byte-identical (SKILL.md + codex/prompt.md + opencode/agent.md). `bash scripts/validate.sh` exits 0.

## Verification
- `bash scripts/validate.sh` → exit 0
- `bats skills/autospec-run/tests/reviewer-tier.bats tests/test_autospec_run_regression_review_lockstep.bats tests/classify-model-fit.bats` → 22/22 green
- Full `bats tests/` green except one **pre-existing, unrelated** failure (`tests/gen-pr-report.bats` green-clean golden) that also fails on clean `origin/main` and is untouched by this diff.

Peer-review: codex — Findings: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)