### PR TITLE
feat(autospec-run): PR-aware worktree ladder + assert gate (#961)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -974,6 +974,60 @@ check_docs_drift_gate_regen_conditional_parity() {
     info "docs-drift-gate regen conditional parity: all 6 trio files carry D2b gate"
 }
 
+# Worktree PR-aware ladder + assert-gate parity (issue #961, spec §D3): the
+# run-trio `process(ISSUE)` step 1 must carry the 3-state recovery ladder
+# (open-pr/branch-only/fresh) wired through `worktree-guard.sh resolve-branch`,
+# plus the mandatory `worktree-guard.sh assert` gate (MUST exit 0 before any
+# edit; non-zero → restore auto-implement + stop) and the prose hard rules
+# (no primary-checkout mutation; cleanup = `git worktree remove` + prune). Both
+# run trios (6 files) AND phase4-implementer.md must agree. Fails CI if either
+# trio drifts back to the unconditional `git worktree add` path.
+check_worktree_ladder_assert_parity() {
+    info "worktree ladder + assert parity (D3): autospec + autospec-run trios (6 files) + phase4-implementer.md"
+    local phase4="skills/autospec-run/prompts/phase4-implementer.md"
+    local targets=""
+    for s in autospec autospec-run; do
+        targets="$targets skills/$s/SKILL.md skills/$s/codex/prompt.md skills/$s/opencode/agent.md"
+    done
+    targets="$targets $phase4"
+    for f in $targets; do
+        [ -f "$f" ] || fail "$f: required file missing"
+        grep -q 'worktree-guard.sh resolve-branch' "$f" \
+            || fail "$f: missing worktree-guard.sh resolve-branch (D3 ladder step 1)"
+        grep -q 'open-pr' "$f"     || fail "$f: missing open-pr ladder state (D3)"
+        grep -q 'branch-only' "$f" || fail "$f: missing branch-only ladder state (D3)"
+        grep -q '\bfresh\b' "$f"   || fail "$f: missing fresh ladder state (D3)"
+        grep -qi 'skip implementation' "$f" \
+            || fail "$f: open-pr path must skip implementation (D3 #886 recovery)"
+        grep -q 'adopt' "$f" \
+            || fail "$f: branch-only path must adopt the branch (D3 #917 recovery)"
+        grep -q 'worktree-guard.sh assert' "$f" \
+            || fail "$f: missing worktree-guard.sh assert gate (D3 step 2)"
+        grep -q 'MUST exit 0' "$f" \
+            || fail "$f: assert gate must require exit 0 before any edit (D3)"
+        grep -qi 'primary checkout' "$f" \
+            || fail "$f: missing primary-checkout hard rule (D3)"
+        grep -q 'git worktree remove' "$f" \
+            || fail "$f: missing 'git worktree remove' cleanup rule (D3)"
+        grep -q 'git worktree prune' "$f" \
+            || fail "$f: missing 'git worktree prune' cleanup rule (D3)"
+    done
+    # Extracted ladder bash from each SKILL.md must be well-formed.
+    for f in skills/autospec/SKILL.md skills/autospec-run/SKILL.md; do
+        local block
+        block="$(awk '
+            /worktree-ladder:begin/{cap=1; next}
+            /worktree-ladder:end/{cap=0}
+            cap{ sub(/^> ?/, ""); print }
+        ' "$f")"
+        [ -n "$block" ] \
+            || fail "$f: missing worktree-ladder:begin/end sentinel block (D3)"
+        printf '%s\n' "$block" | bash -n - \
+            || fail "$f: extracted worktree-ladder block fails bash -n (D3)"
+    done
+    info "worktree ladder + assert parity: all 6 trio files + phase4-implementer.md carry D3 ladder/assert"
+}
+
 # Team-personality contract: autospec should infer the right solving team from
 # the request, repository evidence, memories, and prior specs. If confidence is
 # low, it must ask explicitly with five concrete starter combinations, carry
@@ -2058,6 +2112,7 @@ main() {
     check_phase4_full_test_suite_gate
     check_phase4_cost_epic_parity_lockstep
     check_docs_drift_gate_regen_conditional_parity
+    check_worktree_ladder_assert_parity
     check_autospec_sweep_config_contract
     check_autospec_fleet_scripts
     check_fleet_gui_subcommand_lockstep

--- a/skills/autospec-run/SKILL.md
+++ b/skills/autospec-run/SKILL.md
@@ -724,9 +724,51 @@ inline label-swap path below.
 >
 > <verbatim AC checkbox list from issue body — every checkbox must be green before push>
 >
-> 1. Worktree off origin/main:
+> 1. **PR-aware recovery ladder, then worktree.** Resolve the branch state FIRST, then act on the verdict. NEVER `cd`/`git checkout`/`git commit` in the primary checkout — all work happens in a linked worktree off `origin/main`.
+>    <!-- worktree-ladder:begin -->
+>    ```bash
 >    cd {repo_root} && git fetch origin
->    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
+>    LADDER=$(bash scripts/worktree-guard.sh resolve-branch --branch <BRANCH> --repo {repo})
+>    STATE=$(printf '%s' "$LADDER" | sed -n 's/.*"state":"\([^"]*\)".*/\1/p')
+>    PR=$(printf '%s' "$LADDER" | sed -n 's/.*"pr":\([0-9]*\).*/\1/p')
+>    case "$STATE" in
+>      open-pr)
+>        # #886 recovery: a PR already exists. SKIP implementation entirely.
+>        # Check out the existing PR in a fresh worktree, run the issue's
+>        # verification (tests + validate.sh) and the standard review loop
+>        # against the EXISTING PR, then merge if green. Never re-implement.
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH> --adopt
+>        cd /tmp/wt-<BRANCH>
+>        gh pr checkout "$PR"
+>        echo "[ladder] open-pr #$PR — skip implementation; verify + review + merge existing PR"
+>        ;;
+>      branch-only)
+>        # #917 recovery: the branch exists with un-PR'd work. Adopt it in a
+>        # fresh worktree and CONTINUE the remaining work (do not start over).
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH> --adopt
+>        cd /tmp/wt-<BRANCH>
+>        echo "[ladder] branch-only — adopted <BRANCH>; continue remaining work"
+>        ;;
+>      fresh|*)
+>        # No branch, no PR: create a new worktree off origin/main.
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH>
+>        cd /tmp/wt-<BRANCH>
+>        echo "[ladder] fresh — created <BRANCH>"
+>        ;;
+>    esac
+>    # MANDATORY assert gate: MUST exit 0 before the first file edit/commit. A
+>    # non-zero exit (in_primary_checkout / dirty / stale_base) is NEVER worked
+>    # around — comment the emitted code_health identifier on the issue, restore
+>    # the `auto-implement` label (swap `in-progress-by-bot` → `auto-implement`),
+>    # remove the heartbeat, and stop this issue.
+>    if ! bash scripts/worktree-guard.sh assert; then
+>      gh issue comment <ISSUE> --body "worktree-guard assert failed (see code_health identifier above); restoring auto-implement"
+>      gh issue edit <ISSUE> --remove-label in-progress-by-bot --add-label auto-implement
+>      exit 1
+>    fi
+>    ```
+>    <!-- worktree-ladder:end -->
+>    On the `open-pr` path the verification bar EQUALS fresh work — full tests + the standard review loop, never a blind merge. Cleanup is identical for every path: after the merge is confirmed (or on terminal failure), `git worktree remove` the linked worktree and `git worktree prune`; never delete un-pushed work before merge.
 > 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
 > 3. **Full test suite gate.** Run the target repo's full validation/test suite, not only the Primary smoke test. Command resolution order:
 >    1. If `AUTOSPEC_FULL_TEST_COMMAND` is set, run `bash -lc "$AUTOSPEC_FULL_TEST_COMMAND"`.

--- a/skills/autospec-run/codex/prompt.md
+++ b/skills/autospec-run/codex/prompt.md
@@ -719,9 +719,51 @@ inline label-swap path below.
 >
 > <verbatim AC checkbox list from issue body — every checkbox must be green before push>
 >
-> 1. Worktree off origin/main:
+> 1. **PR-aware recovery ladder, then worktree.** Resolve the branch state FIRST, then act on the verdict. NEVER `cd`/`git checkout`/`git commit` in the primary checkout — all work happens in a linked worktree off `origin/main`.
+>    <!-- worktree-ladder:begin -->
+>    ```bash
 >    cd {repo_root} && git fetch origin
->    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
+>    LADDER=$(bash scripts/worktree-guard.sh resolve-branch --branch <BRANCH> --repo {repo})
+>    STATE=$(printf '%s' "$LADDER" | sed -n 's/.*"state":"\([^"]*\)".*/\1/p')
+>    PR=$(printf '%s' "$LADDER" | sed -n 's/.*"pr":\([0-9]*\).*/\1/p')
+>    case "$STATE" in
+>      open-pr)
+>        # #886 recovery: a PR already exists. SKIP implementation entirely.
+>        # Check out the existing PR in a fresh worktree, run the issue's
+>        # verification (tests + validate.sh) and the standard review loop
+>        # against the EXISTING PR, then merge if green. Never re-implement.
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH> --adopt
+>        cd /tmp/wt-<BRANCH>
+>        gh pr checkout "$PR"
+>        echo "[ladder] open-pr #$PR — skip implementation; verify + review + merge existing PR"
+>        ;;
+>      branch-only)
+>        # #917 recovery: the branch exists with un-PR'd work. Adopt it in a
+>        # fresh worktree and CONTINUE the remaining work (do not start over).
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH> --adopt
+>        cd /tmp/wt-<BRANCH>
+>        echo "[ladder] branch-only — adopted <BRANCH>; continue remaining work"
+>        ;;
+>      fresh|*)
+>        # No branch, no PR: create a new worktree off origin/main.
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH>
+>        cd /tmp/wt-<BRANCH>
+>        echo "[ladder] fresh — created <BRANCH>"
+>        ;;
+>    esac
+>    # MANDATORY assert gate: MUST exit 0 before the first file edit/commit. A
+>    # non-zero exit (in_primary_checkout / dirty / stale_base) is NEVER worked
+>    # around — comment the emitted code_health identifier on the issue, restore
+>    # the `auto-implement` label (swap `in-progress-by-bot` → `auto-implement`),
+>    # remove the heartbeat, and stop this issue.
+>    if ! bash scripts/worktree-guard.sh assert; then
+>      gh issue comment <ISSUE> --body "worktree-guard assert failed (see code_health identifier above); restoring auto-implement"
+>      gh issue edit <ISSUE> --remove-label in-progress-by-bot --add-label auto-implement
+>      exit 1
+>    fi
+>    ```
+>    <!-- worktree-ladder:end -->
+>    On the `open-pr` path the verification bar EQUALS fresh work — full tests + the standard review loop, never a blind merge. Cleanup is identical for every path: after the merge is confirmed (or on terminal failure), `git worktree remove` the linked worktree and `git worktree prune`; never delete un-pushed work before merge.
 > 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
 > 3. **Full test suite gate.** Run the target repo's full validation/test suite, not only the Primary smoke test. Command resolution order:
 >    1. If `AUTOSPEC_FULL_TEST_COMMAND` is set, run `bash -lc "$AUTOSPEC_FULL_TEST_COMMAND"`.

--- a/skills/autospec-run/opencode/agent.md
+++ b/skills/autospec-run/opencode/agent.md
@@ -723,9 +723,51 @@ inline label-swap path below.
 >
 > <verbatim AC checkbox list from issue body — every checkbox must be green before push>
 >
-> 1. Worktree off origin/main:
+> 1. **PR-aware recovery ladder, then worktree.** Resolve the branch state FIRST, then act on the verdict. NEVER `cd`/`git checkout`/`git commit` in the primary checkout — all work happens in a linked worktree off `origin/main`.
+>    <!-- worktree-ladder:begin -->
+>    ```bash
 >    cd {repo_root} && git fetch origin
->    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
+>    LADDER=$(bash scripts/worktree-guard.sh resolve-branch --branch <BRANCH> --repo {repo})
+>    STATE=$(printf '%s' "$LADDER" | sed -n 's/.*"state":"\([^"]*\)".*/\1/p')
+>    PR=$(printf '%s' "$LADDER" | sed -n 's/.*"pr":\([0-9]*\).*/\1/p')
+>    case "$STATE" in
+>      open-pr)
+>        # #886 recovery: a PR already exists. SKIP implementation entirely.
+>        # Check out the existing PR in a fresh worktree, run the issue's
+>        # verification (tests + validate.sh) and the standard review loop
+>        # against the EXISTING PR, then merge if green. Never re-implement.
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH> --adopt
+>        cd /tmp/wt-<BRANCH>
+>        gh pr checkout "$PR"
+>        echo "[ladder] open-pr #$PR — skip implementation; verify + review + merge existing PR"
+>        ;;
+>      branch-only)
+>        # #917 recovery: the branch exists with un-PR'd work. Adopt it in a
+>        # fresh worktree and CONTINUE the remaining work (do not start over).
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH> --adopt
+>        cd /tmp/wt-<BRANCH>
+>        echo "[ladder] branch-only — adopted <BRANCH>; continue remaining work"
+>        ;;
+>      fresh|*)
+>        # No branch, no PR: create a new worktree off origin/main.
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH>
+>        cd /tmp/wt-<BRANCH>
+>        echo "[ladder] fresh — created <BRANCH>"
+>        ;;
+>    esac
+>    # MANDATORY assert gate: MUST exit 0 before the first file edit/commit. A
+>    # non-zero exit (in_primary_checkout / dirty / stale_base) is NEVER worked
+>    # around — comment the emitted code_health identifier on the issue, restore
+>    # the `auto-implement` label (swap `in-progress-by-bot` → `auto-implement`),
+>    # remove the heartbeat, and stop this issue.
+>    if ! bash scripts/worktree-guard.sh assert; then
+>      gh issue comment <ISSUE> --body "worktree-guard assert failed (see code_health identifier above); restoring auto-implement"
+>      gh issue edit <ISSUE> --remove-label in-progress-by-bot --add-label auto-implement
+>      exit 1
+>    fi
+>    ```
+>    <!-- worktree-ladder:end -->
+>    On the `open-pr` path the verification bar EQUALS fresh work — full tests + the standard review loop, never a blind merge. Cleanup is identical for every path: after the merge is confirmed (or on terminal failure), `git worktree remove` the linked worktree and `git worktree prune`; never delete un-pushed work before merge.
 > 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
 > 3. **Full test suite gate.** Run the target repo's full validation/test suite, not only the Primary smoke test. Command resolution order:
 >    1. If `AUTOSPEC_FULL_TEST_COMMAND` is set, run `bash -lc "$AUTOSPEC_FULL_TEST_COMMAND"`.

--- a/skills/autospec-run/prompts/phase4-implementer.md
+++ b/skills/autospec-run/prompts/phase4-implementer.md
@@ -29,6 +29,21 @@ For each candidate, note the file path and a one-line description of what it doe
 
 Skipping this step or leaving the reuse decision undocumented in the PR body is a policy violation.
 
+## Worktree + PR-aware recovery ladder
+
+**Before any code is written**, resolve the branch state and enter an isolated
+worktree. You NEVER `cd`/`git checkout`/`git commit` in the primary checkout —
+all work happens in a linked worktree off `origin/main`. This file is standalone
+(not lock-step with the run trios) but its rules MUST agree with the trio
+contract.
+
+1. **Ladder first.** `bash scripts/worktree-guard.sh resolve-branch --branch <BRANCH> --repo <REPO>` returns `{"state":"open-pr"|"branch-only"|"fresh","pr":N|null}`. Branch on `state`:
+   - **`open-pr`** (#886 recovery): a PR already exists — **skip implementation** entirely. Create an adopt-mode worktree, `gh pr checkout <PR>`, then run the issue's verification (tests + `validate.sh`) and the standard review loop against the EXISTING PR, and merge if green. Never re-implement.
+   - **`branch-only`** (#917 recovery): the branch exists with un-PR'd work — adopt it (`worktree-guard.sh create --adopt`) in a fresh worktree and **continue** the remaining work; do not start over.
+   - **`fresh`**: no branch, no PR — `worktree-guard.sh create --branch <BRANCH>`.
+2. **Assert before any edit.** `bash scripts/worktree-guard.sh assert` MUST exit 0 before the first file edit/commit. A non-zero exit (`in_primary_checkout` / `dirty` / `stale_base`) is NEVER worked around — comment the emitted `code_health:` identifier on the issue, restore the `auto-implement` label, and stop the issue.
+3. **Cleanup.** After the merge is confirmed (or on terminal failure), `git worktree remove` the linked worktree and `git worktree prune`. Never delete un-pushed work before merge.
+
 ## Expand
 
 Before changing any code:

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -898,9 +898,51 @@ Pass the following prompt verbatim to each background subagent:
 > - Schema: `{"issue":"<ISSUE>","branch":"<BRANCH>","step":"<STEP>","ts":<unix_epoch>,"pr":"<PR>","repo":"{repo}"}`
 > - Delete this file on terminal SUCCESS/FAILURE in both clean and failure paths.
 > 
-> 1. Worktree off origin/main:
+> 1. **PR-aware recovery ladder, then worktree.** Resolve the branch state FIRST, then act on the verdict. NEVER `cd`/`git checkout`/`git commit` in the primary checkout — all work happens in a linked worktree off `origin/main`.
+>    <!-- worktree-ladder:begin -->
+>    ```bash
 >    cd {repo_root} && git fetch origin
->    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
+>    LADDER=$(bash scripts/worktree-guard.sh resolve-branch --branch <BRANCH> --repo {repo})
+>    STATE=$(printf '%s' "$LADDER" | sed -n 's/.*"state":"\([^"]*\)".*/\1/p')
+>    PR=$(printf '%s' "$LADDER" | sed -n 's/.*"pr":\([0-9]*\).*/\1/p')
+>    case "$STATE" in
+>      open-pr)
+>        # #886 recovery: a PR already exists. SKIP implementation entirely.
+>        # Check out the existing PR in a fresh worktree, run the issue's
+>        # verification (tests + validate.sh) and the standard review loop
+>        # against the EXISTING PR, then merge if green. Never re-implement.
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH> --adopt
+>        cd /tmp/wt-<BRANCH>
+>        gh pr checkout "$PR"
+>        echo "[ladder] open-pr #$PR — skip implementation; verify + review + merge existing PR"
+>        ;;
+>      branch-only)
+>        # #917 recovery: the branch exists with un-PR'd work. Adopt it in a
+>        # fresh worktree and CONTINUE the remaining work (do not start over).
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH> --adopt
+>        cd /tmp/wt-<BRANCH>
+>        echo "[ladder] branch-only — adopted <BRANCH>; continue remaining work"
+>        ;;
+>      fresh|*)
+>        # No branch, no PR: create a new worktree off origin/main.
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH>
+>        cd /tmp/wt-<BRANCH>
+>        echo "[ladder] fresh — created <BRANCH>"
+>        ;;
+>    esac
+>    # MANDATORY assert gate: MUST exit 0 before the first file edit/commit. A
+>    # non-zero exit (in_primary_checkout / dirty / stale_base) is NEVER worked
+>    # around — comment the emitted code_health identifier on the issue, restore
+>    # the `auto-implement` label (swap `in-progress-by-bot` → `auto-implement`),
+>    # remove the heartbeat, and stop this issue.
+>    if ! bash scripts/worktree-guard.sh assert; then
+>      gh issue comment <ISSUE> --body "worktree-guard assert failed (see code_health identifier above); restoring auto-implement"
+>      gh issue edit <ISSUE> --remove-label in-progress-by-bot --add-label auto-implement
+>      exit 1
+>    fi
+>    ```
+>    <!-- worktree-ladder:end -->
+>    On the `open-pr` path the verification bar EQUALS fresh work — full tests + the standard review loop, never a blind merge. Cleanup is identical for every path: after the merge is confirmed (or on terminal failure), `git worktree remove` the linked worktree and `git worktree prune`; never delete un-pushed work before merge.
 > 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
 > 3. **Full test suite gate.** Run the target repo's full validation/test suite, not only the Primary smoke test. Command resolution order:
 >    1. If `AUTOSPEC_FULL_TEST_COMMAND` is set, run `bash -lc "$AUTOSPEC_FULL_TEST_COMMAND"`.

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -892,9 +892,51 @@ Pass the following prompt verbatim to each background subagent:
 > - Schema: `{"issue":"<ISSUE>","branch":"<BRANCH>","step":"<STEP>","ts":<unix_epoch>,"pr":"<PR>","repo":"{repo}"}`
 > - Delete this file on terminal SUCCESS/FAILURE in both clean and failure paths.
 > 
-> 1. Worktree off origin/main:
+> 1. **PR-aware recovery ladder, then worktree.** Resolve the branch state FIRST, then act on the verdict. NEVER `cd`/`git checkout`/`git commit` in the primary checkout — all work happens in a linked worktree off `origin/main`.
+>    <!-- worktree-ladder:begin -->
+>    ```bash
 >    cd {repo_root} && git fetch origin
->    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
+>    LADDER=$(bash scripts/worktree-guard.sh resolve-branch --branch <BRANCH> --repo {repo})
+>    STATE=$(printf '%s' "$LADDER" | sed -n 's/.*"state":"\([^"]*\)".*/\1/p')
+>    PR=$(printf '%s' "$LADDER" | sed -n 's/.*"pr":\([0-9]*\).*/\1/p')
+>    case "$STATE" in
+>      open-pr)
+>        # #886 recovery: a PR already exists. SKIP implementation entirely.
+>        # Check out the existing PR in a fresh worktree, run the issue's
+>        # verification (tests + validate.sh) and the standard review loop
+>        # against the EXISTING PR, then merge if green. Never re-implement.
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH> --adopt
+>        cd /tmp/wt-<BRANCH>
+>        gh pr checkout "$PR"
+>        echo "[ladder] open-pr #$PR — skip implementation; verify + review + merge existing PR"
+>        ;;
+>      branch-only)
+>        # #917 recovery: the branch exists with un-PR'd work. Adopt it in a
+>        # fresh worktree and CONTINUE the remaining work (do not start over).
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH> --adopt
+>        cd /tmp/wt-<BRANCH>
+>        echo "[ladder] branch-only — adopted <BRANCH>; continue remaining work"
+>        ;;
+>      fresh|*)
+>        # No branch, no PR: create a new worktree off origin/main.
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH>
+>        cd /tmp/wt-<BRANCH>
+>        echo "[ladder] fresh — created <BRANCH>"
+>        ;;
+>    esac
+>    # MANDATORY assert gate: MUST exit 0 before the first file edit/commit. A
+>    # non-zero exit (in_primary_checkout / dirty / stale_base) is NEVER worked
+>    # around — comment the emitted code_health identifier on the issue, restore
+>    # the `auto-implement` label (swap `in-progress-by-bot` → `auto-implement`),
+>    # remove the heartbeat, and stop this issue.
+>    if ! bash scripts/worktree-guard.sh assert; then
+>      gh issue comment <ISSUE> --body "worktree-guard assert failed (see code_health identifier above); restoring auto-implement"
+>      gh issue edit <ISSUE> --remove-label in-progress-by-bot --add-label auto-implement
+>      exit 1
+>    fi
+>    ```
+>    <!-- worktree-ladder:end -->
+>    On the `open-pr` path the verification bar EQUALS fresh work — full tests + the standard review loop, never a blind merge. Cleanup is identical for every path: after the merge is confirmed (or on terminal failure), `git worktree remove` the linked worktree and `git worktree prune`; never delete un-pushed work before merge.
 > 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
 > 3. **Full test suite gate.** Run the target repo's full validation/test suite, not only the Primary smoke test. Command resolution order:
 >    1. If `AUTOSPEC_FULL_TEST_COMMAND` is set, run `bash -lc "$AUTOSPEC_FULL_TEST_COMMAND"`.

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -896,9 +896,51 @@ Pass the following prompt verbatim to each background subagent:
 > - Schema: `{"issue":"<ISSUE>","branch":"<BRANCH>","step":"<STEP>","ts":<unix_epoch>,"pr":"<PR>","repo":"{repo}"}`
 > - Delete this file on terminal SUCCESS/FAILURE in both clean and failure paths.
 > 
-> 1. Worktree off origin/main:
+> 1. **PR-aware recovery ladder, then worktree.** Resolve the branch state FIRST, then act on the verdict. NEVER `cd`/`git checkout`/`git commit` in the primary checkout — all work happens in a linked worktree off `origin/main`.
+>    <!-- worktree-ladder:begin -->
+>    ```bash
 >    cd {repo_root} && git fetch origin
->    git worktree add -b <BRANCH> /tmp/wt-<BRANCH> origin/main && cd /tmp/wt-<BRANCH>
+>    LADDER=$(bash scripts/worktree-guard.sh resolve-branch --branch <BRANCH> --repo {repo})
+>    STATE=$(printf '%s' "$LADDER" | sed -n 's/.*"state":"\([^"]*\)".*/\1/p')
+>    PR=$(printf '%s' "$LADDER" | sed -n 's/.*"pr":\([0-9]*\).*/\1/p')
+>    case "$STATE" in
+>      open-pr)
+>        # #886 recovery: a PR already exists. SKIP implementation entirely.
+>        # Check out the existing PR in a fresh worktree, run the issue's
+>        # verification (tests + validate.sh) and the standard review loop
+>        # against the EXISTING PR, then merge if green. Never re-implement.
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH> --adopt
+>        cd /tmp/wt-<BRANCH>
+>        gh pr checkout "$PR"
+>        echo "[ladder] open-pr #$PR — skip implementation; verify + review + merge existing PR"
+>        ;;
+>      branch-only)
+>        # #917 recovery: the branch exists with un-PR'd work. Adopt it in a
+>        # fresh worktree and CONTINUE the remaining work (do not start over).
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH> --adopt
+>        cd /tmp/wt-<BRANCH>
+>        echo "[ladder] branch-only — adopted <BRANCH>; continue remaining work"
+>        ;;
+>      fresh|*)
+>        # No branch, no PR: create a new worktree off origin/main.
+>        bash scripts/worktree-guard.sh create --branch <BRANCH> --path /tmp/wt-<BRANCH>
+>        cd /tmp/wt-<BRANCH>
+>        echo "[ladder] fresh — created <BRANCH>"
+>        ;;
+>    esac
+>    # MANDATORY assert gate: MUST exit 0 before the first file edit/commit. A
+>    # non-zero exit (in_primary_checkout / dirty / stale_base) is NEVER worked
+>    # around — comment the emitted code_health identifier on the issue, restore
+>    # the `auto-implement` label (swap `in-progress-by-bot` → `auto-implement`),
+>    # remove the heartbeat, and stop this issue.
+>    if ! bash scripts/worktree-guard.sh assert; then
+>      gh issue comment <ISSUE> --body "worktree-guard assert failed (see code_health identifier above); restoring auto-implement"
+>      gh issue edit <ISSUE> --remove-label in-progress-by-bot --add-label auto-implement
+>      exit 1
+>    fi
+>    ```
+>    <!-- worktree-ladder:end -->
+>    On the `open-pr` path the verification bar EQUALS fresh work — full tests + the standard review loop, never a blind merge. Cleanup is identical for every path: after the merge is confirmed (or on terminal failure), `git worktree remove` the linked worktree and `git worktree prune`; never delete un-pushed work before merge.
 > 2. TDD per AGENTS.md: failing test first → implement → refactor → commit. NO DB/external mocks. Follow file paths and signatures from the issue body verbatim.
 > 3. **Full test suite gate.** Run the target repo's full validation/test suite, not only the Primary smoke test. Command resolution order:
 >    1. If `AUTOSPEC_FULL_TEST_COMMAND` is set, run `bash -lc "$AUTOSPEC_FULL_TEST_COMMAND"`.

--- a/tests/phase4/test_worktree_ladder_assert.sh
+++ b/tests/phase4/test_worktree_ladder_assert.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# tests/phase4/test_worktree_ladder_assert.sh
+# Verifies the PR-aware recovery ladder + mandatory worktree-guard.sh assert
+# wiring (issue #961, spec §D3):
+#   1. All 6 run-trio files carry the 3-state ladder (open-pr/branch-only/fresh)
+#      wired through `worktree-guard.sh resolve-branch`.
+#   2. All 6 run-trio files carry the mandatory `worktree-guard.sh assert` gate
+#      that MUST exit 0 before any edit, stopping the issue on non-zero exit
+#      (comment + restore auto-implement).
+#   3. All 6 files carry the prose hard rules (no primary-checkout mutation;
+#      cleanup = git worktree remove after merge + git worktree prune).
+#   4. phase4-implementer.md carries the same assert + ladder instructions.
+#   5. The ladder bash extracted from each SKILL.md is well-formed (bash -n).
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# ── File sets for both run trios ─────────────────────────────────────────────
+
+RUN_SKILL="$SCRIPT_DIR/skills/autospec-run/SKILL.md"
+RUN_CODEX="$SCRIPT_DIR/skills/autospec-run/codex/prompt.md"
+RUN_OPENCODE="$SCRIPT_DIR/skills/autospec-run/opencode/agent.md"
+
+AS_SKILL="$SCRIPT_DIR/skills/autospec/SKILL.md"
+AS_CODEX="$SCRIPT_DIR/skills/autospec/codex/prompt.md"
+AS_OPENCODE="$SCRIPT_DIR/skills/autospec/opencode/agent.md"
+
+ALL_SIX="$RUN_SKILL $RUN_CODEX $RUN_OPENCODE $AS_SKILL $AS_CODEX $AS_OPENCODE"
+
+PHASE4="$SCRIPT_DIR/skills/autospec-run/prompts/phase4-implementer.md"
+
+# ── 1. Ladder: 3 states wired through resolve-branch, in all 6 trio files ─────
+
+for f in $ALL_SIX $PHASE4; do
+    name="${f#"$SCRIPT_DIR"/}"
+
+    grep -q 'worktree-guard.sh resolve-branch' "$f" \
+        || fail "$name: missing worktree-guard.sh resolve-branch (ladder step 1)"
+
+    # All three ladder states must be named.
+    grep -q 'open-pr' "$f" \
+        || fail "$name: missing open-pr ladder state"
+    grep -q 'branch-only' "$f" \
+        || fail "$name: missing branch-only ladder state"
+    grep -q '\bfresh\b' "$f" \
+        || fail "$name: missing fresh ladder state"
+
+    # open-pr semantics: skip implementation, verify+review+merge the existing PR.
+    grep -qi 'skip implementation' "$f" \
+        || fail "$name: open-pr path must skip implementation (#886)"
+
+    # branch-only semantics: adopt and continue.
+    grep -q 'adopt' "$f" \
+        || fail "$name: branch-only path must adopt the branch (#917)"
+done
+
+# ── 2. Mandatory assert gate before any edit, stop-on-failure, in all 6 ──────
+
+for f in $ALL_SIX $PHASE4; do
+    name="${f#"$SCRIPT_DIR"/}"
+
+    grep -q 'worktree-guard.sh assert' "$f" \
+        || fail "$name: missing worktree-guard.sh assert gate (step 2)"
+
+    grep -q 'MUST exit 0' "$f" \
+        || fail "$name: assert gate must require exit 0 before any edit"
+
+    # Non-zero assert stops the issue: comment + restore auto-implement.
+    grep -q 'restore .*auto-implement\|restore `auto-implement`\|swap .*auto-implement\|`in-progress-by-bot` . `auto-implement`' "$f" \
+        || fail "$name: non-zero assert must restore auto-implement and stop"
+done
+
+# ── 3. Prose hard rules: no primary-checkout mutation; cleanup + prune ────────
+
+for f in $ALL_SIX $PHASE4; do
+    name="${f#"$SCRIPT_DIR"/}"
+
+    grep -qi 'primary checkout' "$f" \
+        || fail "$name: missing primary-checkout hard rule"
+    grep -q 'git worktree remove' "$f" \
+        || fail "$name: missing 'git worktree remove' cleanup rule"
+    grep -q 'git worktree prune' "$f" \
+        || fail "$name: missing 'git worktree prune' cleanup rule"
+done
+
+# ── 4. Ladder bash extracted from each SKILL.md is well-formed ───────────────
+# Extract the LADDER fenced block (delimited by sentinel comments) and bash -n it.
+
+for f in "$RUN_SKILL" "$AS_SKILL"; do
+    name="${f#"$SCRIPT_DIR"/}"
+    block="$(awk '
+        /worktree-ladder:begin/{cap=1; next}
+        /worktree-ladder:end/{cap=0}
+        cap{ sub(/^> ?/, ""); print }
+    ' "$f")"
+    [ -n "$block" ] \
+        || fail "$name: missing worktree-ladder:begin/end sentinel block"
+    printf '%s\n' "$block" | bash -n - \
+        || fail "$name: extracted worktree-ladder block fails bash -n"
+done
+
+echo "ok: worktree ladder + assert wiring present in all 6 trio files + phase4-implementer.md"


### PR DESCRIPTION
## Summary

Wires the PR-aware recovery ladder and the mandatory `worktree-guard.sh assert` gate into `process(ISSUE)` step 1 of both run trios and `phase4-implementer.md` (spec §D3, child 3).

- **Ladder first** (`worktree-guard.sh resolve-branch`):
  - `open-pr` (#886): skip implementation; check out the existing PR in a fresh worktree, run full verification + the standard review loop, merge if green — never re-implement.
  - `branch-only` (#917): adopt the branch in a fresh worktree and continue the remaining work.
  - `fresh`: create a new worktree off `origin/main`.
- **Assert before any edit**: `worktree-guard.sh assert` MUST exit 0 before the first edit/commit; non-zero (in_primary_checkout / dirty / stale_base) restores `auto-implement` and stops the issue — never worked around.
- **Prose hard rules**: never `cd`/`git checkout`/`git commit` in the primary checkout; cleanup = `git worktree remove` after merge confirmed + `git worktree prune`.

Consumes the merged #959 guard + #960 dispatch integration.

## Lock-step
Authored each SKILL.md; regenerated codex/prompt.md + opencode/agent.md. Frontmatter-stripped diff empty per trio. Both run trios (6 files) byte-identical; phase4-implementer.md mirrors the contract (standalone file).

## Tests
- New `tests/phase4/test_worktree_ladder_assert.sh` — named-content asserts for ladder/assert/cleanup in all 6 trio files + phase4-implementer.md, plus `bash -n` on the extracted ladder block.
- New `check_worktree_ladder_assert_parity` gate in `scripts/validate.sh`.
- `bash scripts/validate.sh` exits 0.
- Regression green: parallel-dispatch (9), watchdog-GC (3), guardian-trio lockstep (7).

Dogfooded the new guard: `resolve-branch` → `fresh`, `create`, `assert` exit 0 in `/tmp/wt-feat-run-trio-worktree-ladder`.

Closes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)