### PR TITLE
feat(explore): domain-specialist roster discovery — signal scan + schema (#1082)

### DIFF
--- a/schemas/autospec-explore-specialists.schema.json
+++ b/schemas/autospec-explore-specialists.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-explore-specialists.schema.json",
+  "title": "Autospec explore domain-specialist roster",
+  "description": "The cached domain-specialist roster written to .autospec/explore-specialists.json by the deterministic signal scan (scripts/explore-specialist-scan.sh) plus the one-shot LLM roster proposal. Ranked candidate `domains` carry file:line evidence; `suggested_specialists` are the LLM-derived personas dispatched as source=specialist:<slug>. An empty roster (no domain detected) is valid — a generic repo runs the explore loop unchanged.",
+  "type": "object",
+  "required": ["schema_version", "domains", "suggested_specialists"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": 1 },
+    "generated_at": {
+      "type": "string",
+      "description": "ISO-8601 timestamp the roster was cached. Optional; informational only."
+    },
+    "domains": {
+      "type": "array",
+      "description": "Ranked candidate domains from the deterministic signal scan, highest-confidence first. Each domain is evidence-grounded — never a bare guess.",
+      "items": { "$ref": "#/$defs/domain" }
+    },
+    "suggested_specialists": {
+      "type": "array",
+      "description": "LLM-proposed specialist researchers, capped at --num-specialists (default 3, cap 6). Empty when no domain is detected.",
+      "items": { "$ref": "#/$defs/specialist" }
+    }
+  },
+  "$defs": {
+    "evidence": {
+      "type": "object",
+      "description": "A concrete file:line citation backing a detected domain.",
+      "required": ["file", "line", "match"],
+      "additionalProperties": false,
+      "properties": {
+        "file": { "type": "string", "minLength": 1 },
+        "line": { "type": "integer", "minimum": 1 },
+        "match": { "type": "string", "minLength": 1 }
+      }
+    },
+    "domain": {
+      "type": "object",
+      "required": ["name", "score", "evidence"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "score": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of distinct signal hits backing this domain; the rank key."
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/evidence" }
+        }
+      }
+    },
+    "specialist": {
+      "type": "object",
+      "required": ["slug", "persona", "lens", "why", "evidence"],
+      "additionalProperties": false,
+      "properties": {
+        "slug": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "Lowercase kebab-case slug used in the source string source=specialist:<slug>."
+        },
+        "persona": { "type": "string", "minLength": 1 },
+        "lens": { "type": "string", "minLength": 1 },
+        "why": { "type": "string", "minLength": 1 },
+        "evidence": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repo-derived justification (file:line or signal). Personas derive from repo evidence only; no external persona is injected (trust boundary)."
+        }
+      }
+    }
+  }
+}

--- a/scripts/explore-specialist-scan.sh
+++ b/scripts/explore-specialist-scan.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# scripts/explore-specialist-scan.sh — domain-specialist roster DISCOVERY
+# (Issue E1, spec: docs/specs/2026-06-15-autospec-explore-discovery-enhance.md
+# §"Domain-specialist researchers" → "Roster discovery").
+#
+# Step 1 (this script, deterministic, NO LLM): scan dependency manifests,
+# README/AGENTS.md keywords, and directory taxonomy against a small domain
+# lexicon → a ranked list of candidate domains, each with file:line evidence.
+# Never a bare guess: a domain only appears if a concrete signal cited it.
+#
+# Step 2 (LLM roster proposal) is the explore-orchestrator's (SKILL-prose)
+# responsibility. This script provides the seam: given the deterministic
+# signals it produces the `suggested_specialists[]` roster, either from the
+# orchestrator's LLM output (via AUTOSPEC_SPECIALIST_LLM_STUB_OUTPUT, the same
+# stub channel the LLM researchers use) or, absent that, a deterministic
+# persona derived from the top-ranked domains. Personas are repo-evidence-only;
+# no external persona is injected (trust boundary, spec §Guardrails).
+#
+# Output: the roster is cached to .autospec/explore-specialists.json under
+# schemas/autospec-explore-specialists.schema.json and reused idempotently on
+# re-invocation. The same JSON is echoed to stdout.
+#
+# Generic repo (no domain detected) → empty roster; the explore loop runs
+# exactly as today (spec §Guardrails: "degrades gracefully").
+#
+# Out of scope (Issue E2 #1083): the --specialists-mode / --num-specialists /
+# --specialists flags, AskUserQuestion confirm, and dispatch as
+# source=specialist:<slug>. This script only DISCOVERS and CACHES the roster.
+
+set -u
+
+REPO_ROOT="${AUTOSPEC_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+NUM_SPECIALISTS="${AUTOSPEC_NUM_SPECIALISTS:-3}"
+ROSTER_PATH="$REPO_ROOT/.autospec/explore-specialists.json"
+
+# --force re-derives even when a cache exists (idempotent default reuses it).
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=1 ;;
+    esac
+done
+
+cd "$REPO_ROOT" 2>/dev/null || { echo '{"schema_version":1,"domains":[],"suggested_specialists":[]}'; exit 0; }
+
+# ── Idempotent reuse ──────────────────────────────────────────────
+if [ "$FORCE" -ne 1 ] && [ -f "$ROSTER_PATH" ]; then
+    if command -v jq >/dev/null 2>&1 && jq -e . "$ROSTER_PATH" >/dev/null 2>&1; then
+        cat "$ROSTER_PATH"
+        exit 0
+    fi
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    mkdir -p "$REPO_ROOT/.autospec" 2>/dev/null || true
+    printf '%s\n' '{"schema_version":1,"domains":[],"suggested_specialists":[]}' | tee "$ROSTER_PATH" 2>/dev/null || true
+    exit 0
+fi
+
+# ── Deterministic signal scan + roster derivation ─────────────────
+# All scanning happens in python3 for portable file:line evidence on bash 3.2.
+export _AUTOSPEC_REPO_ROOT="$REPO_ROOT"
+export _AUTOSPEC_NUM_SPECIALISTS="$NUM_SPECIALISTS"
+export _AUTOSPEC_LLM_STUB="${AUTOSPEC_SPECIALIST_LLM_STUB_OUTPUT:-}"
+
+ROSTER_JSON="$(python3 - <<'PY'
+import json, os, re
+
+root = os.environ["_AUTOSPEC_REPO_ROOT"]
+try:
+    num = max(0, min(6, int(os.environ.get("_AUTOSPEC_NUM_SPECIALISTS", "3"))))
+except ValueError:
+    num = 3
+stub = os.environ.get("_AUTOSPEC_LLM_STUB", "")
+
+# Small domain lexicon: domain -> (regex of signal tokens, persona, lens).
+# Tokens are matched case-insensitively against manifest deps, README/AGENTS
+# keywords, and directory names. Evidence is always a real file:line.
+LEXICON = {
+    "trading": {
+        "tokens": r"\b(ccxt|backtrader|zipline|alpaca|quantlib|ta-lib|talib|"
+                  r"backtest(?:ing)?|order[- ]?book|market[- ]?data|ohlcv|"
+                  r"exchange[- ]?api|trading|brokerage|portfolio)\b",
+        "persona": "Quantitative trading strategist",
+        "lens": "missing risk controls, order-execution correctness, and "
+                "market-data integrity",
+    },
+    "healthcare": {
+        "tokens": r"\b(hl7|fhir|hipaa|dicom|ehr|emr|patient|clinical|"
+                  r"healthcare|phi|icd-?10)\b",
+        "persona": "Healthcare compliance reviewer",
+        "lens": "PHI handling, HIPAA boundaries, and clinical-data integrity",
+    },
+    "payments": {
+        "tokens": r"\b(stripe|braintree|paypal|pci|pci-dss|payment|checkout|"
+                  r"invoice|billing|ledger|chargeback)\b",
+        "persona": "Payments reliability engineer",
+        "lens": "idempotency, reconciliation, and PCI trust boundaries",
+    },
+    "ml": {
+        "tokens": r"\b(pytorch|torch|tensorflow|keras|scikit-learn|sklearn|"
+                  r"huggingface|transformers|xgboost|lightgbm|inference|"
+                  r"training[- ]?loop|model[- ]?registry)\b",
+        "persona": "ML systems reviewer",
+        "lens": "training/serving skew, data leakage, and reproducibility",
+    },
+    "security": {
+        "tokens": r"\b(oauth|jwt|bcrypt|argon2|crypto|cryptography|tls|mtls|"
+                  r"vault|secrets[- ]?manager|rbac|authz|authentication)\b",
+        "persona": "Application security advisor",
+        "lens": "authz boundaries, secret handling, and injection surfaces",
+    },
+    "infra": {
+        "tokens": r"\b(kubernetes|k8s|terraform|helm|docker[- ]?compose|"
+                  r"ansible|pulumi|cloudformation|prometheus|grafana)\b",
+        "persona": "Infrastructure reliability engineer",
+        "lens": "blast radius, rollout safety, and observability gaps",
+    },
+}
+
+# Files to scan for signal tokens. Manifests + docs; directory taxonomy is
+# handled separately so we cite the directory entry itself.
+MANIFESTS = [
+    "package.json", "requirements.txt", "pyproject.toml", "go.mod",
+    "Cargo.toml", "Gemfile", "pom.xml", "build.gradle",
+]
+DOCS = ["README.md", "AGENTS.md", "README.rst"]
+
+def rel(path):
+    return os.path.relpath(path, root)
+
+# Gather scan targets: explicit manifests/docs at root + any *.csproj anywhere
+# shallow + directory names one level down.
+scan_files = []
+for name in MANIFESTS + DOCS:
+    p = os.path.join(root, name)
+    if os.path.isfile(p):
+        scan_files.append(p)
+
+# *.csproj (shallow walk, skip vcs/vendor dirs)
+SKIP_DIRS = {".git", "node_modules", "vendor", ".venv", "venv", "target",
+             "dist", "build", ".autospec"}
+dir_names = []
+try:
+    for entry in sorted(os.listdir(root)):
+        full = os.path.join(root, entry)
+        if os.path.isdir(full) and entry not in SKIP_DIRS and not entry.startswith("."):
+            dir_names.append(entry)
+        elif os.path.isfile(full) and entry.endswith(".csproj"):
+            scan_files.append(full)
+except OSError:
+    pass
+
+# domain -> list of evidence dicts {file,line,match}
+hits = {d: [] for d in LEXICON}
+
+def record(domain, file_rel, line_no, match_text):
+    # Cap evidence per domain to keep the roster small and deterministic.
+    if len(hits[domain]) >= 8:
+        return
+    hits[domain].append({
+        "file": file_rel,
+        "line": int(line_no),
+        "match": match_text[:120],
+    })
+
+# Scan file contents line-by-line for token matches.
+for fpath in scan_files:
+    try:
+        with open(fpath, "r", encoding="utf-8", errors="replace") as fh:
+            for i, line in enumerate(fh, start=1):
+                low = line.lower()
+                for domain, spec in LEXICON.items():
+                    m = re.search(spec["tokens"], low)
+                    if m:
+                        record(domain, rel(fpath), i, line.strip())
+    except OSError:
+        continue
+
+# Directory taxonomy: a top-level dir whose name matches a domain token is a
+# signal. Cite the directory as file:line (line 0 -> 1 to satisfy schema).
+for d in dir_names:
+    low = d.lower()
+    for domain, spec in LEXICON.items():
+        if re.search(spec["tokens"], low):
+            # Use the directory path with a sentinel line of 1.
+            record(domain, d + "/", 1, "directory: " + d)
+
+# Rank domains by distinct evidence count (score), then name for stability.
+ranked = []
+for domain, ev in hits.items():
+    if not ev:
+        continue
+    ranked.append({"name": domain, "score": len(ev), "evidence": ev})
+ranked.sort(key=lambda x: (-x["score"], x["name"]))
+
+# ── Roster proposal ───────────────────────────────────────────────
+specialists = []
+parsed_stub = None
+if stub.strip():
+    m = re.search(r'\[.*\]|\{.*\}', stub, re.DOTALL)
+    if m:
+        try:
+            parsed_stub = json.loads(m.group(0))
+        except Exception:
+            parsed_stub = None
+
+def clean_specialist(item, allowed_evidence_index):
+    if not isinstance(item, dict):
+        return None
+    slug = str(item.get("slug", "")).strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug).strip("-")
+    persona = str(item.get("persona", "")).strip()
+    lens = str(item.get("lens", "")).strip()
+    why = str(item.get("why", "")).strip()
+    evidence = str(item.get("evidence", "")).strip()
+    if not (slug and persona and lens and why and evidence):
+        return None
+    return {"slug": slug, "persona": persona, "lens": lens,
+            "why": why, "evidence": evidence}
+
+if parsed_stub is not None:
+    arr = parsed_stub
+    if isinstance(parsed_stub, dict):
+        arr = parsed_stub.get("suggested_specialists", [])
+    if isinstance(arr, list):
+        for item in arr:
+            c = clean_specialist(item, None)
+            if c:
+                specialists.append(c)
+else:
+    # Deterministic fallback: derive one specialist per top-ranked domain from
+    # repo evidence only. No external persona injected (trust boundary).
+    for dom in ranked[:num]:
+        spec = LEXICON[dom["name"]]
+        first = dom["evidence"][0]
+        specialists.append({
+            "slug": dom["name"] + "-specialist",
+            "persona": spec["persona"],
+            "lens": spec["lens"],
+            "why": "Repo signals indicate a {} domain; a specialist lens "
+                   "surfaces domain-specific gaps the universal researchers "
+                   "miss.".format(dom["name"]),
+            "evidence": "{}:{} ({})".format(first["file"], first["line"],
+                                            first["match"]),
+        })
+
+specialists = specialists[:num]
+
+roster = {
+    "schema_version": 1,
+    "domains": ranked,
+    "suggested_specialists": specialists,
+}
+print(json.dumps(roster, indent=2))
+PY
+)"
+
+PY_RC=$?
+if [ "$PY_RC" -ne 0 ] || [ -z "$ROSTER_JSON" ]; then
+    ROSTER_JSON='{"schema_version":1,"domains":[],"suggested_specialists":[]}'
+fi
+
+# ── Cache (idempotent) + echo ─────────────────────────────────────
+mkdir -p "$REPO_ROOT/.autospec" 2>/dev/null || true
+printf '%s\n' "$ROSTER_JSON" > "$ROSTER_PATH" 2>/dev/null || true
+printf '%s\n' "$ROSTER_JSON"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -2445,6 +2445,7 @@ main() {
     check_loop_handoff_harness_awareness
     check_autospec_explore_researchers_deterministic
     check_autospec_explore_researchers_llm
+    check_autospec_explore_specialists_discovery
     check_autospec_explore_contract
     check_explore_trio_worktree_assert
     check_autospec_release_area_contract
@@ -2697,6 +2698,35 @@ check_autospec_explore_researchers_llm() {
                 || { cat /tmp/validate-explore-llm.log >&2; fail "$bats_file: failed"; }
         fi
     done
+}
+
+# autospec-explore domain-specialist roster discovery (Issue E1 #1082):
+# the deterministic signal-scan script + the new specialists schema must
+# exist, be executable / well-formed, and the bats coverage must pass when
+# bats is on PATH. The schema must compile with ajv when available.
+check_autospec_explore_specialists_discovery() {
+    info "autospec-explore domain-specialist roster discovery (Issue E1)"
+    local scan="scripts/explore-specialist-scan.sh"
+    [ -f "$scan" ] || fail "$scan: required file missing"
+    [ -x "$scan" ] || fail "$scan: file not executable"
+    bash -n "$scan" || fail "$scan: bash syntax error"
+    local schema="schemas/autospec-explore-specialists.schema.json"
+    [ -f "$schema" ] || fail "$schema: specialists roster schema missing"
+    if command -v jq >/dev/null 2>&1; then
+        jq -e '.properties.domains and .properties.suggested_specialists' "$schema" >/dev/null \
+            || fail "$schema: missing domains/suggested_specialists contract"
+    fi
+    if command -v ajv >/dev/null 2>&1; then
+        ajv compile -s "$schema" --spec=draft2020 >/dev/null 2>&1 \
+            || fail "$schema: does not compile with ajv"
+    fi
+    local bats_file="tests/explore/test_explore_specialists.bats"
+    [ -f "$bats_file" ] || fail "$bats_file: bats coverage missing"
+    if command -v bats >/dev/null 2>&1; then
+        info "  running: $bats_file"
+        bats "$bats_file" >/tmp/validate-explore-specialists.log 2>&1 \
+            || { cat /tmp/validate-explore-specialists.log >&2; fail "$bats_file: failed"; }
+    fi
 }
 
 # autospec-explore orchestrator contract (issue #721): top-level

--- a/tests/explore/test_explore_specialists.bats
+++ b/tests/explore/test_explore_specialists.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+# tests/explore/test_explore_specialists.bats — domain-specialist roster
+# DISCOVERY (Issue E1, spec 2026-06-15-autospec-explore-discovery-enhance.md
+# §"Domain-specialist researchers" → "Roster discovery").
+#
+# Asserts the deterministic signal scan in scripts/explore-specialist-scan.sh:
+#   * a trading-dep fixture (ccxt/backtrader) yields a ranked trading domain
+#     with file:line evidence and a matching specialist;
+#   * a generic/empty fixture yields an empty roster (loop runs unchanged);
+#   * the cached .autospec/explore-specialists.json validates against
+#     schemas/autospec-explore-specialists.schema.json;
+#   * re-invocation is idempotent (reuses the cache);
+#   * signals are evidence-grounded, never bare guesses.
+
+SCAN="scripts/explore-specialist-scan.sh"
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    TMP="$(mktemp -d -t explore-specialists.XXXXXX)"
+    cd "$TMP"
+    git init -q
+    git config user.email t@t.t
+    git config user.name t
+    export AUTOSPEC_REPO_ROOT="$TMP"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+@test "schema defines domains + suggested_specialists and compiles with ajv" {
+    schema="$REPO_ROOT/schemas/autospec-explore-specialists.schema.json"
+    [ -f "$schema" ]
+    run jq -e '.properties.domains and .properties.suggested_specialists' "$schema"
+    [ "$status" -eq 0 ]
+    run jq -e '.["$defs"].specialist.required == ["slug","persona","lens","why","evidence"]' "$schema"
+    [ "$status" -eq 0 ]
+    if command -v ajv >/dev/null 2>&1; then
+        run ajv compile -s "$schema" --spec=draft2020
+        [ "$status" -eq 0 ]
+    fi
+}
+
+@test "trading-dep repo yields a trading domain with file:line evidence" {
+    cat > requirements.txt <<'EOF'
+flask==2.0
+ccxt>=4.0
+backtrader==1.9.78
+EOF
+    git add -A && git commit -q -m init
+
+    run bash "$REPO_ROOT/$SCAN"
+    [ "$status" -eq 0 ]
+
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert d['schema_version'] == 1, d
+names = [x['name'] for x in d['domains']]
+assert 'trading' in names, names
+trading = next(x for x in d['domains'] if x['name'] == 'trading')
+assert trading['score'] >= 1, trading
+# Evidence is grounded: every hit cites a real file + line, never a guess.
+for ev in trading['evidence']:
+    assert ev['file'] == 'requirements.txt', ev
+    assert isinstance(ev['line'], int) and ev['line'] >= 1, ev
+    assert ev['match'], ev
+# A matching specialist is proposed.
+slugs = [s['slug'] for s in d['suggested_specialists']]
+assert any('trading' in s for s in slugs), slugs
+spec = next(s for s in d['suggested_specialists'] if 'trading' in s['slug'])
+assert spec['persona'] and spec['lens'] and spec['why'] and spec['evidence'], spec
+assert 'requirements.txt' in spec['evidence'], spec
+"
+}
+
+@test "generic repo with no detectable domain yields an empty roster" {
+    cat > requirements.txt <<'EOF'
+flask==2.0
+requests>=2.0
+EOF
+    cat > README.md <<'EOF'
+# Generic widget app
+A plain web app. Nothing domain-specific here.
+EOF
+    git add -A && git commit -q -m init
+
+    run bash "$REPO_ROOT/$SCAN"
+    [ "$status" -eq 0 ]
+
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert d['domains'] == [], d
+assert d['suggested_specialists'] == [], d
+"
+}
+
+@test "cached roster validates against the specialists schema (ajv)" {
+    command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available"
+    cat > requirements.txt <<'EOF'
+ccxt>=4.0
+backtrader==1.9.78
+EOF
+    git add -A && git commit -q -m init
+    bash "$REPO_ROOT/$SCAN" >/dev/null
+    [ -f "$TMP/.autospec/explore-specialists.json" ]
+    run ajv validate \
+        -s "$REPO_ROOT/schemas/autospec-explore-specialists.schema.json" \
+        --spec=draft2020 \
+        -d "$TMP/.autospec/explore-specialists.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "empty roster validates against the specialists schema (ajv)" {
+    command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available"
+    git commit -q --allow-empty -m init
+    bash "$REPO_ROOT/$SCAN" >/dev/null
+    run ajv validate \
+        -s "$REPO_ROOT/schemas/autospec-explore-specialists.schema.json" \
+        --spec=draft2020 \
+        -d "$TMP/.autospec/explore-specialists.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "roster is cached and reused idempotently on re-invocation" {
+    cat > requirements.txt <<'EOF'
+ccxt>=4.0
+EOF
+    git add -A && git commit -q -m init
+
+    run bash "$REPO_ROOT/$SCAN"
+    [ "$status" -eq 0 ]
+    [ -f "$TMP/.autospec/explore-specialists.json" ]
+    first="$(cat "$TMP/.autospec/explore-specialists.json")"
+
+    # Mutate the cache marker; a reuse run must echo the cached bytes verbatim.
+    run bash "$REPO_ROOT/$SCAN"
+    [ "$status" -eq 0 ]
+    second="$(cat "$TMP/.autospec/explore-specialists.json")"
+    [ "$first" = "$second" ]
+}
+
+@test "LLM stub seam supplies the suggested_specialists roster" {
+    cat > requirements.txt <<'EOF'
+ccxt>=4.0
+EOF
+    git add -A && git commit -q -m init
+
+    export AUTOSPEC_SPECIALIST_LLM_STUB_OUTPUT='{"domains":[],"suggested_specialists":[{"slug":"market-risk","persona":"Market risk quant","lens":"VaR and drawdown limits","why":"trading deps present","evidence":"requirements.txt:1 ccxt"}]}'
+    run bash "$REPO_ROOT/$SCAN" --force
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+slugs = [s['slug'] for s in d['suggested_specialists']]
+assert 'market-risk' in slugs, slugs
+"
+}


### PR DESCRIPTION
Closes #1082

## Issue E1 — domain-specialist roster DISCOVERY (signal scan + LLM seam + schema)

The DISCOVERY half of domain-specialist researchers. E2 (#1083) owns the flags + dispatch as `source=specialist:<slug>` — a clean seam is left here.

### Deliverables (3 + the validate gate)
- **`scripts/explore-specialist-scan.sh`** (new) — deterministic, no-LLM signal scan over dependency manifests (`requirements.txt`, `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `*.csproj`, …), README/AGENTS.md keywords, and directory taxonomy against a small domain lexicon. Emits ranked candidate domains, each with **file:line evidence — never a bare guess**. Caches the roster to `.autospec/explore-specialists.json`, idempotent on re-invocation. Provides a clean LLM seam (`AUTOSPEC_SPECIALIST_LLM_STUB_OUTPUT`) for the orchestrator's one-shot roster proposal; the deterministic persona fallback derives from repo evidence only (no external persona injected — trust boundary).
- **`schemas/autospec-explore-specialists.schema.json`** (new) — roster contract `{domains[], suggested_specialists[{slug,persona,lens,why,evidence}]}`. An empty roster on a generic repo is valid — the explore loop runs unchanged.
- **`tests/explore/test_explore_specialists.bats`** (new) — 7 tests.
- `scripts/validate.sh` — gates the scan script, schema (jq + ajv compile), and bats coverage.

### Acceptance criteria
- [x] Deterministic signal scan emits ranked candidate domains with file:line evidence
- [x] Seeded trading-dep repo (`ccxt`/`backtrader`) proposes matching specialists
- [x] Generic repo with no detectable domain yields an empty roster
- [x] Roster cached to `.autospec/explore-specialists.json` and reused idempotently
- [x] `schemas/autospec-explore-specialists.schema.json` validates the cached roster (ajv)
- [x] `bash scripts/validate.sh` green

### Counter-team (portability / false-positive audit)
- No host-path leak: evidence paths are repo-relative (`os.path.relpath`); cache lives under `.autospec/`.
- Empty-roster-on-generic-repo proven by test 3.
- Signals are evidence-grounded: a domain only appears if a concrete file:line cited a lexicon token. Persona fallback cites the first evidence hit.
- bash 3.2 safe: all scanning runs in `python3`; `set -u`; graceful degrade when python3/jq absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)