### PR TITLE
feat(autospec-listen): route imperative 'fix' to /autospec end-to-end (#954)

### DIFF
--- a/scripts/listener-match.sh
+++ b/scripts/listener-match.sh
@@ -198,6 +198,7 @@ is_imperative() {
     esac
     for q in should could would shall "do we" "do you" "can we" "can you" \
              "should we" "should i" "could we" "could you" "would you" \
+             "did you" "did we" "did i" "does it" "do they" "do i" \
              why what how when "are we" "is it" "are you"; do
         case "$text" in
             "$q "*|"$q") return 1 ;;
@@ -439,35 +440,40 @@ EOF
     # question/negation/past guards in is_imperative() cover "did you fix it?",
     # "don't fix that yet", and "I fixed it" (past tense — 'fixed' is not the
     # whole word 'fix').
+    # Two tiers of suppression — different exit semantics:
+    #
+    #   (a) Cosmetic table → HARD no-match (stay plain, per spec §D1). These are
+    #       complete trivial-fix requests; emit match:false and return.
+    #   (b) Descriptive/deferred ("a fix" the noun, "... later" the deferral) →
+    #       SKIP the fix route but FALL THROUGH to the downstream
+    #       implement/build/ship chain, so a co-occurring imperative verb still
+    #       routes ("ship a fix" must keep its ship → autospec-run route — #954
+    #       peer-review regression). A bare "this needs a fix" has no other verb
+    #       and falls through to the no-verb-matched no-match anyway.
+    _fix_skip=0
     if has_word "$text_lc" "fix"; then
-        _fix_suppressed=0
-        # Trivial-fix cosmetic table (spec §D1 pins the first seven; "fix the
+        # (a) Trivial-fix cosmetic table (spec §D1 pins the first seven; "fix the
         # whitespace" added during #954 adversarial self-review as a cosmetic
-        # sibling of indentation/formatting). False-negative biased.
+        # sibling of indentation/formatting). False-negative biased; hard exit.
         for _tf in "fix this typo" "fix the typo" "fix the comment" \
                    "fix the indentation" "fix the formatting" "quick fix" \
                    "fix the spelling" "fix the whitespace"; do
             case "$text_lc" in
-                *"$_tf"*) _fix_suppressed=1; break ;;
+                *"$_tf"*) emit_classify_json false "" "" none 0 false "" ""; return 0 ;;
             esac
         done
-        # Descriptive/deferred 'fix' phrasings surfaced by #954 self-review
+        # (b) Descriptive/deferred 'fix' phrasings surfaced by #954 self-review
         # (the #909 noun-co-occurrence lesson): "a fix" is the NOUN, not the
-        # imperative verb ("this needs a fix", "ship a fix"); "i'll fix … later"
-        # / "fix … later" is a deferral, not a now-action. These are too weak an
-        # imperative to launch the full /autospec pipeline. Scoped branch-local
-        # so they only affect the fix route.
-        if [ "$_fix_suppressed" -eq 0 ]; then
-            for _fd in "a fix" "later"; do
-                case "$text_lc" in
-                    *"$_fd"*) _fix_suppressed=1; break ;;
-                esac
-            done
-        fi
-        if [ "$_fix_suppressed" -eq 1 ]; then
-            emit_classify_json false "" "" none 0 false "" ""
-            return 0
-        fi
+        # imperative verb; "... later" is a deferral, not a now-action. Skip the
+        # fix route and let the downstream chain decide — do NOT hard-exit here,
+        # so "ship a fix" keeps its ship route.
+        for _fd in "a fix" "later"; do
+            case "$text_lc" in
+                *"$_fd"*) _fix_skip=1; break ;;
+            esac
+        done
+    fi
+    if has_word "$text_lc" "fix" && [ "$_fix_skip" -eq 0 ]; then
         if is_imperative "$text_lc"; then
             emit_classify_json true autospec fix imperative 0.7 "$is_auto" "" ""
         else

--- a/scripts/listener-match.sh
+++ b/scripts/listener-match.sh
@@ -419,6 +419,63 @@ EOF
         return 0
     fi
 
+    # ── 'fix' — imperative bug-fix intent → /autospec end-to-end (D1, #954) ──────
+    # Whole-word imperative `fix` routes to the `/autospec` umbrella (spec →
+    # issues → run): a fix needs scoping before implementation, unlike the bare
+    # implement/build/ship verbs which route straight to autospec-run. NO gate,
+    # NO confirm (autospec is not a perpetual loop) — the standard one-line
+    # opt-out applies. Confidence 0.7.
+    #
+    # PLACEMENT: evaluated AFTER explore/refine/run (above) so "fix it by
+    # exploring..." and combined-refine phrasings keep their more-specific route,
+    # and BEFORE the implement/build/ship chain below so an incidental build/ship
+    # word in a fix request does not steal it. Mirrors the explore gate's
+    # explicit emit-and-return shape.
+    #
+    # Trivial-fix suppressors (the negative table — false-negative biased): tiny
+    # cosmetic fixes are too small to warrant the full pipeline and must stay
+    # plain. Implemented branch-local (mirroring the run-suppressed objects gate)
+    # so they short-circuit BEFORE the route emits. The inherited D4
+    # question/negation/past guards in is_imperative() cover "did you fix it?",
+    # "don't fix that yet", and "I fixed it" (past tense — 'fixed' is not the
+    # whole word 'fix').
+    if has_word "$text_lc" "fix"; then
+        _fix_suppressed=0
+        # Trivial-fix cosmetic table (spec §D1 pins the first seven; "fix the
+        # whitespace" added during #954 adversarial self-review as a cosmetic
+        # sibling of indentation/formatting). False-negative biased.
+        for _tf in "fix this typo" "fix the typo" "fix the comment" \
+                   "fix the indentation" "fix the formatting" "quick fix" \
+                   "fix the spelling" "fix the whitespace"; do
+            case "$text_lc" in
+                *"$_tf"*) _fix_suppressed=1; break ;;
+            esac
+        done
+        # Descriptive/deferred 'fix' phrasings surfaced by #954 self-review
+        # (the #909 noun-co-occurrence lesson): "a fix" is the NOUN, not the
+        # imperative verb ("this needs a fix", "ship a fix"); "i'll fix … later"
+        # / "fix … later" is a deferral, not a now-action. These are too weak an
+        # imperative to launch the full /autospec pipeline. Scoped branch-local
+        # so they only affect the fix route.
+        if [ "$_fix_suppressed" -eq 0 ]; then
+            for _fd in "a fix" "later"; do
+                case "$text_lc" in
+                    *"$_fd"*) _fix_suppressed=1; break ;;
+                esac
+            done
+        fi
+        if [ "$_fix_suppressed" -eq 1 ]; then
+            emit_classify_json false "" "" none 0 false "" ""
+            return 0
+        fi
+        if is_imperative "$text_lc"; then
+            emit_classify_json true autospec fix imperative 0.7 "$is_auto" "" ""
+        else
+            emit_classify_json false autospec fix incidental 0.2 false "" ""
+        fi
+        return 0
+    fi
+
     # Existing branches (preserved in order).
     if has_word "$text_lc" "autospec"; then
         skill="autospec"; trigger="autospec"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -151,11 +151,21 @@ check_keyword_routing_section() {
             || fail "autospec-listen: $trio missing explore -> /autospec-explore verb-map row"
         grep -q 'explore-confirm' "$skill_dir/$trio" \
             || fail "autospec-listen: $trio missing 'explore-confirm' gate literal"
+        # Issue #954: the imperative `fix` verb-map row must route to the
+        # `/autospec` umbrella with NO gate. The `fix` trigger literal is emitted
+        # by the #954 classifier branch in scripts/listener-match.sh; keep the
+        # trio row in lockstep with it.
+        grep -q '| `fix`' "$skill_dir/$trio" \
+            || fail "autospec-listen: $trio missing 'fix' -> /autospec verb-map row"
     done
     # The explore-confirm gate literal honored in the trio MUST exactly match the
     # one emitted by the classifier (scripts/listener-match.sh, issue #909).
     grep -q 'explore-confirm' scripts/listener-match.sh \
         || fail "scripts/listener-match.sh missing 'explore-confirm' gate literal (classifier/trio drift)"
+    # The `fix` trigger literal honored in the trio MUST exactly match the one
+    # emitted by the classifier (scripts/listener-match.sh, issue #954).
+    grep -q 'autospec fix imperative' scripts/listener-match.sh \
+        || fail "scripts/listener-match.sh missing 'fix' imperative route (classifier/trio drift)"
 }
 
 # Gap-remediation invariants (issue #535, deps #533/#534): the autospec-run

--- a/skills/autospec-listen/SKILL.md
+++ b/skills/autospec-listen/SKILL.md
@@ -118,6 +118,7 @@ The two new trailing fields:
 | `refine and run` / `tune up` (combined) | `/autospec-refine` then `/autospec-run` |
 | `review` | `/autospec-review` |
 | `explore` / `discover` (only with an explicit build/ship/improve action connector, e.g. "explore and ship", "discover features to build") | `/autospec-explore` (gate `explore-confirm`) |
+| `fix` (imperative, e.g. "fix the login flow"; trivial-fix phrasings like "fix the typo", "quick fix", "fix the formatting" stay plain) | the umbrella `/autospec` (no gate) |
 | `autospec …` | the umbrella `/autospec` |
 
 **Auto-route behavior.** When the classifier returns `match:true` with `intent:imperative`, print exactly one line then invoke the mapped skill via the harness skill-invocation primitive:

--- a/skills/autospec-listen/codex/prompt.md
+++ b/skills/autospec-listen/codex/prompt.md
@@ -113,6 +113,7 @@ The two new trailing fields:
 | `refine and run` / `tune up` (combined) | `/autospec-refine` then `/autospec-run` |
 | `review` | `/autospec-review` |
 | `explore` / `discover` (only with an explicit build/ship/improve action connector, e.g. "explore and ship", "discover features to build") | `/autospec-explore` (gate `explore-confirm`) |
+| `fix` (imperative, e.g. "fix the login flow"; trivial-fix phrasings like "fix the typo", "quick fix", "fix the formatting" stay plain) | the umbrella `/autospec` (no gate) |
 | `autospec …` | the umbrella `/autospec` |
 
 **Auto-route behavior.** When the classifier returns `match:true` with `intent:imperative`, print exactly one line then invoke the mapped skill via the harness skill-invocation primitive:

--- a/skills/autospec-listen/opencode/agent.md
+++ b/skills/autospec-listen/opencode/agent.md
@@ -117,6 +117,7 @@ The two new trailing fields:
 | `refine and run` / `tune up` (combined) | `/autospec-refine` then `/autospec-run` |
 | `review` | `/autospec-review` |
 | `explore` / `discover` (only with an explicit build/ship/improve action connector, e.g. "explore and ship", "discover features to build") | `/autospec-explore` (gate `explore-confirm`) |
+| `fix` (imperative, e.g. "fix the login flow"; trivial-fix phrasings like "fix the typo", "quick fix", "fix the formatting" stay plain) | the umbrella `/autospec` (no gate) |
 | `autospec …` | the umbrella `/autospec` |
 
 **Auto-route behavior.** When the classifier returns `match:true` with `intent:imperative`, print exactly one line then invoke the mapped skill via the harness skill-invocation primitive:

--- a/tests/unit/test_listener_classify.bats
+++ b/tests/unit/test_listener_classify.bats
@@ -500,6 +500,14 @@ setup() {
     [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
 }
 
+# No-punctuation interrogative regression (#954 peer-review): "did you fix it"
+# without a trailing '?' must still be caught by the interrogative lead-in.
+@test "classify: 'did you fix it' (no ?) → match:false (interrogative lead-in)" {
+    run "$MATCH" --classify "did you fix it"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
 @test "classify: \"don't fix that yet\" → match:false (negated)" {
     run "$MATCH" --classify "don't fix that yet"
     [ "$status" -eq 0 ]
@@ -548,4 +556,15 @@ setup() {
     [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
     [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec" ]
     [ "$(printf '%s' "$output" | jq -r .trigger)" = "fix" ]
+}
+
+# Regression guard (#954 peer-review): the descriptive "a fix" suppressor must
+# NOT swallow a co-occurring build/ship/implement verb. "ship a fix" keeps its
+# pre-existing ship → autospec-run route (the fix branch falls through, it does
+# not hard no-match).
+@test "classify: 'ship a fix' → autospec-run (ship route preserved, not swallowed)" {
+    run "$MATCH" --classify "ship a fix"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec-run" ]
 }

--- a/tests/unit/test_listener_classify.bats
+++ b/tests/unit/test_listener_classify.bats
@@ -402,3 +402,150 @@ setup() {
     [ "$status" -eq 0 ]
     [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
 }
+
+# ── 'fix' intent → /autospec end-to-end, NO gate (#954, spec §D1) ────────────
+#
+# CLAIM table: imperative whole-word `fix` routes to the `/autospec` umbrella
+# (spec → issues → run) — a fix needs scoping before implementation. The route
+# carries trigger=fix, intent=imperative, confidence=0.7, and NO gate / NO
+# confirm (autospec is not a perpetual loop). Evaluated AFTER explore/refine/run
+# so it never cannibalizes the more-specific branches.
+
+@test "classify: 'fix the login flow' → autospec, intent=imperative, gate=null" {
+    run "$MATCH" --classify "fix the login flow"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec" ]
+    [ "$(printf '%s' "$output" | jq -r .trigger)" = "fix" ]
+    [ "$(printf '%s' "$output" | jq -r .intent)" = "imperative" ]
+    [ "$(printf '%s' "$output" | jq -r .confidence)" = "0.7" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "null" ]
+}
+
+@test "classify: 'fix the race condition in the watchdog' → autospec, gate=null" {
+    run "$MATCH" --classify "fix the race condition in the watchdog"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec" ]
+    [ "$(printf '%s' "$output" | jq -r .trigger)" = "fix" ]
+    [ "$(printf '%s' "$output" | jq -r .intent)" = "imperative" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "null" ]
+}
+
+@test "classify: 'please fix the broken pagination' → autospec, gate=null" {
+    run "$MATCH" --classify "please fix the broken pagination"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec" ]
+    [ "$(printf '%s' "$output" | jq -r .trigger)" = "fix" ]
+    [ "$(printf '%s' "$output" | jq -r .intent)" = "imperative" ]
+    [ "$(printf '%s' "$output" | jq -r .gate)" = "null" ]
+}
+
+# ── 'fix' SUPPRESS table — THE PERMANENT SAFETY GUARD (#954, spec §D1) ────────
+#
+# Trivial-fix phrasings (typo/comment/indentation/formatting/spelling/quick fix)
+# are too small to warrant the /autospec spec→issues→run pipeline and MUST yield
+# match:false (stay plain). Plus the inherited D4 question/negation/past guards
+# ("did you fix it?", "don't fix that yet", "I fixed it"). Do NOT weaken these —
+# a false positive here launches a full end-to-end pipeline on chatter.
+
+@test "classify: 'fix this typo' → match:false (trivial-fix suppressor)" {
+    run "$MATCH" --classify "fix this typo"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'fix the typo' → match:false (trivial-fix suppressor)" {
+    run "$MATCH" --classify "fix the typo"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'fix the comment' → match:false (trivial-fix suppressor)" {
+    run "$MATCH" --classify "fix the comment"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'fix the indentation' → match:false (trivial-fix suppressor)" {
+    run "$MATCH" --classify "fix the indentation"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'fix the formatting' → match:false (trivial-fix suppressor)" {
+    run "$MATCH" --classify "fix the formatting"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'quick fix' → match:false (trivial-fix suppressor)" {
+    run "$MATCH" --classify "quick fix"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'fix the spelling' → match:false (trivial-fix suppressor)" {
+    run "$MATCH" --classify "fix the spelling"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+# Inherited D4 guards applied to 'fix'.
+
+@test "classify: 'did you fix it?' → match:false (interrogative)" {
+    run "$MATCH" --classify "did you fix it?"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: \"don't fix that yet\" → match:false (negated)" {
+    run "$MATCH" --classify "don't fix that yet"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'I fixed it' → match:false (past tense — not the fix verb)" {
+    run "$MATCH" --classify "I fixed it"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+# Additional suppressors surfaced by #954 adversarial self-review (the #909
+# noun-co-occurrence lesson). "fix the whitespace" is a cosmetic sibling of
+# indentation/formatting; "a fix" is the noun not the imperative verb;
+# "i'll fix … later" / "fix … later" is a deferral, not a now-action.
+
+@test "classify: 'fix the whitespace' → match:false (cosmetic suppressor)" {
+    run "$MATCH" --classify "fix the whitespace"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'this needs a fix' → match:false ('a fix' is a noun, not imperative)" {
+    run "$MATCH" --classify "this needs a fix"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: \"I'll fix it later\" → match:false (deferred, not a now-action)" {
+    run "$MATCH" --classify "I'll fix it later"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+@test "classify: 'can you fix the login bug' → match:false (interrogative)" {
+    run "$MATCH" --classify "can you fix the login bug"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "false" ]
+}
+
+# Positive guard: a genuine imperative fix with surrounding words still routes.
+@test "classify: \"let's fix the deploy pipeline\" → autospec (genuine imperative)" {
+    run "$MATCH" --classify "let's fix the deploy pipeline"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r .match)" = "true" ]
+    [ "$(printf '%s' "$output" | jq -r .skill)" = "autospec" ]
+    [ "$(printf '%s' "$output" | jq -r .trigger)" = "fix" ]
+}


### PR DESCRIPTION
Closes #954

## What

Adds a whole-word imperative `fix` branch to the `scripts/listener-match.sh`
classifier that routes to the **`/autospec`** umbrella (spec → issues → run)
with **NO gate** and the standard one-line opt-out, per spec
`docs/specs/2026-06-03-fix-routing-docs-gating-design.md` §D1. A fix needs
scoping before implementation, so it routes to the umbrella rather than
straight to `autospec-run`.

## Placement

Evaluated AFTER the explore/refine/run branches (so "fix it by exploring…"
and combined-refine phrasings keep their more-specific route) and BEFORE the
implement/build/ship chain (so an incidental build/ship word in a fix request
can't steal it).

## Suppressors (the permanent negative safety table)

Two tiers, different exit semantics:

- **Cosmetic table → hard no-match (stay plain, spec §D1):** the seven pinned
  phrases (`fix this typo`, `fix the typo`, `fix the comment`,
  `fix the indentation`, `fix the formatting`, `quick fix`, `fix the spelling`)
  plus `fix the whitespace` (cosmetic sibling, added via adversarial self-review).
- **Descriptive/deferred → skip the fix route, fall through:** `a fix` (noun,
  not the imperative verb) and `… later` (deferral). These do NOT hard-exit, so
  `ship a fix` keeps its existing ship → autospec-run route.

Inherited D4 question/negation/past guards cover `did you fix it?`,
`don't fix that yet`, `I fixed it`. Interrogative lead-ins extended with
`did/do you/we/i` so `did you fix it` (no `?`) is also suppressed.

## Listen trio (lock-step)

Added the `fix → /autospec` verb-map row byte-identically to `SKILL.md`,
`codex/prompt.md`, and `opencode/agent.md`. `scripts/validate.sh` gains a
parallel lock-step check for the fix row + the classifier route literal.

## Pattern survey / reuse

Reusing the existing `has_word` whole-word matcher, the `emit_classify_json`
emitter, and the run-branch's branch-local suppressor-table pattern. No reuse
of new helpers — the explore (#909/#910) and run (#852) branches are the direct
templates this mirrors.

## Tests

`tests/unit/test_listener_classify.bats`: positive table (login flow, watchdog
race, broken pagination, deploy pipeline), the full negative safety table (all
suppressors + question/negation/past/deferred/no-`?` forms), and a `ship a fix`
route-preservation regression guard. All existing explore/refine/run/
implement-build-ship routing tests stay green (70 tests, 0 failures).
`bash scripts/validate.sh` exits 0.

## Peer-review notes (addressed)

Codex peer-review on the diff flagged two must-fix items, both fixed in the
second commit: (1) the `a fix` suppressor swallowing the ship route, and
(2) `did you fix it` (no `?`) not being caught. No nice-to-have findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)