### PR TITLE
feat(autospec-run): gate docs-drift regeneration on auto_regenerate switch (D2b, #955)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -943,6 +943,37 @@ check_phase4_cost_epic_parity_lockstep() {
     info "phase4 cost-epic parity: both trios carry batch=1 + fresh-subagent prose + pinned token-report"
 }
 
+# Docs-drift-gate regeneration conditional parity (issue #955): the D2b gate
+# conditional wrapping the regeneration path must be present in BOTH run trios
+# (autospec + autospec-run, 6 files total). Detection, labels, and the skip log
+# line must be present. Fails CI if either trio drifts back to unconditional regen.
+check_docs_drift_gate_regen_conditional_parity() {
+    info "docs-drift-gate regen conditional parity (D2b): autospec + autospec-run trios (6 files)"
+    for s in autospec autospec-run; do
+        for f in "skills/$s/SKILL.md" "skills/$s/codex/prompt.md" "skills/$s/opencode/agent.md"; do
+            [ -f "$f" ] || fail "$f: required file missing"
+            # Gate conditional: _REGEN resolver must be present.
+            grep -q '_REGEN' "$f" \
+                || fail "$f: missing _REGEN gate variable (D2b auto_regenerate conditional)"
+            # Resolver function must be referenced.
+            grep -q 'resolveAutoRegenerate' "$f" \
+                || fail "$f: missing resolveAutoRegenerate import in gate block (D2b)"
+            # OFF-path log line must be present.
+            grep -qF 'docs: regeneration skipped (auto_regenerate=false)' "$f" \
+                || fail "$f: missing OFF-path log 'docs: regeneration skipped (auto_regenerate=false)' (D2b)"
+            # docs-drift-gate markers must still bracket the section.
+            grep -qF '<!-- docs-drift-gate:begin -->' "$f" \
+                || fail "$f: missing docs-drift-gate:begin marker (D2b)"
+            grep -qF '<!-- docs-drift-gate:end -->' "$f" \
+                || fail "$f: missing docs-drift-gate:end marker (D2b)"
+            # Regeneration path (orchestrator) must still be present inside the gate.
+            grep -q 'doc-orchestrator.mjs' "$f" \
+                || fail "$f: missing doc-orchestrator.mjs inside gate (D2b regenerate path must be preserved)"
+        done
+    done
+    info "docs-drift-gate regen conditional parity: all 6 trio files carry D2b gate"
+}
+
 # Team-personality contract: autospec should infer the right solving team from
 # the request, repository evidence, memories, and prior specs. If confidence is
 # low, it must ask explicitly with five concrete starter combinations, carry
@@ -2026,6 +2057,7 @@ main() {
     check_phase4_adaptive_retry
     check_phase4_full_test_suite_gate
     check_phase4_cost_epic_parity_lockstep
+    check_docs_drift_gate_regen_conditional_parity
     check_autospec_sweep_config_contract
     check_autospec_fleet_scripts
     check_fleet_gui_subcommand_lockstep

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -764,29 +764,49 @@ inline label-swap path below.
 >        VERDICT_JSON="$(printf '%s' "$DRIFT_JSON" | node "$SCRIPTS_DIR/loop-classifier-docs-extension.mjs" --drift-json - --issue "<ISSUE>" --pr "<PR>" 2>/dev/null || true)"
 >        ACTION="$(printf '%s' "$VERDICT_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write((JSON.parse(s).action)||"")}catch{}})' 2>/dev/null || true)"
 >        if [ "$ACTION" = "regenerate" ]; then
->          # Scopes the classifier flagged — regenerate ONLY these via /autospec-doc.
+>          # Scopes the classifier flagged — always extract for labelling/reporting.
 >          mapfile -t SCOPES < <(printf '%s' "$VERDICT_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{for(const x of (JSON.parse(s).scopes||[]))console.log(x)}catch{}})' 2>/dev/null || true)
 >          gh issue edit <ISSUE> --add-label "docs:drift" 2>/dev/null || true
->          doc_ok=1
->          if node "$DOC_SCRIPTS_DIR/doc-orchestrator.mjs" 2>/tmp/docgen-<PR>.err; then
->            # Re-verify regenerated pages; only verified pages are committed.
->            if [ "${#SCOPES[@]}" -gt 0 ] && node "$DOC_SCRIPTS_DIR/verify-examples.mjs" "${SCOPES[@]}" 2>/tmp/docverify-<PR>.err; then
->              if ! git diff --quiet -- "${SCOPES[@]}" 2>/dev/null; then
->                git add -- "${SCOPES[@]}"
->                git commit -m "docs: regenerate ${SCOPES[*]}" || doc_ok=0
->                git push || doc_ok=0
+>          # Resolve the auto_regenerate switch (D2 gate conditional).
+>          # Reads config from .autospec/autospec.yml, issue body from single-fetch file, and
+>          # AUTOSPEC_WITH_DOCS env. Precedence: docs:skip (already handled above) >
+>          # docs:generate > config auto_regenerate=true > AUTOSPEC_WITH_DOCS=1 > default-off.
+>          _REGEN=$(node --input-type=module <<'__REGEN_EOF__' 2>/dev/null || echo "0"
+>          import { resolveAutoRegenerate, loadConfig } from '${AUTOSPEC_DOC_SCRIPTS_DIR:-$HOME/.autospec/skills/autospec-doc/scripts}/doc-config.mjs';
+>          import fs from 'node:fs';
+>          const cfg = (() => { try { return loadConfig('.autospec/autospec.yml'); } catch { return {}; } })();
+>          const body = (() => { try { return fs.readFileSync('/tmp/issue-<ISSUE>-body.md','utf8'); } catch { return ''; } })();
+>          const flag = process.env.AUTOSPEC_WITH_DOCS === '1';
+>          const { generate } = resolveAutoRegenerate({ config: cfg, issueBody: body, withDocsFlag: flag });
+>          process.stdout.write(generate ? '1' : '0');
+>          __REGEN_EOF__
+>          )
+>          if [ "${_REGEN:-0}" = "1" ]; then
+>            # auto_regenerate is ON — run the regenerate self-heal path.
+>            doc_ok=1
+>            if node "$DOC_SCRIPTS_DIR/doc-orchestrator.mjs" 2>/tmp/docgen-<PR>.err; then
+>              # Re-verify regenerated pages; only verified pages are committed.
+>              if [ "${#SCOPES[@]}" -gt 0 ] && node "$DOC_SCRIPTS_DIR/verify-examples.mjs" "${SCOPES[@]}" 2>/tmp/docverify-<PR>.err; then
+>                if ! git diff --quiet -- "${SCOPES[@]}" 2>/dev/null; then
+>                  git add -- "${SCOPES[@]}"
+>                  git commit -m "docs: regenerate ${SCOPES[*]}" || doc_ok=0
+>                  git push || doc_ok=0
+>                fi
+>              else
+>                doc_ok=0  # example verification failed — do NOT commit regenerated docs
 >              fi
 >            else
->              doc_ok=0  # example verification failed — do NOT commit regenerated docs
+>              doc_ok=0    # generation failed
+>            fi
+>            if [ "$doc_ok" = "0" ]; then
+>              gh issue edit <ISSUE> --add-label "docs:failed" 2>/dev/null || true
+>              gh pr comment <PR> --body "$(printf 'docs: regenerate self-heal failed (generation or example verification) — code PR NOT blocked. Scopes: %s' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
+>            else
+>              gh pr comment <PR> --body "$(printf 'docs: regenerated %s in-PR (examples re-verified).' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
 >            fi
 >          else
->            doc_ok=0    # generation failed
->          fi
->          if [ "$doc_ok" = "0" ]; then
->            gh issue edit <ISSUE> --add-label "docs:failed" 2>/dev/null || true
->            gh pr comment <PR> --body "$(printf 'docs: regenerate self-heal failed (generation or example verification) — code PR NOT blocked. Scopes: %s' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
->          else
->            gh pr comment <PR> --body "$(printf 'docs: regenerated %s in-PR (examples re-verified).' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
+>            # auto_regenerate is OFF — log and continue; detection/labels already applied.
+>            echo "docs: regeneration skipped (auto_regenerate=false)"
 >          fi
 >        else
 >          # No regenerate verdict — surface drift for operator review; do not block.

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -759,29 +759,49 @@ inline label-swap path below.
 >        VERDICT_JSON="$(printf '%s' "$DRIFT_JSON" | node "$SCRIPTS_DIR/loop-classifier-docs-extension.mjs" --drift-json - --issue "<ISSUE>" --pr "<PR>" 2>/dev/null || true)"
 >        ACTION="$(printf '%s' "$VERDICT_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write((JSON.parse(s).action)||"")}catch{}})' 2>/dev/null || true)"
 >        if [ "$ACTION" = "regenerate" ]; then
->          # Scopes the classifier flagged — regenerate ONLY these via /autospec-doc.
+>          # Scopes the classifier flagged — always extract for labelling/reporting.
 >          mapfile -t SCOPES < <(printf '%s' "$VERDICT_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{for(const x of (JSON.parse(s).scopes||[]))console.log(x)}catch{}})' 2>/dev/null || true)
 >          gh issue edit <ISSUE> --add-label "docs:drift" 2>/dev/null || true
->          doc_ok=1
->          if node "$DOC_SCRIPTS_DIR/doc-orchestrator.mjs" 2>/tmp/docgen-<PR>.err; then
->            # Re-verify regenerated pages; only verified pages are committed.
->            if [ "${#SCOPES[@]}" -gt 0 ] && node "$DOC_SCRIPTS_DIR/verify-examples.mjs" "${SCOPES[@]}" 2>/tmp/docverify-<PR>.err; then
->              if ! git diff --quiet -- "${SCOPES[@]}" 2>/dev/null; then
->                git add -- "${SCOPES[@]}"
->                git commit -m "docs: regenerate ${SCOPES[*]}" || doc_ok=0
->                git push || doc_ok=0
+>          # Resolve the auto_regenerate switch (D2 gate conditional).
+>          # Reads config from .autospec/autospec.yml, issue body from single-fetch file, and
+>          # AUTOSPEC_WITH_DOCS env. Precedence: docs:skip (already handled above) >
+>          # docs:generate > config auto_regenerate=true > AUTOSPEC_WITH_DOCS=1 > default-off.
+>          _REGEN=$(node --input-type=module <<'__REGEN_EOF__' 2>/dev/null || echo "0"
+>          import { resolveAutoRegenerate, loadConfig } from '${AUTOSPEC_DOC_SCRIPTS_DIR:-$HOME/.autospec/skills/autospec-doc/scripts}/doc-config.mjs';
+>          import fs from 'node:fs';
+>          const cfg = (() => { try { return loadConfig('.autospec/autospec.yml'); } catch { return {}; } })();
+>          const body = (() => { try { return fs.readFileSync('/tmp/issue-<ISSUE>-body.md','utf8'); } catch { return ''; } })();
+>          const flag = process.env.AUTOSPEC_WITH_DOCS === '1';
+>          const { generate } = resolveAutoRegenerate({ config: cfg, issueBody: body, withDocsFlag: flag });
+>          process.stdout.write(generate ? '1' : '0');
+>          __REGEN_EOF__
+>          )
+>          if [ "${_REGEN:-0}" = "1" ]; then
+>            # auto_regenerate is ON — run the regenerate self-heal path.
+>            doc_ok=1
+>            if node "$DOC_SCRIPTS_DIR/doc-orchestrator.mjs" 2>/tmp/docgen-<PR>.err; then
+>              # Re-verify regenerated pages; only verified pages are committed.
+>              if [ "${#SCOPES[@]}" -gt 0 ] && node "$DOC_SCRIPTS_DIR/verify-examples.mjs" "${SCOPES[@]}" 2>/tmp/docverify-<PR>.err; then
+>                if ! git diff --quiet -- "${SCOPES[@]}" 2>/dev/null; then
+>                  git add -- "${SCOPES[@]}"
+>                  git commit -m "docs: regenerate ${SCOPES[*]}" || doc_ok=0
+>                  git push || doc_ok=0
+>                fi
+>              else
+>                doc_ok=0  # example verification failed — do NOT commit regenerated docs
 >              fi
 >            else
->              doc_ok=0  # example verification failed — do NOT commit regenerated docs
+>              doc_ok=0    # generation failed
+>            fi
+>            if [ "$doc_ok" = "0" ]; then
+>              gh issue edit <ISSUE> --add-label "docs:failed" 2>/dev/null || true
+>              gh pr comment <PR> --body "$(printf 'docs: regenerate self-heal failed (generation or example verification) — code PR NOT blocked. Scopes: %s' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
+>            else
+>              gh pr comment <PR> --body "$(printf 'docs: regenerated %s in-PR (examples re-verified).' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
 >            fi
 >          else
->            doc_ok=0    # generation failed
->          fi
->          if [ "$doc_ok" = "0" ]; then
->            gh issue edit <ISSUE> --add-label "docs:failed" 2>/dev/null || true
->            gh pr comment <PR> --body "$(printf 'docs: regenerate self-heal failed (generation or example verification) — code PR NOT blocked. Scopes: %s' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
->          else
->            gh pr comment <PR> --body "$(printf 'docs: regenerated %s in-PR (examples re-verified).' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
+>            # auto_regenerate is OFF — log and continue; detection/labels already applied.
+>            echo "docs: regeneration skipped (auto_regenerate=false)"
 >          fi
 >        else
 >          # No regenerate verdict — surface drift for operator review; do not block.

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -763,29 +763,49 @@ inline label-swap path below.
 >        VERDICT_JSON="$(printf '%s' "$DRIFT_JSON" | node "$SCRIPTS_DIR/loop-classifier-docs-extension.mjs" --drift-json - --issue "<ISSUE>" --pr "<PR>" 2>/dev/null || true)"
 >        ACTION="$(printf '%s' "$VERDICT_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write((JSON.parse(s).action)||"")}catch{}})' 2>/dev/null || true)"
 >        if [ "$ACTION" = "regenerate" ]; then
->          # Scopes the classifier flagged — regenerate ONLY these via /autospec-doc.
+>          # Scopes the classifier flagged — always extract for labelling/reporting.
 >          mapfile -t SCOPES < <(printf '%s' "$VERDICT_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{for(const x of (JSON.parse(s).scopes||[]))console.log(x)}catch{}})' 2>/dev/null || true)
 >          gh issue edit <ISSUE> --add-label "docs:drift" 2>/dev/null || true
->          doc_ok=1
->          if node "$DOC_SCRIPTS_DIR/doc-orchestrator.mjs" 2>/tmp/docgen-<PR>.err; then
->            # Re-verify regenerated pages; only verified pages are committed.
->            if [ "${#SCOPES[@]}" -gt 0 ] && node "$DOC_SCRIPTS_DIR/verify-examples.mjs" "${SCOPES[@]}" 2>/tmp/docverify-<PR>.err; then
->              if ! git diff --quiet -- "${SCOPES[@]}" 2>/dev/null; then
->                git add -- "${SCOPES[@]}"
->                git commit -m "docs: regenerate ${SCOPES[*]}" || doc_ok=0
->                git push || doc_ok=0
+>          # Resolve the auto_regenerate switch (D2 gate conditional).
+>          # Reads config from .autospec/autospec.yml, issue body from single-fetch file, and
+>          # AUTOSPEC_WITH_DOCS env. Precedence: docs:skip (already handled above) >
+>          # docs:generate > config auto_regenerate=true > AUTOSPEC_WITH_DOCS=1 > default-off.
+>          _REGEN=$(node --input-type=module <<'__REGEN_EOF__' 2>/dev/null || echo "0"
+>          import { resolveAutoRegenerate, loadConfig } from '${AUTOSPEC_DOC_SCRIPTS_DIR:-$HOME/.autospec/skills/autospec-doc/scripts}/doc-config.mjs';
+>          import fs from 'node:fs';
+>          const cfg = (() => { try { return loadConfig('.autospec/autospec.yml'); } catch { return {}; } })();
+>          const body = (() => { try { return fs.readFileSync('/tmp/issue-<ISSUE>-body.md','utf8'); } catch { return ''; } })();
+>          const flag = process.env.AUTOSPEC_WITH_DOCS === '1';
+>          const { generate } = resolveAutoRegenerate({ config: cfg, issueBody: body, withDocsFlag: flag });
+>          process.stdout.write(generate ? '1' : '0');
+>          __REGEN_EOF__
+>          )
+>          if [ "${_REGEN:-0}" = "1" ]; then
+>            # auto_regenerate is ON — run the regenerate self-heal path.
+>            doc_ok=1
+>            if node "$DOC_SCRIPTS_DIR/doc-orchestrator.mjs" 2>/tmp/docgen-<PR>.err; then
+>              # Re-verify regenerated pages; only verified pages are committed.
+>              if [ "${#SCOPES[@]}" -gt 0 ] && node "$DOC_SCRIPTS_DIR/verify-examples.mjs" "${SCOPES[@]}" 2>/tmp/docverify-<PR>.err; then
+>                if ! git diff --quiet -- "${SCOPES[@]}" 2>/dev/null; then
+>                  git add -- "${SCOPES[@]}"
+>                  git commit -m "docs: regenerate ${SCOPES[*]}" || doc_ok=0
+>                  git push || doc_ok=0
+>                fi
+>              else
+>                doc_ok=0  # example verification failed — do NOT commit regenerated docs
 >              fi
 >            else
->              doc_ok=0  # example verification failed — do NOT commit regenerated docs
+>              doc_ok=0    # generation failed
+>            fi
+>            if [ "$doc_ok" = "0" ]; then
+>              gh issue edit <ISSUE> --add-label "docs:failed" 2>/dev/null || true
+>              gh pr comment <PR> --body "$(printf 'docs: regenerate self-heal failed (generation or example verification) — code PR NOT blocked. Scopes: %s' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
+>            else
+>              gh pr comment <PR> --body "$(printf 'docs: regenerated %s in-PR (examples re-verified).' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
 >            fi
 >          else
->            doc_ok=0    # generation failed
->          fi
->          if [ "$doc_ok" = "0" ]; then
->            gh issue edit <ISSUE> --add-label "docs:failed" 2>/dev/null || true
->            gh pr comment <PR> --body "$(printf 'docs: regenerate self-heal failed (generation or example verification) — code PR NOT blocked. Scopes: %s' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
->          else
->            gh pr comment <PR> --body "$(printf 'docs: regenerated %s in-PR (examples re-verified).' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
+>            # auto_regenerate is OFF — log and continue; detection/labels already applied.
+>            echo "docs: regeneration skipped (auto_regenerate=false)"
 >          fi
 >        else
 >          # No regenerate verdict — surface drift for operator review; do not block.

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -907,6 +907,79 @@ Pass the following prompt verbatim to each background subagent:
 >    2. Else run every command listed under the issue's **Operator/full verification** section.
 >    3. Else run the repo-standard full suite: `bash scripts/validate.sh` when present; otherwise use the ecosystem default (`npm test`, `pytest`, `go test ./...`, `cargo test`, `mvn test`, etc.).
 >    If the full suite fails, fix the failure, recommit, rerun the full suite, and repeat. Do NOT dispatch LGTM review while the full suite is failing. Do NOT run `gh pr merge` while the full suite is failing. Record the exact full-suite command and passing output summary in the PR comment or final report.
+> 3b. <!-- docs-drift-gate:begin -->
+> ## Docs drift gate
+> Run after full test suite gate, before LGTM review. Skip if issue body contains a line matching `^docs:\s*skip\s*$` (case-insensitive). On `drift`/`missing_scope`/`example_stale` the classifier emits the pinned `regenerate` action carrying the affected scopes; the gate self-heals by invoking `/autospec-doc` (via `doc-orchestrator.mjs`) scoped to ONLY those scopes, re-verifying the regenerated pages with `verify-examples.mjs`, and committing `docs: regenerate <scopes>` onto the SAME PR branch. **Doc generation NEVER blocks the code PR** — generation/verification failure only warns, applies the `docs:failed` label, and comments; the code review loop continues. Only the regenerate commit's own example verification gates the regenerated docs (failing pages are NOT committed):
+>    ```bash
+>    if ! grep -qiE '^docs:[[:space:]]*skip[[:space:]]*$' "/tmp/issue-<ISSUE>-body.md" 2>/dev/null; then
+>      SCRIPTS_DIR="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}"
+>      DOC_SCRIPTS_DIR="${AUTOSPEC_DOC_SCRIPTS_DIR:-$HOME/.autospec/skills/autospec-doc/scripts}"
+>      DRIFT_JSON="$(bash "$SCRIPTS_DIR/check-doc-drift.sh" --pr "<PR>" 2>/tmp/drift-<PR>.err)"; drift_exit=$?
+>      if [ "$drift_exit" = "0" ]; then
+>        : # no drift — continue to LGTM
+>      else
+>        # drift_exit 1 (drift/example_stale) or 2 (missing_scope): classify, then
+>        # self-heal in-PR when the classifier emits the `regenerate` action.
+>        VERDICT_JSON="$(printf '%s' "$DRIFT_JSON" | node "$SCRIPTS_DIR/loop-classifier-docs-extension.mjs" --drift-json - --issue "<ISSUE>" --pr "<PR>" 2>/dev/null || true)"
+>        ACTION="$(printf '%s' "$VERDICT_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write((JSON.parse(s).action)||"")}catch{}})' 2>/dev/null || true)"
+>        if [ "$ACTION" = "regenerate" ]; then
+>          # Scopes the classifier flagged — always extract for labelling/reporting.
+>          mapfile -t SCOPES < <(printf '%s' "$VERDICT_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{for(const x of (JSON.parse(s).scopes||[]))console.log(x)}catch{}})' 2>/dev/null || true)
+>          gh issue edit <ISSUE> --add-label "docs:drift" 2>/dev/null || true
+>          # Resolve the auto_regenerate switch (D2 gate conditional).
+>          # Reads config from .autospec/autospec.yml, issue body from single-fetch file, and
+>          # AUTOSPEC_WITH_DOCS env. Precedence: docs:skip (already handled above) >
+>          # docs:generate > config auto_regenerate=true > AUTOSPEC_WITH_DOCS=1 > default-off.
+>          _REGEN=$(node --input-type=module <<'__REGEN_EOF__' 2>/dev/null || echo "0"
+>          import { resolveAutoRegenerate, loadConfig } from '${AUTOSPEC_DOC_SCRIPTS_DIR:-$HOME/.autospec/skills/autospec-doc/scripts}/doc-config.mjs';
+>          import fs from 'node:fs';
+>          const cfg = (() => { try { return loadConfig('.autospec/autospec.yml'); } catch { return {}; } })();
+>          const body = (() => { try { return fs.readFileSync('/tmp/issue-<ISSUE>-body.md','utf8'); } catch { return ''; } })();
+>          const flag = process.env.AUTOSPEC_WITH_DOCS === '1';
+>          const { generate } = resolveAutoRegenerate({ config: cfg, issueBody: body, withDocsFlag: flag });
+>          process.stdout.write(generate ? '1' : '0');
+>          __REGEN_EOF__
+>          )
+>          if [ "${_REGEN:-0}" = "1" ]; then
+>            # auto_regenerate is ON — run the regenerate self-heal path.
+>            doc_ok=1
+>            if node "$DOC_SCRIPTS_DIR/doc-orchestrator.mjs" 2>/tmp/docgen-<PR>.err; then
+>              # Re-verify regenerated pages; only verified pages are committed.
+>              if [ "${#SCOPES[@]}" -gt 0 ] && node "$DOC_SCRIPTS_DIR/verify-examples.mjs" "${SCOPES[@]}" 2>/tmp/docverify-<PR>.err; then
+>                if ! git diff --quiet -- "${SCOPES[@]}" 2>/dev/null; then
+>                  git add -- "${SCOPES[@]}"
+>                  git commit -m "docs: regenerate ${SCOPES[*]}" || doc_ok=0
+>                  git push || doc_ok=0
+>                fi
+>              else
+>                doc_ok=0  # example verification failed — do NOT commit regenerated docs
+>              fi
+>            else
+>              doc_ok=0    # generation failed
+>            fi
+>            if [ "$doc_ok" = "0" ]; then
+>              gh issue edit <ISSUE> --add-label "docs:failed" 2>/dev/null || true
+>              gh pr comment <PR> --body "$(printf 'docs: regenerate self-heal failed (generation or example verification) — code PR NOT blocked. Scopes: %s' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
+>            else
+>              gh pr comment <PR> --body "$(printf 'docs: regenerated %s in-PR (examples re-verified).' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
+>            fi
+>          else
+>            # auto_regenerate is OFF — log and continue; detection/labels already applied.
+>            echo "docs: regeneration skipped (auto_regenerate=false)"
+>          fi
+>        else
+>          # No regenerate verdict — surface drift for operator review; do not block.
+>          gh pr comment <PR> --body "$(printf 'docs drift detected — no self-heal action emitted:\n\n```json\n%s\n```' "$DRIFT_JSON")" 2>/dev/null || true
+>          gh issue edit <ISSUE> --add-label "docs:drift" 2>/dev/null || true
+>          if [ "$drift_exit" = "2" ]; then gh issue edit <ISSUE> --add-label "docs:missing-scope" 2>/dev/null || true; fi
+>        fi
+>      fi
+>    else
+>      gh pr comment <PR> --body "docs: drift check skipped (docs:skip in issue body)" 2>/dev/null || true
+>      gh issue edit <ISSUE> --add-label "docs:skipped" 2>/dev/null || true
+>    fi
+>    ```
+>    <!-- docs-drift-gate:end -->
 > 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
 > 5. Push: git push -u origin <BRANCH>
 >    ```bash

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -901,6 +901,79 @@ Pass the following prompt verbatim to each background subagent:
 >    2. Else run every command listed under the issue's **Operator/full verification** section.
 >    3. Else run the repo-standard full suite: `bash scripts/validate.sh` when present; otherwise use the ecosystem default (`npm test`, `pytest`, `go test ./...`, `cargo test`, `mvn test`, etc.).
 >    If the full suite fails, fix the failure, recommit, rerun the full suite, and repeat. Do NOT dispatch LGTM review while the full suite is failing. Do NOT run `gh pr merge` while the full suite is failing. Record the exact full-suite command and passing output summary in the PR comment or final report.
+> 3b. <!-- docs-drift-gate:begin -->
+> ## Docs drift gate
+> Run after full test suite gate, before LGTM review. Skip if issue body contains a line matching `^docs:\s*skip\s*$` (case-insensitive). On `drift`/`missing_scope`/`example_stale` the classifier emits the pinned `regenerate` action carrying the affected scopes; the gate self-heals by invoking `/autospec-doc` (via `doc-orchestrator.mjs`) scoped to ONLY those scopes, re-verifying the regenerated pages with `verify-examples.mjs`, and committing `docs: regenerate <scopes>` onto the SAME PR branch. **Doc generation NEVER blocks the code PR** — generation/verification failure only warns, applies the `docs:failed` label, and comments; the code review loop continues. Only the regenerate commit's own example verification gates the regenerated docs (failing pages are NOT committed):
+>    ```bash
+>    if ! grep -qiE '^docs:[[:space:]]*skip[[:space:]]*$' "/tmp/issue-<ISSUE>-body.md" 2>/dev/null; then
+>      SCRIPTS_DIR="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}"
+>      DOC_SCRIPTS_DIR="${AUTOSPEC_DOC_SCRIPTS_DIR:-$HOME/.autospec/skills/autospec-doc/scripts}"
+>      DRIFT_JSON="$(bash "$SCRIPTS_DIR/check-doc-drift.sh" --pr "<PR>" 2>/tmp/drift-<PR>.err)"; drift_exit=$?
+>      if [ "$drift_exit" = "0" ]; then
+>        : # no drift — continue to LGTM
+>      else
+>        # drift_exit 1 (drift/example_stale) or 2 (missing_scope): classify, then
+>        # self-heal in-PR when the classifier emits the `regenerate` action.
+>        VERDICT_JSON="$(printf '%s' "$DRIFT_JSON" | node "$SCRIPTS_DIR/loop-classifier-docs-extension.mjs" --drift-json - --issue "<ISSUE>" --pr "<PR>" 2>/dev/null || true)"
+>        ACTION="$(printf '%s' "$VERDICT_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write((JSON.parse(s).action)||"")}catch{}})' 2>/dev/null || true)"
+>        if [ "$ACTION" = "regenerate" ]; then
+>          # Scopes the classifier flagged — always extract for labelling/reporting.
+>          mapfile -t SCOPES < <(printf '%s' "$VERDICT_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{for(const x of (JSON.parse(s).scopes||[]))console.log(x)}catch{}})' 2>/dev/null || true)
+>          gh issue edit <ISSUE> --add-label "docs:drift" 2>/dev/null || true
+>          # Resolve the auto_regenerate switch (D2 gate conditional).
+>          # Reads config from .autospec/autospec.yml, issue body from single-fetch file, and
+>          # AUTOSPEC_WITH_DOCS env. Precedence: docs:skip (already handled above) >
+>          # docs:generate > config auto_regenerate=true > AUTOSPEC_WITH_DOCS=1 > default-off.
+>          _REGEN=$(node --input-type=module <<'__REGEN_EOF__' 2>/dev/null || echo "0"
+>          import { resolveAutoRegenerate, loadConfig } from '${AUTOSPEC_DOC_SCRIPTS_DIR:-$HOME/.autospec/skills/autospec-doc/scripts}/doc-config.mjs';
+>          import fs from 'node:fs';
+>          const cfg = (() => { try { return loadConfig('.autospec/autospec.yml'); } catch { return {}; } })();
+>          const body = (() => { try { return fs.readFileSync('/tmp/issue-<ISSUE>-body.md','utf8'); } catch { return ''; } })();
+>          const flag = process.env.AUTOSPEC_WITH_DOCS === '1';
+>          const { generate } = resolveAutoRegenerate({ config: cfg, issueBody: body, withDocsFlag: flag });
+>          process.stdout.write(generate ? '1' : '0');
+>          __REGEN_EOF__
+>          )
+>          if [ "${_REGEN:-0}" = "1" ]; then
+>            # auto_regenerate is ON — run the regenerate self-heal path.
+>            doc_ok=1
+>            if node "$DOC_SCRIPTS_DIR/doc-orchestrator.mjs" 2>/tmp/docgen-<PR>.err; then
+>              # Re-verify regenerated pages; only verified pages are committed.
+>              if [ "${#SCOPES[@]}" -gt 0 ] && node "$DOC_SCRIPTS_DIR/verify-examples.mjs" "${SCOPES[@]}" 2>/tmp/docverify-<PR>.err; then
+>                if ! git diff --quiet -- "${SCOPES[@]}" 2>/dev/null; then
+>                  git add -- "${SCOPES[@]}"
+>                  git commit -m "docs: regenerate ${SCOPES[*]}" || doc_ok=0
+>                  git push || doc_ok=0
+>                fi
+>              else
+>                doc_ok=0  # example verification failed — do NOT commit regenerated docs
+>              fi
+>            else
+>              doc_ok=0    # generation failed
+>            fi
+>            if [ "$doc_ok" = "0" ]; then
+>              gh issue edit <ISSUE> --add-label "docs:failed" 2>/dev/null || true
+>              gh pr comment <PR> --body "$(printf 'docs: regenerate self-heal failed (generation or example verification) — code PR NOT blocked. Scopes: %s' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
+>            else
+>              gh pr comment <PR> --body "$(printf 'docs: regenerated %s in-PR (examples re-verified).' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
+>            fi
+>          else
+>            # auto_regenerate is OFF — log and continue; detection/labels already applied.
+>            echo "docs: regeneration skipped (auto_regenerate=false)"
+>          fi
+>        else
+>          # No regenerate verdict — surface drift for operator review; do not block.
+>          gh pr comment <PR> --body "$(printf 'docs drift detected — no self-heal action emitted:\n\n```json\n%s\n```' "$DRIFT_JSON")" 2>/dev/null || true
+>          gh issue edit <ISSUE> --add-label "docs:drift" 2>/dev/null || true
+>          if [ "$drift_exit" = "2" ]; then gh issue edit <ISSUE> --add-label "docs:missing-scope" 2>/dev/null || true; fi
+>        fi
+>      fi
+>    else
+>      gh pr comment <PR> --body "docs: drift check skipped (docs:skip in issue body)" 2>/dev/null || true
+>      gh issue edit <ISSUE> --add-label "docs:skipped" 2>/dev/null || true
+>    fi
+>    ```
+>    <!-- docs-drift-gate:end -->
 > 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
 > 5. Push: git push -u origin <BRANCH>
 >    ```bash

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -905,6 +905,79 @@ Pass the following prompt verbatim to each background subagent:
 >    2. Else run every command listed under the issue's **Operator/full verification** section.
 >    3. Else run the repo-standard full suite: `bash scripts/validate.sh` when present; otherwise use the ecosystem default (`npm test`, `pytest`, `go test ./...`, `cargo test`, `mvn test`, etc.).
 >    If the full suite fails, fix the failure, recommit, rerun the full suite, and repeat. Do NOT dispatch LGTM review while the full suite is failing. Do NOT run `gh pr merge` while the full suite is failing. Record the exact full-suite command and passing output summary in the PR comment or final report.
+> 3b. <!-- docs-drift-gate:begin -->
+> ## Docs drift gate
+> Run after full test suite gate, before LGTM review. Skip if issue body contains a line matching `^docs:\s*skip\s*$` (case-insensitive). On `drift`/`missing_scope`/`example_stale` the classifier emits the pinned `regenerate` action carrying the affected scopes; the gate self-heals by invoking `/autospec-doc` (via `doc-orchestrator.mjs`) scoped to ONLY those scopes, re-verifying the regenerated pages with `verify-examples.mjs`, and committing `docs: regenerate <scopes>` onto the SAME PR branch. **Doc generation NEVER blocks the code PR** — generation/verification failure only warns, applies the `docs:failed` label, and comments; the code review loop continues. Only the regenerate commit's own example verification gates the regenerated docs (failing pages are NOT committed):
+>    ```bash
+>    if ! grep -qiE '^docs:[[:space:]]*skip[[:space:]]*$' "/tmp/issue-<ISSUE>-body.md" 2>/dev/null; then
+>      SCRIPTS_DIR="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}"
+>      DOC_SCRIPTS_DIR="${AUTOSPEC_DOC_SCRIPTS_DIR:-$HOME/.autospec/skills/autospec-doc/scripts}"
+>      DRIFT_JSON="$(bash "$SCRIPTS_DIR/check-doc-drift.sh" --pr "<PR>" 2>/tmp/drift-<PR>.err)"; drift_exit=$?
+>      if [ "$drift_exit" = "0" ]; then
+>        : # no drift — continue to LGTM
+>      else
+>        # drift_exit 1 (drift/example_stale) or 2 (missing_scope): classify, then
+>        # self-heal in-PR when the classifier emits the `regenerate` action.
+>        VERDICT_JSON="$(printf '%s' "$DRIFT_JSON" | node "$SCRIPTS_DIR/loop-classifier-docs-extension.mjs" --drift-json - --issue "<ISSUE>" --pr "<PR>" 2>/dev/null || true)"
+>        ACTION="$(printf '%s' "$VERDICT_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write((JSON.parse(s).action)||"")}catch{}})' 2>/dev/null || true)"
+>        if [ "$ACTION" = "regenerate" ]; then
+>          # Scopes the classifier flagged — always extract for labelling/reporting.
+>          mapfile -t SCOPES < <(printf '%s' "$VERDICT_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{for(const x of (JSON.parse(s).scopes||[]))console.log(x)}catch{}})' 2>/dev/null || true)
+>          gh issue edit <ISSUE> --add-label "docs:drift" 2>/dev/null || true
+>          # Resolve the auto_regenerate switch (D2 gate conditional).
+>          # Reads config from .autospec/autospec.yml, issue body from single-fetch file, and
+>          # AUTOSPEC_WITH_DOCS env. Precedence: docs:skip (already handled above) >
+>          # docs:generate > config auto_regenerate=true > AUTOSPEC_WITH_DOCS=1 > default-off.
+>          _REGEN=$(node --input-type=module <<'__REGEN_EOF__' 2>/dev/null || echo "0"
+>          import { resolveAutoRegenerate, loadConfig } from '${AUTOSPEC_DOC_SCRIPTS_DIR:-$HOME/.autospec/skills/autospec-doc/scripts}/doc-config.mjs';
+>          import fs from 'node:fs';
+>          const cfg = (() => { try { return loadConfig('.autospec/autospec.yml'); } catch { return {}; } })();
+>          const body = (() => { try { return fs.readFileSync('/tmp/issue-<ISSUE>-body.md','utf8'); } catch { return ''; } })();
+>          const flag = process.env.AUTOSPEC_WITH_DOCS === '1';
+>          const { generate } = resolveAutoRegenerate({ config: cfg, issueBody: body, withDocsFlag: flag });
+>          process.stdout.write(generate ? '1' : '0');
+>          __REGEN_EOF__
+>          )
+>          if [ "${_REGEN:-0}" = "1" ]; then
+>            # auto_regenerate is ON — run the regenerate self-heal path.
+>            doc_ok=1
+>            if node "$DOC_SCRIPTS_DIR/doc-orchestrator.mjs" 2>/tmp/docgen-<PR>.err; then
+>              # Re-verify regenerated pages; only verified pages are committed.
+>              if [ "${#SCOPES[@]}" -gt 0 ] && node "$DOC_SCRIPTS_DIR/verify-examples.mjs" "${SCOPES[@]}" 2>/tmp/docverify-<PR>.err; then
+>                if ! git diff --quiet -- "${SCOPES[@]}" 2>/dev/null; then
+>                  git add -- "${SCOPES[@]}"
+>                  git commit -m "docs: regenerate ${SCOPES[*]}" || doc_ok=0
+>                  git push || doc_ok=0
+>                fi
+>              else
+>                doc_ok=0  # example verification failed — do NOT commit regenerated docs
+>              fi
+>            else
+>              doc_ok=0    # generation failed
+>            fi
+>            if [ "$doc_ok" = "0" ]; then
+>              gh issue edit <ISSUE> --add-label "docs:failed" 2>/dev/null || true
+>              gh pr comment <PR> --body "$(printf 'docs: regenerate self-heal failed (generation or example verification) — code PR NOT blocked. Scopes: %s' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
+>            else
+>              gh pr comment <PR> --body "$(printf 'docs: regenerated %s in-PR (examples re-verified).' "${SCOPES[*]:-<none>}")" 2>/dev/null || true
+>            fi
+>          else
+>            # auto_regenerate is OFF — log and continue; detection/labels already applied.
+>            echo "docs: regeneration skipped (auto_regenerate=false)"
+>          fi
+>        else
+>          # No regenerate verdict — surface drift for operator review; do not block.
+>          gh pr comment <PR> --body "$(printf 'docs drift detected — no self-heal action emitted:\n\n```json\n%s\n```' "$DRIFT_JSON")" 2>/dev/null || true
+>          gh issue edit <ISSUE> --add-label "docs:drift" 2>/dev/null || true
+>          if [ "$drift_exit" = "2" ]; then gh issue edit <ISSUE> --add-label "docs:missing-scope" 2>/dev/null || true; fi
+>        fi
+>      fi
+>    else
+>      gh pr comment <PR> --body "docs: drift check skipped (docs:skip in issue body)" 2>/dev/null || true
+>      gh issue edit <ISSUE> --add-label "docs:skipped" 2>/dev/null || true
+>    fi
+>    ```
+>    <!-- docs-drift-gate:end -->
 > 4. Conventional commits (feat:/fix:/test:/docs:/refactor:). NEVER bypass hooks. NEVER amend.
 > 5. Push: git push -u origin <BRANCH>
 >    ```bash

--- a/tests/phase4/test_docs_drift_gate_regen_conditional.sh
+++ b/tests/phase4/test_docs_drift_gate_regen_conditional.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# tests/phase4/test_docs_drift_gate_regen_conditional.sh
+# Verifies the docs-drift-gate auto_regenerate conditional (issue #955, spec §D2b):
+#   1. All 6 run-trio files carry the _REGEN gate wrapping the regeneration path.
+#   2. Detection, labels, and classifier verdict logging are OUTSIDE the _REGEN gate.
+#   3. The OFF-path log line is present in all 6 files.
+#   4. The gate bash extracted from each SKILL.md is well-formed (bash -n).
+#   5. doc-orchestrator.mjs is inside the _REGEN=1 gate in all 6 files.
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# ── File sets for both run trios ─────────────────────────────────────────────
+
+RUN_SKILL="$SCRIPT_DIR/skills/autospec-run/SKILL.md"
+RUN_CODEX="$SCRIPT_DIR/skills/autospec-run/codex/prompt.md"
+RUN_OPENCODE="$SCRIPT_DIR/skills/autospec-run/opencode/agent.md"
+
+AS_SKILL="$SCRIPT_DIR/skills/autospec/SKILL.md"
+AS_CODEX="$SCRIPT_DIR/skills/autospec/codex/prompt.md"
+AS_OPENCODE="$SCRIPT_DIR/skills/autospec/opencode/agent.md"
+
+ALL_SIX="$RUN_SKILL $RUN_CODEX $RUN_OPENCODE $AS_SKILL $AS_CODEX $AS_OPENCODE"
+
+# ── 1. Gate conditional present in all 6 files ───────────────────────────────
+
+for f in $ALL_SIX; do
+    name="${f#"$SCRIPT_DIR"/}"
+
+    # The _REGEN resolver call must be present.
+    grep -q '_REGEN' "$f" \
+        || fail "$name: missing _REGEN gate variable (auto_regenerate conditional)"
+
+    # The resolver import must reference resolveAutoRegenerate.
+    grep -q 'resolveAutoRegenerate' "$f" \
+        || fail "$name: missing resolveAutoRegenerate import in gate block"
+
+    # The OFF-path log line must be present.
+    grep -qF 'docs: regeneration skipped (auto_regenerate=false)' "$f" \
+        || fail "$name: missing OFF-path log line 'docs: regeneration skipped (auto_regenerate=false)'"
+
+    # doc-orchestrator.mjs must still be present (regenerate path preserved).
+    grep -q 'doc-orchestrator.mjs' "$f" \
+        || fail "$name: missing doc-orchestrator.mjs (regenerate path must be preserved)"
+
+    # The docs-drift-gate markers must still bracket the section.
+    grep -qF '<!-- docs-drift-gate:begin -->' "$f" \
+        || fail "$name: missing docs-drift-gate:begin marker"
+    grep -qF '<!-- docs-drift-gate:end -->' "$f" \
+        || fail "$name: missing docs-drift-gate:end marker"
+done
+
+# ── 2. Detection / labels are OUTSIDE the _REGEN gate ─────────────────────────
+# In SKILL.md for each trio: the docs:drift label application for the regenerate
+# branch must appear BEFORE (i.e. at a lower line number than) the _REGEN check.
+# This ensures detection always runs regardless of auto_regenerate setting.
+
+for SKILL in "$RUN_SKILL" "$AS_SKILL"; do
+    name="${SKILL#"$SCRIPT_DIR"/}"
+
+    drift_label_line=$(grep -n '"docs:drift"' "$SKILL" | grep 'add-label' | head -1 | cut -d: -f1)
+    regen_check_line=$(grep -n '_REGEN' "$SKILL" | head -1 | cut -d: -f1)
+
+    [ -n "$drift_label_line" ] \
+        || fail "$name: docs:drift label application not found"
+    [ -n "$regen_check_line" ] \
+        || fail "$name: _REGEN gate check not found"
+
+    if [ "$drift_label_line" -ge "$regen_check_line" ]; then
+        fail "$name: docs:drift label (line $drift_label_line) must appear BEFORE _REGEN gate (line $regen_check_line) — detection must be unconditional"
+    fi
+done
+
+# ── 3. doc-orchestrator.mjs is INSIDE the _REGEN=1 gate ─────────────────────
+# Verify the orchestrator call appears after the _REGEN=1 branch open and before
+# the matching else/fi in each SKILL.md.
+
+for SKILL in "$RUN_SKILL" "$AS_SKILL"; do
+    name="${SKILL#"$SCRIPT_DIR"/}"
+
+    # Extract the docs-drift-gate bash block and check ordering.
+    gate_bash=$(awk '
+        /docs-drift-gate:begin/ { in_gate=1 }
+        /docs-drift-gate:end/   { in_gate=0 }
+        in_gate {
+            line=$0
+            sub(/^>[[:space:]]?/, "", line)
+            if (line ~ /^[[:space:]]*```bash[[:space:]]*$/) { in_fence=1; next }
+            if (line ~ /^[[:space:]]*```[[:space:]]*$/ && in_fence) { in_fence=0; next }
+            if (in_fence) print line
+        }
+    ' "$SKILL")
+
+    [ -n "$gate_bash" ] || fail "$name: could not extract gate bash block"
+
+    # Within the extracted bash, _REGEN=1 branch must precede doc-orchestrator.mjs
+    regen_branch_line=$(echo "$gate_bash" | grep -n '_REGEN.*=.*1\|_REGEN.*1' | head -1 | cut -d: -f1)
+    orchestrator_line=$(echo "$gate_bash" | grep -n 'doc-orchestrator.mjs' | head -1 | cut -d: -f1)
+
+    [ -n "$regen_branch_line" ] \
+        || fail "$name: _REGEN=1 branch not found in extracted gate bash"
+    [ -n "$orchestrator_line" ] \
+        || fail "$name: doc-orchestrator.mjs not found in extracted gate bash"
+
+    if [ "$orchestrator_line" -le "$regen_branch_line" ]; then
+        fail "$name: doc-orchestrator.mjs (line $orchestrator_line) must appear AFTER _REGEN=1 branch (line $regen_branch_line)"
+    fi
+done
+
+# ── 4. bash -n on the gate bash from each SKILL.md ───────────────────────────
+
+extract_gate_bash() {
+    local skill="$1"
+    awk '
+        /docs-drift-gate:begin/ { in_gate=1 }
+        /docs-drift-gate:end/   { in_gate=0 }
+        in_gate {
+            line=$0
+            sub(/^>[[:space:]]?/, "", line)
+            if (line ~ /^[[:space:]]*```bash[[:space:]]*$/) { in_fence=1; next }
+            if (line ~ /^[[:space:]]*```[[:space:]]*$/ && in_fence) { in_fence=0; next }
+            if (in_fence) print line
+        }
+    ' "$skill"
+}
+
+for SKILL in "$RUN_SKILL" "$AS_SKILL"; do
+    name="${SKILL#"$SCRIPT_DIR"/}"
+    gate_bash="$(extract_gate_bash "$SKILL")"
+    [ -n "$gate_bash" ] || fail "$name: could not extract gate bash"
+
+    TMP="$(mktemp -t drift-gate-cond-XXXXXX.sh)"
+    trap 'rm -f "$TMP"' EXIT
+    {
+        echo 'set -eu'
+        printf '%s\n' "$gate_bash" \
+            | sed -e 's/<PR>/999/g' -e 's/<ISSUE>/955/g' \
+            | sed "s|'\${AUTOSPEC_DOC_SCRIPTS_DIR[^']*}'|'/tmp/doc-scripts'|g"
+    } > "$TMP"
+    bash -n "$TMP" || fail "$name: extracted gate bash is not well-formed (bash -n failed)"
+done
+
+echo "OK: docs-drift-gate auto_regenerate conditional verified across both run trios (6 files)"


### PR DESCRIPTION
Closes #955

## Summary

Wraps the #935 `docs-drift-gate` regeneration path (the `doc-orchestrator.mjs` self-heal) in the `resolveAutoRegenerate()` resolver from #953 across **both** run trios (autospec + autospec-run, 6 files total), per spec §D2b.

### What changed

- **Detection, labels, comments, classifier verdict logging: UNCHANGED** — always run regardless of `auto_regenerate` setting.
- **Regeneration path gated**: `doc-orchestrator.mjs` invocation + `docs: regenerate` commit only runs when `resolveAutoRegenerate()` returns `generate: true` (config `auto_regenerate=true` ∨ issue body `docs: generate` ∨ `AUTOSPEC_WITH_DOCS=1`).
- **OFF path**: logs `docs: regeneration skipped (auto_regenerate=false)` and continues the review loop normally.
- **`docs: skip` supremacy**: the existing `grep -qiE '^docs:..skip'` short-circuit at the top of the gate block already precedes the new check — precedence intact.
- **`autospec/SKILL.md`**: docs-drift-gate block was missing from this trio — added (identical to autospec-run trio per lock-step rule).
- **Both trios lock-stepped independently**: body-diff between SKILL.md/codex/prompt.md/opencode/agent.md is zero for each trio.

### New parity gate in validate.sh

`check_docs_drift_gate_regen_conditional_parity` — covers all 6 trio files, enforcing `_REGEN` variable, `resolveAutoRegenerate` import, OFF-path log line, gate markers, and orchestrator call present.

### Tests

- `tests/phase4/test_docs_drift_gate_regen_conditional.sh` — new: gate conditional in all 6 files, detection before gate check, orchestrator inside gate, `bash -n` syntax check on extracted gate bash.
- Existing `tests/phase4/test_docs_drift_gate_regenerate.sh` and `test_docs_drift_gate.sh` still pass.
- `bash scripts/validate.sh` exits 0.

## Self-review

- Detection genuinely unchanged: `check-doc-drift.sh`, `VERDICT_JSON`, `ACTION`, `mapfile SCOPES`, and `docs:drift` label all appear before the `_REGEN` check.
- Only `doc-orchestrator.mjs` and the `git commit` are gated.
- `docs: skip` supremacy intact (the `grep -qiE '^docs:.*skip'` outer guard precedes everything).
- Both trios are byte-identical (lock-step check in validate.sh passes).