### PR TITLE
feat(d3b): harness-adapter block marker sweep — 1 converted, 23 skipped (semantic drift)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -303,7 +303,9 @@ check_subagent_model_tier() {
     info "subagent model tier: $name"
     grep -q -F '**Model tier:**' "$skill_dir/SKILL.md" \
         || fail "$name: SKILL.md missing '**Model tier:**' directive on at least one subagent dispatch"
+    # Accept EITHER the literal row OR the harness-adapter block marker (transition-safe: D3b).
     grep -q -E '^\| Subagent model tier ' "$skill_dir/SKILL.md" \
+        || grep -q -F '<!-- autospec-block:harness-adapter -->' "$skill_dir/SKILL.md" \
         || fail "$name: SKILL.md harness-adapter table missing 'Subagent model tier' row"
 
     # Every **Model tier:** line must label itself Tier A or Tier B.

--- a/skills/autospec/SKILL.md
+++ b/skills/autospec/SKILL.md
@@ -159,21 +159,7 @@ classification path as the normal pipeline.
    Phase 3.5 using that selected spec. Then proceed to the existing Phase 3
    pre-impl gate.
 
-## Required capabilities & harness adapter
-
-This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
-
-| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
-|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
-| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
-| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
-| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
-| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
-| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
-| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
-| Subagent dispatch policy   | per AGENTS.md decision matrix        | per AGENTS.md decision matrix            | per AGENTS.md decision matrix            | inline with main-session token cost                |
-
-**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work (research, decompose, review/label); Tier B (cheaper model + medium thinking) for implementation work (Phase 4 implementer + LGTM review). The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
+<!-- autospec-block:harness-adapter -->
 
 ## Physical STL / CAD design guardrails
 

--- a/skills/autospec/codex/prompt.md
+++ b/skills/autospec/codex/prompt.md
@@ -154,21 +154,7 @@ classification path as the normal pipeline.
    Phase 3.5 using that selected spec. Then proceed to the existing Phase 3
    pre-impl gate.
 
-## Required capabilities & harness adapter
-
-This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
-
-| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
-|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
-| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
-| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
-| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
-| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
-| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
-| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
-| Subagent dispatch policy   | per AGENTS.md decision matrix        | per AGENTS.md decision matrix            | per AGENTS.md decision matrix            | inline with main-session token cost                |
-
-**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work (research, decompose, review/label); Tier B (cheaper model + medium thinking) for implementation work (Phase 4 implementer + LGTM review). The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
+<!-- autospec-block:harness-adapter -->
 
 ## Physical STL / CAD design guardrails
 

--- a/skills/autospec/opencode/agent.md
+++ b/skills/autospec/opencode/agent.md
@@ -158,21 +158,7 @@ classification path as the normal pipeline.
    Phase 3.5 using that selected spec. Then proceed to the existing Phase 3
    pre-impl gate.
 
-## Required capabilities & harness adapter
-
-This workflow assumes five capabilities. Map each one to your harness's actual tool. If a capability is missing, use the listed fallback.
-
-| Capability                  | Claude Code                          | OpenCode                                 | Codex CLI                                | Fallback if missing                                |
-|-----------------------------|--------------------------------------|------------------------------------------|------------------------------------------|----------------------------------------------------|
-| Read-only codebase research | `Agent` (subagent_type=Explore)      | `task` agent in read-only mode           | `apply_patch` read-only / shell `grep`   | Do the search in-thread with `rg`/`grep`           |
-| Foreground delegation       | `Agent` (subagent_type=general-purpose) | nested `task` agent, await output     | spawn nested CLI session                 | Do the work in-thread (more context cost)          |
-| Background delegation       | `Agent` with `run_in_background: true` | detached `task` agent                  | nohup'd CLI session writing to a logfile | Run the monitor in a separate terminal/tmux pane   |
-| Ask the user a question     | `AskUserQuestion`                    | inline prompt                            | inline prompt                            | Ask in the response and wait for the next turn     |
-| Self-paced future wakeup    | `ScheduleWakeup` inside a `/loop`    | a recurring `task` or local `cron`       | local `cron`/`launchd` calling the CLI   | The user runs a status-update prompt manually      |
-| Subagent model tier         | Tier A: `opus` + `ultrathink`; Tier B: `sonnet` + medium thinking | Tier A: top `task` model + high reasoning; Tier B: smaller-tier `task` + medium reasoning | Tier A: top GPT + `reasoning_effort=high`; Tier B: `gpt-5.1-codex-spark` + `reasoning_effort=medium` | Honor the per-phase tier mapping in AGENTS.md; retry the same subagent UP on unavailability |
-| Subagent dispatch policy   | per AGENTS.md decision matrix        | per AGENTS.md decision matrix            | per AGENTS.md decision matrix            | inline with main-session token cost                |
-
-**Persistent project notes**: write durable preferences to **`AGENTS.md`** in the repo root — this is the de-facto standard recognized by Claude Code (also reads `CLAUDE.md`), OpenCode, and Codex. If your harness has its own private memory (e.g. Claude Code's `~/.claude/.../memory/`), mirror the same content there. Per AGENTS.md, subagent dispatches use a **two-tier policy**: Tier A (top model + extended thinking) for spec work (research, decompose, review/label); Tier B (cheaper model + medium thinking) for implementation work (Phase 4 implementer + LGTM review). The orchestrator keeps the user's invoked model. Fall back UP the tier on quota/capacity or other unavailability by retrying the same subagent with the stronger tier while preserving parent context.
+<!-- autospec-block:harness-adapter -->
 
 ## Physical STL / CAD design guardrails
 


### PR DESCRIPTION
## Summary

Replaces the verbatim `## Required capabilities & harness adapter` section with
`<!-- autospec-block:harness-adapter -->` marker for all skills whose block
matches the canonical template byte-exactly (× trio members).

Updates `check_subagent_model_tier` in `validate.sh` to accept EITHER the
literal `| Subagent model tier` row OR the harness-adapter marker
(transition-safe, mirrors D3a startup-self-update precedent).

Closes #1022

## Converted skills

| Skill | Files converted | Words before | Words after | Saved |
|---|---|---|---|---|
| autospec | 3 | 37258 | 36121 | 1137 |
| **TOTAL** | **3 files** | **37258** | **36121** | **1137** |

## Drift analysis

The canonical template (`templates/skill-blocks/harness-adapter.md`) is 15
lines covering `## Required capabilities & harness adapter` through the
`**Persistent project notes**` paragraph verbatim.

**Only `autospec` matched the template byte-exactly.** All 23 other skills have
semantic drift in one or more of: the intro sentence, table rows (different
capabilities listed), or the `**Persistent project notes**` paragraph
(skill-specific tier-policy additions like "— not used by this skill",
different Tier A/B descriptions, different tier rationale).

Per the DRIFT RULE (issue #1022): semantic drift → do NOT convert; list for
operator follow-up.

## Skipped skills (semantic drift)

| Skill | Drift type | Detail |
|---|---|---|
| autospec-classify | semantic (table + notes) | Missing Background delegation + Self-paced future wakeup rows; notes has deterministic-first policy text |
| autospec-continue | semantic (notes) | Persistent notes: "Tier A for spec/refinement, Tier B for implementation" (different from canonical) |
| autospec-define | semantic (notes) | Persistent notes adds "— not used by this skill" parenthetical to Tier B |
| autospec-design | semantic (table + notes) | Missing Background delegation + Self-paced future wakeup rows; notes truncated |
| autospec-doc | semantic (heading + table) | Uses `###` heading; different capability rows (Audience content authoring, Completeness/gap audit) |
| autospec-e2e-clone | semantic (table + no notes) | Different model tier cell text; no Persistent project notes paragraph |
| autospec-explore | semantic (intro + notes) | Intro says "six capabilities"; notes has different tier rationale |
| autospec-fleet | semantic (no notes) | No Persistent project notes paragraph; different model tier paragraph instead |
| autospec-listen | semantic (intro + table) | Intro says "four capabilities"; different capability rows (Read recent conversation, Run gh CLI, Hand off) |
| autospec-loop | semantic (intro + table) | Different intro + capability rows (Per-iteration worker, Independent verifier) |
| autospec-playwright | semantic (table + no notes) | Different column widths, different model tier cell text; no Persistent notes |
| autospec-qa | semantic (format + table) | Alt markdown table format (`| --- |`), completely different rows |
| autospec-refine | semantic (notes) | Persistent notes: "Tier A for spec/refinement work (lens applies fresh-eyes reasoning)" |
| autospec-release | semantic (format + table) | Alt markdown table format; different rows (Existing autospec skills, GitHub operations) |
| autospec-resume | semantic (table + no notes) | Different rows (Run shell command, Tier B only); no Persistent notes |
| autospec-review | semantic (table + no notes) | Only 2 rows (model tier + dispatch policy); no Persistent notes |
| autospec-rollover-status | semantic (table + no notes) | Different rows (Run shell command, haiku-specific tier); no Persistent notes |
| autospec-run | semantic (notes) | Persistent notes adds "— not used by this skill" parenthetical to Tier A |
| autospec-split | semantic (notes) | Persistent notes adds "— not used by this skill" parenthetical to Tier B |
| autospec-stop | semantic (table + no notes) | Different rows (Run shell command); no Persistent notes |
| autospec-story | semantic (table) | Different column widths in table separator |
| autospec-sweep | semantic (table + no notes) | Two separate adapter tables, alt format rows; no Persistent notes |
| autospec-test | semantic (table + no notes) | Two adapter tables, different rows; no Persistent notes |

## Golden hash parity

1 skill verified: `bash scripts/expand-skill-blocks.sh skills/autospec/SKILL.md | shasum -a 256`
matches stored golden `0890ff29cadaa155c7b4d54f720a0d41e6894f6dfba0ccf575e4044e749b1b8d`.

**Statement: all expanded bytes unchanged** — expansion round-trips the
converted skill to its golden SHA.

## Verification

- `bash scripts/validate.sh` → exit 0 ✓
- `bats tests/block-expansion-gate.bats` → 10/10 pass ✓
- `bats tests/install-expansion.bats` → 7/7 pass ✓

## Files-touched exemption

Per #1012 mechanical-sweep precedent — files-touched exemption applies. 4 files
modified: 3 skill trio members + scripts/validate.sh (transition-safe gate).

## Note on acceptance criteria

The issue AC (`grep -rl 'autospec-block:harness-adapter' skills | wc -l | grep -qx 24`)
assumed all 24 skills would convert. Byte-exact drift analysis found only 1
skill (autospec) matches the canonical template. The remaining 23 have semantic
drift in capability rows, intro text, or Persistent project notes — these must
be individually reviewed and canonicalized before their blocks can be markered.
The `dispatch-policy-row` marker is embedded within the harness-adapter template
body and appears in expanded output; no separate marker is needed in skill files.