### PR TITLE
feat(define): route spec-PR commit through temp worktree + AGENTS.md git hygiene section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,3 +413,57 @@ Memory types (mempalace wings):
 - **synthesis** — lessons learned (feedback patterns, anti-patterns, gotchas)
 
 Read memories relevant to your task at session start. Write new memories by adding/editing files in `docs/memory/` and updating the index. Mempalace MCP layer (`mempalace search`, `mempalace traverse`, `mempalace kg_query`) is available if your tool supports MCP.
+
+## Git hygiene (agents)
+
+These rules apply to every autospec skill that mutates the repository (run
+implementers, define spec-PRs, doc regenerate commits, explore sandbox,
+release). The enforcement tool is `scripts/worktree-guard.sh`.
+
+### Primary checkout is read-only for agents
+
+Agents MUST NOT `cd`, `git checkout`, or `git commit` in the primary checkout.
+Operator dirt in it is never touched and never matters. Every git-mutating step
+happens in a linked worktree, never in the primary checkout directory.
+
+### Fetch-before-branch
+
+Always run `git fetch origin` (with one automatic retry) before creating or
+adopting a branch. `worktree-guard.sh create` handles this automatically;
+callers that bypass `create` must fetch explicitly.
+
+### Fresh-or-verified-clean worktrees only
+
+Use `worktree-guard.sh create` to obtain a worktree. Before any edit or commit,
+call `worktree-guard.sh assert`; it MUST exit 0. A non-zero exit means the
+worktree is dirty, primary, or stale — stop work, comment on the issue, and
+restore `auto-implement`. Never force-reuse a dirty worktree.
+
+### PR-aware ladder (standard branch-exists behavior)
+
+Before creating a new worktree, call `worktree-guard.sh resolve-branch`:
+
+- `open-pr` — a PR already exists for this branch: validate + merge the
+  existing PR; skip re-implementation (#886 recovery).
+- `branch-only` — branch exists on origin but no open PR: adopt it in a fresh
+  worktree and continue (#917 recovery).
+- `fresh` — nothing exists: `worktree-guard.sh create` off `origin/main`.
+
+### Cleanup after merge + prune
+
+After a PR is confirmed merged, remove the worktree and prune the git metadata:
+
+```bash
+git worktree remove /tmp/wt-<branch> 2>/dev/null || true
+git worktree prune
+```
+
+Never leave stale worktrees; the watchdog GC (`scripts/autospec-watchdog.sh`)
+sweeps orphans as a safety net, but proactive cleanup is required.
+
+### Pointer to enforcement tool
+
+`scripts/worktree-guard.sh` (installed to `~/.autospec/scripts/worktree-guard.sh`)
+implements `assert`, `resolve-branch`, and `create`. See
+`docs/specs/2026-06-03-worktree-guard-design.md` §D1 for the full contract and
+pinned exit codes.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -2055,6 +2055,70 @@ check_watchdog_worktree_gc() {
     fi
 }
 
+# AGENTS.md git-hygiene section (issue #962, spec §D5): AGENTS.md must carry
+# the `## Git hygiene (agents)` section with the five sub-rules (fetch-before-
+# branch; primary checkout read-only; fresh-or-verified-clean worktrees;
+# cleanup after merge + prune; PR-aware ladder as standard behavior) and a
+# pointer to worktree-guard.sh.
+check_agents_md_git_hygiene() {
+    info "AGENTS.md git hygiene section (issue #962 §D5)"
+    [ -f AGENTS.md ] || fail "AGENTS.md missing at repo root"
+    grep -q '^## Git hygiene (agents)$' AGENTS.md \
+        || fail "AGENTS.md missing '## Git hygiene (agents)' section (issue #962 §D5)"
+    grep -q 'Fetch-before-branch\|fetch-before-branch' AGENTS.md \
+        || fail "AGENTS.md git hygiene section missing fetch-before-branch rule (§D5)"
+    grep -q 'primary checkout' AGENTS.md \
+        || fail "AGENTS.md git hygiene section missing primary-checkout read-only rule (§D5)"
+    grep -q 'fresh-or-verified-clean\|Fresh-or-verified-clean' AGENTS.md \
+        || fail "AGENTS.md git hygiene section missing fresh-or-verified-clean worktrees rule (§D5)"
+    grep -q 'git worktree remove' AGENTS.md \
+        || fail "AGENTS.md git hygiene section missing 'git worktree remove' cleanup rule (§D5)"
+    grep -q 'git worktree prune' AGENTS.md \
+        || fail "AGENTS.md git hygiene section missing 'git worktree prune' cleanup rule (§D5)"
+    grep -q 'open-pr\|branch-only\|fresh' AGENTS.md \
+        || fail "AGENTS.md git hygiene section missing PR-aware ladder states (§D5)"
+    grep -q 'worktree-guard\.sh' AGENTS.md \
+        || fail "AGENTS.md git hygiene section missing pointer to worktree-guard.sh (§D5)"
+}
+
+# Define spec-PR worktree routing (issue #962, spec §D4): the autospec-define
+# trio must route the spec-PR commit through worktree-guard.sh create to a temp
+# worktree (/tmp/wt-spec-<slug>), never the primary checkout. The define-spec-pr
+# sentinel block must be present in all three trio files in lockstep.
+check_define_spec_worktree_routing() {
+    info "define spec-PR worktree routing (issue #962 §D4)"
+    for trio in \
+        skills/autospec-define/SKILL.md \
+        skills/autospec-define/codex/prompt.md \
+        skills/autospec-define/opencode/agent.md
+    do
+        [ -f "$trio" ] || fail "$trio: required file missing (issue #962 §D4)"
+        grep -q 'worktree-guard.sh' "$trio" \
+            || fail "$trio: missing worktree-guard.sh reference (issue #962 §D4)"
+        grep -q '/tmp/wt-spec-' "$trio" \
+            || fail "$trio: missing /tmp/wt-spec-<slug> temp worktree path (issue #962 §D4)"
+        grep -q 'MUST exit 0 before any edit' "$trio" \
+            || fail "$trio: missing 'MUST exit 0 before any edit' assert directive (issue #962 §D4)"
+        grep -q 'resolve-branch' "$trio" \
+            || fail "$trio: missing resolve-branch call (issue #962 §D4)"
+        grep -q 'define-spec-pr:begin' "$trio" \
+            || fail "$trio: missing define-spec-pr:begin sentinel (issue #962 §D4)"
+        grep -q 'define-spec-pr:end' "$trio" \
+            || fail "$trio: missing define-spec-pr:end sentinel (issue #962 §D4)"
+        grep -q 'git worktree remove' "$trio" \
+            || fail "$trio: missing 'git worktree remove' cleanup rule (issue #962 §D4)"
+        grep -q 'git worktree prune' "$trio" \
+            || fail "$trio: missing 'git worktree prune' cleanup rule (issue #962 §D4)"
+    done
+    # bats coverage file must exist.
+    local bats_file="tests/phase4/test_define_spec_worktree.sh"
+    [ -f "$bats_file" ] \
+        || fail "$bats_file: bats coverage missing (issue #962 §D4)"
+    info "  running: $bats_file"
+    bash "$bats_file" >/tmp/validate-define-spec-worktree.log 2>&1 \
+        || { cat /tmp/validate-define-spec-worktree.log >&2; fail "$bats_file: failed (issue #962)"; }
+}
+
 main() {
     info "scanning multi-harness skills under skills/ ..."
     skills="$(discover_skills)"
@@ -2156,6 +2220,8 @@ main() {
     check_autospec_doc_contract
     check_watchdog_worktree_gc
     check_qa_documentation_gate
+    check_agents_md_git_hygiene
+    check_define_spec_worktree_routing
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.

--- a/skills/autospec-define/SKILL.md
+++ b/skills/autospec-define/SKILL.md
@@ -297,12 +297,75 @@ The spec must be implementable end-to-end by an agent reading only the spec.
 
 If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
 
-For an existing repo, land the spec via a short-lived PR so CI can validate it:
-1. Create branch `feat/spec-<topic>`, commit `docs/specs/...design.md`, push.
-2. `gh pr create --base main --head feat/spec-<topic> --title "docs: <topic> design spec" --body "Source spec: docs/specs/..."`
-3. Wait for required CI checks to pass (`gh pr checks <#> --repo {repo}`).
-4. Unless `AUTOSPEC_NO_AUTOMERGE_SPEC=1` is set, admin-merge: `gh pr merge <#> --admin --squash --delete-branch --repo {repo}`. If the env var is set, pause and ask the user to merge before continuing.
-5. Verify the spec is reachable at `https://github.com/{repo}/blob/main/docs/specs/...` before dispatching Phase 3.
+For an existing repo, land the spec via a short-lived PR so CI can validate it.
+The spec commit happens in a temp worktree (`/tmp/wt-spec-<slug>`), never in the
+primary checkout (see §D4 of `docs/specs/2026-06-03-worktree-guard-design.md` and
+`## Git hygiene (agents)` in `AGENTS.md`).
+
+<!-- define-spec-pr:begin -->
+```bash
+SLUG="<topic>"
+BRANCH="feat/spec-${SLUG}"
+WT="/tmp/wt-spec-${SLUG}"
+
+# resolve → create → assert (D4 pattern)
+VERDICT="$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+    resolve-branch --branch "$BRANCH" --repo {repo})"
+STATE="$(printf '%s' "$VERDICT" | jq -r .state)"
+
+case "$STATE" in
+  open-pr)
+    PR_NUM="$(printf '%s' "$VERDICT" | jq -r .pr)"
+    # Spec PR already open — validate CI + merge; skip re-commit.
+    gh pr checks "$PR_NUM" --repo {repo} --watch
+    gh pr merge "$PR_NUM" --admin --squash --delete-branch --repo {repo}
+    ;;
+  branch-only)
+    # Branch exists but no PR — adopt in a fresh worktree and continue.
+    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+        create --branch "$BRANCH" --path "$WT" --adopt
+    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+        assert  # MUST exit 0 before any edit
+    # Push + open PR then fall through to the wait/merge step below.
+    git -C "$WT" push -u origin "$BRANCH"
+    gh pr create --base main --head "$BRANCH" --repo {repo} \
+        --title "docs: ${SLUG} design spec" \
+        --body "Source spec: docs/specs/${SLUG}-design.md"
+    gh pr checks --watch --repo {repo} "$( gh pr list --head "$BRANCH" --repo {repo} --json number -q '.[0].number')"
+    gh pr merge --admin --squash --delete-branch --repo {repo} \
+        "$( gh pr list --head "$BRANCH" --repo {repo} --json number -q '.[0].number')"
+    git worktree remove "$WT" 2>/dev/null || true
+    git worktree prune
+    ;;
+  fresh)
+    # Happy path: create a clean worktree, commit spec there, push, PR.
+    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+        create --branch "$BRANCH" --path "$WT"
+    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+        assert  # MUST exit 0 before any edit; non-zero → stop, restore auto-implement
+    cp "docs/specs/${SLUG}-design.md" "$WT/docs/specs/${SLUG}-design.md"
+    git -C "$WT" add "docs/specs/${SLUG}-design.md"
+    git -C "$WT" commit -m "docs: ${SLUG} design spec"
+    git -C "$WT" push -u origin "$BRANCH"
+    gh pr create --base main --head "$BRANCH" --repo {repo} \
+        --title "docs: ${SLUG} design spec" \
+        --body "Source spec: docs/specs/${SLUG}-design.md"
+    gh pr checks --watch --repo {repo} "$( gh pr list --head "$BRANCH" --repo {repo} --json number -q '.[0].number')"
+    if [ "${AUTOSPEC_NO_AUTOMERGE_SPEC:-0}" != "1" ]; then
+        gh pr merge --admin --squash --delete-branch --repo {repo} \
+            "$( gh pr list --head "$BRANCH" --repo {repo} --json number -q '.[0].number')"
+    else
+        # Env var set — pause and ask user to merge before continuing.
+        echo "AUTOSPEC_NO_AUTOMERGE_SPEC=1: merge the spec PR manually, then continue."
+    fi
+    git worktree remove "$WT" 2>/dev/null || true
+    git worktree prune
+    ;;
+esac
+```
+<!-- define-spec-pr:end -->
+
+6. Verify the spec is reachable at `https://github.com/{repo}/blob/main/docs/specs/...` before dispatching Phase 3.
 
 ## Phase 3 — Decompose into linked GitHub issues (delegate)
 

--- a/skills/autospec-define/codex/prompt.md
+++ b/skills/autospec-define/codex/prompt.md
@@ -291,12 +291,75 @@ The spec must be implementable end-to-end by an agent reading only the spec.
 
 If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
 
-For an existing repo, land the spec via a short-lived PR so CI can validate it:
-1. Create branch `feat/spec-<topic>`, commit `docs/specs/...design.md`, push.
-2. `gh pr create --base main --head feat/spec-<topic> --title "docs: <topic> design spec" --body "Source spec: docs/specs/..."`
-3. Wait for required CI checks to pass (`gh pr checks <#> --repo {repo}`).
-4. Unless `AUTOSPEC_NO_AUTOMERGE_SPEC=1` is set, admin-merge: `gh pr merge <#> --admin --squash --delete-branch --repo {repo}`. If the env var is set, pause and ask the user to merge before continuing.
-5. Verify the spec is reachable at `https://github.com/{repo}/blob/main/docs/specs/...` before dispatching Phase 3.
+For an existing repo, land the spec via a short-lived PR so CI can validate it.
+The spec commit happens in a temp worktree (`/tmp/wt-spec-<slug>`), never in the
+primary checkout (see §D4 of `docs/specs/2026-06-03-worktree-guard-design.md` and
+`## Git hygiene (agents)` in `AGENTS.md`).
+
+<!-- define-spec-pr:begin -->
+```bash
+SLUG="<topic>"
+BRANCH="feat/spec-${SLUG}"
+WT="/tmp/wt-spec-${SLUG}"
+
+# resolve → create → assert (D4 pattern)
+VERDICT="$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+    resolve-branch --branch "$BRANCH" --repo {repo})"
+STATE="$(printf '%s' "$VERDICT" | jq -r .state)"
+
+case "$STATE" in
+  open-pr)
+    PR_NUM="$(printf '%s' "$VERDICT" | jq -r .pr)"
+    # Spec PR already open — validate CI + merge; skip re-commit.
+    gh pr checks "$PR_NUM" --repo {repo} --watch
+    gh pr merge "$PR_NUM" --admin --squash --delete-branch --repo {repo}
+    ;;
+  branch-only)
+    # Branch exists but no PR — adopt in a fresh worktree and continue.
+    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+        create --branch "$BRANCH" --path "$WT" --adopt
+    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+        assert  # MUST exit 0 before any edit
+    # Push + open PR then fall through to the wait/merge step below.
+    git -C "$WT" push -u origin "$BRANCH"
+    gh pr create --base main --head "$BRANCH" --repo {repo} \
+        --title "docs: ${SLUG} design spec" \
+        --body "Source spec: docs/specs/${SLUG}-design.md"
+    gh pr checks --watch --repo {repo} "$( gh pr list --head "$BRANCH" --repo {repo} --json number -q '.[0].number')"
+    gh pr merge --admin --squash --delete-branch --repo {repo} \
+        "$( gh pr list --head "$BRANCH" --repo {repo} --json number -q '.[0].number')"
+    git worktree remove "$WT" 2>/dev/null || true
+    git worktree prune
+    ;;
+  fresh)
+    # Happy path: create a clean worktree, commit spec there, push, PR.
+    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+        create --branch "$BRANCH" --path "$WT"
+    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+        assert  # MUST exit 0 before any edit; non-zero → stop, restore auto-implement
+    cp "docs/specs/${SLUG}-design.md" "$WT/docs/specs/${SLUG}-design.md"
+    git -C "$WT" add "docs/specs/${SLUG}-design.md"
+    git -C "$WT" commit -m "docs: ${SLUG} design spec"
+    git -C "$WT" push -u origin "$BRANCH"
+    gh pr create --base main --head "$BRANCH" --repo {repo} \
+        --title "docs: ${SLUG} design spec" \
+        --body "Source spec: docs/specs/${SLUG}-design.md"
+    gh pr checks --watch --repo {repo} "$( gh pr list --head "$BRANCH" --repo {repo} --json number -q '.[0].number')"
+    if [ "${AUTOSPEC_NO_AUTOMERGE_SPEC:-0}" != "1" ]; then
+        gh pr merge --admin --squash --delete-branch --repo {repo} \
+            "$( gh pr list --head "$BRANCH" --repo {repo} --json number -q '.[0].number')"
+    else
+        # Env var set — pause and ask user to merge before continuing.
+        echo "AUTOSPEC_NO_AUTOMERGE_SPEC=1: merge the spec PR manually, then continue."
+    fi
+    git worktree remove "$WT" 2>/dev/null || true
+    git worktree prune
+    ;;
+esac
+```
+<!-- define-spec-pr:end -->
+
+6. Verify the spec is reachable at `https://github.com/{repo}/blob/main/docs/specs/...` before dispatching Phase 3.
 
 ## Phase 3 — Decompose into linked GitHub issues (delegate)
 

--- a/skills/autospec-define/opencode/agent.md
+++ b/skills/autospec-define/opencode/agent.md
@@ -295,12 +295,75 @@ The spec must be implementable end-to-end by an agent reading only the spec.
 
 If this is a fresh repo, commit the spec to `main` directly (`git add docs/... && git commit -m "docs: <topic> design spec" && git push`) so subsequent issues can reference it as a tracked file.
 
-For an existing repo, land the spec via a short-lived PR so CI can validate it:
-1. Create branch `feat/spec-<topic>`, commit `docs/specs/...design.md`, push.
-2. `gh pr create --base main --head feat/spec-<topic> --title "docs: <topic> design spec" --body "Source spec: docs/specs/..."`
-3. Wait for required CI checks to pass (`gh pr checks <#> --repo {repo}`).
-4. Unless `AUTOSPEC_NO_AUTOMERGE_SPEC=1` is set, admin-merge: `gh pr merge <#> --admin --squash --delete-branch --repo {repo}`. If the env var is set, pause and ask the user to merge before continuing.
-5. Verify the spec is reachable at `https://github.com/{repo}/blob/main/docs/specs/...` before dispatching Phase 3.
+For an existing repo, land the spec via a short-lived PR so CI can validate it.
+The spec commit happens in a temp worktree (`/tmp/wt-spec-<slug>`), never in the
+primary checkout (see §D4 of `docs/specs/2026-06-03-worktree-guard-design.md` and
+`## Git hygiene (agents)` in `AGENTS.md`).
+
+<!-- define-spec-pr:begin -->
+```bash
+SLUG="<topic>"
+BRANCH="feat/spec-${SLUG}"
+WT="/tmp/wt-spec-${SLUG}"
+
+# resolve → create → assert (D4 pattern)
+VERDICT="$(bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+    resolve-branch --branch "$BRANCH" --repo {repo})"
+STATE="$(printf '%s' "$VERDICT" | jq -r .state)"
+
+case "$STATE" in
+  open-pr)
+    PR_NUM="$(printf '%s' "$VERDICT" | jq -r .pr)"
+    # Spec PR already open — validate CI + merge; skip re-commit.
+    gh pr checks "$PR_NUM" --repo {repo} --watch
+    gh pr merge "$PR_NUM" --admin --squash --delete-branch --repo {repo}
+    ;;
+  branch-only)
+    # Branch exists but no PR — adopt in a fresh worktree and continue.
+    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+        create --branch "$BRANCH" --path "$WT" --adopt
+    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+        assert  # MUST exit 0 before any edit
+    # Push + open PR then fall through to the wait/merge step below.
+    git -C "$WT" push -u origin "$BRANCH"
+    gh pr create --base main --head "$BRANCH" --repo {repo} \
+        --title "docs: ${SLUG} design spec" \
+        --body "Source spec: docs/specs/${SLUG}-design.md"
+    gh pr checks --watch --repo {repo} "$( gh pr list --head "$BRANCH" --repo {repo} --json number -q '.[0].number')"
+    gh pr merge --admin --squash --delete-branch --repo {repo} \
+        "$( gh pr list --head "$BRANCH" --repo {repo} --json number -q '.[0].number')"
+    git worktree remove "$WT" 2>/dev/null || true
+    git worktree prune
+    ;;
+  fresh)
+    # Happy path: create a clean worktree, commit spec there, push, PR.
+    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+        create --branch "$BRANCH" --path "$WT"
+    bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/worktree-guard.sh" \
+        assert  # MUST exit 0 before any edit; non-zero → stop, restore auto-implement
+    cp "docs/specs/${SLUG}-design.md" "$WT/docs/specs/${SLUG}-design.md"
+    git -C "$WT" add "docs/specs/${SLUG}-design.md"
+    git -C "$WT" commit -m "docs: ${SLUG} design spec"
+    git -C "$WT" push -u origin "$BRANCH"
+    gh pr create --base main --head "$BRANCH" --repo {repo} \
+        --title "docs: ${SLUG} design spec" \
+        --body "Source spec: docs/specs/${SLUG}-design.md"
+    gh pr checks --watch --repo {repo} "$( gh pr list --head "$BRANCH" --repo {repo} --json number -q '.[0].number')"
+    if [ "${AUTOSPEC_NO_AUTOMERGE_SPEC:-0}" != "1" ]; then
+        gh pr merge --admin --squash --delete-branch --repo {repo} \
+            "$( gh pr list --head "$BRANCH" --repo {repo} --json number -q '.[0].number')"
+    else
+        # Env var set — pause and ask user to merge before continuing.
+        echo "AUTOSPEC_NO_AUTOMERGE_SPEC=1: merge the spec PR manually, then continue."
+    fi
+    git worktree remove "$WT" 2>/dev/null || true
+    git worktree prune
+    ;;
+esac
+```
+<!-- define-spec-pr:end -->
+
+6. Verify the spec is reachable at `https://github.com/{repo}/blob/main/docs/specs/...` before dispatching Phase 3.
 
 ## Phase 3 — Decompose into linked GitHub issues (delegate)
 

--- a/tests/phase4/test_define_spec_worktree.sh
+++ b/tests/phase4/test_define_spec_worktree.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# tests/phase4/test_define_spec_worktree.sh
+# Named-content checks for the autospec-define spec-PR worktree routing (issue
+# #962, spec §D4) and the AGENTS.md ## Git hygiene (agents) section (§D5).
+#
+# Verified invariants:
+#   1. All 3 define-trio files carry the define-spec-pr sentinel block.
+#   2. All 3 files reference worktree-guard.sh and /tmp/wt-spec-<slug>.
+#   3. All 3 files call `worktree-guard.sh assert` before spec commit.
+#   4. All 3 files call `resolve-branch` (PR-aware ladder).
+#   5. All 3 files carry cleanup (git worktree remove + git worktree prune).
+#   6. AGENTS.md carries ## Git hygiene (agents) section with all 5 sub-rules.
+#   7. The define-spec-pr sentinel block bash is well-formed (bash -n).
+#   8. Lock-step: SKILL.md body == codex/prompt.md and == opencode/agent.md body.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+info() { echo "ok: $1"; }
+
+SKILL="$SCRIPT_DIR/skills/autospec-define/SKILL.md"
+CODEX="$SCRIPT_DIR/skills/autospec-define/codex/prompt.md"
+OPENCODE="$SCRIPT_DIR/skills/autospec-define/opencode/agent.md"
+AGENTS="$SCRIPT_DIR/AGENTS.md"
+ALL_TRIO="$SKILL $CODEX $OPENCODE"
+
+# ── 1-5. Define trio: spec-PR worktree routing ────────────────────────────────
+
+for f in $ALL_TRIO; do
+    name="${f#"$SCRIPT_DIR"/}"
+
+    grep -q 'define-spec-pr:begin' "$f" \
+        || fail "$name: missing define-spec-pr:begin sentinel (§D4)"
+    grep -q 'define-spec-pr:end' "$f" \
+        || fail "$name: missing define-spec-pr:end sentinel (§D4)"
+
+    grep -q 'worktree-guard.sh' "$f" \
+        || fail "$name: missing worktree-guard.sh reference (§D4)"
+
+    grep -q '/tmp/wt-spec-' "$f" \
+        || fail "$name: missing /tmp/wt-spec-<slug> temp worktree path (§D4)"
+
+    grep -q 'worktree-guard\.sh assert\|worktree-guard\.sh.*\n.*assert\|worktree-guard\.sh.*create.*assert\|MUST exit 0 before any edit' "$f" \
+        || fail "$name: missing worktree-guard.sh assert call or 'MUST exit 0' directive (§D4)"
+
+    grep -q 'resolve-branch' "$f" \
+        || fail "$name: missing resolve-branch call for PR-aware ladder (§D4)"
+
+    grep -q 'git worktree remove' "$f" \
+        || fail "$name: missing 'git worktree remove' cleanup (§D4)"
+
+    grep -q 'git worktree prune' "$f" \
+        || fail "$name: missing 'git worktree prune' cleanup (§D4)"
+done
+
+info "define-trio spec-PR worktree routing present in all 3 files"
+
+# ── 6. AGENTS.md: ## Git hygiene (agents) section ────────────────────────────
+
+[ -f "$AGENTS" ] || fail "AGENTS.md missing at repo root (§D5)"
+
+grep -q '^## Git hygiene (agents)$' "$AGENTS" \
+    || fail "AGENTS.md missing '## Git hygiene (agents)' section (§D5)"
+
+grep -q 'Fetch-before-branch\|fetch-before-branch' "$AGENTS" \
+    || fail "AGENTS.md git hygiene section missing fetch-before-branch rule (§D5)"
+
+grep -q 'primary checkout' "$AGENTS" \
+    || fail "AGENTS.md git hygiene section missing primary-checkout read-only rule (§D5)"
+
+grep -q 'fresh-or-verified-clean\|Fresh-or-verified-clean' "$AGENTS" \
+    || fail "AGENTS.md git hygiene section missing fresh-or-verified-clean worktrees rule (§D5)"
+
+grep -q 'git worktree remove' "$AGENTS" \
+    || fail "AGENTS.md git hygiene section missing 'git worktree remove' cleanup rule (§D5)"
+
+grep -q 'git worktree prune' "$AGENTS" \
+    || fail "AGENTS.md git hygiene section missing 'git worktree prune' cleanup rule (§D5)"
+
+grep -q 'open-pr\|branch-only' "$AGENTS" \
+    || fail "AGENTS.md git hygiene section missing PR-aware ladder states (§D5)"
+
+grep -q 'worktree-guard\.sh' "$AGENTS" \
+    || fail "AGENTS.md git hygiene section missing pointer to worktree-guard.sh (§D5)"
+
+info "AGENTS.md ## Git hygiene (agents) section present with all 5 sub-rules"
+
+# ── 7. define-spec-pr bash block is well-formed ───────────────────────────────
+
+block="$(awk '
+    /<!-- define-spec-pr:begin -->/ { cap=1; next }
+    /<!-- define-spec-pr:end -->/   { cap=0 }
+    cap && /^```bash/ { code=1; next }
+    cap && code && /^```/ { code=0 }
+    cap && code { print }
+' "$SKILL")"
+
+[ -n "$block" ] \
+    || fail "SKILL.md: no bash block inside define-spec-pr sentinel (§D4)"
+
+# Replace placeholder {repo} with a literal string so bash -n doesn't balk.
+printf '%s\n' "$block" | sed 's/{repo}/example\/repo/g' | bash -n - \
+    || fail "SKILL.md: define-spec-pr bash block fails bash -n (§D4)"
+
+info "define-spec-pr bash block is well-formed"
+
+# ── 8. Lock-step: SKILL.md body == codex/prompt.md == opencode body ──────────
+
+strip_body() { awk '/^---$/{c++; next} c>=2' "$1"; }
+
+diff <(strip_body "$SKILL") <(cat "$CODEX") >/dev/null \
+    || fail "autospec-define: SKILL.md body diverges from codex/prompt.md (lock-step)"
+
+diff <(strip_body "$SKILL") <(strip_body "$OPENCODE") >/dev/null \
+    || fail "autospec-define: SKILL.md body diverges from opencode/agent.md body (lock-step)"
+
+info "autospec-define trio lock-step byte-identical"
+
+echo "ok: all define spec-PR worktree + AGENTS.md git hygiene checks passed"


### PR DESCRIPTION
Closes #962

## Summary

- **§D4 — autospec-define spec-PR worktree routing**: the spec commit now happens in `/tmp/wt-spec-<slug>` via `worktree-guard.sh create`, never the primary checkout. Implements the resolve→create→assert pattern with all three ladder states (`open-pr`/`branch-only`/`fresh`) and cleanup (`git worktree remove` + `git worktree prune`) after merge. The `define-spec-pr:begin/end` sentinel block is locked-step across the full define trio.
- **§D5 — AGENTS.md `## Git hygiene (agents)` section**: five sub-rules documented (fetch-before-branch; primary checkout read-only for agents; fresh-or-verified-clean worktrees only; cleanup after merge + prune; PR-aware ladder as standard behavior) with a pointer to `scripts/worktree-guard.sh`.
- **validate.sh**: two new named-content checks — `check_agents_md_git_hygiene` (guards the AGENTS.md section) and `check_define_spec_worktree_routing` (guards the define trio sentinels + runs the bats test).
- **tests/phase4/test_define_spec_worktree.sh**: eight assertions — sentinel presence in all 3 trio files, worktree-guard references, assert directive, resolve-branch call, cleanup rules, AGENTS.md section sub-rules, bash -n on the spec-PR block, and lock-step byte-identity.
- **Lock-step**: define trio (SKILL.md / codex/prompt.md / opencode/agent.md) updated byte-identical; `bash scripts/validate.sh` exits 0.

## Test plan

- [x] `bash tests/phase4/test_define_spec_worktree.sh` passes (8 assertions)
- [x] `bash scripts/validate.sh` exits 0 — all checks including new `check_agents_md_git_hygiene` and `check_define_spec_worktree_routing`
- [x] Define trio lock-step verified: `diff <(awk '/^---$/{c++; next} c>=2' skills/autospec-define/SKILL.md) <(cat skills/autospec-define/codex/prompt.md)` and opencode body diff both exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)