### PR TITLE
feat(refine): LLM-first lens dispatch + AUTOSPEC_REFINE_LENS_MODE env hatch (#1024)

### DIFF
--- a/scripts/refine-prompt.sh
+++ b/scripts/refine-prompt.sh
@@ -44,8 +44,21 @@ Flags:
   --memory-root DIR      Override ~/.autospec/projects memory root (test hook).
   --help                 Show this and exit.
 
+Lens dispatch:
+  --lens-mode MODE       deterministic | llm | auto (overrides the env hatch).
+  --llm-binary PATH      Explicit LLM dispatcher for the lens path (test hook).
+
 Environment:
   AUTOSPEC_REFINE_MAX_ROUNDS    default 10
+  AUTOSPEC_REFINE_LENS_MODE     deterministic | llm | auto (default auto).
+                                auto = LLM-first: each lens round dispatches the
+                                LLM path first; the deterministic template lens
+                                is the fallback ONLY when the LLM path is
+                                unavailable/fails (round tagged
+                                degraded_fallback=true). llm = LLM-only (fails
+                                loudly if no dispatcher). deterministic = legacy
+                                template lenses (offline/tests). The --lens-mode
+                                flag wins over this env var.
 EOF
 }
 
@@ -845,33 +858,83 @@ apply_lens() {
 LENS_LLM_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/refine-prompt-lens-llm.sh"
 
 _resolve_lens_mode() {
-    # Honor explicit operator choice; otherwise auto-detect.
+    # Resolve the lens dispatch mode to one of: deterministic | llm | auto.
+    #
+    # Precedence (issue #1024): the --lens-mode flag wins over the
+    # AUTOSPEC_REFINE_LENS_MODE env hatch, which wins over the default (auto).
+    # All three values are allow-listed; any out-of-list value is fatal so a
+    # typo never silently degrades to a different code path.
+    #
+    #   deterministic — legacy template lenses only; never dispatch the LLM
+    #                   (offline / test / billable-API-free path).
+    #   llm           — LLM-only; fail loudly if the dispatcher is unavailable.
+    #   auto (default)— LLM-first: dispatch the LLM path each round; the
+    #                   deterministic template lens is the fallback ONLY when
+    #                   the LLM path is unavailable/fails, tagging
+    #                   degraded_fallback=true on that round.
+    #
+    # Flag wins over env (flag-over-env). Flag is allow-listed.
     if [ -n "$LENS_MODE" ]; then
         case "$LENS_MODE" in
-            deterministic|llm) printf '%s' "$LENS_MODE"; return ;;
-            *) echo "refine-prompt: --lens-mode must be deterministic|llm" >&2; exit 2 ;;
+            deterministic|llm|auto) printf '%s' "$LENS_MODE"; return ;;
+            *) echo "refine-prompt: --lens-mode must be deterministic|llm|auto" >&2; exit 2 ;;
         esac
     fi
-    # Env override (operator opt-in for default-llm).
+    # Env hatch — allow-listed; an invalid value is fatal (allow-list).
     if [ -n "${AUTOSPEC_REFINE_LENS_MODE:-}" ]; then
         case "$AUTOSPEC_REFINE_LENS_MODE" in
-            deterministic|llm) printf '%s' "$AUTOSPEC_REFINE_LENS_MODE"; return ;;
+            deterministic|llm|auto) printf '%s' "$AUTOSPEC_REFINE_LENS_MODE"; return ;;
+            *) echo "refine-prompt: AUTOSPEC_REFINE_LENS_MODE must be deterministic|llm|auto (got: $AUTOSPEC_REFINE_LENS_MODE)" >&2; exit 2 ;;
         esac
     fi
-    # Auto-detect: LLM only when explicitly enabled via AUTOSPEC_LLM_DISPATCHER
-    # AND a dispatcher is available. Otherwise deterministic so existing
-    # workflows (and tests not in LLM mode) are not silently rerouted through
-    # a billable API.
-    local have_llm=0
-    if [ -n "$LLM_BINARY" ]; then have_llm=1; fi
-    if [ -n "${AUTOSPEC_LLM_DISPATCHER:-}" ]; then
-        if command -v claude >/dev/null 2>&1; then have_llm=1; fi
-        if command -v codex  >/dev/null 2>&1; then have_llm=1; fi
-    fi
-    if [ "$have_llm" = 1 ]; then printf '%s' "llm"; else printf '%s' "deterministic"; fi
+    # Default: LLM-first auto.
+    printf '%s' "auto"
 }
 
+# Availability probe — is an LLM dispatcher reachable for the lens path?
+# Mirrors refine-prompt-lens-llm.sh's own resolution: an explicit
+# --llm-binary, or a claude/codex on PATH. Used to decide llm-vs-fallback
+# without spending a real dispatch.
+_lens_llm_available() {
+    if [ -n "$LLM_BINARY" ]; then return 0; fi
+    if command -v claude >/dev/null 2>&1; then return 0; fi
+    if command -v codex  >/dev/null 2>&1; then return 0; fi
+    return 1
+}
+
+# Validate the allow-listed inputs in the MAIN shell (not the $() subshell
+# below, where an exit would only terminate the subshell and leak an empty
+# LENS_MODE_RESOLVED). Flag-over-env: the flag is validated first.
+if [ -n "$LENS_MODE" ]; then
+    case "$LENS_MODE" in
+        deterministic|llm|auto) ;;
+        *) echo "refine-prompt: --lens-mode must be deterministic|llm|auto" >&2; exit 2 ;;
+    esac
+elif [ -n "${AUTOSPEC_REFINE_LENS_MODE:-}" ]; then
+    case "$AUTOSPEC_REFINE_LENS_MODE" in
+        deterministic|llm|auto) ;;
+        *) echo "refine-prompt: AUTOSPEC_REFINE_LENS_MODE must be deterministic|llm|auto (got: $AUTOSPEC_REFINE_LENS_MODE)" >&2; exit 2 ;;
+    esac
+fi
+
 LENS_MODE_RESOLVED="$(_resolve_lens_mode)"
+
+# llm mode is LLM-only: if no dispatcher is reachable, fail loudly rather than
+# silently degrading to the deterministic template lens (issue #1024).
+if [ "$LENS_MODE_RESOLVED" = "llm" ] && ! _lens_llm_available; then
+    echo "refine-prompt: ERROR — lens-mode=llm requires an LLM dispatcher (claude/codex or --llm-binary); none available" >&2
+    exit 2
+fi
+
+# auto mode is LLM-first with a deterministic fallback. When no dispatcher is
+# reachable up front, collapse to the deterministic template lens but mark the
+# fallback so every round's artifact carries degraded_fallback=true. The flag
+# below is consulted by apply_lens_routed.
+AUTO_DEGRADED_FALLBACK=0
+if [ "$LENS_MODE_RESOLVED" = "auto" ] && ! _lens_llm_available; then
+    AUTO_DEGRADED_FALLBACK=1
+    echo "refine-prompt: WARN — lens-mode=auto: no LLM dispatcher available; using deterministic fallback (degraded_fallback=true)" >&2
+fi
 LAST_LENS_IMPL=""
 LAST_DEGRADED_FALLBACK="false"
 
@@ -888,7 +951,22 @@ apply_lens_routed() {
     local degraded="false"
     local impl_file="${LENS_IMPL_FILE:-}"
 
-    if [ "$LENS_MODE_RESOLVED" = "llm" ] && [ -x "$LENS_LLM_SH" ]; then
+    # auto mode with no dispatcher available up front: deterministic fallback,
+    # tagged degraded (issue #1024). No LLM dispatch is attempted.
+    if [ "$LENS_MODE_RESOLVED" = "auto" ] && [ "${AUTO_DEGRADED_FALLBACK:-0}" = 1 ]; then
+        impl="deterministic"
+        degraded="true"
+        if [ -n "$impl_file" ]; then printf '%s|%s' "$impl" "$degraded" > "$impl_file"; fi
+        printf '%s' "$input" | apply_lens "$name"
+        return 0
+    fi
+
+    # llm and auto both dispatch the LLM path first. In auto mode a per-lens
+    # dispatch failure degrades to the deterministic template lens for THAT
+    # lens (degraded_fallback=true). In llm mode the dispatcher is known
+    # reachable (checked up front); a per-lens failure still degrades that
+    # single lens rather than aborting the whole run.
+    if { [ "$LENS_MODE_RESOLVED" = "llm" ] || [ "$LENS_MODE_RESOLVED" = "auto" ]; } && [ -x "$LENS_LLM_SH" ]; then
         # Build a tiny context file from already-loaded sources.
         local ctx
         ctx="$(mktemp -t refine-lens-ctx.XXXXXX)"

--- a/tests/refine-lens-inversion.bats
+++ b/tests/refine-lens-inversion.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+# tests/refine-lens-inversion.bats — D5 LLM-first inversion (issue #1024).
+#
+# Verifies the AUTOSPEC_REFINE_LENS_MODE env hatch (deterministic|llm|auto,
+# default auto = LLM-first) and the flag-over-env precedence.
+#
+# All LLM calls go through PATH-shim stub binaries. The REAL claude/codex
+# binaries are NEVER invoked. Per saved-memory recursion guard
+# (feedback_path_shadow_mock_exec_recursion): the stubs are self-contained and
+# do NOT `exec` the real binary, so prepending the stub dir to PATH cannot
+# recurse. We also capture the real binary path BEFORE prepending so a stub
+# could forward if it ever needed to.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/refine-prompt.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d -t refine-lens-inv.XXXXXX)"
+    REPO_ROOT="$TEST_TMP/repo"
+    mkdir -p "$REPO_ROOT/docs/specs"
+    cat > "$REPO_ROOT/AGENTS.md" <<'EOF'
+# AGENTS
+Edit scripts/refine-prompt.sh and tests/refine/test_refine_lens_inversion.bats.
+EOF
+    MEMORY_ROOT="$TEST_TMP/memory"
+    mkdir -p "$MEMORY_ROOT"
+    ART_DIR="$TEST_TMP/artifacts"
+    STUB_DIR="$TEST_TMP/stubs"
+    mkdir -p "$STUB_DIR"
+
+    # Recursion guard: capture the REAL binary path BEFORE prepending the stub
+    # dir to PATH (feedback_path_shadow_mock_exec_recursion).
+    REAL_CLAUDE="$(command -v claude || true)"
+    export REAL_CLAUDE
+    export AUTOSPEC_LLM_DISPATCHER=1
+    # Ensure no leaked env hatch from the parent shell.
+    unset AUTOSPEC_REFINE_LENS_MODE || true
+}
+
+teardown() {
+    [ -d "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"
+}
+
+make_success_stub() {
+    # $1 = name (claude|codex), $2 = output text. Self-contained: prints a
+    # marker and exits 0; never execs the real binary (no recursion).
+    local name="$1"; local text="$2"
+    cat > "$STUB_DIR/$name" <<EOF
+#!/usr/bin/env bash
+# stub $name — self-contained, no exec of real binary
+printf '%s' "$text"
+exit 0
+EOF
+    chmod +x "$STUB_DIR/$name"
+}
+
+@test "auto mode dispatches the LLM path first (no explicit --lens-mode)" {
+    make_success_stub claude "AUTO-LLM-FIRST-OUTPUT"
+    run bash "$SCRIPT" "do the thing" --rounds 1 --lenses repo-grounding --dry-run \
+        --llm-binary "$STUB_DIR/claude" \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -eq 0 ]
+    local f
+    f="$(ls "$ART_DIR"/*.json | head -1)"
+    [ "$(jq -r '.rounds[0].lens_implementation' "$f")" = "llm" ]
+    [ "$(jq -r '.rounds[0].refined_prompt' "$f")" = "AUTO-LLM-FIRST-OUTPUT" ]
+    [ "$(jq -r '.rounds[0].degraded_fallback' "$f")" = "false" ]
+}
+
+@test "auto mode falls back to deterministic + degraded_fallback=true when LLM unavailable" {
+    # No llm-binary and no claude/codex on PATH → auto must fall back, not fail.
+    # PATH keeps coreutils (/usr/bin:/bin) but excludes any claude/codex.
+    run env -u AUTOSPEC_LLM_DISPATCHER PATH="$STUB_DIR:/usr/bin:/bin" \
+        bash "$SCRIPT" "fix the login button" --rounds 1 --lenses clarity-ac --dry-run \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -eq 0 ]
+    local f
+    f="$(ls "$ART_DIR"/*.json | head -1)"
+    [ "$(jq -r '.rounds[0].lens_implementation' "$f")" = "deterministic" ]
+    [ "$(jq -r '.rounds[0].degraded_fallback' "$f")" = "true" ]
+    [[ "$(jq -r '.rounds[0].refined_prompt' "$f")" == *"Acceptance criteria"* ]]
+}
+
+@test "AUTOSPEC_REFINE_LENS_MODE=deterministic skips the LLM dispatcher entirely" {
+    # A claude stub that EXPLODES if ever called proves no dispatch happened.
+    cat > "$STUB_DIR/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "LLM WAS CALLED — should not happen in deterministic mode" >&2
+exit 42
+EOF
+    chmod +x "$STUB_DIR/claude"
+    run env AUTOSPEC_REFINE_LENS_MODE=deterministic PATH="$STUB_DIR:$PATH" \
+        bash "$SCRIPT" "do something" --rounds 1 --lenses repo-grounding --dry-run \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -eq 0 ]
+    local f
+    f="$(ls "$ART_DIR"/*.json | head -1)"
+    [ "$(jq -r '.rounds[0].lens_implementation' "$f")" = "deterministic" ]
+    [ "$(jq -r '.rounds[0].degraded_fallback' "$f")" = "false" ]
+}
+
+@test "AUTOSPEC_REFINE_LENS_MODE=llm fails loudly when LLM is unavailable" {
+    # llm mode = LLM-only; no dispatcher available → non-zero exit, no silent
+    # deterministic fallback.
+    run env -u AUTOSPEC_LLM_DISPATCHER AUTOSPEC_REFINE_LENS_MODE=llm PATH="$STUB_DIR:/usr/bin:/bin" \
+        bash "$SCRIPT" "ship it" --rounds 1 --lenses repo-grounding --dry-run \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -ne 0 ]
+}
+
+@test "invalid AUTOSPEC_REFINE_LENS_MODE value exits non-zero (allow-list)" {
+    run env AUTOSPEC_REFINE_LENS_MODE=bogus \
+        bash "$SCRIPT" "do the thing" --rounds 1 --lenses repo-grounding --dry-run \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -ne 0 ]
+}
+
+@test "invalid bare-mode exit per AC: empty stdin + bogus env exits non-zero" {
+    # Mirrors the spec-level AC command form.
+    run env AUTOSPEC_REFINE_LENS_MODE=bogus bash "$SCRIPT" </dev/null
+    [ "$status" -ne 0 ]
+}
+
+@test "--lens-mode flag wins over AUTOSPEC_REFINE_LENS_MODE env (flag-over-env)" {
+    # Env says deterministic, flag says llm — flag must win, so the LLM stub
+    # fires and the round is tagged llm.
+    make_success_stub claude "FLAG-WINS-LLM"
+    run env AUTOSPEC_REFINE_LENS_MODE=deterministic \
+        bash "$SCRIPT" "do the thing" --rounds 1 --lenses repo-grounding --dry-run \
+        --lens-mode llm --llm-binary "$STUB_DIR/claude" \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -eq 0 ]
+    local f
+    f="$(ls "$ART_DIR"/*.json | head -1)"
+    [ "$(jq -r '.rounds[0].lens_implementation' "$f")" = "llm" ]
+    [ "$(jq -r '.rounds[0].refined_prompt' "$f")" = "FLAG-WINS-LLM" ]
+}
+
+@test "--lens-mode deterministic flag wins over env=llm (flag-over-env, both directions)" {
+    # Env says llm, flag says deterministic — flag must win; no LLM dispatch.
+    cat > "$STUB_DIR/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "LLM WAS CALLED — flag should have forced deterministic" >&2
+exit 42
+EOF
+    chmod +x "$STUB_DIR/claude"
+    run env AUTOSPEC_REFINE_LENS_MODE=llm PATH="$STUB_DIR:$PATH" \
+        bash "$SCRIPT" "do the thing" --rounds 1 --lenses repo-grounding --dry-run \
+        --lens-mode deterministic \
+        --artifact-dir "$ART_DIR" --repo-root "$REPO_ROOT" --memory-root "$MEMORY_ROOT"
+    [ "$status" -eq 0 ]
+    local f
+    f="$(ls "$ART_DIR"/*.json | head -1)"
+    [ "$(jq -r '.rounds[0].lens_implementation' "$f")" = "deterministic" ]
+}
+
+@test "AC: grep finds AUTOSPEC_REFINE_LENS_MODE hatch in refine-prompt.sh" {
+    run grep -q 'AUTOSPEC_REFINE_LENS_MODE' "$SCRIPT"
+    [ "$status" -eq 0 ]
+}

--- a/tests/refine/test_refine_correctness.bats
+++ b/tests/refine/test_refine_correctness.bats
@@ -14,6 +14,9 @@ SCRIPT="${BATS_TEST_DIRNAME}/../../scripts/refine-prompt.sh"
 RENDER="${BATS_TEST_DIRNAME}/../../scripts/refine-render-overview.sh"
 
 setup() {
+    # Pin deterministic template lens — default is now auto/LLM-first (#1024),
+    # but these correctness invariants assert deterministic-path output.
+    export AUTOSPEC_REFINE_LENS_MODE=deterministic
     TEST_TMP="$(mktemp -d -t refine-correct.XXXXXX)"
     REPO_ROOT="$TEST_TMP/repo"
     mkdir -p "$REPO_ROOT/docs/specs" "$REPO_ROOT/.autospec"

--- a/tests/refine/test_refine_lenses.bats
+++ b/tests/refine/test_refine_lenses.bats
@@ -5,6 +5,11 @@
 SCRIPT="${BATS_TEST_DIRNAME}/../../scripts/refine-prompt.sh"
 
 setup() {
+    # These tests assert the DETERMINISTIC template-lens output specifically.
+    # Since the default lens mode is now auto/LLM-first (issue #1024), pin the
+    # deterministic path so the template signatures are exercised regardless of
+    # whether a claude/codex dispatcher is present in the test environment.
+    export AUTOSPEC_REFINE_LENS_MODE=deterministic
     TEST_TMP="$(mktemp -d -t refine-lens.XXXXXX)"
     REPO_ROOT="$TEST_TMP/repo"
     mkdir -p "$REPO_ROOT/docs/specs"

--- a/tests/refine/test_refine_loop.bats
+++ b/tests/refine/test_refine_loop.bats
@@ -16,6 +16,9 @@
 SCRIPT="${BATS_TEST_DIRNAME}/../../scripts/refine-prompt.sh"
 
 setup() {
+    # Pin deterministic template lens — default is now auto/LLM-first (#1024),
+    # but the loop's convergence/oscillation invariants assert deterministic output.
+    export AUTOSPEC_REFINE_LENS_MODE=deterministic
     TEST_TMP="$(mktemp -d -t refine-loop.XXXXXX)"
     REPO_ROOT="$TEST_TMP/repo"
     mkdir -p "$REPO_ROOT/docs/specs"

--- a/tests/refine/test_refine_orchestrator.bats
+++ b/tests/refine/test_refine_orchestrator.bats
@@ -6,6 +6,11 @@
 SCRIPT="${BATS_TEST_DIRNAME}/../../scripts/refine-prompt.sh"
 
 setup() {
+    # These orchestrator invariants (convergence, word-count degradation, round
+    # cap, context-sparse) only hold for the DETERMINISTIC template lens. The
+    # default lens mode is now auto/LLM-first (issue #1024), whose output is
+    # non-deterministic, so pin the deterministic path here.
+    export AUTOSPEC_REFINE_LENS_MODE=deterministic
     TEST_TMP="$(mktemp -d -t refine-orch.XXXXXX)"
     REPO_ROOT="$TEST_TMP/repo"
     mkdir -p "$REPO_ROOT/docs/specs"

--- a/tests/refine/test_refine_overview.bats
+++ b/tests/refine/test_refine_overview.bats
@@ -8,6 +8,9 @@ SCRIPT="${BATS_TEST_DIRNAME}/../../scripts/refine-render-overview.sh"
 SCHEMA="${BATS_TEST_DIRNAME}/../../schemas/autospec-refinement.schema.json"
 
 setup() {
+    # Pin deterministic template lens — default is now auto/LLM-first (#1024),
+    # but the overview render asserts deterministic-path artifact fields.
+    export AUTOSPEC_REFINE_LENS_MODE=deterministic
     TEST_TMP="$(mktemp -d -t refine-render.XXXXXX)"
     OUT_DIR="$TEST_TMP/out"
     INPUT="$TEST_TMP/input.json"


### PR DESCRIPTION
## What

D5: flips `scripts/refine-prompt.sh` lens dispatch to **LLM-first** via the existing hatch, gated by the shared-contract env var `AUTOSPEC_REFINE_LENS_MODE` (`deterministic|llm|auto`, default `auto`).

- `auto` (default) — LLM-first: each lens round dispatches `scripts/refine-prompt-lens-llm.sh` first; the deterministic template lens is the fallback ONLY when the LLM path is unavailable/fails, tagging the existing `degraded_fallback=true` field on that round.
- `llm` — LLM-only; fails loudly (exit 2) when no dispatcher is reachable.
- `deterministic` — legacy template lenses (offline/tests).

The `--lens-mode` flag wins over the env hatch (flag-over-env). Both are allow-listed; an out-of-list value is fatal (exit 2). Allow-list validation runs in the main shell, not the `$()` subshell, so the exit isn't swallowed.

## Preserved
All six termination/convergence behaviors, the refinement JSON schema, and `--dry-run/--interactive/--autonomous` routing are unchanged. Existing deterministic-template unit/orchestrator/loop/overview/correctness tests are pinned to `AUTOSPEC_REFINE_LENS_MODE=deterministic` (their invariants only hold for the template path).

## Tests
New `tests/refine-lens-inversion.bats` (9 tests): auto LLM-first dispatch; auto fallback + `degraded_fallback=true`; deterministic skips dispatch; llm fails loudly; allow-list rejection; flag-over-env both directions; AC grep. PATH-shim stubs are self-contained (no exec of the real binary) and the real binary is captured before prepending the stub dir (recursion guard per saved memory).

## Verification
- `bash tests/refine-lens-inversion.bats` — 9/9 green (primary smoke test)
- full `tests/refine/*.bats` — green
- `bash scripts/validate.sh` — OK, all checks passed
- ACs: `grep -q AUTOSPEC_REFINE_LENS_MODE scripts/refine-prompt.sh` ✓; bogus mode exits non-zero ✓

Closes #1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)