### PR TITLE
feat(explore): deterministic round-spec renderer (gen-explore-round-spec.sh) (#1099)

### DIFF
--- a/scripts/gen-explore-round-spec.sh
+++ b/scripts/gen-explore-round-spec.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# scripts/gen-explore-round-spec.sh — deterministic round-spec renderer.
+#
+# Turns the explore aggregator's ranked-proposals JSON into a round design spec
+# markdown.  One ## <title> section per proposal, carrying evidence,
+# estimated_complexity, source, severity, named_consumer, and an Acceptance
+# block of - [ ] checkboxes so spec-vs-code can later parse it.
+#
+# Usage:
+#   gen-explore-round-spec.sh <proposals-json> [--round N] [--branch <slug>]
+#                             [--out <path>]
+#
+# Output:
+#   docs/specs/<date>-explore-<slug>-round-<N>-design.md style markdown,
+#   written to --out <path> if given, else stdout.
+#
+# Exit codes:
+#   0 — success
+#   1 — missing input file or argument error
+
+set -u
+
+# ── argument parsing ──────────────────────────────────────────────────────────
+
+PROPOSALS_JSON=""
+ROUND="1"
+BRANCH="main"
+OUT_PATH=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --round)
+            if [ -z "${2:-}" ]; then
+                printf 'gen-explore-round-spec.sh: --round requires a value\n' >&2
+                exit 1
+            fi
+            ROUND="$2"
+            shift 2
+            ;;
+        --branch)
+            if [ -z "${2:-}" ]; then
+                printf 'gen-explore-round-spec.sh: --branch requires a value\n' >&2
+                exit 1
+            fi
+            BRANCH="$2"
+            shift 2
+            ;;
+        --out)
+            if [ -z "${2:-}" ]; then
+                printf 'gen-explore-round-spec.sh: --out requires a path argument\n' >&2
+                exit 1
+            fi
+            OUT_PATH="$2"
+            shift 2
+            ;;
+        --help|-h)
+            cat <<'EOF'
+gen-explore-round-spec.sh — deterministic round-spec renderer
+
+Usage:
+  scripts/gen-explore-round-spec.sh <proposals-json> [--round N]
+      [--branch <slug>] [--out <path>]
+
+Arguments:
+  <proposals-json>   Path to the ranked-proposals JSON from explore-research-cycle.sh.
+  --round N          Round number (default: 1).
+  --branch <slug>    Sandbox branch name (default: main).
+  --out <path>       Write output to this path instead of stdout.
+EOF
+            exit 0
+            ;;
+        -*)
+            printf 'gen-explore-round-spec.sh: unknown option: %s\n' "$1" >&2
+            exit 1
+            ;;
+        *)
+            if [ -z "$PROPOSALS_JSON" ]; then
+                PROPOSALS_JSON="$1"
+            else
+                printf 'gen-explore-round-spec.sh: unexpected argument: %s\n' "$1" >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$PROPOSALS_JSON" ]; then
+    printf 'gen-explore-round-spec.sh: <proposals-json> argument required\n' >&2
+    exit 1
+fi
+
+if [ ! -f "$PROPOSALS_JSON" ]; then
+    printf 'gen-explore-round-spec.sh: file not found: %s\n' "$PROPOSALS_JSON" >&2
+    exit 1
+fi
+
+# ── validate jq availability ──────────────────────────────────────────────────
+
+if ! command -v jq >/dev/null 2>&1; then
+    printf 'gen-explore-round-spec.sh: jq is required but not found\n' >&2
+    exit 1
+fi
+
+# ── render ─────────────────────────────────────────────────────────────────────
+
+TODAY="$(date +%Y-%m-%d)"
+
+render_spec() {
+    # Header
+    printf '# %s round %s\n\n' "$BRANCH" "$ROUND"
+    printf '**Date:** %s  \n' "$TODAY"
+    printf '**Branch:** `%s`  \n' "$BRANCH"
+    printf '**Round:** %s  \n\n' "$ROUND"
+
+    printf '**Summary:** Explore round %s for sandbox branch `%s`. ' "$ROUND" "$BRANCH"
+    printf 'Each section below corresponds to one ranked proposal from the research cycle.\n\n'
+
+    # Count proposals
+    local count
+    count="$(jq '.proposals | length' "$PROPOSALS_JSON")"
+
+    if [ "$count" -eq 0 ]; then
+        printf '_No proposals for this round._\n'
+        return 0
+    fi
+
+    # One section per proposal
+    local i=0
+    while [ "$i" -lt "$count" ]; do
+        local title evidence complexity source severity named_consumer
+
+        title="$(jq -r ".proposals[$i].title // \"(untitled)\"" "$PROPOSALS_JSON")"
+        evidence="$(jq -r ".proposals[$i].evidence // \"\"" "$PROPOSALS_JSON")"
+        complexity="$(jq -r ".proposals[$i].estimated_complexity // \"unknown\"" "$PROPOSALS_JSON")"
+        source="$(jq -r ".proposals[$i].source // \"unknown\"" "$PROPOSALS_JSON")"
+        severity="$(jq -r ".proposals[$i].severity // \"feature\"" "$PROPOSALS_JSON")"
+        named_consumer="$(jq -r ".proposals[$i].named_consumer // \"\"" "$PROPOSALS_JSON")"
+
+        printf '## %s\n\n' "$title"
+        printf '| Field | Value |\n'
+        printf '|---|---|\n'
+        printf '| **Evidence** | `%s` |\n' "$evidence"
+        printf '| **Complexity** | %s |\n' "$complexity"
+        printf '| **Source** | %s |\n' "$source"
+        printf '| **Severity** | %s |\n' "$severity"
+        printf '| **Named consumer** | %s |\n' "$named_consumer"
+        printf '\n'
+
+        printf '### Acceptance\n\n'
+        printf -- '- [ ] Implement: %s\n' "$title"
+        printf -- '- [ ] Tests pass for the changed files.\n'
+        printf -- '- [ ] `bash scripts/validate.sh` exits 0.\n'
+        printf '\n'
+
+        i=$((i + 1))
+    done
+}
+
+# ── emit output ───────────────────────────────────────────────────────────────
+
+if [ -n "$OUT_PATH" ]; then
+    render_spec > "$OUT_PATH"
+else
+    render_spec
+fi

--- a/tests/explore/test_explore_round_spec.bats
+++ b/tests/explore/test_explore_round_spec.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+# tests/explore/test_explore_round_spec.bats — deterministic round-spec renderer
+# TDD: tests for scripts/gen-explore-round-spec.sh
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    TMP="$(mktemp -d -t round-spec.XXXXXX)"
+
+    # Write a 2-proposal fixture
+    cat > "$TMP/proposals.json" <<'EOF'
+{
+  "round": "2026-06-16",
+  "proposals": [
+    {
+      "title": "feat: add retry logic to explore loop",
+      "evidence": "scripts/autospec-explore.sh:42",
+      "estimated_complexity": "small",
+      "confidence": 0.9,
+      "source": "spec-vs-code",
+      "severity": "correctness",
+      "named_consumer": "autospec-run"
+    },
+    {
+      "title": "fix: validate proposal schema on emit",
+      "evidence": "scripts/explore-research-cycle.sh:88",
+      "estimated_complexity": "medium",
+      "confidence": 0.75,
+      "source": "codebase-signals",
+      "severity": "stability",
+      "named_consumer": "autospec-explore"
+    }
+  ]
+}
+EOF
+
+    # Write an empty-proposals fixture
+    cat > "$TMP/empty.json" <<'EOF'
+{
+  "round": "2026-06-16",
+  "proposals": []
+}
+EOF
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+# ── basic rendering ────────────────────────────────────────────────────────────
+
+@test "exits 0 on a valid 2-proposal JSON fixture" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 1 --branch demo
+    [ "$status" -eq 0 ]
+}
+
+@test "output contains exactly one ## section per proposal" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 1 --branch demo
+    [ "$status" -eq 0 ]
+    count=$(printf '%s\n' "$output" | grep -c '^## ')
+    [ "$count" -eq 2 ]
+}
+
+@test "each proposal section title appears as a ## heading" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 1 --branch demo
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q '^## feat: add retry logic to explore loop'
+    printf '%s\n' "$output" | grep -q '^## fix: validate proposal schema on emit'
+}
+
+@test "each proposal section contains at least 1 - [ ] acceptance checkbox" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 1 --branch demo
+    [ "$status" -eq 0 ]
+    count=$(printf '%s\n' "$output" | grep -c '^\- \[ \]')
+    [ "$count" -ge 2 ]
+}
+
+@test "output header names the sandbox branch" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 1 --branch demo
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'demo'
+}
+
+@test "output header names the round number" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 3 --branch mybranch
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'round 3'
+}
+
+@test "output contains evidence field value" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 1 --branch demo
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'scripts/autospec-explore.sh:42'
+}
+
+@test "output contains source field value" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 1 --branch demo
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'spec-vs-code'
+}
+
+@test "output contains severity field value" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 1 --branch demo
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'correctness'
+}
+
+@test "output contains named_consumer field value" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 1 --branch demo
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'autospec-run'
+}
+
+@test "output contains estimated_complexity field value" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 1 --branch demo
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'small'
+}
+
+# ── determinism ────────────────────────────────────────────────────────────────
+
+@test "re-running on same fixture yields byte-identical output" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 1 --branch demo
+    [ "$status" -eq 0 ]
+    first="$output"
+
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 1 --branch demo
+    [ "$status" -eq 0 ]
+    [ "$output" = "$first" ]
+}
+
+# ── --out flag ────────────────────────────────────────────────────────────────
+
+@test "--out writes to a file and stdout is empty" {
+    out_file="$TMP/spec.md"
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/proposals.json" --round 1 --branch demo --out "$out_file"
+    [ "$status" -eq 0 ]
+    [ -f "$out_file" ]
+    grep -q '^\- \[ \]' "$out_file"
+}
+
+# ── edge cases ────────────────────────────────────────────────────────────────
+
+@test "empty proposals produces minimal valid spec with # header" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        "$TMP/empty.json" --round 1 --branch demo
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q '^# '
+}
+
+@test "missing proposals JSON file exits non-zero" {
+    run bash "$REPO_ROOT/scripts/gen-explore-round-spec.sh" \
+        /nonexistent/path.json --round 1 --branch demo
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Closes #1099. Spec-first-filing Issue A: renders the explore aggregator's ranked-proposals JSON into a round design spec (one section per proposal, - [ ] acceptance blocks so spec-vs-code can drift-check explore's own output). 15/15 bats green; validate.sh exit 0. (Resumed mechanically after a transient API 500 left the work committed-but-unmerged.)