### PR TITLE
perf(subagents): Output discipline directive (terse, minimal-diff returns)

### DIFF
--- a/skills/autospec-shared/scripts/bundle-static-context.sh
+++ b/skills/autospec-shared/scripts/bundle-static-context.sh
@@ -211,6 +211,12 @@ emit_lockstep() {
 
 # Emit role-specific scaffolding (per-issue acting instructions).
 emit_scaffolding() {
+  # Output discipline (all roles): a subagent's final message flows back into the
+  # orchestrator's context, so verbose returns bloat context + burn tokens. Keep
+  # returns high-density.
+  printf '## Output discipline\n\n'
+  printf 'Your final message returns to the orchestrator — keep it high-density. Return only conclusions, file:line references, and uncertainty; no preamble, prompt restatement, or end-summary. Make minimal diffs — never rewrite a whole file for a small change. Use markdown only where it compresses (tables); otherwise terse prose.\n'
+  printf '\n'
   case "$ROLE" in
     implementer)
       printf '## Implementer scaffolding\n\n'

--- a/tests/bundle-static-context.bats
+++ b/tests/bundle-static-context.bats
@@ -254,3 +254,60 @@ teardown() {
   [ "$status" -eq 0 ]
   ! printf '%s\n' "$output" | grep -q 'Design language (DESIGN.md'
 }
+
+@test "every role's scaffolding carries the Output discipline directive" {
+  # Limited to roles whose SKILL the test fixture provides (autospec-run); the
+  # directive is role-agnostic (emitted before the per-role case), so this is
+  # representative.
+  for role in implementer reviewer; do
+    run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+      AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+      AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+      AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+      "$SCRIPT" --role "$role" --issue-labels "skill:autospec-run"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q '## Output discipline'
+    printf '%s\n' "$output" | grep -q 'minimal diffs'
+  done
+}
+
+@test "bundle-static-context.sh output is cwd-independent (cross-directory invocation)" {
+  # The script resolves all inputs from AUTOSPEC_REPO_ROOT, not $PWD. Run it once
+  # from the tests directory (near the script) and once from an unrelated temp
+  # working dir; output must be byte-identical and carry real content, proving the
+  # script never reads relative to the caller's working directory.
+  local workdir from_near from_elsewhere
+  workdir="$BATS_TEST_TMPDIR/elsewhere"
+  mkdir -p "$workdir"
+
+  from_near=$(cd "$BATS_TEST_DIRNAME" && env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run")
+
+  from_elsewhere=$(cd "$workdir" && env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run")
+
+  [ -n "$from_near" ]
+  [ "$from_near" = "$from_elsewhere" ]
+  # Not merely "it ran": the cross-directory output carries the real bundle.
+  printf '%s\n' "$from_elsewhere" | grep -q "CACHE BOUNDARY"
+  printf '%s\n' "$from_elsewhere" | grep -q "Implementer contract"
+}
+
+@test "Output discipline sits BELOW the implementer cache boundary (prefix stays byte-stable)" {
+  run env AUTOSPEC_REPO_ROOT="$FIXTURES_DIR" \
+    AUTOSPEC_MEMORY_DIR="$FIXTURES_DIR/memory" \
+    AUTOSPEC_SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../scripts" \
+    AUTOSPEC_MANIFEST="$FIXTURES_DIR/memory-tags.yml" \
+    "$SCRIPT" --role implementer --issue-labels "skill:autospec-run"
+  [ "$status" -eq 0 ]
+  # The directive must appear AFTER the second (closing) CACHE BOUNDARY marker.
+  disc_line="$(printf '%s\n' "$output" | grep -n '## Output discipline' | head -1 | cut -d: -f1)"
+  last_boundary="$(printf '%s\n' "$output" | grep -n 'CACHE BOUNDARY' | tail -1 | cut -d: -f1)"
+  [ "$disc_line" -gt "$last_boundary" ]
+}


### PR DESCRIPTION
## Summary
The one genuinely-applicable idea from the community "slash Opus token costs" thread (the rest — model routing, slim context, conclusions-not-transcripts, verify-claims — autospec already does; the "launch subagents" keyword is a debunked placebo).

A subagent's final message flows back into the orchestrator's context, so verbose returns are real context bloat + token burn. This injects a shared **`## Output discipline`** block into every role's scaffolding (implementer / reviewer / decomposer / classifier):
- Return only conclusions + `file:line` + uncertainty — no preamble, prompt restatement, or end-summary.
- **Minimal diffs — never rewrite a whole file for a small change** (the thread's consensus MVP).
- Markdown only where it compresses (tables); else terse prose.

It's emitted **below** the cache boundary with the other per-issue scaffolding, so the byte-stable implementer prefix (the cached prompt) is unaffected.

## Test Plan
- [x] `bundle-static-context.bats` 20/20 (directive present per role; sits below the cache boundary so prefix stays byte-stable)
- [x] `validate.sh` exit 0 (incl. the behavioral `check_implementer_contract` run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)