### PR TITLE
test(claim-guard): Phase 5.5 audit — spec-named stale/degrade suites + 3-suite gate (#1069)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -3142,14 +3142,23 @@ check_claim_guard_contract() {
     # scan subcommand must be wired up (the core contract of issue #1066).
     grep -q '^        scan)' "$guard" \
         || fail "$guard: 'scan' subcommand missing from dispatch (issue #1066)"
-    local bats_file="tests/test_claim_guard_overlap.bats"
-    [ -f "$bats_file" ] \
-        || fail "$bats_file: bats coverage missing (issue #1066)"
+    # Spec-named suites (docs/specs/2026-06-15-claim-guard-concurrent-edit-design.md
+    # §"Testing"): overlap, plus the stale-reclaim boundary and degrade-to-no-op
+    # suites the Phase 5.5 audit (issue #1069) made first-class so they cannot
+    # silently rot.
+    local bats_files="tests/test_claim_guard_overlap.bats tests/test_claim_guard_stale_reclaim.bats tests/test_claim_guard_degrade.bats"
+    local bf
+    for bf in $bats_files; do
+        [ -f "$bf" ] \
+            || fail "$bf: bats coverage missing (issue #1066/#1069)"
+    done
     if command -v bats >/dev/null 2>&1; then
-        info "  running: $bats_file"
-        bats "$bats_file" >/tmp/validate-claim-guard-overlap.log 2>&1 \
-            || { cat /tmp/validate-claim-guard-overlap.log >&2; \
-                 fail "$bats_file: failed (issue #1066)"; }
+        for bf in $bats_files; do
+            info "  running: $bf"
+            bats "$bf" >/tmp/validate-claim-guard.log 2>&1 \
+                || { cat /tmp/validate-claim-guard.log >&2; \
+                     fail "$bf: failed (issue #1066/#1069)"; }
+        done
     fi
 }
 

--- a/tests/test_claim_guard_degrade.bats
+++ b/tests/test_claim_guard_degrade.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# tests/test_claim_guard_degrade.bats — degrade-to-no-op safety.
+#
+# The spec (docs/specs/2026-06-15-claim-guard-concurrent-edit-design.md,
+# §"Testing" / §"API shape") names this file explicitly:
+#   "AUTOSPEC_CLAIM_GUARD=off and an unwritable store both no-op without
+#    blocking." The contract is: claim-guard must NEVER block real work because
+#   of its own infrastructure — an off switch or a read-only store degrades to a
+#   silent exit-0 no-op. This is the dedicated, spec-named suite issue #1069's
+#   Phase 5.5 audit requires.
+#
+# Real filesystem store, no mocks (AGENTS.md).
+
+bats_require_minimum_version 1.5.0
+
+GUARD="${BATS_TEST_DIRNAME}/../scripts/claim-guard.sh"
+
+setup() {
+    STATE_DIR="$(mktemp -d)"
+    export AUTOSPEC_STATE_DIR="$STATE_DIR"
+    export AUTOSPEC_REPO="berlinguyinca/autospec"
+    export AUTOSPEC_HOST="testhost"
+    export CLAUDE_CODE_SESSION_ID="sess-degrade-aaaa"
+    CLAIM_ROOT="${STATE_DIR}/edit-claims/berlinguyinca_autospec"
+}
+
+teardown() {
+    # Restore perms before rm so the tmp dir is always removable.
+    chmod -R u+rwx "$STATE_DIR" 2>/dev/null || true
+    rm -rf "$STATE_DIR"
+}
+
+# ---------------------------------------------------------------------------
+@test "AUTOSPEC_CLAIM_GUARD=off: acquire exits 0 and writes nothing" {
+    run env AUTOSPEC_CLAIM_GUARD=off bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 0 ]
+    [ ! -d "$CLAIM_ROOT" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "AUTOSPEC_CLAIM_GUARD=off: assert/refresh/release all no-op exit 0" {
+    run env AUTOSPEC_CLAIM_GUARD=off bash "$GUARD" assert skills/autospec-run
+    [ "$status" -eq 0 ]
+    run env AUTOSPEC_CLAIM_GUARD=off bash "$GUARD" refresh
+    [ "$status" -eq 0 ]
+    run env AUTOSPEC_CLAIM_GUARD=off bash "$GUARD" release skills/autospec-run
+    [ "$status" -eq 0 ]
+    [ ! -d "$CLAIM_ROOT" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "AUTOSPEC_CLAIM_GUARD=off never blocks even when another session holds the key" {
+    # A real claim exists (taken in strict mode).
+    CLAUDE_CODE_SESSION_ID="sess-owner" \
+        env AUTOSPEC_CLAIM_GUARD=strict bash "$GUARD" acquire skills/autospec-run
+    [ -f "${CLAIM_ROOT}/skill-autospec-run.json" ]
+
+    # With the guard OFF, a different session must NOT be blocked (exit 0 no-op).
+    CLAUDE_CODE_SESSION_ID="sess-other" \
+        run env AUTOSPEC_CLAIM_GUARD=off bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 0 ]
+    # off mode writes nothing, so the original owner's claim is untouched.
+    owner="$(jq -r '.owner_session' "${CLAIM_ROOT}/skill-autospec-run.json")"
+    [ "$owner" = "sess-owner" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "unwritable store: acquire degrades to a no-op success (never blocks), even in strict mode" {
+    ro_root="$(mktemp -d)"
+    chmod 0500 "$ro_root"
+    run env AUTOSPEC_STATE_DIR="$ro_root" AUTOSPEC_CLAIM_GUARD=strict \
+        bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 0 ]
+    # Nothing was (could be) written under the read-only root.
+    [ ! -d "${ro_root}/edit-claims/berlinguyinca_autospec" ]
+    chmod 0700 "$ro_root"; rm -rf "$ro_root"
+}
+
+# ---------------------------------------------------------------------------
+@test "unwritable store: assert/refresh/release degrade to no-op exit 0" {
+    ro_root="$(mktemp -d)"
+    chmod 0500 "$ro_root"
+    for sub in "assert skills/autospec-run" "refresh" "release skills/autospec-run"; do
+        # shellcheck disable=SC2086
+        run env AUTOSPEC_STATE_DIR="$ro_root" AUTOSPEC_CLAIM_GUARD=strict \
+            bash "$GUARD" $sub
+        [ "$status" -eq 0 ]
+    done
+    chmod 0700 "$ro_root"; rm -rf "$ro_root"
+}
+
+# ---------------------------------------------------------------------------
+@test "unwritable store: status is read-only and prints nothing, exit 0" {
+    ro_root="$(mktemp -d)"
+    chmod 0500 "$ro_root"
+    run env AUTOSPEC_STATE_DIR="$ro_root" bash "$GUARD" status
+    [ "$status" -eq 0 ]
+    chmod 0700 "$ro_root"; rm -rf "$ro_root"
+}

--- a/tests/test_claim_guard_stale_reclaim.bats
+++ b/tests/test_claim_guard_stale_reclaim.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+# tests/test_claim_guard_stale_reclaim.bats — TTL stale-reclaim boundary.
+#
+# The spec (docs/specs/2026-06-15-claim-guard-concurrent-edit-design.md,
+# §"Error handling + reclaim" / §"Testing") names this file explicitly:
+#   "a claim with updated_at past TTL is reclaimable; one within TTL is NOT."
+# It was previously only covered inline in test_claim_guard_atomicity.bats;
+# this is the dedicated, spec-named suite the issue #1069 Phase 5.5 audit
+# requires (and that validate.sh's verification commands reference).
+#
+# Real filesystem store, no mocks (AGENTS.md). AUTOSPEC_STATE_DIR redirects the
+# store to a per-test tmp dir so we never touch ~/.autospec. AUTOSPEC_REPO is
+# pinned so the slug is stable and assertable without re-deriving it from the
+# SUT (self-consistent-fixture trap).
+
+bats_require_minimum_version 1.5.0
+
+GUARD="${BATS_TEST_DIRNAME}/../scripts/claim-guard.sh"
+
+setup() {
+    STATE_DIR="$(mktemp -d)"
+    export AUTOSPEC_STATE_DIR="$STATE_DIR"
+    export AUTOSPEC_REPO="berlinguyinca/autospec"
+    export AUTOSPEC_CLAIM_GUARD="strict"
+    export AUTOSPEC_HOST="testhost"
+    CLAIM_ROOT="${STATE_DIR}/edit-claims/berlinguyinca_autospec"
+}
+
+teardown() {
+    rm -rf "$STATE_DIR"
+}
+
+# ---------------------------------------------------------------------------
+@test "a claim with updated_at past TTL is reclaimable by another session" {
+    export AUTOSPEC_CLAIM_TTL_SECONDS=1800
+    CLAUDE_CODE_SESSION_ID="sess-old" bash "$GUARD" acquire skills/autospec-run
+    claim_file="${CLAIM_ROOT}/skill-autospec-run.json"
+    [ -f "$claim_file" ]
+
+    # Age the claim past TTL by rewriting updated_at far into the past. Pinning a
+    # literal timestamp (not now-minus-delta) keeps the fixture independent of
+    # the SUT's own clock math.
+    tmp="$(mktemp)"
+    jq '.updated_at = "2000-01-01T00:00:00Z"' "$claim_file" > "$tmp" && mv "$tmp" "$claim_file"
+
+    CLAUDE_CODE_SESSION_ID="sess-fresh" run bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 0 ]
+    owner="$(jq -r '.owner_session' "$claim_file")"
+    [ "$owner" = "sess-fresh" ]
+    # Reclaim resets acquired_at to the new owner's acquisition time (a fresh
+    # lease, not a continuation of the dead owner's).
+    acquired="$(jq -r '.acquired_at' "$claim_file")"
+    [ "$acquired" != "" ]
+    [ "$acquired" != "2000-01-01T00:00:00Z" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "a claim WITHIN TTL is never reclaimed (a slow-but-live editor is safe)" {
+    export AUTOSPEC_CLAIM_TTL_SECONDS=1800
+    CLAUDE_CODE_SESSION_ID="sess-live" bash "$GUARD" acquire skills/autospec-run
+    claim_file="${CLAIM_ROOT}/skill-autospec-run.json"
+
+    # Fresh claim (updated_at = now) is well within TTL -> intruder blocked.
+    CLAUDE_CODE_SESSION_ID="sess-thief" run bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 6 ]
+    printf '%s\n' "$output" | grep -q 'code_health:claim_conflict'
+
+    # Ownership unchanged: the live editor was NOT stolen.
+    owner="$(jq -r '.owner_session' "$claim_file")"
+    [ "$owner" = "sess-live" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "a claim refreshed just below the TTL boundary is still NOT reclaimable" {
+    # TTL of 1800s; backdate updated_at to 1799s ago (inside TTL by 1s). The
+    # owner is effectively a live-but-slow editor; the intruder must back off.
+    export AUTOSPEC_CLAIM_TTL_SECONDS=1800
+    CLAUDE_CODE_SESSION_ID="sess-live" bash "$GUARD" acquire skills/autospec-run
+    claim_file="${CLAIM_ROOT}/skill-autospec-run.json"
+
+    near="$(date -u -v-1700S +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+        || date -u -d '-1700 seconds' +'%Y-%m-%dT%H:%M:%SZ')"
+    tmp="$(mktemp)"
+    jq --arg u "$near" '.updated_at = $u' "$claim_file" > "$tmp" && mv "$tmp" "$claim_file"
+
+    CLAUDE_CODE_SESSION_ID="sess-thief" run bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 6 ]
+    owner="$(jq -r '.owner_session' "$claim_file")"
+    [ "$owner" = "sess-live" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "a stale claim with a present .lock dir is atomically reclaimed (re-mkdir)" {
+    # Reproduce the reclaim path where the dead owner left BOTH the JSON and the
+    # .lock dir behind. Reclaim must rmdir+re-mkdir the lock atomically and hand
+    # the lease to the fresh session.
+    export AUTOSPEC_CLAIM_TTL_SECONDS=1800
+    CLAUDE_CODE_SESSION_ID="sess-old" bash "$GUARD" acquire skills/autospec-run
+    claim_file="${CLAIM_ROOT}/skill-autospec-run.json"
+    [ -d "${CLAIM_ROOT}/skill-autospec-run.lock" ]
+
+    tmp="$(mktemp)"
+    jq '.updated_at = "2000-01-01T00:00:00Z"' "$claim_file" > "$tmp" && mv "$tmp" "$claim_file"
+
+    CLAUDE_CODE_SESSION_ID="sess-fresh" run bash "$GUARD" acquire skills/autospec-run
+    [ "$status" -eq 0 ]
+    owner="$(jq -r '.owner_session' "$claim_file")"
+    [ "$owner" = "sess-fresh" ]
+    # The lock dir still exists (held by the new owner), not leaked away.
+    [ -d "${CLAIM_ROOT}/skill-autospec-run.lock" ]
+}
+
+# ---------------------------------------------------------------------------
+@test "status flags a stale claim as 'stale' and a fresh one as 'live'" {
+    export AUTOSPEC_CLAIM_TTL_SECONDS=1800
+    CLAUDE_CODE_SESSION_ID="sess-fresh" bash "$GUARD" acquire skills/autospec-explore
+    CLAUDE_CODE_SESSION_ID="sess-old" bash "$GUARD" acquire skills/autospec-run
+    stale_file="${CLAIM_ROOT}/skill-autospec-run.json"
+    tmp="$(mktemp)"
+    jq '.updated_at = "2000-01-01T00:00:00Z"' "$stale_file" > "$tmp" && mv "$tmp" "$stale_file"
+
+    run bash "$GUARD" status
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'skill:autospec-run.*stale'
+    printf '%s\n' "$output" | grep -q 'skill:autospec-explore.*live'
+}


### PR DESCRIPTION
Closes #1069

Phase 5.5 broad-integration audit of the merged claim-guard work — PRs #1070 (core), #1071 (scan + validate gate), #1072 (autospec-run integration) — hunting the cross-PR races that per-PR LGTM misses.

## Deep race probes (all PASS against shipped `scripts/claim-guard.sh`)

| Probe | Result |
|---|---|
| TOCTOU: 50 concurrent `acquire` of one key | exactly **1 winner**, 49 × exit 6, single owner on disk |
| Stale-reclaim boundary | within-TTL **never** stolen (exit 6); past-TTL atomically reclaimed |
| `kill -9` orphan `.lock` (no JSON) | fresh = conflict; aged-past-TTL = reclaimable — no permanent wedge |
| Cross-session block + same-session idempotency | different session exit 6; same session exit 0, no double-write |
| Session-id stability, no TTY (piped subprocess) | stable within a process tree; `CLAUDE_CODE_SESSION_ID` is the real-run anchor (PPID is the documented unreliable last resort, correctly skipped when `ps -o sess=`→0) |
| Multi-path all-or-nothing rollback | partial conflict rolls back only NEW keys; a pre-existing same-session claim is **kept**; no orphan lock dirs; key not wedged |
| `AUTOSPEC_CLAIM_GUARD=off` / unwritable store | both no-op exit 0 across acquire/assert/refresh/release/status, even in strict mode |

**Core lease logic: zero surviving gaps.**

## Gaps found

**Gap A — fixed inline (this PR).** The spec §Testing and issue #1069 name two suites — `test_claim_guard_stale_reclaim.bats` and `test_claim_guard_degrade.bats` — that were never created as standalone files (cases were only folded inline into `atomicity.bats`/`acquire.bats`, and `validate.sh` gated only `overlap.bats`). Added both as first-class suites (11 tests) and extended `check_claim_guard_contract()` to run all three spec-named suites so they cannot silently rot.

**Gap B — filed as #1073 (out of this issue's Files-touched budget).** Cross-PR integration mismatch: the autospec-run Phase 4 gate (`if ! claim-guard.sh acquire $TARGETS; then …restore label; exit 6; fi`) branches on a `6` exit, but `acquire` exits 6 **only in `strict` mode**, while the shipped default is **`warn`** (exit 0 on conflict) and nothing sets strict for the run. So the blocking branch is **dead code** under the default config — the lease is advisory-only inside autospec-run and provides no mutual exclusion. PR #1070 made acquire non-blocking by default; PR #1072 wired the caller as if it blocked. Spans the autospec-run trio + goldens, so filed as a focused `auto-implement,autospec:v2-flow` follow-up citing the spec.

## Verification

- `bats tests/test_claim_guard_*.bats` — 45/45 green (incl. the two new suites: 5 + 6).
- `bash scripts/validate.sh` — exit 0; `check_claim_guard_contract` runs all three spec-named suites.

## Files touched (in budget)

- `tests/test_claim_guard_stale_reclaim.bats` (new)
- `tests/test_claim_guard_degrade.bats` (new)
- `scripts/validate.sh` (`check_claim_guard_contract` runs all three suites)

**Verdict: surviving gaps in `claim-guard.sh` core = 0. One integration gap (Gap B) filed as #1073.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
