### PR TITLE
feat(explore): quality-resilience, dogfooding, self-leverage researchers (Issue B1 #1078)

### DIFF
--- a/scripts/explore-research/dogfooding.sh
+++ b/scripts/explore-research/dogfooding.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# scripts/explore-research/dogfooding.sh — discovery researcher (dogfooding).
+#
+# Reads live ~/.autospec/ run-state, failure ledgers, heartbeats,
+# explore-loop.json, run-summary.md; git log churn + revert archaeology;
+# never-invoked skills/flags (dead surface).
+#
+# Degradation: if ${AUTOSPEC_STATE_DIR:-$HOME/.autospec} is absent or any
+# artifact is missing, emits {"source":"dogfooding","proposals":[]} exit 0 —
+# never hard-fails.
+#
+# Safety: all host-specific absolute paths are redacted to ~/‑relative form
+# before any value reaches a proposal. No live-state value is interpolated
+# into a jq test() regex (uses string equality / capture() instead).
+#
+# Cap: last 20 runs / 200 commits.
+# Default weight: 0.9.
+#
+# Output: JSON to stdout matching schemas/autospec-explore-proposal.schema.json
+# (extended contract with severity + named_consumer).
+
+set -u
+
+REPO_ROOT="${AUTOSPEC_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+STATE_DIR="${AUTOSPEC_STATE_DIR:-$HOME/.autospec}"
+MAX_RUNS=20
+MAX_COMMITS=200
+MAX_PROPOSALS=20   # last 20 runs window per spec
+
+# Graceful degradation: missing state dir → empty output, exit 0.
+if [ ! -d "$STATE_DIR" ]; then
+    echo '{"source":"dogfooding","proposals":[]}'
+    exit 0
+fi
+
+cd "$REPO_ROOT" || { echo '{"source":"dogfooding","proposals":[]}'; exit 0; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo '{"source":"dogfooding","proposals":[]}'
+    exit 0
+fi
+
+# ── Gather artifacts (best-effort; missing files produce empty strings) ─────
+
+run_summary=""
+if [ -f "$STATE_DIR/run-summary.md" ]; then
+    run_summary="$(head -n 100 "$STATE_DIR/run-summary.md" 2>/dev/null || true)"
+fi
+
+explore_loop=""
+if [ -f "$STATE_DIR/explore-loop.json" ]; then
+    explore_loop="$(cat "$STATE_DIR/explore-loop.json" 2>/dev/null || true)"
+fi
+
+# Failure ledger: collect last MAX_RUNS entries from any ledger files.
+failure_tmp="$(mktemp -t dogfood-failures.XXXXXX)"
+trap 'rm -f "$failure_tmp"' EXIT
+
+for ledger_file in "$STATE_DIR"/failure-ledger*.json "$STATE_DIR"/failures*.json; do
+    if [ -f "$ledger_file" ]; then
+        python3 -c "
+import json, sys
+try:
+    data = json.load(open('$ledger_file', encoding='utf-8', errors='ignore'))
+    if isinstance(data, list):
+        for e in data[:$MAX_RUNS]:
+            print(json.dumps(e))
+    elif isinstance(data, dict):
+        entries = data.get('entries', data.get('failures', []))
+        for e in entries[:$MAX_RUNS]:
+            print(json.dumps(e))
+except Exception:
+    pass
+" 2>/dev/null >> "$failure_tmp" || true
+    fi
+done
+
+# Git churn + revert signals (capped).
+git_log_tmp="$(mktemp -t dogfood-gitlog.XXXXXX)"
+trap 'rm -f "$failure_tmp" "$git_log_tmp"' EXIT
+
+if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git log --oneline -n "$MAX_COMMITS" 2>/dev/null \
+        | grep -E -i '(revert|fix.*again|re-fix|broken|rollback|undo)' \
+        | head -n 40 > "$git_log_tmp" || true
+fi
+
+# Redact helper: replace STATE_DIR and HOME with ~/
+HOME_DIR="$HOME"
+STATE_DIR_REL="${STATE_DIR#"$HOME_DIR/"}"
+
+export AUTOSPEC_STATE_DIR_VAL="$STATE_DIR"
+export AUTOSPEC_HOME_VAL="$HOME_DIR"
+export AUTOSPEC_RUN_SUMMARY="$run_summary"
+export AUTOSPEC_EXPLORE_LOOP="$explore_loop"
+export AUTOSPEC_MAX_PROPOSALS="$MAX_PROPOSALS"
+
+python3 - "$failure_tmp" "$git_log_tmp" <<'PY'
+import json, os, re, sys
+
+failure_path = sys.argv[1]
+git_log_path = sys.argv[2]
+
+state_dir  = os.environ.get("AUTOSPEC_STATE_DIR_VAL", "")
+home_dir   = os.environ.get("AUTOSPEC_HOME_VAL", "")
+run_summary = os.environ.get("AUTOSPEC_RUN_SUMMARY", "")
+explore_raw = os.environ.get("AUTOSPEC_EXPLORE_LOOP", "")
+cap         = int(os.environ.get("AUTOSPEC_MAX_PROPOSALS", "20"))
+
+proposals = []
+
+def redact(text):
+    """Replace absolute host paths with ~/‑relative equivalents."""
+    if home_dir and home_dir != "~":
+        text = text.replace(home_dir + "/", "~/")
+        text = text.replace(home_dir, "~")
+    if state_dir and state_dir != "~/.autospec":
+        text = text.replace(state_dir + "/", "~/.autospec/")
+        text = text.replace(state_dir, "~/.autospec")
+    return text
+
+def add(title, evidence, complexity="small", confidence=0.75,
+        severity="operability", named_consumer=""):
+    if len(proposals) >= cap:
+        return
+    proposals.append({
+        "title": redact(title),
+        "evidence": redact(evidence),
+        "estimated_complexity": complexity,
+        "confidence": confidence,
+        "severity": severity,
+        "named_consumer": named_consumer,
+    })
+
+# ── Failure ledger analysis ────────────────────────────────────────────────
+failure_counts = {}
+try:
+    with open(failure_path, "r", encoding="utf-8", errors="ignore") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except Exception:
+                continue
+            # Normalize: look for a 'type', 'error', 'phase', or 'message' key.
+            key = (entry.get("type") or entry.get("phase") or
+                   entry.get("error", "")[:60] or "unknown")
+            failure_counts[key] = failure_counts.get(key, 0) + 1
+except FileNotFoundError:
+    pass
+
+for key, count in sorted(failure_counts.items(), key=lambda x: -x[1]):
+    if count < 2:
+        continue
+    add(
+        f"fix: recurring dogfooding failure '{key}' seen {count}x in run ledger",
+        f"Failure ledger at ~/.autospec/ records '{key}' occurring {count} times in recent runs — a systematic gap, not a one-off.",
+        complexity="medium",
+        confidence=0.8,
+        severity="stability",
+        named_consumer="/autospec-run recovery path; /autospec-loop monitor",
+    )
+
+# ── explore-loop.json: stalled or zero-proposal rounds ────────────────────
+if explore_raw.strip():
+    try:
+        loop_data = json.loads(explore_raw)
+        rounds = loop_data if isinstance(loop_data, list) else loop_data.get("rounds", [])
+        zero_rounds = [r for r in rounds if isinstance(r, dict) and
+                       len(r.get("proposals", [])) == 0]
+        if len(zero_rounds) >= 3:
+            add(
+                "fix(explore): loop producing zero proposals for 3+ consecutive rounds",
+                f"explore-loop.json shows {len(zero_rounds)} zero-proposal rounds — researchers may be returning empty output or the constitution gate is over-filtering.",
+                complexity="medium",
+                confidence=0.75,
+                severity="operability",
+                named_consumer="/autospec-explore loop driver; constitution gate",
+            )
+    except Exception:
+        pass
+
+# ── run-summary.md: repeated manual relaunch notes ────────────────────────
+relaunch_count = len(re.findall(r'(relaunch|re-launch|restarted|manually resumed)',
+                                run_summary, re.IGNORECASE))
+if relaunch_count >= 2:
+    add(
+        f"fix(resilience): autospec required {relaunch_count} manual relaunches — improve silent-exit recovery",
+        f"run-summary.md mentions relaunch/restart {relaunch_count} times. Cf. feedback_monitor_silent_exit memory: Phase 4 monitor exits silently on complex work; automatic relaunch is needed.",
+        complexity="medium",
+        confidence=0.7,
+        severity="operability",
+        named_consumer="/autospec-run Phase 4 monitor; /autospec-loop",
+    )
+
+# ── Git log: revert / fix-again churn ─────────────────────────────────────
+try:
+    with open(git_log_path, "r", encoding="utf-8", errors="ignore") as fh:
+        churn_lines = [l.strip() for l in fh if l.strip()]
+except FileNotFoundError:
+    churn_lines = []
+
+if len(churn_lines) >= 3:
+    # Cluster by repeated keyword tokens.
+    from collections import Counter
+    tokens = []
+    for line in churn_lines:
+        # Strip commit hash prefix.
+        parts = line.split(None, 1)
+        msg = parts[1] if len(parts) > 1 else line
+        tokens.extend(re.findall(r'[a-z][a-z0-9\-]{3,}', msg.lower()))
+    common = Counter(tokens).most_common(3)
+    top_token = common[0][0] if common else "unknown"
+    add(
+        f"fix: high revert/churn rate around '{top_token}' in git history",
+        f"git log shows {len(churn_lines)} revert/fix-again commits; top recurring token: '{top_token}'. Recurring churn signals a missing invariant test or a flaky harness path.",
+        complexity="medium",
+        confidence=0.65,
+        severity="stability",
+        named_consumer="/autospec-run convergence check; mutation gate",
+    )
+
+# ── Dead surface: skills or flags that appear never invoked ───────────────
+# Heuristic: skills listed in AGENTS.md but not referenced in git log last 200.
+agents_path = "AGENTS.md"
+if os.path.isfile(agents_path):
+    try:
+        agents_content = open(agents_path, encoding="utf-8", errors="ignore").read()
+        skill_refs = re.findall(r'/autospec-([a-z][a-z0-9\-]+)', agents_content)
+        # Read git log once (reuse churn file content is partial; use a broader check).
+        import subprocess
+        log_out = ""
+        try:
+            r = subprocess.run(
+                ["git", "log", "--oneline", f"-n{200}"],
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=10,
+            )
+            log_out = r.stdout.decode("utf-8", "ignore")
+        except Exception:
+            pass
+        for skill in set(skill_refs):
+            if skill not in log_out and len(proposals) < cap:
+                # Don't report "common" skills that appear everywhere.
+                if skill in ("run", "define", "explore", "review", "stop"):
+                    continue
+                add(
+                    f"chore: verify /autospec-{skill} is still reachable / not dead surface",
+                    f"AGENTS.md documents /autospec-{skill} but it does not appear in the last 200 commit messages — may be dead surface or under-documented.",
+                    complexity="small",
+                    confidence=0.5,
+                    severity="nicety",
+                    named_consumer="/autospec-explore dead-surface scan",
+                )
+    except Exception:
+        pass
+
+print(json.dumps({"source": "dogfooding", "proposals": proposals}))
+PY

--- a/scripts/explore-research/quality-resilience.sh
+++ b/scripts/explore-research/quality-resilience.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# scripts/explore-research/quality-resilience.sh — discovery researcher (quality-resilience).
+#
+# Four QA lenses:
+#   (a) test files vs their SUT — flags self-consistent fixtures built with the
+#       SUT's own derivation expression and assertion-free tests;
+#   (b) each claimed invariant in validate.sh/SKILL prose vs whether a test AND
+#       a guard exist;
+#   (c) kill-mid-run / non-idempotent / shared-lock / partial-state hazards;
+#   (d) LLM steps that should be deterministic + disproportionate-token phases.
+#
+# Cap: 100 candidates per round.
+# Default weight: 0.95.
+#
+# Output: JSON to stdout matching schemas/autospec-explore-proposal.schema.json
+# (extended contract with severity + named_consumer).
+
+set -u
+
+REPO_ROOT="${AUTOSPEC_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+MAX_PROPOSALS=100
+
+cd "$REPO_ROOT" || { echo '{"source":"quality-resilience","proposals":[]}'; exit 0; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo '{"source":"quality-resilience","proposals":[]}'
+    exit 0
+fi
+
+# Collect test files (bats + shell test helpers).
+test_tmp="$(mktemp -t qr-tests.XXXXXX)"
+trap 'rm -f "$test_tmp"' EXIT
+
+if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git ls-files -- '*.bats' 'tests/*.sh' 'test/*.sh' 'spec/*.sh' 2>/dev/null \
+        | head -n 200 > "$test_tmp" || true
+fi
+
+# Collect validate.sh claim lines.
+validate_tmp="$(mktemp -t qr-validate.XXXXXX)"
+trap 'rm -f "$test_tmp" "$validate_tmp"' EXIT
+
+if [ -f "scripts/validate.sh" ]; then
+    grep -n 'check_\|assert\|must\|require\|ensure' scripts/validate.sh 2>/dev/null \
+        | head -n 100 > "$validate_tmp" || true
+fi
+
+# Collect lock / partial-state hazard signals.
+hazard_tmp="$(mktemp -t qr-hazard.XXXXXX)"
+trap 'rm -f "$test_tmp" "$validate_tmp" "$hazard_tmp"' EXIT
+
+if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git grep -n -I -E '(lock|\.lock|lockfile|partial|PARTIAL|pid|PID|trap.*EXIT|rm.*tmp)' \
+        -- 'scripts/*.sh' '*.sh' 2>/dev/null | head -n 200 > "$hazard_tmp" || true
+fi
+
+# Collect LLM-dispatch sites.
+llm_tmp="$(mktemp -t qr-llm.XXXXXX)"
+trap 'rm -f "$test_tmp" "$validate_tmp" "$hazard_tmp" "$llm_tmp"' EXIT
+
+if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git grep -n -I -E '(claude|llm_dispatch|AskUserQuestion|invoke.*model|--model)' \
+        -- 'scripts/*.sh' 'skills/**/*.md' 'skills/*.md' 2>/dev/null \
+        | head -n 100 > "$llm_tmp" || true
+fi
+
+python3 - "$test_tmp" "$validate_tmp" "$hazard_tmp" "$llm_tmp" "$MAX_PROPOSALS" <<'PY'
+import json, os, re, sys
+
+test_path     = sys.argv[1]
+validate_path = sys.argv[2]
+hazard_path   = sys.argv[3]
+llm_path      = sys.argv[4]
+cap           = int(sys.argv[5])
+
+proposals = []
+
+def add(title, evidence, complexity="small", confidence=0.75,
+        severity="correctness", named_consumer=""):
+    if len(proposals) >= cap:
+        return
+    proposals.append({
+        "title": title,
+        "evidence": evidence,
+        "estimated_complexity": complexity,
+        "confidence": confidence,
+        "severity": severity,
+        "named_consumer": named_consumer,
+    })
+
+# ── Lens (a): assertion-free test files ────────────────────────────────────
+try:
+    with open(test_path, "r", encoding="utf-8", errors="ignore") as fh:
+        test_files = [l.strip() for l in fh if l.strip()]
+except FileNotFoundError:
+    test_files = []
+
+for tf in test_files:
+    if not os.path.isfile(tf):
+        continue
+    try:
+        content = open(tf, "r", encoding="utf-8", errors="ignore").read()
+    except Exception:
+        continue
+
+    # Check for assertion-free bats files.
+    if tf.endswith(".bats"):
+        has_assert = bool(re.search(r'\bassert\b|run\s+.*\n.*assert|assert_output|assert_success|assert_failure', content))
+        if not has_assert:
+            add(
+                f"test: add assertions to {tf} (currently assertion-free)",
+                f"{tf} contains @test blocks but no assert_* calls — tests cannot falsify behaviour.",
+                complexity="small",
+                confidence=0.85,
+                severity="silent-wrong",
+                named_consumer="/autospec-run mutation gate; assertion-density floor",
+            )
+            continue
+
+    # Check for self-consistent fixture pattern: test imports / sources the SUT
+    # and builds expected output via the same function call being tested.
+    if re.search(r'source\s+\S+\s*\n.*expected.*=.*\$\(.*\)', content, re.DOTALL):
+        add(
+            f"test: replace self-consistent fixture in {tf} with pinned expected values",
+            f"{tf} appears to derive expected output by calling the SUT — bugs in the SUT make fixtures self-validating (cf. lstrip transcript-slug bug).",
+            complexity="small",
+            confidence=0.7,
+            severity="silent-wrong",
+            named_consumer="/autospec-run mutation gate",
+        )
+
+# ── Lens (b): validate.sh invariants without matching test ─────────────────
+try:
+    with open(validate_path, "r", encoding="utf-8", errors="ignore") as fh:
+        validate_lines = fh.readlines()
+except FileNotFoundError:
+    validate_lines = []
+
+check_fn_pat = re.compile(r'^\s*(check_\w+)\s*\(\s*\)')
+for i, line in enumerate(validate_lines, start=1):
+    m = check_fn_pat.match(line)
+    if not m:
+        continue
+    fn_name = m.group(1)
+    # Heuristic: look for a bats @test that references this function name.
+    found_test = False
+    for tf in test_files:
+        if not os.path.isfile(tf):
+            continue
+        try:
+            tcontent = open(tf, "r", encoding="utf-8", errors="ignore").read()
+            if fn_name in tcontent:
+                found_test = True
+                break
+        except Exception:
+            continue
+    if not found_test:
+        add(
+            f"test: add bats coverage for validate.sh:{fn_name}",
+            f"validate.sh defines {fn_name} (line {i}) but no bats test references it — the invariant is untested.",
+            complexity="small",
+            confidence=0.7,
+            severity="correctness",
+            named_consumer="/autospec-run validate gate; /autospec-sweep",
+        )
+
+# ── Lens (c): kill-mid-run / partial-state / shared-lock hazards ───────────
+try:
+    with open(hazard_path, "r", encoding="utf-8", errors="ignore") as fh:
+        hazard_lines = fh.readlines()
+except FileNotFoundError:
+    hazard_lines = []
+
+lock_files_seen = set()
+for line in hazard_lines:
+    line = line.strip()
+    if not line:
+        continue
+    m = re.match(r'^(.+?):(\d+):(.+)$', line)
+    if not m:
+        continue
+    fpath, lineno, content = m.group(1), m.group(2), m.group(3).strip()
+
+    # Flag lockfile writes without a matching trap/cleanup.
+    if re.search(r'\.lock\b', content) and fpath not in lock_files_seen:
+        lock_files_seen.add(fpath)
+        # Check if same file has a trap EXIT that removes the lock.
+        try:
+            full = open(fpath, "r", encoding="utf-8", errors="ignore").read()
+            has_trap = bool(re.search(r'trap\s+.*rm.*\.lock|trap\s+.*cleanup', full))
+        except Exception:
+            has_trap = False
+        if not has_trap:
+            add(
+                f"fix(resilience): ensure lockfile cleanup on exit in {fpath}",
+                f"{fpath}:{lineno} uses a lockfile but no trap-on-EXIT cleanup found — kill-mid-run leaves stale locks.",
+                complexity="small",
+                confidence=0.72,
+                severity="stability",
+                named_consumer="/autospec-run concurrent-round guard",
+            )
+
+# ── Lens (d): LLM steps that could be deterministic ───────────────────────
+try:
+    with open(llm_path, "r", encoding="utf-8", errors="ignore") as fh:
+        llm_lines = fh.readlines()
+except FileNotFoundError:
+    llm_lines = []
+
+deterministic_candidates = set()
+for line in llm_lines:
+    line = line.strip()
+    if not line:
+        continue
+    m = re.match(r'^(.+?):(\d+):(.+)$', line)
+    if not m:
+        continue
+    fpath, lineno, content = m.group(1), m.group(2), m.group(3).strip()
+    # If a script invokes claude but the surrounding content looks like a pure
+    # grep/count operation, flag it.
+    if re.search(r'(count|grep|find|ls|wc)\b', content) and re.search(r'claude|llm_dispatch', content):
+        key = fpath
+        if key not in deterministic_candidates:
+            deterministic_candidates.add(key)
+            add(
+                f"refactor: replace LLM call with deterministic tool in {fpath}:{lineno}",
+                f"{fpath}:{lineno} invokes an LLM for what appears to be a grep/count operation — convert to bash (cf. tooling-optimization tracker).",
+                complexity="medium",
+                confidence=0.6,
+                severity="operability",
+                named_consumer="autospec tooling-optimization tracker #421",
+            )
+
+print(json.dumps({"source": "quality-resilience", "proposals": proposals}))
+PY

--- a/scripts/explore-research/self-leverage.sh
+++ b/scripts/explore-research/self-leverage.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# scripts/explore-research/self-leverage.sh — discovery researcher (self-leverage).
+#
+# Scans every point in the trio prose + scripts where a human decision /
+# intervention / relaunch is still required, and checks each against the
+# autonomy-scope rule:
+#   - low-stakes decisions should auto-resolve;
+#   - only run/defer/refine + destructive-remote actions reach the operator.
+#
+# Cap: 50 candidates per round.
+# Default weight: 0.6.
+#
+# Output: JSON to stdout matching schemas/autospec-explore-proposal.schema.json
+# (extended contract with severity + named_consumer).
+
+set -u
+
+REPO_ROOT="${AUTOSPEC_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+MAX_PROPOSALS=50
+
+cd "$REPO_ROOT" || { echo '{"source":"self-leverage","proposals":[]}'; exit 0; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo '{"source":"self-leverage","proposals":[]}'
+    exit 0
+fi
+
+# Collect intervention-signal lines from skill prose and scripts.
+prose_tmp="$(mktemp -t sl-prose.XXXXXX)"
+script_tmp="$(mktemp -t sl-scripts.XXXXXX)"
+trap 'rm -f "$prose_tmp" "$script_tmp"' EXIT
+
+if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    # Skill prose: SKILL.md files and docs/specs/*.md
+    git grep -n -I -E \
+        '(manually|operator must|human must|ask the operator|AskUserQuestion|requires human|intervention|relaunch|re-launch|you must|please run|operator should confirm|operator confirm)' \
+        -- 'skills/**/*.md' 'skills/*.md' 'docs/specs/*.md' 'AGENTS.md' \
+        2>/dev/null | head -n 200 > "$prose_tmp" || true
+
+    # Scripts: explicit prompts / read / confirm patterns
+    git grep -n -I -E \
+        '(read -r|read -p|AskUserQuestion|printf.*\?|echo.*\?.*read|confirm|pause|press enter|--interactive)' \
+        -- 'scripts/*.sh' 'scripts/**/*.sh' \
+        2>/dev/null | head -n 200 > "$script_tmp" || true
+fi
+
+export AUTOSPEC_MAX_PROPOSALS="$MAX_PROPOSALS"
+
+python3 - "$prose_tmp" "$script_tmp" <<'PY'
+import json, os, re, sys
+
+prose_path  = sys.argv[1]
+script_path = sys.argv[2]
+cap         = int(os.environ.get("AUTOSPEC_MAX_PROPOSALS", "50"))
+
+proposals = []
+
+def add(title, evidence, complexity="small", confidence=0.65,
+        severity="operability", named_consumer=""):
+    if len(proposals) >= cap:
+        return
+    proposals.append({
+        "title": title,
+        "evidence": evidence,
+        "estimated_complexity": complexity,
+        "confidence": confidence,
+        "severity": severity,
+        "named_consumer": named_consumer,
+    })
+
+# Patterns that indicate a human-in-the-loop requirement.
+# Split into: (a) legitimately requiring operator (run/defer/refine/destructive)
+# and (b) low-stakes that should auto-resolve.
+OPERATOR_LEGIT = re.compile(
+    r'(run\b|defer\b|refine\b|destructive|push.*force|delete.*branch|'
+    r'merge.*main|reset.*hard|--admin|irreversible)',
+    re.IGNORECASE,
+)
+HUMAN_SIGNAL = re.compile(
+    r'(manually|operator must|human must|ask the operator|AskUserQuestion|'
+    r'requires human|intervention|relaunch|re-launch|you must|please run|'
+    r'operator should confirm|operator confirm|read -[rp]|confirm\b|pause\b|'
+    r'press enter)',
+    re.IGNORECASE,
+)
+
+seen = set()
+
+def process_file(path, source_label):
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+            lines = fh.readlines()
+    except FileNotFoundError:
+        return
+
+    for line in lines:
+        line = line.rstrip("\n")
+        if not line.strip():
+            continue
+        # Format: file:lineno:content
+        m = re.match(r'^(.+?):(\d+):(.+)$', line)
+        if not m:
+            continue
+        fpath, lineno, content = m.group(1), m.group(2), m.group(3).strip()
+
+        if not HUMAN_SIGNAL.search(content):
+            continue
+
+        # Skip if this looks like a legitimately operator-facing action.
+        if OPERATOR_LEGIT.search(content):
+            continue
+
+        key = f"{fpath}:{lineno}"
+        if key in seen:
+            continue
+        seen.add(key)
+
+        snippet = content[:120].replace('"', "'")
+        add(
+            f"feat(autonomy): auto-resolve human-in-loop step at {fpath}:{lineno}",
+            f"{source_label} hit at {fpath}:{lineno}: \"{snippet}\" — this step requires manual operator action but appears low-stakes per the autonomy-scope rule (should auto-resolve; only run/defer/refine/destructive reach the operator).",
+            complexity="medium",
+            confidence=0.65,
+            severity="operability",
+            named_consumer="/autospec-explore autonomy-scope rule; /autospec-run --autonomous",
+        )
+
+process_file(prose_path,  "prose intervention signal")
+process_file(script_path, "script interaction pattern")
+
+print(json.dumps({"source": "self-leverage", "proposals": proposals}))
+PY


### PR DESCRIPTION
## Summary

Ships the three new deterministic researcher scripts for `scripts/explore-research/` (Issue B1 of the discovery-enhance batch):

- **`quality-resilience.sh`** — four QA lenses: assertion-free bats tests, `validate.sh` invariants without bats coverage, kill-mid-run lockfile hazards, LLM calls that should be deterministic. Cap 100, weight 0.95, proposals carry `severity` + `named_consumer`.
- **`dogfooding.sh`** — reads `${AUTOSPEC_STATE_DIR:-~/.autospec}` run-state, failure ledgers, `explore-loop.json`, git revert archaeology. Degrades gracefully to `{"source":"dogfooding","proposals":[]}` exit 0 when the state dir is absent. Redacts all host-absolute paths to `~/`-relative before any value reaches a proposal. No live-state value is interpolated into a `jq test()` regex. Cap 20 runs, weight 0.9.
- **`self-leverage.sh`** — scans skill trio prose + scripts for human-in-loop intervention points and checks each against the autonomy-scope rule (low-stakes → should auto-resolve; only run/defer/refine/destructive reach the operator). Cap 50, weight 0.6.

All three emit the extended proposal JSON contract (`severity` + `named_consumer`) per `schemas/autospec-explore-proposal.schema.json`.

## Verification

- `bash -n` clean on all three scripts ✓
- Primary smoke test: `AUTOSPEC_STATE_DIR=/nonexistent bash scripts/explore-research/dogfooding.sh | jq -e '.source=="dogfooding" and (.proposals|length)==0'` → `true` ✓
- `bash scripts/validate.sh` → `OK — all validation checks passed.` ✓
- Manual JSON validation: each script piped through `jq .` produces valid output ✓

## Out of scope

Bats test suites are Issue B2 (#1079). Aggregator changes are Issue C (#1080).

Closes #1078