### PR TITLE
fix(explore): count issues_filed on spec-first define-success path

### DIFF
--- a/scripts/autospec-explore.sh
+++ b/scripts/autospec-explore.sh
@@ -419,14 +419,45 @@ _explore_file_round() {
         git push -q origin "HEAD:$SANDBOX_BRANCH" 2>/dev/null || true
     fi
 
-    # 3. Decompose via /autospec-define --base <sandbox> (never targets main).
+    # 3. Snapshot open auto-implement issue numbers before decompose so we can
+    #    diff after to count what /autospec-define filed (best-effort; tolerates
+    #    gh absent or returning empty). Numbers are newline-separated integers.
+    local pre_nums post_nums new_num
+    pre_nums=""
+    if command -v gh >/dev/null 2>&1; then
+        pre_nums="$(gh issue list --label auto-implement --json number \
+            --jq '.[].number' 2>/dev/null)" || pre_nums=""
+    fi
+
+    # 4. Decompose via /autospec-define --base <sandbox> (never targets main).
     define_rc=0
     _explore_round_decompose "$spec_path" || define_rc=$?
 
     if [ "$define_rc" -ne 0 ]; then
-        # 4. Fallback — keep the committed spec, raw-file this round, continue.
+        # 5. Fallback — keep the committed spec, raw-file this round, continue.
         echo "code_health:explore_define_unavailable round=$iter rc=$define_rc spec=$spec_path" >&2
         _explore_raw_file_round
+        return 0
+    fi
+
+    # 6. On define success: diff the issue-number sets to count what was filed.
+    #    Guard: gh absent or snapshot empty → skip (issues_filed stays 0).
+    if command -v gh >/dev/null 2>&1; then
+        post_nums="$(gh issue list --label auto-implement --json number \
+            --jq '.[].number' 2>/dev/null)" || post_nums=""
+        if [ -n "$post_nums" ]; then
+            while IFS= read -r new_num; do
+                [ -z "$new_num" ] && continue
+                case "$new_num" in ''|*[!0-9]*) continue ;; esac
+                # Only count if absent from the pre-snapshot.
+                if ! printf '%s\n' "$pre_nums" | grep -qxF "$new_num" 2>/dev/null; then
+                    issues_filed=$((issues_filed + 1))
+                    filed_issue_nums="$filed_issue_nums $new_num"
+                fi
+            done <<EOF
+$post_nums
+EOF
+        fi
     fi
     return 0
 }

--- a/tests/explore/test_explore_define_fallback.bats
+++ b/tests/explore/test_explore_define_fallback.bats
@@ -112,3 +112,51 @@ DRIVER
     [ ! -f "$TMP/gh.log" ]
     ! grep -q 'code_health:explore_define_unavailable' "$TMP/err.log"
 }
+
+# ── issues_filed on fallback path: raw filing counter only (#1109) ───────────
+
+_run_filing_with_counter() {
+    cat > "$TMP/driver_counter.sh" <<DRIVER
+set -u
+SCRIPT_DIR="$REPO_ROOT/scripts"
+SANDBOX_BRANCH="sandbox/explore-demo"
+RESEARCH_SOURCES="codebase-signals"
+iter=1
+research_json="$TMP/.autospec/proposals.json"
+iter_dir="$TMP/.autospec"
+proposals_count=1
+issues_filed=0
+filed_issue_nums=""
+_ledger_append() { :; }
+_ledger_normalize_title() { printf '%s' "\$1"; }
+LEDGER_BIN=""
+$(awk '/^# >>> explore-spec-first-filing >>>/,/^# <<< explore-spec-first-filing <<</' "$ORCH")
+_explore_file_round
+printf 'issues_filed=%s\n' "\$issues_filed"
+DRIVER
+    AUTOSPEC_EXPLORE_ROUND_DEFINE_CMD="$DEFINE_CMD" bash "$TMP/driver_counter.sh" 2>"$TMP/err2.log"
+}
+
+@test "fallback path: issues_filed counts raw-filed issues, not snapshot diff" {
+    # gh stub: list returns nothing (so snapshot diff would give 0), but
+    # issue create returns a URL — raw filing should still count it.
+    cat > bin/gh <<'GHSTUB'
+#!/usr/bin/env bash
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+    # empty — would make snapshot diff yield 0
+    exit 0
+fi
+if [ "$1" = "issue" ] && [ "$2" = "create" ]; then
+    echo "https://github.com/o/r/issues/9002"
+    exit 0
+fi
+exit 0
+GHSTUB
+    chmod +x bin/gh
+
+    DEFINE_CMD='exit 7'
+    run _run_filing_with_counter
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+    # Raw filing incremented issues_filed for the one proposal.
+    [[ "$output" == *"issues_filed=1"* ]]
+}

--- a/tests/explore/test_explore_spec_first_filing.bats
+++ b/tests/explore/test_explore_spec_first_filing.bats
@@ -112,3 +112,93 @@ DRIVER
     run cat "$TMP/define-args.txt"
     [[ "$output" != *"--base main"* ]]
 }
+
+# ── issues_filed / filed_issue_nums on the success path (#1109) ──────────────
+
+# _run_filing_with_counter: like _run_filing but prints issues_filed and
+# filed_issue_nums after the call so tests can assert them.
+_run_filing_with_counter() {
+    cat > "$TMP/driver_counter.sh" <<DRIVER
+set -u
+SCRIPT_DIR="$REPO_ROOT/scripts"
+SANDBOX_BRANCH="sandbox/explore-demo"
+RESEARCH_SOURCES="spec-vs-code"
+iter=1
+research_json="$TMP/.autospec/proposals.json"
+iter_dir="$TMP/.autospec"
+proposals_count=1
+issues_filed=0
+filed_issue_nums=""
+_ledger_append() { :; }
+_ledger_normalize_title() { printf '%s' "\$1"; }
+LEDGER_BIN=""
+$(awk '/^# >>> explore-spec-first-filing >>>/,/^# <<< explore-spec-first-filing <<</' "$ORCH")
+_explore_file_round
+printf 'issues_filed=%s\n' "\$issues_filed"
+printf 'filed_issue_nums=%s\n' "\$filed_issue_nums"
+DRIVER
+    AUTOSPEC_EXPLORE_ROUND_DEFINE_CMD="$DEFINE_CMD" bash "$TMP/driver_counter.sh"
+}
+
+@test "success path: issues_filed reflects issues created by define handoff" {
+    # gh stub: list returns 101 before, 101+102 after define runs
+    local call_count_file="$TMP/gh_calls"
+    printf '0' > "$call_count_file"
+    mkdir -p "$TMP/bin"
+    cat > "$TMP/bin/gh" <<GHSTUB
+#!/usr/bin/env bash
+if [ "\$1" = "issue" ] && [ "\$2" = "list" ]; then
+    n=\$(cat "$call_count_file" 2>/dev/null || echo 0)
+    n=\$((n + 1))
+    printf '%s' "\$n" > "$call_count_file"
+    if [ "\$n" -le 1 ]; then
+        # pre-snapshot: one existing issue
+        printf '101\n'
+    else
+        # post-snapshot: two issues — 102 is new
+        printf '101\n102\n'
+    fi
+    exit 0
+fi
+exit 0
+GHSTUB
+    chmod +x "$TMP/bin/gh"
+    export PATH="$TMP/bin:$PATH"
+
+    DEFINE_CMD='exit 0'
+    run _run_filing_with_counter
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+    [[ "$output" == *"issues_filed=1"* ]]
+    [[ "$output" == *"filed_issue_nums="*"102"* ]]
+}
+
+@test "success path: no double-count when define files zero new issues" {
+    mkdir -p "$TMP/bin"
+    cat > "$TMP/bin/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+    # same set before and after — nothing new
+    printf '101\n'
+    exit 0
+fi
+exit 0
+GHSTUB
+    chmod +x "$TMP/bin/gh"
+    export PATH="$TMP/bin:$PATH"
+
+    DEFINE_CMD='exit 0'
+    run _run_filing_with_counter
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+    [[ "$output" == *"issues_filed=0"* ]]
+}
+
+@test "success path: gh absent — issues_filed stays 0 (no error)" {
+    # Remove gh from PATH entirely for this test.
+    local saved_path="$PATH"
+    export PATH="$(printf '%s' "$PATH" | tr ':' '\n' | grep -v "$TMP/bin" | paste -sd: -)"
+    DEFINE_CMD='exit 0'
+    run _run_filing_with_counter
+    export PATH="$saved_path"
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+    [[ "$output" == *"issues_filed=0"* ]]
+}


### PR DESCRIPTION
Closes #1109

## Summary

- In `_explore_file_round()`, snapshot open `auto-implement` issue numbers (via `gh issue list --label auto-implement --json number --jq '.[].number'`) immediately before calling `_explore_round_decompose` and again after it returns `rc==0`.
- Diff the two sets; each number present only in the post-snapshot increments `issues_filed` and is appended to `filed_issue_nums`.
- Guards: `gh` absent → skip (stays 0); empty post-snapshot → skip; non-numeric entries → skip.
- The raw-fallback path (`_explore_raw_file_round`) is unchanged.

## Tests added

`tests/explore/test_explore_spec_first_filing.bats` (+3 tests):
- success path records non-zero `issues_filed` when define files a new issue
- no double-count when define files nothing new
- gh absent → `issues_filed` stays 0, no error

`tests/explore/test_explore_define_fallback.bats` (+1 test):
- fallback path: `issues_filed` counts raw-filed issues, not snapshot diff

Full suite: `bash scripts/validate.sh` → OK (all checks passed).