### PR TITLE
feat(ux): deterministic design-token-drift linter (lint-ui.sh)

### DIFF
--- a/scripts/lint-ui.sh
+++ b/scripts/lint-ui.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# scripts/lint-ui.sh — deterministic design-token-drift linter for UI files.
+#
+# Complements the LLM-vision visual-fidelity judge (subjective fidelity) with
+# objective, file:line rules that flag code bypassing a design system — the
+# deterministic half of the implementer's DESIGN_DRIFT directive. Intended to run
+# (by the autospec-qa visual cluster / implementer) only when the repo has a root
+# DESIGN.md; this script itself just lints the files it is given.
+#
+# Usage:
+#   scripts/lint-ui.sh <file> [<file> ...]   # lint the given UI files
+#   scripts/lint-ui.sh --directives <file>…  # reformat findings as directive lines
+#   scripts/lint-ui.sh --help
+#
+# Output (default): one finding per stdout line:
+#   RULE_ID:<path>:<line>: <one-line description>
+# With --directives:
+#   Fix <RULE_ID>: <imperative action>
+#
+# Rules (token-drift focus):
+#   UI_RAW_HEX          A raw hex color literal in a value/string (use a DESIGN.md token/CSS var).
+#   UI_OFF_GRID_SPACING margin/padding/gap px value off the 4px grid (and > 2px).
+#   UI_AD_HOC_ZINDEX    z-index outside the scale {0,10,20,30,40,50,100,1000}.
+#   UI_BANNED_FONT      font-family using a banned/generic font (Inter/Roboto/Arial/Helvetica/system stacks).
+#
+# Token/theme source files (basename matching design|token|theme|palette, or DESIGN.md)
+# are skipped — they legitimately declare raw values.
+#
+# Exit code = number of findings (0 = clean), capped at 200.
+#
+# Requires: bash 3.2+, awk.
+
+set +e
+
+DIRECTIVES=0
+FILES=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --directives) DIRECTIVES=1 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    --*) echo "lint-ui: unknown option: $1" >&2; exit 2 ;;
+    *) FILES="$FILES $1" ;;
+  esac
+  shift
+done
+
+[ -n "$FILES" ] || { echo "Usage: scripts/lint-ui.sh <file> [<file> ...]" >&2; exit 0; }
+
+emit() { # emit RULE_ID file line desc
+  if [ "$DIRECTIVES" -eq 1 ]; then
+    case "$1" in
+      UI_RAW_HEX)          printf 'Fix %s: replace the raw hex with a DESIGN.md color token / CSS variable.\n' "$1" ;;
+      UI_OFF_GRID_SPACING) printf 'Fix %s: snap spacing to the 4/8px grid (use a spacing token).\n' "$1" ;;
+      UI_AD_HOC_ZINDEX)    printf 'Fix %s: use a z-index from the declared scale (0/10/20/30/40/50/100/1000).\n' "$1" ;;
+      UI_BANNED_FONT)      printf 'Fix %s: use the DESIGN.md font tokens, not a banned/generic font.\n' "$1" ;;
+    esac
+  else
+    printf '%s:%s:%s: %s\n' "$1" "$2" "$3" "$4"
+  fi
+}
+
+count=0
+out=""
+for f in $FILES; do
+  [ -f "$f" ] || continue
+  base="$(basename "$f")"
+  # Skip token/theme source files (they legitimately declare raw values).
+  case "$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')" in
+    *design*|*token*|*theme*|*palette*) continue ;;
+  esac
+  # One awk pass per file emits TAB-separated RULE\tline\tdesc records.
+  recs="$(awk '
+    {
+      line=$0; n=NR
+      # UI_RAW_HEX: hex as a CSS value (": #abc") or a JS/TS string literal.
+      if (line ~ /:[[:space:]]*#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?([^0-9a-fA-F]|$)/ \
+          || line ~ /["'"'"']#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?["'"'"']/) {
+        print "UI_RAW_HEX\t" n "\traw hex color literal — use a DESIGN.md token/CSS variable"
+      }
+      # UI_OFF_GRID_SPACING: margin/padding/gap px not a multiple of 4 (and > 2px).
+      if (line ~ /(margin|padding|gap)[a-zA-Z-]*[[:space:]]*:/) {
+        tmp=line
+        while (match(tmp, /[0-9]+px/)) {
+          numstr=substr(tmp, RSTART, RLENGTH-2); num=numstr+0
+          if (num > 2 && (num % 4) != 0) {
+            print "UI_OFF_GRID_SPACING\t" n "\tspacing " num "px is off the 4px grid — use a spacing token"
+            break
+          }
+          tmp=substr(tmp, RSTART+RLENGTH)
+        }
+      }
+      # UI_AD_HOC_ZINDEX: z-index outside the allowed scale.
+      if (match(line, /z-index[[:space:]]*:[[:space:]]*[0-9]+/)) {
+        zs=substr(line, RSTART, RLENGTH); sub(/.*:[[:space:]]*/, "", zs); z=zs+0
+        if (z!=0 && z!=10 && z!=20 && z!=30 && z!=40 && z!=50 && z!=100 && z!=1000) {
+          print "UI_AD_HOC_ZINDEX\t" n "\tz-index " z " is outside the scale {0,10,20,30,40,50,100,1000}"
+        }
+      }
+      # UI_BANNED_FONT: font-family with a banned/generic font.
+      if (line ~ /font-family/ && tolower(line) ~ /(inter|roboto|arial|helvetica|space grotesk|system-ui|-apple-system)/) {
+        print "UI_BANNED_FONT\t" n "\tbanned/generic font in font-family — use DESIGN.md font tokens"
+      }
+    }
+  ' "$f")"
+  [ -n "$recs" ] || continue
+  while IFS="$(printf '\t')" read -r rule ln desc; do
+    [ -n "$rule" ] || continue
+    out="${out}$(emit "$rule" "$f" "$ln" "$desc")
+"
+    count=$((count + 1))
+    [ "$count" -ge 200 ] && break
+  done <<EOF
+$recs
+EOF
+  [ "$count" -ge 200 ] && break
+done
+
+[ -n "$out" ] && printf '%s' "$out"
+[ "$count" -gt 200 ] && count=200
+exit "$count"

--- a/skills/autospec-qa/clusters/accessibility-and-responsive.md
+++ b/skills/autospec-qa/clusters/accessibility-and-responsive.md
@@ -34,6 +34,17 @@ Behavioral + a11y checks confirm a screen functions; this loop confirms it
 matches the adopted design language. It runs only when the repo has a root
 `DESIGN.md` (otherwise skip — nothing to judge against).
 
+0. **Deterministic token-drift lint (cheap pre-pass)** — before spending a vision
+   call, run the objective design-token linter on the changed UI files; it catches
+   what regex can prove (raw hex outside the palette, off-grid spacing, ad-hoc
+   z-index, banned fonts) and emits `file:line` findings:
+   ```bash
+   bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-ui.sh" $(git diff --name-only main...HEAD -- '*.css' '*.scss' '*.tsx' '*.jsx' '*.vue' '*.html')
+   ```
+   Map each finding to a `category:"visual_fidelity"` qa-verdict entry (these are
+   the deterministic half of the implementer's `DESIGN_DRIFT` directive). The
+   vision judge below then handles the *subjective* fidelity the linter can't.
+
 1. **Capture** — screenshot each spec route at the viewport matrix using the
    existing `gen-screenshots.mjs` (Mode-II forbidden-URL safety already built in):
    ```bash

--- a/skills/autospec-run/prompts/implementer-contract.md
+++ b/skills/autospec-run/prompts/implementer-contract.md
@@ -72,7 +72,7 @@ implementer's retry prompt as cumulative context:
 | `REPEATED_STRUCTURE_AS_CODE` | "Extract the N branches into a table + single dispatcher loop." |
 | `DOC_OUT_OF_SYNC` | "Update the doc file(s) covering the changed public surface in this same PR." |
 | `INVENTED_CONFIG` | "Remove the invented flag/env/key, or amend the issue body to introduce it as scope." |
-| `DESIGN_DRIFT` | "If the repo has a DESIGN.md, use its tokens (color/spacing/typography/component) instead of hardcoding values; match the adopted design language for any user-facing UI." |
+| `DESIGN_DRIFT` | "If the repo has a DESIGN.md, use its tokens (color/spacing/typography/component) instead of hardcoding values; match the adopted design language for any user-facing UI. Run scripts/lint-ui.sh on changed UI files — it deterministically flags raw hex, off-grid spacing, ad-hoc z-index, and banned fonts." |
 
 ### Enforcement and opt-out
 

--- a/tests/lint/lint-ui.bats
+++ b/tests/lint/lint-ui.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# tests/lint/lint-ui.bats — deterministic design-token-drift linter (scripts/lint-ui.sh).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    L="$REPO_ROOT/scripts/lint-ui.sh"
+    TMP="$(mktemp -d)"
+}
+teardown() { rm -rf "$TMP"; }
+
+@test "--help prints a Usage line" {
+    run bash "$L" --help
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'Usage:'
+}
+
+@test "UI_RAW_HEX: raw hex color value is flagged" {
+    printf '.b { color: #3a7bd5; }\n' > "$TMP/a.css"
+    run bash "$L" "$TMP/a.css"
+    printf '%s\n' "$output" | grep -q '^UI_RAW_HEX:'
+    [ "$status" -ge 1 ]
+}
+
+@test "UI_RAW_HEX: CSS variable / token usage is NOT flagged" {
+    printf '.b { color: var(--primary); }\n' > "$TMP/a.css"
+    run bash "$L" "$TMP/a.css"
+    ! printf '%s\n' "$output" | grep -q 'UI_RAW_HEX'
+}
+
+@test "UI_RAW_HEX: quoted hex in a JS string is flagged" {
+    printf 'const c = "#ff0066";\n' > "$TMP/a.js"
+    run bash "$L" "$TMP/a.js"
+    printf '%s\n' "$output" | grep -q '^UI_RAW_HEX:'
+}
+
+@test "UI_OFF_GRID_SPACING: off-grid padding flagged, on-grid not" {
+    printf '.a { padding: 13px; }\n.b { padding: 8px 16px; }\n' > "$TMP/a.css"
+    run bash "$L" "$TMP/a.css"
+    printf '%s\n' "$output" | grep -q 'UI_OFF_GRID_SPACING:.*:1:'
+    ! printf '%s\n' "$output" | grep -q 'UI_OFF_GRID_SPACING:.*:2:'
+}
+
+@test "UI_OFF_GRID_SPACING: 2px hairline is not flagged" {
+    printf '.a { padding: 2px; }\n' > "$TMP/a.css"
+    run bash "$L" "$TMP/a.css"
+    ! printf '%s\n' "$output" | grep -q 'UI_OFF_GRID_SPACING'
+}
+
+@test "UI_AD_HOC_ZINDEX: off-scale z-index flagged, scale value not" {
+    printf '.a { z-index: 9999; }\n.b { z-index: 100; }\n' > "$TMP/a.css"
+    run bash "$L" "$TMP/a.css"
+    printf '%s\n' "$output" | grep -q 'UI_AD_HOC_ZINDEX:.*:1:'
+    ! printf '%s\n' "$output" | grep -q 'UI_AD_HOC_ZINDEX:.*:2:'
+}
+
+@test "UI_BANNED_FONT: banned font flagged, token font not" {
+    printf '.a { font-family: Inter, sans-serif; }\n.b { font-family: var(--font-display); }\n' > "$TMP/a.css"
+    run bash "$L" "$TMP/a.css"
+    printf '%s\n' "$output" | grep -q 'UI_BANNED_FONT:.*:1:'
+    ! printf '%s\n' "$output" | grep -q 'UI_BANNED_FONT:.*:2:'
+}
+
+@test "clean UI file -> exit 0, no findings" {
+    printf '.a { color: var(--c); padding: 8px; z-index: 20; font-family: var(--f); }\n' > "$TMP/a.css"
+    run bash "$L" "$TMP/a.css"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "token/theme source files are skipped" {
+    printf '.a { color: #3a7bd5; z-index: 9999; }\n' > "$TMP/theme.css"
+    run bash "$L" "$TMP/theme.css"
+    [ "$status" -eq 0 ]
+}
+
+@test "exit code equals finding count" {
+    printf '.a { color: #abc; padding: 13px; z-index: 7; }\n' > "$TMP/a.css"
+    run bash "$L" "$TMP/a.css"
+    [ "$status" -eq 3 ]
+}
+
+@test "--directives reformats findings as Fix lines" {
+    printf '.a { color: #abc; }\n' > "$TMP/a.css"
+    run bash "$L" --directives "$TMP/a.css"
+    printf '%s\n' "$output" | grep -q '^Fix UI_RAW_HEX:'
+}


### PR DESCRIPTION
## Summary
The one genuinely net-new integration from the "best Claude UX/code-quality skills" review (Vercel Web Interface Guidelines + UI-UX Pro Max): a **deterministic** UI/design-token linter that complements the LLM-vision visual-fidelity judge already merged (#1051). It's the deterministic half of `DESIGN_DRIFT` — objective rules the vision judge can't reliably catch.

`scripts/lint-ui.sh` flags, as `RULE_ID:file:line:` findings:
- **`UI_RAW_HEX`** — raw hex color in a value/string (use a DESIGN.md token/CSS var)
- **`UI_OFF_GRID_SPACING`** — margin/padding/gap px off the 4px grid (>2px)
- **`UI_AD_HOC_ZINDEX`** — z-index outside the scale {0,10,20,30,40,50,100,1000}
- **`UI_BANNED_FONT`** — Inter/Roboto/Arial/Helvetica/Space Grotesk/system stacks

Conservative + low-FP (hex only in value/string context; 2px hairlines pass; token/theme source files skipped). `--directives` mode for the adaptive-retry loop.

**Wiring:** a cheap deterministic pre-pass in the autospec-qa visual-fidelity cluster (runs before the vision call), referenced from the implementer `DESIGN_DRIFT` directive, ships via the repo-scripts glob.

## What was reviewed (and skipped, with reasons)
- **GSD** / **TDD** — autospec already embodies these (fresh-subagent-per-issue + slim context + gated phases; tests-first contract). No action.
- **Anthropic Frontend Design** — the banned-font list is folded into `UI_BANNED_FONT`; the skill itself remains available to invoke.
- **Vercel guidelines / UI-UX Pro Max** — the objective rules are implemented here natively (no fork).

## Test Plan
- [x] `tests/lint/lint-ui.bats` 12/12 (each rule positive + negative, clean→0, theme-skip, exit=count, --directives, --help Usage)
- [x] `validate.sh` exit 0 (auto-runs the new bats; lint-ui.sh ships via repo-scripts glob)

Completes the design chain: **define** (#1052 UI sections) → **implement** (#1049 DESIGN.md bundle) → **deterministic lint (this)** + **vision judge** (#1051) → heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)