### PR TITLE
feat(worktree-guard): assert/resolve-branch/create + bats (D1, #959)

### DIFF
--- a/scripts/worktree-guard.sh
+++ b/scripts/worktree-guard.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# scripts/worktree-guard.sh — deterministic worktree preflight + creation guard.
+#
+# The worktree rule (autospec-run SKILL.md) exists only as prose; this script
+# makes it enforceable. It is the shared, no-LLM enforcement tool referenced by
+# docs/specs/2026-06-03-worktree-guard-design.md §D1. Installed to
+# ~/.autospec/scripts/ by install.sh's copy_repo_scripts glob.
+#
+# Subcommands:
+#   worktree-guard.sh assert [--base <ref>] [--strict-base]
+#       Preflight the current directory before any edit/commit.
+#   worktree-guard.sh resolve-branch --branch <B> --repo <O/R>
+#       The G2 PR-aware ladder. Emits a JSON verdict; exit 0 always.
+#   worktree-guard.sh create --branch <B> [--base <ref>] [--path <P>] [--adopt]
+#       Create (or verified-clean reuse) a fresh worktree off the base.
+#
+# Exit codes (PINNED — shared across spec-2 children #959-#966):
+#   0  ok
+#   2  usage / not a git directory
+#   3  in_primary_checkout   (git-dir == git-common-dir)
+#   4  dirty                 (git status --porcelain non-empty, incl. untracked)
+#                            also: create dirty/wrong-branch reuse refusal
+#   5  stale_base            (HEAD behind base after fetch; warn unless --strict-base)
+#
+# resolve-branch JSON: {"state":"open-pr"|"branch-only"|"fresh","pr":N|null}.
+#
+# Conventions: set -eu (no pipefail — we branch on subcommand exits explicitly);
+# usage()/die() helpers per release-issue.sh style; no RETURN traps; if/then/fi
+# for one-sided conditionals under set -e (repo gotchas).
+
+set -eu
+
+PROG="worktree-guard.sh"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  worktree-guard.sh assert [--base <ref>] [--strict-base]
+  worktree-guard.sh resolve-branch --branch <B> --repo <O/R>
+  worktree-guard.sh create --branch <B> [--base <ref>] [--path <P>] [--adopt]
+
+Subcommands:
+  assert          Preflight the current directory. Exit 0 ok / 2 usage|non-git /
+                  3 in_primary_checkout / 4 dirty / 5 stale_base.
+  resolve-branch  PR-aware ladder verdict as JSON on stdout (exit 0 always):
+                  {"state":"open-pr"|"branch-only"|"fresh","pr":N|null}.
+  create          Create or verified-clean-reuse a fresh worktree off the base.
+                  Dirty or wrong-branch reuse is refused (exit 4).
+
+Exit codes: 0 ok, 2 usage/non-git, 3 in_primary_checkout, 4 dirty, 5 stale_base.
+EOF
+}
+
+die() {
+    # die <exit-code> <message...>
+    local code="$1"; shift
+    printf '%s: %s\n' "$PROG" "$*" >&2
+    exit "$code"
+}
+
+# Emit a stable code_health/identifier line so callers can grep it.
+emit() { printf '%s\n' "$*" >&2; }
+
+# ---------------------------------------------------------------------------
+# assert
+# ---------------------------------------------------------------------------
+cmd_assert() {
+    local base="origin/main"
+    local strict_base=0
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --base)        [ $# -ge 2 ] || die 2 "--base requires a value"; base="$2"; shift 2 ;;
+            --strict-base) strict_base=1; shift ;;
+            -h|--help)     usage; exit 0 ;;
+            *)             die 2 "assert: unknown arg: $1" ;;
+        esac
+    done
+
+    # Not a git directory -> usage error (exit 2).
+    local git_dir common_dir
+    if ! git_dir="$(git rev-parse --git-dir 2>/dev/null)"; then
+        die 2 "assert: not inside a git repository"
+    fi
+    common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" \
+        || die 2 "assert: cannot resolve --git-common-dir"
+
+    # Normalise both to absolute paths before comparing: in a linked worktree
+    # --git-dir is <primary>/.git/worktrees/<name> and --git-common-dir is
+    # <primary>/.git, so they differ. In the primary checkout both resolve to
+    # the same .git directory.
+    local abs_git_dir abs_common_dir
+    abs_git_dir="$(cd "$git_dir" 2>/dev/null && pwd -P)" || abs_git_dir="$git_dir"
+    abs_common_dir="$(cd "$common_dir" 2>/dev/null && pwd -P)" || abs_common_dir="$common_dir"
+    if [ "$abs_git_dir" = "$abs_common_dir" ]; then
+        emit "code_health:in_primary_checkout"
+        die 3 "assert: cwd is the primary checkout (git-dir == git-common-dir); agents must work in a linked worktree"
+    fi
+
+    # Dirty tree (untracked included) -> exit 4.
+    local porcelain
+    porcelain="$(git status --porcelain 2>/dev/null || true)"
+    if [ -n "$porcelain" ]; then
+        emit "code_health:dirty"
+        die 4 "assert: worktree is dirty (uncommitted or untracked changes present)"
+    fi
+
+    # Stale base: fetch the base, then compare HEAD against the base tip.
+    # Fetch failure is surfaced (retry once) rather than silently passing.
+    local base_remote base_ref
+    base_remote="${base%%/*}"
+    base_ref="${base#*/}"
+    if [ "$base_remote" = "$base" ]; then
+        base_remote="origin"
+        base_ref="$base"
+    fi
+    if ! git fetch "$base_remote" "$base_ref" >/dev/null 2>&1; then
+        if ! git fetch "$base_remote" "$base_ref" >/dev/null 2>&1; then
+            emit "code_health:fetch_failed"
+            die 5 "assert: git fetch $base_remote $base_ref failed (after retry)"
+        fi
+    fi
+
+    local head_sha base_sha merge_base
+    head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
+    base_sha="$(git rev-parse "$base" 2>/dev/null || true)"
+    if [ -n "$base_sha" ] && [ "$head_sha" != "$base_sha" ]; then
+        # HEAD differs from base tip. For an adopted branch HEAD legitimately
+        # diverges, so "stale" only when base has commits HEAD lacks, i.e.
+        # merge-base(HEAD, base) != base tip.
+        merge_base="$(git merge-base HEAD "$base" 2>/dev/null || true)"
+        if [ "$merge_base" != "$base_sha" ]; then
+            emit "code_health:stale_base base=$base head=$head_sha base_tip=$base_sha"
+            if [ "$strict_base" -eq 1 ]; then
+                die 5 "assert: stale base — $base has advanced beyond this worktree (--strict-base)"
+            fi
+            emit "assert: WARN stale base — $base has advanced; rebase before merge (warn-level)"
+        fi
+    fi
+
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# resolve-branch
+# ---------------------------------------------------------------------------
+cmd_resolve_branch() {
+    local branch="" repo=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --branch)  [ $# -ge 2 ] || die 2 "--branch requires a value"; branch="$2"; shift 2 ;;
+            --repo)    [ $# -ge 2 ] || die 2 "--repo requires a value"; repo="$2"; shift 2 ;;
+            -h|--help) usage; exit 0 ;;
+            *)         die 2 "resolve-branch: unknown arg: $1" ;;
+        esac
+    done
+    [ -n "$branch" ] || die 2 "resolve-branch: --branch is required"
+    [ -n "$repo" ]   || die 2 "resolve-branch: --repo is required"
+
+    # Rung 1: an open PR whose head is this branch -> open-pr.
+    local pr_json pr_number
+    pr_json="$(gh pr list --repo "$repo" --head "$branch" --state open --json number 2>/dev/null || echo '[]')"
+    pr_number="$(printf '%s' "$pr_json" | jq -r 'if type=="array" and length>0 then .[0].number else empty end' 2>/dev/null || true)"
+    if [ -n "$pr_number" ]; then
+        printf '{"state":"open-pr","pr":%s}\n' "$pr_number"
+        exit 0
+    fi
+
+    # Rung 2: branch exists on origin -> branch-only.
+    local lsr
+    lsr="$(git ls-remote --heads origin "$branch" 2>/dev/null || true)"
+    if [ -n "$lsr" ]; then
+        printf '{"state":"branch-only","pr":null}\n'
+        exit 0
+    fi
+
+    # Rung 3: nothing exists -> fresh.
+    printf '{"state":"fresh","pr":null}\n'
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+cmd_create() {
+    local branch="" base="origin/main" path="" adopt=0
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --branch)  [ $# -ge 2 ] || die 2 "--branch requires a value"; branch="$2"; shift 2 ;;
+            --base)    [ $# -ge 2 ] || die 2 "--base requires a value"; base="$2"; shift 2 ;;
+            --path)    [ $# -ge 2 ] || die 2 "--path requires a value"; path="$2"; shift 2 ;;
+            --adopt)   adopt=1; shift ;;
+            -h|--help) usage; exit 0 ;;
+            *)         die 2 "create: unknown arg: $1" ;;
+        esac
+    done
+    [ -n "$branch" ] || die 2 "create: --branch is required"
+    [ -n "$path" ]   || path="/tmp/wt-${branch}"
+
+    # fetch-before-branch (G4) with a single retry; surface on persistent failure.
+    if ! git fetch origin >/dev/null 2>&1; then
+        if ! git fetch origin >/dev/null 2>&1; then
+            emit "code_health:fetch_failed"
+            die 2 "create: git fetch origin failed (after retry)"
+        fi
+    fi
+
+    # Existing path: reuse ONLY if clean AND on the same branch; else refuse.
+    if [ -e "$path" ]; then
+        local existing_branch existing_porcelain
+        existing_branch="$(git -C "$path" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+        existing_porcelain="$(git -C "$path" status --porcelain 2>/dev/null || true)"
+        if [ "$existing_branch" = "$branch" ] && [ -z "$existing_porcelain" ]; then
+            # Clean, same branch -> idempotent reuse.
+            exit 0
+        fi
+        emit "code_health:worktree_dirty_reuse_refused path=$path branch=$existing_branch want=$branch"
+        die 4 "create: refusing to reuse worktree at $path (dirty or wrong branch); never silent-reuse"
+    fi
+
+    # Adopt an existing remote branch, or create a fresh branch off the base.
+    if [ "$adopt" -eq 1 ]; then
+        if ! git worktree add "$path" "origin/$branch" >/dev/null 2>&1; then
+            emit "code_health:worktree_create_failed"
+            die 2 "create: git worktree add (adopt) failed for origin/$branch at $path"
+        fi
+        # Land on a local tracking branch named B, not detached at origin/B.
+        git -C "$path" checkout -q -B "$branch" "origin/$branch" >/dev/null 2>&1 || true
+    else
+        if ! git worktree add -b "$branch" "$path" "$base" >/dev/null 2>&1; then
+            emit "code_health:worktree_create_failed"
+            die 2 "create: git worktree add -b $branch off $base at $path failed"
+        fi
+    fi
+
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# dispatch
+# ---------------------------------------------------------------------------
+main() {
+    [ $# -ge 1 ] || { usage >&2; exit 2; }
+    local sub="$1"; shift
+    case "$sub" in
+        assert)         cmd_assert "$@" ;;
+        resolve-branch) cmd_resolve_branch "$@" ;;
+        create)         cmd_create "$@" ;;
+        -h|--help)      usage; exit 0 ;;
+        *)              echo "$PROG: unknown subcommand: $sub" >&2; usage >&2; exit 2 ;;
+    esac
+}
+
+main "$@"

--- a/scripts/worktree-guard.sh
+++ b/scripts/worktree-guard.sh
@@ -205,17 +205,35 @@ cmd_create() {
         fi
     fi
 
-    # Existing path: reuse ONLY if clean AND on the same branch; else refuse.
+    # Existing path: reuse ONLY if clean AND on the same branch AND it is a
+    # linked worktree (NOT the primary checkout). Reusing the primary checkout
+    # would let `create --branch main --path <primary>` pass while `assert` (the
+    # very next preflight) rejects the same dir with exit 3 — the guard's core
+    # safety property bypassed. So refuse primary-checkout reuse too.
     if [ -e "$path" ]; then
-        local existing_branch existing_porcelain
+        local existing_branch existing_porcelain p_git_dir p_common_dir
         existing_branch="$(git -C "$path" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
         existing_porcelain="$(git -C "$path" status --porcelain 2>/dev/null || true)"
-        if [ "$existing_branch" = "$branch" ] && [ -z "$existing_porcelain" ]; then
-            # Clean, same branch -> idempotent reuse.
+        p_git_dir="$(git -C "$path" rev-parse --git-dir 2>/dev/null || true)"
+        p_common_dir="$(git -C "$path" rev-parse --git-common-dir 2>/dev/null || true)"
+        # Normalise to absolute paths (git may report them relative to $path).
+        if [ -n "$p_git_dir" ]; then
+            p_git_dir="$(cd "$path" && cd "$p_git_dir" 2>/dev/null && pwd -P)" || p_git_dir=""
+        fi
+        if [ -n "$p_common_dir" ]; then
+            p_common_dir="$(cd "$path" && cd "$p_common_dir" 2>/dev/null && pwd -P)" || p_common_dir=""
+        fi
+        local is_linked_worktree=0
+        if [ -n "$p_git_dir" ] && [ "$p_git_dir" != "$p_common_dir" ]; then
+            is_linked_worktree=1
+        fi
+        if [ "$existing_branch" = "$branch" ] && [ -z "$existing_porcelain" ] \
+                && [ "$is_linked_worktree" -eq 1 ]; then
+            # Clean, same branch, genuine linked worktree -> idempotent reuse.
             exit 0
         fi
-        emit "code_health:worktree_dirty_reuse_refused path=$path branch=$existing_branch want=$branch"
-        die 4 "create: refusing to reuse worktree at $path (dirty or wrong branch); never silent-reuse"
+        emit "code_health:worktree_dirty_reuse_refused path=$path branch=$existing_branch want=$branch linked=$is_linked_worktree"
+        die 4 "create: refusing to reuse path $path (dirty, wrong branch, or primary checkout); never silent-reuse"
     fi
 
     # Adopt an existing remote branch, or create a fresh branch off the base.
@@ -225,7 +243,13 @@ cmd_create() {
             die 2 "create: git worktree add (adopt) failed for origin/$branch at $path"
         fi
         # Land on a local tracking branch named B, not detached at origin/B.
-        git -C "$path" checkout -q -B "$branch" "origin/$branch" >/dev/null 2>&1 || true
+        # A failure here (e.g. B already checked out in another worktree) leaves
+        # a detached HEAD that violates the "local tracking branch named B"
+        # contract — surface it rather than swallowing.
+        if ! git -C "$path" checkout -q -B "$branch" "origin/$branch" >/dev/null 2>&1; then
+            emit "code_health:worktree_adopt_checkout_failed"
+            die 2 "create: could not check out branch $branch in adopted worktree $path (already checked out elsewhere?)"
+        fi
     else
         if ! git worktree add -b "$branch" "$path" "$base" >/dev/null 2>&1; then
             emit "code_health:worktree_create_failed"

--- a/tests/worktree-guard/test_assert.bats
+++ b/tests/worktree-guard/test_assert.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+# tests/worktree-guard/test_assert.bats — `worktree-guard.sh assert` exit codes.
+#
+# Covers (docs/specs/2026-06-03-worktree-guard-design.md §D1, issue #959 Shared
+# contracts): the preflight `assert` returns each pinned exit code and each is
+# tested here:
+#   0  ok            — linked worktree, clean tree, HEAD == origin/main
+#   2  usage         — bad subcommand / not a git dir
+#   3  in_primary_checkout — git-dir == git-common-dir (cwd is main checkout)
+#   4  dirty         — `git status --porcelain` non-empty (untracked included)
+#   5  stale_base    — HEAD != origin/main after fetch (warn-level by default,
+#                      fail under --strict-base)
+#
+# `assert` runs against REAL git fixture repos (a bare "origin", a primary
+# checkout, and a linked worktree), so git-dir/git-common-dir detection is
+# exercised for real rather than mocked. Network `git fetch` is neutralised by
+# pointing `origin` at a local bare repo.
+
+ROOT="${BATS_TEST_DIRNAME}/../.."
+GUARD="$ROOT/scripts/worktree-guard.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    export GIT_AUTHOR_NAME="t" GIT_AUTHOR_EMAIL="t@e" \
+           GIT_COMMITTER_NAME="t" GIT_COMMITTER_EMAIL="t@e"
+
+    # Bare "remote" that origin points at — `git fetch origin` is local, no net.
+    ORIGIN="$TEST_TMP/origin.git"
+    git init -q --bare "$ORIGIN"
+
+    # Primary checkout cloned from the bare remote, with one commit on main.
+    PRIMARY="$TEST_TMP/primary"
+    git clone -q "$ORIGIN" "$PRIMARY"
+    git -C "$PRIMARY" checkout -q -b main 2>/dev/null || git -C "$PRIMARY" checkout -q main
+    echo seed > "$PRIMARY/seed.txt"
+    git -C "$PRIMARY" add seed.txt
+    git -C "$PRIMARY" commit -q -m "seed"
+    git -C "$PRIMARY" push -q -u origin main
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+# Add a linked worktree off origin/main and echo its path.
+mk_worktree() {
+    local wt="$TEST_TMP/wt"
+    git -C "$PRIMARY" worktree add -q -b feat/x "$wt" main >/dev/null 2>&1
+    printf '%s' "$wt"
+}
+
+@test "assert: exit 0 in a clean linked worktree at origin/main" {
+    wt="$(mk_worktree)"
+    run bash -c "cd '$wt' && bash '$GUARD' assert"
+    [ "$status" -eq 0 ]
+}
+
+@test "assert: exit 3 in_primary_checkout (git-dir == git-common-dir)" {
+    run bash -c "cd '$PRIMARY' && bash '$GUARD' assert"
+    [ "$status" -eq 3 ]
+    [[ "$output" == *in_primary_checkout* ]]
+}
+
+@test "assert: exit 4 dirty when tracked file modified" {
+    wt="$(mk_worktree)"
+    echo change >> "$wt/seed.txt"
+    run bash -c "cd '$wt' && bash '$GUARD' assert"
+    [ "$status" -eq 4 ]
+    [[ "$output" == *dirty* ]]
+}
+
+@test "assert: exit 4 dirty when an untracked file is present" {
+    wt="$(mk_worktree)"
+    echo new > "$wt/untracked.txt"
+    run bash -c "cd '$wt' && bash '$GUARD' assert"
+    [ "$status" -eq 4 ]
+    [[ "$output" == *dirty* ]]
+}
+
+@test "assert: exit 5 stale_base under --strict-base when HEAD behind origin/main" {
+    wt="$(mk_worktree)"
+    # Advance origin/main beyond the worktree's HEAD.
+    echo more >> "$PRIMARY/seed.txt"
+    git -C "$PRIMARY" commit -q -am "advance"
+    git -C "$PRIMARY" push -q origin main
+    run bash -c "cd '$wt' && bash '$GUARD' assert --strict-base"
+    [ "$status" -eq 5 ]
+    [[ "$output" == *stale_base* ]]
+}
+
+@test "assert: stale base is warn-level (exit 0) without --strict-base" {
+    wt="$(mk_worktree)"
+    echo more >> "$PRIMARY/seed.txt"
+    git -C "$PRIMARY" commit -q -am "advance"
+    git -C "$PRIMARY" push -q origin main
+    run bash -c "cd '$wt' && bash '$GUARD' assert"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *stale_base* ]]
+}
+
+@test "assert: exit 2 on unknown subcommand" {
+    run bash "$GUARD" bogus-subcommand
+    [ "$status" -eq 2 ]
+}
+
+@test "assert: exit 2 when not inside a git repository" {
+    run bash -c "cd '$TEST_TMP' && bash '$GUARD' assert"
+    [ "$status" -eq 2 ]
+}
+
+@test "assert: cannot be fooled into passing from the primary checkout via a symlinked path" {
+    # Adversarial: a symlink to the primary checkout must still be detected as
+    # the primary checkout (pwd -P resolves it). Otherwise an agent could dodge
+    # the exit-3 guard by cd-ing through a symlink.
+    link="$TEST_TMP/primary-link"
+    ln -s "$PRIMARY" "$link"
+    run bash -c "cd '$link' && bash '$GUARD' assert"
+    [ "$status" -eq 3 ]
+    [[ "$output" == *in_primary_checkout* ]]
+}
+
+@test "assert: a nested standalone git repo inside a worktree is refused (exit 3)" {
+    # Adversarial: a fresh `git init` subdir is its OWN primary checkout
+    # (git-dir == git-common-dir). Asserting from inside it must refuse — an
+    # agent must never commit into an unrelated nested repo thinking it is the
+    # task worktree.
+    wt="$(mk_worktree)"
+    git init -q "$wt/nested"
+    run bash -c "cd '$wt/nested' && bash '$GUARD' assert"
+    [ "$status" -eq 3 ]
+    [[ "$output" == *in_primary_checkout* ]]
+}
+
+@test "assert: passes from a symlinked path to a clean linked worktree" {
+    # The mirror of the primary-symlink case: a symlink to a genuine linked
+    # worktree must still pass (the symlink resolves to the real worktree).
+    wt="$(mk_worktree)"
+    link="$TEST_TMP/wt-link"
+    ln -s "$wt" "$link"
+    run bash -c "cd '$link' && bash '$GUARD' assert"
+    [ "$status" -eq 0 ]
+}
+
+@test "assert: --help exits 0" {
+    run bash "$GUARD" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *assert* ]]
+    [[ "$output" == *resolve-branch* ]]
+    [[ "$output" == *create* ]]
+}

--- a/tests/worktree-guard/test_create.bats
+++ b/tests/worktree-guard/test_create.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# tests/worktree-guard/test_create.bats — `worktree-guard.sh create`.
+#
+# Covers (docs/specs/2026-06-03-worktree-guard-design.md §D1 `create`, issue
+# #959 Shared contracts):
+#   - fresh create:  `git worktree add -b B <path> origin/main`
+#   - adopt create:  `git worktree add <path> origin/B` (branch-only recovery)
+#   - idempotent reuse: existing path reused ONLY if clean AND same branch
+#   - dirty-reuse refusal: dirty existing path -> exit 4
+#     `code_health:worktree_dirty_reuse_refused`
+#   - wrong-branch reuse refusal: clean but different branch -> exit 4
+#   - fetch-failure: retry once then surface (non-zero)
+#
+# Uses REAL git fixture repos (bare origin + primary) so `git worktree add`
+# behaves for real; `git fetch origin` is local (no network).
+
+ROOT="${BATS_TEST_DIRNAME}/../.."
+GUARD="$ROOT/scripts/worktree-guard.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    export GIT_AUTHOR_NAME="t" GIT_AUTHOR_EMAIL="t@e" \
+           GIT_COMMITTER_NAME="t" GIT_COMMITTER_EMAIL="t@e"
+
+    ORIGIN="$TEST_TMP/origin.git"
+    git init -q --bare "$ORIGIN"
+
+    PRIMARY="$TEST_TMP/primary"
+    git clone -q "$ORIGIN" "$PRIMARY"
+    git -C "$PRIMARY" checkout -q -b main 2>/dev/null || git -C "$PRIMARY" checkout -q main
+    echo seed > "$PRIMARY/seed.txt"
+    git -C "$PRIMARY" add seed.txt
+    git -C "$PRIMARY" commit -q -m "seed"
+    git -C "$PRIMARY" push -q -u origin main
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+@test "create: fresh worktree off origin/main on a new branch" {
+    wt="$TEST_TMP/wt-fresh"
+    run bash -c "cd '$PRIMARY' && bash '$GUARD' create --branch feat/new --path '$wt'"
+    [ "$status" -eq 0 ]
+    [ -d "$wt" ]
+    [ "$(git -C "$wt" rev-parse --abbrev-ref HEAD)" = "feat/new" ]
+}
+
+@test "create: idempotent reuse of a clean same-branch worktree (exit 0)" {
+    wt="$TEST_TMP/wt-idem"
+    bash -c "cd '$PRIMARY' && bash '$GUARD' create --branch feat/idem --path '$wt'"
+    run bash -c "cd '$PRIMARY' && bash '$GUARD' create --branch feat/idem --path '$wt'"
+    [ "$status" -eq 0 ]
+    [ "$(git -C "$wt" rev-parse --abbrev-ref HEAD)" = "feat/idem" ]
+}
+
+@test "create: refuses dirty reuse with exit 4 + code_health identifier" {
+    wt="$TEST_TMP/wt-dirty"
+    bash -c "cd '$PRIMARY' && bash '$GUARD' create --branch feat/dirty --path '$wt'"
+    echo uncommitted > "$wt/scratch.txt"   # make it dirty
+    run bash -c "cd '$PRIMARY' && bash '$GUARD' create --branch feat/dirty --path '$wt'"
+    [ "$status" -eq 4 ]
+    [[ "$output" == *worktree_dirty_reuse_refused* ]]
+}
+
+@test "create: refuses clean-but-wrong-branch reuse with exit 4" {
+    wt="$TEST_TMP/wt-wrong"
+    bash -c "cd '$PRIMARY' && bash '$GUARD' create --branch feat/aaa --path '$wt'"
+    run bash -c "cd '$PRIMARY' && bash '$GUARD' create --branch feat/bbb --path '$wt'"
+    [ "$status" -eq 4 ]
+    [[ "$output" == *worktree_dirty_reuse_refused* ]]
+}
+
+@test "create: adopt mode checks out an existing remote branch" {
+    # Publish a branch on origin, then adopt it.
+    git -C "$PRIMARY" checkout -q -b feat/published
+    echo work >> "$PRIMARY/seed.txt"
+    git -C "$PRIMARY" commit -q -am "published work"
+    git -C "$PRIMARY" push -q -u origin feat/published
+    git -C "$PRIMARY" checkout -q main
+
+    wt="$TEST_TMP/wt-adopt"
+    run bash -c "cd '$PRIMARY' && bash '$GUARD' create --branch feat/published --adopt --path '$wt'"
+    [ "$status" -eq 0 ]
+    [ -d "$wt" ]
+    [ "$(git -C "$wt" rev-parse --abbrev-ref HEAD)" = "feat/published" ]
+    # The adopted branch carries its published commit (file gained the "work" line).
+    grep -q "work" "$wt/seed.txt"
+    [ "$(git -C "$wt" log -1 --pretty=%s)" = "published work" ]
+}
+
+@test "create: missing --branch is a usage error (exit 2)" {
+    run bash -c "cd '$PRIMARY' && bash '$GUARD' create --path '$TEST_TMP/wt-x'"
+    [ "$status" -eq 2 ]
+}
+
+@test "create: fetch failure surfaces non-zero after a retry" {
+    # Point origin at a non-existent path so `git fetch origin` fails.
+    bad="$TEST_TMP/bad-clone"
+    git clone -q "$ORIGIN" "$bad"
+    git -C "$bad" remote set-url origin "$TEST_TMP/does-not-exist.git"
+    wt="$TEST_TMP/wt-fetchfail"
+    run bash -c "cd '$bad' && bash '$GUARD' create --branch feat/z --path '$wt'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *fetch* ]]
+}

--- a/tests/worktree-guard/test_create.bats
+++ b/tests/worktree-guard/test_create.bats
@@ -87,6 +87,40 @@ teardown() { rm -rf "$TEST_TMP"; }
     [ "$(git -C "$wt" log -1 --pretty=%s)" = "published work" ]
 }
 
+@test "create: refuses to reuse the primary checkout even when clean + same branch (exit 4)" {
+    # Adversarial (peer-review): `create --branch main --path <primary>` must NOT
+    # pass just because the primary is clean and on main — `assert` rejects that
+    # same dir with exit 3, so reuse here would bypass the guard's core property.
+    run bash -c "cd '$PRIMARY' && bash '$GUARD' create --branch main --path '$PRIMARY'"
+    [ "$status" -eq 4 ]
+    [[ "$output" == *worktree_dirty_reuse_refused* ]]
+}
+
+@test "create: adopt fails (non-zero) when the branch is already checked out elsewhere" {
+    # Adversarial (peer-review): adopt must not silently leave a detached HEAD.
+    # Publish a branch, adopt it into one worktree, then try to adopt the same
+    # branch into a second worktree — git refuses a second checkout of B, and
+    # the script must surface that rather than swallow it.
+    git -C "$PRIMARY" checkout -q -b feat/dup
+    echo work >> "$PRIMARY/seed.txt"
+    git -C "$PRIMARY" commit -q -am "dup work"
+    git -C "$PRIMARY" push -q -u origin feat/dup
+    git -C "$PRIMARY" checkout -q main
+
+    wt1="$TEST_TMP/wt-dup-1"
+    bash -c "cd '$PRIMARY' && bash '$GUARD' create --branch feat/dup --adopt --path '$wt1'"
+    [ "$(git -C "$wt1" rev-parse --abbrev-ref HEAD)" = "feat/dup" ]
+
+    wt2="$TEST_TMP/wt-dup-2"
+    run bash -c "cd '$PRIMARY' && bash '$GUARD' create --branch feat/dup --adopt --path '$wt2'"
+    [ "$status" -ne 0 ]
+    # If a worktree dir was left behind, it must not be a detached HEAD pretending success.
+    if [ -d "$wt2" ]; then
+        [ "$(git -C "$wt2" rev-parse --abbrev-ref HEAD 2>/dev/null)" != "HEAD" ] || \
+            [[ "$output" == *adopt_checkout_failed* ]]
+    fi
+}
+
 @test "create: missing --branch is a usage error (exit 2)" {
     run bash -c "cd '$PRIMARY' && bash '$GUARD' create --path '$TEST_TMP/wt-x'"
     [ "$status" -eq 2 ]

--- a/tests/worktree-guard/test_resolve_branch.bats
+++ b/tests/worktree-guard/test_resolve_branch.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# tests/worktree-guard/test_resolve_branch.bats — `resolve-branch` JSON ladder.
+#
+# Covers (docs/specs/2026-06-03-worktree-guard-design.md §D1 G2 ladder, issue
+# #959 Shared contracts): the deterministic verdict ladder, exit 0 always.
+#   open-pr     — `gh pr list --head B --state open` non-empty -> {"state":"open-pr","pr":N}
+#   branch-only — else `git ls-remote --heads origin B` non-empty -> {"state":"branch-only","pr":null}
+#   fresh       — else -> {"state":"fresh","pr":null}
+#
+# `gh` and `git ls-remote` are PATH-shadowed mocks driven by env vars, mirroring
+# the repo's established pattern (tests/resume/*.bats). The mock git falls
+# through to real git for everything except `ls-remote`.
+
+ROOT="${BATS_TEST_DIRNAME}/../.."
+GUARD="$ROOT/scripts/worktree-guard.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    export MOCK_DIR="$TEST_TMP/bin"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+
+    # Mock drivers.
+    export GH_PR_JSON="[]"        # what `gh pr list ... --json number` returns
+    export LSREMOTE_OUT=""        # non-empty => branch exists on origin
+
+    write_gh_mock
+    write_git_mock
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+write_gh_mock() {
+    cat > "$MOCK_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+# PATH-shadow gh mock. Supports `gh pr list --head B --state open --json number`.
+if [ "$1 $2" = "pr list" ]; then
+    printf '%s\n' "$GH_PR_JSON"
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "$MOCK_DIR/gh"
+}
+
+write_git_mock() {
+    REAL_GIT="$(command -v git)"
+    export REAL_GIT
+    cat > "$MOCK_DIR/git" <<EOF
+#!/usr/bin/env bash
+REAL_GIT="$REAL_GIT"
+EOF
+    cat >> "$MOCK_DIR/git" <<'EOF'
+# Intercept `git ls-remote --heads origin <B>`; everything else -> real git.
+for a in "$@"; do
+    if [ "$a" = "ls-remote" ]; then
+        printf '%s' "$LSREMOTE_OUT"
+        [ -n "$LSREMOTE_OUT" ] && printf '\n'
+        exit 0
+    fi
+done
+exec "$REAL_GIT" "$@"
+EOF
+    chmod +x "$MOCK_DIR/git"
+}
+
+@test "resolve-branch: open PR -> open-pr verdict with pr number, exit 0" {
+    export GH_PR_JSON='[{"number":42}]'
+    run bash "$GUARD" resolve-branch --branch feat/x --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"state":"open-pr"'* ]]
+    [[ "$output" == *'"pr":42'* ]]
+}
+
+@test "resolve-branch: no PR but branch on remote -> branch-only, exit 0" {
+    export GH_PR_JSON='[]'
+    export LSREMOTE_OUT="deadbeef refs/heads/feat/x"
+    run bash "$GUARD" resolve-branch --branch feat/x --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"state":"branch-only"'* ]]
+    [[ "$output" == *'"pr":null'* ]]
+}
+
+@test "resolve-branch: no PR and no remote branch -> fresh, exit 0" {
+    export GH_PR_JSON='[]'
+    export LSREMOTE_OUT=""
+    run bash "$GUARD" resolve-branch --branch feat/x --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"state":"fresh"'* ]]
+    [[ "$output" == *'"pr":null'* ]]
+}
+
+@test "resolve-branch: open-pr takes precedence over an existing remote branch" {
+    export GH_PR_JSON='[{"number":7}]'
+    export LSREMOTE_OUT="deadbeef refs/heads/feat/x"
+    run bash "$GUARD" resolve-branch --branch feat/x --repo o/n
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"state":"open-pr"'* ]]
+    [[ "$output" == *'"pr":7'* ]]
+}
+
+@test "resolve-branch: emits valid JSON parseable by jq" {
+    export GH_PR_JSON='[{"number":99}]'
+    run bash -c "bash '$GUARD' resolve-branch --branch feat/x --repo o/n | jq -r .state"
+    [ "$status" -eq 0 ]
+    [ "$output" = "open-pr" ]
+}
+
+@test "resolve-branch: missing --branch is a usage error (exit 2)" {
+    run bash "$GUARD" resolve-branch --repo o/n
+    [ "$status" -eq 2 ]
+}
+
+@test "resolve-branch: missing --repo is a usage error (exit 2)" {
+    run bash "$GUARD" resolve-branch --branch feat/x
+    [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
Closes #959

## What

Adds `scripts/worktree-guard.sh` — the deterministic, no-LLM worktree preflight + creation guard from `docs/specs/2026-06-03-worktree-guard-design.md` §D1. Makes the prose-only worktree rule (`autospec-run/SKILL.md`) enforceable. This is child 1 (dep-free); wiring lands in #960-#965.

## Subcommands (PINNED shared contracts #959-#966)

- **`assert`** — `0` ok / `2` usage|non-git / `3` `in_primary_checkout` (git-dir == git-common-dir) / `4` `dirty` (porcelain incl. untracked) / `5` `stale_base` (HEAD behind base after fetch; warn-level unless `--strict-base`). Paths normalized via `pwd -P` so a symlink can't dodge the primary-checkout guard.
- **`resolve-branch --branch B --repo O/R`** — the G2 ladder, JSON only, exit 0 always: `open-pr` → `branch-only` → `fresh`. Verdict `{"state":...,"pr":N|null}`.
- **`create --branch B [--base] [--path] [--adopt]`** — fetch-before-branch (retry once) then `git worktree add`; existing path reused ONLY if clean AND same branch, else exit `4` `code_health:worktree_dirty_reuse_refused`. Never silent-reuses a dirty tree.

Installed to `~/.autospec/scripts/` automatically via `install.sh` `copy_repo_scripts` glob — no install.sh change needed.

## Reuse decision

No reuse — `dispatch-implementer.sh:78-82` is the *silent-reuse hazard this guard replaces* (removed in #960, per the issue's file-ownership contract), and `autospec-watchdog.sh` is GC/cleanup (complementary, not preflight). No existing helper does git-dir/ls-remote preflight. Mock pattern reused from `tests/resume/*.bats`.

## Tests

`bats tests/worktree-guard/` — 26 tests:
- Every exit code (0,2,3,4,5) on **real git fixture repos** (bare origin + primary + linked worktree; local fetch, no network).
- Primary-checkout detection via fixture + linked worktree; dirty (tracked + untracked); wrong-branch + idempotent create; adopt mode; fetch-failure surfacing.
- Ladder verdicts via PATH-shadowed `gh`/`git ls-remote` mocks.
- **Adversarial regressions**: symlink to primary checkout still refused (exit 3); nested standalone git repo inside a worktree refused (exit 3); symlink to a genuine worktree still passes (exit 0).

`bash scripts/validate.sh` exits 0; `bash -n` clean.

## Repo gotchas honored

No RETURN traps; `if/then/fi` for one-sided conditionals under `set -e`.

Peer-review: codex not invoked in this run (graceful skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)