### PR TITLE
feat(autospec-doc): add documentation.auto_regenerate config key + resolveAutoRegenerate helper

### DIFF
--- a/skills/autospec-doc/README.md
+++ b/skills/autospec-doc/README.md
@@ -91,6 +91,13 @@ documentation:
   examples:
     verify: true               # docs-as-tests on/off (default: true)
     sandbox: worktree          # example execution isolation (default: worktree)
+  # documentation.auto_regenerate — opt-in to automatic doc regeneration in runs.
+  # Default: false. Three ways to enable for a given run (highest precedence first):
+  #   1. Add "docs: skip" to the issue body to suppress regardless of other settings.
+  #   2. Add "docs: generate" to the issue body to enable for that issue only.
+  #   3. Set auto_regenerate: true here, or pass --with-docs (AUTOSPEC_WITH_DOCS=1).
+  documentation:
+    auto_regenerate: false
 ```
 
 **Folder contract** per audience: `index.md`, `getting-started.md`,
@@ -101,16 +108,22 @@ are exported from `scripts/doc-config.mjs` as `FOLDER_CONTRACT`.
 
 ### Migration note
 
-The `style` and `examples` keys are **new and optional** — existing
-`documentation:` configs keep working unchanged. If your repo already declares
-`audiences:` (including custom audiences such as `operators` or
+The `style`, `examples`, and `documentation` keys are **new and optional** —
+existing `documentation:` configs keep working unchanged. If your repo already
+declares `audiences:` (including custom audiences such as `operators` or
 `security-reviewers`, or legacy entries keyed by `id`/`label`), those entries
 are preserved **verbatim**: the loader never rewrites their
 `name`/`path`/`focus`/`require_scope` fields and does **not** inject the four
 defaults when any audience is already declared. To adopt the new behavior, add a
 `style:` and/or `examples:` block; omit them to accept the defaults
 (`palette: light-blue`, `examples.verify: true`, `examples.sandbox: worktree`).
-No action is required to upgrade.
+
+The `documentation.auto_regenerate` key (added in #953) defaults to `false` —
+**doc regeneration is off by default**. To enable it globally set
+`documentation.auto_regenerate: true` in your config, or pass `--with-docs`
+(`AUTOSPEC_WITH_DOCS=1`) at run time. To enable it for a single issue only, add
+a `docs: generate` line to the issue body. To suppress it regardless of any
+setting, add `docs: skip` to the issue body. No action is required to upgrade.
 
 ## Self-update
 

--- a/skills/autospec-doc/scripts/doc-config.mjs
+++ b/skills/autospec-doc/scripts/doc-config.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-// doc-config.mjs — config loader for /autospec-doc (issue #917)
+// doc-config.mjs — config loader for /autospec-doc (issue #917, #953)
 //
 // Parses the `documentation:` block from .autospec/autospec.yml, applies
-// defaults for the new optional `style` and `examples` keys, and seeds the
-// four default audiences (user/developer/admin/general) when `audiences:` is
-// absent or empty.
+// defaults for the new optional `style`, `examples`, and `auto_regenerate` keys,
+// and seeds the four default audiences (user/developer/admin/general) when
+// `audiences:` is absent or empty.
 //
 // Existing `audiences:` entries (with any key shape — name/id/label/path/focus/
 // require_scope) are preserved verbatim; this module never mutates or replaces
@@ -12,7 +12,8 @@
 // default audience strings; any change there must propagate here.
 //
 // Exports:
-//   loadConfig(configPath) → { audiences, style, examples }
+//   loadConfig(configPath) → { audiences, style, examples, documentation }
+//   resolveAutoRegenerate({ config, issueBody, withDocsFlag }) → { generate, reason }
 //   DEFAULT_AUDIENCES — the four canonical defaults (array, read-only)
 //   FOLDER_CONTRACT   — the approved folder-contract constants (object, read-only)
 
@@ -253,10 +254,60 @@ function extractDocumentationBlock(text) {
   return block;
 }
 
+// ── resolveAutoRegenerate ──────────────────────────────────────────────────────
+
+// Regex matchers for per-issue body lines (case-insensitive, anchored).
+const SKIP_RE     = /^docs:\s*skip\s*$/im;
+const GENERATE_RE = /^docs:\s*generate\s*$/im;
+
+/**
+ * resolveAutoRegenerate({ config, issueBody, withDocsFlag }) → { generate, reason }
+ *
+ * Determines whether documentation regeneration should run for a given issue,
+ * applying the 3-opt-in precedence defined in the shared-contracts block:
+ *
+ *   Precedence (highest first):
+ *     1. `docs: skip`     in issueBody   → generate=false, reason='skip-line'
+ *     2. `docs: generate` in issueBody   → generate=true,  reason='generate-line'
+ *     3. config.documentation.auto_regenerate === true
+ *        OR withDocsFlag === true         → generate=true,  reason='config' | 'flag'
+ *     4. default                          → generate=false, reason='default-off'
+ *
+ * @param {{ config: object, issueBody: string, withDocsFlag: boolean }} opts
+ * @returns {{ generate: boolean, reason: 'skip-line'|'generate-line'|'config'|'flag'|'default-off' }}
+ */
+export function resolveAutoRegenerate({ config = {}, issueBody = '', withDocsFlag = false } = {}) {
+  const body = typeof issueBody === 'string' ? issueBody : '';
+
+  // 1. `docs: skip` wins over everything.
+  if (SKIP_RE.test(body)) {
+    return { generate: false, reason: 'skip-line' };
+  }
+
+  // 2. `docs: generate` overrides config/flag.
+  if (GENERATE_RE.test(body)) {
+    return { generate: true, reason: 'generate-line' };
+  }
+
+  // 3a. Config opt-in.
+  const autoRegen = config && config.documentation && config.documentation.auto_regenerate;
+  if (autoRegen === true) {
+    return { generate: true, reason: 'config' };
+  }
+
+  // 3b. Per-run flag opt-in (AUTOSPEC_WITH_DOCS=1).
+  if (withDocsFlag === true) {
+    return { generate: true, reason: 'flag' };
+  }
+
+  // 4. Default off.
+  return { generate: false, reason: 'default-off' };
+}
+
 // ── loadConfig ─────────────────────────────────────────────────────────────────
 
 /**
- * loadConfig(configPath) → { audiences, style, examples }
+ * loadConfig(configPath) → { audiences, style, examples, documentation }
  *
  * Reads the `documentation:` block from .autospec/autospec.yml at `configPath`
  * and returns a normalised config object with defaults applied.
@@ -267,9 +318,10 @@ function extractDocumentationBlock(text) {
  *  - style.palette: defaults to 'light-blue'.
  *  - examples.verify: defaults to true.
  *  - examples.sandbox: defaults to 'worktree'.
+ *  - documentation.auto_regenerate: defaults to false (issue #953).
  *
  * @param {string} configPath  Absolute or CWD-relative path to autospec.yml.
- * @returns {{ audiences: object[], style: { palette: string }, examples: { verify: boolean, sandbox: string } }}
+ * @returns {{ audiences: object[], style: { palette: string }, examples: { verify: boolean, sandbox: string }, documentation: { auto_regenerate: boolean } }}
  */
 export function loadConfig(configPath) {
   let raw = '';
@@ -277,9 +329,10 @@ export function loadConfig(configPath) {
     raw = fs.readFileSync(configPath, 'utf8');
   } catch {
     return {
-      audiences: DEFAULT_AUDIENCES.map(a => ({ ...a })),
-      style:    { palette: 'light-blue' },
-      examples: { verify: true, sandbox: 'worktree' },
+      audiences:     DEFAULT_AUDIENCES.map(a => ({ ...a })),
+      style:         { palette: 'light-blue' },
+      examples:      { verify: true, sandbox: 'worktree' },
+      documentation: { auto_regenerate: false },
     };
   }
 
@@ -309,5 +362,14 @@ export function loadConfig(configPath) {
     sandbox: (exRaw.sandbox != null) ? String(exRaw.sandbox)  : 'worktree',
   };
 
-  return { audiences, style, examples };
+  // ── documentation ─────────────────────────────────────────────────────────
+  // The `documentation` sub-key carries run-time switches; `auto_regenerate`
+  // defaults to false (opt-in only).
+  const docRaw = (typeof doc.documentation === 'object' && doc.documentation !== null && !Array.isArray(doc.documentation))
+    ? doc.documentation : {};
+  const documentation = {
+    auto_regenerate: (docRaw.auto_regenerate != null) ? Boolean(docRaw.auto_regenerate) : false,
+  };
+
+  return { audiences, style, examples, documentation };
 }

--- a/skills/autospec-doc/tests/doc-auto-regenerate.test.mjs
+++ b/skills/autospec-doc/tests/doc-auto-regenerate.test.mjs
@@ -1,0 +1,214 @@
+// doc-auto-regenerate.test.mjs — unit tests for resolveAutoRegenerate + auto_regenerate
+// config key in skills/autospec-doc/scripts/doc-config.mjs (issue #953)
+//
+// Tests:
+//   1.  default: no opt-in → generate=false, reason='default-off'
+//   2.  config opt-in alone → generate=true, reason='config'
+//   3.  withDocsFlag opt-in alone → generate=true, reason='flag'
+//   4.  docs: generate body line alone → generate=true, reason='generate-line'
+//   5.  docs: skip beats docs: generate → generate=false, reason='skip-line'
+//   6.  docs: skip beats config opt-in → generate=false, reason='skip-line'
+//   7.  docs: skip beats withDocsFlag → generate=false, reason='skip-line'
+//   8.  docs: generate beats config opt-in (both present) → reason='generate-line'
+//   9.  docs: generate beats withDocsFlag (both present) → reason='generate-line'
+//  10.  docs: generate is case-insensitive → generate=true
+//  11.  docs: skip is case-insensitive → generate=false
+//  12.  docs: generate on its own line (no leading spaces) → matches
+//  13.  partial match does NOT trigger (e.g. "docs: generate more") → default-off
+//  14.  loadConfig returns documentation.auto_regenerate=false by default (no yml)
+//  15.  loadConfig reads documentation.auto_regenerate=true from yml
+//  16.  loadConfig reads documentation.auto_regenerate=false explicitly from yml
+//  17.  loadConfig includes documentation key alongside audiences/style/examples
+//  18.  init round-trip: auto_regenerate key survives write+read
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIG_MOD = path.resolve(__dirname, '../scripts/doc-config.mjs');
+
+const { loadConfig, resolveAutoRegenerate } = await import(CONFIG_MOD);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'doc-auto-regen-test-'));
+}
+
+function writeYml(dir, content) {
+  fs.mkdirSync(path.join(dir, '.autospec'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.autospec', 'autospec.yml'), content, 'utf8');
+}
+
+function configPath(dir) {
+  return path.join(dir, '.autospec', 'autospec.yml');
+}
+
+// ── resolveAutoRegenerate tests ───────────────────────────────────────────────
+
+test('default: no opt-in returns generate=false, reason=default-off', () => {
+  const result = resolveAutoRegenerate({ config: {}, issueBody: '', withDocsFlag: false });
+  assert.strictEqual(result.generate, false);
+  assert.strictEqual(result.reason, 'default-off');
+});
+
+test('config opt-in alone returns generate=true, reason=config', () => {
+  const config = { documentation: { auto_regenerate: true } };
+  const result = resolveAutoRegenerate({ config, issueBody: '', withDocsFlag: false });
+  assert.strictEqual(result.generate, true);
+  assert.strictEqual(result.reason, 'config');
+});
+
+test('withDocsFlag=true alone returns generate=true, reason=flag', () => {
+  const result = resolveAutoRegenerate({ config: {}, issueBody: '', withDocsFlag: true });
+  assert.strictEqual(result.generate, true);
+  assert.strictEqual(result.reason, 'flag');
+});
+
+test('docs: generate body line alone returns generate=true, reason=generate-line', () => {
+  const result = resolveAutoRegenerate({ config: {}, issueBody: 'Some text\ndocs: generate\nMore text', withDocsFlag: false });
+  assert.strictEqual(result.generate, true);
+  assert.strictEqual(result.reason, 'generate-line');
+});
+
+test('docs: skip beats docs: generate → generate=false, reason=skip-line', () => {
+  const result = resolveAutoRegenerate({
+    config: {},
+    issueBody: 'docs: generate\ndocs: skip',
+    withDocsFlag: false,
+  });
+  assert.strictEqual(result.generate, false);
+  assert.strictEqual(result.reason, 'skip-line');
+});
+
+test('docs: skip beats config opt-in → generate=false, reason=skip-line', () => {
+  const config = { documentation: { auto_regenerate: true } };
+  const result = resolveAutoRegenerate({ config, issueBody: 'docs: skip', withDocsFlag: false });
+  assert.strictEqual(result.generate, false);
+  assert.strictEqual(result.reason, 'skip-line');
+});
+
+test('docs: skip beats withDocsFlag → generate=false, reason=skip-line', () => {
+  const result = resolveAutoRegenerate({ config: {}, issueBody: 'docs: skip', withDocsFlag: true });
+  assert.strictEqual(result.generate, false);
+  assert.strictEqual(result.reason, 'skip-line');
+});
+
+test('docs: generate beats config opt-in when both present → reason=generate-line', () => {
+  const config = { documentation: { auto_regenerate: true } };
+  const result = resolveAutoRegenerate({ config, issueBody: 'docs: generate', withDocsFlag: false });
+  assert.strictEqual(result.generate, true);
+  assert.strictEqual(result.reason, 'generate-line');
+});
+
+test('docs: generate beats withDocsFlag when both present → reason=generate-line', () => {
+  const result = resolveAutoRegenerate({ config: {}, issueBody: 'docs: generate', withDocsFlag: true });
+  assert.strictEqual(result.generate, true);
+  assert.strictEqual(result.reason, 'generate-line');
+});
+
+test('docs: generate is case-insensitive → generate=true', () => {
+  const result = resolveAutoRegenerate({ config: {}, issueBody: 'DOCS: GENERATE', withDocsFlag: false });
+  assert.strictEqual(result.generate, true);
+  assert.strictEqual(result.reason, 'generate-line');
+});
+
+test('docs: skip is case-insensitive → generate=false', () => {
+  const result = resolveAutoRegenerate({ config: {}, issueBody: 'DOCS: SKIP', withDocsFlag: false });
+  assert.strictEqual(result.generate, false);
+  assert.strictEqual(result.reason, 'skip-line');
+});
+
+test('docs: generate on its own line (no leading spaces, trailing newlines) matches', () => {
+  // Spec pattern: ^docs:\s*generate\s*$ — no leading-space allowance; line must start with "docs:".
+  const body = '\n\ndocs: generate\n\n';
+  const result = resolveAutoRegenerate({ config: {}, issueBody: body, withDocsFlag: false });
+  assert.strictEqual(result.generate, true);
+  assert.strictEqual(result.reason, 'generate-line');
+});
+
+test('partial match "docs: generate more" does NOT trigger → default-off', () => {
+  const result = resolveAutoRegenerate({ config: {}, issueBody: 'docs: generate more stuff', withDocsFlag: false });
+  assert.strictEqual(result.generate, false);
+  assert.strictEqual(result.reason, 'default-off');
+});
+
+// ── loadConfig documentation.auto_regenerate tests ───────────────────────────
+
+test('loadConfig returns documentation.auto_regenerate=false by default (missing file)', () => {
+  const dir = makeTmpDir();
+  // No yml written — file missing → defaults.
+  const cfg = loadConfig(configPath(dir));
+  assert.strictEqual(cfg.documentation.auto_regenerate, false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('loadConfig reads documentation.auto_regenerate=true from yml', () => {
+  const dir = makeTmpDir();
+  writeYml(dir, [
+    'documentation:',
+    '  documentation:',
+    '    auto_regenerate: true',
+    '',
+  ].join('\n'));
+  const cfg = loadConfig(configPath(dir));
+  assert.strictEqual(cfg.documentation.auto_regenerate, true);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('loadConfig reads documentation.auto_regenerate=false explicitly from yml', () => {
+  const dir = makeTmpDir();
+  writeYml(dir, [
+    'documentation:',
+    '  documentation:',
+    '    auto_regenerate: false',
+    '',
+  ].join('\n'));
+  const cfg = loadConfig(configPath(dir));
+  assert.strictEqual(cfg.documentation.auto_regenerate, false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('loadConfig returns documentation key alongside audiences/style/examples', () => {
+  const dir = makeTmpDir();
+  writeYml(dir, 'documentation:\n  audiences: []\n');
+  const cfg = loadConfig(configPath(dir));
+  assert.ok(typeof cfg.documentation === 'object', 'documentation key must be present');
+  assert.ok('auto_regenerate' in cfg.documentation, 'auto_regenerate must be present');
+  assert.ok(Array.isArray(cfg.audiences), 'audiences must be present');
+  assert.ok(typeof cfg.style === 'object', 'style must be present');
+  assert.ok(typeof cfg.examples === 'object', 'examples must be present');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('init round-trip: auto_regenerate key survives write+read', () => {
+  const dir = makeTmpDir();
+  // Simulate init output — writes the key explicitly with a comment.
+  writeYml(dir, [
+    'documentation:',
+    '  audiences:',
+    '    - {name: user, path: docs/user, focus: "tasks, workflows, how to use features"}',
+    '    - {name: developer, path: docs/developer, focus: "architecture, APIs, extending"}',
+    '    - {name: admin, path: docs/admin, focus: "install, configure, operate, troubleshoot"}',
+    '    - {name: general, path: docs/general, focus: "what it is, why it matters, plain language"}',
+    '  style:',
+    '    palette: light-blue',
+    '  examples:',
+    '    verify: true',
+    '    sandbox: worktree',
+    '  # Set to true or add "docs: generate" to a per-issue body to opt in.',
+    '  documentation:',
+    '    auto_regenerate: false',
+    '',
+  ].join('\n'));
+  const cfg = loadConfig(configPath(dir));
+  assert.strictEqual(cfg.documentation.auto_regenerate, false);
+  assert.deepEqual(cfg.audiences.map(a => a.name), ['user', 'developer', 'admin', 'general']);
+  assert.strictEqual(cfg.style.palette, 'light-blue');
+  assert.strictEqual(cfg.examples.verify, true);
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
Closes #953

## Summary

- Adds `documentation.auto_regenerate` boolean key (default **false**) to `skills/autospec-doc/scripts/doc-config.mjs`; `loadConfig` now returns a `documentation` sub-object alongside `audiences`/`style`/`examples`.
- Exports `resolveAutoRegenerate({config, issueBody, withDocsFlag}) → {generate, reason}` implementing the shared-contracts precedence: `docs: skip` > `docs: generate` > config/flag > default-off.
- Body-line matchers use `^docs:\s*skip\s*$` and `^docs:\s*generate\s*$` (case-insensitive, multiline), consistent with the existing skip matcher.
- README migration note explains the new key, three opt-ins, and precedence order.
- 18 new `node:test` cases in `tests/doc-auto-regenerate.test.mjs` cover the full precedence matrix, case-insensitivity, partial-match suppression, and init round-trip. All 15 existing `doc-config.test.mjs` tests continue to pass.
- `bash scripts/validate.sh` exits 0.