### PR TITLE
feat(explore): pattern synthesis + ledger refutation-rate down-weighting (#1081)

### DIFF
--- a/scripts/explore-research-cycle.sh
+++ b/scripts/explore-research-cycle.sh
@@ -3,7 +3,7 @@
 #
 # Runs the enabled deterministic researchers in parallel, aggregates their
 # proposals, then threads them through the stage pipeline
-#   dedup -> verify -> ROI gate -> (pattern synthesis: Issue D) -> rank
+#   dedup -> verify -> ROI gate -> pattern synthesis (Issue D) -> rank
 # (constitution + recent-title filters apply before the severity-first rank),
 # and caps output at --max-issues-per-round.
 #
@@ -19,7 +19,7 @@
 #     "proposals_after_verify": N,        # survived the adversarial verify gate
 #     "proposals_refuted": N,             # dropped by the verify gate
 #     "proposals_after_roi": N,           # survived the named-consumer ROI gate
-#     "structural_fixes": N,              # pattern-synthesis output (Issue D; 0)
+#     "structural_fixes": N,              # pattern-synthesis collapses (Issue D)
 #     "proposals_after_recent_filter": N,
 #     "proposals": [ ...top --max-issues-per-round... ] }
 #
@@ -368,8 +368,8 @@ for p in deduped:
 # ---------------------------------------------------------------------------
 # ROI gate (Issue C) — drop NEW-source proposals with empty named_consumer.
 # Legacy universal sources are exempt (rollout safety). The pattern-synthesis
-# hook (Issue D #1081) slots in AFTER this gate and BEFORE ranking; it is not
-# implemented here — structural_fixes stays 0 as the clean seam.
+# stage (Issue D #1081) runs immediately AFTER this gate and BEFORE ranking,
+# collapsing recurring same-class survivors into structural-fix proposals.
 roi_kept = []
 for p in verified:
     src = p.get("source", "")
@@ -379,7 +379,130 @@ for p in verified:
         continue
     roi_kept.append(p)
 
-structural_fixes = 0  # Pattern synthesis is Issue D; seam left intentionally.
+# ---------------------------------------------------------------------------
+# PATTERN SYNTHESIS (Issue D #1081) — runs AFTER the ROI gate, BEFORE the
+# constitution/recent filters and the severity-first rank.
+#
+# Goal: when several survivors describe the SAME recurring defect class (e.g.
+# "missing error handling in <X>" across alpha/beta/gamma), collapse them into
+# ONE `structural-fix` proposal whose evidence lists every instance plus the
+# single guard that would catch them all — so the loop files one durable fix
+# instead of N point patches.
+#
+# Clustering is deterministic and COARSE-but-CONSERVATIVE to avoid the watched
+# risk (over-collapsing unrelated findings):
+#   - Two proposals may cluster ONLY within the SAME severity band (a
+#     silent-wrong defect never merges with a nicety).
+#   - Within a band, cluster by content-token overlap: greedy single-linkage
+#     where membership requires Jaccard(tokens) >= JACCARD_MIN against the
+#     cluster seed. Stopwords + the conventional-commit verb are stripped so
+#     the signal is the subject, not "fix:"/"add"/"the".
+#   - A cluster collapses iff it has >= 2 members, OR its shared-token theme
+#     matches a recurring docs/memory/ theme (memory-grounded structural class
+#     even at size 1). Singletons with no memory match pass through unchanged.
+#
+# Convergence/safety: pure function of the survivor set + a static memory-theme
+# list; no randomness, no global state — deterministic across runs.
+
+# Recurring docs/memory/ themes: coarse token signatures distilled from the
+# persistent feedback memos (bash portability, lockstep duos, regex injection,
+# self-consistent fixtures, installer omissions). A survivor whose shared theme
+# tokens intersect one of these is a known structural class. Kept intentionally
+# small + high-signal; extending it is a deliberate, reviewable act.
+MEMORY_THEMES = [
+    {"bash", "portability", "shell"},
+    {"lockstep", "trio", "duo"},
+    {"regex", "injection", "metachar"},
+    {"fixture", "self", "consistent", "mock"},
+    {"installer", "runtime", "lib", "ship"},
+    {"validator", "retry", "adaptive"},
+]
+
+_STOPWORDS = {
+    "the", "a", "an", "in", "on", "of", "to", "for", "and", "or", "with",
+    "is", "are", "be", "by", "at", "from", "into", "module", "modules",
+    "add", "fix", "feat", "support", "enable", "new",
+}
+
+def _content_tokens(p):
+    toks = normalize_title(p["title"]).split()
+    return {t for t in toks if t not in _STOPWORDS and len(t) > 2}
+
+def _jaccard(a, b):
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+# Conservative threshold: a true recurring class (e.g. "missing error handling
+# in alpha/beta/gamma") shares its whole subject vocabulary minus the leaf token
+# (Jaccard ~0.67-0.75), while two unrelated items that merely share a generic
+# word ("high/low score feature" -> 0.5) stay apart. 0.6 is the seam between.
+JACCARD_MIN = 0.6
+
+def _theme_match(shared):
+    for theme in MEMORY_THEMES:
+        if len(shared & theme) >= 2:
+            return theme
+    return None
+
+# Greedy single-linkage clustering within each severity band.
+structural_fixes = 0
+_synth_out = []
+_by_band = {}
+for _i, p in enumerate(roi_kept):
+    _by_band.setdefault(p.get("severity", "feature"), []).append(p)
+
+for _band, members in _by_band.items():
+    _toks = [_content_tokens(m) for m in members]
+    _used = [False] * len(members)
+    for i in range(len(members)):
+        if _used[i]:
+            continue
+        cluster_idx = [i]
+        _used[i] = True
+        for j in range(i + 1, len(members)):
+            if _used[j]:
+                continue
+            if _jaccard(_toks[i], _toks[j]) >= JACCARD_MIN:
+                cluster_idx.append(j)
+                _used[j] = True
+        cluster = [members[k] for k in cluster_idx]
+        # Shared tokens across the whole cluster (the common defect signature).
+        shared = set(_toks[cluster_idx[0]])
+        for k in cluster_idx[1:]:
+            shared &= _toks[k]
+        theme = _theme_match(_content_tokens(cluster[0]))
+        if len(cluster) >= 2 or (theme is not None):
+            # Collapse to one structural-fix. Highest-scoring member is the
+            # representative for score/consumer; evidence lists every instance.
+            rep = max(cluster, key=lambda q: q["score"])
+            instances = [c["title"] for c in cluster]
+            ev_lines = "; ".join(
+                "%s (%s)" % (c["title"], (c.get("evidence", "") or "").strip())
+                for c in cluster
+            )
+            guard_subject = " ".join(sorted(shared)) or "the shared pattern"
+            sfix = dict(rep)
+            sfix["proposal_kind"] = "structural-fix"
+            sfix["title"] = "fix(structural): one guard for %d instances of [%s]" % (
+                len(cluster), guard_subject,
+            )
+            sfix["evidence"] = (
+                "%d instances collapse to one structural fix — a single guard "
+                "for [%s] would catch them all. Instances: %s"
+                % (len(cluster), guard_subject, ev_lines)
+            )
+            sfix["instances"] = instances
+            if theme is not None:
+                sfix["memory_theme"] = sorted(theme)
+            _synth_out.append(sfix)
+            structural_fixes += 1
+        else:
+            _synth_out.append(cluster[0])
+
+roi_kept = _synth_out
 
 # Constitution gate (deterministic rules D1 evidence + D2 confidence floor).
 # Keep this byte-aligned with explore-constitution.sh --filter. Floor default 0.3

--- a/skills/autospec-shared/scripts/explore-ledger.sh
+++ b/skills/autospec-shared/scripts/explore-ledger.sh
@@ -15,7 +15,11 @@
 #     confidence  number  0..1
 #     issue       integer GitHub issue number, or 0 if not filed
 #     pr          integer PR number, or 0/null if none
-#     outcome     string  pending | merged_clean | qa_failed | reverted | stalled | abandoned
+#     outcome     string  pending | merged_clean | qa_failed | reverted | stalled | abandoned | refuted
+#                 `refuted` records a verify-stage refutation (Issue D): the
+#                 proposal was dropped before becoming an issue, so it carries
+#                 issue=0 and feeds the per-source refutation rate (down-weight)
+#                 WITHOUT counting toward `filed`.
 #     reason      string  (may be empty)
 #     ts          ISO-8601 UTC string (caller-supplied for --append)
 #
@@ -56,7 +60,7 @@
 
 set +e
 
-ALLOWED_OUTCOMES="pending merged_clean qa_failed reverted stalled abandoned"
+ALLOWED_OUTCOMES="pending merged_clean qa_failed reverted stalled abandoned refuted"
 ALLOWED_COMPLEXITY="small medium large"
 
 _usage() {
@@ -235,20 +239,22 @@ case "$CMD" in
     stats_json="$(printf '%s' "$arr" | jq '
       reduce .[] as $r ({};
         ($r.source) as $s
-        | .[$s] //= {filed:0, merged_clean:0, failed:0, pending:0}
-        | .[$s].filed += 1
-        | if   $r.outcome == "merged_clean" then .[$s].merged_clean += 1
-          elif ($r.outcome == "qa_failed" or $r.outcome == "reverted" or $r.outcome == "abandoned") then .[$s].failed += 1
-          elif $r.outcome == "pending" then .[$s].pending += 1
-          else . end)
+        | .[$s] //= {filed:0, merged_clean:0, failed:0, pending:0, refuted:0}
+        | if   $r.outcome == "refuted" then .[$s].refuted += 1
+          else .[$s].filed += 1
+               | if   $r.outcome == "merged_clean" then .[$s].merged_clean += 1
+                 elif ($r.outcome == "qa_failed" or $r.outcome == "reverted" or $r.outcome == "abandoned") then .[$s].failed += 1
+                 elif $r.outcome == "pending" then .[$s].pending += 1
+                 else . end
+          end)
     ')"
     if [ "$JSON" -eq 1 ]; then
       printf '%s\n' "$stats_json"
     else
-      printf '%-22s %6s %12s %6s %7s\n' "source" "filed" "merged_clean" "failed" "pending"
-      printf '%s' "$stats_json" | jq -r 'to_entries[] | [.key, (.value.filed|tostring), (.value.merged_clean|tostring), (.value.failed|tostring), (.value.pending|tostring)] | @tsv' \
-        | while IFS=$'\t' read -r s f m fa p; do
-            printf '%-22s %6s %12s %6s %7s\n' "$s" "$f" "$m" "$fa" "$p"
+      printf '%-22s %6s %12s %6s %7s %7s\n' "source" "filed" "merged_clean" "failed" "pending" "refuted"
+      printf '%s' "$stats_json" | jq -r 'to_entries[] | [.key, (.value.filed|tostring), (.value.merged_clean|tostring), (.value.failed|tostring), (.value.pending|tostring), ((.value.refuted // 0)|tostring)] | @tsv' \
+        | while IFS=$'\t' read -r s f m fa p rf; do
+            printf '%-22s %6s %12s %6s %7s %7s\n' "$s" "$f" "$m" "$fa" "$p" "$rf"
           done
     fi
     exit 0

--- a/skills/autospec-shared/scripts/explore-source-weights.sh
+++ b/skills/autospec-shared/scripts/explore-source-weights.sh
@@ -9,12 +9,30 @@
 #
 # Weighting formula (Bayesian-smoothed clean-ship rate):
 #
-#   weight = (merged_clean + alpha * prior) / (filed + alpha)
+#   base   = (merged_clean + alpha * prior) / (filed + alpha)
+#   weight = base * downweight
 #
 #   prior        = the source's canonical prior (or 0.5 for unknown sources)
 #   merged_clean = # proposals from this source that merged clean (--stats)
 #   filed        = # proposals from this source that were filed   (--stats)
+#   refuted      = # proposals from this source refuted by the verify stage
+#                  (--stats; never counted toward filed) — Issue D
 #   alpha        = smoothing pseudo-count (default 5)
+#
+# Refutation-rate down-weighting (Issue D): a source that the adversarial
+# verify stage keeps refuting is producing false positives, so it is
+# automatically pulled down WITHOUT hand-tuning:
+#
+#   r          = refuted / (refuted + filed)        (0 when never refuted)
+#   downweight = max(FLOOR, 1 - BETA * r)
+#
+#   BETA  = AUTOSPEC_EXPLORE_REFUTE_BETA  (default 0.5) — strength of the pull.
+#   FLOOR = AUTOSPEC_EXPLORE_REFUTE_FLOOR (default 0.25) — a consistently-
+#           refuted source is throttled, never starved to 0 (it can recover as
+#           clean ships accrue). The multiplier is bounded + monotone in r, so
+#           weights CONVERGE rather than oscillate.
+#   With no refutations (r=0) downweight==1.0 -> weights are byte-identical to
+#   the pre-Issue-D behavior (round-trip parity preserved).
 #
 # Properties:
 #   - No data (filed=0)  -> weight == prior exactly (round-1 parity with the old
@@ -69,6 +87,9 @@ LEDGER_SH="$SCRIPT_DIR/explore-ledger.sh"
 LEDGER=""
 ALPHA="5"
 EXPLAIN=0
+# Refutation-rate down-weight tuning (Issue D). Bounded, monotone -> converges.
+REFUTE_BETA="${AUTOSPEC_EXPLORE_REFUTE_BETA:-0.5}"
+REFUTE_FLOOR="${AUTOSPEC_EXPLORE_REFUTE_FLOOR:-0.25}"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -126,14 +147,25 @@ for s in $ordered; do
   prior="$(_prior_for "$s")"
   filed="$(printf '%s' "$stats_json" | jq -r --arg s "$s" '.[$s].filed // 0')"
   clean="$(printf '%s' "$stats_json" | jq -r --arg s "$s" '.[$s].merged_clean // 0')"
+  refuted="$(printf '%s' "$stats_json" | jq -r --arg s "$s" '.[$s].refuted // 0')"
   [ -n "$filed" ] || filed=0
   [ -n "$clean" ] || clean=0
+  [ -n "$refuted" ] || refuted=0
 
-  # weight = (clean + alpha*prior) / (filed + alpha), rounded to 4 decimals.
+  # base   = (clean + alpha*prior) / (filed + alpha)
+  # r      = refuted / (refuted + filed)
+  # weight = base * max(floor, 1 - beta*r), rounded to 4 decimals.
   weight="$(python3 -c "
 import sys
 clean=float(sys.argv[1]); filed=float(sys.argv[2]); alpha=float(sys.argv[3]); prior=float(sys.argv[4])
-w=(clean + alpha*prior)/(filed + alpha)
+refuted=float(sys.argv[5]); beta=float(sys.argv[6]); floor=float(sys.argv[7])
+base=(clean + alpha*prior)/(filed + alpha)
+denom=refuted + filed
+r=(refuted/denom) if denom>0 else 0.0
+downweight=1.0 - beta*r
+if downweight<floor: downweight=floor
+if downweight>1.0: downweight=1.0
+w=base*downweight
 if w<0: w=0.0
 if w>1: w=1.0
 w=round(w,4)
@@ -141,15 +173,15 @@ w=round(w,4)
 # integral values as a single trailing .0 (1.0) so it stays a float literal.
 s=('%.4f' % w).rstrip('0').rstrip('.')
 print(s if '.' in s else s + '.0')
-" "$clean" "$filed" "$ALPHA" "$prior")"
+" "$clean" "$filed" "$ALPHA" "$prior" "$refuted" "$REFUTE_BETA" "$REFUTE_FLOOR")"
 
   jq_obj="$(printf '%s' "$jq_obj" | jq -c --arg s "$s" --argjson w "$weight" '.[$s] = $w')"
 
   if [ "$EXPLAIN" -eq 1 ]; then
     # Use jq's normalized number (e.g. 0.8000 -> 0.8) so explain matches JSON.
     weight_norm="$(printf '%s' "$jq_obj" | jq -r --arg s "$s" '.[$s]')"
-    printf '%s: filed=%s clean=%s prior=%s -> weight=%s\n' \
-      "$s" "$filed" "$clean" "$prior" "$weight_norm" >&2
+    printf '%s: filed=%s clean=%s prior=%s -> weight=%s (refuted=%s)\n' \
+      "$s" "$filed" "$clean" "$prior" "$weight_norm" "$refuted" >&2
   fi
 done
 

--- a/skills/autospec-shared/tests/unit/explore-ledger.bats
+++ b/skills/autospec-shared/tests/unit/explore-ledger.bats
@@ -118,6 +118,75 @@ valid_record() {
     echo "$output" | jq -e '.["internet"].failed == 3'
 }
 
+# ── refutation-rate (Issue D) ────────────────────────────────────────────────
+
+@test "append accepts the refuted outcome (verify-stage refutation record)" {
+    rec="$(valid_record 1 internet 'bogus claim' small 0.8 0 0 refuted)"
+    run bash "$LEDGER_SH" --append "$rec"
+    [ "$status" -eq 0 ]
+    [ "$(wc -l < "$AUTOSPEC_EXPLORE_LEDGER")" -eq 1 ]
+}
+
+@test "stats --json records per-source refuted count separate from filed" {
+    # Two filed (issue!=0) + three refuted (issue=0) for internet.
+    bash "$LEDGER_SH" --append "$(valid_record 1 internet 'A' small 0.8 301 0 merged_clean)"
+    bash "$LEDGER_SH" --append "$(valid_record 1 internet 'B' small 0.8 302 0 qa_failed)"
+    bash "$LEDGER_SH" --append "$(valid_record 1 internet 'R1' small 0.8 0 0 refuted)"
+    bash "$LEDGER_SH" --append "$(valid_record 1 internet 'R2' small 0.8 0 0 refuted)"
+    bash "$LEDGER_SH" --append "$(valid_record 1 internet 'R3' small 0.8 0 0 refuted)"
+    run bash "$LEDGER_SH" --stats --json
+    [ "$status" -eq 0 ]
+    # Refuted records (issue=0) do NOT inflate filed.
+    echo "$output" | jq -e '.["internet"].filed == 2'
+    echo "$output" | jq -e '.["internet"].refuted == 3'
+}
+
+@test "source-weights down-weights a high-refutation source; converges (no oscillation)" {
+    WEIGHTS_SH="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/explore-source-weights.sh"
+    # spec-vs-code: 4 clean, 0 refuted -> no down-weight.
+    for i in 1 2 3 4; do
+        bash "$LEDGER_SH" --append "$(valid_record 1 spec-vs-code "C$i" small 0.8 $((400+i)) 0 merged_clean)"
+    done
+    # internet: 4 clean, 6 refuted -> heavy down-weight.
+    for i in 1 2 3 4; do
+        bash "$LEDGER_SH" --append "$(valid_record 1 internet "C$i" small 0.8 $((500+i)) 0 merged_clean)"
+    done
+    for i in 1 2 3 4 5 6; do
+        bash "$LEDGER_SH" --append "$(valid_record 1 internet "R$i" small 0.8 0 0 refuted)"
+    done
+    run bash "$WEIGHTS_SH" --ledger "$AUTOSPEC_EXPLORE_LEDGER" --alpha 5
+    [ "$status" -eq 0 ]
+    # spec-vs-code has zero refutations -> base weight unchanged.
+    sc="$(echo "$output" | jq -r '.["spec-vs-code"]')"
+    [ "$sc" = "1.0" ] || [ "$sc" = "1" ]
+    # internet base = (4 + 5*0.4)/(4+5) = 0.6667; refutation rate 6/10 down-weights it.
+    iw="$(echo "$output" | jq -r '.["internet"]')"
+    below="$(python3 -c "print(float('$iw') < 0.6667)")"
+    [ "$below" = "True" ]
+    # Stays in [0,1] and does NOT go negative/oscillate (bounded multiplier).
+    inrange="$(python3 -c "w=float('$iw'); print(0.0 <= w <= 1.0)")"
+    [ "$inrange" = "True" ]
+    # Determinism: a second run yields the identical weight (converges, no flip).
+    run bash "$WEIGHTS_SH" --ledger "$AUTOSPEC_EXPLORE_LEDGER" --alpha 5
+    iw2="$(echo "$output" | jq -r '.["internet"]')"
+    [ "$iw" = "$iw2" ]
+}
+
+@test "source-weights does NOT starve a useful but occasionally-refuted source" {
+    WEIGHTS_SH="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/explore-source-weights.sh"
+    # spec-vs-code: 10 clean, 1 refuted -> low refutation rate, weight stays high.
+    for i in $(seq 1 10); do
+        bash "$LEDGER_SH" --append "$(valid_record 1 spec-vs-code "C$i" small 0.8 $((600+i)) 0 merged_clean)"
+    done
+    bash "$LEDGER_SH" --append "$(valid_record 1 spec-vs-code 'R1' small 0.8 0 0 refuted)"
+    run bash "$WEIGHTS_SH" --ledger "$AUTOSPEC_EXPLORE_LEDGER" --alpha 5
+    [ "$status" -eq 0 ]
+    iw="$(echo "$output" | jq -r '.["spec-vs-code"]')"
+    # Base = (10+5*1.0)/15 = 1.0; 1/11 refutation rate barely dents it (>0.9).
+    high="$(python3 -c "print(float('$iw') > 0.9)")"
+    [ "$high" = "True" ]
+}
+
 @test "stats default (human table) exits 0 and mentions source" {
     bash "$LEDGER_SH" --append "$(valid_record 1 spec-vs-code 'A' small 0.8 101 0 merged_clean)"
     run bash "$LEDGER_SH" --stats

--- a/tests/explore/test_explore_severity_roi.bats
+++ b/tests/explore/test_explore_severity_roi.bats
@@ -182,6 +182,79 @@ assert d['proposals_after_roi'] == 7, d
 "
 }
 
+# --- Issue D: pattern synthesis ------------------------------------------
+
+@test "pattern synthesis collapses a 3-instance class to one structural-fix" {
+    # Three survivors share a coarse class key (same severity band + leading
+    # subject tokens). They must collapse to ONE structural-fix proposal whose
+    # evidence lists all three instances, and structural_fixes must count it.
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[
+      {"title":"fix: missing error handling in alpha module","evidence":"alpha lacks try/except","estimated_complexity":"small","confidence":0.9,"severity":"correctness","named_consumer":"x"},
+      {"title":"fix: missing error handling in beta module","evidence":"beta lacks try/except","estimated_complexity":"small","confidence":0.9,"severity":"correctness","named_consumer":"x"},
+      {"title":"fix: missing error handling in gamma module","evidence":"gamma lacks try/except","estimated_complexity":"small","confidence":0.9,"severity":"correctness","named_consumer":"x"}
+    ]}'
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[]}'
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+# The three same-class instances collapse to one structural-fix.
+assert d['structural_fixes'] == 1, d
+sfix = [p for p in d['proposals'] if p.get('proposal_kind') == 'structural-fix']
+assert len(sfix) == 1, d['proposals']
+p = sfix[0]
+# Evidence lists all three instances.
+for tok in ('alpha', 'beta', 'gamma'):
+    assert tok in p['evidence'], p['evidence']
+# The 3 original members are gone; only the structural-fix remains for them.
+titles = [q['title'] for q in d['proposals']]
+assert not any('alpha module' in t and t != p['title'] for t in titles), titles
+"
+}
+
+@test "pattern synthesis does NOT over-collapse unrelated proposals" {
+    # Two survivors in different severity bands / unrelated subjects must each
+    # stay a distinct proposal — no structural-fix, structural_fixes == 0.
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[
+      {"title":"fix: data corruption in writer","evidence":"e1","estimated_complexity":"small","confidence":0.9,"severity":"silent-wrong","named_consumer":"x"},
+      {"title":"feat: add dark mode toggle","evidence":"e2","estimated_complexity":"small","confidence":0.9,"severity":"nicety","named_consumer":"y"}
+    ]}'
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[]}'
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert d['structural_fixes'] == 0, d
+assert not any(p.get('proposal_kind') == 'structural-fix' for p in d['proposals']), d['proposals']
+titles = sorted(p['title'] for p in d['proposals'])
+assert 'fix: data corruption in writer' in titles, titles
+assert 'feat: add dark mode toggle' in titles, titles
+"
+}
+
+@test "structural_fixes counter is 0 with no clustering" {
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: lone item","evidence":"e","estimated_complexity":"small","confidence":0.9}]}'
+    make_fake_researcher prior-reports '{"source":"prior-reports","proposals":[]}'
+    make_fake_researcher codebase-signals '{"source":"codebase-signals","proposals":[]}'
+    make_fake_researcher open-issues '{"source":"open-issues","proposals":[]}'
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert d['structural_fixes'] == 0, d
+"
+}
+
 @test "ROI gate drops empty-consumer specialist:<slug> proposals (new source)" {
     make_fake_researcher 'specialist:market-risk' '{"source":"specialist:market-risk","proposals":[{"title":"feat: risk control gap","evidence":"e","estimated_complexity":"small","confidence":0.9,"severity":"correctness"}]}'
     make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[]}'


### PR DESCRIPTION
Closes #1081

## What

Issue D of the discovery-enhance batch — pattern synthesis in the research-cycle aggregator plus per-source refutation-rate down-weighting in the outcome ledger.

### Pattern synthesis (`scripts/explore-research-cycle.sh`)
- Runs at the spec's stage position: `dedup → verify → ROI → **synthesis** → severity-first rank`.
- Clusters surviving proposals **within a severity band** by content-token Jaccard overlap (greedy single-linkage, threshold 0.6 — conservative to avoid over-collapsing unrelated findings).
- A cluster of ≥2 members, **or** a singleton whose shared theme matches a recurring `docs/memory/` theme, collapses to one `structural-fix` proposal whose `evidence` lists every instance and the single guard; `instances` + optional `memory_theme` recorded.
- Wires the `structural_fixes` per-iteration log counter to the emitted count.

### Ledger refutation-rate down-weighting (`explore-ledger.sh` + `explore-source-weights.sh`)
- New `refuted` outcome: records a verify-stage refutation with `issue=0`, **never counted toward `filed`**. No new ledger file — reuses the existing per-source record.
- `--stats` exposes a per-source `refuted` count (JSON + human table).
- Source weights apply a bounded, monotone multiplicative down-weight `weight = base * max(FLOOR, 1 - BETA*r)` where `r = refuted/(refuted+filed)`, `BETA=0.5`, `FLOOR=0.25` (tunable via env).

## Counter-team review
- **Over-collapse**: threshold 0.6 keeps the tie-break pair ("high/low score feature", J=0.5) apart while clustering a true recurring class ("missing error handling in alpha/beta/gamma", J=0.75). Clustering is bounded to a single severity band. Test asserts unrelated proposals do NOT collapse.
- **Down-weight convergence/starvation**: multiplier is bounded `[FLOOR,1]` and monotone in `r` → deterministic, converges (test asserts identical weight on re-run), floored at 0.25 so a useful-but-occasionally-refuted source is throttled, never starved. With `r=0` weights are byte-identical to pre-Issue-D behavior (parity tests green).

## Tests
- `tests/explore/test_explore_severity_roi.bats` — 3-instance class → one `structural-fix` (+counter); no over-collapse; counter 0 when no clustering.
- `skills/autospec-shared/tests/unit/explore-ledger.bats` — `refuted` outcome accepted; per-source `refuted` stat separate from `filed`; down-weight + convergence; no-starve.
- `bash scripts/validate.sh` → green (only pre-existing warn-only stale-token-baseline notice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)