### PR TITLE
feat(autospec-explore): worktree-guard assert before sandbox commit (D4, #964)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -2147,6 +2147,7 @@ main() {
     check_autospec_explore_researchers_deterministic
     check_autospec_explore_researchers_llm
     check_autospec_explore_contract
+    check_explore_trio_worktree_assert
     check_autospec_release_area_contract
     check_autospec_sweep_area_contract
     check_autospec_qa_cluster_contract
@@ -2451,6 +2452,51 @@ check_autospec_explore_contract() {
         bats "$bats_file" >/tmp/validate-explore-e2e.log 2>&1 \
             || { cat /tmp/validate-explore-e2e.log >&2; fail "$bats_file: failed"; }
     fi
+}
+
+# Explore-trio worktree assert (issue #964, spec §D4): the autospec-explore
+# trio (SKILL.md + codex/prompt.md + opencode/agent.md) must each carry the
+# mandatory `worktree-guard.sh assert` call before any sandbox commit step,
+# the MUST-exit-0 gate wording, the primary-checkout hard rule, and the
+# Sandbox branch contract section must be byte-identical across all three
+# files (lock-step). Runs tests/explore/test_explore_worktree_assert.bats
+# when bats is on PATH.
+check_explore_trio_worktree_assert() {
+    info "explore-trio worktree assert (D4, issue #964)"
+    for trio in \
+        skills/autospec-explore/SKILL.md \
+        skills/autospec-explore/codex/prompt.md \
+        skills/autospec-explore/opencode/agent.md
+    do
+        [ -f "$trio" ] || fail "$trio: required adapter file missing"
+        grep -q 'worktree-guard.sh assert' "$trio" \
+            || fail "$trio: missing worktree-guard.sh assert before sandbox commit (D4)"
+        grep -q 'MUST exit 0' "$trio" \
+            || fail "$trio: assert gate must carry MUST-exit-0 wording (D4)"
+        grep -qi 'primary checkout' "$trio" \
+            || fail "$trio: missing primary-checkout hard rule (D4)"
+    done
+    # Lock-step: Sandbox branch contract section must be byte-identical.
+    local s1 s2 s3
+    s1="$(awk '/^## Sandbox branch contract/,/^## Research cycle contract/' \
+        skills/autospec-explore/SKILL.md)"
+    s2="$(awk '/^## Sandbox branch contract/,/^## Research cycle contract/' \
+        skills/autospec-explore/codex/prompt.md)"
+    s3="$(awk '/^## Sandbox branch contract/,/^## Research cycle contract/' \
+        skills/autospec-explore/opencode/agent.md)"
+    [ -n "$s1" ] || fail "SKILL.md: Sandbox branch contract section missing"
+    diff <(printf '%s\n' "$s1") <(printf '%s\n' "$s2") \
+        || fail "explore-trio: SKILL.md vs codex/prompt.md Sandbox branch contract differs (lock-step violation)"
+    diff <(printf '%s\n' "$s1") <(printf '%s\n' "$s3") \
+        || fail "explore-trio: SKILL.md vs opencode/agent.md Sandbox branch contract differs (lock-step violation)"
+    local bats_file="tests/explore/test_explore_worktree_assert.bats"
+    [ -f "$bats_file" ] || fail "$bats_file: bats coverage missing (issue #964)"
+    if command -v bats >/dev/null 2>&1; then
+        info "  running: $bats_file"
+        bats "$bats_file" >/tmp/validate-explore-worktree-assert.log 2>&1 \
+            || { cat /tmp/validate-explore-worktree-assert.log >&2; fail "$bats_file: failed"; }
+    fi
+    info "explore-trio worktree assert: all three adapter files carry D4 assert + lock-step verified"
 }
 
 # Release area-dispatch contract (issue #731): 6 area files exist under

--- a/skills/autospec-explore/SKILL.md
+++ b/skills/autospec-explore/SKILL.md
@@ -211,27 +211,40 @@ integration (E), and the `check_autospec_explore_contract` gate in `scripts/vali
 
 ## Sandbox branch contract
 
-1. **Creation**: at run start, the orchestrator invokes
+1. **Worktree assert (MUST exit 0 before any sandbox commit/push)**: the
+   orchestrator MUST run `bash scripts/worktree-guard.sh assert` before invoking
+   `explore-sandbox.sh` or performing any sandbox commit step. A non-zero exit
+   (in_primary_checkout / dirty / stale_base) is NEVER worked around — emit
+   the `code_health` identifier from the guard, and stop. The primary checkout
+   is read-only for agents; all sandbox work happens in a linked worktree.
+   ```bash
+   # MANDATORY assert gate: MUST exit 0 before any sandbox commit/push.
+   if ! bash scripts/worktree-guard.sh assert; then
+     echo "worktree-guard assert failed (see code_health identifier above); aborting sandbox commit" >&2
+     exit 1
+   fi
+   ```
+2. **Creation**: at run start, the orchestrator invokes
    `scripts/explore-sandbox.sh --slug <slug> --base main` which creates
    `autospec/explore/<YYYY-MM-DD>-<slug>` off `origin/main` (or the supplied
    `--base`) if not already present, pushes the branch to `origin`, and writes
    `.autospec/explore-mode.json` with `{branch, slug, base, head_sha, created_at}`.
    The branch lives until the operator merges or deletes it.
-2. **Idempotency**: re-invocation with the same `--slug` reuses the existing
+3. **Idempotency**: re-invocation with the same `--slug` reuses the existing
    sandbox branch — no error, no duplicate, no force-push. The script verifies
    the existing branch tracks the expected base via `git merge-base` and
    refreshes `.autospec/explore-mode.json` with the current head SHA.
-3. **Implementer integration**: every child-issue implementer reads
+4. **Implementer integration**: every child-issue implementer reads
    `.autospec/explore-mode.json` (written by the sandbox script) to learn the
    sandbox branch name. PRs target `--base <sandbox-branch>` instead of
    `main`. This is enforced by extending the Phase 4 implementer prompt
    template (`skills/autospec-run/prompts/phase4-implementer.md`) in Issue B.
-4. **No accidental main merges**: orchestrator refuses to invoke
+5. **No accidental main merges**: orchestrator refuses to invoke
    `gh pr merge` against `main` while `.autospec/explore-mode.json` is
    present. The sandbox → main merge is a separate explicit operator
    action (`/autospec-explore-promote <sandbox-branch>` — out of scope
    for v1; documented as the manual path).
-5. **Sandbox refresh policy**: the sandbox branch is NOT auto-rebased onto
+6. **Sandbox refresh policy**: the sandbox branch is NOT auto-rebased onto
    main. Operator does that explicitly. This is intentional — rebasing
    under autonomous shipping is unsafe.
 

--- a/skills/autospec-explore/codex/prompt.md
+++ b/skills/autospec-explore/codex/prompt.md
@@ -207,27 +207,40 @@ integration (E), and the `check_autospec_explore_contract` gate in `scripts/vali
 
 ## Sandbox branch contract
 
-1. **Creation**: at run start, the orchestrator invokes
+1. **Worktree assert (MUST exit 0 before any sandbox commit/push)**: the
+   orchestrator MUST run `bash scripts/worktree-guard.sh assert` before invoking
+   `explore-sandbox.sh` or performing any sandbox commit step. A non-zero exit
+   (in_primary_checkout / dirty / stale_base) is NEVER worked around — emit
+   the `code_health` identifier from the guard, and stop. The primary checkout
+   is read-only for agents; all sandbox work happens in a linked worktree.
+   ```bash
+   # MANDATORY assert gate: MUST exit 0 before any sandbox commit/push.
+   if ! bash scripts/worktree-guard.sh assert; then
+     echo "worktree-guard assert failed (see code_health identifier above); aborting sandbox commit" >&2
+     exit 1
+   fi
+   ```
+2. **Creation**: at run start, the orchestrator invokes
    `scripts/explore-sandbox.sh --slug <slug> --base main` which creates
    `autospec/explore/<YYYY-MM-DD>-<slug>` off `origin/main` (or the supplied
    `--base`) if not already present, pushes the branch to `origin`, and writes
    `.autospec/explore-mode.json` with `{branch, slug, base, head_sha, created_at}`.
    The branch lives until the operator merges or deletes it.
-2. **Idempotency**: re-invocation with the same `--slug` reuses the existing
+3. **Idempotency**: re-invocation with the same `--slug` reuses the existing
    sandbox branch — no error, no duplicate, no force-push. The script verifies
    the existing branch tracks the expected base via `git merge-base` and
    refreshes `.autospec/explore-mode.json` with the current head SHA.
-3. **Implementer integration**: every child-issue implementer reads
+4. **Implementer integration**: every child-issue implementer reads
    `.autospec/explore-mode.json` (written by the sandbox script) to learn the
    sandbox branch name. PRs target `--base <sandbox-branch>` instead of
    `main`. This is enforced by extending the Phase 4 implementer prompt
    template (`skills/autospec-run/prompts/phase4-implementer.md`) in Issue B.
-4. **No accidental main merges**: orchestrator refuses to invoke
+5. **No accidental main merges**: orchestrator refuses to invoke
    `gh pr merge` against `main` while `.autospec/explore-mode.json` is
    present. The sandbox → main merge is a separate explicit operator
    action (`/autospec-explore-promote <sandbox-branch>` — out of scope
    for v1; documented as the manual path).
-5. **Sandbox refresh policy**: the sandbox branch is NOT auto-rebased onto
+6. **Sandbox refresh policy**: the sandbox branch is NOT auto-rebased onto
    main. Operator does that explicitly. This is intentional — rebasing
    under autonomous shipping is unsafe.
 

--- a/skills/autospec-explore/opencode/agent.md
+++ b/skills/autospec-explore/opencode/agent.md
@@ -211,27 +211,40 @@ integration (E), and the `check_autospec_explore_contract` gate in `scripts/vali
 
 ## Sandbox branch contract
 
-1. **Creation**: at run start, the orchestrator invokes
+1. **Worktree assert (MUST exit 0 before any sandbox commit/push)**: the
+   orchestrator MUST run `bash scripts/worktree-guard.sh assert` before invoking
+   `explore-sandbox.sh` or performing any sandbox commit step. A non-zero exit
+   (in_primary_checkout / dirty / stale_base) is NEVER worked around — emit
+   the `code_health` identifier from the guard, and stop. The primary checkout
+   is read-only for agents; all sandbox work happens in a linked worktree.
+   ```bash
+   # MANDATORY assert gate: MUST exit 0 before any sandbox commit/push.
+   if ! bash scripts/worktree-guard.sh assert; then
+     echo "worktree-guard assert failed (see code_health identifier above); aborting sandbox commit" >&2
+     exit 1
+   fi
+   ```
+2. **Creation**: at run start, the orchestrator invokes
    `scripts/explore-sandbox.sh --slug <slug> --base main` which creates
    `autospec/explore/<YYYY-MM-DD>-<slug>` off `origin/main` (or the supplied
    `--base`) if not already present, pushes the branch to `origin`, and writes
    `.autospec/explore-mode.json` with `{branch, slug, base, head_sha, created_at}`.
    The branch lives until the operator merges or deletes it.
-2. **Idempotency**: re-invocation with the same `--slug` reuses the existing
+3. **Idempotency**: re-invocation with the same `--slug` reuses the existing
    sandbox branch — no error, no duplicate, no force-push. The script verifies
    the existing branch tracks the expected base via `git merge-base` and
    refreshes `.autospec/explore-mode.json` with the current head SHA.
-3. **Implementer integration**: every child-issue implementer reads
+4. **Implementer integration**: every child-issue implementer reads
    `.autospec/explore-mode.json` (written by the sandbox script) to learn the
    sandbox branch name. PRs target `--base <sandbox-branch>` instead of
    `main`. This is enforced by extending the Phase 4 implementer prompt
    template (`skills/autospec-run/prompts/phase4-implementer.md`) in Issue B.
-4. **No accidental main merges**: orchestrator refuses to invoke
+5. **No accidental main merges**: orchestrator refuses to invoke
    `gh pr merge` against `main` while `.autospec/explore-mode.json` is
    present. The sandbox → main merge is a separate explicit operator
    action (`/autospec-explore-promote <sandbox-branch>` — out of scope
    for v1; documented as the manual path).
-5. **Sandbox refresh policy**: the sandbox branch is NOT auto-rebased onto
+6. **Sandbox refresh policy**: the sandbox branch is NOT auto-rebased onto
    main. Operator does that explicitly. This is intentional — rebasing
    under autonomous shipping is unsafe.
 

--- a/tests/explore/test_explore_worktree_assert.bats
+++ b/tests/explore/test_explore_worktree_assert.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# Issue #964 — autospec-explore trio worktree assert (D4 split).
+#
+# Asserts that every file in the autospec-explore trio
+# (SKILL.md + codex/prompt.md + opencode/agent.md) carries the mandatory
+# `worktree-guard.sh assert` call before any sandbox commit step, and that
+# the Sandbox branch contract section is byte-identical across all three files.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SKILL="$REPO_ROOT/skills/autospec-explore/SKILL.md"
+    CODEX="$REPO_ROOT/skills/autospec-explore/codex/prompt.md"
+    OPENCODE="$REPO_ROOT/skills/autospec-explore/opencode/agent.md"
+}
+
+# ---------------------------------------------------------------------------
+# Named-content: worktree-guard.sh assert present in each trio file
+# ---------------------------------------------------------------------------
+
+@test "SKILL.md: worktree-guard.sh assert present in Sandbox branch contract" {
+    grep -q 'worktree-guard.sh assert' "$SKILL"
+}
+
+@test "codex/prompt.md: worktree-guard.sh assert present in Sandbox branch contract" {
+    grep -q 'worktree-guard.sh assert' "$CODEX"
+}
+
+@test "opencode/agent.md: worktree-guard.sh assert present in Sandbox branch contract" {
+    grep -q 'worktree-guard.sh assert' "$OPENCODE"
+}
+
+# ---------------------------------------------------------------------------
+# Named-content: MUST exit 0 guard requirement present in each trio file
+# ---------------------------------------------------------------------------
+
+@test "SKILL.md: MUST exit 0 gate wording present" {
+    grep -q 'MUST exit 0' "$SKILL"
+}
+
+@test "codex/prompt.md: MUST exit 0 gate wording present" {
+    grep -q 'MUST exit 0' "$CODEX"
+}
+
+@test "opencode/agent.md: MUST exit 0 gate wording present" {
+    grep -q 'MUST exit 0' "$OPENCODE"
+}
+
+# ---------------------------------------------------------------------------
+# Named-content: primary checkout hard rule present in each trio file
+# ---------------------------------------------------------------------------
+
+@test "SKILL.md: primary checkout read-only rule present" {
+    grep -qi 'primary checkout' "$SKILL"
+}
+
+@test "codex/prompt.md: primary checkout read-only rule present" {
+    grep -qi 'primary checkout' "$CODEX"
+}
+
+@test "opencode/agent.md: primary checkout read-only rule present" {
+    grep -qi 'primary checkout' "$OPENCODE"
+}
+
+# ---------------------------------------------------------------------------
+# Lock-step byte-identity: Sandbox branch contract section must be identical
+# ---------------------------------------------------------------------------
+
+@test "explore trio: Sandbox branch contract section is byte-identical across SKILL.md + codex/prompt.md + opencode/agent.md" {
+    section_skill="$(awk '/^## Sandbox branch contract/,/^## Research cycle contract/' "$SKILL")"
+    section_codex="$(awk '/^## Sandbox branch contract/,/^## Research cycle contract/' "$CODEX")"
+    section_opencode="$(awk '/^## Sandbox branch contract/,/^## Research cycle contract/' "$OPENCODE")"
+
+    [ -n "$section_skill" ]   || { echo "SKILL.md: Sandbox branch contract section missing" >&2; return 1; }
+    [ -n "$section_codex" ]   || { echo "codex/prompt.md: Sandbox branch contract section missing" >&2; return 1; }
+    [ -n "$section_opencode" ] || { echo "opencode/agent.md: Sandbox branch contract section missing" >&2; return 1; }
+
+    diff <(printf '%s\n' "$section_skill") <(printf '%s\n' "$section_codex") \
+        || { echo "SKILL.md vs codex/prompt.md: Sandbox branch contract section differs" >&2; return 1; }
+
+    diff <(printf '%s\n' "$section_skill") <(printf '%s\n' "$section_opencode") \
+        || { echo "SKILL.md vs opencode/agent.md: Sandbox branch contract section differs" >&2; return 1; }
+}


### PR DESCRIPTION
Closes #964

## Summary

- Adds `worktree-guard.sh assert` as item 1 of the **Sandbox branch contract** in the autospec-explore trio, requiring the mandatory assert gate (MUST exit 0) before any sandbox commit/push step. A non-zero exit (in_primary_checkout / dirty / stale_base) is never worked around — emits the `code_health` identifier and stops.
- Lock-step: the `## Sandbox branch contract` section is byte-identical across all three adapter files (SKILL.md + codex/prompt.md + opencode/agent.md).
- Adds `tests/explore/test_explore_worktree_assert.bats` with 10 tests covering assert presence, MUST-exit-0 wording, primary-checkout rule, and byte-identity across the trio.
- Adds `check_explore_trio_worktree_assert()` to `scripts/validate.sh` (called from `main()`).

## Verification

- `bats tests/explore/test_explore_worktree_assert.bats` — 10/10 pass
- `bash scripts/validate.sh` — exit 0, "OK — all validation checks passed."