### PR TITLE
feat(explore): verify stage + ROI gate + severity-first rank + counters (#1080)

### DIFF
--- a/scripts/explore-research-cycle.sh
+++ b/scripts/explore-research-cycle.sh
@@ -2,17 +2,24 @@
 # scripts/explore-research-cycle.sh — autospec-explore research cycle aggregator.
 #
 # Runs the enabled deterministic researchers in parallel, aggregates their
-# proposals, deduplicates by normalized title, ranks by weighted score,
-# filters out proposals matching titles created in the last 7 days, and
-# caps output at --max-issues-per-round.
+# proposals, then threads them through the stage pipeline
+#   dedup -> verify -> ROI gate -> (pattern synthesis: Issue D) -> rank
+# (constitution + recent-title filters apply before the severity-first rank),
+# and caps output at --max-issues-per-round.
 #
 # Implements the "Research cycle contract" + "Per-researcher contracts"
-# rows 1-4 in docs/specs/2026-05-29-autospec-explore-design.md.
+# rows 1-4 in docs/specs/2026-05-29-autospec-explore-design.md and the
+# "Aggregator changes" (verify/ROI/severity-first-rank/counters) in
+# docs/specs/2026-06-15-autospec-explore-discovery-enhance.md.
 #
 # Output: JSON to stdout with shape:
 #   { "round": "<iso-date>",
 #     "proposals_total": N,
 #     "proposals_after_dedup": N,
+#     "proposals_after_verify": N,        # survived the adversarial verify gate
+#     "proposals_refuted": N,             # dropped by the verify gate
+#     "proposals_after_roi": N,           # survived the named-consumer ROI gate
+#     "structural_fixes": N,              # pattern-synthesis output (Issue D; 0)
 #     "proposals_after_recent_filter": N,
 #     "proposals": [ ...top --max-issues-per-round... ] }
 #
@@ -166,7 +173,21 @@ if [ -n "$weights_bin" ] && [ -x "$weights_bin" ]; then
 fi
 export WEIGHTS_JSON
 
-# Aggregate, dedup, rank, filter, cap.
+# Aggregate, dedup, VERIFY, ROI-gate, rank, filter, cap.
+#
+# Verify stage (Issue C): the adversarial LLM-skeptic refutation is an
+# explore-orchestrator (SKILL-prose) responsibility, NOT this deterministic
+# bash aggregator — no LLM is ever invoked from here. What the aggregator owns
+# is the verify *boundary*: every deduped proposal is threaded through a verify
+# gate that consumes an OPTIONAL verdict map supplied by the orchestrator via
+# AUTOSPEC_EXPLORE_VERIFY_VERDICTS (a path to, or inline, JSON mapping
+# normalized-title -> {verdict, reason}). Documented fallback: when no map is
+# supplied the gate no-ops to "all survive" (verdict=unverified). When a map IS
+# supplied, a proposal with no entry is refute-by-default (the skeptic could
+# not affirm it) per the spec.
+VERIFY_VERDICTS="${AUTOSPEC_EXPLORE_VERIFY_VERDICTS:-}"
+export VERIFY_VERDICTS
+
 WORK_DIR="$work_dir" \
 MAX_ISSUES="$MAX_ISSUES" \
 RECENT_FILE="$recent_titles_file" \
@@ -200,6 +221,28 @@ if _wj:
 else:
     SRC_WEIGHTS = DEFAULT_SRC_WEIGHTS
 COMPLEXITY = {"small": 1.0, "medium": 2.0, "large": 4.0}
+
+# Severity bands, highest impact -> lowest. Lower numeric value = higher
+# priority (primary sort key). Mirrors schemas/autospec-explore-proposal.schema
+# .json enum order, which is load-bearing.
+SEVERITY_ORDER = [
+    "silent-wrong", "correctness", "stability",
+    "operability", "feature", "nicety",
+]
+SEVERITY_RANK = {s: i for i, s in enumerate(SEVERITY_ORDER)}
+# Default rank for an unknown severity = just below "feature" (treated as the
+# legacy default band so unknown values never out-rank a real correctness item).
+DEFAULT_SEVERITY_RANK = SEVERITY_RANK["feature"]
+
+# The 7 legacy universal researchers are EXEMPT from the ROI gate during
+# rollout (spec: "only the three new ones are ROI-gated, to avoid silently
+# muting the existing 7"). Any source NOT in this set — the three discovery
+# researchers (quality-resilience, dogfooding, self-leverage) and
+# specialist:<slug> sources — is a "new source" and IS ROI-gated.
+LEGACY_SOURCES = {
+    "spec-vs-code", "prior-reports", "codebase-signals", "open-issues",
+    "source-analysis", "dependency-health", "internet",
+}
 
 def normalize_title(t):
     s = t.lower()
@@ -263,6 +306,81 @@ for p in all_props:
         by_norm[n] = p
 deduped = list(by_norm.values())
 
+# ---------------------------------------------------------------------------
+# VERIFY stage (Issue C) — adversarial-skeptic boundary, between dedup & rank.
+#
+# The deterministic aggregator does NOT call an LLM. It consumes an optional
+# verdict map produced by the explore-orchestrator's per-proposal Tier-B
+# skeptic dispatch. Map shape: { "<normalized title>": {"verdict": "...",
+# "reason": "..."} }. verdict in {"survived","refuted"} (anything not
+# "survived" is treated as refuted). VERIFY_VERDICTS may be a path to a JSON
+# file or an inline JSON string.
+#
+# Fallback (documented degradation): no map supplied -> the gate no-ops, every
+# proposal survives carrying verdict="unverified". This is the safe default for
+# environments with no subagent capability (cf. the installer/runtime-libs and
+# bash-3.2 gotchas — never hard-fail).
+#
+# Refute-by-default: when a map IS supplied but a proposal has no entry, the
+# skeptic could not affirm it, so it is refuted and dropped (spec: "default to
+# refuted=true under uncertainty").
+def _load_verdicts():
+    raw = os.environ.get("VERIFY_VERDICTS", "").strip()
+    if not raw:
+        return None
+    # Prefer a file path; fall back to treating the value as inline JSON.
+    try:
+        if os.path.isfile(raw):
+            with open(raw, "r", encoding="utf-8") as fh:
+                return json.load(fh)
+        return json.loads(raw)
+    except Exception:
+        # Unparseable verdict source -> behave as if no map was supplied
+        # (no-op fallback) rather than refuting everything on a config error.
+        return None
+
+_verdicts = _load_verdicts()
+verified = []
+refuted_count = 0
+for p in deduped:
+    n = normalize_title(p["title"])
+    if _verdicts is None:
+        # No-op fallback: survive, unverified.
+        p["verdict"] = "unverified"
+        p["reason"] = "no verifier verdict supplied (verify stage no-op)"
+        verified.append(p)
+        continue
+    entry = _verdicts.get(n)
+    if not isinstance(entry, dict):
+        # Refute-by-default under uncertainty.
+        refuted_count += 1
+        continue
+    verdict = str(entry.get("verdict", "")).strip().lower()
+    reason = str(entry.get("reason", ""))
+    if verdict == "survived":
+        p["verdict"] = "survived"
+        p["reason"] = reason or "skeptic could not refute"
+        verified.append(p)
+    else:
+        # refuted (or any non-survived verdict) -> drop.
+        refuted_count += 1
+
+# ---------------------------------------------------------------------------
+# ROI gate (Issue C) — drop NEW-source proposals with empty named_consumer.
+# Legacy universal sources are exempt (rollout safety). The pattern-synthesis
+# hook (Issue D #1081) slots in AFTER this gate and BEFORE ranking; it is not
+# implemented here — structural_fixes stays 0 as the clean seam.
+roi_kept = []
+for p in verified:
+    src = p.get("source", "")
+    consumer = str(p.get("named_consumer", "")).strip()
+    if src not in LEGACY_SOURCES and consumer == "":
+        # New source, no named consumer -> dropped by the ROI gate.
+        continue
+    roi_kept.append(p)
+
+structural_fixes = 0  # Pattern synthesis is Issue D; seam left intentionally.
+
 # Constitution gate (deterministic rules D1 evidence + D2 confidence floor).
 # Keep this byte-aligned with explore-constitution.sh --filter. Floor default 0.3
 # reproduces prior behavior for well-formed proposals (all carry evidence and
@@ -271,7 +389,7 @@ try:
     _floor = float(os.environ.get("AUTOSPEC_EXPLORE_MIN_CONFIDENCE", "0.3") or "0.3")
 except Exception:
     _floor = 0.3
-constitutional = [p for p in deduped
+constitutional = [p for p in roi_kept
                   if str(p.get("evidence", "")).strip() != ""
                   and p.get("confidence", 0) >= _floor]
 
@@ -288,14 +406,25 @@ except FileNotFoundError:
 
 filtered = [p for p in constitutional if normalize_title(p["title"]) not in recent_norms]
 
-# Rank descending by score; cap.
-filtered.sort(key=lambda p: p["score"], reverse=True)
+# Severity-first ranking (Issue C): primary key = severity rank (lower rank =
+# higher impact = ranked first); secondary key = the existing weighted score
+# (confidence * source_weight / complexity), descending. A high-severity item
+# behind auto-merge thus out-ranks a low-severity high-score one, while score
+# still breaks ties within a band.
+def _rank_key(p):
+    sev_rank = SEVERITY_RANK.get(p.get("severity", "feature"), DEFAULT_SEVERITY_RANK)
+    return (sev_rank, -p["score"])
+filtered.sort(key=_rank_key)
 final = filtered[:cap]
 
 out = {
     "round": datetime.date.today().isoformat(),
     "proposals_total": total,
     "proposals_after_dedup": len(deduped),
+    "proposals_after_verify": len(verified),
+    "proposals_refuted": refuted_count,
+    "proposals_after_roi": len(roi_kept),
+    "structural_fixes": structural_fixes,
     "proposals_after_constitution": len(constitutional),
     "proposals_after_recent_filter": len(filtered),
     "proposals": final,

--- a/tests/explore/test_explore_severity_roi.bats
+++ b/tests/explore/test_explore_severity_roi.bats
@@ -89,3 +89,114 @@ assert p['severity'] == 'silent-wrong', p
 assert p['named_consumer'] == 'autospec-run Phase 4', p
 "
 }
+
+# --- Issue C: severity-first ranking -------------------------------------
+
+@test "ranking sorts by severity rank first, score second" {
+    # A high-severity, LOW-score proposal must out-rank a low-severity,
+    # HIGH-score one. Without severity-first the large-complexity silent-wrong
+    # item would sink below the small-complexity nicety item.
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[
+      {"title":"feat: tiny polish","evidence":"e1","estimated_complexity":"small","confidence":0.99,"severity":"nicety","named_consumer":"x"},
+      {"title":"feat: data corruption guard","evidence":"e2","estimated_complexity":"large","confidence":0.5,"severity":"silent-wrong","named_consumer":"y"}
+    ]}'
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[]}'
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+titles = [p['title'] for p in d['proposals']]
+assert titles[0] == 'feat: data corruption guard', titles
+assert titles[1] == 'feat: tiny polish', titles
+"
+}
+
+@test "within one severity band, score still breaks the tie" {
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[
+      {"title":"feat: low score feature","evidence":"e1","estimated_complexity":"large","confidence":0.4,"severity":"feature","named_consumer":"x"},
+      {"title":"feat: high score feature","evidence":"e2","estimated_complexity":"small","confidence":0.95,"severity":"feature","named_consumer":"y"}
+    ]}'
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[]}'
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+titles = [p['title'] for p in d['proposals']]
+assert titles[0] == 'feat: high score feature', titles
+"
+}
+
+# --- Issue C: ROI gate ---------------------------------------------------
+
+@test "ROI gate drops a new-source proposal with empty named_consumer; keeps a legacy one" {
+    # A NEW researcher (quality-resilience) with empty named_consumer is
+    # dropped by the ROI gate. A LEGACY researcher (spec-vs-code) with empty
+    # named_consumer is exempt and survives.
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: legacy keeps","evidence":"e1","estimated_complexity":"small","confidence":0.9}]}'
+    make_fake_researcher quality-resilience '{"source":"quality-resilience","proposals":[
+      {"title":"feat: new no consumer","evidence":"e2","estimated_complexity":"small","confidence":0.9,"severity":"correctness"},
+      {"title":"feat: new with consumer","evidence":"e3","estimated_complexity":"small","confidence":0.9,"severity":"correctness","named_consumer":"validate.sh"}
+    ]}'
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[]}'
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" \
+        --research-sources spec-vs-code,prior-reports,codebase-signals,open-issues,quality-resilience \
+        --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+titles = sorted(p['title'] for p in d['proposals'])
+assert 'feat: legacy keeps' in titles, titles          # legacy empty-consumer kept
+assert 'feat: new with consumer' in titles, titles      # new + consumer kept
+assert 'feat: new no consumer' not in titles, titles     # new empty-consumer dropped
+assert d['proposals_after_roi'] == 2, d
+"
+}
+
+@test "ROI gate exempts ALL seven legacy universal sources" {
+    # Each legacy universal source emitting an empty-consumer proposal must
+    # survive the ROI gate. Guards against silently muting the existing 7.
+    for s in spec-vs-code prior-reports codebase-signals open-issues source-analysis dependency-health internet; do
+        make_fake_researcher "$s" "{\"source\":\"$s\",\"proposals\":[{\"title\":\"feat: $s item\",\"evidence\":\"e\",\"estimated_complexity\":\"small\",\"confidence\":0.9}]}"
+    done
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" \
+        --research-sources spec-vs-code,prior-reports,codebase-signals,open-issues,source-analysis,dependency-health,internet \
+        --max-issues-per-round 20
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert d['proposals_after_roi'] == 7, d
+"
+}
+
+@test "ROI gate drops empty-consumer specialist:<slug> proposals (new source)" {
+    make_fake_researcher 'specialist:market-risk' '{"source":"specialist:market-risk","proposals":[{"title":"feat: risk control gap","evidence":"e","estimated_complexity":"small","confidence":0.9,"severity":"correctness"}]}'
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[]}'
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[]}'
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" \
+        --research-sources spec-vs-code,prior-reports,codebase-signals,open-issues,specialist:market-risk \
+        --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert d['proposals_after_roi'] == 0, d
+assert len(d['proposals']) == 0, d
+"
+}

--- a/tests/explore/test_explore_verify_stage.bats
+++ b/tests/explore/test_explore_verify_stage.bats
@@ -1,0 +1,147 @@
+#!/usr/bin/env bats
+# tests/explore/test_explore_verify_stage.bats — adversarial VERIFY stage
+# (Issue C) in scripts/explore-research-cycle.sh.
+#
+# The deterministic aggregator owns the verify *boundary*, not the LLM
+# refutation itself (the skeptic is an explore-orchestrator/SKILL-prose
+# responsibility). The aggregator:
+#   - threads every deduped proposal through a verify boundary,
+#   - consumes an OPTIONAL verifier verdict map (normalized title ->
+#     {verdict, reason}) supplied via AUTOSPEC_EXPLORE_VERIFY_VERDICTS,
+#   - DROPS proposals whose verdict is "refuted",
+#   - attaches {verdict, reason} to survivors,
+#   - falls back to "all survive" (no-op) when no verdict is supplied,
+#   - emits proposals_after_verify and proposals_refuted counters.
+#
+# No LLM is invoked from bash. The tests inject verdicts directly to exercise
+# the deterministic boundary.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    TMP="$(mktemp -d -t explore-verify.XXXXXX)"
+    cd "$TMP"
+    git init -q
+    git config user.email t@t.t
+    git config user.name t
+    export AUTOSPEC_REPO_ROOT="$TMP"
+    export PATH="$TMP/bin:$PATH"
+    mkdir -p "$TMP/bin"
+    cat > "$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$TMP/bin/gh"
+    export AUTOSPEC_RESEARCH_DIR="$TMP/fake-research"
+    mkdir -p "$AUTOSPEC_RESEARCH_DIR"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+make_fake_researcher() {
+    local name="$1"
+    local payload="$2"
+    cat > "$AUTOSPEC_RESEARCH_DIR/$name.sh" <<EOF
+#!/usr/bin/env bash
+cat <<JSON
+$payload
+JSON
+EOF
+    chmod +x "$AUTOSPEC_RESEARCH_DIR/$name.sh"
+}
+
+empties() {
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[]}'
+}
+
+@test "no verdict map supplied -> verify is a no-op; all survive, zero refuted" {
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: alpha widget","evidence":"e1","estimated_complexity":"small","confidence":0.9}]}'
+    empties
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert d['proposals_after_dedup'] == 1, d
+assert d['proposals_after_verify'] == 1, d
+assert d['proposals_refuted'] == 0, d
+assert len(d['proposals']) == 1, d
+p = d['proposals'][0]
+# Survivor carries a verdict + reason even in the no-op fallback.
+assert p['verdict'] in ('survived', 'unverified'), p
+assert 'reason' in p, p
+"
+}
+
+@test "a refuted proposal is dropped; a real one survives with verdict+reason" {
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: real fix","evidence":"e1","estimated_complexity":"small","confidence":0.9},{"title":"feat: bogus claim","evidence":"e2","estimated_complexity":"small","confidence":0.9}]}'
+    empties
+
+    # Verdict map is keyed by NORMALIZED title (the aggregator strips the
+    # conventional-commit prefix before keying).
+    cat > "$TMP/verdicts.json" <<'EOF'
+{
+  "real fix": {"verdict":"survived","reason":"reproduced the gap"},
+  "bogus claim": {"verdict":"refuted","reason":"claim does not hold"}
+}
+EOF
+    export AUTOSPEC_EXPLORE_VERIFY_VERDICTS="$TMP/verdicts.json"
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert d['proposals_after_dedup'] == 2, d
+assert d['proposals_after_verify'] == 1, d
+assert d['proposals_refuted'] == 1, d
+titles = [p['title'] for p in d['proposals']]
+assert titles == ['feat: real fix'], titles
+p = d['proposals'][0]
+assert p['verdict'] == 'survived', p
+assert p['reason'] == 'reproduced the gap', p
+"
+}
+
+@test "refute-by-default on the ambiguous case (verdict map present, proposal absent)" {
+    # When a verdict map IS supplied but a given proposal has no entry, the
+    # skeptic could not affirm it -> refute by default (drop).
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: affirmed","evidence":"e1","estimated_complexity":"small","confidence":0.9},{"title":"feat: unmentioned","evidence":"e2","estimated_complexity":"small","confidence":0.9}]}'
+    empties
+
+    cat > "$TMP/verdicts.json" <<'EOF'
+{ "affirmed": {"verdict":"survived","reason":"verified"} }
+EOF
+    export AUTOSPEC_EXPLORE_VERIFY_VERDICTS="$TMP/verdicts.json"
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert d['proposals_refuted'] == 1, d
+assert d['proposals_after_verify'] == 1, d
+titles = [p['title'] for p in d['proposals']]
+assert titles == ['feat: affirmed'], titles
+"
+}
+
+@test "all four discovery-enhance counters are present in the iteration log" {
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: a","evidence":"e1","estimated_complexity":"small","confidence":0.9}]}'
+    empties
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+for k in ('proposals_after_verify','proposals_refuted','proposals_after_roi','structural_fixes'):
+    assert k in d, ('missing counter', k, d)
+# Issue C leaves a clean seam for pattern synthesis (Issue D): zero for now.
+assert d['structural_fixes'] == 0, d
+"
+}


### PR DESCRIPTION
Closes #1080

Implements the Issue C aggregator changes in `scripts/explore-research-cycle.sh` (stage order: dedup -> verify -> ROI gate -> [synthesis seam] -> severity-first rank).

## What changed
- **Verify boundary**: every deduped proposal is threaded through an adversarial verify gate that consumes an OPTIONAL orchestrator-supplied verdict map via `AUTOSPEC_EXPLORE_VERIFY_VERDICTS` (file path or inline JSON, keyed by normalized title -> `{verdict, reason}`). Refuted proposals are dropped; survivors carry `{verdict, reason}`. **No LLM is called from bash** — the per-proposal Tier-B skeptic dispatch is an explore-orchestrator (SKILL-prose) responsibility. Documented fallback: no map supplied -> no-op, all survive as `unverified`. Map present but a proposal absent -> refute-by-default under uncertainty (per spec).
- **ROI gate**: drop new-source proposals (the 3 discovery researchers + `specialist:<slug>`) with empty `named_consumer`. The 7 legacy universal sources (spec-vs-code, prior-reports, codebase-signals, open-issues, source-analysis, dependency-health, internet) are **exempt** during rollout — they are never silently muted.
- **Severity-first ranking**: primary key = severity rank (silent-wrong > correctness > stability > operability > feature > nicety); secondary = the existing `confidence * source_weight / complexity` score (breaks ties within a band).
- **Counters**: per-iteration JSON gains `proposals_after_verify`, `proposals_refuted`, `proposals_after_roi`, and `structural_fixes` (0 — clean seam for Issue D pattern synthesis, #1081).

## Deterministic vs LLM boundary
The bash aggregator owns only the verify *boundary* and counters; it never invokes an LLM. Pattern synthesis (item 3) is intentionally left as a no-op seam for Issue D.

## Tests
- New `tests/explore/test_explore_verify_stage.bats`: no-op fallback; refuted dropped + survivor verdict/reason; refute-by-default; all four counters present.
- Extended `tests/explore/test_explore_severity_roi.bats`: severity-first ordering; score tie-break within band; ROI gate new-vs-legacy; all-7-legacy exemption; `specialist:<slug>` ROI-gated.
- `bash scripts/validate.sh` green (incl. `check_autospec_explore_researchers_deterministic`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)