### PR TITLE
fix(watchdog): unify heartbeat-dir env var across writers and watchdog

### DIFF
--- a/scripts/autospec-watchdog.sh
+++ b/scripts/autospec-watchdog.sh
@@ -6,7 +6,8 @@
 # files and detect stalled workers.
 #
 # Environment overrides:
-#   AUTOSPEC_WATCHDOG_DIR              heartbeat directory (default: ~/.autospec/process-heartbeats)
+#   AUTOSPEC_WATCHDOG_DIR              heartbeat directory (default: ~/.autospec/process-heartbeats);
+#                                     AUTOSPEC_HEARTBEAT_DIR (writers' var) takes precedence so both agree
 #   AUTOSPEC_WATCHDOG_REPO              override repo for gh calls (default: gh repo context)
 #   AUTOSPEC_WATCHDOG_STALE_SECS         stale threshold (default: 1800)
 #   AUTOSPEC_WATCHDOG_RECLAIM_SECS       reclaim threshold (default: 10800)
@@ -16,7 +17,7 @@
 
 set -eu
 
-WATCHDOG_BASE="${AUTOSPEC_WATCHDOG_DIR:-$HOME/.autospec/process-heartbeats}"
+WATCHDOG_BASE="${AUTOSPEC_HEARTBEAT_DIR:-${AUTOSPEC_WATCHDOG_DIR:-$HOME/.autospec/process-heartbeats}}"
 WATCHDOG_REPO="${AUTOSPEC_WATCHDOG_REPO:-${AUTOSPEC_REPO:-}}"
 WATCHDOG_STALE_SECS="${AUTOSPEC_WATCHDOG_STALE_SECS:-1800}"
 WATCHDOG_RECLAIM_SECS="${AUTOSPEC_WATCHDOG_RECLAIM_SECS:-10800}"

--- a/skills/autospec-run/scripts/autospec-run-status.sh
+++ b/skills/autospec-run/scripts/autospec-run-status.sh
@@ -49,7 +49,7 @@ if [ -z "$repo" ] && command -v gh >/dev/null 2>&1; then
   repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)"
 fi
 slug="$(printf '%s' "$repo" | tr '/' '_')"
-HB_BASE="${AUTOSPEC_HEARTBEAT_DIR:-$HOME/.autospec/process-heartbeats}"
+HB_BASE="${AUTOSPEC_HEARTBEAT_DIR:-${AUTOSPEC_WATCHDOG_DIR:-$HOME/.autospec/process-heartbeats}}"
 hb_dir="$HB_BASE/$slug"
 
 # Build a JSON array of per-issue rows by reading the heartbeat files directly

--- a/skills/autospec-run/scripts/heartbeat-read.sh
+++ b/skills/autospec-run/scripts/heartbeat-read.sh
@@ -10,12 +10,13 @@
 # Reads from: ~/.autospec/process-heartbeats/<repo-slug>/
 #
 # Environment:
-#   AUTOSPEC_HEARTBEAT_DIR   base dir (default: ~/.autospec/process-heartbeats)
+#   AUTOSPEC_HEARTBEAT_DIR   base dir (default: ~/.autospec/process-heartbeats);
+#                            AUTOSPEC_WATCHDOG_DIR is honored as a back-compat alias
 #   AUTOSPEC_REPO            repo override (owner/repo format)
 
 set -eu
 
-HEARTBEAT_BASE="${AUTOSPEC_HEARTBEAT_DIR:-$HOME/.autospec/process-heartbeats}"
+HEARTBEAT_BASE="${AUTOSPEC_HEARTBEAT_DIR:-${AUTOSPEC_WATCHDOG_DIR:-$HOME/.autospec/process-heartbeats}}"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 

--- a/skills/autospec-run/scripts/heartbeat-write.sh
+++ b/skills/autospec-run/scripts/heartbeat-write.sh
@@ -8,12 +8,15 @@
 # where <repo-slug> is derived from <owner/repo> with '/' replaced by '_'.
 #
 # Environment:
-#   AUTOSPEC_HEARTBEAT_DIR   base dir (default: ~/.autospec/process-heartbeats)
+#   AUTOSPEC_HEARTBEAT_DIR   base dir (default: ~/.autospec/process-heartbeats);
+#                            AUTOSPEC_WATCHDOG_DIR is honored as a back-compat alias
 #   AUTOSPEC_REPO            repo override (owner/repo format)
 
 set -eu
 
-HEARTBEAT_BASE="${AUTOSPEC_HEARTBEAT_DIR:-$HOME/.autospec/process-heartbeats}"
+# Honor both env-var names so writers and the watchdog never point at different
+# dirs (a mismatch silently hid every heartbeat from the watchdog).
+HEARTBEAT_BASE="${AUTOSPEC_HEARTBEAT_DIR:-${AUTOSPEC_WATCHDOG_DIR:-$HOME/.autospec/process-heartbeats}}"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 

--- a/skills/autospec-shared/scripts/detect-monitor-exit-mode.sh
+++ b/skills/autospec-shared/scripts/detect-monitor-exit-mode.sh
@@ -32,7 +32,7 @@
 set -eu
 
 REPO=""
-HB_BASE="${AUTOSPEC_WATCHDOG_DIR:-$HOME/.autospec/process-heartbeats}"
+HB_BASE="${AUTOSPEC_HEARTBEAT_DIR:-${AUTOSPEC_WATCHDOG_DIR:-$HOME/.autospec/process-heartbeats}}"
 WT_BASE="${AUTOSPEC_WORKTREE_BASE:-/tmp}"
 # ~185 tool calls is where the empirical "Prompt is too long" overflow hit
 # (see feedback_monitor_silent_exit.md, third confirmation). 180 leaves margin.

--- a/tests/heartbeat-env-unify.bats
+++ b/tests/heartbeat-env-unify.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# heartbeat-env-unify.bats — writers and the watchdog must resolve the SAME
+# heartbeat dir whether the operator sets AUTOSPEC_HEARTBEAT_DIR or the
+# back-compat alias AUTOSPEC_WATCHDOG_DIR. (Bug: they used different var names,
+# so overriding one silently hid heartbeats from the other.)
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    HBW="$REPO_ROOT/skills/autospec-run/scripts/heartbeat-write.sh"
+    TMP="$(mktemp -d)"
+    export AUTOSPEC_REPO="me/repo"
+    unset AUTOSPEC_HEARTBEAT_DIR AUTOSPEC_WATCHDOG_DIR
+}
+teardown() { rm -rf "$TMP"; }
+
+@test "heartbeat-write honors AUTOSPEC_WATCHDOG_DIR (back-compat alias)" {
+    run env AUTOSPEC_WATCHDOG_DIR="$TMP/wd" bash "$HBW" --issue 1 --step claimed --repo me/repo
+    [ "$status" -eq 0 ]
+    [ -f "$TMP/wd/me_repo/1.json" ]
+}
+
+@test "heartbeat-write honors AUTOSPEC_HEARTBEAT_DIR" {
+    run env AUTOSPEC_HEARTBEAT_DIR="$TMP/hb" bash "$HBW" --issue 2 --step claimed --repo me/repo
+    [ "$status" -eq 0 ]
+    [ -f "$TMP/hb/me_repo/2.json" ]
+}
+
+@test "AUTOSPEC_HEARTBEAT_DIR takes precedence when both are set (consistent across components)" {
+    run env AUTOSPEC_HEARTBEAT_DIR="$TMP/hb" AUTOSPEC_WATCHDOG_DIR="$TMP/wd" bash "$HBW" --issue 3 --step claimed --repo me/repo
+    [ "$status" -eq 0 ]
+    [ -f "$TMP/hb/me_repo/3.json" ]
+    [ ! -f "$TMP/wd/me_repo/3.json" ]
+}
+
+@test "all five heartbeat-dir resolvers use the unified both-var form" {
+    # Guard against regressing one site back to a single-var resolution.
+    for f in \
+        "$REPO_ROOT/skills/autospec-run/scripts/heartbeat-write.sh" \
+        "$REPO_ROOT/skills/autospec-run/scripts/heartbeat-read.sh" \
+        "$REPO_ROOT/skills/autospec-run/scripts/autospec-run-status.sh" \
+        "$REPO_ROOT/scripts/autospec-watchdog.sh" \
+        "$REPO_ROOT/skills/autospec-shared/scripts/detect-monitor-exit-mode.sh"; do
+        grep -qE 'AUTOSPEC_HEARTBEAT_DIR:-\$\{AUTOSPEC_WATCHDOG_DIR:-' "$f" \
+            || { echo "MISSING unified resolver in $f"; false; }
+    done
+}


### PR DESCRIPTION
## Summary
Latent bug found in the deep optimization review: the heartbeat directory is read under **two different env-var names**.

- Writers/reader/status (`heartbeat-write.sh`, `heartbeat-read.sh`, `autospec-run-status.sh`) read **`AUTOSPEC_HEARTBEAT_DIR`**.
- The watchdog (`autospec-watchdog.sh`) and `detect-monitor-exit-mode.sh` read **`AUTOSPEC_WATCHDOG_DIR`**.

Both default to the same path, so it's invisible by default — but an operator overriding **one** silently points the watchdog at a different dir than the writers, so the watchdog sees **zero heartbeats**: stale-claim reclaim and orphan-worktree GC never fire (the self-heal everything depends on goes dark).

**Fix:** all five resolvers now use `${AUTOSPEC_HEARTBEAT_DIR:-${AUTOSPEC_WATCHDOG_DIR:-<default>}}` — `AUTOSPEC_HEARTBEAT_DIR` takes precedence, `AUTOSPEC_WATCHDOG_DIR` stays as a back-compat alias, and every component always resolves the same dir.

## Test Plan
- [x] `tests/heartbeat-env-unify.bats` 4/4 (each var honored; precedence when both set; a guard asserting all 5 sites use the unified form)
- [x] `validate.sh` exit 0 (existing heartbeat/watchdog/detect tests still pass)

## Note on the rest of the review
The audit's "`[ test ] && assign` aborts under set -e" finding was a **false alarm** (verified — does not abort in this bash; the scripts run fine in production). The broad helper-dedup-into-lib is **blocked by the install model** (`scripts/lib/` isn't installed to `~/.autospec/scripts`). This PR is the one unambiguous correctness bug. Token-reduction + validate-parallelism tracks follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)