### PR TITLE
feat(explore): proposal contract + severity/named_consumer schema + aggregator defaults

### DIFF
--- a/schemas/autospec-explore-proposal.schema.json
+++ b/schemas/autospec-explore-proposal.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autospec.local/schemas/autospec-explore-proposal.schema.json",
+  "title": "Autospec explore proposal",
+  "description": "A single feature proposal emitted by an autospec-explore researcher and carried through the research-cycle aggregator. Extends the base contract (title/evidence/estimated_complexity/confidence/source) with the severity band and named_consumer fields introduced by the discovery-enhance batch.",
+  "type": "object",
+  "required": ["title", "evidence", "estimated_complexity", "confidence"],
+  "additionalProperties": true,
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evidence": {
+      "type": "string"
+    },
+    "estimated_complexity": {
+      "type": "string",
+      "enum": ["small", "medium", "large"]
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "source": {
+      "type": "string"
+    },
+    "severity": {
+      "type": "string",
+      "description": "Impact band, highest to lowest: silent-wrong > correctness > stability > operability > feature > nicety. The enum order is load-bearing — it is the primary ranking key. Legacy researchers that omit this field are defaulted to `feature` by the aggregator.",
+      "enum": [
+        "silent-wrong",
+        "correctness",
+        "stability",
+        "operability",
+        "feature",
+        "nicety"
+      ]
+    },
+    "named_consumer": {
+      "type": "string",
+      "description": "Free text naming a skill/workflow/operator step that benefits from this proposal today. Empty string means no named consumer; new-source proposals with an empty value are dropped by the ROI gate (Issue C). Legacy researchers that omit this field are defaulted to \"\" by the aggregator and are NOT auto-dropped."
+    },
+    "score": {
+      "type": "number",
+      "description": "Aggregator-computed ranking score (confidence * source_weight / complexity)."
+    }
+  }
+}

--- a/scripts/explore-research-cycle.sh
+++ b/scripts/explore-research-cycle.sh
@@ -17,7 +17,17 @@
 #     "proposals": [ ...top --max-issues-per-round... ] }
 #
 # Each proposal carries: title, evidence, estimated_complexity, confidence,
-# source, score.
+# source, severity, named_consumer, score.
+#
+# Proposal contract (schemas/autospec-explore-proposal.schema.json):
+#   - severity        impact band, high->low: silent-wrong > correctness >
+#                     stability > operability > feature > nicety. Legacy
+#                     researchers that omit it are defaulted to "feature" here.
+#   - named_consumer  free text naming a skill/workflow/operator step that
+#                     benefits today. Missing -> defaulted to "" here. The
+#                     default-empty value does NOT auto-drop legacy proposals
+#                     (the ROI gate that drops empty-consumer proposals is
+#                     new-source-only; it lands in Issue C).
 
 set -u
 
@@ -223,12 +233,24 @@ for f in sorted(glob.glob(os.path.join(work, "*.json"))):
         weight = SRC_WEIGHTS.get(src, 0.5)
         cscale = COMPLEXITY.get(comp, 2.0)
         score = conf * weight / cscale
+        # Default the proposal-contract extension fields safely for legacy
+        # researchers that don't emit them (Issue A). Missing severity ->
+        # "feature"; missing named_consumer -> "". This is a pure default: it
+        # never drops a proposal, so the existing 7 researchers keep flowing.
+        severity = p.get("severity")
+        if not isinstance(severity, str) or not severity.strip():
+            severity = "feature"
+        named_consumer = p.get("named_consumer")
+        if not isinstance(named_consumer, str):
+            named_consumer = ""
         all_props.append({
             "title": title,
             "evidence": p.get("evidence",""),
             "estimated_complexity": comp,
             "confidence": conf,
             "source": src,
+            "severity": severity,
+            "named_consumer": named_consumer,
             "score": round(score, 4),
         })
         total += 1

--- a/tests/explore/test_explore_severity_roi.bats
+++ b/tests/explore/test_explore_severity_roi.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# tests/explore/test_explore_severity_roi.bats — proposal contract extension
+# (Issue A): the real aggregator must default a legacy proposal that lacks
+# `severity` and `named_consumer` to `feature` / "" without error, and must NOT
+# silently drop legacy researchers that omit the fields. The proposal schema
+# must define both new fields. No mocks of the aggregator itself.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    TMP="$(mktemp -d -t explore-severity.XXXXXX)"
+    cd "$TMP"
+    git init -q
+    git config user.email t@t.t
+    git config user.name t
+    export AUTOSPEC_REPO_ROOT="$TMP"
+    # Override gh; aggregator must still succeed without it.
+    export PATH="$TMP/bin:$PATH"
+    mkdir -p "$TMP/bin"
+    cat > "$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$TMP/bin/gh"
+
+    export AUTOSPEC_RESEARCH_DIR="$TMP/fake-research"
+    mkdir -p "$AUTOSPEC_RESEARCH_DIR"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+make_fake_researcher() {
+    local name="$1"
+    local payload="$2"
+    cat > "$AUTOSPEC_RESEARCH_DIR/$name.sh" <<EOF
+#!/usr/bin/env bash
+cat <<JSON
+$payload
+JSON
+EOF
+    chmod +x "$AUTOSPEC_RESEARCH_DIR/$name.sh"
+}
+
+@test "proposal schema defines severity enum and named_consumer string" {
+    schema="$REPO_ROOT/schemas/autospec-explore-proposal.schema.json"
+    [ -f "$schema" ]
+    run jq -e '.properties.severity.enum and (.properties.named_consumer.type == "string")' "$schema"
+    [ "$status" -eq 0 ]
+    # Severity enum order is load-bearing: silent-wrong is the highest band.
+    run jq -e '.properties.severity.enum == ["silent-wrong","correctness","stability","operability","feature","nicety"]' "$schema"
+    [ "$status" -eq 0 ]
+}
+
+@test "aggregator defaults a legacy proposal lacking severity/named_consumer" {
+    # Legacy researcher emits the base contract only — no severity, no consumer.
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: alpha widget","evidence":"e1","estimated_complexity":"small","confidence":0.9}]}'
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[]}'
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+# Legacy researcher is NOT silently muted.
+assert len(d['proposals']) == 1, d
+p = d['proposals'][0]
+assert p['source'] == 'spec-vs-code'
+assert p['severity'] == 'feature', p
+assert p['named_consumer'] == '', p
+"
+}
+
+@test "aggregator preserves explicitly-emitted severity/named_consumer" {
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: silent corruption guard","evidence":"e1","estimated_complexity":"small","confidence":0.9,"severity":"silent-wrong","named_consumer":"autospec-run Phase 4"}]}'
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[]}'
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+p = d['proposals'][0]
+assert p['severity'] == 'silent-wrong', p
+assert p['named_consumer'] == 'autospec-run Phase 4', p
+"
+}


### PR DESCRIPTION
Closes #1077

## Summary
Foundation of the discovery-enhance batch (#1078/#1080/#1082 depend on it). Issue A = the proposal contract + schema + safe defaults only; no verify stage / ROI gate / severity ranking (those are Issue C #1080).

- **New schema** `schemas/autospec-explore-proposal.schema.json` — base proposal fields plus `severity` (enum, high→low: `silent-wrong` > `correctness` > `stability` > `operability` > `feature` > `nicety`) and `named_consumer` (string).
- **Aggregator defaulting** in `scripts/explore-research-cycle.sh` — missing `severity` → `feature`, missing/non-string `named_consumer` → `""`. Pure defaulting: never drops a proposal, so the existing 7 researchers keep flowing.
- **Tests** `tests/explore/test_explore_severity_roi.bats` — schema enum + load-bearing order, legacy-default path, and explicit-field passthrough, all against the real aggregator (no mocks).

## Acceptance
- [x] Schema defines the `severity` enum and `named_consumer` string
- [x] Aggregator defaults missing `severity` → `feature` for every proposal
- [x] Aggregator defaults missing `named_consumer` → `""` for every proposal
- [x] Legacy researchers are NOT auto-dropped by the defaulting logic
- [x] `bash scripts/validate.sh` green

## Verification
- Primary smoke: `jq -e '.properties.severity.enum and .properties.named_consumer' schemas/autospec-explore-proposal.schema.json` → OK
- `bats tests/explore/test_explore_severity_roi.bats` → 3/3 green
- `bats tests/explore/test_explore_research_cycle.bats` (backward-compat) → 6/6 green
- `bash scripts/validate.sh` → all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)