### PR TITLE
feat(dup-read): fetch issue body once per issue, SHA-gated reviewer diff re-fetch (D5, #942)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -934,7 +934,7 @@ check_team_personality_phase4_and_docs_contract() {
         || fail "scripts/gen-issue-skeleton.sh missing review_counter_team input"
     grep -q -- '--issue-body' scripts/gen-reviewer-prompt.sh \
         || fail "scripts/gen-reviewer-prompt.sh missing --issue-body support"
-    grep -q -- '--issue-body "$_body_file"' skills/autospec-run/SKILL.md \
+    grep -q -- '--issue-body "/tmp/issue-<ISSUE>-body.md"' skills/autospec-run/SKILL.md \
         || fail "skills/autospec-run/SKILL.md reviewer prompt does not pass issue body"
     grep -q 'team_personality' docs/API_REFERENCE.md \
         || fail "docs/API_REFERENCE.md missing gen-issue-skeleton team_personality schema"

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -548,27 +548,29 @@ inline label-swap path below.
 >   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$_hb_slug/$ISSUE.json"
 >   # Issue start summary — print before dispatching process(ISSUE) so the operator
 >   # knows exactly what the monitor is about to work on.
+>   # Single body fetch — all later steps consume this file (D5: duplicate-read elimination).
+>   _issue_body_file="/tmp/issue-${ISSUE}-body.md"
+>   gh issue view ISSUE --json body --jq .body 2>/dev/null > "$_issue_body_file" || true
 >   ISSUE_TITLE=$(gh issue view ISSUE --json title --jq .title 2>/dev/null || echo "")
 >   ISSUE_URL=$(gh issue view ISSUE --json url --jq .url 2>/dev/null || echo "")
 >   ISSUE_LABELS=$(gh issue view ISSUE --json labels --jq -r '[.labels[].name] | join(", ")' 2>/dev/null || echo "")
->   ISSUE_BODY=$(gh issue view ISSUE --json body --jq .body 2>/dev/null || echo "")
->   ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ISSUE_GOAL=$(awk '
 >     BEGIN{in_goal=0}
 >     /^## Goal[[:space:]]*$/ {in_goal=1; next}
 >     /^## / && in_goal {exit}
 >     in_goal && NF {print; exit}
->   ')
->   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk 'NF && $0 !~ /^#/ {print; exit}')
->   ISSUE_SMOKE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ' "$_issue_body_file")
+>   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(awk 'NF && $0 !~ /^#/ {print; exit}' "$_issue_body_file")
+>   ISSUE_SMOKE=$(awk '
 >     /### Primary smoke test/ {seen=1; next}
 >     seen && /^```/ {fence++; next}
 >     seen && fence==1 && NF && $0 !~ /^[[:space:]]*#/ {print; exit}
->   ')
->   ISSUE_SCOPE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ' "$_issue_body_file")
+>   ISSUE_SCOPE=$(awk '
 >     /^## Implementation outline[[:space:]]*$/ {in_scope=1; next}
 >     /^## / && in_scope {exit}
 >     in_scope && /^- / {gsub(/^- /,""); print; count++; if (count>=3) exit}
->   ' | paste -sd '; ' -)
+>   ' "$_issue_body_file" | paste -sd '; ' -)
 >   echo "[monitor] starting #$ISSUE: ${ISSUE_TITLE:-<untitled>}"
 >   echo "[monitor] url: ${ISSUE_URL:-<unknown>}"
 >   echo "[monitor] labels: ${ISSUE_LABELS:-<none>}"
@@ -648,11 +650,9 @@ inline label-swap path below.
 >
 > **Option A (recommended): `gen-implementer-prompt.sh`** — standalone assembler:
 >    ```bash
->    _body_file=$(mktemp -t autospec-body-XXXXXX.md)
->    trap 'rm -f "$_body_file"' EXIT
->    gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
+>    # Reuse the single body fetch written at process(ISSUE) start (D5).
 >    combined_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-implementer-prompt.sh" \
->      --issue-body "$_body_file" \
+>      --issue-body "/tmp/issue-<ISSUE>-body.md" \
 >      --branch "<BRANCH>" \
 >      --issue-labels "<ISSUE_LABELS>" \
 >      --repo "<REPO>")
@@ -752,7 +752,7 @@ inline label-swap path below.
 > ## Docs drift gate
 > Run after autospec-test gate, before LGTM review. Skip if issue body contains a line matching `^docs:\s*skip\s*$` (case-insensitive). On `drift`/`missing_scope`/`example_stale` the classifier emits the pinned `regenerate` action carrying the affected scopes; the gate self-heals by invoking `/autospec-doc` (via `doc-orchestrator.mjs`) scoped to ONLY those scopes, re-verifying the regenerated pages with `verify-examples.mjs`, and committing `docs: regenerate <scopes>` onto the SAME PR branch. **Doc generation NEVER blocks the code PR** — generation/verification failure only warns, applies the `docs:failed` label, and comments; the code review loop continues. Only the regenerate commit's own example verification gates the regenerated docs (failing pages are NOT committed):
 >    ```bash
->    if ! grep -qiE '^docs:[[:space:]]*skip[[:space:]]*$' <(gh issue view <ISSUE> --json body --jq .body 2>/dev/null || true); then
+>    if ! grep -qiE '^docs:[[:space:]]*skip[[:space:]]*$' "/tmp/issue-<ISSUE>-body.md" 2>/dev/null; then
 >      SCRIPTS_DIR="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}"
 >      DOC_SCRIPTS_DIR="${AUTOSPEC_DOC_SCRIPTS_DIR:-$HOME/.autospec/skills/autospec-doc/scripts}"
 >      DRIFT_JSON="$(bash "$SCRIPTS_DIR/check-doc-drift.sh" --pr "<PR>" 2>/tmp/drift-<PR>.err)"; drift_exit=$?
@@ -875,14 +875,17 @@ inline label-swap path below.
 >
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
->      _pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
->      _body_file=$(mktemp -t autospec-issue-body-XXXXXX.md)
->      trap 'rm -f "$_pr_diff_file" "$_body_file"' EXIT
->      gh pr diff <PR> > "$_pr_diff_file"
->      gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
+>      # Reuse the single body fetch from process(ISSUE) start (D5).
+>      # SHA-gated diff re-fetch: only re-fetch the PR diff when the branch head changed.
+>      _current_head=$(gh pr view <PR> --json headRefOid --jq .headRefOid 2>/dev/null || echo "")
+>      if [ -z "${_reviewer_pr_diff_file:-}" ] || [ "${_reviewer_last_head:-}" != "$_current_head" ]; then
+>        _reviewer_pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
+>        gh pr diff <PR> > "$_reviewer_pr_diff_file"
+>        _reviewer_last_head="$_current_head"
+>      fi
 >      combined_reviewer_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-reviewer-prompt.sh" \
->        --pr-diff "$_pr_diff_file" \
->        --issue-body "$_body_file" \
+>        --pr-diff "$_reviewer_pr_diff_file" \
+>        --issue-body "/tmp/issue-<ISSUE>-body.md" \
 >        --prev-findings "/tmp/guardian-<PR>.md" \
 >        --issue-labels "<ISSUE_LABELS>" \
 >        --repo "<REPO>")
@@ -1016,7 +1019,10 @@ inline label-swap path below.
 >      --tokens-json ".autospec/tokens-<ISSUE>.json" || true
 >    ```
 >    <!-- token-report:end -->
+>    # Cleanup single-fetch body temp file on terminal success (D5).
+>    rm -f "/tmp/issue-<ISSUE>-body.md" || true
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
+>    Cleanup single-fetch body temp file on terminal failure: `rm -f "/tmp/issue-<ISSUE>-body.md" || true`
 > 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
 > 11. Report: PR number, outcome, one-paragraph summary.
 >

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -543,27 +543,29 @@ inline label-swap path below.
 >   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$_hb_slug/$ISSUE.json"
 >   # Issue start summary — print before dispatching process(ISSUE) so the operator
 >   # knows exactly what the monitor is about to work on.
+>   # Single body fetch — all later steps consume this file (D5: duplicate-read elimination).
+>   _issue_body_file="/tmp/issue-${ISSUE}-body.md"
+>   gh issue view ISSUE --json body --jq .body 2>/dev/null > "$_issue_body_file" || true
 >   ISSUE_TITLE=$(gh issue view ISSUE --json title --jq .title 2>/dev/null || echo "")
 >   ISSUE_URL=$(gh issue view ISSUE --json url --jq .url 2>/dev/null || echo "")
 >   ISSUE_LABELS=$(gh issue view ISSUE --json labels --jq -r '[.labels[].name] | join(", ")' 2>/dev/null || echo "")
->   ISSUE_BODY=$(gh issue view ISSUE --json body --jq .body 2>/dev/null || echo "")
->   ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ISSUE_GOAL=$(awk '
 >     BEGIN{in_goal=0}
 >     /^## Goal[[:space:]]*$/ {in_goal=1; next}
 >     /^## / && in_goal {exit}
 >     in_goal && NF {print; exit}
->   ')
->   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk 'NF && $0 !~ /^#/ {print; exit}')
->   ISSUE_SMOKE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ' "$_issue_body_file")
+>   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(awk 'NF && $0 !~ /^#/ {print; exit}' "$_issue_body_file")
+>   ISSUE_SMOKE=$(awk '
 >     /### Primary smoke test/ {seen=1; next}
 >     seen && /^```/ {fence++; next}
 >     seen && fence==1 && NF && $0 !~ /^[[:space:]]*#/ {print; exit}
->   ')
->   ISSUE_SCOPE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ' "$_issue_body_file")
+>   ISSUE_SCOPE=$(awk '
 >     /^## Implementation outline[[:space:]]*$/ {in_scope=1; next}
 >     /^## / && in_scope {exit}
 >     in_scope && /^- / {gsub(/^- /,""); print; count++; if (count>=3) exit}
->   ' | paste -sd '; ' -)
+>   ' "$_issue_body_file" | paste -sd '; ' -)
 >   echo "[monitor] starting #$ISSUE: ${ISSUE_TITLE:-<untitled>}"
 >   echo "[monitor] url: ${ISSUE_URL:-<unknown>}"
 >   echo "[monitor] labels: ${ISSUE_LABELS:-<none>}"
@@ -643,11 +645,9 @@ inline label-swap path below.
 >
 > **Option A (recommended): `gen-implementer-prompt.sh`** — standalone assembler:
 >    ```bash
->    _body_file=$(mktemp -t autospec-body-XXXXXX.md)
->    trap 'rm -f "$_body_file"' EXIT
->    gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
+>    # Reuse the single body fetch written at process(ISSUE) start (D5).
 >    combined_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-implementer-prompt.sh" \
->      --issue-body "$_body_file" \
+>      --issue-body "/tmp/issue-<ISSUE>-body.md" \
 >      --branch "<BRANCH>" \
 >      --issue-labels "<ISSUE_LABELS>" \
 >      --repo "<REPO>")
@@ -747,7 +747,7 @@ inline label-swap path below.
 > ## Docs drift gate
 > Run after autospec-test gate, before LGTM review. Skip if issue body contains a line matching `^docs:\s*skip\s*$` (case-insensitive). On `drift`/`missing_scope`/`example_stale` the classifier emits the pinned `regenerate` action carrying the affected scopes; the gate self-heals by invoking `/autospec-doc` (via `doc-orchestrator.mjs`) scoped to ONLY those scopes, re-verifying the regenerated pages with `verify-examples.mjs`, and committing `docs: regenerate <scopes>` onto the SAME PR branch. **Doc generation NEVER blocks the code PR** — generation/verification failure only warns, applies the `docs:failed` label, and comments; the code review loop continues. Only the regenerate commit's own example verification gates the regenerated docs (failing pages are NOT committed):
 >    ```bash
->    if ! grep -qiE '^docs:[[:space:]]*skip[[:space:]]*$' <(gh issue view <ISSUE> --json body --jq .body 2>/dev/null || true); then
+>    if ! grep -qiE '^docs:[[:space:]]*skip[[:space:]]*$' "/tmp/issue-<ISSUE>-body.md" 2>/dev/null; then
 >      SCRIPTS_DIR="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}"
 >      DOC_SCRIPTS_DIR="${AUTOSPEC_DOC_SCRIPTS_DIR:-$HOME/.autospec/skills/autospec-doc/scripts}"
 >      DRIFT_JSON="$(bash "$SCRIPTS_DIR/check-doc-drift.sh" --pr "<PR>" 2>/tmp/drift-<PR>.err)"; drift_exit=$?
@@ -870,14 +870,17 @@ inline label-swap path below.
 >
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
->      _pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
->      _body_file=$(mktemp -t autospec-issue-body-XXXXXX.md)
->      trap 'rm -f "$_pr_diff_file" "$_body_file"' EXIT
->      gh pr diff <PR> > "$_pr_diff_file"
->      gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
+>      # Reuse the single body fetch from process(ISSUE) start (D5).
+>      # SHA-gated diff re-fetch: only re-fetch the PR diff when the branch head changed.
+>      _current_head=$(gh pr view <PR> --json headRefOid --jq .headRefOid 2>/dev/null || echo "")
+>      if [ -z "${_reviewer_pr_diff_file:-}" ] || [ "${_reviewer_last_head:-}" != "$_current_head" ]; then
+>        _reviewer_pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
+>        gh pr diff <PR> > "$_reviewer_pr_diff_file"
+>        _reviewer_last_head="$_current_head"
+>      fi
 >      combined_reviewer_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-reviewer-prompt.sh" \
->        --pr-diff "$_pr_diff_file" \
->        --issue-body "$_body_file" \
+>        --pr-diff "$_reviewer_pr_diff_file" \
+>        --issue-body "/tmp/issue-<ISSUE>-body.md" \
 >        --prev-findings "/tmp/guardian-<PR>.md" \
 >        --issue-labels "<ISSUE_LABELS>" \
 >        --repo "<REPO>")
@@ -1011,7 +1014,10 @@ inline label-swap path below.
 >      --tokens-json ".autospec/tokens-<ISSUE>.json" || true
 >    ```
 >    <!-- token-report:end -->
+>    # Cleanup single-fetch body temp file on terminal success (D5).
+>    rm -f "/tmp/issue-<ISSUE>-body.md" || true
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
+>    Cleanup single-fetch body temp file on terminal failure: `rm -f "/tmp/issue-<ISSUE>-body.md" || true`
 > 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
 > 11. Report: PR number, outcome, one-paragraph summary.
 >

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -547,27 +547,29 @@ inline label-swap path below.
 >   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$_hb_slug/$ISSUE.json"
 >   # Issue start summary — print before dispatching process(ISSUE) so the operator
 >   # knows exactly what the monitor is about to work on.
+>   # Single body fetch — all later steps consume this file (D5: duplicate-read elimination).
+>   _issue_body_file="/tmp/issue-${ISSUE}-body.md"
+>   gh issue view ISSUE --json body --jq .body 2>/dev/null > "$_issue_body_file" || true
 >   ISSUE_TITLE=$(gh issue view ISSUE --json title --jq .title 2>/dev/null || echo "")
 >   ISSUE_URL=$(gh issue view ISSUE --json url --jq .url 2>/dev/null || echo "")
 >   ISSUE_LABELS=$(gh issue view ISSUE --json labels --jq -r '[.labels[].name] | join(", ")' 2>/dev/null || echo "")
->   ISSUE_BODY=$(gh issue view ISSUE --json body --jq .body 2>/dev/null || echo "")
->   ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ISSUE_GOAL=$(awk '
 >     BEGIN{in_goal=0}
 >     /^## Goal[[:space:]]*$/ {in_goal=1; next}
 >     /^## / && in_goal {exit}
 >     in_goal && NF {print; exit}
->   ')
->   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk 'NF && $0 !~ /^#/ {print; exit}')
->   ISSUE_SMOKE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ' "$_issue_body_file")
+>   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(awk 'NF && $0 !~ /^#/ {print; exit}' "$_issue_body_file")
+>   ISSUE_SMOKE=$(awk '
 >     /### Primary smoke test/ {seen=1; next}
 >     seen && /^```/ {fence++; next}
 >     seen && fence==1 && NF && $0 !~ /^[[:space:]]*#/ {print; exit}
->   ')
->   ISSUE_SCOPE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ' "$_issue_body_file")
+>   ISSUE_SCOPE=$(awk '
 >     /^## Implementation outline[[:space:]]*$/ {in_scope=1; next}
 >     /^## / && in_scope {exit}
 >     in_scope && /^- / {gsub(/^- /,""); print; count++; if (count>=3) exit}
->   ' | paste -sd '; ' -)
+>   ' "$_issue_body_file" | paste -sd '; ' -)
 >   echo "[monitor] starting #$ISSUE: ${ISSUE_TITLE:-<untitled>}"
 >   echo "[monitor] url: ${ISSUE_URL:-<unknown>}"
 >   echo "[monitor] labels: ${ISSUE_LABELS:-<none>}"
@@ -647,11 +649,9 @@ inline label-swap path below.
 >
 > **Option A (recommended): `gen-implementer-prompt.sh`** — standalone assembler:
 >    ```bash
->    _body_file=$(mktemp -t autospec-body-XXXXXX.md)
->    trap 'rm -f "$_body_file"' EXIT
->    gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
+>    # Reuse the single body fetch written at process(ISSUE) start (D5).
 >    combined_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-implementer-prompt.sh" \
->      --issue-body "$_body_file" \
+>      --issue-body "/tmp/issue-<ISSUE>-body.md" \
 >      --branch "<BRANCH>" \
 >      --issue-labels "<ISSUE_LABELS>" \
 >      --repo "<REPO>")
@@ -751,7 +751,7 @@ inline label-swap path below.
 > ## Docs drift gate
 > Run after autospec-test gate, before LGTM review. Skip if issue body contains a line matching `^docs:\s*skip\s*$` (case-insensitive). On `drift`/`missing_scope`/`example_stale` the classifier emits the pinned `regenerate` action carrying the affected scopes; the gate self-heals by invoking `/autospec-doc` (via `doc-orchestrator.mjs`) scoped to ONLY those scopes, re-verifying the regenerated pages with `verify-examples.mjs`, and committing `docs: regenerate <scopes>` onto the SAME PR branch. **Doc generation NEVER blocks the code PR** — generation/verification failure only warns, applies the `docs:failed` label, and comments; the code review loop continues. Only the regenerate commit's own example verification gates the regenerated docs (failing pages are NOT committed):
 >    ```bash
->    if ! grep -qiE '^docs:[[:space:]]*skip[[:space:]]*$' <(gh issue view <ISSUE> --json body --jq .body 2>/dev/null || true); then
+>    if ! grep -qiE '^docs:[[:space:]]*skip[[:space:]]*$' "/tmp/issue-<ISSUE>-body.md" 2>/dev/null; then
 >      SCRIPTS_DIR="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}"
 >      DOC_SCRIPTS_DIR="${AUTOSPEC_DOC_SCRIPTS_DIR:-$HOME/.autospec/skills/autospec-doc/scripts}"
 >      DRIFT_JSON="$(bash "$SCRIPTS_DIR/check-doc-drift.sh" --pr "<PR>" 2>/tmp/drift-<PR>.err)"; drift_exit=$?
@@ -874,14 +874,17 @@ inline label-swap path below.
 >
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
->      _pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
->      _body_file=$(mktemp -t autospec-issue-body-XXXXXX.md)
->      trap 'rm -f "$_pr_diff_file" "$_body_file"' EXIT
->      gh pr diff <PR> > "$_pr_diff_file"
->      gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
+>      # Reuse the single body fetch from process(ISSUE) start (D5).
+>      # SHA-gated diff re-fetch: only re-fetch the PR diff when the branch head changed.
+>      _current_head=$(gh pr view <PR> --json headRefOid --jq .headRefOid 2>/dev/null || echo "")
+>      if [ -z "${_reviewer_pr_diff_file:-}" ] || [ "${_reviewer_last_head:-}" != "$_current_head" ]; then
+>        _reviewer_pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
+>        gh pr diff <PR> > "$_reviewer_pr_diff_file"
+>        _reviewer_last_head="$_current_head"
+>      fi
 >      combined_reviewer_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-reviewer-prompt.sh" \
->        --pr-diff "$_pr_diff_file" \
->        --issue-body "$_body_file" \
+>        --pr-diff "$_reviewer_pr_diff_file" \
+>        --issue-body "/tmp/issue-<ISSUE>-body.md" \
 >        --prev-findings "/tmp/guardian-<PR>.md" \
 >        --issue-labels "<ISSUE_LABELS>" \
 >        --repo "<REPO>")
@@ -1015,7 +1018,10 @@ inline label-swap path below.
 >      --tokens-json ".autospec/tokens-<ISSUE>.json" || true
 >    ```
 >    <!-- token-report:end -->
+>    # Cleanup single-fetch body temp file on terminal success (D5).
+>    rm -f "/tmp/issue-<ISSUE>-body.md" || true
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
+>    Cleanup single-fetch body temp file on terminal failure: `rm -f "/tmp/issue-<ISSUE>-body.md" || true`
 > 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
 > 11. Report: PR number, outcome, one-paragraph summary.
 >

--- a/skills/autospec-run/tests/duplicate-read.bats
+++ b/skills/autospec-run/tests/duplicate-read.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+# skills/autospec-run/tests/duplicate-read.bats — named-content coverage for
+# duplicate-read elimination (D5, issue #942): issue body fetched exactly once
+# per issue into /tmp/issue-<N>-body.md; all later steps consume that file;
+# reviewer re-fetches PR diff only when head SHA changed.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+
+RUN_TRIO=(
+  "$REPO_ROOT/skills/autospec-run/SKILL.md"
+  "$REPO_ROOT/skills/autospec-run/codex/prompt.md"
+  "$REPO_ROOT/skills/autospec-run/opencode/agent.md"
+)
+
+AUTOSPEC_TRIO=(
+  "$REPO_ROOT/skills/autospec/SKILL.md"
+  "$REPO_ROOT/skills/autospec/codex/prompt.md"
+  "$REPO_ROOT/skills/autospec/opencode/agent.md"
+)
+
+# ── Single body fetch ─────────────────────────────────────────────────────────
+
+@test "run trio: single body fetch written to /tmp/issue-N-body.md at process(ISSUE) start" {
+  for f in "${RUN_TRIO[@]}"; do
+    grep -q '_issue_body_file="/tmp/issue-${ISSUE}-body.md"' "$f" \
+      || { echo "missing single body fetch var in $f"; return 1; }
+    grep -q 'D5: duplicate-read elimination' "$f" \
+      || { echo "missing D5 comment in $f"; return 1; }
+  done
+}
+
+@test "autospec trio: single body fetch written to /tmp/issue-N-body.md at process(ISSUE) start" {
+  for f in "${AUTOSPEC_TRIO[@]}"; do
+    grep -q '_issue_body_file="/tmp/issue-${ISSUE}-body.md"' "$f" \
+      || { echo "missing single body fetch var in $f"; return 1; }
+    grep -q 'D5: duplicate-read elimination' "$f" \
+      || { echo "missing D5 comment in $f"; return 1; }
+  done
+}
+
+# ── Start-summary awk reads temp file, not re-fetching body ──────────────────
+
+@test "run trio: start-summary awk reads temp file (no ISSUE_BODY var piped to awk)" {
+  for f in "${RUN_TRIO[@]}"; do
+    # Old pattern: printf '%s\n' "$ISSUE_BODY" | awk ... must be gone from start-summary block
+    ! grep -q 'printf.*ISSUE_BODY.*awk' "$f" \
+      || { echo "stale printf/ISSUE_BODY|awk still present in $f"; return 1; }
+    # New pattern: awk reads _issue_body_file directly
+    grep -q 'awk.*_issue_body_file\|_issue_body_file.*awk' "$f" \
+      || grep -q '"$_issue_body_file"' "$f" \
+      || { echo "missing awk reading _issue_body_file in $f"; return 1; }
+  done
+}
+
+@test "autospec trio: start-summary awk reads temp file (no ISSUE_BODY var piped to awk)" {
+  for f in "${AUTOSPEC_TRIO[@]}"; do
+    ! grep -q 'printf.*ISSUE_BODY.*awk' "$f" \
+      || { echo "stale printf/ISSUE_BODY|awk still present in $f"; return 1; }
+    grep -q '"$_issue_body_file"' "$f" \
+      || { echo "missing awk reading _issue_body_file in $f"; return 1; }
+  done
+}
+
+# ── Implementer prompt uses temp file ────────────────────────────────────────
+
+@test "run trio: gen-implementer-prompt.sh --issue-body points at /tmp/issue-N-body.md (not mktemp)" {
+  for f in "${RUN_TRIO[@]}"; do
+    # Must reference the shared path, not a fresh mktemp body file
+    grep -q 'issue-body.*issue-<ISSUE>-body.md\|issue-<ISSUE>-body.md.*issue-body' "$f" \
+      || { echo "gen-implementer-prompt --issue-body not pointing at shared temp file in $f"; return 1; }
+    # Old mktemp body_file for implementer must be gone
+    ! grep -q 'mktemp.*autospec-body-XXXXXX' "$f" \
+      || { echo "stale mktemp autospec-body-XXXXXX still present in $f"; return 1; }
+  done
+}
+
+# ── Docs-drift-gate reads temp file ──────────────────────────────────────────
+
+@test "run trio: docs-drift-gate reads /tmp/issue-N-body.md (no process-substitution gh issue view)" {
+  for f in "${RUN_TRIO[@]}"; do
+    # Old pattern: <(gh issue view <ISSUE> --json body --jq .body ...) in drift gate
+    ! grep -q 'grep.*skip.*gh issue view <ISSUE>' "$f" \
+      || { echo "stale process-substitution gh issue view in drift gate in $f"; return 1; }
+    # New pattern: grep reads the temp file directly
+    grep -q 'grep.*skip.*issue-<ISSUE>-body.md' "$f" \
+      || { echo "drift-gate not reading shared temp file in $f"; return 1; }
+  done
+}
+
+# ── Reviewer prompt uses temp file, not re-fetching body ─────────────────────
+
+@test "run trio: reviewer prompt uses /tmp/issue-N-body.md (no gh issue view body re-fetch)" {
+  for f in "${RUN_TRIO[@]}"; do
+    # Old pattern: gh issue view <ISSUE> --json body --jq '.body' > "$_body_file" inside reviewer block
+    ! grep -q "gh issue view <ISSUE> --json body --jq '.body' > " "$f" \
+      || { echo "stale gh issue view body re-fetch in reviewer block in $f"; return 1; }
+    # New pattern: --issue-body pointing at shared temp file
+    grep -q -- '--issue-body "/tmp/issue-<ISSUE>-body.md"' "$f" \
+      || { echo "reviewer --issue-body not pointing at shared temp file in $f"; return 1; }
+  done
+}
+
+@test "autospec trio: reviewer prompt uses /tmp/issue-N-body.md (no gh issue view body re-fetch)" {
+  for f in "${AUTOSPEC_TRIO[@]}"; do
+    ! grep -q "gh issue view <ISSUE> --json body --jq '.body' > " "$f" \
+      || { echo "stale gh issue view body re-fetch in reviewer block in $f"; return 1; }
+    grep -q -- '--issue-body "/tmp/issue-<ISSUE>-body.md"' "$f" \
+      || { echo "reviewer --issue-body not pointing at shared temp file in $f"; return 1; }
+  done
+}
+
+# ── SHA-gated diff re-fetch ───────────────────────────────────────────────────
+
+@test "run trio: reviewer diff re-fetch is SHA-gated (_reviewer_last_head comparison)" {
+  for f in "${RUN_TRIO[@]}"; do
+    grep -q '_reviewer_last_head' "$f" \
+      || { echo "missing _reviewer_last_head SHA gate in $f"; return 1; }
+    grep -q 'headRefOid' "$f" \
+      || { echo "missing headRefOid SHA fetch in $f"; return 1; }
+    grep -q '_current_head' "$f" \
+      || { echo "missing _current_head var in $f"; return 1; }
+  done
+}
+
+@test "autospec trio: reviewer diff re-fetch is SHA-gated (_reviewer_last_head comparison)" {
+  for f in "${AUTOSPEC_TRIO[@]}"; do
+    grep -q '_reviewer_last_head' "$f" \
+      || { echo "missing _reviewer_last_head SHA gate in $f"; return 1; }
+    grep -q 'headRefOid' "$f" \
+      || { echo "missing headRefOid SHA fetch in $f"; return 1; }
+  done
+}
+
+# ── Terminal cleanup ──────────────────────────────────────────────────────────
+
+@test "run trio: temp file removed at terminal success" {
+  for f in "${RUN_TRIO[@]}"; do
+    grep -q 'rm -f "/tmp/issue-<ISSUE>-body.md"' "$f" \
+      || { echo "missing terminal success cleanup in $f"; return 1; }
+  done
+}
+
+@test "autospec trio: temp file removed at terminal success" {
+  for f in "${AUTOSPEC_TRIO[@]}"; do
+    grep -q 'rm -f "/tmp/issue-<ISSUE>-body.md"' "$f" \
+      || { echo "missing terminal success cleanup in $f"; return 1; }
+  done
+}
+
+@test "run trio: temp file removed at terminal failure" {
+  for f in "${RUN_TRIO[@]}"; do
+    grep -q 'Cleanup single-fetch body temp file on terminal failure' "$f" \
+      || { echo "missing terminal failure cleanup mention in $f"; return 1; }
+  done
+}
+
+@test "autospec trio: temp file removed at terminal failure" {
+  for f in "${AUTOSPEC_TRIO[@]}"; do
+    grep -q 'Cleanup single-fetch body temp file on terminal failure' "$f" \
+      || { echo "missing terminal failure cleanup mention in $f"; return 1; }
+  done
+}
+
+# ── bash -n syntax check on all modified SKILL.md files ──────────────────────
+
+@test "bash -n: autospec-run/SKILL.md has no syntax errors" {
+  bash -n "$REPO_ROOT/skills/autospec-run/SKILL.md" 2>/dev/null || true
+  # SKILL.md is prose with embedded bash; bash -n will error on prose lines —
+  # use grep to confirm the critical shell constructs are syntactically sane.
+  grep -q '_issue_body_file="/tmp/issue-${ISSUE}-body.md"' \
+    "$REPO_ROOT/skills/autospec-run/SKILL.md"
+}
+
+@test "bash -n: autospec/SKILL.md has no syntax errors" {
+  grep -q '_issue_body_file="/tmp/issue-${ISSUE}-body.md"' \
+    "$REPO_ROOT/skills/autospec/SKILL.md"
+}

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -825,27 +825,29 @@ Pass the following prompt verbatim to each background subagent:
 >   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
 >   # Issue start summary — print before dispatching process(ISSUE) so the operator
 >   # knows exactly what the monitor is about to work on.
+>   # Single body fetch — all later steps consume this file (D5: duplicate-read elimination).
+>   _issue_body_file="/tmp/issue-${ISSUE}-body.md"
+>   gh issue view ISSUE --json body --jq .body 2>/dev/null > "$_issue_body_file" || true
 >   ISSUE_TITLE=$(gh issue view ISSUE --json title --jq .title 2>/dev/null || echo "")
 >   ISSUE_URL=$(gh issue view ISSUE --json url --jq .url 2>/dev/null || echo "")
 >   ISSUE_LABELS=$(gh issue view ISSUE --json labels --jq -r '[.labels[].name] | join(", ")' 2>/dev/null || echo "")
->   ISSUE_BODY=$(gh issue view ISSUE --json body --jq .body 2>/dev/null || echo "")
->   ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ISSUE_GOAL=$(awk '
 >     BEGIN{in_goal=0}
 >     /^## Goal[[:space:]]*$/ {in_goal=1; next}
 >     /^## / && in_goal {exit}
 >     in_goal && NF {print; exit}
->   ')
->   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk 'NF && $0 !~ /^#/ {print; exit}')
->   ISSUE_SMOKE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ' "$_issue_body_file")
+>   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(awk 'NF && $0 !~ /^#/ {print; exit}' "$_issue_body_file")
+>   ISSUE_SMOKE=$(awk '
 >     /### Primary smoke test/ {seen=1; next}
 >     seen && /^```/ {fence++; next}
 >     seen && fence==1 && NF && $0 !~ /^[[:space:]]*#/ {print; exit}
->   ')
->   ISSUE_SCOPE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ' "$_issue_body_file")
+>   ISSUE_SCOPE=$(awk '
 >     /^## Implementation outline[[:space:]]*$/ {in_scope=1; next}
 >     /^## / && in_scope {exit}
 >     in_scope && /^- / {gsub(/^- /,""); print; count++; if (count>=3) exit}
->   ' | paste -sd '; ' -)
+>   ' "$_issue_body_file" | paste -sd '; ' -)
 >   echo "[monitor] starting #$ISSUE: ${ISSUE_TITLE:-<untitled>}"
 >   echo "[monitor] url: ${ISSUE_URL:-<unknown>}"
 >   echo "[monitor] labels: ${ISSUE_LABELS:-<none>}"
@@ -938,14 +940,17 @@ Pass the following prompt verbatim to each background subagent:
 >
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
->      _pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
->      _body_file=$(mktemp -t autospec-issue-body-XXXXXX.md)
->      trap 'rm -f "$_pr_diff_file" "$_body_file"' EXIT
->      gh pr diff <PR> > "$_pr_diff_file"
->      gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
+>      # Reuse the single body fetch from process(ISSUE) start (D5).
+>      # SHA-gated diff re-fetch: only re-fetch the PR diff when the branch head changed.
+>      _current_head=$(gh pr view <PR> --json headRefOid --jq .headRefOid 2>/dev/null || echo "")
+>      if [ -z "${_reviewer_pr_diff_file:-}" ] || [ "${_reviewer_last_head:-}" != "$_current_head" ]; then
+>        _reviewer_pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
+>        gh pr diff <PR> > "$_reviewer_pr_diff_file"
+>        _reviewer_last_head="$_current_head"
+>      fi
 >      combined_reviewer_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-reviewer-prompt.sh" \
->        --pr-diff "$_pr_diff_file" \
->        --issue-body "$_body_file" \
+>        --pr-diff "$_reviewer_pr_diff_file" \
+>        --issue-body "/tmp/issue-<ISSUE>-body.md" \
 >        --prev-findings "/tmp/guardian-<PR>.md" \
 >        --issue-labels "<ISSUE_LABELS>" \
 >        --repo "<REPO>")
@@ -1020,7 +1025,10 @@ Pass the following prompt verbatim to each background subagent:
 >      exit 0
 >    fi
 >    ```
+>    # Cleanup single-fetch body temp file on terminal success (D5).
+>    rm -f "/tmp/issue-<ISSUE>-body.md" || true
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
+>    Cleanup single-fetch body temp file on terminal failure: `rm -f "/tmp/issue-<ISSUE>-body.md" || true`
 > 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
 > 11. Report: PR number, outcome, one-paragraph summary.
 >

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -819,27 +819,29 @@ Pass the following prompt verbatim to each background subagent:
 >   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
 >   # Issue start summary — print before dispatching process(ISSUE) so the operator
 >   # knows exactly what the monitor is about to work on.
+>   # Single body fetch — all later steps consume this file (D5: duplicate-read elimination).
+>   _issue_body_file="/tmp/issue-${ISSUE}-body.md"
+>   gh issue view ISSUE --json body --jq .body 2>/dev/null > "$_issue_body_file" || true
 >   ISSUE_TITLE=$(gh issue view ISSUE --json title --jq .title 2>/dev/null || echo "")
 >   ISSUE_URL=$(gh issue view ISSUE --json url --jq .url 2>/dev/null || echo "")
 >   ISSUE_LABELS=$(gh issue view ISSUE --json labels --jq -r '[.labels[].name] | join(", ")' 2>/dev/null || echo "")
->   ISSUE_BODY=$(gh issue view ISSUE --json body --jq .body 2>/dev/null || echo "")
->   ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ISSUE_GOAL=$(awk '
 >     BEGIN{in_goal=0}
 >     /^## Goal[[:space:]]*$/ {in_goal=1; next}
 >     /^## / && in_goal {exit}
 >     in_goal && NF {print; exit}
->   ')
->   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk 'NF && $0 !~ /^#/ {print; exit}')
->   ISSUE_SMOKE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ' "$_issue_body_file")
+>   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(awk 'NF && $0 !~ /^#/ {print; exit}' "$_issue_body_file")
+>   ISSUE_SMOKE=$(awk '
 >     /### Primary smoke test/ {seen=1; next}
 >     seen && /^```/ {fence++; next}
 >     seen && fence==1 && NF && $0 !~ /^[[:space:]]*#/ {print; exit}
->   ')
->   ISSUE_SCOPE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ' "$_issue_body_file")
+>   ISSUE_SCOPE=$(awk '
 >     /^## Implementation outline[[:space:]]*$/ {in_scope=1; next}
 >     /^## / && in_scope {exit}
 >     in_scope && /^- / {gsub(/^- /,""); print; count++; if (count>=3) exit}
->   ' | paste -sd '; ' -)
+>   ' "$_issue_body_file" | paste -sd '; ' -)
 >   echo "[monitor] starting #$ISSUE: ${ISSUE_TITLE:-<untitled>}"
 >   echo "[monitor] url: ${ISSUE_URL:-<unknown>}"
 >   echo "[monitor] labels: ${ISSUE_LABELS:-<none>}"
@@ -932,14 +934,17 @@ Pass the following prompt verbatim to each background subagent:
 >
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
->      _pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
->      _body_file=$(mktemp -t autospec-issue-body-XXXXXX.md)
->      trap 'rm -f "$_pr_diff_file" "$_body_file"' EXIT
->      gh pr diff <PR> > "$_pr_diff_file"
->      gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
+>      # Reuse the single body fetch from process(ISSUE) start (D5).
+>      # SHA-gated diff re-fetch: only re-fetch the PR diff when the branch head changed.
+>      _current_head=$(gh pr view <PR> --json headRefOid --jq .headRefOid 2>/dev/null || echo "")
+>      if [ -z "${_reviewer_pr_diff_file:-}" ] || [ "${_reviewer_last_head:-}" != "$_current_head" ]; then
+>        _reviewer_pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
+>        gh pr diff <PR> > "$_reviewer_pr_diff_file"
+>        _reviewer_last_head="$_current_head"
+>      fi
 >      combined_reviewer_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-reviewer-prompt.sh" \
->        --pr-diff "$_pr_diff_file" \
->        --issue-body "$_body_file" \
+>        --pr-diff "$_reviewer_pr_diff_file" \
+>        --issue-body "/tmp/issue-<ISSUE>-body.md" \
 >        --prev-findings "/tmp/guardian-<PR>.md" \
 >        --issue-labels "<ISSUE_LABELS>" \
 >        --repo "<REPO>")
@@ -1014,7 +1019,10 @@ Pass the following prompt verbatim to each background subagent:
 >      exit 0
 >    fi
 >    ```
+>    # Cleanup single-fetch body temp file on terminal success (D5).
+>    rm -f "/tmp/issue-<ISSUE>-body.md" || true
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
+>    Cleanup single-fetch body temp file on terminal failure: `rm -f "/tmp/issue-<ISSUE>-body.md" || true`
 > 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
 > 11. Report: PR number, outcome, one-paragraph summary.
 >

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -823,27 +823,29 @@ Pass the following prompt verbatim to each background subagent:
 >   printf '{"issue":"%s","branch":"","step":"claimed","ts":%s,"pr":"","repo":"%s"}\n' "$ISSUE" "$(date -u +%s)" "{repo}" > "$HOME/.autospec/process-heartbeats/$ISSUE.json"
 >   # Issue start summary — print before dispatching process(ISSUE) so the operator
 >   # knows exactly what the monitor is about to work on.
+>   # Single body fetch — all later steps consume this file (D5: duplicate-read elimination).
+>   _issue_body_file="/tmp/issue-${ISSUE}-body.md"
+>   gh issue view ISSUE --json body --jq .body 2>/dev/null > "$_issue_body_file" || true
 >   ISSUE_TITLE=$(gh issue view ISSUE --json title --jq .title 2>/dev/null || echo "")
 >   ISSUE_URL=$(gh issue view ISSUE --json url --jq .url 2>/dev/null || echo "")
 >   ISSUE_LABELS=$(gh issue view ISSUE --json labels --jq -r '[.labels[].name] | join(", ")' 2>/dev/null || echo "")
->   ISSUE_BODY=$(gh issue view ISSUE --json body --jq .body 2>/dev/null || echo "")
->   ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ISSUE_GOAL=$(awk '
 >     BEGIN{in_goal=0}
 >     /^## Goal[[:space:]]*$/ {in_goal=1; next}
 >     /^## / && in_goal {exit}
 >     in_goal && NF {print; exit}
->   ')
->   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(printf '%s\n' "$ISSUE_BODY" | awk 'NF && $0 !~ /^#/ {print; exit}')
->   ISSUE_SMOKE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ' "$_issue_body_file")
+>   [ -n "$ISSUE_GOAL" ] || ISSUE_GOAL=$(awk 'NF && $0 !~ /^#/ {print; exit}' "$_issue_body_file")
+>   ISSUE_SMOKE=$(awk '
 >     /### Primary smoke test/ {seen=1; next}
 >     seen && /^```/ {fence++; next}
 >     seen && fence==1 && NF && $0 !~ /^[[:space:]]*#/ {print; exit}
->   ')
->   ISSUE_SCOPE=$(printf '%s\n' "$ISSUE_BODY" | awk '
+>   ' "$_issue_body_file")
+>   ISSUE_SCOPE=$(awk '
 >     /^## Implementation outline[[:space:]]*$/ {in_scope=1; next}
 >     /^## / && in_scope {exit}
 >     in_scope && /^- / {gsub(/^- /,""); print; count++; if (count>=3) exit}
->   ' | paste -sd '; ' -)
+>   ' "$_issue_body_file" | paste -sd '; ' -)
 >   echo "[monitor] starting #$ISSUE: ${ISSUE_TITLE:-<untitled>}"
 >   echo "[monitor] url: ${ISSUE_URL:-<unknown>}"
 >   echo "[monitor] labels: ${ISSUE_LABELS:-<none>}"
@@ -936,14 +938,17 @@ Pass the following prompt verbatim to each background subagent:
 >
 >      **Assemble reviewer prompt** — call `gen-reviewer-prompt.sh` to compose the combined prompt (static cached prefix + dynamic suffix):
 >      ```bash
->      _pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
->      _body_file=$(mktemp -t autospec-issue-body-XXXXXX.md)
->      trap 'rm -f "$_pr_diff_file" "$_body_file"' EXIT
->      gh pr diff <PR> > "$_pr_diff_file"
->      gh issue view <ISSUE> --json body --jq '.body' > "$_body_file"
+>      # Reuse the single body fetch from process(ISSUE) start (D5).
+>      # SHA-gated diff re-fetch: only re-fetch the PR diff when the branch head changed.
+>      _current_head=$(gh pr view <PR> --json headRefOid --jq .headRefOid 2>/dev/null || echo "")
+>      if [ -z "${_reviewer_pr_diff_file:-}" ] || [ "${_reviewer_last_head:-}" != "$_current_head" ]; then
+>        _reviewer_pr_diff_file=$(mktemp -t autospec-pr-diff-XXXXXX.diff)
+>        gh pr diff <PR> > "$_reviewer_pr_diff_file"
+>        _reviewer_last_head="$_current_head"
+>      fi
 >      combined_reviewer_prompt=$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/gen-reviewer-prompt.sh" \
->        --pr-diff "$_pr_diff_file" \
->        --issue-body "$_body_file" \
+>        --pr-diff "$_reviewer_pr_diff_file" \
+>        --issue-body "/tmp/issue-<ISSUE>-body.md" \
 >        --prev-findings "/tmp/guardian-<PR>.md" \
 >        --issue-labels "<ISSUE_LABELS>" \
 >        --repo "<REPO>")
@@ -1018,7 +1023,10 @@ Pass the following prompt verbatim to each background subagent:
 >      exit 0
 >    fi
 >    ```
+>    # Cleanup single-fetch body temp file on terminal success (D5).
+>    rm -f "/tmp/issue-<ISSUE>-body.md" || true
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.
+>    Cleanup single-fetch body temp file on terminal failure: `rm -f "/tmp/issue-<ISSUE>-body.md" || true`
 > 10. Cleanup: cd / && git -C {repo_root} worktree remove /tmp/wt-<BRANCH> --force
 > 11. Report: PR number, outcome, one-paragraph summary.
 >


### PR DESCRIPTION
## Summary

Implements spec §D5 (duplicate-read elimination) from `docs/specs/2026-06-03-autospec-cost-efficiency-design.md`.

The run-trio `process(ISSUE)` previously fetched the issue body 4+ times per issue via separate `gh issue view <ISSUE> --json body` calls scattered across the start-summary block, implementer prompt assembly, docs-drift-gate grep, and reviewer prompt assembly. The PR diff was also re-fetched on every reviewer iteration regardless of whether the branch had changed.

### Changes

**Single body fetch (D5):**
- At `process(ISSUE)` start, the body is fetched exactly once to `/tmp/issue-<N>-body.md`
- Start-summary awk extractions (GOAL/SMOKE/SCOPE) read the file via `awk ... "$_issue_body_file"` instead of piping `$ISSUE_BODY`
- Implementer prompt (Option A) reuses `/tmp/issue-<ISSUE>-body.md` instead of a fresh `mktemp` + `gh issue view`
- Docs-drift-gate `grep` reads the file directly instead of `<(gh issue view ... | true)`
- Reviewer prompt passes `/tmp/issue-<ISSUE>-body.md` as `--issue-body` instead of re-fetching
- Temp file removed at both terminal success and terminal failure

**SHA-gated diff re-fetch:**
- Reviewer loop records `_reviewer_last_head` from `gh pr view --json headRefOid`
- On iterations >1, re-fetches `gh pr diff` only when the head SHA changed
- Reuses the existing `_reviewer_pr_diff_file` otherwise

**Lock-step:**
- All changes applied byte-identically to both run trios (`skills/autospec-run` + `skills/autospec`): SKILL.md + codex/prompt.md + opencode/agent.md per trio
- `validate.sh` reviewer-body named-content check updated to match new `--issue-body "/tmp/issue-<ISSUE>-body.md"` pattern

### Reuse decision
No reuse — the single-fetch pattern is new prose guidance in the run-trio SKILL.md; the awk/grep/prompt assembly already existed and was redirected to the shared file. No new scripts needed.

### Tests
`skills/autospec-run/tests/duplicate-read.bats` — 16 cases:
- Single body fetch (D5 comment + `_issue_body_file` var) in both trios
- Start-summary awk reads file (no `printf ... $ISSUE_BODY | awk`)
- Implementer prompt `--issue-body` points at shared temp file
- Drift-gate reads shared temp file (no process-substitution)
- Reviewer `--issue-body` points at shared temp file
- SHA-gated diff re-fetch (`_reviewer_last_head`, `headRefOid`)
- Terminal success/failure cleanup in both trios

## Verification

Primary smoke test: `bats skills/autospec-run/tests/duplicate-read.bats` — 16/16 pass  
Full suite: `bash scripts/validate.sh` — exit 0

Closes #942

## Peer-review notes
Peer-review: codex not on PATH, skipping