### PR TITLE
feat(claim-guard): atomic path/skill edit-lease core with TTL reclaim (#1065)

### DIFF
--- a/scripts/claim-guard.sh
+++ b/scripts/claim-guard.sh
@@ -1,0 +1,528 @@
+#!/usr/bin/env bash
+# scripts/claim-guard.sh — atomic file/skill edit-lease with heartbeat-TTL reclaim.
+#
+# The fine-grained complement to the issue-level claim: the issue claim says
+# "I own issue #N"; claim-guard says "I own skills/autospec-explore right now".
+# It is the inner layer of the concurrency fix described in
+# docs/specs/2026-06-15-claim-guard-concurrent-edit-design.md (Issue A: core).
+#
+# Subcommands:
+#   claim-guard.sh acquire <path|skill>...   atomic all-or-nothing lease.
+#                                            0 ok / 6 claim_conflict.
+#   claim-guard.sh assert  <path|skill>...   read-only check.
+#                                            0 if free/mine, 6 if held by other.
+#   claim-guard.sh refresh                   bump updated_at on my claims (heartbeat).
+#   claim-guard.sh release [<path|skill>...] drop my claims (default: all mine).
+#   claim-guard.sh status                    list live claims for this repo.
+#
+# `scan` (overlap pre-flight) and the validate.sh gate are Issue B; not here.
+#
+# Store: ${AUTOSPEC_STATE_DIR:-$HOME/.autospec}/edit-claims/<repo-slug>/<key>.json
+#   path-scoped by repo slug subdir (feedback_heartbeat_cross_repo_collision).
+#   The on-disk file name is the lock key with ':' and '/' slugified to '-';
+#   the canonical lock_key (e.g. skill:autospec-run) lives inside the JSON.
+#
+# Atomicity: a per-key `.lock` DIR is created with mkdir(2) (POSIX-atomic,
+# bash-3.2 safe) before the JSON is written. Multi-path acquire sorts keys and
+# takes them in order (deadlock-free), releasing already-taken keys on any
+# conflict (all-or-nothing).
+#
+# Strictness: AUTOSPEC_CLAIM_GUARD=off|warn|strict (default warn).
+#   off            -> no-op success, writes nothing.
+#   warn (default) -> on conflict, log + proceed (exit 0).
+#   strict         -> on conflict, refuse (exit 6).
+# An unwritable store always degrades to a no-op success (never blocks work).
+#
+# Session identity: CLAUDE_CODE_SESSION_ID fallback chain
+# (reference_harness_session_id_envs). PPID is the unreliable last resort.
+#
+# Conventions mirror worktree-guard.sh: usage()/die() helpers, stable
+# code_health: identifiers on stderr, no RETURN traps, if/then/fi for one-sided
+# conditionals under set -e, bash 3.2 safe.
+
+set -eu
+
+PROG="claim-guard.sh"
+
+STATE_DIR="${AUTOSPEC_STATE_DIR:-$HOME/.autospec}"
+MODE="${AUTOSPEC_CLAIM_GUARD:-warn}"
+TTL_SECONDS="${AUTOSPEC_CLAIM_TTL_SECONDS:-1800}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  claim-guard.sh acquire <path|skill>...    atomic all-or-nothing lease (0 ok / 6 conflict)
+  claim-guard.sh assert  <path|skill>...    read-only check (0 free/mine / 6 held by other)
+  claim-guard.sh refresh                     bump updated_at on my claims (heartbeat)
+  claim-guard.sh release [<path|skill>...]   drop my claims (default: all mine in this repo)
+  claim-guard.sh status                      list live claims for this repo
+
+Env:
+  AUTOSPEC_CLAIM_GUARD   off|warn|strict (default warn). off / unwritable store => no-op.
+  AUTOSPEC_STATE_DIR     store root (default ~/.autospec).
+  AUTOSPEC_CLAIM_TTL_SECONDS  lease TTL before stale reclaim (default 1800).
+
+Exit codes: 0 ok, 2 usage, 6 claim_conflict.
+EOF
+}
+
+die() {
+    # die <exit-code> <message...>
+    code="$1"; shift
+    printf '%s: %s\n' "$PROG" "$*" >&2
+    exit "$code"
+}
+
+emit() { printf '%s\n' "$*" >&2; }
+
+now_iso() { date -u +'%Y-%m-%dT%H:%M:%SZ'; }
+now_epoch() { date -u +%s; }
+
+# Portable ISO8601 -> epoch (BSD date first, GNU fallback) — mirrors
+# autospec-run-registry.sh's iso_to_epoch. Unparseable => 0.
+iso_to_epoch() {
+    ts="$1"
+    [ -n "$ts" ] || { echo 0; return; }
+    date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$ts" +%s 2>/dev/null \
+        || date -u -d "$ts" +%s 2>/dev/null \
+        || echo 0
+}
+
+# Stable per-session token: first non-empty wins (reference_harness_session_id_envs).
+session_id() {
+    v=""
+    for v in "${AUTOSPEC_SESSION_ID:-}" "${CLAUDE_CODE_SESSION_ID:-}" \
+             "${CODEX_SESSION_ID:-}" "${CODEX_THREAD_ID:-}" \
+             "${OPENCODE_SESSION_ID:-}" "${OPENCODE_SESSION:-}" \
+             "${TERM_SESSION_ID:-}"; do
+        if [ -n "$v" ]; then printf '%s' "$v"; return 0; fi
+    done
+    sid="$(ps -o sess= -p "$$" 2>/dev/null | tr -d ' ')"
+    if [ -n "$sid" ] && [ "$sid" != "0" ]; then printf 'sid-%s' "$sid"; return 0; fi
+    printf 'ppid-%s' "${PPID:-unknown}"
+}
+
+repo_slug() {
+    repo="${AUTOSPEC_REPO:-}"
+    if [ -z "$repo" ] && command -v gh >/dev/null 2>&1; then
+        repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+    fi
+    if [ -z "$repo" ]; then
+        # Fall back to the git remote URL -> owner/repo.
+        url="$(git config --get remote.origin.url 2>/dev/null || true)"
+        if [ -n "$url" ]; then
+            repo="$(printf '%s' "$url" \
+                | sed -e 's#^.*[:/]\([^/]*/[^/]*\)$#\1#' -e 's/\.git$//')"
+        fi
+    fi
+    [ -n "$repo" ] || repo="unknown_repo"
+    printf '%s' "$repo" | tr '/' '_'
+}
+
+# Slugify a lock key into a safe file-name stem (':' and '/' -> '-').
+key_to_filename() {
+    printf '%s' "$1" | tr -c 'A-Za-z0-9_.-' '-'
+}
+
+# Resolve an input path/skill token to its canonical lock key.
+#   skills/<name>/...                          -> skill:<name>
+#   tests/fixtures/skill-goldens/<name>.*      -> skill:<name>
+#   <name> when skills/<name>/ exists          -> skill:<name>
+#   anything else                              -> path:<normalized>
+resolve_key() {
+    p="$1"
+    # Strip a leading ./ and any trailing slash for normalization.
+    p="${p#./}"
+    case "$p" in
+        skills/*/*|skills/*)
+            rest="${p#skills/}"
+            name="${rest%%/*}"
+            if [ -n "$name" ]; then printf 'skill:%s' "$name"; return 0; fi
+            ;;
+        tests/fixtures/skill-goldens/*)
+            base="${p#tests/fixtures/skill-goldens/}"
+            name="${base%%.*}"
+            name="${name%%/*}"
+            if [ -n "$name" ]; then printf 'skill:%s' "$name"; return 0; fi
+            ;;
+    esac
+    # A bare skill name (no slash) that matches an existing skill dir.
+    case "$p" in
+        */*) : ;;
+        *)
+            if [ -n "$p" ] && [ -d "skills/$p" ]; then
+                printf 'skill:%s' "$p"; return 0
+            fi
+            ;;
+    esac
+    # Normalize a path key: drop trailing slash.
+    np="${p%/}"
+    printf 'path:%s' "$np"
+}
+
+CLAIM_DIR=""           # set by ensure_store
+STORE_OK=0             # 1 when the store dir is usable
+
+# Prepare the per-repo store dir. On any failure, STORE_OK stays 0 so callers
+# degrade to a no-op (never block work).
+ensure_store() {
+    slug="$(repo_slug)"
+    CLAIM_DIR="${STATE_DIR}/edit-claims/${slug}"
+    if mkdir -p "$CLAIM_DIR" 2>/dev/null && [ -w "$CLAIM_DIR" ]; then
+        STORE_OK=1
+    else
+        STORE_OK=0
+    fi
+}
+
+claim_path()  { printf '%s/%s.json' "$CLAIM_DIR" "$(key_to_filename "$1")"; }
+lock_path()   { printf '%s/%s.lock' "$CLAIM_DIR" "$(key_to_filename "$1")"; }
+
+# Is a claim file stale (updated_at older than now - TTL)? A missing/unparseable
+# updated_at counts as stale (reclaimable). True (exit 0) == stale.
+claim_is_stale() {
+    file="$1"
+    [ -f "$file" ] || return 0
+    updated="$(jq -r '.updated_at // empty' "$file" 2>/dev/null || true)"
+    epoch="$(iso_to_epoch "$updated")"
+    [ "$epoch" -gt 0 ] || return 0
+    age=$(( $(now_epoch) - epoch ))
+    [ "$age" -ge "$TTL_SECONDS" ]
+}
+
+# Owner session recorded in a claim file ('' if unreadable).
+claim_owner() {
+    jq -r '.owner_session // empty' "$1" 2>/dev/null || true
+}
+
+# Write/refresh a claim JSON for one key held by me.
+write_claim() {
+    key="$1"; me="$2"; iso="$3"; acquired="$4"
+    paths_json="$5"
+    cf="$(claim_path "$key")"
+    host="${AUTOSPEC_HOST:-$(hostname 2>/dev/null || echo unknown)}"
+    branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
+    worktree="$(git rev-parse --show-toplevel 2>/dev/null || echo '')"
+    tmp="${cf}.tmp.$$"
+    # Build the JSON with jq so every field is correctly escaped (branch names,
+    # worktree paths, and arbitrary path tokens may contain quotes/backslashes).
+    # --argjson injects the already-valid paths[] array verbatim.
+    jq -n \
+        --arg lock_key "$key" \
+        --argjson paths "$paths_json" \
+        --arg owner_session "$me" \
+        --arg host "$host" \
+        --argjson pid "$$" \
+        --arg branch "$branch" \
+        --arg worktree "$worktree" \
+        --arg acquired_at "$acquired" \
+        --arg updated_at "$iso" \
+        --argjson ttl_seconds "$TTL_SECONDS" \
+        '{lock_key:$lock_key, paths:$paths, owner_session:$owner_session,
+          host:$host, pid:$pid, branch:$branch, worktree:$worktree,
+          acquired_at:$acquired_at, updated_at:$updated_at,
+          ttl_seconds:$ttl_seconds}' > "$tmp"
+    mv -f "$tmp" "$cf"
+}
+
+# A lock dir with NO backing claim file is an orphan from a crash between
+# `mkdir <lock>` and `write_claim` (kill -9 window). Treat it as reclaimable
+# once it is itself older than the TTL, so a dead acquire never wedges a key
+# forever. True (exit 0) == orphaned-and-reclaimable.
+lock_is_orphaned() {
+    lock="$1"
+    [ -d "$lock" ] || return 1
+    # Lock dir age via mtime epoch (BSD `stat -f %m`, GNU `stat -c %Y`).
+    mt="$(stat -f %m "$lock" 2>/dev/null || stat -c %Y "$lock" 2>/dev/null || echo 0)"
+    [ "$mt" -gt 0 ] || return 1
+    age=$(( $(now_epoch) - mt ))
+    [ "$age" -ge "$TTL_SECONDS" ]
+}
+
+# Take a single key atomically for me. Echoes one of:
+#   "acquired"  newly taken (fresh, stale-reclaimed, or orphan-reclaimed)
+#   "mine"      I already hold this live claim (idempotent; NOT rolled back)
+#   "conflict"  held by a live other session, or a fresh concurrent acquire won
+# Never exits — the caller decides the all-or-nothing rollback (only "acquired"
+# keys are released on a later conflict; pre-existing "mine" keys are kept).
+take_key() {
+    key="$1"; me="$2"; iso="$3"; paths_json="$4"
+    cf="$(claim_path "$key")"
+    lock="$(lock_path "$key")"
+
+    # If a live claim by ANOTHER session exists, that's a conflict regardless of
+    # the .lock dir state.
+    if [ -f "$cf" ]; then
+        owner="$(claim_owner "$cf")"
+        if [ -n "$owner" ] && [ "$owner" != "$me" ] && ! claim_is_stale "$cf"; then
+            printf 'conflict'
+            return 0
+        fi
+    fi
+
+    # Atomic gate: mkdir the .lock dir. If it already exists, someone else is
+    # mid-acquire OR holds the key. Re-check the claim to decide.
+    if mkdir "$lock" 2>/dev/null; then
+        # We own the lock dir. A stale claim file may still be present; the live
+        # check above already proved it is mine or stale, so overwrite is safe.
+        acq="$iso"
+        if [ -f "$cf" ] && [ "$(claim_owner "$cf")" = "$me" ]; then
+            acq="$(jq -r '.acquired_at // empty' "$cf" 2>/dev/null || true)"
+            [ -n "$acq" ] || acq="$iso"
+        fi
+        write_claim "$key" "$me" "$iso" "$acq" "$paths_json"
+        printf 'acquired'
+        return 0
+    fi
+
+    # Could not take the lock dir.
+    if [ -f "$cf" ]; then
+        owner="$(claim_owner "$cf")"
+        if [ "$owner" = "$me" ]; then
+            # Idempotent re-acquire of my own live claim: refresh updated_at but
+            # do NOT report it as newly acquired (so rollback keeps it).
+            acq="$(jq -r '.acquired_at // empty' "$cf" 2>/dev/null || true)"
+            [ -n "$acq" ] || acq="$iso"
+            write_claim "$key" "$me" "$iso" "$acq" "$paths_json"
+            printf 'mine'
+            return 0
+        fi
+        if claim_is_stale "$cf"; then
+            # Reclaim. Re-take the lock dir atomically, then RE-VALIDATE that the
+            # claim is still stale: the owner may have refreshed in the window
+            # between our staleness check and winning the lock. If it went live,
+            # back off and report conflict — never steal a now-live lease.
+            rmdir "$lock" 2>/dev/null || true
+            if mkdir "$lock" 2>/dev/null; then
+                if [ -f "$cf" ] \
+                        && [ "$(claim_owner "$cf")" != "$me" ] \
+                        && ! claim_is_stale "$cf"; then
+                    rmdir "$lock" 2>/dev/null || true
+                    printf 'conflict'
+                    return 0
+                fi
+                write_claim "$key" "$me" "$iso" "$iso" "$paths_json"
+                printf 'acquired'
+                return 0
+            fi
+        fi
+        printf 'conflict'
+        return 0
+    fi
+
+    # Lock dir exists with NO claim file: either a concurrent acquire is
+    # mid-flight (it mkdir'd but hasn't written JSON yet — exactly one racer
+    # wins, the other lands here as conflict), OR a crashed acquire orphaned the
+    # lock. Reclaim only when the lock dir has itself aged past TTL.
+    if lock_is_orphaned "$lock"; then
+        rmdir "$lock" 2>/dev/null || true
+        if mkdir "$lock" 2>/dev/null; then
+            # Re-check: another session may have re-taken it concurrently.
+            if [ -f "$cf" ] && [ "$(claim_owner "$cf")" != "$me" ] \
+                    && ! claim_is_stale "$cf"; then
+                rmdir "$lock" 2>/dev/null || true
+                printf 'conflict'
+                return 0
+            fi
+            write_claim "$key" "$me" "$iso" "$iso" "$paths_json"
+            printf 'acquired'
+            return 0
+        fi
+    fi
+    printf 'conflict'
+    return 0
+}
+
+drop_key() {
+    key="$1"
+    rm -f "$(claim_path "$key")" 2>/dev/null || true
+    rmdir "$(lock_path "$key")" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# acquire
+# ---------------------------------------------------------------------------
+cmd_acquire() {
+    [ $# -ge 1 ] || die 2 "acquire: at least one <path|skill> is required"
+    [ "$MODE" != "off" ] || exit 0
+    ensure_store
+    [ "$STORE_OK" -eq 1 ] || exit 0   # unwritable store => no-op success
+
+    me="$(session_id)"
+    iso="$(now_iso)"
+
+    # Resolve + de-dup keys, sorted for deadlock-free ordering.
+    keys="$(for a in "$@"; do resolve_key "$a"; printf '\n'; done | sort -u)"
+
+    # Only keys NEWLY acquired in this invocation are rolled back on a conflict.
+    # A key I already held ("mine") is left intact — rolling it back would drop a
+    # pre-existing lease the caller still legitimately owns.
+    acquired_keys=""
+    conflict_key=""
+    for k in $keys; do
+        # Collect the original input tokens that resolve to this key for the
+        # paths[] field (data-model fidelity: paths are source globs, not the
+        # key). Build the JSON array from the matching tokens.
+        pj="$(
+            for a in "$@"; do
+                if [ "$(resolve_key "$a")" = "$k" ]; then printf '%s\n' "$a"; fi
+            done | jq -R . | jq -s -c .
+        )"
+        res="$(take_key "$k" "$me" "$iso" "$pj")"
+        case "$res" in
+            acquired) acquired_keys="$acquired_keys $k" ;;
+            mine)     : ;;   # already held by me; keep on rollback
+            *)        conflict_key="$k"; break ;;
+        esac
+    done
+
+    if [ -n "$conflict_key" ]; then
+        # all-or-nothing: release only the keys this invocation newly acquired.
+        for k in $acquired_keys; do drop_key "$k"; done
+        cf="$(claim_path "$conflict_key")"
+        owner="$(claim_owner "$cf")"
+        host="$(jq -r '.host // empty' "$cf" 2>/dev/null || true)"
+        branch="$(jq -r '.branch // empty' "$cf" 2>/dev/null || true)"
+        emit "code_health:claim_conflict key=$conflict_key owner_session=$owner host=$host branch=$branch"
+        if [ "$MODE" = "strict" ]; then
+            exit 6
+        fi
+        # warn mode: log + proceed.
+        emit "$PROG: WARN claim conflict on $conflict_key (held by $owner) — proceeding (AUTOSPEC_CLAIM_GUARD=warn)"
+        exit 0
+    fi
+
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# assert (read-only)
+# ---------------------------------------------------------------------------
+cmd_assert() {
+    [ $# -ge 1 ] || die 2 "assert: at least one <path|skill> is required"
+    [ "$MODE" != "off" ] || exit 0
+    ensure_store
+    [ "$STORE_OK" -eq 1 ] || exit 0
+
+    me="$(session_id)"
+    keys="$(for a in "$@"; do resolve_key "$a"; printf '\n'; done | sort -u)"
+    for k in $keys; do
+        cf="$(claim_path "$k")"
+        if [ -f "$cf" ]; then
+            owner="$(claim_owner "$cf")"
+            if [ -n "$owner" ] && [ "$owner" != "$me" ] && ! claim_is_stale "$cf"; then
+                host="$(jq -r '.host // empty' "$cf" 2>/dev/null || true)"
+                branch="$(jq -r '.branch // empty' "$cf" 2>/dev/null || true)"
+                emit "code_health:claim_conflict key=$k owner_session=$owner host=$host branch=$branch"
+                if [ "$MODE" = "strict" ]; then exit 6; fi
+                emit "$PROG: WARN claim conflict on $k (held by $owner) — proceeding (warn)"
+            fi
+        fi
+    done
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# refresh — bump updated_at on every claim owned by me.
+# ---------------------------------------------------------------------------
+cmd_refresh() {
+    [ "$MODE" != "off" ] || exit 0
+    ensure_store
+    [ "$STORE_OK" -eq 1 ] || exit 0
+    me="$(session_id)"
+    iso="$(now_iso)"
+    if [ -d "$CLAIM_DIR" ]; then
+        for cf in "$CLAIM_DIR"/*.json; do
+            [ -e "$cf" ] || continue
+            owner="$(claim_owner "$cf")"
+            if [ "$owner" = "$me" ]; then
+                tmp="${cf}.tmp.$$"
+                jq --arg u "$iso" '.updated_at = $u' "$cf" > "$tmp" 2>/dev/null \
+                    && mv -f "$tmp" "$cf" || rm -f "$tmp"
+            fi
+        done
+    fi
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# release — drop my claims (default: all mine; or only the given keys).
+# ---------------------------------------------------------------------------
+cmd_release() {
+    [ "$MODE" != "off" ] || exit 0
+    ensure_store
+    [ "$STORE_OK" -eq 1 ] || exit 0
+    me="$(session_id)"
+
+    if [ $# -ge 1 ]; then
+        keys="$(for a in "$@"; do resolve_key "$a"; printf '\n'; done | sort -u)"
+        for k in $keys; do
+            cf="$(claim_path "$k")"
+            if [ -f "$cf" ]; then
+                owner="$(claim_owner "$cf")"
+                # Only drop a key that is mine (never release another session's).
+                if [ -z "$owner" ] || [ "$owner" = "$me" ]; then drop_key "$k"; fi
+            else
+                drop_key "$k"
+            fi
+        done
+        exit 0
+    fi
+
+    # No keys -> release ALL claims owned by me in this repo.
+    if [ -d "$CLAIM_DIR" ]; then
+        for cf in "$CLAIM_DIR"/*.json; do
+            [ -e "$cf" ] || continue
+            owner="$(claim_owner "$cf")"
+            if [ "$owner" = "$me" ]; then
+                key="$(jq -r '.lock_key // empty' "$cf" 2>/dev/null || true)"
+                rm -f "$cf" 2>/dev/null || true
+                if [ -n "$key" ]; then rmdir "$(lock_path "$key")" 2>/dev/null || true; fi
+            fi
+        done
+    fi
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# status — list live claims for this repo, flagging stale ones.
+# ---------------------------------------------------------------------------
+cmd_status() {
+    ensure_store
+    # status is read-only: an unwritable/empty store just prints nothing.
+    if [ ! -d "$CLAIM_DIR" ]; then exit 0; fi
+    any=0
+    for cf in "$CLAIM_DIR"/*.json; do
+        [ -e "$cf" ] || continue
+        any=1
+        key="$(jq -r '.lock_key // empty' "$cf" 2>/dev/null || true)"
+        owner="$(jq -r '.owner_session // empty' "$cf" 2>/dev/null || true)"
+        host="$(jq -r '.host // empty' "$cf" 2>/dev/null || true)"
+        updated="$(jq -r '.updated_at // empty' "$cf" 2>/dev/null || true)"
+        flag="live"
+        if claim_is_stale "$cf"; then flag="stale"; fi
+        printf '%s\towner=%s\thost=%s\tupdated_at=%s\t%s\n' \
+            "$key" "$owner" "$host" "$updated" "$flag"
+    done
+    [ "$any" -eq 1 ] || printf '%s: no live claims for this repo\n' "$PROG"
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# dispatch
+# ---------------------------------------------------------------------------
+main() {
+    [ $# -ge 1 ] || { usage >&2; exit 2; }
+    sub="$1"; shift
+    case "$sub" in
+        acquire)   cmd_acquire "$@" ;;
+        assert)    cmd_assert "$@" ;;
+        refresh)   cmd_refresh "$@" ;;
+        release)   cmd_release "$@" ;;
+        status)    cmd_status "$@" ;;
+        -h|--help) usage; exit 0 ;;
+        *)         echo "$PROG: unknown subcommand: $sub" >&2; usage >&2; exit 2 ;;
+    esac
+}
+
+main "$@"

--- a/tests/test_claim_guard_acquire.bats
+++ b/tests/test_claim_guard_acquire.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+# tests/test_claim_guard_acquire.bats — acquire/release round-trip + status.
+#
+# Covers AC: acquire writes a JSON claim under edit-claims/<repo-slug>/,
+# status lists it, release removes it, skill-path resolution to skill:<name>,
+# AUTOSPEC_CLAIM_GUARD=off degrades to a no-op, and assert sees a free key.
+#
+# Real filesystem store, no mocks (AGENTS.md). The store root is redirected via
+# AUTOSPEC_STATE_DIR to a per-test tmp dir so we never touch ~/.autospec.
+
+bats_require_minimum_version 1.5.0
+
+GUARD="${BATS_TEST_DIRNAME}/../scripts/claim-guard.sh"
+
+setup() {
+    STATE_DIR="$(mktemp -d)"
+    export AUTOSPEC_STATE_DIR="$STATE_DIR"
+    # Deterministic repo identity so the slug is stable and assertable without
+    # re-deriving it from the SUT (self-consistent-fixture trap).
+    export AUTOSPEC_REPO="berlinguyinca/autospec"
+    export AUTOSPEC_CLAIM_GUARD="strict"
+    export CLAUDE_CODE_SESSION_ID="sess-acquire-aaaa"
+    export AUTOSPEC_HOST="testhost"
+    CLAIM_ROOT="${STATE_DIR}/edit-claims/berlinguyinca_autospec"
+}
+
+teardown() {
+    rm -rf "$STATE_DIR"
+}
+
+# ---------------------------------------------------------------------------
+@test "claim-guard.sh is executable and bash-valid" {
+    [ -x "$GUARD" ]
+    run bash -n "$GUARD"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+@test "acquire a skill path writes a skill:<name> JSON claim under edit-claims/<repo-slug>/" {
+    run bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 0 ]
+
+    # Lock key for a skills/<name>/... path is skill:<name>; the file name
+    # encodes the key with ':' slugified to '-'.
+    claim_file="${CLAIM_ROOT}/skill-autospec-run.json"
+    [ -f "$claim_file" ]
+
+    run jq -r '.lock_key' "$claim_file"
+    [ "$status" -eq 0 ]
+    [ "$output" = "skill:autospec-run" ]
+
+    run jq -r '.owner_session' "$claim_file"
+    [ "$output" = "sess-acquire-aaaa" ]
+
+    run jq -r '.host' "$claim_file"
+    [ "$output" = "testhost" ]
+
+    run jq -r '.ttl_seconds' "$claim_file"
+    [ "$status" -eq 0 ]
+    [ "$output" -gt 0 ]
+}
+
+# ---------------------------------------------------------------------------
+@test "a deeper skill subpath and a skill golden both resolve to skill:<name>" {
+    run bash "$GUARD" acquire "skills/autospec-run/scripts/heartbeat-write.sh"
+    [ "$status" -eq 0 ]
+    [ -f "${CLAIM_ROOT}/skill-autospec-run.json" ]
+
+    bash "$GUARD" release
+    run bash "$GUARD" acquire "tests/fixtures/skill-goldens/autospec-run.sha256"
+    [ "$status" -eq 0 ]
+    [ -f "${CLAIM_ROOT}/skill-autospec-run.json" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "a non-skill path resolves to a path:<glob> claim" {
+    run bash "$GUARD" acquire "scripts/validate.sh"
+    [ "$status" -eq 0 ]
+    # exactly one claim json exists, and its key is path:...
+    claim_file="$(ls "${CLAIM_ROOT}"/*.json)"
+    run jq -r '.lock_key' "$claim_file"
+    [ "$status" -eq 0 ]
+    case "$output" in
+        path:*) : ;;
+        *) printf 'expected path: key, got %s\n' "$output" >&2; return 1 ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+@test "status lists a live claim after acquire and is empty after release" {
+    bash "$GUARD" acquire skills/autospec-run
+
+    run bash "$GUARD" status
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q "skill:autospec-run"
+
+    run bash "$GUARD" release
+    [ "$status" -eq 0 ]
+    [ ! -f "${CLAIM_ROOT}/skill-autospec-run.json" ]
+
+    run bash "$GUARD" status
+    [ "$status" -eq 0 ]
+    ! printf '%s\n' "$output" | grep -q "skill:autospec-run"
+}
+
+# ---------------------------------------------------------------------------
+@test "release with explicit keys drops only those claims" {
+    bash "$GUARD" acquire skills/autospec-run skills/autospec-explore
+    [ -f "${CLAIM_ROOT}/skill-autospec-run.json" ]
+    [ -f "${CLAIM_ROOT}/skill-autospec-explore.json" ]
+
+    run bash "$GUARD" release skills/autospec-run
+    [ "$status" -eq 0 ]
+    [ ! -f "${CLAIM_ROOT}/skill-autospec-run.json" ]
+    [ -f "${CLAIM_ROOT}/skill-autospec-explore.json" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "re-acquire of my own live claim is an idempotent success" {
+    run bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 0 ]
+    run bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+@test "assert on a free key exits 0; on my own key exits 0" {
+    run bash "$GUARD" assert skills/autospec-run
+    [ "$status" -eq 0 ]
+    bash "$GUARD" acquire skills/autospec-run
+    run bash "$GUARD" assert skills/autospec-run
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+@test "refresh bumps updated_at on my claim" {
+    bash "$GUARD" acquire skills/autospec-run
+    claim_file="${CLAIM_ROOT}/skill-autospec-run.json"
+    before="$(jq -r '.updated_at' "$claim_file")"
+    # force a measurable time gap by rewriting updated_at into the past
+    tmp="$(mktemp)"
+    jq '.updated_at = "2000-01-01T00:00:00Z"' "$claim_file" > "$tmp" && mv "$tmp" "$claim_file"
+    run bash "$GUARD" refresh
+    [ "$status" -eq 0 ]
+    after="$(jq -r '.updated_at' "$claim_file")"
+    [ "$after" != "2000-01-01T00:00:00Z" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "AUTOSPEC_CLAIM_GUARD=off acquire exits 0 and writes no claim" {
+    run env AUTOSPEC_CLAIM_GUARD=off bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 0 ]
+    [ ! -d "${CLAIM_ROOT}" ] || [ -z "$(ls -A "${CLAIM_ROOT}" 2>/dev/null)" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "unwritable store degrades to a no-op success (never blocks)" {
+    # Point the state dir at a location we cannot create under.
+    ro_root="$(mktemp -d)"
+    chmod 0500 "$ro_root"
+    run env AUTOSPEC_STATE_DIR="${ro_root}/sub" AUTOSPEC_CLAIM_GUARD=strict \
+        bash "$GUARD" acquire skills/autospec-run
+    chmod 0700 "$ro_root"; rm -rf "$ro_root"
+    [ "$status" -eq 0 ]
+}

--- a/tests/test_claim_guard_atomicity.bats
+++ b/tests/test_claim_guard_atomicity.bats
@@ -1,0 +1,215 @@
+#!/usr/bin/env bats
+# tests/test_claim_guard_atomicity.bats — concurrency, overlap, stale reclaim,
+# session identity, and degrade safety for claim-guard.sh.
+#
+# These are the counter-team (concurrency + portability) assertions:
+#   - two concurrent acquires of ONE key grant exactly one owner (no TOCTOU
+#     double-grant); the loser exits 6.
+#   - an overlapping skill golden path conflicts with a held skill:<name>;
+#     a disjoint path does not.
+#   - a claim past TTL is reclaimable; one within TTL is never stolen.
+#   - a different session is blocked; the same session is not.
+#
+# Real filesystem store, no mocks. Two "sessions" are simulated by toggling
+# CLAUDE_CODE_SESSION_ID between subprocess invocations — that is exactly the
+# stable per-session token claim-guard keys on.
+
+bats_require_minimum_version 1.5.0
+
+GUARD="${BATS_TEST_DIRNAME}/../scripts/claim-guard.sh"
+
+setup() {
+    STATE_DIR="$(mktemp -d)"
+    export AUTOSPEC_STATE_DIR="$STATE_DIR"
+    export AUTOSPEC_REPO="berlinguyinca/autospec"
+    export AUTOSPEC_CLAIM_GUARD="strict"
+    export AUTOSPEC_HOST="testhost"
+    CLAIM_ROOT="${STATE_DIR}/edit-claims/berlinguyinca_autospec"
+}
+
+teardown() {
+    rm -rf "$STATE_DIR"
+}
+
+# ---------------------------------------------------------------------------
+@test "code_health:claim_conflict identifier is present in the script" {
+    grep -q 'code_health:claim_conflict' "$GUARD"
+}
+
+# ---------------------------------------------------------------------------
+@test "a second session cannot acquire a key already held within TTL (exit 6)" {
+    CLAUDE_CODE_SESSION_ID="sess-owner" run bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 0 ]
+
+    CLAUDE_CODE_SESSION_ID="sess-intruder" run bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 6 ]
+    printf '%s\n' "$output" | grep -q 'code_health:claim_conflict'
+}
+
+# ---------------------------------------------------------------------------
+@test "assert by another session on a held key exits 6; the owner exits 0" {
+    CLAUDE_CODE_SESSION_ID="sess-owner" bash "$GUARD" acquire skills/autospec-run
+
+    CLAUDE_CODE_SESSION_ID="sess-intruder" run bash "$GUARD" assert skills/autospec-run
+    [ "$status" -eq 6 ]
+
+    CLAUDE_CODE_SESSION_ID="sess-owner" run bash "$GUARD" assert skills/autospec-run
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+@test "two concurrent acquires of one key grant exactly one owner; the loser exits 6" {
+    race_dir="$(mktemp -d)"
+    out_a="${race_dir}/a.rc"
+    out_b="${race_dir}/b.rc"
+
+    # Launch two acquires racing for the same key from two distinct sessions.
+    # Capture each PID and wait on it explicitly. NOTE: bats runs tests under
+    # `set -e`, which the backgrounded subshells inherit — so the failing (exit
+    # 6) acquire would abort the subshell before it could record its rc. Guard
+    # the acquire with `|| rc=$?` so the rc is always written to the file.
+    ( CLAUDE_CODE_SESSION_ID="sess-A" rc=0
+      bash "$GUARD" acquire skills/autospec-run >/dev/null 2>&1 || rc=$?
+      printf '%s' "$rc" > "$out_a" ) &
+    pid_a=$!
+    ( CLAUDE_CODE_SESSION_ID="sess-B" rc=0
+      bash "$GUARD" acquire skills/autospec-run >/dev/null 2>&1 || rc=$?
+      printf '%s' "$rc" > "$out_b" ) &
+    pid_b=$!
+    # `wait <pid>` returns the job's exit status; the loser exits 6, which would
+    # abort this test under bats' set -e. Swallow it — we read rc from the files.
+    wait "$pid_a" || true
+    wait "$pid_b" || true
+
+    rc_a="$(cat "$out_a")"
+    rc_b="$(cat "$out_b")"
+    rm -rf "$race_dir"
+
+    # Exactly one winner (rc 0) and one loser (rc 6).
+    winners=0
+    [ "$rc_a" = "0" ] && winners=$((winners + 1)) || true
+    [ "$rc_b" = "0" ] && winners=$((winners + 1)) || true
+    [ "$winners" -eq 1 ]
+
+    losers=0
+    [ "$rc_a" = "6" ] && losers=$((losers + 1)) || true
+    [ "$rc_b" = "6" ] && losers=$((losers + 1)) || true
+    [ "$losers" -eq 1 ]
+
+    # The persisted claim is owned by exactly one of the two sessions.
+    claim_file="${CLAIM_ROOT}/skill-autospec-run.json"
+    [ -f "$claim_file" ]
+    owner="$(jq -r '.owner_session' "$claim_file")"
+    case "$owner" in sess-A|sess-B) : ;; *) return 1 ;; esac
+}
+
+# ---------------------------------------------------------------------------
+@test "multi-path acquire is all-or-nothing: a partial conflict releases the taken key" {
+    # sess-owner already holds skill:autospec-explore.
+    CLAUDE_CODE_SESSION_ID="sess-owner" bash "$GUARD" acquire skills/autospec-explore
+
+    # sess-new tries to grab autospec-run AND autospec-explore atomically; the
+    # explore key conflicts, so the whole acquire fails AND autospec-run must NOT
+    # be left claimed by sess-new.
+    CLAUDE_CODE_SESSION_ID="sess-new" run bash "$GUARD" \
+        acquire skills/autospec-run skills/autospec-explore
+    [ "$status" -eq 6 ]
+
+    [ ! -f "${CLAIM_ROOT}/skill-autospec-run.json" ]
+    # explore is still owned by the original owner.
+    owner="$(jq -r '.owner_session' "${CLAIM_ROOT}/skill-autospec-explore.json")"
+    [ "$owner" = "sess-owner" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "a partial-conflict rollback keeps a claim the SAME session already held" {
+    # I already hold skill:autospec-run from a previous acquire.
+    CLAUDE_CODE_SESSION_ID="sess-me" bash "$GUARD" acquire skills/autospec-run
+    [ -f "${CLAIM_ROOT}/skill-autospec-run.json" ]
+
+    # Another session holds skill:autospec-explore.
+    CLAUDE_CODE_SESSION_ID="sess-other" bash "$GUARD" acquire skills/autospec-explore
+
+    # I now try to acquire BOTH run (already mine) and explore (conflict). The
+    # all-or-nothing rollback must NOT drop my pre-existing run claim.
+    CLAUDE_CODE_SESSION_ID="sess-me" run bash "$GUARD" \
+        acquire skills/autospec-run skills/autospec-explore
+    [ "$status" -eq 6 ]
+
+    [ -f "${CLAIM_ROOT}/skill-autospec-run.json" ]
+    owner="$(jq -r '.owner_session' "${CLAIM_ROOT}/skill-autospec-run.json")"
+    [ "$owner" = "sess-me" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "a crash-orphaned lock dir (no claim file) is reclaimable past TTL" {
+    export AUTOSPEC_CLAIM_TTL_SECONDS=1
+    mkdir -p "$CLAIM_ROOT"
+    # Simulate a kill -9 between mkdir <lock> and write_claim: a .lock dir with
+    # no backing JSON. Age it past TTL.
+    orphan="${CLAIM_ROOT}/skill-autospec-run.lock"
+    mkdir -p "$orphan"
+    # Backdate the lock dir mtime well past the 1s TTL (portable touch -t).
+    touch -t 200001010000 "$orphan" 2>/dev/null || true
+
+    CLAUDE_CODE_SESSION_ID="sess-fresh" run bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 0 ]
+    [ -f "${CLAIM_ROOT}/skill-autospec-run.json" ]
+    owner="$(jq -r '.owner_session' "${CLAIM_ROOT}/skill-autospec-run.json")"
+    [ "$owner" = "sess-fresh" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "an overlapping skill golden path conflicts with a held skill:<name> claim" {
+    CLAUDE_CODE_SESSION_ID="sess-owner" bash "$GUARD" acquire skills/autospec-run
+
+    # The golden of the same skill resolves to the same lock key -> conflict.
+    CLAUDE_CODE_SESSION_ID="sess-other" run bash "$GUARD" \
+        assert "tests/fixtures/skill-goldens/autospec-run.sha256"
+    [ "$status" -eq 6 ]
+
+    # A disjoint skill does NOT conflict.
+    CLAUDE_CODE_SESSION_ID="sess-other" run bash "$GUARD" assert skills/autospec-explore
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+@test "stale reclaim: a claim past TTL is reclaimable by another session" {
+    export AUTOSPEC_CLAIM_TTL_SECONDS=1
+    CLAUDE_CODE_SESSION_ID="sess-old" bash "$GUARD" acquire skills/autospec-run
+    claim_file="${CLAIM_ROOT}/skill-autospec-run.json"
+
+    # Age the claim past TTL by rewriting updated_at far into the past.
+    tmp="$(mktemp)"
+    jq '.updated_at = "2000-01-01T00:00:00Z"' "$claim_file" > "$tmp" && mv "$tmp" "$claim_file"
+
+    CLAUDE_CODE_SESSION_ID="sess-fresh" run bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 0 ]
+    owner="$(jq -r '.owner_session' "$claim_file")"
+    [ "$owner" = "sess-fresh" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "stale reclaim never steals a live claim within TTL" {
+    export AUTOSPEC_CLAIM_TTL_SECONDS=1800
+    CLAUDE_CODE_SESSION_ID="sess-live" bash "$GUARD" acquire skills/autospec-run
+
+    # Claim is fresh (updated_at = now), well within TTL -> intruder is blocked.
+    CLAUDE_CODE_SESSION_ID="sess-thief" run bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 6 ]
+    owner="$(jq -r '.owner_session' "${CLAIM_ROOT}/skill-autospec-run.json")"
+    [ "$owner" = "sess-live" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "status flags a stale claim" {
+    export AUTOSPEC_CLAIM_TTL_SECONDS=1
+    CLAUDE_CODE_SESSION_ID="sess-old" bash "$GUARD" acquire skills/autospec-run
+    claim_file="${CLAIM_ROOT}/skill-autospec-run.json"
+    tmp="$(mktemp)"
+    jq '.updated_at = "2000-01-01T00:00:00Z"' "$claim_file" > "$tmp" && mv "$tmp" "$claim_file"
+
+    run bash "$GUARD" status
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -qi 'stale'
+}


### PR DESCRIPTION
Closes #1065

## What

Ships `scripts/claim-guard.sh` — the fine-grained inner layer of the concurrent-edit guard (Issue A of `docs/specs/2026-06-15-claim-guard-concurrent-edit-design.md`). The issue claim says "I own issue #N"; claim-guard says "I own `skills/autospec-run` right now."

`acquire` / `assert` / `refresh` / `release` / `status` over a per-repo-slug-scoped JSON claim store at `${AUTOSPEC_STATE_DIR:-~/.autospec}/edit-claims/<slug>/`.

- **Lock unit = skill directory:** `skills/<name>/...`, its goldens `tests/fixtures/skill-goldens/<name>.*`, and `skills/<name>/tests/...` all resolve to `skill:<name>`; other paths to `path:<glob>`.
- **Atomic all-or-nothing multi-path acquire** via `mkdir`(2) `.lock` dirs in sorted-key order (deadlock-free); a conflict releases only the keys this invocation newly acquired and exits 6 (strict) / warns (warn).
- **TTL stale reclaim** only when `updated_at < now - ttl_seconds`; a live claim within TTL is never stolen. After winning the reclaim lock, staleness is **re-validated** so a concurrent `refresh` is never overwritten.
- **Crash-leak recovery:** a `.lock` dir orphaned by a `kill -9` between `mkdir` and the JSON write is itself TTL-reclaimable (never wedges a key forever).
- **AUTOSPEC_CLAIM_GUARD=off|warn|strict**; unwritable store degrades to a no-op success (never blocks work).
- **Session identity** via the `CLAUDE_CODE_SESSION_ID` fallback chain (`reference_harness_session_id_envs`).

JSON is built with `jq -n --arg/--argjson` so branch names, worktree paths, and arbitrary path tokens are correctly escaped.

## Reuse decision

No reuse — `worktree-guard.sh` is whole-worktree scoped and `heartbeat-write.sh` writes a single heartbeat; neither performs per-key atomic leasing. This is a distinct file/skill-granular lease that **mirrors their style/conventions** (`usage()`/`die()`, `code_health:` stderr identifiers, `iso_to_epoch`, `repo_slug`, bash 3.2 safety).

## Out of scope

`scan` + the `validate.sh` gate (Issue B) and autospec-run Phase 4 integration (Issue C).

## Tests (22 bats, real filesystem store, no mocks)

- `tests/test_claim_guard_acquire.bats` — acquire/release round-trip, status, resolver, idempotent re-acquire, refresh, `off`-mode + unwritable-store degrade.
- `tests/test_claim_guard_atomicity.bats` — two concurrent acquires grant exactly one owner (8x flake-checked), cross-session conflict, all-or-nothing rollback, **pre-existing same-session claim survives a partial-conflict rollback**, **crash-orphaned lock reclaim**, overlap (golden ↔ skill), stale reclaim past TTL, live-claim-never-stolen, status stale flag.

Verification: `bats tests/test_claim_guard_acquire.bats tests/test_claim_guard_atomicity.bats` green (22/22); `bash scripts/validate.sh` green (exit 0).

## Peer-review (Codex)

Codex flagged 4 must-fix concurrency/correctness issues, all **addressed in this PR**:
1. Stale-reclaim race — owner could `refresh` in the reclaim window → now re-validates staleness after winning the lock dir.
2. Crash between `mkdir` and JSON write left a permanent dead lock → orphaned lock dirs are TTL-reclaimable (new regression test).
3. All-or-nothing rollback dropped a pre-existing same-session claim → `take_key` now distinguishes `acquired` vs `mine`; rollback drops only newly-acquired keys (new regression test).
4. Hand-built JSON could be invalid for fields with quotes/backslashes → switched to `jq -n`.

### Peer-review notes (not addressed)
- **nice-to-have:** path-token collection through the acquire loop is documented as repo-path-safe; tokens with embedded spaces are escaped via `jq -R`, but multi-token globbing is not exercised (repo paths never contain spaces).