### PR TITLE
perf(validate): --fast/--no-bats mode for quick local feedback

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -13,6 +13,29 @@
 
 set -eu
 
+# ── Fast mode ────────────────────────────────────────────────────────────────
+# `--no-bats` / `--fast` skips the bats SUITES (the slow part, ~minutes) while
+# still running every structural check (lock-step, goldens, frontmatter, named
+# content, file presence) for quick local feedback. CI/pre-merge runs the full
+# suite by default.
+#
+# Implemented by shadowing the `bats` command with a wrapper: every `bats ...`
+# call (guarded or not) routes through it. `_REAL_BATS` is detected BEFORE the
+# function is defined, so the wrapper preserves today's "skip when bats is not
+# installed" behavior even though `command -v bats` now resolves to the function.
+RUN_BATS=1
+_REAL_BATS=0; command -v bats >/dev/null 2>&1 && _REAL_BATS=1
+bats() {
+    { [ "$RUN_BATS" = 1 ] && [ "$_REAL_BATS" = 1 ]; } || return 0
+    command bats "$@"
+}
+for _arg in "$@"; do
+    case "$_arg" in
+        --no-bats|--fast) RUN_BATS=0 ;;
+    esac
+done
+[ "$RUN_BATS" = 1 ] || printf 'validate: fast mode — skipping bats suites (structural checks only)\n' >&2
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 


### PR DESCRIPTION
## Summary
`scripts/validate.sh` ran the **entire bats suite serially on every invocation** (~287s locally; the bats runs dominate). The deep optimization review flagged this as the top dev-experience cost.

Adds a **`--fast` / `--no-bats`** flag that skips the bats *suites* while still running every structural check (lock-step, block-expansion goldens, frontmatter parse, named-content invariants, file presence, `bash -n`). Local feedback drops from **~287s → ~38s**. CI/pre-merge runs the full suite by default (no behavior change without the flag).

**Implementation (zero call-site churn):** a `bats()` wrapper function shadows the command, so all 31 `bats …` invocations (guarded and unguarded) route through it. `_REAL_BATS` is detected *before* the function is defined, so the wrapper preserves the existing "skip when bats isn't installed" behavior even though `command -v bats` now resolves to the function.

## Test Plan
- [x] `--fast`: exit 0, ~38s, prints "fast mode" notice, all structural checks pass, 0 failures
- [x] Full (default): exit 0, ~287s, **real bats verified executing** (per-suite /tmp logs show real `ok N` lines) — no regression
- [x] `bash -n` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)