### PR TITLE
fix(validate): wire ship-completeness.bats into the gate + fix bare lint-ui ref

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -755,6 +755,21 @@ check_supersession_contract() {
     fi
 }
 
+# Ship-completeness gate (#556/#985): every script a skill surface invokes via
+# ${AUTOSPEC_SCRIPTS_DIR} must be shipped by the installers, every $SCRIPT_DIR/lib
+# source must ship via copy_runtime_subdirs, and no bare repo-relative invocation
+# may remain in a surface file. Run tests/ship-completeness.bats as part of the
+# lock-step gate so install-drift fails closed HERE, not silently in a target repo.
+check_ship_completeness() {
+    [ -f tests/ship-completeness.bats ] \
+        || fail "tests/ship-completeness.bats: missing (ship-completeness gate)"
+    if command -v bats >/dev/null 2>&1; then
+        info "ship-completeness gate: tests/ship-completeness.bats"
+        bats tests/ship-completeness.bats >/tmp/validate-ship-completeness.log 2>&1 \
+            || { cat /tmp/validate-ship-completeness.log >&2; fail "tests/ship-completeness.bats: failed"; }
+    fi
+}
+
 # Phase 4 guardian block lock-step invariants (introduced by issue #212): the
 # outer guardian dispatch block (between <!-- guardian-block:begin --> and
 # <!-- guardian-block:end --> markers) must be byte-identical across all 6
@@ -2384,6 +2399,7 @@ main() {
     check_quality_differential
     check_usage_limit_helper
     check_supersession_contract
+    check_ship_completeness
     check_phase4_guardian_block_lockstep
     check_phase1_bounded_context_contract
     check_phase4_issue_start_summary

--- a/skills/autospec-run/prompts/implementer-contract.md
+++ b/skills/autospec-run/prompts/implementer-contract.md
@@ -72,7 +72,7 @@ implementer's retry prompt as cumulative context:
 | `REPEATED_STRUCTURE_AS_CODE` | "Extract the N branches into a table + single dispatcher loop." |
 | `DOC_OUT_OF_SYNC` | "Update the doc file(s) covering the changed public surface in this same PR." |
 | `INVENTED_CONFIG` | "Remove the invented flag/env/key, or amend the issue body to introduce it as scope." |
-| `DESIGN_DRIFT` | "If the repo has a DESIGN.md, use its tokens (color/spacing/typography/component) instead of hardcoding values; match the adopted design language for any user-facing UI. Run scripts/lint-ui.sh on changed UI files — it deterministically flags raw hex, off-grid spacing, ad-hoc z-index, and banned fonts." |
+| `DESIGN_DRIFT` | "If the repo has a DESIGN.md, use its tokens (color/spacing/typography/component) instead of hardcoding values; match the adopted design language for any user-facing UI. Run `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-ui.sh` on changed UI files — it deterministically flags raw hex, off-grid spacing, ad-hoc z-index, and banned fonts." |
 
 ### Enforcement and opt-out
 


### PR DESCRIPTION
## Why

`tests/ship-completeness.bats` guards that every script a skill surface invokes via `${AUTOSPEC_SCRIPTS_DIR}` is actually shipped by the installers, and that no bare repo-relative invocation remains in a surface file. But **`validate.sh` never ran it** — so this entire class of install-drift could ship green. That's exactly how the `scripts/lib` + `explore-research` ship gap (fixed in #1058) reached `main` undetected.

## Changes

- **`scripts/validate.sh`**: add `check_ship_completeness()` and register it in `main()`, running `tests/ship-completeness.bats` as part of the lock-step gate. Fails closed if the test file is missing; degrades gracefully when `bats` is absent (mirrors `check_supersession_contract` and the other inline bats checks).
- **`skills/autospec-run/prompts/implementer-contract.md`**: #1053 added a bare `scripts/lint-ui.sh` reference in the `DESIGN_DRIFT` row. Rewrite to the shipped form `${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/lint-ui.sh` — the convention already used for `lint-issue.sh` / `lint-implementation.sh`. Without this, the newly-wired gate (correctly) fails.

## Verification

- `tests/ship-completeness.bats`: 2/2 pass after the lint-ui fix.
- `validate.sh`: all checks pass, now including the wired ship-completeness gate.
- Independent code review: APPROVE, 0 actionable findings.

## Relationship to #1058 / #1059

Independent files; no merge conflicts. #1058 adds a third ship-completeness test (the `$SCRIPT_DIR/lib` cross-check) alongside `copy_runtime_subdirs`; whichever order these land, the wired gate stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)