### PR TITLE
feat(autospec-test): authoring-config.mjs — e2e.authoring/reset/control_effects loader + validation (#992)

### DIFF
--- a/skills/autospec-test/scripts/authoring-config.mjs
+++ b/skills/autospec-test/scripts/authoring-config.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+// scripts/authoring-config.mjs
+// loadAuthoringConfig(testYmlPath) -> {authoring, reset, control_effects}
+//
+// Loads and validates the e2e.authoring / e2e.reset / e2e.control_effects
+// blocks from a .autospec/test.yml file, merging with conservative defaults.
+//
+// Fail-closed validation:
+//   - Throws if reset.generate_if_missing=true and reset.guard_env is missing/empty
+//   - Throws if e2e.forbidden_url_patterns is missing/empty (unless
+//     forbidden_url_patterns_intentionally_empty=true is set)
+//
+// Export: loadAuthoringConfig(testYmlPath) async function
+// CLI:    node authoring-config.mjs <testYmlPath>
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const __filename = fileURLToPath(import.meta.url);
+
+// ── Defaults (conservative) ────────────────────────────────────────────────────
+
+const AUTHORING_DEFAULTS = {
+    enabled: false,
+    spec_dir: 'e2e/specs',
+    helpers_dir: 'e2e/helpers',
+    route_clusters: 'auto',
+    coverage_target_pct: 80,
+    fanout_max: 4,
+};
+
+const RESET_DEFAULTS = {
+    endpoint: '/api/test/reset',
+    generate_if_missing: false,
+    guard_env: 'AUTOSPEC_TEST_STACK',
+};
+
+const CONTROL_EFFECTS_DEFAULTS = {
+    enabled: true,
+};
+
+// ── YAML parser — uses yq if available, falls back to Node built-in ────────────
+
+/**
+ * Parse a YAML file to a plain JS object.
+ * Tries `yq -o=json` first (same dependency as load-contract.sh),
+ * then falls back to a lightweight built-in YAML-subset parser for simple
+ * key: value / list structures (sufficient for test.yml).
+ *
+ * @param {string} filePath
+ * @returns {Promise<object>}
+ */
+async function parseYamlFile(filePath) {
+    // Try yq (preferred — handles all YAML)
+    try {
+        const { stdout } = await execFileAsync('yq', ['-o=json', '.', filePath], { timeout: 10000 });
+        const trimmed = stdout.trim();
+        if (trimmed && trimmed !== 'null') {
+            return JSON.parse(trimmed);
+        }
+        return {};
+    } catch {
+        // yq not available or failed — try js-yaml if available
+    }
+
+    // Try js-yaml (may be installed as a dev dependency)
+    try {
+        const { createRequire } = await import('node:module');
+        const require = createRequire(import.meta.url);
+        const yaml = require('js-yaml');
+        const text = fs.readFileSync(filePath, 'utf8');
+        return yaml.load(text) || {};
+    } catch {
+        // Not available
+    }
+
+    // Fallback: minimal YAML parser for the subset used in test.yml
+    // Handles: scalar keys, quoted/unquoted string values, boolean, integer,
+    // nested objects (indented blocks), and simple string lists.
+    const text = fs.readFileSync(filePath, 'utf8');
+    return parseMinimalYaml(text);
+}
+
+/**
+ * Minimal YAML parser for the subset used in .autospec/test.yml.
+ * Not a general-purpose parser — handles the shapes present in test.yml:
+ *   - top-level and nested key: value scalars
+ *   - boolean true/false
+ *   - integer values
+ *   - simple string list items (- "value" or - value)
+ *   - nested objects via indentation
+ *
+ * @param {string} text
+ * @returns {object}
+ */
+function parseMinimalYaml(text) {
+    const lines = text.split('\n');
+    const root = {};
+    const stack = [{ indent: -1, obj: root }];
+
+    for (let i = 0; i < lines.length; i++) {
+        const rawLine = lines[i];
+        const stripped = rawLine.replace(/#.*$/, '').trimEnd(); // strip comments
+        if (!stripped.trim()) continue;
+
+        const indent = stripped.length - stripped.trimStart().length;
+        const line = stripped.trimStart();
+
+        // Pop stack to current indent level
+        while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
+            stack.pop();
+        }
+
+        const parent = stack[stack.length - 1].obj;
+
+        // List item
+        if (line.startsWith('- ')) {
+            const val = parseScalar(line.slice(2).trim());
+            const lastKey = Object.keys(parent).pop();
+            if (lastKey !== undefined && !Array.isArray(parent[lastKey])) {
+                parent[lastKey] = [];
+            }
+            if (lastKey !== undefined) {
+                parent[lastKey].push(val);
+            }
+            continue;
+        }
+
+        // Key: value or Key: (nested block)
+        const colonIdx = line.indexOf(':');
+        if (colonIdx === -1) continue;
+        const key = line.slice(0, colonIdx).trim();
+        const rest = line.slice(colonIdx + 1).trim();
+
+        if (rest === '' || rest.startsWith('#')) {
+            // Start of a nested object
+            const nested = {};
+            parent[key] = nested;
+            stack.push({ indent, obj: nested });
+        } else {
+            parent[key] = parseScalar(rest);
+        }
+    }
+
+    return root;
+}
+
+/**
+ * Parse a YAML scalar value string to JS primitive.
+ * Handles: quoted strings, booleans, integers, plain strings.
+ *
+ * @param {string} s
+ * @returns {string|boolean|number}
+ */
+function parseScalar(s) {
+    // Strip inline comment
+    const noComment = s.replace(/\s+#.*$/, '').trim();
+
+    // Quoted string (single or double)
+    if ((noComment.startsWith('"') && noComment.endsWith('"')) ||
+        (noComment.startsWith("'") && noComment.endsWith("'"))) {
+        return noComment.slice(1, -1);
+    }
+    // Boolean
+    if (noComment === 'true') return true;
+    if (noComment === 'false') return false;
+    // Null
+    if (noComment === 'null' || noComment === '~') return null;
+    // Integer
+    if (/^-?\d+$/.test(noComment)) return parseInt(noComment, 10);
+    // Float
+    if (/^-?\d+\.\d+$/.test(noComment)) return parseFloat(noComment);
+    // Plain string
+    return noComment;
+}
+
+// ── Main export ────────────────────────────────────────────────────────────────
+
+/**
+ * Load and validate the e2e.authoring, e2e.reset, and e2e.control_effects
+ * blocks from a .autospec/test.yml file.
+ *
+ * Returns defaults for any missing blocks/keys. Throws for invalid combinations
+ * (fail-closed behaviour per spec §4).
+ *
+ * @param {string} testYmlPath - absolute or relative path to test.yml
+ * @returns {Promise<{authoring: object, reset: object, control_effects: object}>}
+ * @throws {Error} if fail-closed validation rules are violated
+ */
+export async function loadAuthoringConfig(testYmlPath) {
+    let raw = {};
+
+    if (fs.existsSync(testYmlPath)) {
+        raw = await parseYamlFile(testYmlPath);
+        if (!raw || typeof raw !== 'object') {
+            raw = {};
+        }
+    }
+
+    const e2e = (raw && typeof raw.e2e === 'object' && raw.e2e !== null) ? raw.e2e : {};
+
+    // ── Merge authoring block with defaults ────────────────────────────────────
+    const rawAuthoring = (typeof e2e.authoring === 'object' && e2e.authoring !== null)
+        ? e2e.authoring : {};
+    const authoring = { ...AUTHORING_DEFAULTS, ...rawAuthoring };
+
+    // ── Merge reset block with defaults ───────────────────────────────────────
+    const rawReset = (typeof e2e.reset === 'object' && e2e.reset !== null)
+        ? e2e.reset : {};
+
+    // Build reset by merging defaults, but do NOT apply guard_env default when
+    // generate_if_missing=true — the caller must supply an explicit guard_env.
+    // This makes the fail-closed rule meaningful (the default would silently satisfy it).
+    const effectiveGenerateIfMissing = rawReset.generate_if_missing !== undefined
+        ? rawReset.generate_if_missing
+        : RESET_DEFAULTS.generate_if_missing;
+
+    let resetBase;
+    if (rawReset.cmd !== undefined) {
+        // cmd variant — no endpoint default
+        resetBase = { generate_if_missing: false, guard_env: 'AUTOSPEC_TEST_STACK', ...rawReset };
+    } else if (effectiveGenerateIfMissing === true) {
+        // generate_if_missing=true: guard_env must be explicitly supplied — no default injection
+        resetBase = { ...RESET_DEFAULTS, ...rawReset };
+        // Strip the defaulted guard_env if it was NOT explicitly set by the caller
+        if (!('guard_env' in rawReset)) {
+            delete resetBase.guard_env;
+        }
+    } else {
+        resetBase = { ...RESET_DEFAULTS, ...rawReset };
+    }
+    const reset = resetBase;
+
+    // ── Merge control_effects block with defaults ──────────────────────────────
+    const rawControlEffects = (typeof e2e.control_effects === 'object' && e2e.control_effects !== null)
+        ? e2e.control_effects : {};
+    const control_effects = { ...CONTROL_EFFECTS_DEFAULTS, ...rawControlEffects };
+
+    // ── Fail-closed validation ─────────────────────────────────────────────────
+    // Validation order: guard_env check first (more specific), then forbidden_url_patterns.
+
+    // Rule 1: generate_if_missing=true requires a non-empty guard_env
+    if (reset.generate_if_missing === true) {
+        const guardEnv = reset.guard_env;
+        if (!guardEnv || (typeof guardEnv === 'string' && guardEnv.trim() === '')) {
+            throw new Error(
+                'authoring-config: validation error: reset.generate_if_missing=true requires ' +
+                'reset.guard_env to be set to a non-empty environment variable name. ' +
+                'Set reset.guard_env (e.g. AUTOSPEC_TEST_STACK) to name the guard env var ' +
+                'that must be present before the generated reset endpoint is exposed.'
+            );
+        }
+    }
+
+    // Rule 2: forbidden_url_patterns must be present and non-empty in yml
+    // (only when a yml file exists — if yml is missing, we're in default-only mode
+    //  which is safe since authoring.enabled defaults to false)
+    if (fs.existsSync(testYmlPath)) {
+        const patterns = e2e.forbidden_url_patterns;
+        const intentionallyEmpty = e2e.forbidden_url_patterns_intentionally_empty === true;
+
+        if (!intentionallyEmpty) {
+            if (!Array.isArray(patterns) || patterns.length === 0) {
+                throw new Error(
+                    'authoring-config: validation error: e2e.forbidden_url_patterns is missing or empty. ' +
+                    'Set at least one forbidden URL pattern (e.g. "^https?://prod\\\\.example\\\\.com") to ' +
+                    'prevent tests from running against production environments. ' +
+                    'If no URL restrictions apply, set e2e.forbidden_url_patterns_intentionally_empty: true.'
+                );
+            }
+        }
+    }
+
+    return { authoring, reset, control_effects };
+}
+
+// ── CLI entrypoint ─────────────────────────────────────────────────────────────
+
+if (process.argv[1] && fs.existsSync(process.argv[1]) &&
+    fs.realpathSync(path.resolve(process.argv[1])) === fs.realpathSync(path.resolve(__filename))) {
+    const testYmlPath = process.argv[2];
+    if (!testYmlPath) {
+        process.stderr.write('Usage: authoring-config.mjs <testYmlPath>\n');
+        process.exit(1);
+    }
+
+    try {
+        const cfg = await loadAuthoringConfig(path.resolve(testYmlPath));
+        process.stdout.write(JSON.stringify(cfg, null, 2) + '\n');
+    } catch (err) {
+        process.stderr.write(`authoring-config: ${err.message}\n`);
+        process.exit(2);
+    }
+}

--- a/skills/autospec-test/tests/unit/authoring-config.test.mjs
+++ b/skills/autospec-test/tests/unit/authoring-config.test.mjs
@@ -1,0 +1,373 @@
+// skills/autospec-test/tests/unit/authoring-config.test.mjs
+// node --test  (Node.js built-in test runner)
+// Tests for scripts/authoring-config.mjs — loadAuthoringConfig()
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = path.resolve(__dirname, '../../scripts');
+
+const { loadAuthoringConfig } = await import(`file://${SCRIPTS_DIR}/authoring-config.mjs`);
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function writeTempYml(content) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'authoring-config-test-'));
+    const ymlPath = path.join(dir, 'test.yml');
+    fs.writeFileSync(ymlPath, content, 'utf8');
+    return { dir, ymlPath };
+}
+
+function cleanup(dir) {
+    fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ── Defaults ───────────────────────────────────────────────────────────────────
+
+test('loadAuthoringConfig: returns authoring disabled by default when no yml', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'authoring-config-test-'));
+    const ymlPath = path.join(dir, 'missing.yml');
+    try {
+        const cfg = await loadAuthoringConfig(ymlPath);
+        assert.equal(cfg.authoring.enabled, false, 'authoring.enabled should default to false');
+        assert.equal(cfg.authoring.spec_dir, 'e2e/specs');
+        assert.equal(cfg.authoring.helpers_dir, 'e2e/helpers');
+        assert.equal(cfg.authoring.route_clusters, 'auto');
+        assert.equal(cfg.authoring.coverage_target_pct, 80);
+        assert.equal(cfg.authoring.fanout_max, 4);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('loadAuthoringConfig: returns reset defaults when no yml', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'authoring-config-test-'));
+    const ymlPath = path.join(dir, 'missing.yml');
+    try {
+        const cfg = await loadAuthoringConfig(ymlPath);
+        assert.equal(cfg.reset.endpoint, '/api/test/reset');
+        assert.equal(cfg.reset.generate_if_missing, false, 'generate_if_missing defaults false');
+        assert.equal(cfg.reset.guard_env, 'AUTOSPEC_TEST_STACK');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('loadAuthoringConfig: returns control_effects defaults when no yml', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'authoring-config-test-'));
+    const ymlPath = path.join(dir, 'missing.yml');
+    try {
+        const cfg = await loadAuthoringConfig(ymlPath);
+        assert.equal(cfg.control_effects.enabled, true, 'control_effects.enabled defaults true');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+// ── Happy path: well-formed yml ───────────────────────────────────────────────
+
+test('loadAuthoringConfig: reads authoring block from yml', async () => {
+    const { dir, ymlPath } = writeTempYml(`
+e2e:
+  authoring:
+    enabled: true
+    spec_dir: tests/e2e/specs
+    helpers_dir: tests/e2e/helpers
+    route_clusters: auto
+    coverage_target_pct: 90
+    fanout_max: 6
+  reset:
+    endpoint: /api/test/reset
+    generate_if_missing: false
+    guard_env: AUTOSPEC_TEST_STACK
+  control_effects:
+    enabled: true
+  forbidden_url_patterns:
+    - "^https?://prod.example.com"
+`);
+    try {
+        const cfg = await loadAuthoringConfig(ymlPath);
+        assert.equal(cfg.authoring.enabled, true);
+        assert.equal(cfg.authoring.spec_dir, 'tests/e2e/specs');
+        assert.equal(cfg.authoring.helpers_dir, 'tests/e2e/helpers');
+        assert.equal(cfg.authoring.coverage_target_pct, 90);
+        assert.equal(cfg.authoring.fanout_max, 6);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('loadAuthoringConfig: reads reset block from yml', async () => {
+    const { dir, ymlPath } = writeTempYml(`
+e2e:
+  authoring:
+    enabled: false
+  reset:
+    endpoint: /api/v2/reset
+    generate_if_missing: true
+    guard_env: MY_TEST_ENV
+  control_effects:
+    enabled: false
+  forbidden_url_patterns:
+    - "^https?://prod.example.com"
+`);
+    try {
+        const cfg = await loadAuthoringConfig(ymlPath);
+        assert.equal(cfg.reset.endpoint, '/api/v2/reset');
+        assert.equal(cfg.reset.generate_if_missing, true);
+        assert.equal(cfg.reset.guard_env, 'MY_TEST_ENV');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('loadAuthoringConfig: reads reset.cmd instead of endpoint', async () => {
+    const { dir, ymlPath } = writeTempYml(`
+e2e:
+  authoring:
+    enabled: false
+  reset:
+    cmd: "make db-reset"
+    generate_if_missing: false
+  control_effects:
+    enabled: false
+  forbidden_url_patterns:
+    - "^https?://prod.example.com"
+`);
+    try {
+        const cfg = await loadAuthoringConfig(ymlPath);
+        assert.equal(cfg.reset.cmd, 'make db-reset');
+        assert.equal(cfg.reset.endpoint, undefined);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('loadAuthoringConfig: reads control_effects block from yml', async () => {
+    const { dir, ymlPath } = writeTempYml(`
+e2e:
+  authoring:
+    enabled: false
+  reset:
+    generate_if_missing: false
+  control_effects:
+    enabled: false
+  forbidden_url_patterns:
+    - "^https?://prod.example.com"
+`);
+    try {
+        const cfg = await loadAuthoringConfig(ymlPath);
+        assert.equal(cfg.control_effects.enabled, false);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+// ── Fail-closed: generate_if_missing without guard_env ───────────────────────
+
+test('loadAuthoringConfig: throws if generate_if_missing=true and guard_env missing', async () => {
+    const { dir, ymlPath } = writeTempYml(`
+e2e:
+  authoring:
+    enabled: false
+  reset:
+    endpoint: /api/test/reset
+    generate_if_missing: true
+  control_effects:
+    enabled: false
+  forbidden_url_patterns:
+    - "^https?://prod.example.com"
+`);
+    try {
+        await assert.rejects(
+            async () => await loadAuthoringConfig(ymlPath),
+            (err) => {
+                assert.ok(err.message.includes('guard_env'), `Expected guard_env mention in: ${err.message}`);
+                return true;
+            }
+        );
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('loadAuthoringConfig: throws if generate_if_missing=true and guard_env is empty string', async () => {
+    const { dir, ymlPath } = writeTempYml(`
+e2e:
+  authoring:
+    enabled: false
+  reset:
+    endpoint: /api/test/reset
+    generate_if_missing: true
+    guard_env: ""
+  control_effects:
+    enabled: false
+  forbidden_url_patterns:
+    - "^https?://prod.example.com"
+`);
+    try {
+        await assert.rejects(
+            async () => await loadAuthoringConfig(ymlPath),
+            (err) => {
+                assert.ok(err.message.includes('guard_env'), `Expected guard_env mention in: ${err.message}`);
+                return true;
+            }
+        );
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('loadAuthoringConfig: no throw if generate_if_missing=false and guard_env missing', async () => {
+    const { dir, ymlPath } = writeTempYml(`
+e2e:
+  authoring:
+    enabled: false
+  reset:
+    endpoint: /api/test/reset
+    generate_if_missing: false
+  control_effects:
+    enabled: false
+  forbidden_url_patterns:
+    - "^https?://prod.example.com"
+`);
+    try {
+        const cfg = await loadAuthoringConfig(ymlPath);
+        assert.equal(cfg.reset.generate_if_missing, false);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+// ── Fail-closed: forbidden_url_patterns ──────────────────────────────────────
+
+test('loadAuthoringConfig: throws if forbidden_url_patterns is missing', async () => {
+    const { dir, ymlPath } = writeTempYml(`
+e2e:
+  authoring:
+    enabled: false
+  reset:
+    generate_if_missing: false
+  control_effects:
+    enabled: false
+`);
+    try {
+        await assert.rejects(
+            async () => await loadAuthoringConfig(ymlPath),
+            (err) => {
+                assert.ok(
+                    err.message.includes('forbidden_url_patterns'),
+                    `Expected forbidden_url_patterns mention in: ${err.message}`
+                );
+                return true;
+            }
+        );
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('loadAuthoringConfig: throws if forbidden_url_patterns is empty array', async () => {
+    const { dir, ymlPath } = writeTempYml(`
+e2e:
+  authoring:
+    enabled: false
+  reset:
+    generate_if_missing: false
+  control_effects:
+    enabled: false
+  forbidden_url_patterns: []
+`);
+    try {
+        await assert.rejects(
+            async () => await loadAuthoringConfig(ymlPath),
+            (err) => {
+                assert.ok(
+                    err.message.includes('forbidden_url_patterns'),
+                    `Expected forbidden_url_patterns mention in: ${err.message}`
+                );
+                return true;
+            }
+        );
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('loadAuthoringConfig: forbidden_url_patterns_intentionally_empty bypasses check', async () => {
+    const { dir, ymlPath } = writeTempYml(`
+e2e:
+  authoring:
+    enabled: false
+  reset:
+    generate_if_missing: false
+  control_effects:
+    enabled: false
+  forbidden_url_patterns: []
+  forbidden_url_patterns_intentionally_empty: true
+`);
+    try {
+        const cfg = await loadAuthoringConfig(ymlPath);
+        assert.equal(cfg.authoring.enabled, false);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+// ── No e2e block at all — defaults apply, but forbidden_url_patterns missing throws ──
+
+test('loadAuthoringConfig: throws if yml exists with no e2e.forbidden_url_patterns', async () => {
+    const { dir, ymlPath } = writeTempYml(`
+e2e:
+  authoring:
+    enabled: false
+  reset:
+    generate_if_missing: false
+  control_effects:
+    enabled: true
+`);
+    try {
+        await assert.rejects(
+            async () => await loadAuthoringConfig(ymlPath),
+            (err) => {
+                assert.ok(
+                    err.message.includes('forbidden_url_patterns'),
+                    `Expected forbidden_url_patterns mention in: ${err.message}`
+                );
+                return true;
+            }
+        );
+    } finally {
+        cleanup(dir);
+    }
+});
+
+// ── Return shape ──────────────────────────────────────────────────────────────
+
+test('loadAuthoringConfig: returned object has exactly authoring, reset, control_effects keys', async () => {
+    const { dir, ymlPath } = writeTempYml(`
+e2e:
+  authoring:
+    enabled: true
+  reset:
+    generate_if_missing: true
+    guard_env: MY_GUARD
+  control_effects:
+    enabled: true
+  forbidden_url_patterns:
+    - "^https?://prod.example.com"
+`);
+    try {
+        const cfg = await loadAuthoringConfig(ymlPath);
+        assert.ok('authoring' in cfg, 'must have authoring key');
+        assert.ok('reset' in cfg, 'must have reset key');
+        assert.ok('control_effects' in cfg, 'must have control_effects key');
+    } finally {
+        cleanup(dir);
+    }
+});


### PR DESCRIPTION
Closes #992

## Summary

- New `skills/autospec-test/scripts/authoring-config.mjs` exporting `loadAuthoringConfig(testYmlPath) -> {authoring, reset, control_effects}`
- Extends the `.autospec/test.yml` schema with the `e2e.authoring`, `e2e.reset`, and `e2e.control_effects` blocks per the shared contracts in #992
- Fail-closed validation: throws if `reset.generate_if_missing=true` without `reset.guard_env`; throws if `e2e.forbidden_url_patterns` missing/empty in yml (unless `forbidden_url_patterns_intentionally_empty: true`)
- Conservative defaults: `authoring.enabled=false`, `generate_if_missing=false`
- Uses `yq` (same dependency as `load-contract.sh`) with a minimal YAML fallback parser
- 15 unit tests under `skills/autospec-test/tests/unit/authoring-config.test.mjs`

## Shared contracts honored

- Export name `loadAuthoringConfig` matches contract table verbatim
- File path `skills/autospec-test/scripts/authoring-config.mjs` matches contract table
- Return shape `{authoring, reset, control_effects}` matches spec §4
- Fail-closed rules match issue body: `generate_if_missing && !guard_env` → throw; `forbidden_url_patterns` missing/empty → throw

## Test plan

- [x] `node --test skills/autospec-test/tests/unit/authoring-config.test.mjs` — 15/15 pass
- [x] Defaults return correct values when yml is missing
- [x] Fail-closed: throws with `guard_env` in message when `generate_if_missing=true` without guard
- [x] Fail-closed: throws with `forbidden_url_patterns` in message when patterns missing/empty
- [x] Bypass: `forbidden_url_patterns_intentionally_empty: true` suppresses the patterns check
- [x] `reset.cmd` variant supported (no endpoint defaulted)