### PR TITLE
feat(autospec-test): selector-evidence.mjs — source-grep resolver + manifest builder (#994)

### DIFF
--- a/skills/autospec-test/scripts/selector-evidence.mjs
+++ b/skills/autospec-test/scripts/selector-evidence.mjs
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+// scripts/selector-evidence.mjs
+// Selector-evidence manifest builder — source-grep resolver.
+//
+// extractSelectors(specText) -> [{selector, type, line}]
+// resolveSelector(selector, srcGlobs, repoRoot) -> "file:line" | null
+// buildEvidence(specFile, srcGlobs, repoRoot) -> {selector: "file:line"|null}
+// writeManifest(manifestData, repoRoot) -> manifestPath
+//
+// Manifest shape: {spec_file: {selector: "file:line"}}
+// Written to: <repoRoot>/e2e/.autospec/selector-evidence.json
+//
+// Export: extractSelectors, resolveSelector, buildEvidence, writeManifest
+// CLI:    node selector-evidence.mjs --spec <file> --src <glob,...> [--repo-root <dir>]
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+
+// ── Manifest path (per shared contracts §8) ────────────────────────────────────
+const MANIFEST_REL_PATH = path.join('e2e', '.autospec', 'selector-evidence.json');
+
+// ── Selector extraction patterns ───────────────────────────────────────────────
+// Each pattern has: regex, type label, capture group index for selector value
+
+const SELECTOR_PATTERNS = [
+    // getByTestId('submit-btn') or getByTestId("submit-btn")
+    {
+        re: /getByTestId\s*\(\s*['"`]([^'"`]+)['"`]/g,
+        type: 'data-testid',
+    },
+    // [data-testid="submit-btn"] or [data-testid='submit-btn']
+    {
+        re: /data-testid\s*[=:]\s*['"`]([^'"`]+)['"`]/g,
+        type: 'data-testid',
+    },
+    // getByLabel('Email address') — aria-label
+    {
+        re: /getByLabel\s*\(\s*['"`]([^'"`]+)['"`]/g,
+        type: 'aria-label',
+    },
+    // aria-label="Email address" or aria-label='...'
+    {
+        re: /aria-label\s*=\s*['"`]([^'"`]+)['"`]/g,
+        type: 'aria-label',
+    },
+    // getByText('Welcome back') — text content
+    {
+        re: /getByText\s*\(\s*['"`]([^'"`]+)['"`]/g,
+        type: 'text',
+    },
+    // getByRole('button', { name: 'Save changes' }) — role name
+    {
+        re: /getByRole\s*\(\s*['"`][^'"`]*['"`]\s*,\s*\{[^}]*\bname\s*:\s*['"`]([^'"`]+)['"`]/g,
+        type: 'role-name',
+    },
+];
+
+// ── extractSelectors ───────────────────────────────────────────────────────────
+
+/**
+ * Extract all selectors referenced in a Playwright spec text.
+ * Returns deduplicated list of {selector, type, line}.
+ * Multiple occurrences of the same selector value are deduplicated (first occurrence wins).
+ *
+ * @param {string} specText - content of the spec file
+ * @returns {Array<{selector: string, type: string, line: number}>}
+ */
+export function extractSelectors(specText) {
+    const lines = specText.split('\n');
+    const seen = new Set();
+    const results = [];
+
+    for (const { re, type } of SELECTOR_PATTERNS) {
+        // Reset regex lastIndex for each pattern application
+        re.lastIndex = 0;
+        let match;
+        while ((match = re.exec(specText)) !== null) {
+            const selector = match[1];
+            if (!selector || seen.has(selector)) continue;
+            seen.add(selector);
+
+            // Determine line number from match index
+            const textBefore = specText.slice(0, match.index);
+            const line = textBefore.split('\n').length;
+
+            results.push({ selector, type, line });
+        }
+    }
+
+    return results;
+}
+
+// ── resolveSelector ────────────────────────────────────────────────────────────
+
+/**
+ * Resolve a selector string to its first occurrence in app source files.
+ * Returns "relative/path/to/file.tsx:lineNumber" or null if not found.
+ *
+ * Searches each source file for a literal occurrence of the selector string.
+ * This covers: data-testid="...", aria-label="...", text content, role names.
+ *
+ * @param {string} selector - the selector string to find
+ * @param {string[]} srcGlobs - globs or absolute paths to search
+ * @param {string} repoRoot - repository root (for relative path computation)
+ * @returns {string|null} - "file:line" relative to repoRoot, or null
+ */
+export function resolveSelector(selector, srcGlobs, repoRoot) {
+    if (!selector || srcGlobs.length === 0) return null;
+
+    const files = expandGlobs(srcGlobs);
+
+    for (const filePath of files) {
+        let text;
+        try {
+            text = fs.readFileSync(filePath, 'utf8');
+        } catch {
+            continue;
+        }
+
+        const lines = text.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+            if (lines[i].includes(selector)) {
+                const relPath = path.relative(repoRoot, filePath);
+                return `${relPath}:${i + 1}`;
+            }
+        }
+    }
+
+    return null;
+}
+
+// ── buildEvidence ──────────────────────────────────────────────────────────────
+
+/**
+ * Build the selector-evidence object for a single spec file.
+ * Returns {selector: "file:line" | null} — null means selector was not found in app source.
+ *
+ * @param {string} specFile - absolute path to the spec file
+ * @param {string[]} srcGlobs - globs or absolute paths for app source files
+ * @param {string} repoRoot - repository root for relative path computation
+ * @returns {Object<string, string|null>}
+ */
+export function buildEvidence(specFile, srcGlobs, repoRoot) {
+    let specText;
+    try {
+        specText = fs.readFileSync(specFile, 'utf8');
+    } catch {
+        return {};
+    }
+
+    const selectors = extractSelectors(specText);
+    if (selectors.length === 0) return {};
+
+    const evidence = {};
+    for (const { selector } of selectors) {
+        evidence[selector] = resolveSelector(selector, srcGlobs, repoRoot);
+    }
+    return evidence;
+}
+
+// ── writeManifest ──────────────────────────────────────────────────────────────
+
+/**
+ * Write the full selector-evidence manifest to e2e/.autospec/selector-evidence.json.
+ * Creates parent directories if missing. Overwrites any existing manifest.
+ *
+ * @param {Object<string, Object<string, string|null>>} manifestData
+ *   Shape: {spec_file: {selector: "file:line"|null}}
+ * @param {string} repoRoot - repository root
+ * @returns {string} - absolute path to the written manifest file
+ */
+export function writeManifest(manifestData, repoRoot) {
+    const manifestPath = path.join(repoRoot, MANIFEST_REL_PATH);
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+    fs.writeFileSync(manifestPath, JSON.stringify(manifestData, null, 2) + '\n', 'utf8');
+    return manifestPath;
+}
+
+// ── Glob expansion ─────────────────────────────────────────────────────────────
+
+/**
+ * Expand an array of globs/paths to a list of file paths.
+ * For simple absolute file paths (no glob chars), includes them directly.
+ * For patterns with glob chars, does a recursive directory scan.
+ *
+ * Note: uses fs.readdirSync for portability (no external glob dependency).
+ *
+ * @param {string[]} patterns
+ * @returns {string[]}
+ */
+function expandGlobs(patterns) {
+    const results = [];
+    const seen = new Set();
+
+    for (const pattern of patterns) {
+        if (!hasGlobChars(pattern)) {
+            // Direct path
+            if (fs.existsSync(pattern)) {
+                const stat = fs.statSync(pattern);
+                if (stat.isFile() && !seen.has(pattern)) {
+                    results.push(pattern);
+                    seen.add(pattern);
+                } else if (stat.isDirectory()) {
+                    collectFiles(pattern, results, seen);
+                }
+            }
+            continue;
+        }
+
+        // Simple glob expansion: handle **/ prefix and file extension suffix
+        // Pattern like /some/dir/src/** or /some/dir/**/*.tsx
+        const { base, ext } = parseGlob(pattern);
+
+        if (base && fs.existsSync(base)) {
+            const files = collectFilesWithExt(base, ext);
+            for (const f of files) {
+                if (!seen.has(f)) {
+                    results.push(f);
+                    seen.add(f);
+                }
+            }
+        }
+    }
+
+    return results;
+}
+
+function hasGlobChars(pattern) {
+    return pattern.includes('*') || pattern.includes('?') || pattern.includes('{');
+}
+
+/**
+ * Parse a glob pattern into {base, ext}.
+ * e.g. "/dir/src/**" -> {base: "/dir/src", ext: null}
+ *      "/dir/src/**\/*.tsx" -> {base: "/dir/src", ext: ".tsx"}
+ *      "/dir/src/**\/*.{ts,tsx}" -> {base: "/dir/src", ext: null} (collect all)
+ */
+function parseGlob(pattern) {
+    // Remove trailing ** or **/*
+    let base = pattern;
+    let ext = null;
+
+    // Find the first glob character's path component
+    const parts = pattern.split('/');
+    const globIdx = parts.findIndex(p => hasGlobChars(p));
+    if (globIdx > 0) {
+        base = parts.slice(0, globIdx).join('/');
+    } else if (globIdx === 0) {
+        base = '/';
+    } else {
+        base = pattern;
+    }
+
+    // Check for extension pattern like *.tsx or *.{ts,tsx}
+    const lastPart = parts[parts.length - 1];
+    if (lastPart && !hasGlobChars(lastPart.replace(/\.\w+$/, ''))) {
+        const extMatch = lastPart.match(/\*(\.\w+)$/);
+        if (extMatch) ext = extMatch[1];
+    }
+
+    return { base, ext };
+}
+
+function collectFiles(dir, results, seen) {
+    let entries;
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+        return;
+    }
+    for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory() && !entry.name.startsWith('.')) {
+            collectFiles(full, results, seen);
+        } else if (entry.isFile() && !seen.has(full)) {
+            results.push(full);
+            seen.add(full);
+        }
+    }
+}
+
+function collectFilesWithExt(dir, ext) {
+    const results = [];
+    const seen = new Set();
+
+    function recurse(d) {
+        let entries;
+        try {
+            entries = fs.readdirSync(d, { withFileTypes: true });
+        } catch {
+            return;
+        }
+        for (const entry of entries) {
+            const full = path.join(d, entry.name);
+            if (entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules') {
+                recurse(full);
+            } else if (entry.isFile() && !seen.has(full)) {
+                if (!ext || full.endsWith(ext)) {
+                    results.push(full);
+                    seen.add(full);
+                }
+            }
+        }
+    }
+
+    recurse(dir);
+    return results;
+}
+
+// ── CLI entrypoint ─────────────────────────────────────────────────────────────
+
+if (process.argv[1] && fs.existsSync(process.argv[1]) &&
+    fs.realpathSync(path.resolve(process.argv[1])) === fs.realpathSync(path.resolve(__filename))) {
+    const args = process.argv.slice(2);
+    let specFile = null;
+    const srcGlobs = [];
+    let repoRoot = process.cwd();
+
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--spec') specFile = path.resolve(args[++i]);
+        else if (args[i] === '--src') srcGlobs.push(...args[++i].split(','));
+        else if (args[i] === '--repo-root') repoRoot = path.resolve(args[++i]);
+    }
+
+    if (!specFile) {
+        process.stderr.write('Usage: selector-evidence.mjs --spec <file> --src <glob,...> [--repo-root <dir>]\n');
+        process.exit(1);
+    }
+
+    // Read existing manifest if present
+    const manifestPath = path.join(repoRoot, MANIFEST_REL_PATH);
+    let manifest = {};
+    if (fs.existsSync(manifestPath)) {
+        try {
+            manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+        } catch { /* start fresh */ }
+    }
+
+    // Build evidence for this spec and merge into manifest
+    const evidence = buildEvidence(specFile, srcGlobs, repoRoot);
+    manifest[specFile] = evidence;
+
+    const written = writeManifest(manifest, repoRoot);
+    process.stdout.write(JSON.stringify(evidence, null, 2) + '\n');
+    process.stderr.write(`selector-evidence: wrote manifest to ${written}\n`);
+
+    const unresolved = Object.values(evidence).filter(v => v === null).length;
+    if (unresolved > 0) {
+        process.stderr.write(`selector-evidence: ${unresolved} unresolved selector(s)\n`);
+        process.exit(1);
+    }
+    process.exit(0);
+}

--- a/skills/autospec-test/tests/unit/selector-evidence.test.mjs
+++ b/skills/autospec-test/tests/unit/selector-evidence.test.mjs
@@ -1,0 +1,291 @@
+// skills/autospec-test/tests/unit/selector-evidence.test.mjs
+// node --test  (Node.js built-in test runner)
+// Tests for scripts/selector-evidence.mjs
+// Covers: extractSelectors, resolveSelector, buildEvidence, writeManifest
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = path.resolve(__dirname, '../../scripts');
+
+const { extractSelectors, resolveSelector, buildEvidence, writeManifest } =
+    await import(`file://${SCRIPTS_DIR}/selector-evidence.mjs`);
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function tmpDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sel-ev-test-'));
+}
+
+function writeFile(dir, relPath, content) {
+    const full = path.join(dir, relPath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content, 'utf8');
+    return full;
+}
+
+function cleanup(dir) {
+    fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ── extractSelectors ───────────────────────────────────────────────────────────
+
+test('extractSelectors: extracts data-testid from spec', () => {
+    const specText = `
+await page.getByTestId('submit-btn').click();
+await page.locator('[data-testid="user-name"]').fill('Alice');
+`;
+    const selectors = extractSelectors(specText);
+    assert.ok(selectors.some(s => s.selector === 'submit-btn' && s.type === 'data-testid'),
+        `Expected submit-btn data-testid, got ${JSON.stringify(selectors)}`);
+    assert.ok(selectors.some(s => s.selector === 'user-name' && s.type === 'data-testid'),
+        `Expected user-name data-testid`);
+});
+
+test('extractSelectors: extracts aria-label from spec', () => {
+    const specText = `await page.getByLabel('Email address').fill('test@example.com');`;
+    const selectors = extractSelectors(specText);
+    assert.ok(selectors.some(s => s.selector === 'Email address'),
+        `Expected 'Email address', got ${JSON.stringify(selectors)}`);
+});
+
+test('extractSelectors: extracts getByText literals', () => {
+    const specText = `
+const el = page.getByText('Welcome back', { exact: true });
+await expect(el).toBeVisible();
+`;
+    const selectors = extractSelectors(specText);
+    assert.ok(selectors.some(s => s.selector === 'Welcome back'),
+        `Expected 'Welcome back' text selector`);
+});
+
+test('extractSelectors: extracts getByRole name strings', () => {
+    const specText = `
+await page.getByRole('button', { name: 'Save changes', exact: true }).click();
+`;
+    const selectors = extractSelectors(specText);
+    assert.ok(selectors.some(s => s.selector === 'Save changes'),
+        `Expected 'Save changes' role-name selector`);
+});
+
+test('extractSelectors: returns line numbers for each selector', () => {
+    const specText = `import { test } from '@playwright/test';
+test('foo', async ({ page }) => {
+    await page.getByTestId('my-button').click();
+});`;
+    const selectors = extractSelectors(specText);
+    const found = selectors.find(s => s.selector === 'my-button');
+    assert.ok(found, 'Should find my-button');
+    assert.equal(found.line, 3, `Expected line 3, got ${found.line}`);
+});
+
+test('extractSelectors: returns empty array for spec with no selectors', () => {
+    const specText = `
+import { test } from '@playwright/test';
+test('foo', async ({ page }) => { await page.goto('/'); });
+`;
+    const selectors = extractSelectors(specText);
+    assert.equal(selectors.length, 0);
+});
+
+test('extractSelectors: deduplicates same selector appearing multiple times', () => {
+    const specText = `
+await page.getByTestId('save-btn').click();
+await page.getByTestId('save-btn').isVisible();
+`;
+    const selectors = extractSelectors(specText);
+    const saveBtns = selectors.filter(s => s.selector === 'save-btn');
+    // Should have at most 1 unique entry per selector value (deduplicated)
+    // OR multiple entries with different lines — either is acceptable; test for presence
+    assert.ok(saveBtns.length >= 1, 'Should find save-btn at least once');
+});
+
+// ── resolveSelector ────────────────────────────────────────────────────────────
+
+test('resolveSelector: returns file:line when selector found in source files', () => {
+    const dir = tmpDir();
+    try {
+        writeFile(dir, 'src/Button.tsx', `
+export function Button() {
+    return <button data-testid="submit-btn">Submit</button>;
+}
+`);
+        const result = resolveSelector('submit-btn', [path.join(dir, 'src/**')], dir);
+        assert.ok(result !== null, 'Should resolve submit-btn');
+        assert.ok(result.includes('Button.tsx'), `Expected Button.tsx in result: ${result}`);
+        // Should be file:line format
+        assert.ok(/:\d+$/.test(result), `Expected file:line format: ${result}`);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('resolveSelector: returns null when selector not found in source', () => {
+    const dir = tmpDir();
+    try {
+        writeFile(dir, 'src/Button.tsx', `
+export function Button() {
+    return <button data-testid="other-btn">Other</button>;
+}
+`);
+        const result = resolveSelector('nonexistent-btn', [path.join(dir, 'src/**')], dir);
+        assert.equal(result, null);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('resolveSelector: finds aria-label in source', () => {
+    const dir = tmpDir();
+    try {
+        writeFile(dir, 'src/Input.tsx', `
+export function Input() {
+    return <input aria-label="Email address" type="email" />;
+}
+`);
+        const result = resolveSelector('Email address', [path.join(dir, 'src/**')], dir);
+        assert.ok(result !== null, 'Should resolve Email address');
+        assert.ok(result.includes('Input.tsx'), `Expected Input.tsx: ${result}`);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('resolveSelector: finds text in JSX content', () => {
+    const dir = tmpDir();
+    try {
+        writeFile(dir, 'src/Header.tsx', `
+export function Header() {
+    return <h1>Welcome back</h1>;
+}
+`);
+        const result = resolveSelector('Welcome back', [path.join(dir, 'src/**')], dir);
+        assert.ok(result !== null, 'Should resolve Welcome back text');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('resolveSelector: works with absolute file paths (no glob)', () => {
+    const dir = tmpDir();
+    try {
+        const srcFile = writeFile(dir, 'src/Form.tsx', `
+<button data-testid="form-submit">Go</button>
+`);
+        const result = resolveSelector('form-submit', [srcFile], dir);
+        assert.ok(result !== null, 'Should find form-submit with direct path');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+// ── buildEvidence ──────────────────────────────────────────────────────────────
+
+test('buildEvidence: returns manifest shape {spec_file: {selector: "file:line"}}', () => {
+    const dir = tmpDir();
+    try {
+        const specFile = writeFile(dir, 'e2e/specs/home.spec.ts', `
+await page.getByTestId('hero-title').isVisible();
+`);
+        writeFile(dir, 'src/Home.tsx', `
+<h1 data-testid="hero-title">Home</h1>
+`);
+        const evidence = buildEvidence(specFile, [path.join(dir, 'src/**')], dir);
+        assert.ok(typeof evidence === 'object', 'Should return an object');
+        // Keys should be selector strings
+        const keys = Object.keys(evidence);
+        assert.ok(keys.includes('hero-title'), `Expected hero-title key, got ${JSON.stringify(keys)}`);
+        // Values should be file:line strings
+        for (const val of Object.values(evidence)) {
+            assert.ok(typeof val === 'string', `Expected string value, got ${typeof val}`);
+        }
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('buildEvidence: unresolved selector maps to null', () => {
+    const dir = tmpDir();
+    try {
+        const specFile = writeFile(dir, 'e2e/specs/dash.spec.ts', `
+await page.getByTestId('missing-widget').click();
+`);
+        const evidence = buildEvidence(specFile, [path.join(dir, 'src/**')], dir);
+        assert.ok('missing-widget' in evidence, 'Should include missing-widget key');
+        assert.equal(evidence['missing-widget'], null);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('buildEvidence: empty spec returns empty object', () => {
+    const dir = tmpDir();
+    try {
+        const specFile = writeFile(dir, 'e2e/specs/empty.spec.ts', `
+import { test } from '@playwright/test';
+test('noop', async ({ page }) => { await page.goto('/'); });
+`);
+        const evidence = buildEvidence(specFile, [], dir);
+        assert.deepEqual(evidence, {});
+    } finally {
+        cleanup(dir);
+    }
+});
+
+// ── writeManifest ──────────────────────────────────────────────────────────────
+
+test('writeManifest: writes manifest JSON to e2e/.autospec/selector-evidence.json', () => {
+    const dir = tmpDir();
+    try {
+        const specFile = path.join(dir, 'e2e/specs/home.spec.ts');
+        const manifestData = { [specFile]: { 'hero-title': 'src/Home.tsx:3' } };
+        const manifestPath = writeManifest(manifestData, dir);
+        assert.ok(fs.existsSync(manifestPath), `Manifest file should exist at ${manifestPath}`);
+        const written = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+        assert.deepEqual(written, manifestData);
+        // Path should be e2e/.autospec/selector-evidence.json relative to dir
+        const rel = path.relative(dir, manifestPath);
+        assert.equal(rel, path.join('e2e', '.autospec', 'selector-evidence.json'));
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('writeManifest: creates parent directories if missing', () => {
+    const dir = tmpDir();
+    try {
+        const manifestPath = writeManifest({}, dir);
+        assert.ok(fs.existsSync(path.dirname(manifestPath)), 'Parent dir should exist');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('writeManifest: overwrites existing manifest', () => {
+    const dir = tmpDir();
+    try {
+        writeManifest({ 'old.spec.ts': { 'old-sel': 'old:1' } }, dir);
+        const newData = { 'new.spec.ts': { 'new-sel': 'new:5' } };
+        const manifestPath = writeManifest(newData, dir);
+        const written = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+        assert.deepEqual(written, newData);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('writeManifest: returns the path to the manifest file', () => {
+    const dir = tmpDir();
+    try {
+        const p = writeManifest({}, dir);
+        assert.equal(typeof p, 'string');
+        assert.ok(p.endsWith('selector-evidence.json'));
+    } finally {
+        cleanup(dir);
+    }
+});


### PR DESCRIPTION
Closes #994

## Summary

- New `skills/autospec-test/scripts/selector-evidence.mjs` with exports:
  - `extractSelectors(specText)` → `[{selector, type, line}]` — extracts data-testid, aria-label, getByText, getByRole name selectors with line numbers; deduplicates by selector value
  - `resolveSelector(selector, srcGlobs, repoRoot)` → `"file:line" | null` — greps app source files for literal selector occurrence, returns relative path + line
  - `buildEvidence(specFile, srcGlobs, repoRoot)` → `{selector: "file:line"|null}` — builds evidence map for one spec file; null means unresolved
  - `writeManifest(manifestData, repoRoot)` → manifest path — writes `{spec_file: {selector: "file:line"}}` to `e2e/.autospec/selector-evidence.json`
- Glob expansion is portable (uses `fs.readdirSync` recursion, no external dep)
- CLI: `node selector-evidence.mjs --spec <file> --src <glob,...>` updates and writes manifest
- 19 unit tests covering all four exports

## Shared contracts honored

- All four export names match contract table verbatim
- Manifest path `e2e/.autospec/selector-evidence.json` matches spec §8
- Manifest shape `{spec_file: {selector: "file:line"}}` matches spec §8
- `PW_SELECTOR_UNVERIFIED` in lint-playwright-author.mjs (#993) defers to this resolver when appSrcGlobs provided

## Test plan

- [x] `node --test skills/autospec-test/tests/unit/selector-evidence.test.mjs` — 19/19 pass
- [x] extractSelectors: all 4 selector types, line numbers, deduplication, empty spec
- [x] resolveSelector: found/not-found, aria-label, JSX text content, direct file path
- [x] buildEvidence: full manifest shape, null for unresolved, empty spec → {}
- [x] writeManifest: correct path, creates dirs, overwrites, returns path