### PR TITLE
fix(autospec): autospec trio Phase 4 loop cost-epic D1+D2 parity (#971)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -878,6 +878,61 @@ check_phase4_full_test_suite_gate() {
     done
 }
 
+# Phase 4 cost-epic parity (issue #971): the cost-efficiency epic (#937) D1
+# (per-issue token reporting) and D2 (batch=1 / fresh-subagent-per-issue) were
+# applied to the autospec-run trio but silently missed the autospec trio's
+# embedded Phase 4 monitor loop, and the existing phase4 lock-step gates
+# (guardian / issue-start / next-pickup / test-suite) did NOT cover the
+# batch-default, token-report slot, or absorbed-discipline prose — so the
+# divergence passed CI. This gate ties those three surfaces between BOTH run
+# trios so the divergence CLASS fails CI going forward. Each assertion below
+# must PASS after parity and provably FAIL if either trio drifts back.
+check_phase4_cost_epic_parity_lockstep() {
+    info "phase4 cost-epic parity (D1 token-report + D2 batch=1): autospec + autospec-run trios"
+    for s in autospec autospec-run; do
+        for f in "skills/$s/SKILL.md" "skills/$s/codex/prompt.md" "skills/$s/opencode/agent.md"; do
+            [ -f "$f" ] || fail "$f: required file missing"
+            # D2: batch default must be 1, never the legacy 3, anywhere a
+            # batch-size default or prose is stated.
+            if grep -F 'AUTOSPEC_BATCH_SIZE:-3' "$f" >/dev/null 2>&1; then
+                fail "$f still defaults AUTOSPEC_BATCH_SIZE to 3 (D2 requires :-1)"
+            fi
+            if grep -Eq 'AUTOSPEC_BATCH_SIZE` issues \(default:? 3\)' "$f"; then
+                fail "$f still states batch 'default 3' prose (D2 requires 1)"
+            fi
+            grep -F 'AUTOSPEC_BATCH_SIZE:-1' "$f" >/dev/null \
+                || fail "$f missing AUTOSPEC_BATCH_SIZE:-1 default (D2 batch=1)"
+            # D2: fresh-subagent-per-issue prose (orchestrator never implements
+            # in its own context; default is 1; reasoning:deep force-to-1).
+            grep -F 'Fresh-subagent-per-issue (canonical Phase 4 path, formerly single-agent absorbed-discipline)' "$f" >/dev/null \
+                || fail "$f missing fresh-subagent-per-issue canonical prose (D2)"
+            grep -F 'The orchestrator NEVER implements in its own context' "$f" >/dev/null \
+                || fail "$f missing 'orchestrator NEVER implements in its own context' (D2)"
+            grep -F 'the default is 1 (one issue per subagent)' "$f" >/dev/null \
+                || fail "$f missing 'default is 1 (one issue per subagent)' (D2)"
+            grep -F 'reasoning:deep` force-to-1 rule is retained' "$f" >/dev/null \
+                || fail "$f missing reasoning:deep force-to-1 retention (D2)"
+            # D1: per-issue token-report step at the pinned slot — after the
+            # admin-merge SUCCESS step (8) and before the FAILURE step (9) /
+            # batch-done. Enforce both the markers and their pinned position.
+            grep -F '<!-- token-report:begin -->' "$f" >/dev/null \
+                || fail "$f missing token-report:begin marker (D1)"
+            grep -F '<!-- token-report:end -->' "$f" >/dev/null \
+                || fail "$f missing token-report:end marker (D1)"
+            grep -F 'post-token-report.sh' "$f" >/dev/null \
+                || fail "$f missing post-token-report.sh invocation (D1)"
+            slot="$(awk '
+                /(^|> )8\. SUCCESS/             { after_success=1 }
+                /(^|> )9\. FAILURE/             { after_success=0 }
+                after_success && /token-report:begin/ { print "FOUND" }
+            ' "$f")"
+            [ "$slot" = "FOUND" ] \
+                || fail "$f: token-report:begin not at pinned slot (must follow admin-merge SUCCESS step 8, precede FAILURE step 9 / batch-done) (D1)"
+        done
+    done
+    info "phase4 cost-epic parity: both trios carry batch=1 + fresh-subagent prose + pinned token-report"
+}
+
 # Team-personality contract: autospec should infer the right solving team from
 # the request, repository evidence, memories, and prior specs. If confidence is
 # low, it must ask explicitly with five concrete starter combinations, carry
@@ -1960,6 +2015,7 @@ main() {
     check_phase4_single_agent_discipline
     check_phase4_adaptive_retry
     check_phase4_full_test_suite_gate
+    check_phase4_cost_epic_parity_lockstep
     check_autospec_sweep_config_contract
     check_autospec_fleet_scripts
     check_fleet_gui_subcommand_lockstep

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -678,14 +678,14 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 **Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
 
-**Single-agent absorbed-discipline (canonical Phase 4 path).** The monitor agent IS the implementer for the issue it claims — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — all in one agent's context. The main session orchestrator relaunches the monitor between issues so each one gets a fresh top-level `Agent` call with full tool access. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch its own inner implementer. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "the monitor agent now does the implementation work itself in this same context", NOT a nested subagent dispatch. `AUTOSPEC_BATCH_SIZE` semantics are preserved: a single agent can still process up to N issues sequentially within its 40-tool-call budget, exiting with `BATCH_COMPLETE` when the budget is approaching or after N issues, whichever comes first.
+**Fresh-subagent-per-issue (canonical Phase 4 path, formerly single-agent absorbed-discipline).** Each issue is processed by a FRESH top-level subagent dispatched by the orchestrator — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — in that subagent's own context. The orchestrator NEVER implements in its own context; it only claims, dispatches, and waits. Each subagent receives full tool access because it is a top-level `Agent` call launched directly by the main session orchestrator. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so nested monitors cannot dispatch inner implementers. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "dispatch a fresh top-level subagent to do this work", NOT in-context implementation by the orchestrator. Batch>1 is an explicit operator opt-in via `AUTOSPEC_BATCH_SIZE=N`; the default is 1 (one issue per subagent). The `reasoning:deep` force-to-1 rule is retained: deep issues stay batch=1 even under an operator `AUTOSPEC_BATCH_SIZE=N` override.
 
-Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
+Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 1). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
 ```
 batch_num=1
 while true:
-  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3})
+  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-1})
   wait for task-notification (monitor agent completes)
 
   # Read and consume the batch-done signal.
@@ -707,7 +707,7 @@ while true:
 
 Pass the following prompt verbatim to each background subagent:
 
-> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
+> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 1) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
 
 > **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
 > 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
@@ -719,7 +719,7 @@ Pass the following prompt verbatim to each background subagent:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 1) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Shared helper scripts.** Helper scripts live at `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}` after installation. Do not assume the target repository has an autospec `scripts/` directory.
@@ -728,7 +728,7 @@ Pass the following prompt verbatim to each background subagent:
 > ```
 > # Before the loop (run-once init):
 > #   batch_issue_count=0
-> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-1}"
 > #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3   # guard against 0 or negative
 > #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
 >
@@ -1025,6 +1025,16 @@ Pass the following prompt verbatim to each background subagent:
 >      exit 0
 >    fi
 >    ```
+>    <!-- token-report:begin -->
+>    Post the per-issue token report (best-effort; never fails the run):
+>    ```bash
+>    # Orchestrator writes .autospec/tokens-<ISSUE>.json from Agent-result usage
+>    # (harness-dependent, best-effort; absent fields → null, never blocking).
+>    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/post-token-report.sh" \
+>      --issue "<ISSUE>" --repo "<REPO>" \
+>      --tokens-json ".autospec/tokens-<ISSUE>.json" || true
+>    ```
+>    <!-- token-report:end -->
 >    # Cleanup single-fetch body temp file on terminal success (D5).
 >    rm -f "/tmp/issue-<ISSUE>-body.md" || true
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -672,14 +672,14 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 **Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
 
-**Single-agent absorbed-discipline (canonical Phase 4 path).** The monitor agent IS the implementer for the issue it claims — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — all in one agent's context. The main session orchestrator relaunches the monitor between issues so each one gets a fresh top-level `Agent` call with full tool access. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch its own inner implementer. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "the monitor agent now does the implementation work itself in this same context", NOT a nested subagent dispatch. `AUTOSPEC_BATCH_SIZE` semantics are preserved: a single agent can still process up to N issues sequentially within its 40-tool-call budget, exiting with `BATCH_COMPLETE` when the budget is approaching or after N issues, whichever comes first.
+**Fresh-subagent-per-issue (canonical Phase 4 path, formerly single-agent absorbed-discipline).** Each issue is processed by a FRESH top-level subagent dispatched by the orchestrator — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — in that subagent's own context. The orchestrator NEVER implements in its own context; it only claims, dispatches, and waits. Each subagent receives full tool access because it is a top-level `Agent` call launched directly by the main session orchestrator. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so nested monitors cannot dispatch inner implementers. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "dispatch a fresh top-level subagent to do this work", NOT in-context implementation by the orchestrator. Batch>1 is an explicit operator opt-in via `AUTOSPEC_BATCH_SIZE=N`; the default is 1 (one issue per subagent). The `reasoning:deep` force-to-1 rule is retained: deep issues stay batch=1 even under an operator `AUTOSPEC_BATCH_SIZE=N` override.
 
-Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
+Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 1). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
 ```
 batch_num=1
 while true:
-  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3})
+  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-1})
   wait for task-notification (monitor agent completes)
 
   # Read and consume the batch-done signal.
@@ -701,7 +701,7 @@ while true:
 
 Pass the following prompt verbatim to each background subagent:
 
-> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
+> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 1) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
 
 > **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
 > 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
@@ -713,7 +713,7 @@ Pass the following prompt verbatim to each background subagent:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 1) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Shared helper scripts.** Helper scripts live at `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}` after installation. Do not assume the target repository has an autospec `scripts/` directory.
@@ -722,7 +722,7 @@ Pass the following prompt verbatim to each background subagent:
 > ```
 > # Before the loop (run-once init):
 > #   batch_issue_count=0
-> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-1}"
 > #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3   # guard against 0 or negative
 > #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
 >
@@ -1019,6 +1019,16 @@ Pass the following prompt verbatim to each background subagent:
 >      exit 0
 >    fi
 >    ```
+>    <!-- token-report:begin -->
+>    Post the per-issue token report (best-effort; never fails the run):
+>    ```bash
+>    # Orchestrator writes .autospec/tokens-<ISSUE>.json from Agent-result usage
+>    # (harness-dependent, best-effort; absent fields → null, never blocking).
+>    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/post-token-report.sh" \
+>      --issue "<ISSUE>" --repo "<REPO>" \
+>      --tokens-json ".autospec/tokens-<ISSUE>.json" || true
+>    ```
+>    <!-- token-report:end -->
 >    # Cleanup single-fetch body temp file on terminal success (D5).
 >    rm -f "/tmp/issue-<ISSUE>-body.md" || true
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -676,14 +676,14 @@ Record this durable preference in `AGENTS.md` (idempotent — skip if already pr
 
 **Off-peak tip:** For queues of 10+ issues (8+ hour runs), consider launching at night or on weekends. Usage limits are shared across all sessions — running long batches off-peak preserves daytime tokens for interactive work.
 
-**Single-agent absorbed-discipline (canonical Phase 4 path).** The monitor agent IS the implementer for the issue it claims — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — all in one agent's context. The main session orchestrator relaunches the monitor between issues so each one gets a fresh top-level `Agent` call with full tool access. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so a backgrounded monitor cannot dispatch its own inner implementer. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "the monitor agent now does the implementation work itself in this same context", NOT a nested subagent dispatch. `AUTOSPEC_BATCH_SIZE` semantics are preserved: a single agent can still process up to N issues sequentially within its 40-tool-call budget, exiting with `BATCH_COMPLETE` when the budget is approaching or after N issues, whichever comes first.
+**Fresh-subagent-per-issue (canonical Phase 4 path, formerly single-agent absorbed-discipline).** Each issue is processed by a FRESH top-level subagent dispatched by the orchestrator — expand → implement → finalize → peer-review → evaluate-findings → PR → merge — in that subagent's own context. The orchestrator NEVER implements in its own context; it only claims, dispatches, and waits. Each subagent receives full tool access because it is a top-level `Agent` call launched directly by the main session orchestrator. **Constraint:** Subagents spawned by background `Agent` calls do NOT inherit the `Agent` tool, so nested monitors cannot dispatch inner implementers. Phase 4 implementers must be top-level agents launched directly by the main session orchestrator, not nested inside a monitor. The `process(ISSUE)` notation below is shorthand for "dispatch a fresh top-level subagent to do this work", NOT in-context implementation by the orchestrator. Batch>1 is an explicit operator opt-in via `AUTOSPEC_BATCH_SIZE=N`; the default is 1 (one issue per subagent). The `reasoning:deep` force-to-1 rule is retained: deep issues stay batch=1 even under an operator `AUTOSPEC_BATCH_SIZE=N` override.
 
-Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 3). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
+Then launch a **background monitor loop** — the orchestrator relaunches the monitor with fresh context after each batch of `AUTOSPEC_BATCH_SIZE` issues (default: 1). The monitor is stateless: all persistent state lives in GitHub labels and heartbeat files, so relaunches are always safe.
 
 ```
 batch_num=1
 while true:
-  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-3})
+  launch background subagent (pass batch_num; AUTOSPEC_BATCH_SIZE=${AUTOSPEC_BATCH_SIZE:-1})
   wait for task-notification (monitor agent completes)
 
   # Read and consume the batch-done signal.
@@ -705,7 +705,7 @@ while true:
 
 Pass the following prompt verbatim to each background subagent:
 
-> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 3) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
+> You are the auto-implement monitor for `{repo}`. Process `auto-implement` issues one at a time. Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default: 1) by writing `~/.autospec/batch-done.json` — the orchestrator will relaunch you with fresh context.
 
 > **Harness adaptation (loop persistence).** The `while true:` below is pseudocode. In Claude Code, use `/loop` or `ScheduleWakeup` to persist across turns. In Codex CLI and OpenCode, you lack a built-in loop primitive — implement persistence via one of these patterns:
 > 1. **Shell wrapper (preferred):** `exec bash << 'EOF'
@@ -717,7 +717,7 @@ Pass the following prompt verbatim to each background subagent:
 > 3. **tmux pane:** `tmux new-window 'bash << '''HEREDOC'''
 > while true; do ...; done
 > HEREDOC'`
-> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 3) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
+> **Session batching:** Exit after processing `AUTOSPEC_BATCH_SIZE` issues (default 1) by writing `~/.autospec/batch-done.json` with `status=BATCH_COMPLETE`. The orchestrator relaunches you with fresh context. When the queue is fully drained, write `status=ALL_DONE` instead. This keeps each monitor session short to prevent context overflow.
 
 >
 > **Shared helper scripts.** Helper scripts live at `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}` after installation. Do not assume the target repository has an autospec `scripts/` directory.
@@ -726,7 +726,7 @@ Pass the following prompt verbatim to each background subagent:
 > ```
 > # Before the loop (run-once init):
 > #   batch_issue_count=0
-> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-3}"
+> #   BATCH_SIZE="${AUTOSPEC_BATCH_SIZE:-1}"
 > #   [ "$BATCH_SIZE" -gt 0 ] 2>/dev/null || BATCH_SIZE=3   # guard against 0 or negative
 > #   rm -f "$HOME/.autospec/batch-done.json"   # clear stale file from prior crash
 >
@@ -1023,6 +1023,16 @@ Pass the following prompt verbatim to each background subagent:
 >      exit 0
 >    fi
 >    ```
+>    <!-- token-report:begin -->
+>    Post the per-issue token report (best-effort; never fails the run):
+>    ```bash
+>    # Orchestrator writes .autospec/tokens-<ISSUE>.json from Agent-result usage
+>    # (harness-dependent, best-effort; absent fields → null, never blocking).
+>    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/post-token-report.sh" \
+>      --issue "<ISSUE>" --repo "<REPO>" \
+>      --tokens-json ".autospec/tokens-<ISSUE>.json" || true
+>    ```
+>    <!-- token-report:end -->
 >    # Cleanup single-fetch body temp file on terminal success (D5).
 >    rm -f "/tmp/issue-<ISSUE>-body.md" || true
 > 9. FAILURE (loop exhausted): comment failure on issue, swap label `in-progress-by-bot` → `auto-implement`, `gh pr close <PR> --delete-branch`.

--- a/tests/batch-size-gating.bats
+++ b/tests/batch-size-gating.bats
@@ -54,6 +54,41 @@ setup() {
   grep -q 'AUTOSPEC_BATCH_SIZE:-1' "$skill_md"
 }
 
+@test "autospec trio default AUTOSPEC_BATCH_SIZE is 1 (parity with autospec-run, issue #971)" {
+  for f in SKILL.md codex/prompt.md opencode/agent.md; do
+    p="${BATS_TEST_DIRNAME}/../skills/autospec/$f"
+    [ -f "$p" ]
+    # D2: default must be 1, never the legacy 3.
+    grep -q 'AUTOSPEC_BATCH_SIZE:-1' "$p"
+    ! grep -qF 'AUTOSPEC_BATCH_SIZE:-3' "$p"
+    ! grep -qE 'AUTOSPEC_BATCH_SIZE` issues \(default:? 3\)' "$p"
+  done
+}
+
+@test "autospec trio carries fresh-subagent-per-issue prose (D2 parity, issue #971)" {
+  for f in SKILL.md codex/prompt.md opencode/agent.md; do
+    p="${BATS_TEST_DIRNAME}/../skills/autospec/$f"
+    grep -qF 'Fresh-subagent-per-issue (canonical Phase 4 path, formerly single-agent absorbed-discipline)' "$p"
+    grep -qF 'The orchestrator NEVER implements in its own context' "$p"
+    grep -qF 'the default is 1 (one issue per subagent)' "$p"
+  done
+}
+
+@test "autospec trio posts per-issue token report at pinned slot (D1 parity, issue #971)" {
+  for f in SKILL.md codex/prompt.md opencode/agent.md; do
+    p="${BATS_TEST_DIRNAME}/../skills/autospec/$f"
+    grep -qF '<!-- token-report:begin -->' "$p"
+    grep -qF 'post-token-report.sh' "$p"
+    # Pinned slot: token-report:begin must fall between SUCCESS step 8 and FAILURE step 9.
+    slot=$(awk '
+      /(^|> )8\. SUCCESS/ { after=1 }
+      /(^|> )9\. FAILURE/ { after=0 }
+      after && /token-report:begin/ { print "FOUND" }
+    ' "$p")
+    [ "$slot" = "FOUND" ]
+  done
+}
+
 @test "AGENTS.md documents batch default and reasoning:deep gating" {
   agents_md="${BATS_TEST_DIRNAME}/../AGENTS.md"
   [ -f "$agents_md" ]


### PR DESCRIPTION
Closes #971

## Problem
The cost-efficiency epic (#937) D1 (per-issue token reporting) and D2 (batch=1 / fresh-subagent-per-issue) landed on the `skills/autospec-run` trio but silently missed the `skills/autospec` trio's embedded Phase 4 monitor loop. `/autospec` end-to-end runs therefore still defaulted to batch=3 and emitted zero token telemetry. The existing phase4 lock-step gates (guardian / issue-start / next-pickup / test-suite) did not cover batch-default, token-report slot, or absorbed-discipline prose — so the divergence passed CI (Phase 5.5 audit #944 finding).

## Changes (autospec trio: SKILL.md + codex/prompt.md + opencode/agent.md)
- **D2**: both `AUTOSPEC_BATCH_SIZE:-3` → `:-1`; all `default 3`/`default: 3` batch prose → 1; absorbed-discipline paragraph rewritten to the post-#939 fresh-subagent-per-issue wording (textually identical to autospec-run); `reasoning:deep` force-to-1 retained.
- **D1**: `<!-- token-report:begin/end -->` `post-token-report.sh` step inserted at the pinned slot (after admin-merge SUCCESS step 8, before FAILURE step 9 / batch-done), byte-identical to autospec-run.
- Lock-step regenerated; frontmatter-stripped diff empty for both adapters.

## Gate tightening (closes the divergence CLASS)
- New `check_phase4_cost_epic_parity_lockstep` ties batch-default, fresh-subagent prose, and the pinned token-report slot between **both** run trios. Proven to fail on consistent drift of each surface (batch→3, prose revert, token-report removal, slot misplacement).
- bats: autospec-trio batch=1 / fresh-subagent / pinned-token-report assertions added to `tests/batch-size-gating.bats`.

## Verification
`bash scripts/validate.sh` → exit 0 (new gate runs); full bats green; `grep -rn ':-3' skills/autospec/` → zero batch hits. No changes to `skills/autospec-run` (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)