### PR TITLE
feat(autospec-test): control inventory + effect-assertion taxonomy (#995)

### DIFF
--- a/skills/autospec-test/scripts/control-effects.mjs
+++ b/skills/autospec-test/scripts/control-effects.mjs
@@ -1,0 +1,469 @@
+#!/usr/bin/env node
+// scripts/control-effects.mjs
+// Control inventory + effect-assertion taxonomy (implements spec §§controls/effects
+// from docs/specs/2026-05-27-playwright-control-effect-coverage-design.md and
+// docs/specs/2026-06-04-autospec-playwright-authoring-design.md §6 step 4).
+//
+// Exports:
+//   CONTROL_KINDS        — ordered array of control-kind descriptors
+//   EFFECT_TAXONOMY      — ordered array of effect-assertion descriptors
+//   inventoryControls(page, opts) -> Promise<ControlEntry[]>
+//   effectPromptFragment(inventory, opts) -> string
+//
+// A ControlEntry has the shape:
+//   { kind, selector, label, enabled, defaultValue, readOnly }
+//
+// Export: CONTROL_KINDS, EFFECT_TAXONOMY, inventoryControls, effectPromptFragment
+// CLI:    node control-effects.mjs --url <url> [--read-only-selectors <csv>]
+
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+
+// ── Control kinds (spec §2 "Control Inventory Contract") ──────────────────────
+
+/**
+ * Ordered list of UI control categories autospec must enumerate.
+ * Each entry:
+ *   kind        — canonical snake_case identifier
+ *   label       — human-readable label used in reports / prompts
+ *   selectors   — CSS/ARIA selectors used to find controls of this kind
+ *   description — one-liner for the prompt template
+ */
+export const CONTROL_KINDS = [
+    {
+        kind: 'button',
+        label: 'Button',
+        selectors: ['button', '[role=button]'],
+        description: 'Clickable button or element with role="button"',
+    },
+    {
+        kind: 'link',
+        label: 'Link / Tab',
+        selectors: ['a[href]', '[role=tab]', '[role=link]'],
+        description: 'Anchor links and ARIA tab/link elements',
+    },
+    {
+        kind: 'text_input',
+        label: 'Text / Search Input',
+        selectors: [
+            'input[type=text]',
+            'input[type=search]',
+            'input[type=email]',
+            'input[type=password]',
+            'input[type=url]',
+            'input[type=tel]',
+            'input[type=number]',
+            'input:not([type])',
+            'textarea',
+        ],
+        description: 'Free-text inputs and textareas',
+    },
+    {
+        kind: 'checkbox',
+        label: 'Checkbox',
+        selectors: ['input[type=checkbox]', '[role=checkbox]'],
+        description: 'Binary toggle checkbox or ARIA equivalent',
+    },
+    {
+        kind: 'radio',
+        label: 'Radio',
+        selectors: ['input[type=radio]', '[role=radio]'],
+        description: 'Single-select radio button',
+    },
+    {
+        kind: 'switch',
+        label: 'Switch',
+        selectors: ['[role=switch]'],
+        description: 'On/off toggle switch (ARIA role="switch")',
+    },
+    {
+        kind: 'native_select',
+        label: 'Native Select',
+        selectors: ['select'],
+        description: 'HTML native <select> dropdown',
+    },
+    {
+        kind: 'custom_dropdown',
+        label: 'Custom Dropdown / Listbox / Combobox',
+        selectors: ['[role=listbox]', '[role=combobox]', '[aria-haspopup=listbox]', '[aria-haspopup=true]'],
+        description: 'Custom ARIA-based dropdown, listbox, or combobox',
+    },
+    {
+        kind: 'date_input',
+        label: 'Date / Time Input',
+        selectors: [
+            'input[type=date]',
+            'input[type=time]',
+            'input[type=datetime-local]',
+            'input[type=month]',
+            'input[type=week]',
+        ],
+        description: 'Date, time, or datetime picker input',
+    },
+    {
+        kind: 'disclosure',
+        label: 'Disclosure / Foldout',
+        selectors: ['details', '[aria-expanded]', '[role=button][aria-controls]'],
+        description: 'Expandable/collapsible disclosure section',
+    },
+    {
+        kind: 'file_upload',
+        label: 'File Upload',
+        selectors: ['input[type=file]'],
+        description: 'File upload input',
+    },
+    {
+        kind: 'drag_drop',
+        label: 'Drag / Drop',
+        selectors: ['[draggable=true]', '[role=listitem][draggable]'],
+        description: 'Draggable element for drag-and-drop interactions',
+    },
+];
+
+// ── Effect taxonomy (spec §3 "Effect Assertions") ─────────────────────────────
+
+/**
+ * Ordered list of measurable effect categories that a non-read-only control
+ * interaction MUST assert at least one of.
+ * Each entry:
+ *   effect      — canonical snake_case identifier
+ *   label       — human-readable label for reports
+ *   description — one-liner for the prompt template
+ *   example     — example assertion snippet
+ */
+export const EFFECT_TAXONOMY = [
+    {
+        effect: 'ui_state_change',
+        label: 'Visible UI State Change',
+        description: 'The rendered DOM visibly changes after interaction (element appears/disappears/changes text).',
+        example: 'await expect(page.getByTestId("status-badge")).toHaveText("Active");',
+    },
+    {
+        effect: 'network_request_change',
+        label: 'Outbound Request Change',
+        description: 'An outbound REST/fetch request URL, query, headers, or JSON body changes as expected.',
+        example: 'const req = await page.waitForRequest(r => r.url().includes("/api/items")); assert(req.postDataJSON().taxonomy === "compound");',
+    },
+    {
+        effect: 'persistence_change',
+        label: 'Persisted State Change',
+        description: 'A setting, record, or local/session-storage value changes and survives a page reload.',
+        example: 'await page.reload(); await expect(page.getByTestId("selected-taxonomy")).toHaveText("compound");',
+    },
+    {
+        effect: 'list_or_table_change',
+        label: 'List / Table / Chart Change',
+        description: 'A resulting list, table, or chart changes in a way tied to the selected value.',
+        example: 'await expect(page.getByRole("row")).toHaveCount(3);',
+    },
+    {
+        effect: 'navigation',
+        label: 'Navigation',
+        description: 'The browser navigates to a new URL or route after interaction.',
+        example: 'await expect(page).toHaveURL(/\\/dashboard/);',
+    },
+    {
+        effect: 'api_state_via_helper',
+        label: 'API State via Real-API Helper',
+        description: 'After a UI write (create/update/delete), a real-API helper confirms the backend reflects the change.',
+        example: 'const items = await apiHelper.getItems(); assert(items.some(i => i.name === "New Item"));',
+    },
+];
+
+// ── inventoryControls ─────────────────────────────────────────────────────────
+
+/**
+ * Inventory all visible, enabled, and disabled controls on the current page.
+ * Requires an active Playwright `page` object.
+ *
+ * @param {import('playwright').Page} page - active Playwright page
+ * @param {object} [opts]
+ * @param {string[]} [opts.readOnlySelectors=[]] - CSS selectors declared read-only in test.yml
+ * @param {string[]} [opts.kinds] - subset of CONTROL_KINDS.kind to inventory (default: all)
+ * @returns {Promise<ControlEntry[]>}
+ *
+ * @typedef {object} ControlEntry
+ * @property {string} kind - from CONTROL_KINDS[].kind
+ * @property {string} selector - CSS/ARIA selector used to locate the element
+ * @property {string} label - accessible name or best-effort label
+ * @property {boolean} enabled - whether the control is interactive (not disabled)
+ * @property {string|null} defaultValue - current value for inputs/selects; null otherwise
+ * @property {boolean} readOnly - declared read-only in test.yml opts.readOnlySelectors
+ */
+export async function inventoryControls(page, opts = {}) {
+    const { readOnlySelectors = [], kinds } = opts;
+
+    const kindFilter = kinds && kinds.length > 0
+        ? new Set(kinds)
+        : null;
+
+    const activeKinds = kindFilter
+        ? CONTROL_KINDS.filter(k => kindFilter.has(k.kind))
+        : CONTROL_KINDS;
+
+    const results = [];
+
+    for (const kindDef of activeKinds) {
+        for (const sel of kindDef.selectors) {
+            let elements;
+            try {
+                elements = await page.locator(sel).all();
+            } catch {
+                continue;
+            }
+
+            for (const el of elements) {
+                try {
+                    const visible = await el.isVisible();
+                    if (!visible) continue;
+
+                    const disabled = await el.isDisabled();
+                    const label = await _bestLabel(el, page);
+                    const defaultValue = await _defaultValue(el, kindDef.kind);
+
+                    // Check if element matches any read-only selector
+                    const roMatch = readOnlySelectors.length > 0
+                        ? await _matchesAnySelector(el, page, readOnlySelectors)
+                        : false;
+
+                    results.push({
+                        kind: kindDef.kind,
+                        selector: sel,
+                        label,
+                        enabled: !disabled,
+                        defaultValue,
+                        readOnly: roMatch,
+                    });
+                } catch {
+                    // Element may have gone stale during enumeration — skip
+                }
+            }
+        }
+    }
+
+    return results;
+}
+
+/**
+ * Try to derive a human-readable accessible name for an element.
+ * Falls back through: aria-label → aria-labelledby → associated <label> → placeholder → text content.
+ *
+ * @param {import('playwright').Locator} el
+ * @param {import('playwright').Page} page
+ * @returns {Promise<string>}
+ */
+async function _bestLabel(el, page) {
+    try {
+        const ariaLabel = await el.getAttribute('aria-label');
+        if (ariaLabel && ariaLabel.trim()) return ariaLabel.trim();
+
+        const labelledBy = await el.getAttribute('aria-labelledby');
+        if (labelledBy) {
+            try {
+                const labelEl = page.locator(`#${CSS.escape(labelledBy)}`);
+                const labelText = await labelEl.textContent({ timeout: 500 });
+                if (labelText && labelText.trim()) return labelText.trim();
+            } catch { /* ignore */ }
+        }
+
+        const id = await el.getAttribute('id');
+        if (id) {
+            try {
+                const labelEl = page.locator(`label[for="${id}"]`);
+                const labelText = await labelEl.textContent({ timeout: 500 });
+                if (labelText && labelText.trim()) return labelText.trim();
+            } catch { /* ignore */ }
+        }
+
+        const placeholder = await el.getAttribute('placeholder');
+        if (placeholder && placeholder.trim()) return placeholder.trim();
+
+        const text = await el.textContent({ timeout: 500 });
+        if (text && text.trim()) return text.trim().slice(0, 80);
+    } catch { /* ignore */ }
+
+    return '';
+}
+
+/**
+ * Get the current default value for value-bearing controls.
+ *
+ * @param {import('playwright').Locator} el
+ * @param {string} kind
+ * @returns {Promise<string|null>}
+ */
+async function _defaultValue(el, kind) {
+    try {
+        if (kind === 'native_select' || kind === 'text_input' || kind === 'date_input') {
+            return await el.inputValue({ timeout: 500 });
+        }
+        if (kind === 'checkbox' || kind === 'radio') {
+            const checked = await el.isChecked({ timeout: 500 });
+            return checked ? 'checked' : 'unchecked';
+        }
+    } catch { /* ignore */ }
+    return null;
+}
+
+/**
+ * Check whether an element matches any of the given CSS selectors.
+ *
+ * @param {import('playwright').Locator} el
+ * @param {import('playwright').Page} _page
+ * @param {string[]} selectors
+ * @returns {Promise<boolean>}
+ */
+async function _matchesAnySelector(el, _page, selectors) {
+    for (const sel of selectors) {
+        try {
+            const matches = await el.evaluate(
+                (node, s) => node.matches(s),
+                sel
+            );
+            if (matches) return true;
+        } catch { /* ignore */ }
+    }
+    return false;
+}
+
+// ── effectPromptFragment ──────────────────────────────────────────────────────
+
+/**
+ * Generate the effect-assertion section of the Playwright authoring prompt.
+ * Embeds the control inventory and effect taxonomy into a structured prompt
+ * fragment that the author subagent receives.
+ *
+ * @param {ControlEntry[]} inventory - output of inventoryControls()
+ * @param {object} [opts]
+ * @param {string} [opts.routeCluster=''] - name of the route cluster being authored
+ * @param {string[]} [opts.readOnlySelectors=[]] - selectors declared read-only
+ * @returns {string} - prompt fragment (markdown)
+ */
+export function effectPromptFragment(inventory, opts = {}) {
+    const { routeCluster = '', readOnlySelectors = [] } = opts;
+
+    const lines = [];
+
+    lines.push('## Control inventory + effect-assertion requirements');
+    lines.push('');
+
+    if (routeCluster) {
+        lines.push(`Route cluster: **${routeCluster}**`);
+        lines.push('');
+    }
+
+    lines.push(
+        'For every visible form or navigation control on each page in this cluster:'
+    );
+    lines.push('');
+
+    // Control kinds table
+    lines.push('### Control categories to enumerate');
+    lines.push('');
+    lines.push('| Kind | Selectors | Description |');
+    lines.push('|---|---|---|');
+    for (const ck of CONTROL_KINDS) {
+        lines.push(`| ${ck.label} | \`${ck.selectors.join('`, `')}\` | ${ck.description} |`);
+    }
+    lines.push('');
+
+    // Effect taxonomy
+    lines.push('### Required effect assertions (each non-read-only control must assert ≥1)');
+    lines.push('');
+    lines.push('| Effect | Description | Example |');
+    lines.push('|---|---|---|');
+    for (const et of EFFECT_TAXONOMY) {
+        lines.push(`| **${et.label}** | ${et.description} | \`${et.example}\` |`);
+    }
+    lines.push('');
+
+    // Specific inventory
+    if (inventory && inventory.length > 0) {
+        lines.push('### Controls found on this cluster (pre-inventoried)');
+        lines.push('');
+
+        const byKind = {};
+        for (const entry of inventory) {
+            if (!byKind[entry.kind]) byKind[entry.kind] = [];
+            byKind[entry.kind].push(entry);
+        }
+
+        for (const [kind, entries] of Object.entries(byKind)) {
+            const kindDef = CONTROL_KINDS.find(k => k.kind === kind);
+            const kindLabel = kindDef ? kindDef.label : kind;
+            lines.push(`**${kindLabel}** (${entries.length}):`);
+            for (const entry of entries) {
+                const readOnlyNote = entry.readOnly ? ' *(declared read-only)*' : '';
+                const enabledNote = entry.enabled ? '' : ' *(disabled)*';
+                const valueNote = entry.defaultValue !== null ? ` default: \`${entry.defaultValue}\`` : '';
+                const labelPart = entry.label ? ` "${entry.label}"` : '';
+                lines.push(`  - selector: \`${entry.selector}\`${labelPart}${valueNote}${enabledNote}${readOnlyNote}`);
+            }
+            lines.push('');
+        }
+    }
+
+    // Hard rules
+    lines.push('### Hard rules for authored specs');
+    lines.push('');
+    lines.push('- **Every enabled non-read-only control** must have a test that exercises it and asserts ≥1 effect from the table above.');
+    lines.push('- **Native `<select>`**: must assert it has ≥2 options (unless documented read-only); select a non-default option; submit/trigger; assert the selected value reaches the request or output.');
+    lines.push('- **Custom dropdown/listbox/combobox**: open it, assert options are visible, choose a non-default option, assert request/output/persistence effect.');
+    lines.push('- **Disabled visible control** = FAIL unless `.autospec/test.yml` declares it read-only with a reason.');
+    lines.push('- **Decorative control** (no measurable effect after interaction) = `product_bug` violation — never suppress the assertion.');
+    lines.push('- All API-state checks must go through the real-API helper, not direct DB writes.');
+
+    if (readOnlySelectors.length > 0) {
+        lines.push('');
+        lines.push('### Selectors declared read-only (skip effect assertion for these)');
+        for (const sel of readOnlySelectors) {
+            lines.push(`  - \`${sel}\``);
+        }
+    }
+
+    lines.push('');
+    return lines.join('\n');
+}
+
+// ── CLI entrypoint ────────────────────────────────────────────────────────────
+
+if (process.argv[1] && fs.existsSync(process.argv[1]) &&
+    fs.realpathSync(path.resolve(process.argv[1])) === fs.realpathSync(path.resolve(__filename))) {
+    const args = process.argv.slice(2);
+    const getArg = (flag) => {
+        const idx = args.indexOf(flag);
+        return idx >= 0 ? args[idx + 1] : null;
+    };
+
+    const url = getArg('--url');
+    const readOnlyCsv = getArg('--read-only-selectors');
+
+    if (!url) {
+        process.stderr.write('Usage: control-effects.mjs --url <url> [--read-only-selectors <csv>]\n');
+        process.stderr.write('\nWithout --url, prints taxonomy tables:\n');
+        // Print taxonomy tables as JSON
+        process.stdout.write(JSON.stringify({ CONTROL_KINDS, EFFECT_TAXONOMY }, null, 2) + '\n');
+        process.exit(0);
+    }
+
+    const readOnlySelectors = readOnlyCsv ? readOnlyCsv.split(',').map(s => s.trim()).filter(Boolean) : [];
+
+    try {
+        // Dynamic import of playwright — only needed for CLI inventory mode
+        const { chromium } = await import('playwright');
+        const browser = await chromium.launch({ headless: true });
+        const page = await browser.newPage();
+        await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 });
+
+        const inventory = await inventoryControls(page, { readOnlySelectors });
+        await browser.close();
+
+        process.stdout.write(JSON.stringify(inventory, null, 2) + '\n');
+    } catch (err) {
+        process.stderr.write(`control-effects: ${err.message}\n`);
+        process.exit(2);
+    }
+}

--- a/skills/autospec-test/tests/unit/control-effects.test.mjs
+++ b/skills/autospec-test/tests/unit/control-effects.test.mjs
@@ -1,0 +1,297 @@
+// skills/autospec-test/tests/unit/control-effects.test.mjs
+// node --test  (Node.js built-in test runner)
+// Tests for scripts/control-effects.mjs
+// Covers: CONTROL_KINDS, EFFECT_TAXONOMY, inventoryControls (mock page), effectPromptFragment
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = path.resolve(__dirname, '../../scripts');
+
+const { CONTROL_KINDS, EFFECT_TAXONOMY, inventoryControls, effectPromptFragment } =
+    await import(`file://${SCRIPTS_DIR}/control-effects.mjs`);
+
+// ── CONTROL_KINDS ─────────────────────────────────────────────────────────────
+
+test('CONTROL_KINDS: is a non-empty array', () => {
+    assert.ok(Array.isArray(CONTROL_KINDS), 'CONTROL_KINDS must be an array');
+    assert.ok(CONTROL_KINDS.length > 0, 'CONTROL_KINDS must not be empty');
+});
+
+test('CONTROL_KINDS: each entry has required fields', () => {
+    for (const ck of CONTROL_KINDS) {
+        assert.ok(typeof ck.kind === 'string' && ck.kind.length > 0,
+            `kind missing or empty in ${JSON.stringify(ck)}`);
+        assert.ok(typeof ck.label === 'string' && ck.label.length > 0,
+            `label missing or empty in ${JSON.stringify(ck)}`);
+        assert.ok(Array.isArray(ck.selectors) && ck.selectors.length > 0,
+            `selectors missing or empty in ${JSON.stringify(ck)}`);
+        assert.ok(typeof ck.description === 'string' && ck.description.length > 0,
+            `description missing or empty in ${JSON.stringify(ck)}`);
+    }
+});
+
+test('CONTROL_KINDS: includes button, native_select, checkbox, text_input, custom_dropdown', () => {
+    const kinds = CONTROL_KINDS.map(k => k.kind);
+    for (const required of ['button', 'native_select', 'checkbox', 'text_input', 'custom_dropdown']) {
+        assert.ok(kinds.includes(required), `Missing kind: ${required}`);
+    }
+});
+
+test('CONTROL_KINDS: kinds are unique', () => {
+    const kinds = CONTROL_KINDS.map(k => k.kind);
+    const unique = new Set(kinds);
+    assert.equal(unique.size, kinds.length, 'CONTROL_KINDS has duplicate kind values');
+});
+
+test('CONTROL_KINDS: native_select kind uses "select" selector', () => {
+    const ns = CONTROL_KINDS.find(k => k.kind === 'native_select');
+    assert.ok(ns, 'native_select kind must exist');
+    assert.ok(ns.selectors.includes('select'), 'native_select must include "select" selector');
+});
+
+test('CONTROL_KINDS: custom_dropdown kind includes ARIA role selectors', () => {
+    const cd = CONTROL_KINDS.find(k => k.kind === 'custom_dropdown');
+    assert.ok(cd, 'custom_dropdown kind must exist');
+    const hasListbox = cd.selectors.some(s => s.includes('listbox'));
+    const hasCombobox = cd.selectors.some(s => s.includes('combobox'));
+    assert.ok(hasListbox || hasCombobox,
+        'custom_dropdown must include [role=listbox] or [role=combobox] selector');
+});
+
+// ── EFFECT_TAXONOMY ───────────────────────────────────────────────────────────
+
+test('EFFECT_TAXONOMY: is a non-empty array', () => {
+    assert.ok(Array.isArray(EFFECT_TAXONOMY), 'EFFECT_TAXONOMY must be an array');
+    assert.ok(EFFECT_TAXONOMY.length > 0, 'EFFECT_TAXONOMY must not be empty');
+});
+
+test('EFFECT_TAXONOMY: each entry has required fields', () => {
+    for (const et of EFFECT_TAXONOMY) {
+        assert.ok(typeof et.effect === 'string' && et.effect.length > 0,
+            `effect field missing in ${JSON.stringify(et)}`);
+        assert.ok(typeof et.label === 'string' && et.label.length > 0,
+            `label field missing in ${JSON.stringify(et)}`);
+        assert.ok(typeof et.description === 'string' && et.description.length > 0,
+            `description field missing in ${JSON.stringify(et)}`);
+        assert.ok(typeof et.example === 'string' && et.example.length > 0,
+            `example field missing in ${JSON.stringify(et)}`);
+    }
+});
+
+test('EFFECT_TAXONOMY: includes all required effect classes', () => {
+    const effects = EFFECT_TAXONOMY.map(e => e.effect);
+    for (const required of [
+        'ui_state_change',
+        'network_request_change',
+        'persistence_change',
+        'api_state_via_helper',
+    ]) {
+        assert.ok(effects.includes(required), `Missing effect: ${required}`);
+    }
+});
+
+test('EFFECT_TAXONOMY: effects are unique', () => {
+    const effects = EFFECT_TAXONOMY.map(e => e.effect);
+    const unique = new Set(effects);
+    assert.equal(unique.size, effects.length, 'EFFECT_TAXONOMY has duplicate effect values');
+});
+
+// ── inventoryControls (mock page) ─────────────────────────────────────────────
+
+/**
+ * Build a minimal mock Playwright page object that returns pre-canned locators.
+ * Each entry in `controlMap` has shape:
+ *   { selector, visible, disabled, ariaLabel, value, checked, matchesReadOnly }
+ */
+function makeMockPage(elements) {
+    // Group elements by selector
+    const bySelector = {};
+    for (const el of elements) {
+        if (!bySelector[el.selector]) bySelector[el.selector] = [];
+        bySelector[el.selector].push(el);
+    }
+
+    function makeLocator(el) {
+        return {
+            isVisible: async () => el.visible !== false,
+            isDisabled: async () => el.disabled === true,
+            isChecked: async () => el.checked === true,
+            inputValue: async () => el.value || '',
+            getAttribute: async (attr) => {
+                if (attr === 'aria-label') return el.ariaLabel || null;
+                if (attr === 'aria-labelledby') return null;
+                if (attr === 'id') return el.id || null;
+                if (attr === 'placeholder') return el.placeholder || null;
+                return null;
+            },
+            textContent: async () => el.textContent || '',
+            evaluate: async (fn, s) => {
+                // For _matchesAnySelector: simulate el.matches(s)
+                return el.matchesReadOnly === true && s === el.readOnlySel;
+            },
+            all: async () => [],
+        };
+    }
+
+    return {
+        locator: (sel) => {
+            const elList = bySelector[sel] || [];
+            return {
+                all: async () => elList.map(el => makeLocator(el)),
+                textContent: async () => '',
+            };
+        },
+    };
+}
+
+test('inventoryControls: returns empty array for empty page', async () => {
+    const page = makeMockPage([]);
+    const result = await inventoryControls(page, {});
+    assert.deepEqual(result, []);
+});
+
+test('inventoryControls: includes visible button', async () => {
+    const page = makeMockPage([
+        { selector: 'button', visible: true, disabled: false, textContent: 'Save' },
+    ]);
+    const result = await inventoryControls(page, {});
+    const btn = result.find(e => e.kind === 'button');
+    assert.ok(btn, 'Expected a button entry');
+    assert.equal(btn.enabled, true);
+    assert.equal(btn.readOnly, false);
+});
+
+test('inventoryControls: excludes invisible elements', async () => {
+    const page = makeMockPage([
+        { selector: 'button', visible: false, disabled: false, textContent: 'Hidden' },
+    ]);
+    const result = await inventoryControls(page, {});
+    assert.equal(result.length, 0, 'Hidden elements must not appear in inventory');
+});
+
+test('inventoryControls: marks disabled control as enabled=false', async () => {
+    const page = makeMockPage([
+        { selector: 'button', visible: true, disabled: true, textContent: 'Disabled Btn' },
+    ]);
+    const result = await inventoryControls(page, {});
+    const btn = result.find(e => e.kind === 'button');
+    assert.ok(btn, 'Expected a button entry');
+    assert.equal(btn.enabled, false, 'disabled button must have enabled=false');
+});
+
+test('inventoryControls: captures aria-label as label', async () => {
+    const page = makeMockPage([
+        { selector: 'button', visible: true, disabled: false, ariaLabel: 'Submit form' },
+    ]);
+    const result = await inventoryControls(page, {});
+    const btn = result.find(e => e.kind === 'button');
+    assert.ok(btn, 'Expected a button entry');
+    assert.equal(btn.label, 'Submit form');
+});
+
+test('inventoryControls: captures native select value', async () => {
+    const page = makeMockPage([
+        { selector: 'select', visible: true, disabled: false, value: 'lipid' },
+    ]);
+    const result = await inventoryControls(page, {});
+    const sel = result.find(e => e.kind === 'native_select');
+    assert.ok(sel, 'Expected a native_select entry');
+    assert.equal(sel.defaultValue, 'lipid');
+});
+
+test('inventoryControls: checkbox reports checked state', async () => {
+    const page = makeMockPage([
+        { selector: 'input[type=checkbox]', visible: true, disabled: false, checked: true },
+    ]);
+    const result = await inventoryControls(page, {});
+    const cb = result.find(e => e.kind === 'checkbox');
+    assert.ok(cb, 'Expected a checkbox entry');
+    assert.equal(cb.defaultValue, 'checked');
+});
+
+test('inventoryControls: filters to requested kinds only', async () => {
+    const page = makeMockPage([
+        { selector: 'button', visible: true, disabled: false, textContent: 'Go' },
+        { selector: 'select', visible: true, disabled: false, value: 'a' },
+    ]);
+    const result = await inventoryControls(page, { kinds: ['native_select'] });
+    assert.ok(!result.some(e => e.kind === 'button'), 'button must be excluded when not in kinds');
+    assert.ok(result.some(e => e.kind === 'native_select'), 'native_select must appear');
+});
+
+// ── effectPromptFragment ──────────────────────────────────────────────────────
+
+test('effectPromptFragment: returns non-empty string', () => {
+    const fragment = effectPromptFragment([], {});
+    assert.ok(typeof fragment === 'string' && fragment.length > 0,
+        'effectPromptFragment must return a non-empty string');
+});
+
+test('effectPromptFragment: contains control kinds section', () => {
+    const fragment = effectPromptFragment([], {});
+    assert.ok(fragment.includes('Control categories to enumerate'),
+        'Must include control categories header');
+    assert.ok(fragment.includes('Native Select'), 'Must mention Native Select kind');
+    assert.ok(fragment.includes('Button'), 'Must mention Button kind');
+});
+
+test('effectPromptFragment: contains effect taxonomy section', () => {
+    const fragment = effectPromptFragment([], {});
+    assert.ok(fragment.includes('Required effect assertions'),
+        'Must include effect assertions header');
+    assert.ok(fragment.includes('Visible UI State Change'),
+        'Must mention UI state change effect');
+    assert.ok(fragment.includes('Outbound Request Change'),
+        'Must mention network request change effect');
+});
+
+test('effectPromptFragment: includes hard rules for authored specs', () => {
+    const fragment = effectPromptFragment([], {});
+    assert.ok(fragment.includes('Hard rules for authored specs'),
+        'Must include hard rules section');
+    assert.ok(fragment.includes('Decorative control'),
+        'Must mention decorative-control violation rule');
+    assert.ok(fragment.includes('real-API helper'),
+        'Must mention real-API helper requirement');
+});
+
+test('effectPromptFragment: includes route cluster when provided', () => {
+    const fragment = effectPromptFragment([], { routeCluster: '/dashboard' });
+    assert.ok(fragment.includes('/dashboard'), 'Must include route cluster in output');
+});
+
+test('effectPromptFragment: lists pre-inventoried controls by kind', () => {
+    const inventory = [
+        { kind: 'button', selector: 'button', label: 'Save', enabled: true, defaultValue: null, readOnly: false },
+        { kind: 'native_select', selector: 'select', label: 'Taxonomy', enabled: true, defaultValue: 'lipid', readOnly: false },
+    ];
+    const fragment = effectPromptFragment(inventory, {});
+    assert.ok(fragment.includes('Controls found on this cluster'), 'Must include inventory section');
+    assert.ok(fragment.includes('Save'), 'Must mention button label');
+    assert.ok(fragment.includes('Taxonomy'), 'Must mention select label');
+    assert.ok(fragment.includes('lipid'), 'Must mention default value');
+});
+
+test('effectPromptFragment: marks read-only controls in inventory', () => {
+    const inventory = [
+        { kind: 'button', selector: 'button[disabled]', label: 'Archive', enabled: false, defaultValue: null, readOnly: true },
+    ];
+    const fragment = effectPromptFragment(inventory, {});
+    assert.ok(fragment.includes('declared read-only'), 'Must mark read-only controls');
+});
+
+test('effectPromptFragment: includes read-only selectors section when provided', () => {
+    const fragment = effectPromptFragment([], { readOnlySelectors: ['select[disabled]', '.read-only-ctrl'] });
+    assert.ok(fragment.includes('Selectors declared read-only'), 'Must include read-only selectors section');
+    assert.ok(fragment.includes('select[disabled]'), 'Must list read-only selector');
+});
+
+test('effectPromptFragment: native select rule explicitly mentions 2 options', () => {
+    const fragment = effectPromptFragment([], {});
+    assert.ok(fragment.includes('≥2 options') || fragment.includes('at least 2') || fragment.includes('two options'),
+        'Must mention that native select must have 2+ options');
+});


### PR DESCRIPTION
Closes #995

## Summary

Implements `skills/autospec-test/scripts/control-effects.mjs` per the shared contracts for the playwright-authoring feature (#992–#1001).

### Exports (shared contract verbatim)
- `CONTROL_KINDS` — 12 control categories each with CSS/ARIA selectors and descriptions (button, link, text_input, checkbox, radio, switch, native_select, custom_dropdown, date_input, disclosure, file_upload, drag_drop)
- `EFFECT_TAXONOMY` — 6 measurable effect classes (ui_state_change, network_request_change, persistence_change, list_or_table_change, navigation, api_state_via_helper) each with description + example assertion snippet
- `inventoryControls(page, opts)` — enumerates visible controls on a live Playwright page, capturing kind/selector/label/enabled/defaultValue/readOnly; supports readOnlySelectors + kinds filter
- `effectPromptFragment(inventory, opts)` — generates the authoring-prompt control+effect section embedding the full inventory, taxonomy table, and hard rules (decorative-control violation, native select ≥2 options rule, real-API-helper-only assertion requirement)

### Sources honored
- 2026-05-27 spec §§2–4 (control inventory contract, effect assertions, prompt template)
- 2026-06-04 playwright-authoring design §6 step 4 (authoring prompt embeds control inventory + effect-assertion taxonomy)

## Test plan

- [x] 27 unit tests (node:test) — all green: CONTROL_KINDS structure, EFFECT_TAXONOMY structure, inventoryControls with mock page (visible/invisible/disabled/labels/values/kind filtering), effectPromptFragment output sections
- [x] `bash scripts/validate.sh` — OK
- [x] No Playwright dependency required at import time (CLI-only dynamic import)