### PR TITLE
fix(explore): Phase 5.5 audit — surface inert adversarial-verify gate (#1086)

### DIFF
--- a/scripts/autospec-explore.sh
+++ b/scripts/autospec-explore.sh
@@ -320,8 +320,20 @@ while [ "$iter" -lt "$_max_iter" ]; do
         --out "$research_json" > "$iter_dir/research.log" 2>&1 || research_rc=$?
 
     proposals_count=0
+    verify_mode="unknown"
     if [ -f "$research_json" ]; then
         proposals_count="$(python3 -c "import json; print(len(json.load(open('$research_json')).get('proposals',[])))" 2>/dev/null || echo 0)"
+        verify_mode="$(python3 -c "import json; print(json.load(open('$research_json')).get('verify_mode','unknown'))" 2>/dev/null || echo unknown)"
+    fi
+
+    # Surface the inert-verify-gate state (audit #1086 seam-1): when no
+    # adversarial-skeptic verdict map drove the verify stage, the headline
+    # false-positive defense ran as a no-op and every deduped proposal survived
+    # unverified. Make that loud rather than silent so the operator (and any log
+    # scraper) sees the gate is inactive. Wiring a live skeptic dispatch that
+    # populates AUTOSPEC_EXPLORE_VERIFY_VERDICTS is tracked as a follow-up.
+    if [ "$verify_mode" = "no-op-unverified" ]; then
+        echo "code_health:explore_verify_noop iter=$iter (adversarial verify gate INACTIVE — no verdict map supplied; proposals survive unverified)" >&2
     fi
 
     if [ "$proposals_count" -eq 0 ] && [ "$research_rc" -ne 0 ]; then

--- a/scripts/explore-research-cycle.sh
+++ b/scripts/explore-research-cycle.sh
@@ -16,6 +16,8 @@
 #   { "round": "<iso-date>",
 #     "proposals_total": N,
 #     "proposals_after_dedup": N,
+#     "verify_mode": "active"|"no-op-unverified",  # whether a verdict map drove
+#                                          # refutation, or the gate no-op'd
 #     "proposals_after_verify": N,        # survived the adversarial verify gate
 #     "proposals_refuted": N,             # dropped by the verify gate
 #     "proposals_after_roi": N,           # survived the named-consumer ROI gate
@@ -484,6 +486,15 @@ def _load_verdicts():
         return None
 
 _verdicts = _load_verdicts()
+# verify_mode makes the gate's effective state observable in explore-loop.json
+# (audit #1086 seam-1): "active" when an orchestrator-supplied verdict map drove
+# real refutations, "no-op-unverified" when no map was supplied and every
+# proposal survived carrying verdict=unverified. Without this an operator cannot
+# distinguish "skeptic refuted nothing" from "skeptic never ran" — the inert
+# dead-gate failure mode. The aggregator keeps stdout pure JSON (many consumers
+# parse it directly); the loud operator warning is emitted by the orchestrator
+# (autospec-explore.sh) off this field, not from here.
+verify_mode = "active" if _verdicts is not None else "no-op-unverified"
 verified = []
 refuted_count = 0
 for p in deduped:
@@ -688,6 +699,7 @@ out = {
     "round": datetime.date.today().isoformat(),
     "proposals_total": total,
     "proposals_after_dedup": len(deduped),
+    "verify_mode": verify_mode,
     "proposals_after_verify": len(verified),
     "proposals_refuted": refuted_count,
     "proposals_after_roi": len(roi_kept),

--- a/tests/explore/test_explore_verify_stage.bats
+++ b/tests/explore/test_explore_verify_stage.bats
@@ -130,6 +130,42 @@ assert titles == ['feat: affirmed'], titles
 "
 }
 
+@test "verify_mode=no-op-unverified surfaces the inert-gate state (audit #1086 seam-1)" {
+    # Regression for the inert-dead-gate failure mode: with no orchestrator-
+    # supplied verdict map the verify stage no-ops, and that MUST be observable
+    # in the structured output so an operator (and the orchestrator's
+    # code_health warning) can tell "skeptic refuted nothing" from "skeptic
+    # never ran". stdout stays pure JSON — the human warning is the
+    # orchestrator's job off this field.
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: alpha","evidence":"e1","estimated_complexity":"small","confidence":0.9}]}'
+    empties
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert d['verify_mode'] == 'no-op-unverified', d
+"
+}
+
+@test "verify_mode=active when a verdict map is supplied (audit #1086 seam-1)" {
+    make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: real fix","evidence":"e1","estimated_complexity":"small","confidence":0.9}]}'
+    empties
+    cat > "$TMP/verdicts.json" <<'EOF'
+{ "real fix": {"verdict":"survived","reason":"verified"} }
+EOF
+    export AUTOSPEC_EXPLORE_VERIFY_VERDICTS="$TMP/verdicts.json"
+
+    run bash "$REPO_ROOT/scripts/explore-research-cycle.sh" --max-issues-per-round 5
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert d['verify_mode'] == 'active', d
+"
+}
+
 @test "all four discovery-enhance counters are present in the iteration log" {
     make_fake_researcher spec-vs-code '{"source":"spec-vs-code","proposals":[{"title":"feat: a","evidence":"e1","estimated_complexity":"small","confidence":0.9}]}'
     empties


### PR DESCRIPTION
Closes #1086

## Phase 5.5 broad-integration audit — discovery-enhance (PRs #1087–#1094)

Traced one proposal (and a `specialist:<slug>` source) end-to-end through the merged pipeline and stress-tested the five integration seams per-PR LGTM can't see. Ran every researcher with real input, not just read them.

### Seam 1 — verify-stage wiring (HIGH — real gap, the "dead gate")

The adversarial verify stage — the spec's headline false-positive defense — is **inert in production**. The aggregator consumes an OPTIONAL verdict map via `AUTOSPEC_EXPLORE_VERIFY_VERDICTS` and defaults to "all survive (unverified)" when absent; **nothing supplies it** (`grep -rn AUTOSPEC_EXPLORE_VERIFY_VERDICTS` matches only the aggregator's own consumer). The orchestrator (`autospec-explore.sh:314`) never dispatches a skeptic and never sets the var. Root cause: dedup runs *inside* the single aggregator pass, so the verdict map (keyed by deduped-normalized title) can't be produced before the aggregator runs — the documented design is architecturally un-wireable without a two-pass split. The ledger refutation-rate down-weighting (#1091) is correctly plumbed but consequently also inert (nothing ever records a `refuted` outcome).

**Inline remediation (this PR):** make the inert state observable instead of silent — the aggregator emits a structured `verify_mode` field, and the orchestrator emits `code_health:explore_verify_noop` when the gate ran inactive. stdout stays pure JSON. Regression tests added.

**Architectural fix (filed):** #1095 — two-pass aggregator + real skeptic dispatch that populates the map + records `refuted` to the ledger. `auto-implement,autospec:v2-flow,priority:high`.

### Seams 2–5 — verified clean (no defect)

- **ROI gate vs new researchers:** ran `quality-resilience` (100 props), `self-leverage` (50), `dogfooding` (graceful empty, no `~/.autospec`). All emit non-empty `named_consumer` on every proposal → all pass the ROI gate. ✓
- **End-to-end pipeline:** real researcher output + a `specialist:market-risk` source compose through dedup→verify→ROI→pattern-synthesis→severity-first rank with no valid drops/mis-orders; the 4 counters reflect reality; specialist weight = 0.6 (score 0.48, covered by bats). ✓
- **Trio prose vs behavior:** stage order / researcher set / flags match the code. ✓
- **Synthesis over-collapse + ledger convergence:** pattern synthesis does not cross severity bands (test 219); refutation down-weighting converges without oscillation and doesn't starve (unit tests 131–132). ✓

### Out of scope (noted, not fixed)

`skills/autospec-shared/tests/unit/explore-constitution.bats` tests 3–5 fail on origin/main (pre-existing) — the bats `run` merges the script's stderr diagnostic into `$output` before piping to jq. Not part of the discovery-enhance work, not in the validate gate. Left untouched.

## Gates

- `bats tests/explore/` — **93/93 green** (added 2 regression tests)
- `bash scripts/validate.sh` — **green (exit 0)**

## Verdict

Surviving gaps = 1 (seam-1 verify-stage wiring) — root fix tracked as #1095; observable-inertness mitigation landed inline here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)