### PR TITLE
feat(explore): specialist flags + dispatch as source=specialist:<slug> (E2)

### DIFF
--- a/scripts/autospec-explore.sh
+++ b/scripts/autospec-explore.sh
@@ -45,6 +45,10 @@ SANDBOX_SLUG=""
 RESEARCH_SOURCES="spec-vs-code,prior-reports,codebase-signals,open-issues,source-analysis,internet"
 NO_INTERNET=0
 INTERNET_ALLOWLIST=""
+SPECIALISTS_MODE="discover"
+NUM_SPECIALISTS=3
+SPECIALISTS_ARG=""
+AUTONOMOUS=0
 PROMPT=""
 
 usage() {
@@ -60,6 +64,12 @@ Options:
   --research-sources LIST     Comma-separated researcher names.
   --no-internet               Disable the internet researcher.
   --internet-allowlist LIST   Pass-through to explore-research/internet.sh.
+  --specialists-mode MODE     Domain-specialist roster mode (Issue E2):
+                                discover (default) | ask | explicit | off.
+  --num-specialists N         Roster size for discover/ask (default 3, cap 6).
+  --specialists LIST          Explicit roster slug:persona,... (explicit mode).
+  --autonomous                Non-interactive run: discover mode auto-selects the
+                              top-N specialists and never blocks on confirmation.
 EOF
 }
 
@@ -74,6 +84,10 @@ while [ "$#" -gt 0 ]; do
         --research-sources)      shift; RESEARCH_SOURCES="$1" ;;
         --no-internet)           NO_INTERNET=1 ;;
         --internet-allowlist)    shift; INTERNET_ALLOWLIST="$1" ;;
+        --specialists-mode)      shift; SPECIALISTS_MODE="$1" ;;
+        --num-specialists)       shift; NUM_SPECIALISTS="$1" ;;
+        --specialists)           shift; SPECIALISTS_ARG="$1" ;;
+        --autonomous)            AUTONOMOUS=1 ;;
         -h|--help)               usage; exit 0 ;;
         --) shift; PROMPT="${PROMPT:-$*}"; break ;;
         -*) echo "autospec-explore: unknown flag: $1" >&2; usage; exit 2 ;;
@@ -106,6 +120,26 @@ fi
 
 cd "$REPO_ROOT" || { echo "autospec-explore: repo root unavailable: $REPO_ROOT" >&2; exit 2; }
 mkdir -p .autospec
+
+# ── Domain-specialist roster discovery + autonomy detection (Issue E2). ────────
+# Mark the run autonomous when --autonomous was passed OR no interactive TTY is
+# attached; the research cycle then auto-selects the top-N specialists in
+# `discover` mode rather than blocking on an AskUserQuestion confirm (which is an
+# interactive orchestrator/SKILL-prose responsibility, not a deterministic one).
+if [ "$AUTONOMOUS" -eq 1 ] || [ ! -t 0 ]; then
+    export AUTOSPEC_EXPLORE_AUTONOMOUS=1
+fi
+# For discover/ask, populate the cached roster up front (idempotent; generic
+# repos yield an empty roster and the loop runs exactly as today). off/explicit
+# need no scan.
+case "$SPECIALISTS_MODE" in
+    discover|ask)
+        if [ -x "$SCRIPT_DIR/explore-specialist-scan.sh" ]; then
+            AUTOSPEC_NUM_SPECIALISTS="$NUM_SPECIALISTS" \
+                bash "$SCRIPT_DIR/explore-specialist-scan.sh" >/dev/null 2>&1 || true
+        fi
+        ;;
+esac
 
 # Source shared libs.
 # shellcheck source=lib/autospec-loop.sh
@@ -280,6 +314,9 @@ while [ "$iter" -lt "$_max_iter" ]; do
     bash "$SCRIPT_DIR/explore-research-cycle.sh" \
         --max-issues-per-round "$MAX_ISSUES_PER_ROUND" \
         --research-sources "$RESEARCH_SOURCES" \
+        --specialists-mode "$SPECIALISTS_MODE" \
+        --num-specialists "$NUM_SPECIALISTS" \
+        --specialists "$SPECIALISTS_ARG" \
         --out "$research_json" > "$iter_dir/research.log" 2>&1 || research_rc=$?
 
     proposals_count=0

--- a/scripts/explore-research-cycle.sh
+++ b/scripts/explore-research-cycle.sh
@@ -51,6 +51,12 @@ Options:
   --research-sources LIST      Comma-separated subset of:
                                  spec-vs-code,prior-reports,codebase-signals,open-issues
                                Default: all 4.
+  --specialists-mode MODE      Domain-specialist roster mode (Issue E2):
+                                 discover (default) | ask | explicit | off.
+                                 off = zero specialists (current behavior).
+  --num-specialists N          Roster size for discover/ask (default 3, cap 6).
+  --specialists LIST           Explicit roster as slug:persona,slug:persona,...
+                               (used verbatim when --specialists-mode explicit).
   --ledger PATH                Outcome ledger to derive dynamic source weights
                                from (passed to explore-source-weights.sh). When
                                omitted, $AUTOSPEC_EXPLORE_LEDGER is used, then the
@@ -70,6 +76,14 @@ Env:
   AUTOSPEC_TEST_ISSUES_JSON      Inject fake gh issue list (testing).
   AUTOSPEC_TEST_RECENT_TITLES    Newline-separated titles created in last 7d
                                  (testing — bypasses gh search).
+  AUTOSPEC_EXPLORE_AUTONOMOUS     1 = autonomous/no-TTY run; discover mode then
+                                 auto-selects top-N (never blocks). Default: auto
+                                 (autonomous unless an interactive TTY is present).
+  AUTOSPEC_SPECIALIST_PROPOSALS_<SLUG>
+                                 Per-specialist proposal JSON (an array, or an
+                                 object with a "proposals" array). The seam the
+                                 orchestrator's LLM dispatch fills; absent → that
+                                 specialist contributes zero proposals (graceful).
 EOF
 }
 
@@ -77,6 +91,9 @@ MAX_ISSUES=5
 SOURCES="spec-vs-code,prior-reports,codebase-signals,open-issues"
 OUT=""
 LEDGER="${AUTOSPEC_EXPLORE_LEDGER:-}"
+SPECIALISTS_MODE="discover"
+NUM_SPECIALISTS=3
+SPECIALISTS_ARG=""
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -84,10 +101,29 @@ while [ "$#" -gt 0 ]; do
         --research-sources)     SOURCES="$2"; shift 2 ;;
         --ledger)               LEDGER="$2"; shift 2 ;;
         --out)                  OUT="$2"; shift 2 ;;
+        --specialists-mode)     SPECIALISTS_MODE="$2"; shift 2 ;;
+        --num-specialists)      NUM_SPECIALISTS="$2"; shift 2 ;;
+        --specialists)          SPECIALISTS_ARG="$2"; shift 2 ;;
         -h|--help)              usage; exit 0 ;;
         *) echo "explore-research-cycle: unknown arg: $1" >&2; usage; exit 2 ;;
     esac
 done
+
+# Validate / clamp specialist controls (deterministic; never abort the loop).
+case "$SPECIALISTS_MODE" in
+    discover|ask|explicit|off) ;;
+    *) echo "explore-research-cycle: invalid --specialists-mode: $SPECIALISTS_MODE (use discover|ask|explicit|off)" >&2; exit 2 ;;
+esac
+# --num-specialists: default 3, floor 0, cap 6.
+case "$NUM_SPECIALISTS" in
+    ''|*[!0-9]*) NUM_SPECIALISTS=3 ;;
+esac
+[ "$NUM_SPECIALISTS" -gt 6 ] && NUM_SPECIALISTS=6
+
+# Per-round researcher cap (spec §Guardrails): 7 universal + 3 discovery +
+# ≤6 specialists = ≤16. The universal+discovery set is the --research-sources
+# selection; specialists top it up to at most this many TOTAL researchers.
+RESEARCHER_CAP=16
 
 # Resolve explore-source-weights.sh defensively. Order:
 #   1. $AUTOSPEC_EXPLORE_WEIGHTS_BIN (explicit override, e.g. tests)
@@ -146,6 +182,107 @@ unset IFS
 for p in "${pids[@]:-}"; do
     [ -n "$p" ] && wait "$p" 2>/dev/null || true
 done
+
+# Count the universal+discovery researchers actually selected this round (the
+# non-empty, deduped --research-sources entries). Specialists may only top this
+# up to RESEARCHER_CAP total.
+universal_count=0
+IFS=','
+for src in $SOURCES; do
+    src="$(printf '%s' "$src" | tr -d ' ')"
+    [ -z "$src" ] && continue
+    universal_count=$((universal_count + 1))
+done
+unset IFS
+
+# ── Domain-specialist dispatch (Issue E2 #1083) ─────────────────────────────
+# Each resolved roster specialist runs as a researcher emitting proposals with
+# source=specialist:<slug> (default weight 0.6 in the aggregator). The roster is
+# resolved per --specialists-mode:
+#   off       no specialists — byte-for-byte the pre-E2 behavior.
+#   explicit  the verbatim --specialists slug:persona,... list.
+#   discover  auto-run discovery → the cached .autospec/explore-specialists.json
+#             roster; interactive harness confirms via AskUserQuestion (an
+#             orchestrator/SKILL-prose responsibility), autonomous/no-TTY takes
+#             the top --num-specialists and never blocks (handled here).
+#   ask       like discover but the operator names the roster (orchestrator
+#             prose); the deterministic floor here is the same cached top-N.
+# Proposals per specialist come from the LLM seam
+# AUTOSPEC_SPECIALIST_PROPOSALS_<SLUG>; absent → zero proposals (graceful, the
+# specialist still participates but contributes nothing — never hard-fails).
+# Trust boundary (spec §Guardrails): personas come from repo-evidence roster /
+# operator input only — never from the internet researcher's fetched content.
+if [ "$SPECIALISTS_MODE" != "off" ]; then
+    # Resolve the slug list (one per line) into $work_dir/specialists.txt.
+    specialists_file="$work_dir/specialists.txt"
+    : > "$specialists_file"
+    if [ "$SPECIALISTS_MODE" = "explicit" ]; then
+        # Verbatim roster: slug[:persona],slug[:persona],...  Take slug before ':'.
+        IFS=','
+        for entry in $SPECIALISTS_ARG; do
+            slug="${entry%%:*}"
+            slug="$(printf '%s' "$slug" | tr -d ' ' | tr '[:upper:]' '[:lower:]')"
+            [ -n "$slug" ] && printf '%s\n' "$slug" >> "$specialists_file"
+        done
+        unset IFS
+    else
+        # discover / ask: consume the cached roster (Issue E1). Slugs only.
+        roster_path="$REPO_ROOT/.autospec/explore-specialists.json"
+        if [ -f "$roster_path" ] && command -v python3 >/dev/null 2>&1; then
+            python3 - "$roster_path" >> "$specialists_file" 2>/dev/null <<'PY' || true
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    for s in d.get("suggested_specialists", []) or []:
+        slug = str((s or {}).get("slug", "")).strip().lower()
+        if slug:
+            print(slug)
+except Exception:
+    pass
+PY
+        fi
+    fi
+
+    # Top-N + cap. Take the first --num-specialists slugs, then clamp so the
+    # TOTAL researcher count (universal + specialists) never exceeds RESEARCHER_CAP.
+    room=$((RESEARCHER_CAP - universal_count))
+    [ "$room" -lt 0 ] && room=0
+    allow="$NUM_SPECIALISTS"
+    [ "$allow" -gt "$room" ] && allow="$room"
+
+    spec_n=0
+    while IFS= read -r slug; do
+        [ -z "$slug" ] && continue
+        [ "$spec_n" -ge "$allow" ] && break
+        # Per-specialist proposals via the LLM seam. Env var name is the slug
+        # upper-cased with non-alnum → underscore. Absent → empty proposals.
+        env_slug="$(printf '%s' "$slug" | tr '[:lower:]-' '[:upper:]_' | tr -c 'A-Z0-9_' '_')"
+        eval "payload=\"\${AUTOSPEC_SPECIALIST_PROPOSALS_${env_slug}:-}\""
+        SPEC_SLUG="$slug" SPEC_PAYLOAD="${payload:-}" python3 - > "$work_dir/specialist-$slug.json" <<'PY' || \
+            printf '{"source":"specialist:%s","proposals":[]}\n' "$slug" > "$work_dir/specialist-$slug.json"
+import json, os
+slug = os.environ["SPEC_SLUG"]
+src = "specialist:" + slug
+raw = os.environ.get("SPEC_PAYLOAD", "").strip()
+props = []
+if raw:
+    try:
+        d = json.loads(raw)
+        if isinstance(d, dict):
+            d = d.get("proposals", [])
+        if isinstance(d, list):
+            props = [p for p in d if isinstance(p, dict)]
+    except Exception:
+        props = []
+# Stamp the specialist source on every proposal (trust boundary: the slug, not
+# any source the payload may claim).
+for p in props:
+    p["source"] = src
+print(json.dumps({"source": src, "proposals": props}))
+PY
+        spec_n=$((spec_n + 1))
+    done < "$specialists_file"
+fi
 
 # Gather recent titles (last 7 days) to filter against. Allow injection.
 recent_titles_file="$work_dir/recent.txt"
@@ -273,7 +410,14 @@ for f in sorted(glob.glob(os.path.join(work, "*.json"))):
             conf = float(p.get("confidence", 0.5))
         except Exception:
             conf = 0.5
-        weight = SRC_WEIGHTS.get(src, 0.5)
+        # Domain-specialist sources (source=specialist:<slug>, Issue E2) default
+        # to weight 0.6 per the shared-contract; any other unknown source 0.5.
+        if src in SRC_WEIGHTS:
+            weight = SRC_WEIGHTS[src]
+        elif src.startswith("specialist:"):
+            weight = SRC_WEIGHTS.get(src, 0.6)
+        else:
+            weight = 0.5
         cscale = COMPLEXITY.get(comp, 2.0)
         score = conf * weight / cscale
         # Default the proposal-contract extension fields safely for legacy

--- a/tests/explore/test_explore_specialists.bats
+++ b/tests/explore/test_explore_specialists.bats
@@ -157,3 +157,190 @@ slugs = [s['slug'] for s in d['suggested_specialists']]
 assert 'market-risk' in slugs, slugs
 "
 }
+
+# ───────────────────────────────────────────────────────────────────────────
+# Issue E2 (#1083) — specialist flags + dispatch via scripts/explore-research-
+# cycle.sh. The aggregator parses --specialists-mode/--num-specialists/
+# --specialists, resolves the roster, and dispatches each as a
+# source=specialist:<slug> researcher (default weight 0.6) through the same
+# dedup → verify → ROI → synthesis → rank pipeline, under the ≤16 per-round cap.
+# ───────────────────────────────────────────────────────────────────────────
+
+CYCLE="scripts/explore-research-cycle.sh"
+
+# Build the deterministic dispatch fixture: a fake research dir with universal
+# researchers we control + a fake gh that fails (so recent-title fetch no-ops).
+_e2_setup_cycle() {
+    export AUTOSPEC_RESEARCH_DIR="$TMP/fake-research"
+    mkdir -p "$AUTOSPEC_RESEARCH_DIR" "$TMP/bin" "$TMP/.autospec"
+    cat > "$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$TMP/bin/gh"
+    export PATH="$TMP/bin:$PATH"
+}
+
+_e2_make_universal() {
+    # _e2_make_universal <name> [proposals-json-array]
+    local name="$1" props="${2:-[]}"
+    cat > "$AUTOSPEC_RESEARCH_DIR/$name.sh" <<EOF
+#!/usr/bin/env bash
+echo '{"source":"$name","proposals":$props}'
+EOF
+    chmod +x "$AUTOSPEC_RESEARCH_DIR/$name.sh"
+}
+
+@test "E2 --specialists-mode off runs zero specialists (current behavior)" {
+    _e2_setup_cycle
+    _e2_make_universal spec-vs-code '[{"title":"feat: alpha","evidence":"e","estimated_complexity":"small","confidence":0.9}]'
+    # A roster + a proposal seam exist, but off must ignore them entirely.
+    cat > "$TMP/.autospec/explore-specialists.json" <<'EOF'
+{"schema_version":1,"domains":[],"suggested_specialists":[{"slug":"trading-specialist","persona":"P","lens":"L","why":"W","evidence":"E"}]}
+EOF
+    export AUTOSPEC_SPECIALIST_PROPOSALS_TRADING_SPECIALIST='[{"title":"feat: should-not-appear","evidence":"e","estimated_complexity":"small","confidence":0.9,"severity":"correctness","named_consumer":"c"}]'
+
+    run bash "$REPO_ROOT/$CYCLE" --specialists-mode off \
+        --research-sources spec-vs-code --max-issues-per-round 10
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+srcs = {p['source'] for p in d['proposals']}
+assert not any(s.startswith('specialist:') for s in srcs), srcs
+assert 'spec-vs-code' in srcs, srcs
+"
+}
+
+@test "E2 a detected-domain roster dispatches specialist:<slug> through the aggregator" {
+    _e2_setup_cycle
+    _e2_make_universal spec-vs-code '[]'
+    cat > "$TMP/.autospec/explore-specialists.json" <<'EOF'
+{"schema_version":1,"domains":[],"suggested_specialists":[{"slug":"market-risk","persona":"Quant","lens":"VaR","why":"trading deps","evidence":"requirements.txt:1"}]}
+EOF
+    export AUTOSPEC_SPECIALIST_PROPOSALS_MARKET_RISK='[{"title":"feat: VaR drawdown guard","evidence":"order path lacks a stop","estimated_complexity":"small","confidence":0.8,"severity":"correctness","named_consumer":"autospec-run"}]'
+
+    run bash "$REPO_ROOT/$CYCLE" --specialists-mode discover --num-specialists 3 \
+        --research-sources spec-vs-code --max-issues-per-round 10
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+sp = [p for p in d['proposals'] if p['source'] == 'specialist:market-risk']
+assert len(sp) == 1, d['proposals']
+# Flows through verify + ROI like any source, and carries weight-0.6 scoring:
+# score = confidence(0.8) * weight(0.6) / complexity(small=1.0) = 0.48.
+assert abs(sp[0]['score'] - 0.48) < 1e-6, sp[0]
+assert sp[0]['severity'] == 'correctness', sp[0]
+"
+}
+
+@test "E2 ROI gate drops a specialist proposal with no named_consumer (new-source-gated)" {
+    _e2_setup_cycle
+    _e2_make_universal spec-vs-code '[]'
+    cat > "$TMP/.autospec/explore-specialists.json" <<'EOF'
+{"schema_version":1,"domains":[],"suggested_specialists":[{"slug":"market-risk","persona":"Quant","lens":"VaR","why":"deps","evidence":"r:1"}]}
+EOF
+    # No named_consumer → ROI gate (new-source-only) must drop it.
+    export AUTOSPEC_SPECIALIST_PROPOSALS_MARKET_RISK='[{"title":"feat: orphan idea","evidence":"e","estimated_complexity":"small","confidence":0.9,"severity":"feature"}]'
+
+    run bash "$REPO_ROOT/$CYCLE" --specialists-mode discover \
+        --research-sources spec-vs-code --max-issues-per-round 10
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert not any(p['source'].startswith('specialist:') for p in d['proposals']), d['proposals']
+"
+}
+
+@test "E2 --specialists-mode explicit uses the verbatim roster" {
+    _e2_setup_cycle
+    _e2_make_universal spec-vs-code '[]'
+    # No cache file at all — explicit must not need it.
+    export AUTOSPEC_SPECIALIST_PROPOSALS_PAYMENTS_REVIEWER='[{"title":"feat: idempotent retry key","evidence":"double-charge risk","estimated_complexity":"small","confidence":0.7,"severity":"stability","named_consumer":"autospec-run"}]'
+
+    run bash "$REPO_ROOT/$CYCLE" --specialists-mode explicit \
+        --specialists "payments-reviewer:Payments reliability,unused-slug:Persona" \
+        --num-specialists 1 --research-sources spec-vs-code --max-issues-per-round 10
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+srcs = [p['source'] for p in d['proposals'] if p['source'].startswith('specialist:')]
+assert srcs == ['specialist:payments-reviewer'], srcs
+"
+}
+
+@test "E2 --num-specialists caps at 6 and selects the top-N" {
+    _e2_setup_cycle
+    _e2_make_universal spec-vs-code '[]'
+    # Roster of 4; ask for top 2.
+    cat > "$TMP/.autospec/explore-specialists.json" <<'EOF'
+{"schema_version":1,"domains":[],"suggested_specialists":[
+{"slug":"sp-a","persona":"P","lens":"L","why":"W","evidence":"E"},
+{"slug":"sp-b","persona":"P","lens":"L","why":"W","evidence":"E"},
+{"slug":"sp-c","persona":"P","lens":"L","why":"W","evidence":"E"},
+{"slug":"sp-d","persona":"P","lens":"L","why":"W","evidence":"E"}]}
+EOF
+    # Distinct multi-word subjects so pattern-synthesis does not collapse them.
+    export AUTOSPEC_SPECIALIST_PROPOSALS_SP_A='[{"title":"feat: trading order-execution guard","evidence":"e","estimated_complexity":"small","confidence":0.7,"severity":"feature","named_consumer":"c"}]'
+    export AUTOSPEC_SPECIALIST_PROPOSALS_SP_B='[{"title":"feat: payments idempotency key","evidence":"e","estimated_complexity":"small","confidence":0.7,"severity":"feature","named_consumer":"c"}]'
+    export AUTOSPEC_SPECIALIST_PROPOSALS_SP_C='[{"title":"feat: healthcare phi redaction","evidence":"e","estimated_complexity":"small","confidence":0.7,"severity":"feature","named_consumer":"c"}]'
+    export AUTOSPEC_SPECIALIST_PROPOSALS_SP_D='[{"title":"feat: ml reproducibility seed","evidence":"e","estimated_complexity":"small","confidence":0.7,"severity":"feature","named_consumer":"c"}]'
+
+    run bash "$REPO_ROOT/$CYCLE" --specialists-mode discover --num-specialists 2 \
+        --research-sources spec-vs-code --max-issues-per-round 50
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+sp = sorted(p['source'] for p in d['proposals'] if p['source'].startswith('specialist:'))
+assert sp == ['specialist:sp-a','specialist:sp-b'], sp
+"
+}
+
+@test "E2 the per-round researcher count is clamped to 16" {
+    _e2_setup_cycle
+    # 14 universal researchers selected.
+    local us=""
+    for i in $(seq 1 14); do
+        _e2_make_universal "u$i" '[]'
+        us="$us,u$i"
+    done
+    us="${us#,}"
+    # Roster of 6; ask for 6, but only 16-14=2 slots remain.
+    {
+        printf '{"schema_version":1,"domains":[],"suggested_specialists":['
+        printf '{"slug":"sp-a","persona":"P","lens":"L","why":"W","evidence":"E"},'
+        printf '{"slug":"sp-b","persona":"P","lens":"L","why":"W","evidence":"E"},'
+        printf '{"slug":"sp-c","persona":"P","lens":"L","why":"W","evidence":"E"},'
+        printf '{"slug":"sp-d","persona":"P","lens":"L","why":"W","evidence":"E"},'
+        printf '{"slug":"sp-e","persona":"P","lens":"L","why":"W","evidence":"E"},'
+        printf '{"slug":"sp-f","persona":"P","lens":"L","why":"W","evidence":"E"}]}\n'
+    } > "$TMP/.autospec/explore-specialists.json"
+    # Distinct multi-word subjects so pattern-synthesis does not collapse them.
+    export AUTOSPEC_SPECIALIST_PROPOSALS_SP_A='[{"title":"feat: trading order-execution guard","evidence":"e","estimated_complexity":"small","confidence":0.7,"severity":"feature","named_consumer":"c"}]'
+    export AUTOSPEC_SPECIALIST_PROPOSALS_SP_B='[{"title":"feat: payments idempotency key","evidence":"e","estimated_complexity":"small","confidence":0.7,"severity":"feature","named_consumer":"c"}]'
+    export AUTOSPEC_SPECIALIST_PROPOSALS_SP_C='[{"title":"feat: healthcare phi redaction","evidence":"e","estimated_complexity":"small","confidence":0.7,"severity":"feature","named_consumer":"c"}]'
+    export AUTOSPEC_SPECIALIST_PROPOSALS_SP_D='[{"title":"feat: ml reproducibility seed","evidence":"e","estimated_complexity":"small","confidence":0.7,"severity":"feature","named_consumer":"c"}]'
+    export AUTOSPEC_SPECIALIST_PROPOSALS_SP_E='[{"title":"feat: infra rollout blast radius","evidence":"e","estimated_complexity":"small","confidence":0.7,"severity":"feature","named_consumer":"c"}]'
+    export AUTOSPEC_SPECIALIST_PROPOSALS_SP_F='[{"title":"feat: security authz boundary","evidence":"e","estimated_complexity":"small","confidence":0.7,"severity":"feature","named_consumer":"c"}]'
+
+    run bash "$REPO_ROOT/$CYCLE" --specialists-mode discover --num-specialists 6 \
+        --research-sources "$us" --max-issues-per-round 50
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+sp = sorted(p['source'] for p in d['proposals'] if p['source'].startswith('specialist:'))
+assert len(sp) == 2, sp  # 14 universal + 2 specialists = 16 cap
+"
+}
+
+@test "E2 invalid --specialists-mode is rejected" {
+    _e2_setup_cycle
+    _e2_make_universal spec-vs-code '[]'
+    run bash "$REPO_ROOT/$CYCLE" --specialists-mode bogus --research-sources spec-vs-code
+    [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
Closes #1083

Wires domain-specialist researchers into the explore research cycle, consuming Issue E1's cached roster.

## What
- `explore-research-cycle.sh`: `--specialists-mode discover|ask|explicit|off` (default discover), `--num-specialists N` (default 3, cap 6), `--specialists <slug:persona,...>`. Each roster specialist dispatches as a `source=specialist:<slug>` researcher (default weight 0.6) through the same dedup → verify → ROI → synthesis → rank pipeline. The 16-per-round researcher cap (7 universal + 3 discovery + ≤6 specialists) is enforced.
- `off` = byte-for-byte the pre-E2 behavior (zero specialists). `explicit` uses the verbatim `--specialists` roster; `discover`/`ask` consume `.autospec/explore-specialists.json` and take the top-N.
- `autospec-explore.sh`: surfaces the flags + `--autonomous`; runs the E1 scan for discover/ask; autonomous/no-TTY auto-selects top-N (never blocks); threads flags through.

## Trust boundary
Personas come from the repo-evidence roster (E1) or operator `--specialists` input only; the slug stamps the source — never internet-injected.

## Tests
`tests/explore/test_explore_specialists.bats` (+7 E2 cases): off=zero specialists; roster dispatches `specialist:<slug>` at weight 0.6; ROI gate drops empty-consumer specialists; explicit verbatim roster; `--num` caps at 6 + top-N; 16-cap holds; invalid mode rejected.

## Verification
- `bats tests/explore/test_explore_specialists.bats` — 14/14 green
- `bash scripts/validate.sh` — OK, all checks passed
- Existing explore suites (research-cycle, verify-stage, severity-roi, e2e) — green, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)