### PR TITLE
feat(autospec-test): reset-endpoint generation + guard-env rails + fallback chain (#997)

### DIFF
--- a/skills/autospec-test/scripts/reset-endpoint-gen.mjs
+++ b/skills/autospec-test/scripts/reset-endpoint-gen.mjs
@@ -1,0 +1,650 @@
+#!/usr/bin/env node
+// scripts/reset-endpoint-gen.mjs
+// Reset-endpoint generation — guard-env rails + fallback chain.
+//
+// Implements spec §7 of docs/specs/2026-06-04-autospec-playwright-authoring-design.md
+//
+// Exports:
+//   detectFramework(repoRoot)          -> Promise<FrameworkInfo>
+//   generateResetRoute(repoRoot, opts) -> Promise<GenerateResult>
+//   preflightHostname(url)             -> { ok: boolean, reason: string|null }
+//   resolveResetStrategy(resetCfg, repoRoot) -> Promise<ResetStrategy>
+//
+// Safety rails (all mandatory per spec §7):
+//   - Generated handler is a no-op 404 unless process.env[guard_env] is set
+//   - Pre-flight production-hostname check must pass before any generation
+//   - Generated file carries an "AUTOSPEC-GENERATED test-only" header
+//   - Fallback chain: declared reset → generated reset → autospec-e2e-clone isolation
+//
+// Export: detectFramework, generateResetRoute, preflightHostname, resolveResetStrategy
+// CLI:    node reset-endpoint-gen.mjs --repo-root <dir> [--guard-env <VAR>] [--dry-run]
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+
+// ── Production-hostname blocklist (pre-flight check) ──────────────────────────
+
+const PRODUCTION_HOSTNAME_PATTERNS = [
+    /^(www\.)?(?!localhost|127\.|0\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.).*\.(com|net|org|io|app|dev|co|ai|cloud|online|live|pro|site|biz|info)$/i,
+    /^(prod|production|staging|stage)\./i,
+    /vercel\.app$/i,
+    /netlify\.app$/i,
+    /railway\.app$/i,
+    /fly\.dev$/i,
+    /herokuapp\.com$/i,
+    /\.aws\.amazon\.com$/i,
+    /\.cloudfront\.net$/i,
+    /\.azurewebsites\.net$/i,
+];
+
+const SAFE_HOSTNAME_PATTERNS = [
+    /^localhost$/i,
+    /^127\.\d+\.\d+\.\d+$/,
+    /^0\.0\.0\.0$/,
+    /^10\.\d+\.\d+\.\d+$/,
+    /^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/,
+    /^192\.168\.\d+\.\d+$/,
+    /^::1$/,
+];
+
+// ── Framework detection ────────────────────────────────────────────────────────
+
+/**
+ * @typedef {object} FrameworkInfo
+ * @property {'express'|'fastify'|'nextjs'|'nuxt'|'unknown'} framework
+ * @property {string|null} routesDir   - inferred server routes directory
+ * @property {string|null} mainFile    - inferred entry file (e.g. server.js, app.js)
+ * @property {string}      confidence  - 'high'|'medium'|'low'
+ */
+
+/**
+ * Detect the server framework used in the target repo.
+ *
+ * Checks package.json dependencies and common file conventions.
+ *
+ * @param {string} repoRoot - absolute path to the target repo
+ * @returns {Promise<FrameworkInfo>}
+ */
+export async function detectFramework(repoRoot) {
+    const pkgPath = path.join(repoRoot, 'package.json');
+    let deps = {};
+    let devDeps = {};
+
+    if (fs.existsSync(pkgPath)) {
+        try {
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+            deps = { ...(pkg.dependencies || {}), ...(pkg.peerDependencies || {}) };
+            devDeps = pkg.devDependencies || {};
+        } catch {
+            // ignore parse errors
+        }
+    }
+
+    const allDeps = { ...deps, ...devDeps };
+    const hasPackage = (name) => name in allDeps;
+
+    // ── Next.js ──────────────────────────────────────────────────────────────
+    if (hasPackage('next')) {
+        // Next.js API routes live in pages/api/ or app/api/
+        let routesDir = null;
+        if (fs.existsSync(path.join(repoRoot, 'app', 'api'))) {
+            routesDir = path.join('app', 'api');
+        } else if (fs.existsSync(path.join(repoRoot, 'pages', 'api'))) {
+            routesDir = path.join('pages', 'api');
+        } else if (fs.existsSync(path.join(repoRoot, 'src', 'app', 'api'))) {
+            routesDir = path.join('src', 'app', 'api');
+        } else if (fs.existsSync(path.join(repoRoot, 'src', 'pages', 'api'))) {
+            routesDir = path.join('src', 'pages', 'api');
+        }
+        return { framework: 'nextjs', routesDir, mainFile: null, confidence: 'high' };
+    }
+
+    // ── Fastify ───────────────────────────────────────────────────────────────
+    if (hasPackage('fastify')) {
+        const mainFile = _findMainFile(repoRoot, ['server.js', 'server.ts', 'app.js', 'app.ts', 'src/server.js', 'src/server.ts', 'src/app.js', 'src/app.ts']);
+        const routesDir = _findDir(repoRoot, ['routes', 'src/routes']);
+        return { framework: 'fastify', routesDir, mainFile, confidence: 'high' };
+    }
+
+    // ── Express ───────────────────────────────────────────────────────────────
+    if (hasPackage('express')) {
+        const mainFile = _findMainFile(repoRoot, ['server.js', 'server.ts', 'app.js', 'app.ts', 'index.js', 'index.ts', 'src/server.js', 'src/server.ts', 'src/app.js', 'src/app.ts', 'src/index.js', 'src/index.ts']);
+        const routesDir = _findDir(repoRoot, ['routes', 'src/routes', 'api', 'src/api']);
+        return { framework: 'express', routesDir, mainFile, confidence: 'high' };
+    }
+
+    // ── Nuxt ──────────────────────────────────────────────────────────────────
+    if (hasPackage('nuxt') || hasPackage('nuxt3')) {
+        const routesDir = _findDir(repoRoot, ['server/api', 'server/routes']);
+        return { framework: 'nuxt', routesDir, mainFile: null, confidence: 'high' };
+    }
+
+    // ── Heuristic fallback: check package.json "main" or "scripts.start" ──────
+    const pkgMain = (() => {
+        try {
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+            return pkg.main || null;
+        } catch {
+            return null;
+        }
+    })();
+
+    if (pkgMain && fs.existsSync(path.join(repoRoot, pkgMain))) {
+        const content = fs.readFileSync(path.join(repoRoot, pkgMain), 'utf8');
+        if (/require\s*\(\s*['"]express['"]\s*\)/.test(content) || /from\s+['"]express['"]/.test(content)) {
+            return { framework: 'express', routesDir: null, mainFile: pkgMain, confidence: 'medium' };
+        }
+        if (/require\s*\(\s*['"]fastify['"]\s*\)/.test(content) || /from\s+['"]fastify['"]/.test(content)) {
+            return { framework: 'fastify', routesDir: null, mainFile: pkgMain, confidence: 'medium' };
+        }
+    }
+
+    return { framework: 'unknown', routesDir: null, mainFile: null, confidence: 'low' };
+}
+
+function _findMainFile(repoRoot, candidates) {
+    for (const rel of candidates) {
+        if (fs.existsSync(path.join(repoRoot, rel))) return rel;
+    }
+    return null;
+}
+
+function _findDir(repoRoot, candidates) {
+    for (const rel of candidates) {
+        if (fs.existsSync(path.join(repoRoot, rel))) return rel;
+    }
+    return null;
+}
+
+// ── Pre-flight hostname check ─────────────────────────────────────────────────
+
+/**
+ * Check whether a URL's hostname is safe (not production-like).
+ * Must pass before any reset-endpoint generation or invocation.
+ *
+ * @param {string} url
+ * @returns {{ ok: boolean, reason: string|null }}
+ */
+export function preflightHostname(url) {
+    if (!url || typeof url !== 'string') {
+        return { ok: false, reason: 'URL is empty or not a string' };
+    }
+
+    let hostname;
+    try {
+        hostname = new URL(url).hostname;
+    } catch {
+        return { ok: false, reason: `Cannot parse URL: ${url}` };
+    }
+
+    // Explicitly safe
+    if (SAFE_HOSTNAME_PATTERNS.some(p => p.test(hostname))) {
+        return { ok: true, reason: null };
+    }
+
+    // Check against production patterns
+    for (const pattern of PRODUCTION_HOSTNAME_PATTERNS) {
+        if (pattern.test(hostname)) {
+            return {
+                ok: false,
+                reason: `Hostname "${hostname}" matches a production-like pattern (${pattern}). ` +
+                    'Set a local test URL (localhost or private IP) in e2e.reset or E2E_BASE_URL.',
+            };
+        }
+    }
+
+    // Unknown — conservative: allow but warn (caller decides)
+    return { ok: true, reason: null };
+}
+
+// ── Reset route code generators ───────────────────────────────────────────────
+
+const AUTOSPEC_HEADER = '// AUTOSPEC-GENERATED test-only — do not edit manually; regenerate via autospec-playwright';
+
+/**
+ * Generate Express reset route handler content.
+ *
+ * @param {string} guardEnv - environment variable name that gates the endpoint
+ * @returns {string}
+ */
+function _expressRouteContent(guardEnv) {
+    return `${AUTOSPEC_HEADER}
+// This file is safe to commit — it is a no-op 404 in production.
+// The reset endpoint is ONLY active when process.env.${guardEnv} is set.
+import express from 'express';
+
+const router = express.Router();
+
+/**
+ * POST /api/test/reset
+ * Truncates and re-seeds the test database.
+ * No-op (404) unless ${guardEnv} env var is set.
+ */
+router.post('/reset', async (req, res) => {
+    if (!process.env['${guardEnv}']) {
+        return res.status(404).json({ error: 'Not found' });
+    }
+
+    try {
+        // TODO: replace with your actual DB reset logic, e.g.:
+        //   await prisma.$executeRawUnsafe('TRUNCATE TABLE ...');
+        //   await runMigrations();
+        //   await seedTestData();
+        res.status(200).json({ ok: true, reset: true });
+    } catch (err) {
+        res.status(500).json({ error: String(err.message) });
+    }
+});
+
+export default router;
+`;
+}
+
+/**
+ * Generate Fastify reset route plugin content.
+ *
+ * @param {string} guardEnv
+ * @returns {string}
+ */
+function _fastifyRouteContent(guardEnv) {
+    return `${AUTOSPEC_HEADER}
+// This file is safe to commit — it is a no-op 404 in production.
+// The reset endpoint is ONLY active when process.env.${guardEnv} is set.
+
+/**
+ * Fastify plugin: POST /api/test/reset
+ * Truncates and re-seeds the test database.
+ * No-op (404) unless ${guardEnv} env var is set.
+ *
+ * @param {import('fastify').FastifyInstance} fastify
+ */
+async function resetPlugin(fastify) {
+    fastify.post('/api/test/reset', async (request, reply) => {
+        if (!process.env['${guardEnv}']) {
+            return reply.status(404).send({ error: 'Not found' });
+        }
+
+        try {
+            // TODO: replace with your actual DB reset logic
+            return { ok: true, reset: true };
+        } catch (err) {
+            return reply.status(500).send({ error: String(err.message) });
+        }
+    });
+}
+
+export default resetPlugin;
+`;
+}
+
+/**
+ * Generate Next.js API route handler content (App Router route.ts or pages/api handler).
+ *
+ * @param {string} guardEnv
+ * @param {'app'|'pages'} routerStyle
+ * @returns {string}
+ */
+function _nextjsRouteContent(guardEnv, routerStyle = 'app') {
+    if (routerStyle === 'app') {
+        return `${AUTOSPEC_HEADER}
+// This file is safe to commit — it is a no-op 404 in production.
+// The reset endpoint is ONLY active when process.env.${guardEnv} is set.
+import { NextResponse } from 'next/server';
+
+/**
+ * POST /api/test/reset (App Router)
+ * Truncates and re-seeds the test database.
+ * No-op (404) unless ${guardEnv} env var is set.
+ */
+export async function POST() {
+    if (!process.env['${guardEnv}']) {
+        return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    try {
+        // TODO: replace with your actual DB reset logic
+        return NextResponse.json({ ok: true, reset: true });
+    } catch (err) {
+        return NextResponse.json({ error: String(err.message) }, { status: 500 });
+    }
+}
+`;
+    }
+
+    // Pages router
+    return `${AUTOSPEC_HEADER}
+// This file is safe to commit — it is a no-op 404 in production.
+// The reset endpoint is ONLY active when process.env.${guardEnv} is set.
+
+/**
+ * POST /api/test/reset (Pages Router)
+ * Truncates and re-seeds the test database.
+ * No-op (404) unless ${guardEnv} env var is set.
+ *
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+export default async function handler(req, res) {
+    if (req.method !== 'POST') {
+        return res.status(405).json({ error: 'Method not allowed' });
+    }
+
+    if (!process.env['${guardEnv}']) {
+        return res.status(404).json({ error: 'Not found' });
+    }
+
+    try {
+        // TODO: replace with your actual DB reset logic
+        return res.status(200).json({ ok: true, reset: true });
+    } catch (err) {
+        return res.status(500).json({ error: String(err.message) });
+    }
+}
+`;
+}
+
+/**
+ * Generate generic/unknown framework reset handler content.
+ *
+ * @param {string} guardEnv
+ * @returns {string}
+ */
+function _genericRouteContent(guardEnv) {
+    return `${AUTOSPEC_HEADER}
+// This file is safe to commit — it is a no-op 404 in production.
+// The reset endpoint is ONLY active when process.env.${guardEnv} is set.
+//
+// Wire this handler into your server at POST /api/test/reset.
+// Framework: unknown — adapt the handler signature as needed.
+
+/**
+ * Test-reset handler (framework-agnostic)
+ * Truncates and re-seeds the test database.
+ * No-op unless ${guardEnv} env var is set.
+ *
+ * @param {object} req - incoming request
+ * @param {object} res - outgoing response
+ */
+export async function testResetHandler(req, res) {
+    if (!process.env['${guardEnv}']) {
+        // Production guard — 404 unless test-stack env var is set
+        if (typeof res.status === 'function') {
+            return res.status(404).json({ error: 'Not found' });
+        }
+        return;
+    }
+
+    try {
+        // TODO: replace with your actual DB reset logic
+        if (typeof res.status === 'function') {
+            return res.status(200).json({ ok: true, reset: true });
+        }
+    } catch (err) {
+        if (typeof res.status === 'function') {
+            return res.status(500).json({ error: String(err.message) });
+        }
+    }
+}
+`;
+}
+
+// ── generateResetRoute ────────────────────────────────────────────────────────
+
+/**
+ * @typedef {object} GenerateResult
+ * @property {boolean} generated   - true if a file was written
+ * @property {string|null} filePath - absolute path to the generated file (null if dry-run or skipped)
+ * @property {string|null} relativePath - repo-relative path (null if not generated)
+ * @property {string} framework     - detected framework
+ * @property {string} guardEnv      - guard env var name used
+ * @property {string|null} warning  - non-fatal warning (e.g. unknown framework)
+ * @property {boolean} dryRun       - true if dry-run mode, no file written
+ * @property {string} content       - generated file content (always present)
+ */
+
+/**
+ * Generate a test-stack-only reset route handler in the target repo.
+ *
+ * Pre-conditions (enforced):
+ *   1. baseUrl hostname must pass preflightHostname()
+ *   2. guardEnv must be non-empty
+ *
+ * @param {string} repoRoot - absolute path to the target repo
+ * @param {object} [opts]
+ * @param {string} [opts.guardEnv='AUTOSPEC_TEST_STACK'] - env var that gates the endpoint
+ * @param {string} [opts.baseUrl='http://localhost:3000'] - target app URL (for hostname check)
+ * @param {boolean} [opts.dryRun=false] - if true, return content but don't write file
+ * @param {FrameworkInfo} [opts.frameworkInfo] - pre-detected framework (skip detection if provided)
+ * @returns {Promise<GenerateResult>}
+ * @throws {Error} if pre-conditions fail
+ */
+export async function generateResetRoute(repoRoot, opts = {}) {
+    const {
+        guardEnv = 'AUTOSPEC_TEST_STACK',
+        baseUrl = 'http://localhost:3000',
+        dryRun = false,
+        frameworkInfo: preDetected = null,
+    } = opts;
+
+    // ── Validate guardEnv ────────────────────────────────────────────────────
+    if (!guardEnv || typeof guardEnv !== 'string' || guardEnv.trim() === '') {
+        throw new Error(
+            'reset-endpoint-gen: guardEnv must be a non-empty environment variable name. ' +
+            'Set reset.guard_env in .autospec/test.yml (e.g. AUTOSPEC_TEST_STACK).'
+        );
+    }
+
+    // ── Pre-flight hostname check ────────────────────────────────────────────
+    const preflight = preflightHostname(baseUrl);
+    if (!preflight.ok) {
+        throw new Error(
+            `reset-endpoint-gen: pre-flight hostname check failed: ${preflight.reason} ` +
+            'Aborting reset-route generation to prevent production exposure.'
+        );
+    }
+
+    // ── Detect framework ─────────────────────────────────────────────────────
+    const fw = preDetected || await detectFramework(repoRoot);
+    let content;
+    let relativePath;
+    let warning = null;
+
+    switch (fw.framework) {
+        case 'express': {
+            const routesDir = fw.routesDir || 'routes';
+            relativePath = path.join(routesDir, 'test-reset.mjs');
+            content = _expressRouteContent(guardEnv);
+            break;
+        }
+        case 'fastify': {
+            const routesDir = fw.routesDir || 'routes';
+            relativePath = path.join(routesDir, 'test-reset.mjs');
+            content = _fastifyRouteContent(guardEnv);
+            break;
+        }
+        case 'nextjs': {
+            // Determine router style
+            let routerStyle = 'pages';
+            let routesDir = fw.routesDir;
+            if (routesDir && (routesDir.startsWith('app') || routesDir.startsWith('src/app'))) {
+                routerStyle = 'app';
+                relativePath = path.join(routesDir, 'test', 'reset', 'route.ts');
+            } else if (routesDir && (routesDir.startsWith('pages') || routesDir.startsWith('src/pages'))) {
+                routerStyle = 'pages';
+                relativePath = path.join(routesDir, 'test', 'reset.ts');
+            } else {
+                // Default: try app router
+                routerStyle = 'app';
+                relativePath = path.join('app', 'api', 'test', 'reset', 'route.ts');
+            }
+            content = _nextjsRouteContent(guardEnv, routerStyle);
+            break;
+        }
+        case 'nuxt': {
+            const routesDir = fw.routesDir || 'server/api';
+            relativePath = path.join(routesDir, 'test', 'reset.post.ts');
+            content = _fastifyRouteContent(guardEnv); // Nuxt H3 is Fastify-compatible shape
+            warning = 'Nuxt H3 handler generated with Fastify shape — adapt if needed';
+            break;
+        }
+        default: {
+            relativePath = path.join('test-reset-handler.mjs');
+            content = _genericRouteContent(guardEnv);
+            warning = `Framework not detected (confidence: ${fw.confidence}). Generic handler generated — wire it into your server at POST /api/test/reset.`;
+        }
+    }
+
+    const absolutePath = path.join(repoRoot, relativePath);
+
+    if (!dryRun) {
+        fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+        fs.writeFileSync(absolutePath, content, 'utf8');
+    }
+
+    return {
+        generated: !dryRun,
+        filePath: dryRun ? null : absolutePath,
+        relativePath,
+        framework: fw.framework,
+        guardEnv,
+        warning,
+        dryRun,
+        content,
+    };
+}
+
+// ── resolveResetStrategy ──────────────────────────────────────────────────────
+
+/**
+ * @typedef {'declared_endpoint'|'declared_cmd'|'generated'|'clone_isolation'} ResetStrategyKind
+ *
+ * @typedef {object} ResetStrategy
+ * @property {ResetStrategyKind} kind
+ * @property {string|null} endpoint  - resolved endpoint URL (kind=declared_endpoint or generated)
+ * @property {string|null} cmd       - reset command (kind=declared_cmd)
+ * @property {string|null} guardEnv  - guard env var (kind=generated)
+ * @property {string} description    - human-readable description for the report
+ */
+
+/**
+ * Resolve the reset strategy from e2e.reset config.
+ *
+ * Implements the fallback chain per spec §7:
+ *   declared reset → generated reset → autospec-e2e-clone per-suite isolation
+ *
+ * This function only resolves the strategy — it does not execute it.
+ * Call generateResetRoute() separately when kind==='generated' and dryRun=false.
+ *
+ * @param {object} resetCfg - e2e.reset config block (from loadAuthoringConfig)
+ * @param {string} repoRoot - absolute path to the target repo
+ * @returns {Promise<ResetStrategy>}
+ */
+export async function resolveResetStrategy(resetCfg, repoRoot) {
+    if (!resetCfg || typeof resetCfg !== 'object') {
+        return {
+            kind: 'clone_isolation',
+            endpoint: null,
+            cmd: null,
+            guardEnv: null,
+            description: 'No reset config found — falling back to autospec-e2e-clone per-suite isolation (mutating tests serialized).',
+        };
+    }
+
+    // ── 1. Declared endpoint ─────────────────────────────────────────────────
+    if (resetCfg.endpoint && typeof resetCfg.endpoint === 'string' && resetCfg.endpoint.trim()) {
+        return {
+            kind: 'declared_endpoint',
+            endpoint: resetCfg.endpoint.trim(),
+            cmd: null,
+            guardEnv: resetCfg.guard_env || null,
+            description: `Using declared reset endpoint: ${resetCfg.endpoint.trim()}`,
+        };
+    }
+
+    // ── 2. Declared cmd ──────────────────────────────────────────────────────
+    if (resetCfg.cmd && typeof resetCfg.cmd === 'string' && resetCfg.cmd.trim()) {
+        return {
+            kind: 'declared_cmd',
+            endpoint: null,
+            cmd: resetCfg.cmd.trim(),
+            guardEnv: null,
+            description: `Using declared reset command: ${resetCfg.cmd.trim()}`,
+        };
+    }
+
+    // ── 3. Generate reset route ──────────────────────────────────────────────
+    if (resetCfg.generate_if_missing === true) {
+        const guardEnv = resetCfg.guard_env;
+        if (!guardEnv || (typeof guardEnv === 'string' && guardEnv.trim() === '')) {
+            // Should have been caught by authoring-config validation, but guard here too
+            return {
+                kind: 'clone_isolation',
+                endpoint: null,
+                cmd: null,
+                guardEnv: null,
+                description: 'generate_if_missing=true but guard_env is missing — cannot generate safely. Falling back to clone isolation.',
+            };
+        }
+        return {
+            kind: 'generated',
+            endpoint: '/api/test/reset',
+            cmd: null,
+            guardEnv: guardEnv.trim(),
+            description: `Will generate reset route at POST /api/test/reset (guard: ${guardEnv.trim()}). Call generateResetRoute() to write the file.`,
+        };
+    }
+
+    // ── 4. Fallback: clone isolation ─────────────────────────────────────────
+    return {
+        kind: 'clone_isolation',
+        endpoint: null,
+        cmd: null,
+        guardEnv: null,
+        description: 'No reset strategy declared or applicable — falling back to autospec-e2e-clone per-suite isolation (mutating tests serialized).',
+    };
+}
+
+// ── CLI entrypoint ────────────────────────────────────────────────────────────
+
+if (process.argv[1] && fs.existsSync(process.argv[1]) &&
+    fs.realpathSync(path.resolve(process.argv[1])) === fs.realpathSync(path.resolve(__filename))) {
+    const args = process.argv.slice(2);
+    const getArg = (flag) => {
+        const idx = args.indexOf(flag);
+        return idx >= 0 ? args[idx + 1] : null;
+    };
+    const hasFlag = (flag) => args.includes(flag);
+
+    const repoRoot = getArg('--repo-root') || process.cwd();
+    const guardEnv = getArg('--guard-env') || 'AUTOSPEC_TEST_STACK';
+    const baseUrl = getArg('--base-url') || 'http://localhost:3000';
+    const dryRun = hasFlag('--dry-run');
+    const detectOnly = hasFlag('--detect-only');
+    const checkUrl = getArg('--check-url');
+
+    if (checkUrl) {
+        const result = preflightHostname(checkUrl);
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+        process.exit(result.ok ? 0 : 1);
+    }
+
+    if (detectOnly) {
+        const fw = await detectFramework(repoRoot);
+        process.stdout.write(JSON.stringify(fw, null, 2) + '\n');
+        process.exit(0);
+    }
+
+    try {
+        const result = await generateResetRoute(repoRoot, { guardEnv, baseUrl, dryRun });
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+        if (result.warning) {
+            process.stderr.write(`WARNING: ${result.warning}\n`);
+        }
+    } catch (err) {
+        process.stderr.write(`reset-endpoint-gen: ${err.message}\n`);
+        process.exit(2);
+    }
+}

--- a/skills/autospec-test/tests/unit/reset-endpoint-gen.test.mjs
+++ b/skills/autospec-test/tests/unit/reset-endpoint-gen.test.mjs
@@ -1,0 +1,422 @@
+// skills/autospec-test/tests/unit/reset-endpoint-gen.test.mjs
+// node --test  (Node.js built-in test runner)
+// Tests for scripts/reset-endpoint-gen.mjs
+// Covers: detectFramework, generateResetRoute, preflightHostname, resolveResetStrategy
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = path.resolve(__dirname, '../../scripts');
+
+const { detectFramework, generateResetRoute, preflightHostname, resolveResetStrategy } =
+    await import(`file://${SCRIPTS_DIR}/reset-endpoint-gen.mjs`);
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function tmpDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'reset-gen-test-'));
+}
+
+function cleanup(dir) {
+    fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writeFile(dir, relPath, content) {
+    const full = path.join(dir, relPath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content, 'utf8');
+    return full;
+}
+
+function writePkg(dir, deps = {}, devDeps = {}) {
+    writeFile(dir, 'package.json', JSON.stringify({
+        name: 'test-app',
+        dependencies: deps,
+        devDependencies: devDeps,
+    }));
+}
+
+// ── preflightHostname ─────────────────────────────────────────────────────────
+
+test('preflightHostname: localhost is safe', () => {
+    const r = preflightHostname('http://localhost:3000');
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, null);
+});
+
+test('preflightHostname: 127.0.0.1 is safe', () => {
+    const r = preflightHostname('http://127.0.0.1:3000/foo');
+    assert.equal(r.ok, true);
+});
+
+test('preflightHostname: 192.168.x.x is safe', () => {
+    const r = preflightHostname('http://192.168.1.100:3000');
+    assert.equal(r.ok, true);
+});
+
+test('preflightHostname: 10.x.x.x is safe', () => {
+    const r = preflightHostname('http://10.0.0.1:8080');
+    assert.equal(r.ok, true);
+});
+
+test('preflightHostname: vercel.app is not safe', () => {
+    const r = preflightHostname('https://myapp.vercel.app');
+    assert.equal(r.ok, false);
+    assert.ok(r.reason && r.reason.length > 0, 'reason must explain the failure');
+});
+
+test('preflightHostname: netlify.app is not safe', () => {
+    const r = preflightHostname('https://myapp.netlify.app');
+    assert.equal(r.ok, false);
+});
+
+test('preflightHostname: prod.example.com is not safe', () => {
+    const r = preflightHostname('https://prod.example.com');
+    assert.equal(r.ok, false);
+});
+
+test('preflightHostname: staging.myapp.com is not safe', () => {
+    const r = preflightHostname('https://staging.myapp.com/api');
+    assert.equal(r.ok, false);
+});
+
+test('preflightHostname: empty string returns ok=false', () => {
+    const r = preflightHostname('');
+    assert.equal(r.ok, false);
+});
+
+test('preflightHostname: invalid URL returns ok=false', () => {
+    const r = preflightHostname('not-a-url');
+    assert.equal(r.ok, false);
+    assert.ok(r.reason && r.reason.length > 0);
+});
+
+test('preflightHostname: fly.dev is not safe', () => {
+    const r = preflightHostname('https://myapp.fly.dev');
+    assert.equal(r.ok, false);
+});
+
+test('preflightHostname: herokuapp.com is not safe', () => {
+    const r = preflightHostname('https://myapp.herokuapp.com');
+    assert.equal(r.ok, false);
+});
+
+// ── detectFramework ───────────────────────────────────────────────────────────
+
+test('detectFramework: detects express from package.json', async () => {
+    const dir = tmpDir();
+    try {
+        writePkg(dir, { express: '^4.18.0' });
+        const fw = await detectFramework(dir);
+        assert.equal(fw.framework, 'express');
+        assert.equal(fw.confidence, 'high');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('detectFramework: detects fastify from package.json', async () => {
+    const dir = tmpDir();
+    try {
+        writePkg(dir, { fastify: '^4.0.0' });
+        const fw = await detectFramework(dir);
+        assert.equal(fw.framework, 'fastify');
+        assert.equal(fw.confidence, 'high');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('detectFramework: detects nextjs from package.json', async () => {
+    const dir = tmpDir();
+    try {
+        writePkg(dir, { next: '^14.0.0', react: '^18.0.0' });
+        const fw = await detectFramework(dir);
+        assert.equal(fw.framework, 'nextjs');
+        assert.equal(fw.confidence, 'high');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('detectFramework: detects nextjs app router directory', async () => {
+    const dir = tmpDir();
+    try {
+        writePkg(dir, { next: '^14.0.0' });
+        fs.mkdirSync(path.join(dir, 'app', 'api'), { recursive: true });
+        const fw = await detectFramework(dir);
+        assert.equal(fw.framework, 'nextjs');
+        assert.ok(fw.routesDir && fw.routesDir.includes('app/api'),
+            `Expected app/api routesDir, got ${fw.routesDir}`);
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('detectFramework: detects express routes directory', async () => {
+    const dir = tmpDir();
+    try {
+        writePkg(dir, { express: '^4.0.0' });
+        fs.mkdirSync(path.join(dir, 'routes'), { recursive: true });
+        const fw = await detectFramework(dir);
+        assert.equal(fw.framework, 'express');
+        assert.equal(fw.routesDir, 'routes');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('detectFramework: returns unknown for empty repo', async () => {
+    const dir = tmpDir();
+    try {
+        const fw = await detectFramework(dir);
+        assert.equal(fw.framework, 'unknown');
+        assert.equal(fw.confidence, 'low');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('detectFramework: prefers next over express when both present', async () => {
+    const dir = tmpDir();
+    try {
+        writePkg(dir, { next: '^14.0.0', express: '^4.0.0' });
+        const fw = await detectFramework(dir);
+        // next check comes first in implementation
+        assert.equal(fw.framework, 'nextjs');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+// ── generateResetRoute ────────────────────────────────────────────────────────
+
+test('generateResetRoute: throws when guardEnv is empty', async () => {
+    const dir = tmpDir();
+    try {
+        await assert.rejects(
+            () => generateResetRoute(dir, { guardEnv: '' }),
+            /guardEnv must be a non-empty/
+        );
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('generateResetRoute: throws on production hostname', async () => {
+    const dir = tmpDir();
+    try {
+        await assert.rejects(
+            () => generateResetRoute(dir, { guardEnv: 'AUTOSPEC_TEST_STACK', baseUrl: 'https://prod.myapp.com' }),
+            /pre-flight hostname check failed/
+        );
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('generateResetRoute: dry-run does not write file', async () => {
+    const dir = tmpDir();
+    try {
+        writePkg(dir, { express: '^4.0.0' });
+        const result = await generateResetRoute(dir, {
+            guardEnv: 'AUTOSPEC_TEST_STACK',
+            baseUrl: 'http://localhost:3000',
+            dryRun: true,
+        });
+        assert.equal(result.dryRun, true);
+        assert.equal(result.generated, false);
+        assert.equal(result.filePath, null);
+        assert.ok(result.content.length > 0, 'content must be present even in dry-run');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('generateResetRoute: express — writes file with AUTOSPEC-GENERATED header', async () => {
+    const dir = tmpDir();
+    try {
+        writePkg(dir, { express: '^4.0.0' });
+        const result = await generateResetRoute(dir, {
+            guardEnv: 'MY_TEST_GUARD',
+            baseUrl: 'http://localhost:3000',
+        });
+        assert.equal(result.generated, true);
+        assert.ok(result.filePath, 'filePath must be set');
+        assert.ok(fs.existsSync(result.filePath), 'file must exist on disk');
+        const content = fs.readFileSync(result.filePath, 'utf8');
+        assert.ok(content.includes('AUTOSPEC-GENERATED test-only'), 'must include AUTOSPEC-GENERATED header');
+        assert.ok(content.includes('MY_TEST_GUARD'), 'must embed guardEnv name');
+        assert.ok(content.includes('404'), 'must have 404 guard');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('generateResetRoute: fastify — writes file with guard-env check', async () => {
+    const dir = tmpDir();
+    try {
+        writePkg(dir, { fastify: '^4.0.0' });
+        const result = await generateResetRoute(dir, {
+            guardEnv: 'AUTOSPEC_TEST_STACK',
+            baseUrl: 'http://localhost:3000',
+        });
+        const content = fs.readFileSync(result.filePath, 'utf8');
+        assert.ok(content.includes('AUTOSPEC-GENERATED test-only'));
+        assert.ok(content.includes('AUTOSPEC_TEST_STACK'));
+        assert.equal(result.framework, 'fastify');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('generateResetRoute: nextjs — writes file with guard-env check', async () => {
+    const dir = tmpDir();
+    try {
+        writePkg(dir, { next: '^14.0.0' });
+        const result = await generateResetRoute(dir, {
+            guardEnv: 'AUTOSPEC_TEST_STACK',
+            baseUrl: 'http://localhost:3000',
+        });
+        const content = fs.readFileSync(result.filePath, 'utf8');
+        assert.ok(content.includes('AUTOSPEC-GENERATED test-only'));
+        assert.ok(content.includes('AUTOSPEC_TEST_STACK'));
+        assert.equal(result.framework, 'nextjs');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('generateResetRoute: unknown framework — writes generic handler with warning', async () => {
+    const dir = tmpDir();
+    try {
+        const result = await generateResetRoute(dir, {
+            guardEnv: 'AUTOSPEC_TEST_STACK',
+            baseUrl: 'http://localhost:3000',
+        });
+        assert.equal(result.framework, 'unknown');
+        assert.ok(result.warning && result.warning.length > 0, 'must emit warning for unknown framework');
+        const content = fs.readFileSync(result.filePath, 'utf8');
+        assert.ok(content.includes('AUTOSPEC-GENERATED test-only'));
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('generateResetRoute: pre-detected frameworkInfo skips detection', async () => {
+    const dir = tmpDir();
+    try {
+        // No package.json — would be unknown, but we provide frameworkInfo
+        const result = await generateResetRoute(dir, {
+            guardEnv: 'AUTOSPEC_TEST_STACK',
+            baseUrl: 'http://localhost:3000',
+            frameworkInfo: { framework: 'express', routesDir: 'routes', mainFile: null, confidence: 'high' },
+        });
+        assert.equal(result.framework, 'express');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+test('generateResetRoute: created directories recursively', async () => {
+    const dir = tmpDir();
+    try {
+        writePkg(dir, { express: '^4.0.0' });
+        fs.mkdirSync(path.join(dir, 'routes'), { recursive: true });
+        const result = await generateResetRoute(dir, {
+            guardEnv: 'AUTOSPEC_TEST_STACK',
+            baseUrl: 'http://localhost:3000',
+        });
+        assert.ok(fs.existsSync(path.dirname(result.filePath)),
+            'parent directories must be created');
+    } finally {
+        cleanup(dir);
+    }
+});
+
+// ── resolveResetStrategy ──────────────────────────────────────────────────────
+
+test('resolveResetStrategy: declared endpoint takes priority', async () => {
+    const dir = tmpDir();
+    const strategy = await resolveResetStrategy(
+        { endpoint: '/api/test/reset', guard_env: 'AUTOSPEC_TEST_STACK' },
+        dir
+    );
+    assert.equal(strategy.kind, 'declared_endpoint');
+    assert.equal(strategy.endpoint, '/api/test/reset');
+    assert.equal(strategy.cmd, null);
+});
+
+test('resolveResetStrategy: declared cmd taken when no endpoint', async () => {
+    const dir = tmpDir();
+    const strategy = await resolveResetStrategy(
+        { cmd: 'make db-reset' },
+        dir
+    );
+    assert.equal(strategy.kind, 'declared_cmd');
+    assert.equal(strategy.cmd, 'make db-reset');
+    assert.equal(strategy.endpoint, null);
+});
+
+test('resolveResetStrategy: generate_if_missing=true → generated strategy', async () => {
+    const dir = tmpDir();
+    const strategy = await resolveResetStrategy(
+        { generate_if_missing: true, guard_env: 'AUTOSPEC_TEST_STACK' },
+        dir
+    );
+    assert.equal(strategy.kind, 'generated');
+    assert.equal(strategy.endpoint, '/api/test/reset');
+    assert.equal(strategy.guardEnv, 'AUTOSPEC_TEST_STACK');
+});
+
+test('resolveResetStrategy: generate_if_missing=true without guard_env → clone_isolation fallback', async () => {
+    const dir = tmpDir();
+    const strategy = await resolveResetStrategy(
+        { generate_if_missing: true },
+        dir
+    );
+    assert.equal(strategy.kind, 'clone_isolation');
+    assert.ok(strategy.description.length > 0);
+});
+
+test('resolveResetStrategy: no config → clone_isolation fallback', async () => {
+    const dir = tmpDir();
+    const strategy = await resolveResetStrategy(null, dir);
+    assert.equal(strategy.kind, 'clone_isolation');
+});
+
+test('resolveResetStrategy: empty config → clone_isolation fallback', async () => {
+    const dir = tmpDir();
+    const strategy = await resolveResetStrategy({}, dir);
+    assert.equal(strategy.kind, 'clone_isolation');
+});
+
+test('resolveResetStrategy: description is always a non-empty string', async () => {
+    const dir = tmpDir();
+    for (const cfg of [
+        null,
+        {},
+        { endpoint: '/api/test/reset' },
+        { cmd: 'make reset' },
+        { generate_if_missing: true, guard_env: 'GUARD' },
+    ]) {
+        const s = await resolveResetStrategy(cfg, dir);
+        assert.ok(typeof s.description === 'string' && s.description.length > 0,
+            `description must be non-empty for cfg=${JSON.stringify(cfg)}`);
+    }
+});
+
+test('resolveResetStrategy: fallback chain order — endpoint > cmd > generate > clone', async () => {
+    const dir = tmpDir();
+    // endpoint wins even when cmd and generate_if_missing are also set
+    const s = await resolveResetStrategy(
+        { endpoint: '/api/test/reset', cmd: 'make reset', generate_if_missing: true, guard_env: 'GUARD' },
+        dir
+    );
+    assert.equal(s.kind, 'declared_endpoint');
+});

--- a/skills/autospec-test/tests/unit/reset-endpoint-gen.test.mjs
+++ b/skills/autospec-test/tests/unit/reset-endpoint-gen.test.mjs
@@ -292,6 +292,24 @@ test('generateResetRoute: nextjs — writes file with guard-env check', async ()
     }
 });
 
+test('generateResetRoute: nuxt — writes file with AUTOSPEC-GENERATED header', async () => {
+    const dir = tmpDir();
+    try {
+        writePkg(dir, { nuxt: '^3.0.0' });
+        const result = await generateResetRoute(dir, {
+            guardEnv: 'AUTOSPEC_TEST_STACK',
+            baseUrl: 'http://localhost:3000',
+        });
+        const content = fs.readFileSync(result.filePath, 'utf8');
+        assert.ok(content.includes('AUTOSPEC-GENERATED test-only'));
+        assert.ok(content.includes('AUTOSPEC_TEST_STACK'));
+        assert.equal(result.framework, 'nuxt');
+        assert.ok(result.warning && result.warning.length > 0, 'must emit nuxt adaptation warning');
+    } finally {
+        cleanup(dir);
+    }
+});
+
 test('generateResetRoute: unknown framework — writes generic handler with warning', async () => {
     const dir = tmpDir();
     try {


### PR DESCRIPTION
Closes #997

## Summary

- Adds `skills/autospec-test/scripts/reset-endpoint-gen.mjs` with four exports matching the shared contracts: `detectFramework`, `generateResetRoute`, `preflightHostname`, `resolveResetStrategy`
- Generated handler always carries `AUTOSPEC-GENERATED test-only` header and is a no-op 404 unless `process.env[guard_env]` is set (default `AUTOSPEC_TEST_STACK`)
- Pre-flight hostname check rejects production-like hosts (vercel.app, netlify.app, fly.dev, prod.*, staging.*, public TLDs) before any file generation
- Fallback chain: declared endpoint → declared cmd → generated route → clone-isolation (spec §7)
- Framework detection covers express, fastify, nextjs (app + pages router), nuxt, and unknown with heuristic fallback
- 37 unit tests covering all four exports; all pass with `node --test`

## Test plan

- [x] `node --test skills/autospec-test/tests/unit/reset-endpoint-gen.test.mjs` — 37/37 pass
- [x] `bash skills/autospec-test/validate.sh` — all structural checks pass
- [x] CLI smoke: `node reset-endpoint-gen.mjs --repo-root /tmp/smoke --dry-run` returns valid JSON with `AUTOSPEC-GENERATED` content
- [x] Pre-flight blocks production URLs (vercel.app, netlify.app, fly.dev, prod.*)
- [x] Guard-env rail: generated handler returns 404 unless `AUTOSPEC_TEST_STACK` env var is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)