### PR TITLE
feat(claim-guard): scan pre-flight overlap detection + validate.sh gate

### DIFF
--- a/scripts/claim-guard.sh
+++ b/scripts/claim-guard.sh
@@ -56,6 +56,7 @@ Usage:
   claim-guard.sh refresh                     bump updated_at on my claims (heartbeat)
   claim-guard.sh release [<path|skill>...]   drop my claims (default: all mine in this repo)
   claim-guard.sh status                      list live claims for this repo
+  claim-guard.sh scan    <path|skill>...     advisory overlap pre-flight (always exit 0)
 
 Env:
   AUTOSPEC_CLAIM_GUARD   off|warn|strict (default warn). off / unwritable store => no-op.
@@ -509,6 +510,129 @@ cmd_status() {
 }
 
 # ---------------------------------------------------------------------------
+# scan — advisory pre-flight overlap detection. Always exits 0.
+#
+# Checks three sources for in-flight edits that overlap the given targets:
+#   1. Live claim JSON files in the store (same-filesystem sessions).
+#   2. git worktree list --porcelain (other branches on this machine).
+#   3. Open PRs via `gh pr list` (degrades gracefully if gh absent/offline).
+#
+# Emits `code_health:claim_overlap` advisory lines on stderr; never blocks.
+# ---------------------------------------------------------------------------
+cmd_scan() {
+    [ $# -ge 1 ] || die 2 "scan: at least one <path|skill> is required"
+
+    # Resolve target keys.
+    target_keys="$(for a in "$@"; do resolve_key "$a"; printf '\n'; done | sort -u)"
+
+    # ------------------------------------------------------------------ #
+    # 1. Live claim files: any claim whose lock_key matches a target key  #
+    #    and belongs to a different, non-stale session.                   #
+    # ------------------------------------------------------------------ #
+    ensure_store
+    me="$(session_id)"
+    if [ "$STORE_OK" -eq 1 ] && [ -d "$CLAIM_DIR" ]; then
+        for cf in "$CLAIM_DIR"/*.json; do
+            [ -e "$cf" ] || continue
+            claim_is_stale "$cf" && continue
+            owner="$(claim_owner "$cf")"
+            [ -n "$owner" ] || continue
+            [ "$owner" = "$me" ] && continue
+            held_key="$(jq -r '.lock_key // empty' "$cf" 2>/dev/null || true)"
+            [ -n "$held_key" ] || continue
+            for tk in $target_keys; do
+                if [ "$held_key" = "$tk" ]; then
+                    host="$(jq -r '.host // empty' "$cf" 2>/dev/null || true)"
+                    branch="$(jq -r '.branch // empty' "$cf" 2>/dev/null || true)"
+                    emit "code_health:claim_overlap source=live_claim key=$tk owner_session=$owner host=$host branch=$branch"
+                    break
+                fi
+            done
+        done
+    fi
+
+    # ------------------------------------------------------------------ #
+    # 2. git worktree list: other checked-out branches that are not the   #
+    #    current worktree (same-machine; advisory only).                  #
+    # ------------------------------------------------------------------ #
+    current_wt="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    if command -v git >/dev/null 2>&1; then
+        wt_output="$(git worktree list --porcelain 2>/dev/null || true)"
+        wt_path=""
+        wt_branch=""
+        while IFS= read -r line; do
+            case "$line" in
+                worktree\ *)
+                    wt_path="${line#worktree }"
+                    wt_branch=""
+                    ;;
+                branch\ refs/heads/*)
+                    wt_branch="${line#branch refs/heads/}"
+                    ;;
+                "")
+                    # End of a worktree stanza — emit advisory if it is another
+                    # worktree on a different branch (it may be editing the same
+                    # skill; we cannot know without a claim file, so this is
+                    # purely informational when the target skill is contested).
+                    if [ -n "$wt_path" ] && [ -n "$wt_branch" ] \
+                            && [ "$wt_path" != "$current_wt" ] \
+                            && [ "$wt_branch" != "$current_branch" ]; then
+                        # Only emit if the worktree branch name contains a
+                        # fragment of any target key name (heuristic; not a
+                        # hard conflict check).
+                        for tk in $target_keys; do
+                            skill_name="${tk#skill:}"
+                            skill_name="${skill_name#path:}"
+                            if printf '%s' "$wt_branch" | grep -qF "$skill_name"; then
+                                emit "code_health:claim_overlap source=worktree key=$tk worktree=$wt_path branch=$wt_branch"
+                                break
+                            fi
+                        done
+                    fi
+                    wt_path=""
+                    wt_branch=""
+                    ;;
+            esac
+        done <<EOF_WL
+$wt_output
+EOF_WL
+    fi
+
+    # ------------------------------------------------------------------ #
+    # 3. Open PRs via gh pr list (degrade cleanly if gh absent/offline). #
+    # ------------------------------------------------------------------ #
+    if command -v gh >/dev/null 2>&1; then
+        pr_json="$(gh pr list --state open --json number,headRefName \
+            --limit 50 2>/dev/null || echo '[]')"
+        if [ -n "$pr_json" ] && [ "$pr_json" != '[]' ]; then
+            pr_count="$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null || echo 0)"
+            i=0
+            while [ "$i" -lt "$pr_count" ]; do
+                pr_branch="$(printf '%s' "$pr_json" | \
+                    jq -r ".[$i].headRefName // empty" 2>/dev/null || true)"
+                pr_num="$(printf '%s' "$pr_json" | \
+                    jq -r ".[$i].number // empty" 2>/dev/null || true)"
+                if [ -n "$pr_branch" ]; then
+                    for tk in $target_keys; do
+                        skill_name="${tk#skill:}"
+                        skill_name="${skill_name#path:}"
+                        if printf '%s' "$pr_branch" | grep -qF "$skill_name"; then
+                            emit "code_health:claim_overlap source=open_pr key=$tk pr=#${pr_num} branch=$pr_branch"
+                            break
+                        fi
+                    done
+                fi
+                i=$(( i + 1 ))
+            done
+        fi
+    fi
+
+    # scan is always advisory — never block.
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
 # dispatch
 # ---------------------------------------------------------------------------
 main() {
@@ -520,6 +644,7 @@ main() {
         refresh)   cmd_refresh "$@" ;;
         release)   cmd_release "$@" ;;
         status)    cmd_status "$@" ;;
+        scan)      cmd_scan "$@" ;;
         -h|--help) usage; exit 0 ;;
         *)         echo "$PROG: unknown subcommand: $sub" >&2; usage >&2; exit 2 ;;
     esac

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -2461,6 +2461,7 @@ main() {
     check_define_spec_worktree_routing
     check_token_baseline_fresh
     check_block_expansion
+    check_claim_guard_contract
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.
@@ -3123,6 +3124,33 @@ check_qa_documentation_gate() {
     done
     local bats_file="tests/qa/test_qa_documentation_gate.bats"
     [ -f "$bats_file" ] || fail "$bats_file: bats coverage missing (issue #956)"
+}
+
+# claim-guard contract (issue #1066): scripts/claim-guard.sh must be present
+# and executable, pass `bash -n` syntax check, and the overlap bats suite must
+# be green. Mirrors the pattern used by check_supersession_contract and
+# check_watchdog_worktree_gc.
+check_claim_guard_contract() {
+    info "claim-guard contract: scripts/claim-guard.sh + bats suite (issue #1066)"
+    local guard="scripts/claim-guard.sh"
+    [ -f "$guard" ] \
+        || fail "$guard: file missing (issue #1066)"
+    [ -x "$guard" ] \
+        || fail "$guard: file not executable (issue #1066)"
+    bash -n "$guard" \
+        || fail "$guard: bash syntax error (issue #1066)"
+    # scan subcommand must be wired up (the core contract of issue #1066).
+    grep -q '^        scan)' "$guard" \
+        || fail "$guard: 'scan' subcommand missing from dispatch (issue #1066)"
+    local bats_file="tests/test_claim_guard_overlap.bats"
+    [ -f "$bats_file" ] \
+        || fail "$bats_file: bats coverage missing (issue #1066)"
+    if command -v bats >/dev/null 2>&1; then
+        info "  running: $bats_file"
+        bats "$bats_file" >/tmp/validate-claim-guard-overlap.log 2>&1 \
+            || { cat /tmp/validate-claim-guard-overlap.log >&2; \
+                 fail "$bats_file: failed (issue #1066)"; }
+    fi
 }
 
 main "$@"

--- a/tests/test_claim_guard_overlap.bats
+++ b/tests/test_claim_guard_overlap.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+# tests/test_claim_guard_overlap.bats — scan pre-flight overlap detection.
+#
+# Covers AC for issue #1066:
+#   - scan exits 0 always (advisory, never blocks).
+#   - scan on a skill golden path with a held skill:<name> claim prints overlap advisory.
+#   - scan on a disjoint path prints no advisory for the held claim.
+#   - scan exits 0 when `gh` is absent from PATH.
+#
+# Real filesystem store; AUTOSPEC_STATE_DIR redirected to per-test tmp dir.
+# No mocks for git/gh — gh is skipped via a stub PATH that hides it
+# (degrade path). git worktree list runs real but scans an empty-ish list.
+
+bats_require_minimum_version 1.5.0
+
+GUARD="${BATS_TEST_DIRNAME}/../scripts/claim-guard.sh"
+
+setup() {
+    STATE_DIR="$(mktemp -d)"
+    export AUTOSPEC_STATE_DIR="$STATE_DIR"
+    export AUTOSPEC_REPO="berlinguyinca/autospec"
+    export AUTOSPEC_CLAIM_GUARD="warn"
+    export CLAUDE_CODE_SESSION_ID="sess-overlap-bbbb"
+    export AUTOSPEC_HOST="testhost"
+    CLAIM_ROOT="${STATE_DIR}/edit-claims/berlinguyinca_autospec"
+
+    # Create a fake-gh bin dir that hides the real gh so degrade tests run
+    # even on machines with gh installed.
+    FAKE_GH_DIR="$(mktemp -d)"
+    # No gh binary in FAKE_GH_DIR — it simply does not exist there.
+}
+
+teardown() {
+    rm -rf "$STATE_DIR"
+    rm -rf "${FAKE_GH_DIR:-}"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: plant a live claim for skill:autospec-run owned by a DIFFERENT session.
+plant_other_session_claim() {
+    mkdir -p "$CLAIM_ROOT"
+    local now
+    now="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+    cat > "${CLAIM_ROOT}/skill-autospec-run.json" <<EOF
+{
+  "lock_key": "skill:autospec-run",
+  "paths": ["skills/autospec-run/"],
+  "owner_session": "sess-other-zzzz",
+  "host": "otherhost",
+  "pid": 9999,
+  "branch": "feat/other-branch",
+  "worktree": "/tmp/other-wt",
+  "acquired_at": "${now}",
+  "updated_at": "${now}",
+  "ttl_seconds": 1800
+}
+EOF
+    # Also create the .lock dir so the claim is consistent.
+    mkdir -p "${CLAIM_ROOT}/skill-autospec-run.lock"
+}
+
+# ---------------------------------------------------------------------------
+@test "scan is a valid subcommand and exits 0 on a free skill" {
+    run bash "$GUARD" scan skills/autospec-run
+    [ "$status" -eq 0 ]
+}
+
+@test "scan exits 0 even when a conflicting live claim exists (advisory only)" {
+    plant_other_session_claim
+    run bash "$GUARD" scan skills/autospec-run
+    [ "$status" -eq 0 ]
+}
+
+@test "scan prints overlap advisory when a live claim is held by another session" {
+    plant_other_session_claim
+    run bash "$GUARD" scan skills/autospec-run
+    [ "$status" -eq 0 ]
+    # Advisory must mention claim_overlap or the key.
+    echo "$output" | grep -qE 'claim_overlap|skill:autospec-run'
+}
+
+@test "assert of skill-golden path conflicts with a held skill:<name> claim" {
+    # Acquire a claim for skill:autospec-run as a different session.
+    plant_other_session_claim
+    # assert in strict mode should see the conflict (non-zero exit).
+    AUTOSPEC_CLAIM_GUARD=strict run bash "$GUARD" assert \
+        tests/fixtures/skill-goldens/autospec-run.SKILL.md.sha256
+    [ "$status" -ne 0 ]
+}
+
+@test "scan on a disjoint path prints no claim_overlap advisory for the held claim" {
+    plant_other_session_claim
+    # skills/autospec-explore is disjoint from skills/autospec-run.
+    run bash "$GUARD" scan skills/autospec-explore
+    [ "$status" -eq 0 ]
+    # Must not print an overlap advisory for the autospec-run claim.
+    echo "$output" | grep -qv 'claim_overlap.*skill:autospec-run' || true
+    # Simpler: output must not contain claim_overlap for autospec-run.
+    if echo "$output" | grep -q 'claim_overlap'; then
+        echo "$output" | grep -v 'autospec-run' | grep -qv 'claim_overlap' || true
+        # If the only claim_overlap lines mention autospec-run, that's a false-positive.
+        local overlap_lines
+        overlap_lines="$(echo "$output" | grep 'claim_overlap' || true)"
+        # None of the overlap_lines should be for autospec-run when scanning autospec-explore.
+        ! echo "$overlap_lines" | grep -q 'autospec-run'
+    fi
+}
+
+@test "scan exits 0 when gh is absent from PATH (degrade gracefully)" {
+    # Run with a PATH that contains no 'gh' binary.
+    run env PATH="${FAKE_GH_DIR}:/usr/bin:/bin" bash "$GUARD" scan skills/autospec-run
+    [ "$status" -eq 0 ]
+}
+
+@test "scan exits 0 even with AUTOSPEC_CLAIM_GUARD=strict (scan is always advisory)" {
+    plant_other_session_claim
+    AUTOSPEC_CLAIM_GUARD=strict run bash "$GUARD" scan skills/autospec-run
+    [ "$status" -eq 0 ]
+}
+
+@test "scan accepts multiple path arguments and exits 0" {
+    run bash "$GUARD" scan skills/autospec-run skills/autospec-explore
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #1066

## Summary

- **`scripts/claim-guard.sh scan <path|skill>...`**: new advisory pre-flight subcommand that checks three overlap sources (live claim JSONs, `git worktree list` branch-name heuristic, open PRs via `gh pr list`) and emits `code_health:claim_overlap` lines on stderr. Always exits 0 — never blocks.
- **`scripts/validate.sh check_claim_guard_contract()`**: asserts `scripts/claim-guard.sh` is present, executable, bash-valid, has `scan` wired in dispatch, and runs `tests/test_claim_guard_overlap.bats` as part of the full suite gate.
- **`tests/test_claim_guard_overlap.bats`**: 8 TDD bats tests covering advisory-only exit, live-claim overlap advisory, disjoint-path no-overlap, gh-absent degrade, strict-mode still-advisory, multi-arg invocation, and the assert/golden-path conflict AC.

## Acceptance criteria verification

- [x] `bash scripts/claim-guard.sh scan skills/autospec-run` exits 0 and prints overlap advisories
- [x] `scan` exits 0 even when `gh` is unavailable on `PATH`
- [x] `grep -q 'check_claim_guard_contract' scripts/validate.sh`
- [x] `check_claim_guard_contract` runs `bash -n scripts/claim-guard.sh` and the bats suite
- [x] `bats tests/test_claim_guard_overlap.bats` is green (8/8)
- [x] `assert` of `tests/fixtures/skill-goldens/autospec-run.SKILL.md.sha256` conflicts with a held `skill:autospec-run`
- [x] `bash scripts/validate.sh` passes fully

## Self-review (counter-team: concurrency + portability)

- **`gh` absent/offline**: `command -v gh >/dev/null 2>&1` guard; degrade path tested in bats.
- **Same-box only**: documented in spec; cross-machine authority remains the issue-comment lease. `scan` is advisory so silent same-box-only is acceptable v1 behaviour.
- **validate gate fails closed when bats red**: `check_claim_guard_contract` runs `bats` and calls `fail` on non-zero exit, so red bats → red validate. ✓
- **Race on live-claim read**: `scan` is read-only, no writes, no TOCTOU concern.
- **Strict-mode does not block scan**: `cmd_scan` ignores `$MODE` and always exits 0.