### PR TITLE
feat(autospec-doc): worktree-guard assert before regenerate commit (§D4, #963)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -2655,6 +2655,15 @@ check_autospec_doc_contract() {
         grep -q -- '--audience' "$f" || fail "$f missing --audience subcommand"
         grep -qE '/autospec-doc init|`init`' "$f" \
             || fail "$f missing init subcommand"
+        # §D4 worktree assert: the regenerate commit step must be preceded by a
+        # worktree-guard.sh assert call. The sentinel block must be present and
+        # the assert MUST exit 0 rule must be stated in every trio file.
+        grep -q 'worktree-guard.sh assert' "$f" \
+            || fail "$f: missing worktree-guard.sh assert before doc regenerate commit (issue #963 §D4)"
+        grep -q 'MUST exit 0' "$f" \
+            || fail "$f: doc-regen assert gate must require exit 0 before commit (issue #963 §D4)"
+        grep -q 'doc-regen-assert:begin' "$f" \
+            || fail "$f: missing doc-regen-assert:begin sentinel (issue #963 §D4)"
     done
     orch="$skill/scripts/doc-orchestrator.mjs"
     [ -f "$orch" ] || fail "$orch: orchestrator stub missing"

--- a/skills/autospec-doc/SKILL.md
+++ b/skills/autospec-doc/SKILL.md
@@ -222,6 +222,25 @@ docs-completeness dimension; `/autospec-sweep --full` and `/autospec-define`'s
 auto-docs step redirect to `/autospec-doc`. *(wiring filled in by
 #922/#923/#924.)*
 
+## Worktree assert (regenerate commit)
+
+The regenerate commit step runs inside the implementer's PR-branch worktree
+(already a linked worktree off `origin/main`, never the primary checkout).
+Before committing any regenerated content, the doc orchestrator MUST call
+`worktree-guard.sh assert` and verify it exits 0.
+
+<!-- doc-regen-assert:begin -->
+```bash
+# MANDATORY assert gate before the doc regenerate commit.
+# MUST exit 0 before any commit. A non-zero exit (in_primary_checkout / dirty /
+# stale_base) is NEVER worked around — stop and surface the code_health identifier.
+if ! bash scripts/worktree-guard.sh assert; then
+  echo "worktree-guard assert failed before doc regenerate commit; aborting" >&2
+  exit 1
+fi
+```
+<!-- doc-regen-assert:end -->
+
 ## Invocation
 
 ```

--- a/skills/autospec-doc/codex/prompt.md
+++ b/skills/autospec-doc/codex/prompt.md
@@ -218,6 +218,25 @@ docs-completeness dimension; `/autospec-sweep --full` and `/autospec-define`'s
 auto-docs step redirect to `/autospec-doc`. *(wiring filled in by
 #922/#923/#924.)*
 
+## Worktree assert (regenerate commit)
+
+The regenerate commit step runs inside the implementer's PR-branch worktree
+(already a linked worktree off `origin/main`, never the primary checkout).
+Before committing any regenerated content, the doc orchestrator MUST call
+`worktree-guard.sh assert` and verify it exits 0.
+
+<!-- doc-regen-assert:begin -->
+```bash
+# MANDATORY assert gate before the doc regenerate commit.
+# MUST exit 0 before any commit. A non-zero exit (in_primary_checkout / dirty /
+# stale_base) is NEVER worked around — stop and surface the code_health identifier.
+if ! bash scripts/worktree-guard.sh assert; then
+  echo "worktree-guard assert failed before doc regenerate commit; aborting" >&2
+  exit 1
+fi
+```
+<!-- doc-regen-assert:end -->
+
 ## Invocation
 
 ```

--- a/skills/autospec-doc/opencode/agent.md
+++ b/skills/autospec-doc/opencode/agent.md
@@ -222,6 +222,25 @@ docs-completeness dimension; `/autospec-sweep --full` and `/autospec-define`'s
 auto-docs step redirect to `/autospec-doc`. *(wiring filled in by
 #922/#923/#924.)*
 
+## Worktree assert (regenerate commit)
+
+The regenerate commit step runs inside the implementer's PR-branch worktree
+(already a linked worktree off `origin/main`, never the primary checkout).
+Before committing any regenerated content, the doc orchestrator MUST call
+`worktree-guard.sh assert` and verify it exits 0.
+
+<!-- doc-regen-assert:begin -->
+```bash
+# MANDATORY assert gate before the doc regenerate commit.
+# MUST exit 0 before any commit. A non-zero exit (in_primary_checkout / dirty /
+# stale_base) is NEVER worked around — stop and surface the code_health identifier.
+if ! bash scripts/worktree-guard.sh assert; then
+  echo "worktree-guard assert failed before doc regenerate commit; aborting" >&2
+  exit 1
+fi
+```
+<!-- doc-regen-assert:end -->
+
 ## Invocation
 
 ```

--- a/tests/phase4/test_doc_trio_worktree_assert.bats
+++ b/tests/phase4/test_doc_trio_worktree_assert.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# tests/phase4/test_doc_trio_worktree_assert.bats
+# Verifies the doc-trio worktree-guard.sh assert wiring (issue #963, spec §D4):
+#   1. All three doc-trio files carry `worktree-guard.sh assert` before the
+#      regenerate commit step.
+#   2. All three files carry the MUST-exit-0 rule.
+#   3. All three files carry the doc-regen-assert sentinel block.
+#   4. The new section is byte-identical across all three trio files (lock-step).
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SKILL="$REPO_ROOT/skills/autospec-doc"
+SKILL_MD="$SKILL/SKILL.md"
+CODEX_MD="$SKILL/codex/prompt.md"
+OPENCODE_MD="$SKILL/opencode/agent.md"
+
+# ── 1. worktree-guard.sh assert present in all three trio files ───────────────
+
+@test "SKILL.md: worktree-guard.sh assert present before regenerate commit" {
+    grep -q 'worktree-guard.sh assert' "$SKILL_MD"
+}
+
+@test "codex/prompt.md: worktree-guard.sh assert present before regenerate commit" {
+    grep -q 'worktree-guard.sh assert' "$CODEX_MD"
+}
+
+@test "opencode/agent.md: worktree-guard.sh assert present before regenerate commit" {
+    grep -q 'worktree-guard.sh assert' "$OPENCODE_MD"
+}
+
+# ── 2. MUST exit 0 rule present in all three trio files ──────────────────────
+
+@test "SKILL.md: doc-regen assert gate requires MUST exit 0" {
+    grep -q 'MUST exit 0' "$SKILL_MD"
+}
+
+@test "codex/prompt.md: doc-regen assert gate requires MUST exit 0" {
+    grep -q 'MUST exit 0' "$CODEX_MD"
+}
+
+@test "opencode/agent.md: doc-regen assert gate requires MUST exit 0" {
+    grep -q 'MUST exit 0' "$OPENCODE_MD"
+}
+
+# ── 3. doc-regen-assert sentinel block present in all three trio files ────────
+
+@test "SKILL.md: doc-regen-assert:begin sentinel present" {
+    grep -q 'doc-regen-assert:begin' "$SKILL_MD"
+}
+
+@test "codex/prompt.md: doc-regen-assert:begin sentinel present" {
+    grep -q 'doc-regen-assert:begin' "$CODEX_MD"
+}
+
+@test "opencode/agent.md: doc-regen-assert:begin sentinel present" {
+    grep -q 'doc-regen-assert:begin' "$OPENCODE_MD"
+}
+
+# ── 4. Lock-step byte-identity of the Worktree assert section ─────────────────
+
+extract_assert_section() {
+    awk '/^## Worktree assert \(regenerate commit\)$/{p=1} /^## Invocation$/{p=0} p{print}' "$1"
+}
+
+@test "doc-trio lock-step: SKILL.md and codex/prompt.md assert section byte-identical" {
+    s1="$(extract_assert_section "$SKILL_MD")"
+    s2="$(extract_assert_section "$CODEX_MD")"
+    [ -n "$s1" ]
+    [ "$s1" = "$s2" ]
+}
+
+@test "doc-trio lock-step: codex/prompt.md and opencode/agent.md assert section byte-identical" {
+    s2="$(extract_assert_section "$CODEX_MD")"
+    s3="$(extract_assert_section "$OPENCODE_MD")"
+    [ -n "$s2" ]
+    [ "$s2" = "$s3" ]
+}


### PR DESCRIPTION
Closes #963

## Summary

- Adds a `## Worktree assert (regenerate commit)` section to all three autospec-doc trio files (`SKILL.md`, `codex/prompt.md`, `opencode/agent.md`), byte-identical across all three (lock-step).
- The new section instructs the doc regenerate commit step to call `worktree-guard.sh assert` and verify exit 0 before committing any regenerated content; a non-zero exit aborts and surfaces the `code_health` identifier.
- Adds three named-content checks to `scripts/validate.sh` inside `check_autospec_doc_contract()`: sentinel block present, assert call present, MUST-exit-0 rule present.
- Adds `tests/phase4/test_doc_trio_worktree_assert.bats` (11 tests): assert present, MUST-exit-0 present, sentinel present in all three files, and lock-step byte-identity.
- All 11 bats tests pass; `bash scripts/validate.sh` exits 0.