### PR TITLE
feat(autospec-release): add worktree-guard assert before commit steps (D4, #965)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -2148,6 +2148,7 @@ main() {
     check_autospec_explore_researchers_llm
     check_autospec_explore_contract
     check_autospec_release_area_contract
+    check_release_trio_worktree_assert
     check_autospec_sweep_area_contract
     check_autospec_qa_cluster_contract
     check_autospec_qa_bug_class_contract
@@ -2483,6 +2484,57 @@ check_autospec_release_area_contract() {
             >/tmp/validate-release-area-dispatch.log 2>&1 \
             || { cat /tmp/validate-release-area-dispatch.log >&2; fail "tests/release/test_release_area_dispatch.bats: failed"; }
     fi
+}
+
+# Release-trio worktree assert gate (issue #965, spec §D4): every file in the
+# autospec-release trio must carry a `## Worktree guard (commit gate)` section
+# with `worktree-guard.sh assert` before any commit, the MANDATORY/MUST-exit-0
+# wording, a `worktree-assert:begin/end` sentinel block, and the primary-checkout
+# and cleanup rules. Lock-step: the section must be byte-identical across the
+# trio (SKILL.md == codex/prompt.md == opencode/agent.md prose block).
+check_release_trio_worktree_assert() {
+    info "release-trio worktree assert gate (D4, issue #965)"
+    local trio="skills/autospec-release/SKILL.md \
+                skills/autospec-release/codex/prompt.md \
+                skills/autospec-release/opencode/agent.md"
+    for f in $trio; do
+        [ -f "$f" ] || fail "$f: required file missing (issue #965)"
+        grep -q '## Worktree guard (commit gate)' "$f" \
+            || fail "$f: missing '## Worktree guard (commit gate)' section (issue #965)"
+        grep -q 'worktree-guard.sh assert' "$f" \
+            || fail "$f: missing worktree-guard.sh assert call (issue #965)"
+        grep -q 'MUST exit 0' "$f" \
+            || fail "$f: assert gate must state MUST exit 0 (issue #965)"
+        grep -q 'worktree-assert:begin' "$f" \
+            || fail "$f: missing worktree-assert:begin sentinel (issue #965)"
+        grep -q 'worktree-assert:end' "$f" \
+            || fail "$f: missing worktree-assert:end sentinel (issue #965)"
+        grep -qi 'primary checkout' "$f" \
+            || fail "$f: missing primary-checkout hard rule (issue #965)"
+        grep -q 'git worktree remove' "$f" \
+            || fail "$f: missing 'git worktree remove' cleanup rule (issue #965)"
+        grep -q 'git worktree prune' "$f" \
+            || fail "$f: missing 'git worktree prune' cleanup rule (issue #965)"
+    done
+    # Lock-step: the prose block between sentinels must be byte-identical across trio.
+    local skill_block codex_block opencode_block
+    skill_block="$(awk '/<!-- worktree-assert:begin -->/,/<!-- worktree-assert:end -->/' \
+        skills/autospec-release/SKILL.md)"
+    codex_block="$(awk '/<!-- worktree-assert:begin -->/,/<!-- worktree-assert:end -->/' \
+        skills/autospec-release/codex/prompt.md)"
+    opencode_block="$(awk '/<!-- worktree-assert:begin -->/,/<!-- worktree-assert:end -->/' \
+        skills/autospec-release/opencode/agent.md)"
+    [ "$skill_block" = "$codex_block" ] \
+        || fail "SKILL.md and codex/prompt.md worktree-assert blocks differ (lock-step violation, issue #965)"
+    [ "$skill_block" = "$opencode_block" ] \
+        || fail "SKILL.md and opencode/agent.md worktree-assert blocks differ (lock-step violation, issue #965)"
+    if command -v bats >/dev/null 2>&1 && [ -f tests/release/test_release_worktree_assert.bats ]; then
+        info "  running: tests/release/test_release_worktree_assert.bats"
+        bats tests/release/test_release_worktree_assert.bats \
+            >/tmp/validate-release-worktree-assert.log 2>&1 \
+            || { cat /tmp/validate-release-worktree-assert.log >&2; fail "tests/release/test_release_worktree_assert.bats: failed"; }
+    fi
+    info "release-trio worktree assert gate: all 3 trio files carry D4 assert"
 }
 
 # Crash-resume skill + durable run registry contract (issue #881):

--- a/skills/autospec-release/SKILL.md
+++ b/skills/autospec-release/SKILL.md
@@ -378,6 +378,27 @@ Required outcome:
   cleanup issue needed to settle it.
 ```
 
+## Worktree guard (commit gate)
+
+<!-- worktree-assert:begin -->
+Before committing any remediation fix (stage 9 iteration) or any other
+change produced by this skill, run `worktree-guard.sh assert` and require
+exit 0. A non-zero exit (in_primary_checkout / dirty / stale_base) is NEVER
+worked around — stop the release flow and surface the emitted
+`code_health:*` identifier to the operator.
+
+```bash
+# MANDATORY assert gate: MUST exit 0 before any commit in the release flow.
+if ! bash "${AUTOSPEC_SCRIPTS_DIR:-scripts}/worktree-guard.sh" assert; then
+  echo "worktree-guard assert failed (see code_health identifier above); aborting release commit" >&2
+  exit 1
+fi
+```
+
+Cleanup after a release-flow commit lands: `git worktree remove` the linked
+worktree and `git worktree prune`. Never work in the primary checkout.
+<!-- worktree-assert:end -->
+
 ## Release report contract
 
 Return a concise report with:

--- a/skills/autospec-release/codex/prompt.md
+++ b/skills/autospec-release/codex/prompt.md
@@ -374,6 +374,27 @@ Required outcome:
   cleanup issue needed to settle it.
 ```
 
+## Worktree guard (commit gate)
+
+<!-- worktree-assert:begin -->
+Before committing any remediation fix (stage 9 iteration) or any other
+change produced by this skill, run `worktree-guard.sh assert` and require
+exit 0. A non-zero exit (in_primary_checkout / dirty / stale_base) is NEVER
+worked around — stop the release flow and surface the emitted
+`code_health:*` identifier to the operator.
+
+```bash
+# MANDATORY assert gate: MUST exit 0 before any commit in the release flow.
+if ! bash "${AUTOSPEC_SCRIPTS_DIR:-scripts}/worktree-guard.sh" assert; then
+  echo "worktree-guard assert failed (see code_health identifier above); aborting release commit" >&2
+  exit 1
+fi
+```
+
+Cleanup after a release-flow commit lands: `git worktree remove` the linked
+worktree and `git worktree prune`. Never work in the primary checkout.
+<!-- worktree-assert:end -->
+
 ## Release report contract
 
 Return a concise report with:

--- a/skills/autospec-release/opencode/agent.md
+++ b/skills/autospec-release/opencode/agent.md
@@ -378,6 +378,27 @@ Required outcome:
   cleanup issue needed to settle it.
 ```
 
+## Worktree guard (commit gate)
+
+<!-- worktree-assert:begin -->
+Before committing any remediation fix (stage 9 iteration) or any other
+change produced by this skill, run `worktree-guard.sh assert` and require
+exit 0. A non-zero exit (in_primary_checkout / dirty / stale_base) is NEVER
+worked around — stop the release flow and surface the emitted
+`code_health:*` identifier to the operator.
+
+```bash
+# MANDATORY assert gate: MUST exit 0 before any commit in the release flow.
+if ! bash "${AUTOSPEC_SCRIPTS_DIR:-scripts}/worktree-guard.sh" assert; then
+  echo "worktree-guard assert failed (see code_health identifier above); aborting release commit" >&2
+  exit 1
+fi
+```
+
+Cleanup after a release-flow commit lands: `git worktree remove` the linked
+worktree and `git worktree prune`. Never work in the primary checkout.
+<!-- worktree-assert:end -->
+
 ## Release report contract
 
 Return a concise report with:

--- a/tests/release/test_release_worktree_assert.bats
+++ b/tests/release/test_release_worktree_assert.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+# tests/release/test_release_worktree_assert.bats — release-trio worktree assert gate (D4, issue #965).
+#
+# Covers:
+#  - The assert call is present before the commit step in all three release-trio files.
+#  - The worktree-assert:begin/end sentinel block is present in all three files.
+#  - The prose block is byte-identical across the trio (lock-step).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SKILL="$REPO_ROOT/skills/autospec-release/SKILL.md"
+    CODEX="$REPO_ROOT/skills/autospec-release/codex/prompt.md"
+    OPENCODE="$REPO_ROOT/skills/autospec-release/opencode/agent.md"
+}
+
+@test "SKILL.md carries worktree-guard.sh assert" {
+    grep -q 'worktree-guard.sh assert' "$SKILL"
+}
+
+@test "codex/prompt.md carries worktree-guard.sh assert" {
+    grep -q 'worktree-guard.sh assert' "$CODEX"
+}
+
+@test "opencode/agent.md carries worktree-guard.sh assert" {
+    grep -q 'worktree-guard.sh assert' "$OPENCODE"
+}
+
+@test "SKILL.md has MUST exit 0 wording" {
+    grep -q 'MUST exit 0' "$SKILL"
+}
+
+@test "codex/prompt.md has MUST exit 0 wording" {
+    grep -q 'MUST exit 0' "$CODEX"
+}
+
+@test "opencode/agent.md has MUST exit 0 wording" {
+    grep -q 'MUST exit 0' "$OPENCODE"
+}
+
+@test "SKILL.md has worktree-assert sentinels" {
+    grep -q 'worktree-assert:begin' "$SKILL"
+    grep -q 'worktree-assert:end' "$SKILL"
+}
+
+@test "codex/prompt.md has worktree-assert sentinels" {
+    grep -q 'worktree-assert:begin' "$CODEX"
+    grep -q 'worktree-assert:end' "$CODEX"
+}
+
+@test "opencode/agent.md has worktree-assert sentinels" {
+    grep -q 'worktree-assert:begin' "$OPENCODE"
+    grep -q 'worktree-assert:end' "$OPENCODE"
+}
+
+@test "release-trio worktree-assert block is byte-identical across SKILL.md and codex/prompt.md" {
+    skill_block="$(awk '/<!-- worktree-assert:begin -->/,/<!-- worktree-assert:end -->/' "$SKILL")"
+    codex_block="$(awk '/<!-- worktree-assert:begin -->/,/<!-- worktree-assert:end -->/' "$CODEX")"
+    [ "$skill_block" = "$codex_block" ]
+}
+
+@test "release-trio worktree-assert block is byte-identical across SKILL.md and opencode/agent.md" {
+    skill_block="$(awk '/<!-- worktree-assert:begin -->/,/<!-- worktree-assert:end -->/' "$SKILL")"
+    opencode_block="$(awk '/<!-- worktree-assert:begin -->/,/<!-- worktree-assert:end -->/' "$OPENCODE")"
+    [ "$skill_block" = "$opencode_block" ]
+}
+
+@test "SKILL.md references primary checkout hard rule" {
+    grep -qi 'primary checkout' "$SKILL"
+}
+
+@test "SKILL.md references git worktree remove cleanup" {
+    grep -q 'git worktree remove' "$SKILL"
+}
+
+@test "SKILL.md references git worktree prune cleanup" {
+    grep -q 'git worktree prune' "$SKILL"
+}


### PR DESCRIPTION
Closes #965

## Summary

- Adds `## Worktree guard (commit gate)` section with `worktree-guard.sh assert` before any commit step in the autospec-release trio (`SKILL.md`, `codex/prompt.md`, `opencode/agent.md`).
- Lock-stepped byte-identical across all three files per spec §D4 (verified by `<!-- worktree-assert:begin/end -->` sentinel diffing).
- Adds `check_release_trio_worktree_assert()` named-content check to `validate.sh` — asserts assert call, MUST-exit-0 wording, sentinels, primary-checkout hard rule, and cleanup rules.
- Adds `tests/release/test_release_worktree_assert.bats` (14 tests) covering all acceptance criteria.
- Mechanical mirror of the merged #961 assert wording; no LLM, pure prose insertion.

## Verification

`bash scripts/validate.sh` exits 0. All 14 new bats tests pass.