### PR TITLE
fix(autospec-classify): route classify-model-fit.sh through AUTOSPEC_SCRIPTS_DIR (#986)

### DIFF
--- a/skills/autospec-classify/SKILL.md
+++ b/skills/autospec-classify/SKILL.md
@@ -206,7 +206,7 @@ Default for issues that lack any of these signals: `ctx:64k`, `reasoning:medium`
 
 > **Model tier:** **deterministic-first; `TIER_B` on ambiguity (never `TIER_A`).**
 > Classification runs the deterministic
-> rubric (`scripts/classify-model-fit.sh` — file counts, verb keywords, per
+> rubric (`${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/classify-model-fit.sh` — file counts, verb keywords, per
 > tracker #421) FIRST, with **no LLM dispatch** for issues it can score
 > confidently. Only issues the rubric flags as ambiguous (confidence below
 > `LLM_ESCALATION_THRESHOLD`, default 0.3) escalate to a single `TIER_B` LLM
@@ -223,7 +223,7 @@ For each candidate issue:
    - Skip — do not modify body, do not assign a model-fit class.
 
 2. **Classify (deterministic-first).** Run the deterministic rubric first
-   (`scripts/classify-model-fit.sh <body-file>`): it assigns one `ctx:*` and one
+   (`${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/classify-model-fit.sh <body-file>`): it assigns one `ctx:*` and one
    `reasoning:*` label from file counts and verb keywords with **zero LLM cost**.
    Only when the rubric reports `deterministic:false` (confidence below
    `LLM_ESCALATION_THRESHOLD`) escalate that single ambiguous issue to one

--- a/skills/autospec-classify/codex/prompt.md
+++ b/skills/autospec-classify/codex/prompt.md
@@ -201,7 +201,7 @@ Default for issues that lack any of these signals: `ctx:64k`, `reasoning:medium`
 
 > **Model tier:** **deterministic-first; `TIER_B` on ambiguity (never `TIER_A`).**
 > Classification runs the deterministic
-> rubric (`scripts/classify-model-fit.sh` — file counts, verb keywords, per
+> rubric (`${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/classify-model-fit.sh` — file counts, verb keywords, per
 > tracker #421) FIRST, with **no LLM dispatch** for issues it can score
 > confidently. Only issues the rubric flags as ambiguous (confidence below
 > `LLM_ESCALATION_THRESHOLD`, default 0.3) escalate to a single `TIER_B` LLM
@@ -218,7 +218,7 @@ For each candidate issue:
    - Skip — do not modify body, do not assign a model-fit class.
 
 2. **Classify (deterministic-first).** Run the deterministic rubric first
-   (`scripts/classify-model-fit.sh <body-file>`): it assigns one `ctx:*` and one
+   (`${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/classify-model-fit.sh <body-file>`): it assigns one `ctx:*` and one
    `reasoning:*` label from file counts and verb keywords with **zero LLM cost**.
    Only when the rubric reports `deterministic:false` (confidence below
    `LLM_ESCALATION_THRESHOLD`) escalate that single ambiguous issue to one

--- a/skills/autospec-classify/opencode/agent.md
+++ b/skills/autospec-classify/opencode/agent.md
@@ -205,7 +205,7 @@ Default for issues that lack any of these signals: `ctx:64k`, `reasoning:medium`
 
 > **Model tier:** **deterministic-first; `TIER_B` on ambiguity (never `TIER_A`).**
 > Classification runs the deterministic
-> rubric (`scripts/classify-model-fit.sh` — file counts, verb keywords, per
+> rubric (`${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/classify-model-fit.sh` — file counts, verb keywords, per
 > tracker #421) FIRST, with **no LLM dispatch** for issues it can score
 > confidently. Only issues the rubric flags as ambiguous (confidence below
 > `LLM_ESCALATION_THRESHOLD`, default 0.3) escalate to a single `TIER_B` LLM
@@ -222,7 +222,7 @@ For each candidate issue:
    - Skip — do not modify body, do not assign a model-fit class.
 
 2. **Classify (deterministic-first).** Run the deterministic rubric first
-   (`scripts/classify-model-fit.sh <body-file>`): it assigns one `ctx:*` and one
+   (`${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/classify-model-fit.sh <body-file>`): it assigns one `ctx:*` and one
    `reasoning:*` label from file counts and verb keywords with **zero LLM cost**.
    Only when the rubric reports `deterministic:false` (confidence below
    `LLM_ESCALATION_THRESHOLD`) escalate that single ambiguous issue to one


### PR DESCRIPTION
Closes #986

## Problem
The `autospec-classify` skill trio invoked `scripts/classify-model-fit.sh` as a bare repo-relative path. Installed skills run from `~/.autospec/scripts`, so the repo-relative path does not resolve.

## Fix
Replace all 6 occurrences (2 per file) of `scripts/classify-model-fit.sh` with `\${AUTOSPEC_SCRIPTS_DIR:-\$HOME/.autospec/scripts}/classify-model-fit.sh` across the full lockstep trio:
- `skills/autospec-classify/SKILL.md`
- `skills/autospec-classify/codex/prompt.md`
- `skills/autospec-classify/opencode/agent.md`

Trio bodies remain byte-identical (lockstep preserved).

## Verification
- `bats tests/ship-completeness.bats -f 'no bare repo-relative'` — all 6 classify offenders removed (verified via grep; remaining failures in that test are pre-existing offenders in other skills, out of scope for #986).
- `bash scripts/validate.sh` — passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)