### PR TITLE
feat(quality-differential): D4 boilerplate-guard harness + refine-lens fixtures (#1023)

### DIFF
--- a/scripts/quality-differential.sh
+++ b/scripts/quality-differential.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# scripts/quality-differential.sh — the boilerplate guard (spec §5 D4).
+#
+# Purpose
+#   When a previously LLM-driven step is "determinized" (replaced by a cheap
+#   deterministic text path), this harness proves whether the deterministic
+#   path is GOOD ENOUGH to ship — or whether the step must keep/restore its
+#   LLM path. It does so empirically, from fixtures, not from intuition.
+#
+# Usage
+#   scripts/quality-differential.sh --step <name> --fixtures <dir>
+#
+#   For each immediate fixture subdir under <dir>:
+#     1. run the named step's DETERMINISTIC path on the fixture's `input`
+#        file, capturing stdout as the deterministic output;
+#     2. evaluate that output via the fixture's own `assert.sh`, which checks
+#        SIGNAL PROPERTIES (NOT string equality) — e.g. "output references
+#        >=2 content tokens from the input prompt", "no canned boilerplate
+#        markers". `assert.sh` is invoked as:
+#            bash <fixture>/assert.sh <det-output-file> <llm-golden-file>
+#        and must exit 0 (pass) / non-zero (fail).
+#
+#   The harness exits NON-ZERO if ANY fixture's assert fails. A non-zero exit
+#   is the verdict: "this step must keep/restore its LLM path." A zero exit
+#   means the deterministic path carries the same signal as the LLM golden on
+#   every fixture and is safe to ship.
+#
+# Fixture layout (per fixture subdir)
+#   input        Input file(s) for the step. For `refine-lenses` this is the
+#                raw operator prompt; the deterministic lens output produced
+#                FROM it is what gets asserted.
+#   llm-golden   Recorded LLM output for the same input, kept for reference
+#                and passed to assert.sh as $2 (assertions MAY compare signal
+#                properties against it, but MUST NOT do string equality).
+#   assert.sh    Signal-property checks. Receives ($1 det-output-file,
+#                $2 llm-golden-file). Exit 0 pass / non-zero fail.
+#
+# Steps
+#   synthetic       Self-test step (see run_step_synthetic). Echoes the input
+#                   verbatim — fixtures decide pass/fail, so the suite ships a
+#                   negative-path pair (one signal-bearing PASS fixture, one
+#                   canned-string FAIL fixture).
+#   refine-lenses   First real consumer. Runs the REAL deterministic refine
+#                   lens path (scripts/refine-prompt.sh --lens-mode
+#                   deterministic) on the fixture prompt. Per spec §7 this is
+#                   EXPECTED TO FAIL the asserts (the deterministic lenses
+#                   append canned boilerplate such as the literal
+#                   "What happens on empty input?"), so the harness exits
+#                   non-zero — that failing verdict is the documented success
+#                   condition for keeping the LLM path on refine lenses.
+#
+# Bash rules (repo gotchas)
+#   set -eu; NO RETURN traps; if/then/fi (never `[ x ] && y`) for one-sided
+#   conditionals under set -e; inline cleanup only.
+#
+# Exit codes
+#   0  every fixture passed its assert (deterministic path is safe)
+#   1  >=1 fixture failed its assert (step must keep/restore LLM path)
+#   2  usage / bad args / no fixtures found / unknown step
+
+set -eu
+
+PROG="quality-differential.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  quality-differential.sh --step <name> --fixtures <dir>
+
+For each fixture subdir under <dir>, run the step's deterministic path on the
+fixture's `input` and evaluate the output via the fixture's `assert.sh`
+(signal-property checks, NOT string equality). Exit non-zero if ANY fixture
+fails => verdict: "step must keep/restore its LLM path."
+
+Fixture layout (per subdir):
+  input        input file for the step
+  llm-golden   recorded LLM output (reference; passed to assert.sh as $2)
+  assert.sh    signal-property checks; argv: <det-output-file> <llm-golden-file>
+
+Steps:
+  synthetic       self-test step (echoes input verbatim; fixtures decide)
+  refine-lenses   real deterministic refine-prompt.sh lens path (expected FAIL
+                  per spec §7 — non-zero exit is the documented verdict)
+
+Exit codes:
+  0  all fixtures passed (deterministic path safe)
+  1  >=1 fixture failed (keep/restore LLM path)
+  2  usage / no fixtures / unknown step
+EOF
+}
+
+die() {
+    # die <exit-code> <message...>
+    local code="$1"; shift
+    printf '%s: %s\n' "$PROG" "$*" >&2
+    exit "$code"
+}
+
+# ---------------------------------------------------------------------------
+# Deterministic step paths
+# ---------------------------------------------------------------------------
+# Each step reads an input file path ($1) and writes its deterministic output
+# to stdout. Adding a new determinized step == adding one run_step_<name>.
+
+# synthetic — self-test step. Echoes input verbatim so that the FIXTURES (via
+# their assert.sh) decide pass/fail. This lets the self-test ship a
+# negative-path pair without any step-specific logic.
+run_step_synthetic() {
+    local input="$1"
+    cat "$input"
+}
+
+# refine-lenses — the real first consumer. Runs the actual deterministic refine
+# lens path on the operator prompt held in the fixture's `input`. The
+# deterministic output is what gets asserted (and is expected to fail).
+run_step_refine_lenses() {
+    local input="$1"
+    local refine="$SCRIPT_DIR/refine-prompt.sh"
+    if [ ! -x "$refine" ]; then
+        die 2 "refine-lenses: $refine not found/executable"
+    fi
+    local outfile
+    outfile="$(mktemp -t qd-refine.XXXXXX)"
+    local artdir
+    artdir="$(mktemp -d -t qd-refine-art.XXXXXX)"
+    # Force the deterministic lens path; dry-run avoids any handoff. We capture
+    # the refined prompt via --output. Failures are surfaced, not swallowed.
+    if AUTOSPEC_REFINE_LENS_MODE=deterministic bash "$refine" \
+            --from-file "$input" \
+            --lens-mode deterministic \
+            --rounds 4 \
+            --dry-run \
+            --output "$outfile" \
+            --artifact-dir "$artdir" \
+            --repo-root "$SCRIPT_DIR/.." >/dev/null 2>&1; then
+        cat "$outfile"
+        rm -rf "$outfile" "$artdir"
+    else
+        rm -rf "$outfile" "$artdir"
+        die 2 "refine-lenses: refine-prompt.sh deterministic run failed for $input"
+    fi
+}
+
+run_deterministic_step() {
+    # run_deterministic_step <step-name> <input-file>  -> stdout
+    local name="$1" input="$2"
+    case "$name" in
+        synthetic)     run_step_synthetic "$input" ;;
+        refine-lenses) run_step_refine_lenses "$input" ;;
+        *)             die 2 "unknown step: $name (known: synthetic, refine-lenses)" ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+STEP=""
+FIXTURES=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --step)     [ $# -ge 2 ] || die 2 "--step requires a value"; STEP="$2"; shift 2 ;;
+        --fixtures) [ $# -ge 2 ] || die 2 "--fixtures requires a value"; FIXTURES="$2"; shift 2 ;;
+        -h|--help)  usage; exit 0 ;;
+        *)          die 2 "unknown arg: $1" ;;
+    esac
+done
+
+if [ -z "$STEP" ]; then
+    die 2 "--step is required"
+fi
+if [ -z "$FIXTURES" ]; then
+    die 2 "--fixtures is required"
+fi
+if [ ! -d "$FIXTURES" ]; then
+    die 2 "--fixtures dir not found: $FIXTURES"
+fi
+
+# Validate the step name early (so an empty fixture dir + bad step still errors
+# with the right code path rather than silently passing).
+case "$STEP" in
+    synthetic|refine-lenses) ;;
+    *) die 2 "unknown step: $STEP (known: synthetic, refine-lenses)" ;;
+esac
+
+rc=0
+fixture_count=0
+
+for fdir in "$FIXTURES"/*/; do
+    # Guard against a literal glob when no subdirs exist.
+    if [ ! -d "$fdir" ]; then
+        continue
+    fi
+    fdir="${fdir%/}"
+    local_input="$fdir/input"
+    local_golden="$fdir/llm-golden"
+    local_assert="$fdir/assert.sh"
+
+    if [ ! -f "$local_input" ]; then
+        printf 'SKIP %s (no input file)\n' "$fdir" >&2
+        continue
+    fi
+    if [ ! -f "$local_assert" ]; then
+        printf 'SKIP %s (no assert.sh)\n' "$fdir" >&2
+        continue
+    fi
+
+    fixture_count=$((fixture_count + 1))
+
+    # Run the deterministic step, capturing stdout to a temp file.
+    det_out="$(mktemp -t qd-det.XXXXXX)"
+    if ! run_deterministic_step "$STEP" "$local_input" >"$det_out" 2>/dev/null; then
+        printf 'FAIL %s (deterministic step errored)\n' "$fdir" >&2
+        rm -f "$det_out"
+        rc=1
+        continue
+    fi
+
+    # llm-golden is optional; pass an empty file if absent so assert.sh sees a
+    # readable $2 either way.
+    golden_arg="$local_golden"
+    if [ ! -f "$local_golden" ]; then
+        golden_arg="$(mktemp -t qd-golden-empty.XXXXXX)"
+    fi
+
+    if bash "$local_assert" "$det_out" "$golden_arg" >&2; then
+        printf 'PASS %s\n' "$fdir" >&2
+    else
+        printf 'FAIL %s (assert.sh signal check failed)\n' "$fdir" >&2
+        rc=1
+    fi
+
+    rm -f "$det_out"
+    if [ "$golden_arg" != "$local_golden" ]; then
+        rm -f "$golden_arg"
+    fi
+done
+
+if [ "$fixture_count" -eq 0 ]; then
+    die 2 "no usable fixtures found under $FIXTURES"
+fi
+
+if [ "$rc" -ne 0 ]; then
+    printf '%s: VERDICT step=%s — deterministic path BELOW BAR; keep/restore LLM path\n' "$PROG" "$STEP" >&2
+else
+    printf '%s: VERDICT step=%s — deterministic path OK on all %d fixtures\n' "$PROG" "$STEP" "$fixture_count" >&2
+fi
+
+exit "$rc"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1722,6 +1722,29 @@ check_lint_heredoc_handling() {
     fi
 }
 
+# Quality-differential harness (issue #1023, spec §5 D4): the boilerplate guard
+# (scripts/quality-differential.sh) plus its synthetic self-test negative pair
+# and the >=3 refine-lens fixtures whose deterministic path is the documented
+# KEEP-LLM failure.
+check_quality_differential() {
+    info "quality-differential harness: scripts/quality-differential.sh + tests/quality-differential.bats"
+    [ -f scripts/quality-differential.sh ] \
+        || fail "scripts/quality-differential.sh: missing (issue #1023)"
+    [ -f tests/quality-differential.bats ] \
+        || fail "tests/quality-differential.bats: bats coverage missing (issue #1023)"
+    bash -n scripts/quality-differential.sh \
+        || fail "scripts/quality-differential.sh: bash -n failed"
+    local refine_count
+    refine_count="$(ls tests/fixtures/quality-diff/refine-lenses/*/assert.sh 2>/dev/null | wc -l | tr -d ' ')"
+    [ "${refine_count:-0}" -ge 3 ] \
+        || fail "tests/fixtures/quality-diff/refine-lenses: need >=3 fixtures with assert.sh (got ${refine_count:-0})"
+    if command -v bats >/dev/null 2>&1; then
+        info "  running: tests/quality-differential.bats"
+        bats tests/quality-differential.bats >/tmp/validate-quality-diff.log 2>&1 \
+            || { cat /tmp/validate-quality-diff.log >&2; fail "tests/quality-differential.bats: failed"; }
+    fi
+}
+
 # Autonomous-mode contract (issue #662): the autospec + autospec-listen +
 # autospec-define + autospec-run trios each carry an "## Autonomous mode"
 # section, the autonomy-gate script is installed, and the bats coverage exists.
@@ -2179,6 +2202,7 @@ main() {
     check_lint_implementation_helpers
     check_implementer_contract
     check_lint_heredoc_handling
+    check_quality_differential
     check_usage_limit_helper
     check_supersession_contract
     check_phase4_guardian_block_lockstep

--- a/tests/fixtures/quality-diff/README.md
+++ b/tests/fixtures/quality-diff/README.md
@@ -1,0 +1,40 @@
+<!-- Quality-differential fixtures (issue #1023, spec §5 D4). -->
+
+# quality-diff fixtures
+
+Fixtures consumed by `scripts/quality-differential.sh --step <name> --fixtures
+<dir>` — the boilerplate guard. The harness runs a determinized step's
+deterministic path on each fixture's `input`, then evaluates the output through
+the fixture's own `assert.sh` (signal-property checks, **not** string equality).
+The harness exits non-zero if **any** fixture fails its assert, and that
+non-zero exit is the verdict: *the step must keep/restore its LLM path.*
+
+## Fixture layout (per `<step>/<fixture>/` subdir)
+
+| File         | Role                                                                                  |
+|--------------|---------------------------------------------------------------------------------------|
+| `input`      | Input file(s) for the step. For `refine-lenses` this is the raw operator prompt.       |
+| `llm-golden` | Recorded LLM output for that input. Reference only; passed to `assert.sh` as `$2`.     |
+| `assert.sh`  | Signal-property checks. Argv: `<det-output-file> <llm-golden-file>`. Exit 0 pass.      |
+
+`assert.sh` MUST check signal properties, never string equality. The shipped
+contract checks two properties:
+
+1. **Content-token coverage** — the deterministic output references ≥2 distinct
+   content tokens (≥4-char, non-stopword) drawn from the `llm-golden`, proving
+   the output is about the right thing.
+2. **No canned boilerplate** — the output contains none of the known
+   template-only markers (e.g. the literal `What happens on empty input?`) that
+   a padding path emits regardless of input.
+
+## Steps / dirs
+
+- `synth/` — self-test for the `synthetic` step (echoes input verbatim). A
+  negative-path pair: `pass-signal/` passes, `fail-canned/` carries a canned
+  marker and fails, so the harness exits non-zero over the pair.
+- `refine-lenses/` — the real first consumer. `input` holds a raw operator
+  prompt; the harness runs the actual `scripts/refine-prompt.sh --lens-mode
+  deterministic` path on it. The deterministic lenses append canned boilerplate,
+  so every fixture fails and the harness exits non-zero — the documented
+  spec §7 KEEP-LLM verdict for refine lenses. The 3 prompts were recorded from
+  real `refine-prompt.sh` lens runs.

--- a/tests/fixtures/quality-diff/refine-lenses/caching-profile-api/assert.sh
+++ b/tests/fixtures/quality-diff/refine-lenses/caching-profile-api/assert.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# assert.sh — signal-property checks for a determinized-step output.
+#
+# Invoked by scripts/quality-differential.sh as:
+#     bash assert.sh <det-output-file> <llm-golden-file>
+#
+# These are SIGNAL-PROPERTY checks, NOT string equality. They verify that the
+# deterministic output carries the same useful signal a human/LLM refinement
+# would, without demanding byte identity:
+#
+#   1. Content-token coverage: the deterministic output references >=2 distinct
+#      "content tokens" (lowercased words >=4 chars, excluding stopwords) drawn
+#      from the llm-golden reference. Proves the output is ABOUT the right
+#      thing, not generic.
+#   2. No canned boilerplate: the output contains none of the known canned
+#      boilerplate markers that a template-only path emits regardless of input
+#      (e.g. the literal "What happens on empty input?"). Their presence is the
+#      tell-tale of a deterministic path that pads instead of reasoning.
+#
+# Exit 0 = pass (signal present, no boilerplate); non-zero = fail.
+
+set -eu
+
+DET_OUT="${1:?det-output file required}"
+GOLDEN="${2:?llm-golden file required}"
+
+# Canned boilerplate markers emitted verbatim by the deterministic refine
+# lenses regardless of the input prompt. Any of these in the output is a fail.
+CANNED_MARKERS=(
+    "What happens on empty input?"
+    "What happens on malformed input?"
+    "What forbidden paths could the change accidentally touch?"
+)
+
+fail() {
+    printf 'assert: FAIL — %s\n' "$*" >&2
+    exit 1
+}
+
+# ── Check 2 first (cheap, decisive): no canned boilerplate markers. ──
+for marker in "${CANNED_MARKERS[@]}"; do
+    if grep -qF "$marker" "$DET_OUT"; then
+        fail "canned boilerplate marker present: \"$marker\""
+    fi
+done
+
+# ── Check 1: content-token coverage vs the llm-golden. ──
+# Stopwords kept short and generic so the check stays signal-focused.
+STOPWORDS=" the and that this with from your into when then should must will have been your shall does each onto over under more most some such only also they them their there here what which while where -- "
+
+# Build the set of content tokens from the golden (lowercased, alnum, >=4 chars,
+# de-duplicated, stopwords removed).
+golden_tokens="$(tr '[:upper:]' '[:lower:]' < "$GOLDEN" \
+    | tr -cs 'a-z0-9' '\n' \
+    | awk 'length($0) >= 4' \
+    | sort -u)"
+
+matches=0
+while IFS= read -r tok; do
+    if [ -z "$tok" ]; then
+        continue
+    fi
+    case "$STOPWORDS" in
+        *" $tok "*) continue ;;
+    esac
+    if grep -qiwF "$tok" "$DET_OUT"; then
+        matches=$((matches + 1))
+    fi
+    if [ "$matches" -ge 2 ]; then
+        break
+    fi
+done <<EOF
+$golden_tokens
+EOF
+
+if [ "$matches" -lt 2 ]; then
+    fail "content-token coverage below 2 (got $matches) — output not grounded in the input/golden"
+fi
+
+printf 'assert: PASS — %d+ content tokens, no canned boilerplate\n' "$matches" >&2
+exit 0

--- a/tests/fixtures/quality-diff/refine-lenses/caching-profile-api/input
+++ b/tests/fixtures/quality-diff/refine-lenses/caching-profile-api/input
@@ -1,0 +1,1 @@
+Add a caching layer to the user profile API endpoint to reduce database load on repeated reads.

--- a/tests/fixtures/quality-diff/refine-lenses/caching-profile-api/llm-golden
+++ b/tests/fixtures/quality-diff/refine-lenses/caching-profile-api/llm-golden
@@ -1,0 +1,7 @@
+Implement a read-through cache in front of the user profile API endpoint to cut
+database load on repeated reads. Specify a configurable TTL, invalidate cached
+profiles on write, and fall back to a direct database read when the cache
+backend is unreachable. Acceptance: a cold read populates the cache; a warm read
+serves from cache without a database query; a profile write evicts the stale
+entry; cache-backend outage degrades to direct reads with no errors surfaced to
+callers.

--- a/tests/fixtures/quality-diff/refine-lenses/csv-export-stream/assert.sh
+++ b/tests/fixtures/quality-diff/refine-lenses/csv-export-stream/assert.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# assert.sh — signal-property checks for a determinized-step output.
+#
+# Invoked by scripts/quality-differential.sh as:
+#     bash assert.sh <det-output-file> <llm-golden-file>
+#
+# These are SIGNAL-PROPERTY checks, NOT string equality. They verify that the
+# deterministic output carries the same useful signal a human/LLM refinement
+# would, without demanding byte identity:
+#
+#   1. Content-token coverage: the deterministic output references >=2 distinct
+#      "content tokens" (lowercased words >=4 chars, excluding stopwords) drawn
+#      from the llm-golden reference. Proves the output is ABOUT the right
+#      thing, not generic.
+#   2. No canned boilerplate: the output contains none of the known canned
+#      boilerplate markers that a template-only path emits regardless of input
+#      (e.g. the literal "What happens on empty input?"). Their presence is the
+#      tell-tale of a deterministic path that pads instead of reasoning.
+#
+# Exit 0 = pass (signal present, no boilerplate); non-zero = fail.
+
+set -eu
+
+DET_OUT="${1:?det-output file required}"
+GOLDEN="${2:?llm-golden file required}"
+
+# Canned boilerplate markers emitted verbatim by the deterministic refine
+# lenses regardless of the input prompt. Any of these in the output is a fail.
+CANNED_MARKERS=(
+    "What happens on empty input?"
+    "What happens on malformed input?"
+    "What forbidden paths could the change accidentally touch?"
+)
+
+fail() {
+    printf 'assert: FAIL — %s\n' "$*" >&2
+    exit 1
+}
+
+# ── Check 2 first (cheap, decisive): no canned boilerplate markers. ──
+for marker in "${CANNED_MARKERS[@]}"; do
+    if grep -qF "$marker" "$DET_OUT"; then
+        fail "canned boilerplate marker present: \"$marker\""
+    fi
+done
+
+# ── Check 1: content-token coverage vs the llm-golden. ──
+# Stopwords kept short and generic so the check stays signal-focused.
+STOPWORDS=" the and that this with from your into when then should must will have been your shall does each onto over under more most some such only also they them their there here what which while where -- "
+
+# Build the set of content tokens from the golden (lowercased, alnum, >=4 chars,
+# de-duplicated, stopwords removed).
+golden_tokens="$(tr '[:upper:]' '[:lower:]' < "$GOLDEN" \
+    | tr -cs 'a-z0-9' '\n' \
+    | awk 'length($0) >= 4' \
+    | sort -u)"
+
+matches=0
+while IFS= read -r tok; do
+    if [ -z "$tok" ]; then
+        continue
+    fi
+    case "$STOPWORDS" in
+        *" $tok "*) continue ;;
+    esac
+    if grep -qiwF "$tok" "$DET_OUT"; then
+        matches=$((matches + 1))
+    fi
+    if [ "$matches" -ge 2 ]; then
+        break
+    fi
+done <<EOF
+$golden_tokens
+EOF
+
+if [ "$matches" -lt 2 ]; then
+    fail "content-token coverage below 2 (got $matches) — output not grounded in the input/golden"
+fi
+
+printf 'assert: PASS — %d+ content tokens, no canned boilerplate\n' "$matches" >&2
+exit 0

--- a/tests/fixtures/quality-diff/refine-lenses/csv-export-stream/input
+++ b/tests/fixtures/quality-diff/refine-lenses/csv-export-stream/input
@@ -1,0 +1,1 @@
+Build a CSV export feature for the inventory dashboard that streams large datasets without exhausting memory.

--- a/tests/fixtures/quality-diff/refine-lenses/csv-export-stream/llm-golden
+++ b/tests/fixtures/quality-diff/refine-lenses/csv-export-stream/llm-golden
@@ -1,0 +1,8 @@
+Add a streaming CSV export to the inventory dashboard that handles large
+datasets without exhausting memory. Page the inventory query and write rows to
+the response stream incrementally rather than buffering the full result set,
+emit a Content-Disposition attachment header, and flush periodically so the
+download starts promptly. Acceptance: exporting a multi-hundred-thousand-row
+inventory completes within a bounded memory envelope; the streamed file opens
+cleanly in a spreadsheet; a query error mid-stream is surfaced without producing
+a truncated file that looks complete.

--- a/tests/fixtures/quality-diff/refine-lenses/oauth-token-refresh/assert.sh
+++ b/tests/fixtures/quality-diff/refine-lenses/oauth-token-refresh/assert.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# assert.sh — signal-property checks for a determinized-step output.
+#
+# Invoked by scripts/quality-differential.sh as:
+#     bash assert.sh <det-output-file> <llm-golden-file>
+#
+# These are SIGNAL-PROPERTY checks, NOT string equality. They verify that the
+# deterministic output carries the same useful signal a human/LLM refinement
+# would, without demanding byte identity:
+#
+#   1. Content-token coverage: the deterministic output references >=2 distinct
+#      "content tokens" (lowercased words >=4 chars, excluding stopwords) drawn
+#      from the llm-golden reference. Proves the output is ABOUT the right
+#      thing, not generic.
+#   2. No canned boilerplate: the output contains none of the known canned
+#      boilerplate markers that a template-only path emits regardless of input
+#      (e.g. the literal "What happens on empty input?"). Their presence is the
+#      tell-tale of a deterministic path that pads instead of reasoning.
+#
+# Exit 0 = pass (signal present, no boilerplate); non-zero = fail.
+
+set -eu
+
+DET_OUT="${1:?det-output file required}"
+GOLDEN="${2:?llm-golden file required}"
+
+# Canned boilerplate markers emitted verbatim by the deterministic refine
+# lenses regardless of the input prompt. Any of these in the output is a fail.
+CANNED_MARKERS=(
+    "What happens on empty input?"
+    "What happens on malformed input?"
+    "What forbidden paths could the change accidentally touch?"
+)
+
+fail() {
+    printf 'assert: FAIL — %s\n' "$*" >&2
+    exit 1
+}
+
+# ── Check 2 first (cheap, decisive): no canned boilerplate markers. ──
+for marker in "${CANNED_MARKERS[@]}"; do
+    if grep -qF "$marker" "$DET_OUT"; then
+        fail "canned boilerplate marker present: \"$marker\""
+    fi
+done
+
+# ── Check 1: content-token coverage vs the llm-golden. ──
+# Stopwords kept short and generic so the check stays signal-focused.
+STOPWORDS=" the and that this with from your into when then should must will have been your shall does each onto over under more most some such only also they them their there here what which while where -- "
+
+# Build the set of content tokens from the golden (lowercased, alnum, >=4 chars,
+# de-duplicated, stopwords removed).
+golden_tokens="$(tr '[:upper:]' '[:lower:]' < "$GOLDEN" \
+    | tr -cs 'a-z0-9' '\n' \
+    | awk 'length($0) >= 4' \
+    | sort -u)"
+
+matches=0
+while IFS= read -r tok; do
+    if [ -z "$tok" ]; then
+        continue
+    fi
+    case "$STOPWORDS" in
+        *" $tok "*) continue ;;
+    esac
+    if grep -qiwF "$tok" "$DET_OUT"; then
+        matches=$((matches + 1))
+    fi
+    if [ "$matches" -ge 2 ]; then
+        break
+    fi
+done <<EOF
+$golden_tokens
+EOF
+
+if [ "$matches" -lt 2 ]; then
+    fail "content-token coverage below 2 (got $matches) — output not grounded in the input/golden"
+fi
+
+printf 'assert: PASS — %d+ content tokens, no canned boilerplate\n' "$matches" >&2
+exit 0

--- a/tests/fixtures/quality-diff/refine-lenses/oauth-token-refresh/input
+++ b/tests/fixtures/quality-diff/refine-lenses/oauth-token-refresh/input
@@ -1,0 +1,1 @@
+Implement OAuth2 token refresh in the mobile authentication module so expired sessions renew silently.

--- a/tests/fixtures/quality-diff/refine-lenses/oauth-token-refresh/llm-golden
+++ b/tests/fixtures/quality-diff/refine-lenses/oauth-token-refresh/llm-golden
@@ -1,0 +1,7 @@
+Add silent OAuth2 token refresh to the mobile authentication module so an
+expired access token is renewed from the refresh token without interrupting the
+user. Detect expiry from the token expiry claim, exchange the refresh token for
+a new access token, retry the original request once, and force re-authentication
+only when the refresh token itself is rejected. Acceptance: an expired session
+renews transparently; a revoked refresh token surfaces a re-login prompt; a
+single in-flight refresh is shared across concurrent requests.

--- a/tests/fixtures/quality-diff/synth/fail-canned/assert.sh
+++ b/tests/fixtures/quality-diff/synth/fail-canned/assert.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# assert.sh — signal-property checks for a determinized-step output.
+#
+# Invoked by scripts/quality-differential.sh as:
+#     bash assert.sh <det-output-file> <llm-golden-file>
+#
+# These are SIGNAL-PROPERTY checks, NOT string equality. They verify that the
+# deterministic output carries the same useful signal a human/LLM refinement
+# would, without demanding byte identity:
+#
+#   1. Content-token coverage: the deterministic output references >=2 distinct
+#      "content tokens" (lowercased words >=4 chars, excluding stopwords) drawn
+#      from the llm-golden reference. Proves the output is ABOUT the right
+#      thing, not generic.
+#   2. No canned boilerplate: the output contains none of the known canned
+#      boilerplate markers that a template-only path emits regardless of input
+#      (e.g. the literal "What happens on empty input?"). Their presence is the
+#      tell-tale of a deterministic path that pads instead of reasoning.
+#
+# Exit 0 = pass (signal present, no boilerplate); non-zero = fail.
+
+set -eu
+
+DET_OUT="${1:?det-output file required}"
+GOLDEN="${2:?llm-golden file required}"
+
+# Canned boilerplate markers emitted verbatim by the deterministic refine
+# lenses regardless of the input prompt. Any of these in the output is a fail.
+CANNED_MARKERS=(
+    "What happens on empty input?"
+    "What happens on malformed input?"
+    "What forbidden paths could the change accidentally touch?"
+)
+
+fail() {
+    printf 'assert: FAIL — %s\n' "$*" >&2
+    exit 1
+}
+
+# ── Check 2 first (cheap, decisive): no canned boilerplate markers. ──
+for marker in "${CANNED_MARKERS[@]}"; do
+    if grep -qF "$marker" "$DET_OUT"; then
+        fail "canned boilerplate marker present: \"$marker\""
+    fi
+done
+
+# ── Check 1: content-token coverage vs the llm-golden. ──
+# Stopwords kept short and generic so the check stays signal-focused.
+STOPWORDS=" the and that this with from your into when then should must will have been your shall does each onto over under more most some such only also they them their there here what which while where -- "
+
+# Build the set of content tokens from the golden (lowercased, alnum, >=4 chars,
+# de-duplicated, stopwords removed).
+golden_tokens="$(tr '[:upper:]' '[:lower:]' < "$GOLDEN" \
+    | tr -cs 'a-z0-9' '\n' \
+    | awk 'length($0) >= 4' \
+    | sort -u)"
+
+matches=0
+while IFS= read -r tok; do
+    if [ -z "$tok" ]; then
+        continue
+    fi
+    case "$STOPWORDS" in
+        *" $tok "*) continue ;;
+    esac
+    if grep -qiwF "$tok" "$DET_OUT"; then
+        matches=$((matches + 1))
+    fi
+    if [ "$matches" -ge 2 ]; then
+        break
+    fi
+done <<EOF
+$golden_tokens
+EOF
+
+if [ "$matches" -lt 2 ]; then
+    fail "content-token coverage below 2 (got $matches) — output not grounded in the input/golden"
+fi
+
+printf 'assert: PASS — %d+ content tokens, no canned boilerplate\n' "$matches" >&2
+exit 0

--- a/tests/fixtures/quality-diff/synth/fail-canned/input
+++ b/tests/fixtures/quality-diff/synth/fail-canned/input
@@ -1,0 +1,6 @@
+Refine this prompt.
+
+## Adversarial review
+- What happens on empty input? Add a test.
+- What happens on malformed input? Add a test.
+- What forbidden paths could the change accidentally touch? Enforce allowlist.

--- a/tests/fixtures/quality-diff/synth/fail-canned/llm-golden
+++ b/tests/fixtures/quality-diff/synth/fail-canned/llm-golden
@@ -1,0 +1,1 @@
+Implement a read-through cache for the user profile API endpoint with a configurable TTL, write-through invalidation, and graceful database fallback when the cache backend is unreachable.

--- a/tests/fixtures/quality-diff/synth/pass-signal/assert.sh
+++ b/tests/fixtures/quality-diff/synth/pass-signal/assert.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# assert.sh — signal-property checks for a determinized-step output.
+#
+# Invoked by scripts/quality-differential.sh as:
+#     bash assert.sh <det-output-file> <llm-golden-file>
+#
+# These are SIGNAL-PROPERTY checks, NOT string equality. They verify that the
+# deterministic output carries the same useful signal a human/LLM refinement
+# would, without demanding byte identity:
+#
+#   1. Content-token coverage: the deterministic output references >=2 distinct
+#      "content tokens" (lowercased words >=4 chars, excluding stopwords) drawn
+#      from the llm-golden reference. Proves the output is ABOUT the right
+#      thing, not generic.
+#   2. No canned boilerplate: the output contains none of the known canned
+#      boilerplate markers that a template-only path emits regardless of input
+#      (e.g. the literal "What happens on empty input?"). Their presence is the
+#      tell-tale of a deterministic path that pads instead of reasoning.
+#
+# Exit 0 = pass (signal present, no boilerplate); non-zero = fail.
+
+set -eu
+
+DET_OUT="${1:?det-output file required}"
+GOLDEN="${2:?llm-golden file required}"
+
+# Canned boilerplate markers emitted verbatim by the deterministic refine
+# lenses regardless of the input prompt. Any of these in the output is a fail.
+CANNED_MARKERS=(
+    "What happens on empty input?"
+    "What happens on malformed input?"
+    "What forbidden paths could the change accidentally touch?"
+)
+
+fail() {
+    printf 'assert: FAIL — %s\n' "$*" >&2
+    exit 1
+}
+
+# ── Check 2 first (cheap, decisive): no canned boilerplate markers. ──
+for marker in "${CANNED_MARKERS[@]}"; do
+    if grep -qF "$marker" "$DET_OUT"; then
+        fail "canned boilerplate marker present: \"$marker\""
+    fi
+done
+
+# ── Check 1: content-token coverage vs the llm-golden. ──
+# Stopwords kept short and generic so the check stays signal-focused.
+STOPWORDS=" the and that this with from your into when then should must will have been your shall does each onto over under more most some such only also they them their there here what which while where -- "
+
+# Build the set of content tokens from the golden (lowercased, alnum, >=4 chars,
+# de-duplicated, stopwords removed).
+golden_tokens="$(tr '[:upper:]' '[:lower:]' < "$GOLDEN" \
+    | tr -cs 'a-z0-9' '\n' \
+    | awk 'length($0) >= 4' \
+    | sort -u)"
+
+matches=0
+while IFS= read -r tok; do
+    if [ -z "$tok" ]; then
+        continue
+    fi
+    case "$STOPWORDS" in
+        *" $tok "*) continue ;;
+    esac
+    if grep -qiwF "$tok" "$DET_OUT"; then
+        matches=$((matches + 1))
+    fi
+    if [ "$matches" -ge 2 ]; then
+        break
+    fi
+done <<EOF
+$golden_tokens
+EOF
+
+if [ "$matches" -lt 2 ]; then
+    fail "content-token coverage below 2 (got $matches) — output not grounded in the input/golden"
+fi
+
+printf 'assert: PASS — %d+ content tokens, no canned boilerplate\n' "$matches" >&2
+exit 0

--- a/tests/fixtures/quality-diff/synth/pass-signal/input
+++ b/tests/fixtures/quality-diff/synth/pass-signal/input
@@ -1,0 +1,1 @@
+Add a caching layer to the user profile API endpoint to reduce database load on repeated reads. The cache should honor a configurable TTL, invalidate on profile writes, and degrade gracefully to a direct database read when the cache backend is unreachable.

--- a/tests/fixtures/quality-diff/synth/pass-signal/llm-golden
+++ b/tests/fixtures/quality-diff/synth/pass-signal/llm-golden
@@ -1,0 +1,1 @@
+Implement a read-through cache for the user profile API endpoint. Use a configurable TTL, invalidate cache entries when a profile is written, and fall back to a direct database read if the cache backend is unreachable so reads never fail.

--- a/tests/quality-differential.bats
+++ b/tests/quality-differential.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# tests/quality-differential.bats — coverage for scripts/quality-differential.sh
+# (spec §5 D4: the boilerplate guard).
+#
+# Real files, no mocks. Two layers:
+#   * Self-test with the synthetic step — a negative-path pair: the
+#     signal-bearing fixture PASSES, the canned-string fixture FAILS, and the
+#     harness exits non-zero because ANY fixture failing is a fail.
+#   * The real first consumer, refine-lenses — per spec §7 the deterministic
+#     lens path is EXPECTED to fail (it appends canned boilerplate), so the
+#     harness exiting NON-ZERO on refine-lenses is the documented success
+#     condition for this issue.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+BIN="$REPO_ROOT/scripts/quality-differential.sh"
+SYNTH_FIX="$REPO_ROOT/tests/fixtures/quality-diff/synth"
+REFINE_FIX="$REPO_ROOT/tests/fixtures/quality-diff/refine-lenses"
+
+setup() {
+    TMPWORK="$(mktemp -d -t qd-bats.XXXXXX)"
+}
+
+teardown() {
+    if [ -n "${TMPWORK:-}" ]; then
+        rm -rf "$TMPWORK"
+    fi
+}
+
+# ── usage / arg handling ──────────────────────────────────────────
+
+@test "missing --step errors with usage exit 2" {
+    run bash "$BIN" --fixtures "$SYNTH_FIX"
+    [ "$status" -eq 2 ]
+}
+
+@test "missing --fixtures errors with usage exit 2" {
+    run bash "$BIN" --step synthetic
+    [ "$status" -eq 2 ]
+}
+
+@test "unknown step errors exit 2" {
+    run bash "$BIN" --step nope --fixtures "$SYNTH_FIX"
+    [ "$status" -eq 2 ]
+}
+
+@test "nonexistent fixtures dir errors exit 2" {
+    run bash "$BIN" --step synthetic --fixtures "$TMPWORK/does-not-exist"
+    [ "$status" -eq 2 ]
+}
+
+@test "fixtures dir with no usable fixtures errors exit 2" {
+    mkdir -p "$TMPWORK/empty"
+    run bash "$BIN" --step synthetic --fixtures "$TMPWORK/empty"
+    [ "$status" -eq 2 ]
+}
+
+@test "--help exits 0 and prints usage" {
+    run bash "$BIN" --help
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "step must keep/restore its LLM path"
+}
+
+# ── synthetic self-test: negative-path pair ───────────────────────
+
+@test "synthetic step over full synth dir exits non-zero (any fail => fail)" {
+    run bash "$BIN" --step synthetic --fixtures "$SYNTH_FIX"
+    [ "$status" -eq 1 ]
+    echo "$output" | grep -q "FAIL .*fail-canned"
+    echo "$output" | grep -q "PASS .*pass-signal"
+}
+
+@test "synthetic: signal-bearing fixture alone PASSES (exit 0)" {
+    mkdir -p "$TMPWORK/only-pass/pass-signal"
+    cp "$SYNTH_FIX/pass-signal/input"      "$TMPWORK/only-pass/pass-signal/input"
+    cp "$SYNTH_FIX/pass-signal/llm-golden" "$TMPWORK/only-pass/pass-signal/llm-golden"
+    cp "$SYNTH_FIX/pass-signal/assert.sh"  "$TMPWORK/only-pass/pass-signal/assert.sh"
+    run bash "$BIN" --step synthetic --fixtures "$TMPWORK/only-pass"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "deterministic path OK"
+}
+
+@test "synthetic: canned-string fixture alone FAILS (exit 1)" {
+    mkdir -p "$TMPWORK/only-fail/fail-canned"
+    cp "$SYNTH_FIX/fail-canned/input"      "$TMPWORK/only-fail/fail-canned/input"
+    cp "$SYNTH_FIX/fail-canned/llm-golden" "$TMPWORK/only-fail/fail-canned/llm-golden"
+    cp "$SYNTH_FIX/fail-canned/assert.sh"  "$TMPWORK/only-fail/fail-canned/assert.sh"
+    run bash "$BIN" --step synthetic --fixtures "$TMPWORK/only-fail"
+    [ "$status" -eq 1 ]
+    echo "$output" | grep -q "canned boilerplate marker present"
+}
+
+# ── assert.sh is signal-property, NOT string equality ─────────────
+
+@test "assert.sh passes when det-output differs from golden but shares >=2 content tokens" {
+    # det output is paraphrased (no string equality with golden) yet on-topic.
+    printf 'A read-through cache fronts the profile API to cut database load.\n' > "$TMPWORK/det"
+    printf 'Implement a read-through cache for the user profile API endpoint.\n' > "$TMPWORK/golden"
+    run bash "$SYNTH_FIX/pass-signal/assert.sh" "$TMPWORK/det" "$TMPWORK/golden"
+    [ "$status" -eq 0 ]
+    # And prove it is NOT string equality: the two files differ.
+    run diff "$TMPWORK/det" "$TMPWORK/golden"
+    [ "$status" -ne 0 ]
+}
+
+@test "assert.sh fails on generic output lacking content-token overlap" {
+    printf 'Please refine the prompt below per the rubric.\n' > "$TMPWORK/det"
+    printf 'Implement a streaming CSV export for the inventory dashboard.\n' > "$TMPWORK/golden"
+    run bash "$SYNTH_FIX/pass-signal/assert.sh" "$TMPWORK/det" "$TMPWORK/golden"
+    [ "$status" -ne 0 ]
+}
+
+@test "assert.sh fails on any canned boilerplate marker regardless of token overlap" {
+    printf 'Cache the profile API endpoint.\nWhat happens on empty input? Add a test.\n' > "$TMPWORK/det"
+    printf 'Cache the profile API endpoint with a TTL.\n' > "$TMPWORK/golden"
+    run bash "$SYNTH_FIX/pass-signal/assert.sh" "$TMPWORK/det" "$TMPWORK/golden"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q "canned boilerplate"
+}
+
+# ── refine-lenses real consumer: documented FAILING verdict ───────
+
+@test "refine-lenses fixtures number >= 3" {
+    count="$(ls -d "$REFINE_FIX"/*/ 2>/dev/null | wc -l | tr -d ' ')"
+    [ "$count" -ge 3 ]
+}
+
+@test "every refine-lenses fixture ships input + assert.sh" {
+    for d in "$REFINE_FIX"/*/; do
+        [ -f "${d}input" ]
+        [ -f "${d}assert.sh" ]
+    done
+}
+
+@test "refine-lenses step exits NON-ZERO (spec §7 documented verdict: keep LLM path)" {
+    run bash "$BIN" --step refine-lenses --fixtures "$REFINE_FIX"
+    [ "$status" -eq 1 ]
+    echo "$output" | grep -q "keep/restore LLM path"
+    # The deterministic refine lens path appends canned boilerplate -> the
+    # boilerplate marker is the proof of why it fails.
+    echo "$output" | grep -q "canned boilerplate marker present"
+}


### PR DESCRIPTION
## Summary

Implements spec §5 **D4 — quality-differential harness (the boilerplate guard)**.

`scripts/quality-differential.sh --step <name> --fixtures <dir>`: for each
fixture subdir, runs the step's **deterministic** path on the fixture `input`,
then evaluates the output via the fixture's own `assert.sh` (signal-property
checks, **NOT** string equality). Exits non-zero if **any** fixture fails →
verdict: *the step must keep/restore its LLM path.*

### Steps
- **synthetic** — self-test that echoes input verbatim so the fixtures decide.
  Ships a **negative-path pair**: `pass-signal/` PASSES, `fail-canned/` (carries
  the literal `What happens on empty input?` marker) FAILS, so the harness exits
  non-zero over the pair.
- **refine-lenses** — the real first consumer. Runs the actual
  `scripts/refine-prompt.sh --lens-mode deterministic` path on each fixture
  prompt. Per **spec §7** the deterministic lenses append canned boilerplate, so
  all 3 fixtures FAIL and the harness exits non-zero. **That failing verdict is
  the documented success condition** for refine lenses (KEEP-LLM), and a bats
  test asserts exactly it.

### assert.sh signal contract (not string equality)
1. ≥2 distinct content tokens from the `llm-golden` appear in the deterministic
   output (proves it's on-topic).
2. No canned boilerplate markers present.

Fixtures recorded from real `refine-prompt.sh` lens runs on 3 distinct prompts
(caching / OAuth refresh / CSV streaming). Layout documented in `--help` and
`tests/fixtures/quality-diff/README.md`.

### Acceptance criteria
- [x] `quality-differential.sh --step synthetic --fixtures .../synth` is non-zero
- [x] `bats tests/quality-differential.bats` exits 0 (15/15)
- [x] `ls .../refine-lenses/*/assert.sh | wc -l` ≥ 3
- [x] `bash scripts/validate.sh` exits 0 (new `check_quality_differential` gate wired in)

### Verification
```
bats tests/quality-differential.bats
scripts/quality-differential.sh --step refine-lenses --fixtures tests/fixtures/quality-diff/refine-lenses  # reports KEEP-LLM verdict (non-zero)
bash scripts/validate.sh
```

Bash discipline: `set -eu`, no RETURN traps, `if/then/fi` (no `[ x ] && y`) under set -e.

Closes #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)