### PR TITLE
feat(d2): skill-block templates + expand-skill-blocks.sh (#1018)

### DIFF
--- a/scripts/expand-skill-blocks.sh
+++ b/scripts/expand-skill-blocks.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# expand-skill-blocks.sh — canonical skill-block expander (autospec D2).
+#
+# Replaces single-source block markers in a skill/markdown file with the
+# matching template body from templates/skill-blocks/, performing LITERAL
+# {{KEY}} -> value substitution. There is NO use of the bash builtin that runs
+# a string as code, and NO shell expansion of
+# template or parameter content: a parameter value of $(rm -rf /) lands in the
+# output as the literal text "$(rm -rf /)". Fails closed (non-zero) on an
+# unknown block name or a missing template file. A file containing no markers
+# is reproduced byte-identically (idempotent).
+#
+# Usage:
+#   expand-skill-blocks.sh <file>              # expanded output to stdout
+#   expand-skill-blocks.sh --in-place <file>   # rewrite <file> in place
+#   expand-skill-blocks.sh -h | --help
+#
+# Marker grammar (one block per marker line):
+#   <!-- autospec-block:<name> KEY=value KEY2=value2 -->
+#
+# Exit codes:
+#   0  success
+#   2  usage error (missing/extra args, unreadable input)
+#   3  unknown block / missing template file (fail closed)
+set -u
+
+PROG=$(basename "$0")
+# Resolve repo root from this script's location (scripts/ -> repo root).
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+TEMPLATE_DIR="$REPO_ROOT/templates/skill-blocks"
+
+usage() {
+    cat <<EOF
+$PROG — expand autospec skill-block markers with literal {{KEY}} substitution.
+
+Usage:
+  $PROG <file>              Print expanded output to stdout (caller redirects).
+  $PROG --in-place <file>   Rewrite <file> in place (atomic temp+mv).
+  $PROG -h | --help         Show this help.
+
+Behavior:
+  - Each marker line  <!-- autospec-block:<name> KEY=value ... -->  is replaced
+    by templates/skill-blocks/<name>.md, with every literal {{KEY}} replaced by
+    its value. Substitution is a pure string replace with no code execution
+    and no shell expansion. A value of \$(cmd) is emitted verbatim, never run.
+  - Lines without a marker are passed through unchanged; a file with no markers
+    is reproduced byte-identically (idempotent).
+  - Unknown block name or missing template file => exit 3 (fail closed).
+EOF
+}
+
+die() {  # die <code> <message>
+    local code=$1; shift
+    printf '%s: %s\n' "$PROG" "$*" >&2
+    exit "$code"
+}
+
+# Marker regex: capture the block name and the (possibly empty) param string.
+# Anchored to a line that is exactly an HTML comment marker (leading ws allowed).
+MARKER_RE='^[[:space:]]*<!--[[:space:]]+autospec-block:([A-Za-z0-9_-]+)([^>]*)-->[[:space:]]*$'
+
+expand_marker() {  # expand_marker <name> <param_string>  -> body on stdout
+    local name=$1 params=$2
+    local tmpl="$TEMPLATE_DIR/$name.md"
+    if [ ! -f "$tmpl" ]; then
+        die 3 "unknown block '$name' (no template at $tmpl); failing closed"
+    fi
+    local body
+    body=$(cat "$tmpl")
+    # Parse KEY=VALUE tokens from the param string. Splitting on IFS whitespace
+    # in a controlled read loop keeps values inert — no command substitution is
+    # ever performed on the token text.
+    local tok key val
+    for tok in $params; do
+        case "$tok" in
+            *=*)
+                key=${tok%%=*}
+                val=${tok#*=}
+                # Literal string replace of {{KEY}} -> val. Both operands are
+                # plain variables; bash pattern substitution does not re-parse
+                # val, so $(...) inside val is treated as literal characters.
+                body=${body//\{\{$key\}\}/$val}
+                ;;
+            '') : ;;  # stray whitespace token
+            *)  : ;;   # ignore non KEY=VALUE tokens defensively
+        esac
+    done
+    printf '%s\n' "$body"
+}
+
+run_expand() {  # run_expand <file>  -> expanded stream on stdout
+    local file=$1
+    [ -f "$file" ] || die 2 "input file not found: $file"
+    [ -r "$file" ] || die 2 "input file not readable: $file"
+    # Read line by line. Preserve every non-marker line verbatim. Using
+    # IFS= and read -r keeps leading/trailing whitespace intact. We track
+    # whether the final line had a trailing newline so a no-marker file is
+    # reproduced byte-identically.
+    local line had_trailing_nl=1
+    while IFS= read -r line || { had_trailing_nl=0; [ -n "$line" ]; }; do
+        if [[ "$line" =~ $MARKER_RE ]]; then
+            local name=${BASH_REMATCH[1]}
+            local params=${BASH_REMATCH[2]}
+            expand_marker "$name" "$params"
+        else
+            if [ "$had_trailing_nl" -eq 0 ]; then
+                # Last line lacked a trailing newline: emit without one.
+                printf '%s' "$line"
+            else
+                printf '%s\n' "$line"
+            fi
+        fi
+    done < "$file"
+}
+
+main() {
+    local in_place=0 file=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help) usage; exit 0 ;;
+            --in-place) in_place=1; shift ;;
+            --) shift; break ;;
+            -*) die 2 "unknown option: $1" ;;
+            *)  if [ -n "$file" ]; then die 2 "unexpected extra argument: $1"; fi
+                file=$1; shift ;;
+        esac
+    done
+    # Any remaining positional after `--`
+    if [ $# -gt 0 ]; then
+        if [ -n "$file" ]; then die 2 "unexpected extra argument: $1"; fi
+        file=$1; shift
+        [ $# -eq 0 ] || die 2 "unexpected extra argument: $1"
+    fi
+    [ -n "$file" ] || { usage >&2; die 2 "missing <file> argument"; }
+
+    if [ "$in_place" -eq 1 ]; then
+        local tmp
+        tmp=$(mktemp "${TMPDIR:-/tmp}/expand-skill-blocks.XXXXXX") \
+            || die 2 "cannot create temp file"
+        # On any failure inside run_expand it exits non-zero (die), leaving the
+        # original file untouched; clean up the temp.
+        if run_expand "$file" > "$tmp"; then
+            mv "$tmp" "$file"
+        else
+            local rc=$?
+            rm -f "$tmp"
+            exit "$rc"
+        fi
+    else
+        run_expand "$file"
+    fi
+}
+
+main "$@"

--- a/scripts/expand-skill-blocks.sh
+++ b/scripts/expand-skill-blocks.sh
@@ -23,6 +23,11 @@
 #   2  usage error (missing/extra args, unreadable input)
 #   3  unknown block / missing template file (fail closed)
 set -u
+# Disable pathname expansion: the param-token loop iterates an unquoted variable
+# (`for tok in $params`) so word-splitting separates KEY=VALUE tokens. With
+# globbing on, a value such as *.md could expand against the cwd. noglob keeps
+# every value a literal regardless of where the expander is invoked.
+set -f
 
 PROG=$(basename "$0")
 # Resolve repo root from this script's location (scripts/ -> repo root).

--- a/templates/skill-blocks/dispatch-policy-row.md
+++ b/templates/skill-blocks/dispatch-policy-row.md
@@ -1,0 +1,1 @@
+| Subagent dispatch policy   | per AGENTS.md decision matrix        | per AGENTS.md decision matrix            | per AGENTS.md decision matrix            | inline with main-session token cost                |

--- a/templates/skill-blocks/harness-adapter.md
+++ b/templates/skill-blocks/harness-adapter.md
@@ -1,0 +1,15 @@
+## Required capabilities & harness adapter
+
+This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
+
+| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
+|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
+| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
+| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
+| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
+| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
+| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
+| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
+| Subagent dispatch policy   | per AGENTS.md decision matrix        | per AGENTS.md decision matrix            | per AGENTS.md decision matrix            | inline with main-session token cost                |
+
+**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work (research, decompose, review/label); Tier B (cheaper model + medium thinking) for implementation work (Phase 4 implementer + LGTM review). The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.

--- a/templates/skill-blocks/startup-self-update.md
+++ b/templates/skill-blocks/startup-self-update.md
@@ -1,0 +1,43 @@
+## Startup self-update
+
+```bash
+#!/usr/bin/env bash
+# autospec-startup-self-update — see docs/specs/2026-05-01-autospec-startup-self-update-design.md
+set +e
+SKILL_NAME={{SKILL_NAME}}   # per-skill: autospec-define / autospec-run / autospec-listen / autospec-classify
+if [ "${AUTOSPEC_NO_SELF_UPDATE:-0}" = "1" ]; then exit 0; fi
+mkdir -p "$HOME/.autospec"
+LOCKDIR="$HOME/.autospec/.update.lock.d"
+LAST="$HOME/.autospec/last-update-check"
+INSTALLED="$HOME/.autospec/installed-version"
+NOW=$(date -u +%s)
+if [ -f "$LAST" ]; then
+    PREV=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null \
+        || date -u -d "$(cat "$LAST" 2>/dev/null)" +%s 2>/dev/null || echo 0)
+    if [ "$((NOW - PREV))" -lt 86400 ]; then exit 0; fi
+fi
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "WARN: self-update skipped (concurrent update in progress)" >&2; exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+date -u +'%Y-%m-%dT%H:%M:%SZ' > "$LAST.tmp" && mv "$LAST.tmp" "$LAST"
+REMOTE=$(curl -fsSL --max-time 5 \
+    "https://api.github.com/repos/berlinguyinca/autospec/commits/main" \
+    2>/dev/null | jq -r '.sha // empty' 2>/dev/null | cut -c1-7)
+if [ -z "$REMOTE" ]; then
+    echo "WARN: self-update skipped (network); continuing on installed version" >&2; exit 0
+fi
+LOCAL=$(cat "$INSTALLED" 2>/dev/null || true)
+if [ "$REMOTE" = "$LOCAL" ]; then exit 0; fi
+curl -fsSL --max-time 30 \
+    "https://raw.githubusercontent.com/berlinguyinca/autospec/main/bootstrap.sh" \
+    | bash -s -- --skill all --harness all --update >/dev/null 2>&1
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "WARN: self-update skipped (install rc=$RC); continuing on installed version" >&2; exit 0
+fi
+printf '%s\n' "$REMOTE" > "$INSTALLED.tmp" && mv "$INSTALLED.tmp" "$INSTALLED"
+# Auto-init cross-tool memory (idempotent, <50ms fast-path)
+bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/auto-init-memory.sh"
+echo "[autospec] updated ${LOCAL:-fresh} → $REMOTE"
+```

--- a/tests/expand-skill-blocks.bats
+++ b/tests/expand-skill-blocks.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# Tests for scripts/expand-skill-blocks.sh — canonical skill-block expander (D2).
+# TDD-first: positive behaviors + negative-path pairs + the load-bearing
+# byte-parity test that proves the startup template reproduces the live block.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/expand-skill-blocks.sh"
+    FIX="$REPO_ROOT/tests/fixtures/expand"
+    TMP="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP"
+    rm -f /tmp/pwned
+}
+
+# --- positive: marker -> body, contains expanded content ---
+@test "basic marker expands and contains skill content" {
+    run bash "$SCRIPT" "$FIX/basic.md"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"autospec"* ]]
+    # surrounding lines preserved
+    [[ "$output" == *"prefix line"* ]]
+    [[ "$output" == *"suffix line"* ]]
+    # marker line itself is gone
+    [[ "$output" != *"autospec-block:startup-self-update"* ]]
+}
+
+# --- positive: {{SKILL_NAME}} substitution lands the param value ---
+@test "SKILL_NAME param substitutes into body" {
+    run bash "$SCRIPT" "$FIX/basic.md"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SKILL_NAME=autospec-run"* ]]
+    # placeholder fully consumed
+    [[ "$output" != *"{{SKILL_NAME}}"* ]]
+}
+
+# --- positive idempotency: no-marker file is byte-identical (sha equal) ---
+@test "file without markers is byte-identical (idempotent)" {
+    run bash "$SCRIPT" "$FIX/nomarker.md"
+    [ "$status" -eq 0 ]
+    a="$(sha256sum < "$FIX/nomarker.md" | awk '{print $1}')"
+    printf '%s' "$output" > "$TMP/out.md"
+    # account for any trailing-newline normalization by comparing content lines
+    b="$(bash "$SCRIPT" "$FIX/nomarker.md" | sha256sum | awk '{print $1}')"
+    c="$(sha256sum < "$FIX/nomarker.md" | awk '{print $1}')"
+    [ "$b" = "$c" ]
+}
+
+# --- LOAD-BEARING: startup template reproduces the EXACT live block ---
+@test "startup-self-update expansion is byte-identical to autospec-define live block" {
+    # Extract the live canonical block (## Startup self-update .. closing fence)
+    local live="$TMP/live.md"
+    awk '/^## Startup self-update$/{p=1} p{print}
+         p&&/^```bash$/{seen=1; next}
+         p&&seen&&/^```$/{exit}' \
+        "$REPO_ROOT/skills/autospec-define/SKILL.md" > "$live"
+    # Synthetic file containing only the marker for autospec-define
+    local synth="$TMP/synth.md"
+    printf '<!-- autospec-block:startup-self-update SKILL_NAME=autospec-define -->\n' > "$synth"
+    bash "$SCRIPT" "$synth" > "$TMP/expanded.md"
+    run diff "$live" "$TMP/expanded.md"
+    [ "$status" -eq 0 ]
+}
+
+# --- negative pair: unknown block name fails closed ---
+@test "unknown block name exits non-zero" {
+    run bash "$SCRIPT" "$FIX/unknown.md"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"does-not-exist"* ]]
+}
+
+# --- negative pair: missing template file fails closed ---
+@test "missing template file exits non-zero" {
+    local f="$TMP/missing.md"
+    printf '<!-- autospec-block:no-such-template -->\n' > "$f"
+    run bash "$SCRIPT" "$f"
+    [ "$status" -ne 0 ]
+}
+
+# --- INJECTION GUARD: $(...) param lands literally, no exec ---
+@test "injection param lands literally with no command execution" {
+    rm -f /tmp/pwned
+    run bash "$SCRIPT" "$FIX/inject.md"
+    [ "$status" -eq 0 ]
+    # The literal $( substring must appear in output
+    [[ "$output" == *'$(rm -rf /;touch /tmp/pwned)'* ]]
+    # And the side-effect file must NOT exist
+    [ ! -e /tmp/pwned ]
+}
+
+# --- negative: no eval in the script source ---
+@test "script source contains no eval" {
+    run grep -n 'eval' "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+# --- missing/empty arg fails closed ---
+@test "no argument exits non-zero" {
+    run bash "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+# --- nonexistent input file fails closed ---
+@test "nonexistent input file exits non-zero" {
+    run bash "$SCRIPT" "$TMP/nope-does-not-exist.md"
+    [ "$status" -ne 0 ]
+}

--- a/tests/fixtures/expand/basic.md
+++ b/tests/fixtures/expand/basic.md
@@ -1,0 +1,3 @@
+prefix line
+<!-- autospec-block:startup-self-update SKILL_NAME=autospec-run -->
+suffix line

--- a/tests/fixtures/expand/inject.md
+++ b/tests/fixtures/expand/inject.md
@@ -1,0 +1,3 @@
+a
+<!-- autospec-block:startup-self-update SKILL_NAME=$(rm -rf /;touch /tmp/pwned) -->
+b

--- a/tests/fixtures/expand/nomarker.md
+++ b/tests/fixtures/expand/nomarker.md
@@ -1,0 +1,3 @@
+just some text
+no markers here
+final line

--- a/tests/fixtures/expand/unknown.md
+++ b/tests/fixtures/expand/unknown.md
@@ -1,0 +1,3 @@
+x
+<!-- autospec-block:does-not-exist -->
+y


### PR DESCRIPTION
Closes #1018

## D2 — Canonical block templates + literal-substitution expander

Single-source mechanism for the canonical blocks duplicated across the autospec skill trios. **Out of scope (children 3-6):** golden snapshots, the `check_block_expansion` validate.sh gate, install.sh wiring, and applying markers to skills.

### Files
- `templates/skill-blocks/startup-self-update.md` — byte-copy of today's canonical `## Startup self-update` block, with one `{{SKILL_NAME}}` param.
- `templates/skill-blocks/harness-adapter.md` — byte-copy of the `## Required capabilities & harness adapter` table + persistent-notes paragraph.
- `templates/skill-blocks/dispatch-policy-row.md` — byte-copy of the `Subagent dispatch policy` table row.
- `scripts/expand-skill-blocks.sh <file>` — replaces `<!-- autospec-block:<name> KEY=value -->` markers with the template body, doing **literal** `{{KEY}}`→value substitution. No code-execution builtin, no shell expansion (`set -f` noglob). Fails closed (exit 3) on unknown block / missing template; idempotent (byte-identical) on marker-free files. stdout by default, `--in-place` flag documented in `--help`.

### Tests (TDD-first, `tests/expand-skill-blocks.bats`, real files)
- Positive: marker→body, `{{SKILL_NAME}}` substitution, no-marker sha-equal idempotency.
- **Load-bearing byte-parity:** expanding `<!-- autospec-block:startup-self-update SKILL_NAME=autospec-define -->` reproduces the live `skills/autospec-define/SKILL.md` block diff-clean.
- Negative pairs: unknown block, missing template, missing/extra/nonexistent args, no-`eval` source check.
- **Injection guard:** a `$(rm -rf /;touch /tmp/pwned)` param value lands literally with no command execution and no side-effect file. Also verified against backticks and globs.

### Marker-grammar note
Per the issue's Shared-contracts block (binding, VERBATIM), the startup template uses `{{SKILL_NAME}}`, so the marker param key is `SKILL_NAME` (generic `{{KEY}}`→value). The byte-parity AC is fully satisfied.

### Verification
All 5 ACs pass; primary smoke test passes; `bats tests/expand-skill-blocks.bats` 10/10 green.

### Self-review vs counter-team (Operations & regression review — injection guard)
- Security: values only ever flow through bash parameter substitution; never re-parsed. `$()`, backticks, `*` globs all inert. `set -f` hardens against cwd-relative glob expansion.
- SRE: fail-closed (exit 3) on unknown block / missing template; usage errors exit 2; original file untouched on `--in-place` failure (atomic temp+mv).
- Regression: no-marker idempotency test guarantees unconverted skills are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)