### PR TITLE
test(validate): harness-detection warn → hard fail (migration complete)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -453,7 +453,9 @@ check_harness_detection_block() {
     file="$1"
     name="$(basename "$(dirname "$file")")"
     if ! grep -q '## Harness detection' "$file"; then
-        printf 'validate: WARN — %s: missing ## Harness detection section (incremental migration OK)\n' "$name" >&2
+        # Migration complete (all skills carry the section); a new skill omitting
+        # it is now a regression, not incremental migration — fail closed.
+        fail "$name: missing ## Harness detection section (required; defines TIER_A/TIER_B)"
         return 0
     fi
     info "harness detection block: $name"


### PR DESCRIPTION
## Summary
The `## Harness detection` check in `validate.sh` was warn-only "(incremental migration OK)". The migration is now **100% complete** — every skill carries the section — so the warn path is dead for current state but would silently let a *new* skill land without it (leaving `TIER_A`/`TIER_B` undefined for that skill's dispatches). Promote it to a hard fail.

## Test Plan
- [x] Negative path: a SKILL.md without the section now fails the check
- [x] Full `validate.sh` exit 0 (all 27 skills comply — no current breakage)

## Context
This is the safe hardening from the deep optimization review. The bigger token-reduction item (QA cluster inversion) is **correctly deferred**: its prerequisite is unmet — `qa-cluster-dispatch.sh` is a recorder stub that doesn't inject cluster prose into subagents, and the QA prompt references detector gates by name, so moving prose out of `autospec-qa/SKILL.md` now would drop those detectors from the live run (validate wouldn't catch it, as those sections aren't gated). It needs the dispatch model matured first, as the maintainer's note states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)