### PR TITLE
feat(autospec-playwright): thin dispatcher trio + registration (#999)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
 #   ./install.sh --help                          # show this help
 #
 # Flags:
-#   --skill   one of: autospec | autospec-release | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | autospec-qa | all
+#   --skill   one of: autospec | autospec-release | autospec-split | autospec-define | autospec-run | autospec-review | autospec-classify | autospec-listen | autospec-story | autospec-stop | autospec-sweep | autospec-design | autospec-fleet | autospec-qa | autospec-playwright | all
 #             (default: all)
 #   --harness one of: claude | opencode | codex | all
 #             (default: all)

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1264,6 +1264,21 @@ check_autospec_test_skill_present() {
         || { bash "$validate_sh" >&2; fail "$validate_sh: structural lint failed"; }
 }
 
+# autospec-playwright skill structural check (issue #999): run per-skill validate.sh
+# to verify trio lockstep, leading blank line in codex/prompt.md, and required sections.
+check_autospec_playwright_skill_present() {
+    info "autospec-playwright skill structural lint"
+    local skill_dir="skills/autospec-playwright"
+    local validate_sh="$skill_dir/validate.sh"
+    [ -d "$skill_dir" ] || fail "$skill_dir: directory missing"
+    [ -f "$skill_dir/SKILL.md" ] || fail "$skill_dir/SKILL.md: required file missing"
+    [ -f "$skill_dir/codex/prompt.md" ] || fail "$skill_dir/codex/prompt.md: required file missing"
+    [ -f "$validate_sh" ] || fail "$validate_sh: per-skill validate.sh missing"
+    bash -n "$validate_sh" || fail "$validate_sh: bash syntax error"
+    bash "$validate_sh" >/dev/null 2>&1 \
+        || { bash "$validate_sh" >&2; fail "$validate_sh: structural lint failed"; }
+}
+
 check_autospec_qa_contract() {
     info "autospec-qa contract: no-mock smoke blocker handling"
     local skill_file="skills/autospec-qa/SKILL.md"
@@ -2187,6 +2202,7 @@ main() {
     check_autospec_review_skill_present
     check_autospec_review_tier_a_directives
     check_autospec_test_skill_present
+    check_autospec_playwright_skill_present
     check_autospec_qa_contract
     check_brute_force_rule_ids
     check_dogfood_detectors

--- a/skills/autospec-playwright/README.md
+++ b/skills/autospec-playwright/README.md
@@ -1,0 +1,36 @@
+# autospec-playwright
+
+Thin dispatcher for the `autospec-test` Stage 2A disciplined Playwright
+authoring pipeline. Reads `.autospec/test.yml` authoring and reset blocks,
+invokes Stage 2A, and prints the e2e coverage report.
+
+## Install
+
+```sh
+# All harnesses (Claude Code, OpenCode, Codex CLI):
+./install.sh --harness all
+
+# Or pipe from curl:
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-playwright/install.sh \
+  | sh -s -- --harness all
+```
+
+## Usage
+
+```
+/autospec-playwright [--dry-run]
+```
+
+Set `e2e.authoring.enabled: true` in `.autospec/test.yml` to enable Stage 2A.
+
+## Uninstall
+
+```sh
+./uninstall.sh --harness all
+```
+
+## Validate
+
+```sh
+bash validate.sh
+```

--- a/skills/autospec-playwright/SKILL.md
+++ b/skills/autospec-playwright/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: autospec-playwright
+description: Use when you want to run disciplined no-mock Playwright UI-test authoring (Stage 2A) for a project. Detects the .autospec/test.yml authoring blocks, invokes autospec-test Stage 2A, and prints the coverage report.
+---
+
+# autospec-playwright — Disciplined Playwright Authoring Dispatcher
+
+Thin dispatcher for the `autospec-test` Stage 2A disciplined-authoring pipeline.
+Reads `.autospec/test.yml` authoring and reset blocks, invokes Stage 2A, and
+prints the e2e coverage report from `e2e/.autospec/coverage.json`. Carries NO
+machinery of its own — all logic lives in `autospec-test`.
+
+## Self-update mode
+
+Decide this purely from the request text the harness handed you. Do NOT
+shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
+test the user's free-form request — passing it through a shell is what
+historically tripped harness permission engines. Read the request, normalize
+it in your reasoning (collapse whitespace, trim, lowercase), and if the result is
+exactly `update`, this skill enters self-update mode and does NOT run the
+normal pipeline.
+
+1. Detect harness by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-playwright/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-playwright.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-playwright.md`
+2. Re-install from `main` by piping the canonical installer:
+   ```
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. Show the diff between the prior installed file(s) and the freshly fetched copy.
+4. Stop. Do not enter any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-playwright found; run install.sh first.` and exit.
+
+## Model tier
+
+**Model tier:** `TIER_B` for all dispatch work (thin dispatcher; no design decisions).
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your harness's actual tool.
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                             | Fallback if missing                    |
+|-----------------------------|-----------------------------------------|---------------------------------------|---------------------------------------|----------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)         | `task` agent in read-only mode        | shell `grep`                          | Do the search in-thread                |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent                   | spawn nested CLI session              | Do the work in-thread                  |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                         | Ask in response and wait               |
+| Subagent model tier         | **Model tier:** `TIER_B` for all dispatch work | top task model + medium reasoning | top GPT + reasoning_effort=medium | Honor per-phase tier mapping          |
+| Subagent dispatch policy    | per AGENTS.md decision matrix           | per AGENTS.md decision matrix         | per AGENTS.md decision matrix         | inline with main-session token cost    |
+
+## Harness detection
+
+Detect your harness by checking available tools before any phase:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`
+   - `TIER_B` = `sonnet`
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available (quota, capacity, or authorization failure),
+silently retry with `TIER_A`. Never ask the user.
+
+## Invocation
+
+```
+/autospec-playwright [--dry-run]
+```
+
+- `--dry-run` — print what would be done; do not invoke Stage 2A.
+
+## Dispatcher flow
+
+1. **Locate config.** Read `.autospec/test.yml` via `loadAuthoringConfig()` from
+   `skills/autospec-test/scripts/authoring-config.mjs`. If the file is missing or
+   `e2e.authoring.enabled` is false, print:
+   ```
+   autospec-playwright: e2e.authoring.enabled is false (or .autospec/test.yml missing).
+   Set e2e.authoring.enabled: true to enable Stage 2A authoring.
+   ```
+   and exit 0.
+
+2. **Invoke Stage 2A.** Call `autospec-test` Stage 2A — disciplined authoring —
+   passing the resolved `spec_dir`, `helpers_dir`, `route_clusters`, `coverage_target_pct`,
+   and `fanout_max` from the authoring config. Stage 2A is owned by
+   `skills/autospec-test/scripts/stage2a-orchestrator.mjs`; this dispatcher does
+   NOT duplicate any of its logic.
+
+3. **Print coverage report.** After Stage 2A completes, read
+   `e2e/.autospec/coverage.json` (shape: `{total, covered, pct}`) and print:
+   ```
+   autospec-playwright coverage: covered=<covered>/<total> (<pct>%)
+   ```
+   If the file is absent, print `autospec-playwright: coverage.json not found — Stage 2A may not have run.`
+
+4. **Exit code.** Exit 0 on success, 1 on Stage 2A failure.
+
+## Out of scope
+
+- Stage 2A machinery (owned by `autospec-test` issue #996).
+- Reset-endpoint generation (owned by `autospec-test` issue #997).
+- Loop classification (owned by `autospec-test` issue #998).
+- Any Playwright spec file authoring directly — this dispatcher wires; it does not author.

--- a/skills/autospec-playwright/codex/prompt.md
+++ b/skills/autospec-playwright/codex/prompt.md
@@ -1,0 +1,107 @@
+
+# autospec-playwright — Disciplined Playwright Authoring Dispatcher
+
+Thin dispatcher for the `autospec-test` Stage 2A disciplined-authoring pipeline.
+Reads `.autospec/test.yml` authoring and reset blocks, invokes Stage 2A, and
+prints the e2e coverage report from `e2e/.autospec/coverage.json`. Carries NO
+machinery of its own — all logic lives in `autospec-test`.
+
+## Self-update mode
+
+Decide this purely from the request text the harness handed you. Do NOT
+shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
+test the user's free-form request — passing it through a shell is what
+historically tripped harness permission engines. Read the request, normalize
+it in your reasoning (collapse whitespace, trim, lowercase), and if the result is
+exactly `update`, this skill enters self-update mode and does NOT run the
+normal pipeline.
+
+1. Detect harness by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-playwright/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-playwright.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-playwright.md`
+2. Re-install from `main` by piping the canonical installer:
+   ```
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. Show the diff between the prior installed file(s) and the freshly fetched copy.
+4. Stop. Do not enter any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-playwright found; run install.sh first.` and exit.
+
+## Model tier
+
+**Model tier:** `TIER_B` for all dispatch work (thin dispatcher; no design decisions).
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your harness's actual tool.
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                             | Fallback if missing                    |
+|-----------------------------|-----------------------------------------|---------------------------------------|---------------------------------------|----------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)         | `task` agent in read-only mode        | shell `grep`                          | Do the search in-thread                |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent                   | spawn nested CLI session              | Do the work in-thread                  |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                         | Ask in response and wait               |
+| Subagent model tier         | **Model tier:** `TIER_B` for all dispatch work | top task model + medium reasoning | top GPT + reasoning_effort=medium | Honor per-phase tier mapping          |
+| Subagent dispatch policy    | per AGENTS.md decision matrix           | per AGENTS.md decision matrix         | per AGENTS.md decision matrix         | inline with main-session token cost    |
+
+## Harness detection
+
+Detect your harness by checking available tools before any phase:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`
+   - `TIER_B` = `sonnet`
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available (quota, capacity, or authorization failure),
+silently retry with `TIER_A`. Never ask the user.
+
+## Invocation
+
+```
+/autospec-playwright [--dry-run]
+```
+
+- `--dry-run` — print what would be done; do not invoke Stage 2A.
+
+## Dispatcher flow
+
+1. **Locate config.** Read `.autospec/test.yml` via `loadAuthoringConfig()` from
+   `skills/autospec-test/scripts/authoring-config.mjs`. If the file is missing or
+   `e2e.authoring.enabled` is false, print:
+   ```
+   autospec-playwright: e2e.authoring.enabled is false (or .autospec/test.yml missing).
+   Set e2e.authoring.enabled: true to enable Stage 2A authoring.
+   ```
+   and exit 0.
+
+2. **Invoke Stage 2A.** Call `autospec-test` Stage 2A — disciplined authoring —
+   passing the resolved `spec_dir`, `helpers_dir`, `route_clusters`, `coverage_target_pct`,
+   and `fanout_max` from the authoring config. Stage 2A is owned by
+   `skills/autospec-test/scripts/stage2a-orchestrator.mjs`; this dispatcher does
+   NOT duplicate any of its logic.
+
+3. **Print coverage report.** After Stage 2A completes, read
+   `e2e/.autospec/coverage.json` (shape: `{total, covered, pct}`) and print:
+   ```
+   autospec-playwright coverage: covered=<covered>/<total> (<pct>%)
+   ```
+   If the file is absent, print `autospec-playwright: coverage.json not found — Stage 2A may not have run.`
+
+4. **Exit code.** Exit 0 on success, 1 on Stage 2A failure.
+
+## Out of scope
+
+- Stage 2A machinery (owned by `autospec-test` issue #996).
+- Reset-endpoint generation (owned by `autospec-test` issue #997).
+- Loop classification (owned by `autospec-test` issue #998).
+- Any Playwright spec file authoring directly — this dispatcher wires; it does not author.

--- a/skills/autospec-playwright/install.sh
+++ b/skills/autospec-playwright/install.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env sh
+# install.sh — install the autospec-playwright skill into one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./install.sh                     # interactive — prompts for harness
+#   ./install.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./install.sh --update            # update an existing install
+#   ./install.sh --symlink           # symlink instead of copy
+#   ./install.sh --dry-run           # print what would be done; do nothing
+#
+# Can also be piped from curl:
+#   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/skills/autospec-playwright/install.sh \
+#     | sh -s -- --harness all
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#   AUTOSPEC_PLAYWRIGHT_REF         (default: main)
+#   AUTOSPEC_PLAYWRIGHT_RAW_BASE    (override raw URL base)
+
+set -eu
+
+SKILL_NAME="autospec-playwright"
+SKILL_RAW_BASE="${AUTOSPEC_PLAYWRIGHT_RAW_BASE:-https://raw.githubusercontent.com/berlinguyinca/autospec/${AUTOSPEC_PLAYWRIGHT_REF:-main}/skills/autospec-playwright}"
+
+SCRIPT_PATH="${0:-}"
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+    SKILL_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+else
+    SKILL_DIR=""
+fi
+
+HARNESS=""
+SYMLINK=0
+DRY_RUN=0
+UPDATE=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--update] [--symlink] [--dry-run]
+
+Installs the ${SKILL_NAME} skill into the chosen harness.
+EOF
+}
+
+run_cmd() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+fetch_file() {
+    src="$1"
+    dst="$2"
+    if [ -n "$SKILL_DIR" ] && [ -f "$SKILL_DIR/$src" ]; then
+        run_cmd "cp \"$SKILL_DIR/$src\" \"$dst\""
+    else
+        run_cmd "curl -fsSL \"$SKILL_RAW_BASE/$src\" -o \"$dst\""
+    fi
+}
+
+install_one() {
+    target="$1"
+    src_file="${2:-SKILL.md}"
+    target_dir="$(dirname "$target")"
+    run_cmd "mkdir -p \"$target_dir\""
+    fetch_file "$src_file" "$target"
+    info "  installed: $target"
+}
+
+# ---------- arg parse -------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift; HARNESS="${1:-}" ;;
+        --harness=*)
+            HARNESS="${1#--harness=}" ;;
+        --update)
+            UPDATE=1 ;;
+        --symlink)
+            SYMLINK=1 ;;
+        --dry-run)
+            DRY_RUN=1 ;;
+        -h|--help)
+            usage; exit 0 ;;
+        *)
+            err "unknown arg: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we install into?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths -----------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+CODEX_SKILLS_DEST="$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+
+# ---------- install ---------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    install_one "$CLAUDE_DEST" "SKILL.md"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    install_one "$OPENCODE_DEST" "opencode/agent.md"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    install_one "$CODEX_DEST" "codex/prompt.md"
+    install_one "$CODEX_SKILLS_DEST" "SKILL.md"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were written."
+else
+    info "Done. Run /autospec-playwright to run disciplined Playwright authoring (Stage 2A)."
+fi
+
+exit 0

--- a/skills/autospec-playwright/opencode/agent.md
+++ b/skills/autospec-playwright/opencode/agent.md
@@ -1,0 +1,111 @@
+---
+name: autospec-playwright
+description: Use when you want to run disciplined no-mock Playwright UI-test authoring (Stage 2A) for a project. Detects the .autospec/test.yml authoring blocks, invokes autospec-test Stage 2A, and prints the coverage report.
+---
+
+# autospec-playwright — Disciplined Playwright Authoring Dispatcher
+
+Thin dispatcher for the `autospec-test` Stage 2A disciplined-authoring pipeline.
+Reads `.autospec/test.yml` authoring and reset blocks, invokes Stage 2A, and
+prints the e2e coverage report from `e2e/.autospec/coverage.json`. Carries NO
+machinery of its own — all logic lives in `autospec-test`.
+
+## Self-update mode
+
+Decide this purely from the request text the harness handed you. Do NOT
+shell out (no `grep`, `sed`, `[[ =~ ]]`, command substitution, etc.) to
+test the user's free-form request — passing it through a shell is what
+historically tripped harness permission engines. Read the request, normalize
+it in your reasoning (collapse whitespace, trim, lowercase), and if the result is
+exactly `update`, this skill enters self-update mode and does NOT run the
+normal pipeline.
+
+1. Detect harness by checking which install path exists for this skill:
+   - Claude Code: `~/.claude/skills/autospec-playwright/SKILL.md`
+   - OpenCode:    `~/.config/opencode/agent/autospec-playwright.md`
+   - Codex CLI:   `~/.codex/prompts/autospec-playwright.md`
+2. Re-install from `main` by piping the canonical installer:
+   ```
+   curl -fsSL https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh | bash -s -- --skill all --harness all --update
+   ```
+   Run this one-liner once; it refreshes all autospec skills across all harnesses.
+3. Show the diff between the prior installed file(s) and the freshly fetched copy.
+4. Stop. Do not enter any pipeline phase. Print the upgrade summary and return to the user.
+
+If no install path is detected, print `Self-update: no installed copy of autospec-playwright found; run install.sh first.` and exit.
+
+## Model tier
+
+**Model tier:** `TIER_B` for all dispatch work (thin dispatcher; no design decisions).
+
+## Required capabilities & harness adapter
+
+This workflow assumes a small set of capabilities. Map each one to your harness's actual tool.
+
+| Capability                  | Claude Code                             | OpenCode                              | Codex CLI                             | Fallback if missing                    |
+|-----------------------------|-----------------------------------------|---------------------------------------|---------------------------------------|----------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)         | `task` agent in read-only mode        | shell `grep`                          | Do the search in-thread                |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent                   | spawn nested CLI session              | Do the work in-thread                  |
+| Ask the user a question     | `AskUserQuestion`                       | inline prompt                         | inline prompt                         | Ask in response and wait               |
+| Subagent model tier         | **Model tier:** `TIER_B` for all dispatch work | top task model + medium reasoning | top GPT + reasoning_effort=medium | Honor per-phase tier mapping          |
+| Subagent dispatch policy    | per AGENTS.md decision matrix           | per AGENTS.md decision matrix         | per AGENTS.md decision matrix         | inline with main-session token cost    |
+
+## Harness detection
+
+Detect your harness by checking available tools before any phase:
+
+1. **Claude Code** — the `Agent` tool with a `subagent_type` parameter is available.
+   - `TIER_A` = `opus` + `ultrathink`
+   - `TIER_B` = `sonnet`
+
+2. **OpenCode** — a `task` tool with model/tier configuration is available (no `subagent_type`).
+   - `TIER_A` = top-tier task model + high reasoning
+   - `TIER_B` = smaller-tier task model + medium reasoning
+
+3. **Codex CLI** — neither `Agent` nor a configurable `task` tool is available.
+   - `TIER_A` = current top GPT model + `reasoning_effort=high`
+   - `TIER_B` = `gpt-5.1-codex-spark` + `reasoning_effort=medium`
+
+**Fallback rule:** If `TIER_B` is not available (quota, capacity, or authorization failure),
+silently retry with `TIER_A`. Never ask the user.
+
+## Invocation
+
+```
+/autospec-playwright [--dry-run]
+```
+
+- `--dry-run` — print what would be done; do not invoke Stage 2A.
+
+## Dispatcher flow
+
+1. **Locate config.** Read `.autospec/test.yml` via `loadAuthoringConfig()` from
+   `skills/autospec-test/scripts/authoring-config.mjs`. If the file is missing or
+   `e2e.authoring.enabled` is false, print:
+   ```
+   autospec-playwright: e2e.authoring.enabled is false (or .autospec/test.yml missing).
+   Set e2e.authoring.enabled: true to enable Stage 2A authoring.
+   ```
+   and exit 0.
+
+2. **Invoke Stage 2A.** Call `autospec-test` Stage 2A — disciplined authoring —
+   passing the resolved `spec_dir`, `helpers_dir`, `route_clusters`, `coverage_target_pct`,
+   and `fanout_max` from the authoring config. Stage 2A is owned by
+   `skills/autospec-test/scripts/stage2a-orchestrator.mjs`; this dispatcher does
+   NOT duplicate any of its logic.
+
+3. **Print coverage report.** After Stage 2A completes, read
+   `e2e/.autospec/coverage.json` (shape: `{total, covered, pct}`) and print:
+   ```
+   autospec-playwright coverage: covered=<covered>/<total> (<pct>%)
+   ```
+   If the file is absent, print `autospec-playwright: coverage.json not found — Stage 2A may not have run.`
+
+4. **Exit code.** Exit 0 on success, 1 on Stage 2A failure.
+
+## Out of scope
+
+- Stage 2A machinery (owned by `autospec-test` issue #996).
+- Reset-endpoint generation (owned by `autospec-test` issue #997).
+- Loop classification (owned by `autospec-test` issue #998).
+- Any Playwright spec file authoring directly — this dispatcher wires; it does not author.

--- a/skills/autospec-playwright/uninstall.sh
+++ b/skills/autospec-playwright/uninstall.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env sh
+# uninstall.sh — remove the autospec-playwright skill from one or more
+# agent harnesses (Claude Code, OpenCode, Codex CLI).
+#
+# Usage:
+#   ./uninstall.sh                     # interactive — prompts for harness
+#   ./uninstall.sh --harness <name>    # one of: claude | opencode | codex | all
+#   ./uninstall.sh --dry-run           # print what would be done; do nothing
+#
+# Honors:
+#   CLAUDE_CONFIG_DIR    (default: $HOME/.claude)
+#   OPENCODE_CONFIG_DIR  (default: $HOME/.config/opencode)
+#   CODEX_HOME           (default: $HOME/.codex)
+#
+# Idempotent: removing an already-uninstalled file is a no-op.
+
+set -eu
+
+SKILL_NAME="autospec-playwright"
+
+HARNESS=""
+DRY_RUN=0
+
+err()  { printf 'error: %s\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: $0 [--harness claude|opencode|codex|all] [--dry-run]
+
+Removes the ${SKILL_NAME} skill from the chosen harness's standard
+skill/agent/prompt directory.
+EOF
+}
+
+run_cmd() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '  [dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+remove_one() {
+    target="$1"
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        run_cmd "rm -f \"$target\""
+        info "  removed: $target"
+        parent="$(dirname "$target")"
+        case "$parent" in
+            */skills/"$SKILL_NAME")
+                if [ "$DRY_RUN" -eq 0 ] && [ -d "$parent" ]; then
+                    rmdir "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+    else
+        info "  not installed: $target"
+    fi
+}
+
+# ---------- arg parse -------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --harness)
+            shift; HARNESS="${1:-}" ;;
+        --harness=*)
+            HARNESS="${1#--harness=}" ;;
+        --dry-run)
+            DRY_RUN=1 ;;
+        -h|--help)
+            usage; exit 0 ;;
+        *)
+            err "unknown arg: $1"; usage; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$HARNESS" ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
+        info "Which harness should we uninstall from?"
+        info "  1) claude    (Claude Code)"
+        info "  2) opencode  (OpenCode)"
+        info "  3) codex     (Codex CLI)"
+        info "  4) all"
+        printf 'choice [4]: '
+        read -r choice || choice=""
+        case "${choice:-4}" in
+            1) HARNESS=claude ;;
+            2) HARNESS=opencode ;;
+            3) HARNESS=codex ;;
+            4|"") HARNESS=all ;;
+            claude|opencode|codex|all) HARNESS="$choice" ;;
+            *) err "invalid choice: $choice"; exit 2 ;;
+        esac
+    else
+        HARNESS=all
+    fi
+fi
+
+case "$HARNESS" in
+    claude|opencode|codex|all) ;;
+    *) err "invalid --harness: $HARNESS"; usage; exit 2 ;;
+esac
+
+# ---------- per-harness paths -----------------------------------------------
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+
+CLAUDE_DEST="$CLAUDE_DIR/skills/$SKILL_NAME/SKILL.md"
+OPENCODE_DEST="$OPENCODE_DIR/agent/$SKILL_NAME.md"
+CODEX_DEST="$CODEX_DIR/prompts/$SKILL_NAME.md"
+CODEX_SKILLS_DEST="$CODEX_DIR/skills/$SKILL_NAME/SKILL.md"
+
+# ---------- remove ----------------------------------------------------------
+
+if [ "$HARNESS" = "claude" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Claude Code:"
+    remove_one "$CLAUDE_DEST"
+fi
+
+if [ "$HARNESS" = "opencode" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "OpenCode:"
+    remove_one "$OPENCODE_DEST"
+fi
+
+if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
+    info ""
+    info "Codex CLI:"
+    remove_one "$CODEX_DEST"
+    remove_one "$CODEX_SKILLS_DEST"
+fi
+
+info ""
+if [ "$DRY_RUN" -eq 1 ]; then
+    info "Dry run complete. No files were removed."
+else
+    info "Done."
+fi
+
+exit 0

--- a/skills/autospec-playwright/validate.sh
+++ b/skills/autospec-playwright/validate.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# validate.sh — per-skill structural lint for autospec-playwright.
+# Called by the repo-level scripts/validate.sh check_autospec_playwright_skill_present.
+# Also runnable standalone from the skill directory or the repo root.
+#
+# Exits 0 on success, 1 on first failure.
+
+set -eu
+
+SKILL_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_NAME="autospec-playwright"
+
+fail() { printf 'validate(%s): FAIL — %s\n' "$SKILL_NAME" "$*" >&2; exit 1; }
+info() { printf 'validate(%s): %s\n' "$SKILL_NAME" "$*"; }
+
+# ── Required files ────────────────────────────────────────────────────────────
+for f in SKILL.md codex/prompt.md opencode/agent.md install.sh uninstall.sh README.md; do
+    [ -f "$SKILL_DIR/$f" ] || fail "missing required file: $f"
+done
+info "required files present"
+
+# ── Lockstep: SKILL.md body == codex/prompt.md (leading blank line stripped) ─
+strip_body() {
+    awk '/^---$/{c++; next} c>=2' "$1"
+}
+
+skill_body="$(strip_body "$SKILL_DIR/SKILL.md")"
+codex_body="$(cat "$SKILL_DIR/codex/prompt.md")"
+opencode_body="$(strip_body "$SKILL_DIR/opencode/agent.md")"
+
+# codex/prompt.md must start with a newline (leading blank line)
+first_byte="$(head -c1 "$SKILL_DIR/codex/prompt.md" | od -An -c | tr -d ' \n')"
+[ "$first_byte" = "\\n" ] || fail "codex/prompt.md must start with a leading blank line (first byte must be newline)"
+info "codex/prompt.md leading blank line: ok"
+
+# codex/prompt.md is compared as-is (the repo-level check_lockstep does cat codex/prompt.md)
+if ! diff <(printf '%s\n' "$skill_body") <(printf '%s\n' "$codex_body") >/dev/null 2>&1; then
+    diff <(printf '%s\n' "$skill_body") <(printf '%s\n' "$codex_body") | head -20 >&2
+    fail "SKILL.md body diverges from codex/prompt.md"
+fi
+info "lockstep SKILL.md == codex/prompt.md: ok"
+
+if ! diff <(printf '%s\n' "$skill_body") <(printf '%s\n' "$opencode_body") >/dev/null 2>&1; then
+    diff <(printf '%s\n' "$skill_body") <(printf '%s\n' "$opencode_body") | head -20 >&2
+    fail "SKILL.md body diverges from opencode/agent.md"
+fi
+info "lockstep SKILL.md == opencode/agent.md: ok"
+
+# ── SKILL.md required sections ───────────────────────────────────────────────
+grep -q '^## Self-update mode' "$SKILL_DIR/SKILL.md" \
+    || fail "SKILL.md missing '## Self-update mode' section"
+info "Self-update mode section: ok"
+
+grep -qF '**Model tier:**' "$SKILL_DIR/SKILL.md" \
+    || fail "SKILL.md missing '**Model tier:**' directive"
+info "Model tier directive: ok"
+
+grep -q '^| Subagent model tier' "$SKILL_DIR/SKILL.md" \
+    || fail "SKILL.md missing 'Subagent model tier' row in harness-adapter table"
+info "Subagent model tier row: ok"
+
+grep -q '^## Harness detection' "$SKILL_DIR/SKILL.md" \
+    || fail "SKILL.md missing '## Harness detection' section"
+grep -q 'TIER_A' "$SKILL_DIR/SKILL.md" \
+    || fail "SKILL.md Harness detection missing TIER_A"
+grep -q 'TIER_B' "$SKILL_DIR/SKILL.md" \
+    || fail "SKILL.md Harness detection missing TIER_B"
+grep -qi 'silently' "$SKILL_DIR/SKILL.md" \
+    || fail "SKILL.md Harness detection missing 'silently' fallback"
+info "Harness detection section: ok"
+
+# ── install.sh has --update ───────────────────────────────────────────────────
+grep -q -- '--update' "$SKILL_DIR/install.sh" \
+    || fail "install.sh missing --update flag handling"
+info "install.sh --update: ok"
+
+# ── bash syntax ───────────────────────────────────────────────────────────────
+bash -n "$SKILL_DIR/install.sh"   || fail "install.sh: bash syntax error"
+bash -n "$SKILL_DIR/uninstall.sh" || fail "uninstall.sh: bash syntax error"
+info "bash syntax: ok"
+
+info "all checks passed"
+exit 0


### PR DESCRIPTION
## Summary

- Adds `skills/autospec-playwright/` with lockstep trio: `SKILL.md` + `codex/prompt.md` (leading blank line) + `opencode/agent.md` with byte-identical bodies
- `SKILL.md` includes `## Self-update mode`, `**Model tier:**` (TIER_B), `## Harness detection` (TIER_A/TIER_B/silently), and the harness-adapter row with `Subagent model tier`
- Per-skill `install.sh` (with `--update`), `uninstall.sh`, `validate.sh`, and `README.md` mirroring `skills/autospec-e2e-clone/` pattern
- Registers `check_autospec_playwright_skill_present` in `scripts/validate.sh` (3 mentions total) and adds `autospec-playwright` to `install.sh` `--skill` usage string
- Dispatcher flow: detect `.autospec/test.yml` authoring blocks → invoke autospec-test Stage 2A → print coverage report from `e2e/.autospec/coverage.json`; NO machinery duplicated

## ACs verified

- [x] `SKILL.md` contains `## Self-update mode`, `**Model tier:**`, and the harness-adapter row
- [x] `head -c1 skills/autospec-playwright/codex/prompt.md | od -An -c` shows `\n` (leading blank line)
- [x] trio bodies byte-identical — validate.sh lockstep check passes
- [x] `grep -c autospec-playwright scripts/validate.sh` = 3; `install.sh` usage lists it
- [x] `bash scripts/validate.sh` exits 0

## Test plan

- [x] `bash skills/autospec-playwright/validate.sh` — all checks pass
- [x] `bash scripts/validate.sh` — exits 0

Closes #999