### PR TITLE
feat(ux): DESIGN.md → implementer + config/flags reference (Track 4 part 1)

### DIFF
--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -1,0 +1,69 @@
+# autospec configuration reference
+
+The operator-relevant `AUTOSPEC_*` environment variables, grouped by area. (Internal
+plumbing vars such as `AUTOSPEC_SCRIPTS_DIR`, `AUTOSPEC_REPO_ROOT`, and test-only
+`AUTOSPEC_TEST_*` overrides are intentionally omitted.) Behavior toggles that are
+flag-files rather than env vars live in [`FLAGS.md`](FLAGS.md).
+
+Set them in your shell, an `.env`, or inline for one run:
+```bash
+AUTOSPEC_BATCH_SIZE=1 /autospec-run        # one issue per subagent
+```
+
+## Core paths & repo
+| Var | Default | Effect |
+|---|---|---|
+| `AUTOSPEC_STATE_DIR` | `~/.autospec` | Root for run-state, heartbeats, flag files. |
+| `AUTOSPEC_DIR` | `~/.autospec` | Legacy alias for the state dir in some scripts. |
+| `AUTOSPEC_REPO` | gh context | `owner/name` slug when not inferable from the checkout. |
+
+## Batch, caps & budgets
+| Var | Default | Effect |
+|---|---|---|
+| `AUTOSPEC_BATCH_SIZE` | `1` | Issues processed per subagent. `reasoning:deep` issues force-stay at 1. |
+| `AUTOSPEC_AUTONOMOUS_ISSUE_CAP` | (unset) | Max issues an autonomous run will process before stopping. |
+| `AUTOSPEC_AUTONOMOUS_TOKEN_CAP` | (unset) | Token ceiling for an autonomous run. |
+| `AUTOSPEC_LOOP_TOKEN_CAP` | (unset) | Token ceiling for loop entrypoints (`--loop`, explore). |
+| `AUTOSPEC_LOOP_TIME_CAP` | (unset) | Wall-clock ceiling for loop entrypoints. |
+| `AUTOSPEC_GAP_MAX_ROUNDS` | `2` | Phase 5.5 gap-remediation round cap. |
+| `AUTOSPEC_HEAL_MAX_ROUNDS` | (skill default) | autospec-qa self-heal round cap. |
+| `AUTOSPEC_RESUME_MAX_ATTEMPTS` | `3` | Consecutive crash-resume attempts before giving up. |
+
+## Model tiers & dispatch
+| Var | Default | Effect |
+|---|---|---|
+| `AUTOSPEC_REVIEWER_TIER` | tier-policy default | Override the model tier for the LGTM/guardian reviewer. |
+| `AUTOSPEC_HARNESS_DISPATCHER` | auto-detected | Force a harness dispatcher (claude/opencode/codex). |
+| `AUTOSPEC_NO_GUARDIAN` | (unset) | Disable the guardian RULE_ID pass (not recommended). |
+
+## Testing & QA
+| Var | Default | Effect |
+|---|---|---|
+| `AUTOSPEC_FULL_TEST_COMMAND` | repo-detected | Override the full test command. |
+| `AUTOSPEC_TEST_STACK` | auto-detected | Force the test stack (node/python/go/…). |
+| `AUTOSPEC_QA_STRICT` | (unset) | Stricter autospec-qa gating. |
+| `AUTOSPEC_CUSTOM_VERIFY_CMD` / `_SNAPSHOT_CMD` / `_RESTORE_CMD` | (unset) | Custom verify/snapshot/restore hooks for E2E reset. |
+| `AUTOSPEC_WITH_DOCS` | (unset) | Include the docs dimension in sweeps/reviews. |
+
+## Crash-resume & watchdog
+| Var | Default | Effect |
+|---|---|---|
+| `AUTOSPEC_WATCHDOG_STALE_SECS` | (skill default) | Age after which a heartbeat is considered stale. |
+| `AUTOSPEC_WATCHDOG_RECLAIM_SECS` | (skill default) | Age after which a stale claim lease may be reclaimed. |
+| `AUTOSPEC_RESUME_COMMAND` | derived | Command the usage-limit supervisor relaunches on reset. |
+
+## Security (autospec-secaudit)
+| Var | Default | Effect |
+|---|---|---|
+| `AUTOSPEC_SEC_MAX_ROUNDS` | `3` | Phase 4 security gate fix/re-scan loop cap. |
+| `AUTOSPEC_SKIP_ENSURE_TOOL` / `_<TOOL>` | (unset) | Disable scanner auto-install (all, or one tool). |
+
+## Explore (autospec-explore RSI)
+| Var | Default | Effect |
+|---|---|---|
+| `AUTOSPEC_EXPLORE_LEDGER` | `.autospec/explore-ledger.jsonl` | Outcome-ledger path. |
+| `AUTOSPEC_EXPLORE_MIN_CONFIDENCE` | `0.3` | Constitution confidence floor (D2). |
+| `AUTOSPEC_EXPLORE_CONSTITUTION` | `.autospec/explore-constitution.md` | Proposal-constitution path. |
+
+For automation toggles (skip-review, stop, no-heal, …) see [`FLAGS.md`](FLAGS.md).
+This reference covers the operator-facing knobs; run `grep -rho 'AUTOSPEC_[A-Z0-9_]*' skills scripts | sort -u` for the exhaustive internal set.

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -1,0 +1,28 @@
+# autospec flag-file reference
+
+autospec reads small **sentinel files** under `~/.autospec/` (the state dir; override with `AUTOSPEC_STATE_DIR`) to toggle behavior without env vars or arguments. A flag is "set" when the file **exists** (contents are ignored). Create one with `touch`, clear it with `rm`.
+
+```bash
+touch ~/.autospec/no-secaudit.flag     # set
+rm    ~/.autospec/no-secaudit.flag     # clear
+```
+
+| Flag file | Effect | Set / cleared by |
+|---|---|---|
+| `stop.flag` | The autospec-run monitor halts after the current issue finishes. | `/autospec-stop --graceful` (set); `/autospec-stop --resume` (clear) |
+| `autonomous.flag` | Marks the run as operating in autonomous mode (affects confirmation prompts). | autospec autonomous entrypoints |
+| `init-done.flag` | Records that first-run init/bootstrap completed; skips re-init. | autospec init / sweep wizard |
+| `no-review.flag` | Skips the end-of-run Phase 5.5 gap-remediation broad review. | operator |
+| `no-secaudit.flag` | Skips the post-batch security sweep dimension (Phase 5.5). | operator |
+| `no-test.flag` | Skips the test step (use only when tests are run elsewhere). | operator |
+| `no-heal.flag` | Disables the autospec self-heal loop. | operator |
+| `qa-no-heal.flag` | Disables the autospec-qa self-heal loop specifically. | operator |
+| `qa-heal-stop.flag` | Stops an in-progress autospec-qa heal loop after the current round. | `/autospec-qa` stop path |
+| `refine-loop-stop.flag` | Stops an in-progress `/autospec-refine --continue` loop. | `/autospec-refine` stop path |
+| `continue-no-loop.flag` | Makes `/autospec-continue` run once instead of looping. | operator |
+| `explore-stop.flag` | Stops the `/autospec-explore` perpetual loop after the current round. | `/autospec-explore` stop path |
+
+Notes:
+- The monitor and loops check these at round/step boundaries, so a flag takes effect at the next safe checkpoint, not mid-step.
+- `stop.flag` is the global halt; the `*-stop.flag` variants halt one specific loop without stopping everything else.
+- Removing a flag re-enables the behavior on the next run; no restart of unrelated work is needed.

--- a/skills/autospec-run/prompts/implementer-contract.md
+++ b/skills/autospec-run/prompts/implementer-contract.md
@@ -72,6 +72,7 @@ implementer's retry prompt as cumulative context:
 | `REPEATED_STRUCTURE_AS_CODE` | "Extract the N branches into a table + single dispatcher loop." |
 | `DOC_OUT_OF_SYNC` | "Update the doc file(s) covering the changed public surface in this same PR." |
 | `INVENTED_CONFIG` | "Remove the invented flag/env/key, or amend the issue body to introduce it as scope." |
+| `DESIGN_DRIFT` | "If the repo has a DESIGN.md, use its tokens (color/spacing/typography/component) instead of hardcoding values; match the adopted design language for any user-facing UI." |
 
 ### Enforcement and opt-out
 

--- a/skills/autospec-shared/scripts/bundle-static-context.sh
+++ b/skills/autospec-shared/scripts/bundle-static-context.sh
@@ -243,6 +243,17 @@ emit_scaffolding() {
   esac
 }
 
+# Emit the repo's adopted design language (DESIGN.md at repo root), if present, so
+# the implementer honors design tokens/constraints instead of hardcoding values.
+# Repo-wide and byte-stable across issues, so it lives inside the cache boundary.
+emit_design() {
+  design_md="$REPO_ROOT/DESIGN.md"
+  [ -f "$design_md" ] || return 0
+  printf '## Design language (DESIGN.md — honor these tokens; do not hardcode)\n\n'
+  cat "$design_md"
+  printf '\n'
+}
+
 # ── emit output ───────────────────────────────────────────────────────────────
 
 if [ "$ROLE" = "implementer" ]; then
@@ -266,6 +277,10 @@ if [ "$ROLE" = "implementer" ]; then
     in_sec { print }
   ' "$AGENTS_MD"
   printf '\n'
+
+  # 3. Adopted design language (DESIGN.md), if the repo has one — repo-wide and
+  #    byte-stable, so it stays inside the cache boundary.
+  emit_design
 
   printf '<!-- CACHE BOUNDARY -->\n'
 

--- a/tests/bundle-static-context.bats
+++ b/tests/bundle-static-context.bats
@@ -230,3 +230,27 @@ teardown() {
   [ -f "$skill_md" ]
   grep -q "bundle-static-context.sh" "$skill_md"
 }
+
+@test "implementer bundle injects DESIGN.md when the repo has one" {
+  printf '# Design Language\nprimary: #112233\nspacing: 8px grid\n' > "$FIXTURES_DIR/DESIGN.md"
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run"
+  rm -f "$FIXTURES_DIR/DESIGN.md"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q 'Design language (DESIGN.md'
+  printf '%s\n' "$output" | grep -q '8px grid'
+}
+
+@test "implementer bundle omits the design section when no DESIGN.md exists" {
+  rm -f "$FIXTURES_DIR/DESIGN.md"
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run"
+  [ "$status" -eq 0 ]
+  ! printf '%s\n' "$output" | grep -q 'Design language (DESIGN.md'
+}


### PR DESCRIPTION
## Summary
First slice of Track 4 (UX-dev + Operator-UX), the two highest-leverage low-risk pieces.

**UX-dev — close the design loop's first gap.** The Phase 4 implementer bundle never included `DESIGN.md`, so the adopted design language was decorative. Now `bundle-static-context.sh --role implementer` injects repo-root `DESIGN.md` (inside the cache boundary — repo-wide and byte-stable), and the implementer contract carries a `DESIGN_DRIFT` directive ("use DESIGN.md tokens, don't hardcode"). Generated UI is now design-token-aware.

**Operator-UX — collapse config sprawl.** `docs/FLAGS.md` documents all 12 `~/.autospec/*.flag` sentinels; `docs/CONFIG_REFERENCE.md` documents the operator-facing `AUTOSPEC_*` knobs grouped by area. Both derived from the actual code.

## Test Plan
- [x] `bundle-static-context.bats` 18/18 (incl. 2 new: DESIGN.md injected when present, omitted otherwise)
- [x] Implementer-contract drift gate still passes (DESIGN_DRIFT is an extra directive; contract ≤24KB)
- [x] `validate.sh` exit 0

## Deferred to follow-up PRs (each substantial)
- `/autospec-run --status` live operator view (heartbeats + queue + stop-flag)
- Phase 4 silent-exit self-heal
- screenshot → LLM-vision-judge visual-fidelity QA loop (reuses gen-screenshots.mjs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)