### PR TITLE
fix(install): ship 9 per-skill runtime scripts referenced via ${AUTOSPEC_SCRIPTS_DIR}

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -888,6 +888,51 @@ copy_repo_scripts() {
     info "copy_repo_scripts: copied repo-root scripts to $autospec_scripts_dir/"
 }
 
+copy_runtime_skill_scripts() {
+    # Ship the per-skill helper scripts that skill *surfaces* invoke at runtime via
+    # ${AUTOSPEC_SCRIPTS_DIR}/<name> but that copy_shared_scripts()/copy_repo_scripts()
+    # do not reach (they live under skills/<skill>/scripts/, not scripts/ or
+    # skills/autospec-shared/scripts/). The per-skill installers also ship these, but a
+    # top-level `install.sh` invocation must land every runtime reference on its own so a
+    # single install is complete (issue #985). Explicit src->dest manifest (not a glob):
+    # several skills reuse generic basenames (sweep run.sh/wizard.sh, autospec-test
+    # wizard.sh), so a flat copy would collide; the sweep scripts also ship under
+    # autospec-sweep-* renames. tests/ship-completeness.bats mirrors this manifest.
+    autospec_scripts_dir="${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}"
+
+    # Each entry is "<repo-relative source>::<dest basename under $AUTOSPEC_SCRIPTS_DIR>".
+    runtime_skill_scripts="\
+skills/autospec-run/scripts/autospec-run-session-lock.sh::autospec-run-session-lock.sh \
+skills/autospec-run/scripts/claim-issue.sh::claim-issue.sh \
+skills/autospec-run/scripts/list-ready-issues.sh::list-ready-issues.sh \
+skills/autospec-run/scripts/post-token-report.sh::post-token-report.sh \
+skills/autospec-run/scripts/release-issue.sh::release-issue.sh \
+skills/autospec-resume/scripts/resume-scan.sh::resume-scan.sh \
+skills/autospec-doc/scripts/doc-orchestrator.mjs::doc-orchestrator.mjs \
+skills/autospec-sweep/scripts/run.sh::autospec-sweep-run.sh \
+skills/autospec-sweep/scripts/wizard.sh::autospec-sweep-wizard.sh"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        info "[dry-run] copy_runtime_skill_scripts: would copy 9 per-skill runtime scripts to $autospec_scripts_dir/"
+        return 0
+    fi
+
+    mkdir -p "$autospec_scripts_dir"
+    for entry in $runtime_skill_scripts; do
+        src="$REPO_ROOT/${entry%%::*}"
+        dest="$autospec_scripts_dir/${entry##*::}"
+        if [ -f "$src" ]; then
+            cp "$src" "$dest"
+            case "$dest" in
+                *.sh|*.mjs) chmod +x "$dest" ;;
+            esac
+        else
+            warn "copy_runtime_skill_scripts: source not found: $src (skipping)"
+        fi
+    done
+    info "copy_runtime_skill_scripts: copied per-skill runtime scripts to $autospec_scripts_dir/"
+}
+
 copy_schemas() {
     # Copy repo-root schemas/*.json into $AUTOSPEC_SCHEMAS_DIR (default ~/.autospec/schemas/).
     # Mirrors copy_repo_scripts for the schemas/ directory. Runs on every install
@@ -920,6 +965,7 @@ copy_schemas() {
 pull_autospec
 copy_shared_scripts
 copy_repo_scripts
+copy_runtime_skill_scripts
 copy_schemas
 ensure_system_tools
 bootstrap_peer_ecosystems

--- a/tests/ship-completeness.bats
+++ b/tests/ship-completeness.bats
@@ -5,8 +5,9 @@
 #
 # Rationale (#556): repo-root scripts ship to ~/.autospec/scripts via install.sh's
 # copy_repo_scripts() glob + skills/autospec-shared/scripts via copy_shared_scripts().
-# A runtime reference to a script that the installers never copy would be missing in
-# a target repo. This guard catches such drift at test time.
+# Per-skill runtime helpers (skills/<skill>/scripts/) ship via copy_runtime_skill_scripts()'s
+# explicit src->dest manifest (#985). A runtime reference to a script that the installers
+# never copy would be missing in a target repo. This guard catches such drift at test time.
 
 REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 
@@ -37,6 +38,16 @@ shippable_paths() {
       ( cd "$REPO_ROOT/skills/autospec-shared/scripts" && \
         find . -type f \( -name '*.sh' -o -name '*.mjs' -o -name '*.ps1' \) \
           | sed 's#^\./##' )
+    fi
+    # Per-skill runtime helpers ship flat (basename) via copy_runtime_skill_scripts()'s
+    # explicit "<src>::<dest>" manifest in install.sh. Read the manifest's declared
+    # destinations so this guard tracks what the installer actually copies (#985). The
+    # references being checked come from skill surface files, not from install.sh, so
+    # this is not a self-consistent fixture.
+    if [ -f "$REPO_ROOT/install.sh" ]; then
+      grep -oE 'skills/[A-Za-z0-9_./-]+\.(sh|mjs|ps1)::[A-Za-z0-9_.-]+\.(sh|mjs|ps1)' \
+        "$REPO_ROOT/install.sh" \
+        | sed -E 's#^.*::##'
     fi
   } | sort -u
 }


### PR DESCRIPTION
Closes #985

## Root cause
Nine helper scripts that skill surfaces invoke at runtime via `${AUTOSPEC_SCRIPTS_DIR}/<name>` live under `skills/<skill>/scripts/`. The top-level `install.sh` only reached `skills/autospec-shared/scripts/**` (`copy_shared_scripts`) and repo-root `scripts/**` (`copy_repo_scripts`) — so a single top-level `install.sh` run left these runtime references unshipped, and `tests/ship-completeness.bats` test 1 failed at HEAD:

`autospec-run-session-lock.sh autospec-sweep-run.sh autospec-sweep-wizard.sh claim-issue.sh doc-orchestrator.mjs list-ready-issues.sh post-token-report.sh release-issue.sh resume-scan.sh`

## Fix
- Add `copy_runtime_skill_scripts()` to `install.sh` with an **explicit src->dest manifest** (not a glob — several skills reuse generic basenames like `run.sh`/`wizard.sh` that would collide, and the sweep scripts ship under `autospec-sweep-*` renames). Wired into the bootstrap sequence after `copy_repo_scripts`.
- `tests/ship-completeness.bats` `shippable_paths()` now reads the manifest's declared destinations from `install.sh`, so the guard tracks what the installer actually copies. The references it checks come from skill **surface files**, not from `install.sh`, so this is not a self-consistent fixture.

## Scope note
- `ship-completeness.bats` test 1 ("...shipped by the installers") now passes.
- `uninstall.sh` removes whole skill directories (it keeps no flat per-script manifest), so no mirror is needed there.
- Test 2 ("no bare repo-relative shell/mjs invocation") is a **separate, pre-existing failure** (295 prose-reference offenders across 38 surface files, present on clean origin/main) — the `scripts/classify-model-fit.sh` slice of it is tracked under #986. It is out of scope for this issue, whose remediation directive and evidence target test 1 only.

## Verification
- `bats -f "shipped by the installers" tests/ship-completeness.bats` → pass
- install dry-run harness confirms all 9 land under their referenced names
- `bash scripts/validate.sh` → exit 0 (includes install dry-run + update-flag tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)