### PR TITLE
test(self-enforce-qa): drop stale CI-workflow assertions, assert intentional absence

### DIFF
--- a/tests/self-enforce-qa.bats
+++ b/tests/self-enforce-qa.bats
@@ -128,19 +128,11 @@ EOF
   [ "$status" -eq 0 ]
 }
 
-@test "workflow file exists at .github/workflows/autospec-self-enforce.yml" {
-  [ -f "${BATS_TEST_DIRNAME}/../.github/workflows/autospec-self-enforce.yml" ]
-}
-
-@test "workflow triggers on pull_request to main" {
-  workflow="${BATS_TEST_DIRNAME}/../.github/workflows/autospec-self-enforce.yml"
-  grep -q "pull_request" "$workflow"
-  grep -q "main" "$workflow"
-}
-
-@test "workflow has path filter for skills/** scripts/** docs/specs/**" {
-  workflow="${BATS_TEST_DIRNAME}/../.github/workflows/autospec-self-enforce.yml"
-  grep -q "skills/\*\*" "$workflow"
-  grep -q "scripts/\*\*" "$workflow"
-  grep -q "docs/specs/\*\*" "$workflow"
+# The autospec-self-enforce GitHub Actions workflow was deliberately removed
+# in #481 (commit 21d4f52, "chore: disable GitHub Actions / CI") when CI was
+# disabled repo-wide; local pre-commit hooks + on-demand scripts/validate.sh
+# now carry self-enforcement. This asserts the workflow stays absent so the
+# stale existence/trigger/path-filter assertions can never silently re-appear.
+@test "autospec-self-enforce workflow is intentionally absent (CI disabled in #481)" {
+  [ ! -f "${BATS_TEST_DIRNAME}/../.github/workflows/autospec-self-enforce.yml" ]
 }


### PR DESCRIPTION
Closes #984

## Root cause
`tests/self-enforce-qa.bats` tests 9-11 asserted that `.github/workflows/autospec-self-enforce.yml` exists, triggers on `pull_request` to `main`, and carries a `skills/** scripts/** docs/specs/**` path filter. That workflow was **deliberately deleted in #481** (commit `21d4f52`, "chore: disable GitHub Actions / CI") when CI was disabled repo-wide — so the three assertions fail at HEAD. Legacy residue, not a regression.

## Fix
Replace the three positive-existence assertions with a single test asserting the workflow stays **absent**, with an inline comment recording the #481 rationale. This keeps the deliberate-removal decision under test (the stale assertions can never silently reappear) without recreating the retired workflow. The workflow is **not** restored.

Self-enforcement now runs via local pre-commit hooks + on-demand `scripts/validate.sh`.

## Verification
- `bats tests/self-enforce-qa.bats` → 9/9 pass (new test 9 green; the 3 stale tests removed)
- `bash scripts/validate.sh` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)