### PR TITLE
feat(dispatch): delegate worktree creation to worktree-guard.sh (D2, #960)

### DIFF
--- a/scripts/dispatch-implementer.sh
+++ b/scripts/dispatch-implementer.sh
@@ -5,33 +5,45 @@
 # Per issue #690: when the orchestrator dispatches multiple background
 # implementer Agents in the same git workdir, they collide on `git checkout`
 # even when file-level scopes are disjoint. This helper enforces worktree
-# isolation by creating /tmp/wt-<branch> and pre-pending a worktree directive
-# to the implementer prompt so the LLM cannot stray into the main checkout.
+# isolation by delegating to worktree-guard.sh (create/resolve-branch) and
+# pre-pending a worktree directive to the implementer prompt so the LLM cannot
+# stray into the main checkout.
+#
+# Per issue #960 (D2): the silent-reuse fallback has been removed. Worktree
+# creation is fully delegated to `worktree-guard.sh create`, which refuses dirty
+# or wrong-branch reuse with exit 4 / code_health:worktree_dirty_reuse_refused.
+# `worktree-guard.sh resolve-branch` is called first so the orchestrator can act
+# on open-pr / branch-only / fresh state before dispatch.
 #
 # Usage:
 #   dispatch-implementer.sh --issue <N> --branch <name> --prompt-file <path>
-#   dispatch-implementer.sh --issue <N> --branch <name> --prompt-file <path> --cleanup
+#                            [--repo <O/R>] [--base <ref>]
+#   dispatch-implementer.sh --issue <N> --branch <name> --cleanup
 #
 # Modes:
-#   default: create worktree, emit augmented prompt on stdout, exit 0
-#   --cleanup: remove the worktree at /tmp/wt-<branch> and exit
+#   default: resolve branch, create worktree, emit augmented prompt on stdout.
+#            BRANCH_VERDICT env is printed as a comment in the output header.
+#   --cleanup: remove the worktree at /tmp/wt-<branch> and exit.
 #
 # Exit codes:
 #   0  success
-#   1  bad arguments
-#   2  worktree creation/removal failed
+#   1  bad arguments / worktree-guard.sh not found
+#   2  worktree creation/removal failed (propagated from worktree-guard.sh)
 #   3  prompt-file missing or unreadable
+#   4  dirty/wrong-branch reuse refused (propagated from worktree-guard.sh)
 
 set -eu
 
 usage() {
     cat <<'EOF'
 Usage: dispatch-implementer.sh --issue <N> --branch <name> --prompt-file <path>
+                                [--repo <O/R>] [--base <ref>]
        dispatch-implementer.sh --issue <N> --branch <name> --cleanup
 
-Creates /tmp/wt-<branch> via `git worktree add` and pre-pends a worktree
-directive to the implementer prompt. Pass --cleanup to remove the worktree
-after the implementer has completed.
+Resolves the branch ladder verdict via worktree-guard.sh resolve-branch, then
+creates /tmp/wt-<branch> via worktree-guard.sh create (no silent dirty reuse),
+and pre-pends a worktree directive + verdict to the implementer prompt.
+Pass --cleanup to remove the worktree after the implementer has completed.
 EOF
 }
 
@@ -40,6 +52,7 @@ BRANCH=""
 PROMPT_FILE=""
 CLEANUP=0
 BASE_REF="${AUTOSPEC_DISPATCH_BASE_REF:-origin/main}"
+REPO="${AUTOSPEC_DISPATCH_REPO:-}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -48,6 +61,7 @@ while [ $# -gt 0 ]; do
         --prompt-file) PROMPT_FILE="$2"; shift 2 ;;
         --cleanup)     CLEANUP=1; shift ;;
         --base)        BASE_REF="$2"; shift 2 ;;
+        --repo)        REPO="$2"; shift 2 ;;
         -h|--help)     usage; exit 0 ;;
         *)             echo "dispatch-implementer.sh: unknown arg: $1" >&2; usage >&2; exit 1 ;;
     esac
@@ -59,6 +73,18 @@ if [ -z "$ISSUE" ] || [ -z "$BRANCH" ]; then
     exit 1
 fi
 
+# Locate worktree-guard.sh: prefer the repo-local copy, then ~/.autospec/scripts/.
+SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd -P)" || SCRIPT_DIR=""
+GUARD=""
+if [ -n "$SCRIPT_DIR" ] && [ -x "$SCRIPT_DIR/worktree-guard.sh" ]; then
+    GUARD="$SCRIPT_DIR/worktree-guard.sh"
+elif [ -x "${HOME}/.autospec/scripts/worktree-guard.sh" ]; then
+    GUARD="${HOME}/.autospec/scripts/worktree-guard.sh"
+else
+    echo "dispatch-implementer.sh: worktree-guard.sh not found (checked $SCRIPT_DIR and ~/.autospec/scripts/)" >&2
+    exit 1
+fi
+
 WT_PATH="/tmp/wt-${BRANCH}"
 
 if [ "$CLEANUP" -eq 1 ]; then
@@ -66,6 +92,7 @@ if [ "$CLEANUP" -eq 1 ]; then
         git worktree remove --force "$WT_PATH" 2>/dev/null \
             || rm -rf "$WT_PATH" \
             || { echo "dispatch-implementer.sh: failed to remove $WT_PATH" >&2; exit 2; }
+        git worktree prune 2>/dev/null || true
     fi
     exit 0
 fi
@@ -75,15 +102,40 @@ if [ -z "$PROMPT_FILE" ] || [ ! -r "$PROMPT_FILE" ]; then
     exit 3
 fi
 
-# Create the worktree. If it already exists (rare; orchestrator restart), reuse.
-if [ ! -d "$WT_PATH" ]; then
-    git worktree add -b "$BRANCH" "$WT_PATH" "$BASE_REF" >/dev/null 2>&1 \
-        || git worktree add "$WT_PATH" "$BRANCH" >/dev/null 2>&1 \
-        || { echo "dispatch-implementer.sh: failed to create worktree at $WT_PATH" >&2; exit 2; }
+# Step 1: resolve-branch ladder — surface the verdict BEFORE worktree creation
+# so the orchestrator can decide open-pr / branch-only / fresh handling.
+VERDICT_JSON=""
+if [ -n "$REPO" ]; then
+    VERDICT_JSON="$("$GUARD" resolve-branch --branch "$BRANCH" --repo "$REPO" 2>/dev/null || true)"
+else
+    # No --repo provided: skip the open-PR rung (requires gh), do branch-only check only.
+    VERDICT_JSON='{"state":"fresh","pr":null}'
+fi
+# Normalise: if guard returned nothing, treat as fresh.
+if [ -z "$VERDICT_JSON" ]; then
+    VERDICT_JSON='{"state":"fresh","pr":null}'
 fi
 
-# Emit the augmented prompt: worktree directive + original prompt body.
+# Step 2: delegate worktree creation to worktree-guard.sh create.
+# This enforces: no silent dirty reuse (exit 4 with code_health:worktree_dirty_reuse_refused),
+# fetch-before-branch (G4), and idempotent clean reuse.
+guard_exit=0
+"$GUARD" create --branch "$BRANCH" --path "$WT_PATH" --base "$BASE_REF" 2>&1 || guard_exit=$?
+if [ "$guard_exit" -ne 0 ]; then
+    echo "dispatch-implementer.sh: worktree-guard.sh create exited $guard_exit for $WT_PATH (branch=$BRANCH)" >&2
+    exit "$guard_exit"
+fi
+
+# Emit the augmented prompt: verdict header + worktree directive + original prompt body.
 cat <<EOF
+<!-- dispatch-implementer: branch_verdict=$VERDICT_JSON -->
+
+**Branch verdict:** \`$VERDICT_JSON\`
+The orchestrator should act on \`state\` before proceeding:
+- \`open-pr\`: an open PR already exists — validate + merge the existing PR, no re-implementation.
+- \`branch-only\`: branch exists remotely but no open PR — adopt in this worktree and continue.
+- \`fresh\`: no prior work exists — proceed with new implementation.
+
 **Workdir:** \`$WT_PATH\` (worktree). All \`cd\`, \`git\`, \`gh\`, edit, and
 test commands MUST run from this worktree. Do NOT touch the main checkout.
 Do NOT \`git checkout\` other branches. This is parallel-safety isolation

--- a/tests/autospec-run/test_parallel_dispatch.bats
+++ b/tests/autospec-run/test_parallel_dispatch.bats
@@ -1,21 +1,29 @@
 #!/usr/bin/env bats
 # tests/autospec-run/test_parallel_dispatch.bats — parallel implementer
-# worktree isolation contract (issue #690).
+# worktree isolation contract (issue #690 + #960).
 #
 # Fixtures (per spec):
 #   a. helper creates worktree at /tmp/wt-<branch>
 #   b. prompt pre-pend includes worktree path
 #   c. helper removes worktree on completion (--cleanup)
 #   d. two parallel invocations don't collide (distinct worktrees, distinct branches)
+#   e. (new #960) ladder verdict 'fresh' surfaced when no --repo given
+#   f. (new #960) ladder verdict 'branch-only' surfaced via mocked git ls-remote
+#   g. (new #960) ladder verdict 'open-pr' surfaced via mocked gh pr list
+#   h. (new #960) dirty-reuse refusal propagates (exit 4 + code_health marker)
+#   i. (new #960) clean same-branch reuse still works (idempotent create)
 
 setup() {
     REPO_ROOT="$(git rev-parse --show-toplevel)"
     HELPER="$REPO_ROOT/scripts/dispatch-implementer.sh"
+    GUARD="$REPO_ROOT/scripts/worktree-guard.sh"
     TMPDIR_BATS="$(mktemp -d)"
     PROMPT_FILE="$TMPDIR_BATS/prompt.md"
     printf 'IMPLEMENTER_PROMPT_BODY\n' > "$PROMPT_FILE"
     BRANCH_A="test-690-fixture-a-$$"
     BRANCH_B="test-690-fixture-b-$$"
+    MOCK_BIN="$TMPDIR_BATS/bin"
+    mkdir -p "$MOCK_BIN"
 }
 
 teardown() {
@@ -57,4 +65,119 @@ teardown() {
     branch_b_head="$(git -C "/tmp/wt-$BRANCH_B" rev-parse --abbrev-ref HEAD)"
     [ "$branch_a_head" = "$BRANCH_A" ]
     [ "$branch_b_head" = "$BRANCH_B" ]
+}
+
+@test "fixture e (#960): ladder verdict 'fresh' surfaced when no --repo given" {
+    run bash "$HELPER" --issue 960 --branch "$BRANCH_A" --prompt-file "$PROMPT_FILE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'branch_verdict='* ]]
+    [[ "$output" == *'"state":"fresh"'* ]]
+    [[ "$output" == *"Branch verdict:"* ]]
+}
+
+@test "fixture f (#960): ladder verdict 'branch-only' surfaced via mocked git ls-remote" {
+    # Locate the real git binary BEFORE prepending the mock bin to PATH.
+    REAL_GIT="$(command -v git)"
+    REAL_GH="$(command -v gh)"
+
+    # Mock git: ls-remote --heads returns a ref line (branch exists remotely);
+    # fetch is stubbed to avoid a real network call; all other git commands
+    # delegate to the real git binary (by absolute path, not via PATH lookup).
+    cat > "$MOCK_BIN/git" <<MOCKEOF
+#!/usr/bin/env bash
+if [ "\$1" = "ls-remote" ] && [ "\$2" = "--heads" ]; then
+    printf 'abc123\trefs/heads/%s\n' "\${4:-branch}"
+    exit 0
+fi
+if [ "\$1" = "fetch" ]; then
+    exit 0
+fi
+exec "$REAL_GIT" "\$@"
+MOCKEOF
+    chmod +x "$MOCK_BIN/git"
+
+    # Mock gh: no open PRs so the open-pr rung doesn't fire first.
+    cat > "$MOCK_BIN/gh" <<MOCKEOF
+#!/usr/bin/env bash
+if [ "\$1" = "pr" ] && [ "\$2" = "list" ]; then
+    printf '[]\n'
+    exit 0
+fi
+exec "$REAL_GH" "\$@"
+MOCKEOF
+    chmod +x "$MOCK_BIN/gh"
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$HELPER" \
+        --issue 960 --branch "$BRANCH_A" --prompt-file "$PROMPT_FILE" \
+        --repo "berlinguyinca/autospec"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"state":"branch-only"'* ]]
+    [[ "$output" == *"Branch verdict:"* ]]
+}
+
+@test "fixture g (#960): ladder verdict 'open-pr' surfaced via mocked gh pr list" {
+    # Locate the real binaries BEFORE prepending the mock bin to PATH.
+    REAL_GIT="$(command -v git)"
+    REAL_GH="$(command -v gh)"
+
+    # Mock gh: return one open PR with number 42.
+    cat > "$MOCK_BIN/gh" <<MOCKEOF
+#!/usr/bin/env bash
+if [ "\$1" = "pr" ] && [ "\$2" = "list" ]; then
+    printf '[{"number":42}]\n'
+    exit 0
+fi
+exec "$REAL_GH" "\$@"
+MOCKEOF
+    chmod +x "$MOCK_BIN/gh"
+
+    # Mock git: stub fetch to avoid a real network call (create calls git fetch origin).
+    cat > "$MOCK_BIN/git" <<MOCKEOF
+#!/usr/bin/env bash
+if [ "\$1" = "fetch" ]; then
+    exit 0
+fi
+exec "$REAL_GIT" "\$@"
+MOCKEOF
+    chmod +x "$MOCK_BIN/git"
+
+    run env PATH="$MOCK_BIN:$PATH" bash "$HELPER" \
+        --issue 960 --branch "$BRANCH_A" --prompt-file "$PROMPT_FILE" \
+        --repo "berlinguyinca/autospec"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"state":"open-pr"'* ]]
+    [[ "$output" == *'"pr":42'* ]]
+    [[ "$output" == *"Branch verdict:"* ]]
+}
+
+@test "fixture h (#960): dirty-reuse refusal propagates (exit 4 + code_health marker)" {
+    DIRTY_BRANCH="test-960-dirty-$$"
+    DIRTY_PATH="/tmp/wt-$DIRTY_BRANCH"
+
+    # Create a real worktree, then dirty it with an untracked file.
+    git worktree add -b "$DIRTY_BRANCH" "$DIRTY_PATH" origin/main >/dev/null 2>&1
+    printf 'dirty-file\n' > "$DIRTY_PATH/dirty-untracked.txt"
+
+    run bash "$HELPER" --issue 960 --branch "$DIRTY_BRANCH" --prompt-file "$PROMPT_FILE"
+
+    # Cleanup regardless of test outcome.
+    git worktree remove --force "$DIRTY_PATH" 2>/dev/null || rm -rf "$DIRTY_PATH"
+    git worktree prune 2>/dev/null || true
+
+    [ "$status" -eq 4 ]
+    # The code_health marker must appear or the propagated error message.
+    [[ "$output" == *"code_health:worktree_dirty_reuse_refused"* ]] \
+        || [[ "$output" == *"worktree-guard.sh create exited 4"* ]]
+}
+
+@test "fixture i (#960): clean same-branch reuse still succeeds (idempotent create)" {
+    # First call: creates the worktree.
+    bash "$HELPER" --issue 960 --branch "$BRANCH_A" --prompt-file "$PROMPT_FILE" >/dev/null
+    [ -d "/tmp/wt-$BRANCH_A" ]
+
+    # Second call: same branch, clean worktree — must succeed (idempotent reuse).
+    run bash "$HELPER" --issue 960 --branch "$BRANCH_A" --prompt-file "$PROMPT_FILE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"/tmp/wt-$BRANCH_A"* ]]
+    [[ "$output" == *"IMPLEMENTER_PROMPT_BODY"* ]]
 }


### PR DESCRIPTION
## Summary

Implements docs/specs/2026-06-03-worktree-guard-design.md §D2 (decomposition child 2): `scripts/dispatch-implementer.sh` now delegates worktree creation to the merged `worktree-guard.sh` (child 1, #959) and surfaces the `resolve-branch` ladder verdict.

## Changes

- **Removed the silent dirty-reuse fallback chain** (old `dispatch-implementer.sh:78-82`: `git worktree add -b ... || git worktree add ... || die`). Worktree creation flows entirely through `worktree-guard.sh create`, which refuses dirty/wrong-branch reuse with exit `4` + `code_health:worktree_dirty_reuse_refused`. That refusal exit code is propagated to the caller.
- **Call `worktree-guard.sh resolve-branch` first** (when `--repo` is provided) and surface the `{state, pr}` verdict in the dispatch output contract (header comment + human-readable block), so the orchestrator can decide open-pr / branch-only / fresh handling **before** dispatch. With no `--repo`, defaults to `fresh` (no `gh` dependency for existing callers).
- Reuse the merged child-1 guard — no reimplementation of worktree logic (honors per-issue file ownership).
- Existing prompt-prepend + `--cleanup` contract intact (`--cleanup` now additionally runs `git worktree prune`).

**Reuse decision:** Reusing `scripts/worktree-guard.sh` (child 1, #959, merged) for all worktree create/resolve-branch logic, per the shared-contracts block — exit codes and ladder JSON are pinned upstream.

## Tests

`tests/autospec-run/test_parallel_dispatch.bats`:
- Existing fixtures a-d stay green (backward-compatible).
- New **e**: `fresh` verdict surfaced when no `--repo` given.
- New **f**: `branch-only` verdict surfaced (PATH-shadowed `git ls-remote` mock; real-binary `exec` to avoid mock recursion + `fetch` stub to avoid network).
- New **g**: `open-pr` verdict surfaced (PATH-shadowed `gh pr list` mock).
- New **h**: dirty-reuse refusal propagates (exit `4` + `code_health:worktree_dirty_reuse_refused`).
- New **i**: clean same-branch reuse still works (idempotent `create`).

All 9 parallel-dispatch + 28 worktree-guard bats green; `bash scripts/validate.sh` exit 0; `bash -n` clean.

### Primary smoke test
```
bats tests/autospec-run/test_parallel_dispatch.bats
```

Peer-review: codex not on PATH, skipping.

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)