### PR TITLE
fix(gen-pr-report): commit missing loop.log fixture for green-clean golden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ dist/homebrew/*
 !dist/homebrew/autospec.rb
 build/
 *.log
+# Allow committed *.log test fixtures (e.g. gen-pr-report loop-log golden input)
+!tests/fixtures/**/*.log
 *.tmp
 *.bak
 artifacts/

--- a/tests/fixtures/gen-pr-report/loop.log
+++ b/tests/fixtures/gen-pr-report/loop.log
@@ -1,0 +1,3 @@
+iter=1 ts=2026-05-22T10:00:00Z step=implement status=ok
+iter=2 ts=2026-05-22T10:05:00Z step=test status=ok
+iter=3 ts=2026-05-22T10:12:00Z step=review status=ok


### PR DESCRIPTION
Closes #968

## Root cause
`tests/gen-pr-report.bats` test 1 (green-clean) invokes the generator with `--loop-log tests/fixtures/gen-pr-report/loop.log`, but that fixture was **never committed** in #479 (`4ec2cff`) — the repo-wide `*.log` rule in `.gitignore` silently swallowed it alongside the script, goldens, and other fixtures. `gen-pr-report.sh` correctly errors `loop-log file not found` and exits 1, failing `[ "$status" -eq 0 ]` on a clean `origin/main`.

Neither the script nor the golden regressed — `expected-green.md` already embeds the exact 3 iteration lines that `gen-pr-report.sh` cats verbatim into the "Loop iterations" block.

## Fix
- Add a scoped `.gitignore` negation `!tests/fixtures/**/*.log` (mirroring the existing fixture-negation pattern in that file) so committed `*.log` test fixtures survive.
- Commit the missing `loop.log` fixture with the 3 iteration lines the golden expects.

## Verification
- `bats tests/gen-pr-report.bats` → 6/6 pass (was 1 failing)
- `bash scripts/validate.sh` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)