### PR TITLE
feat(explore): QA sandbox-promotion gate runner (#1113)

### DIFF
--- a/schemas/autospec-explore-qa-gate.schema.json
+++ b/schemas/autospec-explore-qa-gate.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-explore-qa-gate.schema.json",
+  "title": "autospec explore QA sandbox-promotion gate result",
+  "description": "Result of scripts/explore-qa-gate.sh: runs autospec-qa --no-heal against the explore sandbox HEAD in a fresh worktree and records the promotion-gate verdict. 'skipped' is fail-open (no QA config, not penalized); 'error' is fail-closed (an attempted gate crashed/errored, blocks).",
+  "type": "object",
+  "required": ["verdict", "sandbox_branch", "sandbox_head_sha", "qa_verdict_path", "blocking_findings", "ran_at"],
+  "additionalProperties": false,
+  "properties": {
+    "verdict": {
+      "type": "string",
+      "enum": ["PASS", "PARTIAL", "FAIL", "skipped", "error"]
+    },
+    "sandbox_branch": { "type": "string", "minLength": 1 },
+    "sandbox_head_sha": { "type": "string" },
+    "qa_verdict_path": { "type": "string" },
+    "blocking_findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "category": { "type": "string" },
+          "release_blocking": { "type": "boolean" },
+          "status": { "type": "string" },
+          "summary": { "type": "string" },
+          "evidence": { "type": "string" }
+        }
+      }
+    },
+    "ran_at": { "type": "string", "minLength": 1 },
+    "reason": { "type": "string" }
+  }
+}

--- a/scripts/explore-qa-gate.sh
+++ b/scripts/explore-qa-gate.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# scripts/explore-qa-gate.sh — autospec-explore QA sandbox-promotion gate
+# runner (issue #1113).
+#
+# Stands the sandbox-HEAD app up in a fresh, throwaway worktree (NEVER the
+# operator's primary checkout), runs `autospec-qa --no-heal` against it (the
+# gate proves; it does not mutate the sandbox), and persists the promotion
+# verdict to `.autospec/explore-qa-gate.json` per
+# `schemas/autospec-explore-qa-gate.schema.json`.
+#
+# Fail-open SKIP vs fail-closed error:
+#   - No QA config (no .autospec/test.yml and no autospec-qa config) → SKIP:
+#     verdict "skipped", emit code_health:explore_qa_gate_skipped_no_config,
+#     exit 0. A repo with no QA setup is NOT penalized.
+#   - An *attempted* gate that crashes (missing autospec-qa, QA crash, jq
+#     error, no verdict file) → verdict "error", BLOCK (non-zero). Distinct
+#     from skip.
+#   - QA FAIL or PARTIAL → block (non-zero). PASS → exit 0.
+#   - No sandbox (.autospec/explore-mode.json absent) → operator error:
+#     emit code_health:explore_qa_gate_no_sandbox, exit non-zero.
+#
+# Exit codes:
+#   0  PASS or skipped (promotable / not penalized)
+#   1  FAIL / PARTIAL / error (blocks promotion)
+#   2  no sandbox (explore-mode.json absent — gate requested with no sandbox)
+#
+# Conventions (AGENTS.md): set -u (branch on exits explicitly, no -e
+# short-circuit traps); bash 3.2 safe; no RETURN traps (inline cleanup);
+# if/then/fi for one-sided conditionals; no `git add -A`.
+
+set -u
+
+PROG="explore-qa-gate.sh"
+
+emit() { printf '%s\n' "$*" >&2; }
+err()  { printf '%s: %s\n' "$PROG" "$*" >&2; }
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+MODE_FILE="$REPO_ROOT/.autospec/explore-mode.json"
+GATE_FILE="$REPO_ROOT/.autospec/explore-qa-gate.json"
+RAN_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+# worktree-guard.sh lives next to this script (repo) or in the installed
+# scripts dir.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKTREE_GUARD="$SCRIPT_DIR/worktree-guard.sh"
+
+# ---------------------------------------------------------------------------
+# 1. No sandbox → operator error (fail-closed, exit 2).
+# ---------------------------------------------------------------------------
+if [ ! -f "$MODE_FILE" ]; then
+    emit "code_health:explore_qa_gate_no_sandbox"
+    err "no sandbox: $MODE_FILE absent (run /autospec-explore to create one)"
+    exit 2
+fi
+
+# Read {branch, head_sha} from explore-mode.json.
+SANDBOX_BRANCH="$(jq -r '.branch // empty' "$MODE_FILE" 2>/dev/null || true)"
+SANDBOX_HEAD_SHA="$(jq -r '.head_sha // empty' "$MODE_FILE" 2>/dev/null || true)"
+
+# Helper: write the gate artifact and (optionally) a worktree cleanup.
+# write_gate <verdict> <blocking_findings_json> [reason]
+write_gate() {
+    local verdict="$1"
+    local findings="$2"
+    local reason="${3:-}"
+    mkdir -p "$REPO_ROOT/.autospec"
+    local tmp="$GATE_FILE.tmp.$$"
+    if [ -n "$reason" ]; then
+        jq -n \
+            --arg verdict "$verdict" \
+            --arg branch "$SANDBOX_BRANCH" \
+            --arg head "$SANDBOX_HEAD_SHA" \
+            --arg qvp ".autospec/qa-verdict.json" \
+            --arg ran "$RAN_AT" \
+            --arg reason "$reason" \
+            --argjson findings "$findings" \
+            '{verdict:$verdict, sandbox_branch:$branch, sandbox_head_sha:$head, qa_verdict_path:$qvp, blocking_findings:$findings, ran_at:$ran, reason:$reason}' \
+            > "$tmp" 2>/dev/null
+    else
+        jq -n \
+            --arg verdict "$verdict" \
+            --arg branch "$SANDBOX_BRANCH" \
+            --arg head "$SANDBOX_HEAD_SHA" \
+            --arg qvp ".autospec/qa-verdict.json" \
+            --arg ran "$RAN_AT" \
+            --argjson findings "$findings" \
+            '{verdict:$verdict, sandbox_branch:$branch, sandbox_head_sha:$head, qa_verdict_path:$qvp, blocking_findings:$findings, ran_at:$ran}' \
+            > "$tmp" 2>/dev/null
+    fi
+    if [ ! -s "$tmp" ]; then
+        # jq itself failed — fall back to a minimal hand-written object so the
+        # artifact is never left missing.
+        printf '{"verdict":"error","sandbox_branch":"%s","sandbox_head_sha":"%s","qa_verdict_path":".autospec/qa-verdict.json","blocking_findings":[],"ran_at":"%s","reason":"gate jq write failed"}\n' \
+            "$SANDBOX_BRANCH" "$SANDBOX_HEAD_SHA" "$RAN_AT" > "$tmp"
+    fi
+    mv "$tmp" "$GATE_FILE"
+    chmod 644 "$GATE_FILE" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# 2. QA-config probe (fail-open SKIP).
+# Probe the PRIMARY repo: an explore sandbox built off it shares config layout.
+# No .autospec/test.yml and no autospec-qa config → SKIP, exit 0.
+# ---------------------------------------------------------------------------
+HAS_QA_CONFIG=0
+if [ -f "$REPO_ROOT/.autospec/test.yml" ]; then
+    HAS_QA_CONFIG=1
+fi
+if [ -f "$REPO_ROOT/.autospec/qa.yml" ] || [ -f "$REPO_ROOT/.autospec/reliability.yml" ]; then
+    HAS_QA_CONFIG=1
+fi
+
+if [ "$HAS_QA_CONFIG" -eq 0 ]; then
+    emit "code_health:explore_qa_gate_skipped_no_config"
+    write_gate "skipped" "[]" "no QA config (.autospec/test.yml / autospec-qa config) present; not penalized"
+    printf '%s: skipped (no QA config) — promotion not penalized\n' "$PROG"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Create a fresh worktree on the sandbox branch at head_sha.
+# NEVER the primary checkout. Removed inline on every exit path below.
+# ---------------------------------------------------------------------------
+WT_PATH="${AUTOSPEC_QA_GATE_WORKTREE:-/tmp/wt-explore-qa-gate-$$}"
+
+# Inline cleanup (no RETURN trap): remove the worktree we created.
+cleanup_worktree() {
+    if [ -n "${WT_PATH:-}" ] && [ -d "$WT_PATH" ]; then
+        git -C "$REPO_ROOT" worktree remove --force "$WT_PATH" >/dev/null 2>&1 || true
+        git -C "$REPO_ROOT" worktree prune >/dev/null 2>&1 || true
+        rm -rf "$WT_PATH" 2>/dev/null || true
+    fi
+}
+
+# Branch the worktree off the recorded sandbox HEAD sha (detached-safe via a
+# throwaway local branch name). worktree-guard create refuses the primary
+# checkout and dirty reuse.
+WT_BRANCH="explore-qa-gate-$$"
+WT_CREATE_OK=0
+if [ -f "$WORKTREE_GUARD" ]; then
+    if bash "$WORKTREE_GUARD" create \
+        --branch "$WT_BRANCH" \
+        --base "$SANDBOX_HEAD_SHA" \
+        --path "$WT_PATH" >/dev/null 2>&1; then
+        WT_CREATE_OK=1
+    fi
+fi
+if [ "$WT_CREATE_OK" -ne 1 ]; then
+    # Fallback: direct worktree add off the sandbox HEAD sha.
+    if git -C "$REPO_ROOT" worktree add -b "$WT_BRANCH" "$WT_PATH" "$SANDBOX_HEAD_SHA" >/dev/null 2>&1; then
+        WT_CREATE_OK=1
+    fi
+fi
+if [ "$WT_CREATE_OK" -ne 1 ]; then
+    emit "code_health:explore_qa_gate_worktree_failed branch=$SANDBOX_BRANCH head=$SANDBOX_HEAD_SHA"
+    write_gate "error" "[]" "could not create sandbox-HEAD worktree at $WT_PATH"
+    err "worktree creation failed for $SANDBOX_HEAD_SHA at $WT_PATH"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Run autospec-qa --no-heal against the sandbox-HEAD worktree.
+# Missing skill / crash / jq error → verdict "error" (fail-closed block).
+# ---------------------------------------------------------------------------
+QA_VERDICT_FILE="$WT_PATH/.autospec/qa-verdict.json"
+
+# AUTOSPEC_QA_CMD test/operator seam; default to the autospec-qa binary.
+QA_CMD="${AUTOSPEC_QA_CMD:-autospec-qa --no-heal}"
+
+# Resolve the binary name (first word) to detect a missing skill up front.
+QA_BIN="$(printf '%s\n' "$QA_CMD" | awk '{print $1}')"
+if ! command -v "$QA_BIN" >/dev/null 2>&1; then
+    emit "code_health:explore_qa_gate_failed missing autospec-qa ($QA_BIN)"
+    write_gate "error" "[]" "autospec-qa not found on PATH ($QA_BIN)"
+    cleanup_worktree
+    err "autospec-qa not found ($QA_BIN); fail-closed error"
+    exit 1
+fi
+
+QA_RC=0
+( cd "$WT_PATH" && sh -c "$QA_CMD" ) >/dev/null 2>&1 || QA_RC=$?
+
+if [ "$QA_RC" -ne 0 ] && [ ! -f "$QA_VERDICT_FILE" ]; then
+    emit "code_health:explore_qa_gate_failed qa crash rc=$QA_RC"
+    write_gate "error" "[]" "autospec-qa crashed (rc=$QA_RC) and wrote no verdict"
+    cleanup_worktree
+    err "autospec-qa crashed (rc=$QA_RC); fail-closed error"
+    exit 1
+fi
+
+if [ ! -f "$QA_VERDICT_FILE" ]; then
+    emit "code_health:explore_qa_gate_failed no qa-verdict.json produced"
+    write_gate "error" "[]" "autospec-qa produced no .autospec/qa-verdict.json"
+    cleanup_worktree
+    err "no qa-verdict.json after autospec-qa; fail-closed error"
+    exit 1
+fi
+
+# Read the verdict + blocking findings. A jq error here → fail-closed error.
+QA_VERDICT="$(jq -r '.verdict // empty' "$QA_VERDICT_FILE" 2>/dev/null || true)"
+if [ -z "$QA_VERDICT" ]; then
+    emit "code_health:explore_qa_gate_failed unreadable qa-verdict.json"
+    write_gate "error" "[]" "could not read .verdict from qa-verdict.json (jq error?)"
+    cleanup_worktree
+    err "unreadable qa-verdict.json; fail-closed error"
+    exit 1
+fi
+
+BLOCKING_FINDINGS="$(jq -c '[(.findings // [])[] | select(.release_blocking == true)]' "$QA_VERDICT_FILE" 2>/dev/null || true)"
+if [ -z "$BLOCKING_FINDINGS" ]; then
+    BLOCKING_FINDINGS="[]"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Persist the gate artifact and translate the verdict to an exit code.
+# ---------------------------------------------------------------------------
+write_gate "$QA_VERDICT" "$BLOCKING_FINDINGS"
+cleanup_worktree
+
+case "$QA_VERDICT" in
+    PASS)
+        printf '%s: PASS — sandbox %s promotable\n' "$PROG" "$SANDBOX_BRANCH"
+        exit 0
+        ;;
+    FAIL|PARTIAL)
+        emit "code_health:explore_qa_gate_failed verdict=$QA_VERDICT"
+        printf '%s: %s — promotion blocked\n' "$PROG" "$QA_VERDICT" >&2
+        exit 1
+        ;;
+    *)
+        # Any other verdict string is treated conservatively as a block.
+        emit "code_health:explore_qa_gate_failed verdict=$QA_VERDICT (unrecognized)"
+        printf '%s: unrecognized verdict %s — promotion blocked\n' "$PROG" "$QA_VERDICT" >&2
+        exit 1
+        ;;
+esac

--- a/tests/explore/test_explore_qa_gate_runner.bats
+++ b/tests/explore/test_explore_qa_gate_runner.bats
@@ -1,0 +1,257 @@
+#!/usr/bin/env bats
+# tests/explore/test_explore_qa_gate_runner.bats — Issue #1113.
+#
+# scripts/explore-qa-gate.sh stands up the sandbox-HEAD app in a fresh
+# worktree, runs `autospec-qa --no-heal`, and persists
+# .autospec/explore-qa-gate.json per the pinned schema.
+#
+# Real shell, no mocks beyond a stub `autospec-qa` on PATH and a stub
+# worktree-guard create seam. bash 3.2 safe.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    GATE="$REPO_ROOT/scripts/explore-qa-gate.sh"
+    SCHEMA="$REPO_ROOT/schemas/autospec-explore-qa-gate.schema.json"
+
+    TMP="$(mktemp -d -t explore-qag.XXXXXX)"
+    # Primary checkout (sandbox source) — a real git repo with a commit.
+    PRIMARY="$TMP/primary"
+    mkdir -p "$PRIMARY"
+    cd "$PRIMARY"
+    git init -q
+    git config user.email t@t.t
+    git config user.name t
+    git checkout -q -b sandbox-branch
+    echo "app" > app.txt
+    git add app.txt
+    git commit -q -m "seed"
+    HEAD_SHA="$(git rev-parse HEAD)"
+
+    # Isolated state dir so we never touch the real ~/.autospec.
+    export AUTOSPEC_STATE_DIR="$TMP/state"
+    mkdir -p "$AUTOSPEC_STATE_DIR"
+
+    # bin/ on PATH for stubs (autospec-qa, worktree-guard seam markers).
+    export PATH="$TMP/bin:$PATH"
+    mkdir -p "$TMP/bin"
+
+    # Worktree target the runner will create; keep it inside TMP.
+    export AUTOSPEC_QA_GATE_WORKTREE="$TMP/wt-sandbox"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+# Seed .autospec/explore-mode.json in the primary checkout.
+seed_mode() {
+    mkdir -p "$PRIMARY/.autospec"
+    cat > "$PRIMARY/.autospec/explore-mode.json" <<EOF
+{
+  "branch": "sandbox-branch",
+  "slug": "demo",
+  "base": "main",
+  "head_sha": "$HEAD_SHA",
+  "created_at": "2026-06-16T00:00:00Z"
+}
+EOF
+}
+
+# Stub autospec-qa: on --no-heal, write a qa-verdict.json with the verdict
+# captured in $QA_STUB_VERDICT into the cwd's .autospec/.
+make_qa_stub() {
+    local verdict="$1"
+    cat > "$TMP/bin/autospec-qa" <<EOF
+#!/usr/bin/env bash
+mkdir -p .autospec
+cat > .autospec/qa-verdict.json <<JSON
+{
+  "verdict": "$verdict",
+  "head_sha": "$HEAD_SHA",
+  "generated_at": "2026-06-16T00:00:00Z",
+  "findings": [
+    { "category": "other", "release_blocking": true, "status": "$verdict", "summary": "stub finding" }
+  ]
+}
+JSON
+exit 0
+EOF
+    chmod +x "$TMP/bin/autospec-qa"
+}
+
+# Stub autospec-qa that crashes (non-zero, no verdict file).
+make_qa_crash_stub() {
+    cat > "$TMP/bin/autospec-qa" <<'EOF'
+#!/usr/bin/env bash
+echo "boom" >&2
+exit 7
+EOF
+    chmod +x "$TMP/bin/autospec-qa"
+}
+
+# Mark a QA config so the probe does not SKIP.
+add_qa_config() {
+    mkdir -p "$PRIMARY/.autospec"
+    printf 'spec_file: spec.md\n' > "$PRIMARY/.autospec/test.yml"
+}
+
+# ---------------------------------------------------------------------------
+# Schema sanity
+# ---------------------------------------------------------------------------
+
+@test "schema file exists and is valid JSON" {
+    [ -f "$SCHEMA" ]
+    run jq -e . "$SCHEMA"
+    [ "$status" -eq 0 ]
+}
+
+@test "bash -n parses the runner" {
+    run bash -n "$GATE"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# No sandbox -> fail-closed operator error
+# ---------------------------------------------------------------------------
+
+@test "missing explore-mode.json -> non-zero + explore_qa_gate_no_sandbox" {
+    cd "$PRIMARY"
+    run bash "$GATE"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q 'code_health:explore_qa_gate_no_sandbox'
+}
+
+# ---------------------------------------------------------------------------
+# No QA config -> SKIP (fail-open)
+# ---------------------------------------------------------------------------
+
+@test "no QA config -> verdict skipped, exit 0, skip code_health" {
+    cd "$PRIMARY"
+    seed_mode
+    make_qa_stub PASS   # present but must not be invoked; probe skips first
+    run bash "$GATE"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'code_health:explore_qa_gate_skipped_no_config'
+    run jq -r '.verdict' "$PRIMARY/.autospec/explore-qa-gate.json"
+    [ "$output" = "skipped" ]
+}
+
+# ---------------------------------------------------------------------------
+# PASS / FAIL / PARTIAL passthrough
+# ---------------------------------------------------------------------------
+
+@test "QA PASS -> explore-qa-gate.json verdict PASS, exit 0" {
+    cd "$PRIMARY"
+    seed_mode
+    add_qa_config
+    make_qa_stub PASS
+    run bash "$GATE"
+    [ "$status" -eq 0 ]
+    run jq -r '.verdict' "$PRIMARY/.autospec/explore-qa-gate.json"
+    [ "$output" = "PASS" ]
+}
+
+@test "QA FAIL -> verdict FAIL and non-zero block" {
+    cd "$PRIMARY"
+    seed_mode
+    add_qa_config
+    make_qa_stub FAIL
+    run bash "$GATE"
+    [ "$status" -ne 0 ]
+    run jq -r '.verdict' "$PRIMARY/.autospec/explore-qa-gate.json"
+    [ "$output" = "FAIL" ]
+}
+
+@test "QA PARTIAL -> verdict PARTIAL and non-zero block" {
+    cd "$PRIMARY"
+    seed_mode
+    add_qa_config
+    make_qa_stub PARTIAL
+    run bash "$GATE"
+    [ "$status" -ne 0 ]
+    run jq -r '.verdict' "$PRIMARY/.autospec/explore-qa-gate.json"
+    [ "$output" = "PARTIAL" ]
+}
+
+# ---------------------------------------------------------------------------
+# QA crash -> error (fail-closed block)
+# ---------------------------------------------------------------------------
+
+@test "QA crash -> verdict error and non-zero block" {
+    cd "$PRIMARY"
+    seed_mode
+    add_qa_config
+    make_qa_crash_stub
+    run bash "$GATE"
+    [ "$status" -ne 0 ]
+    run jq -r '.verdict' "$PRIMARY/.autospec/explore-qa-gate.json"
+    [ "$output" = "error" ]
+}
+
+@test "missing autospec-qa on PATH -> verdict error and non-zero block" {
+    cd "$PRIMARY"
+    seed_mode
+    add_qa_config
+    # no autospec-qa stub created; ensure none resolves
+    rm -f "$TMP/bin/autospec-qa"
+    run bash "$GATE"
+    [ "$status" -ne 0 ]
+    run jq -r '.verdict' "$PRIMARY/.autospec/explore-qa-gate.json"
+    [ "$output" = "error" ]
+}
+
+# ---------------------------------------------------------------------------
+# Reads sandbox HEAD from explore-mode.json; records it
+# ---------------------------------------------------------------------------
+
+@test "records sandbox_branch and sandbox_head_sha from explore-mode.json" {
+    cd "$PRIMARY"
+    seed_mode
+    add_qa_config
+    make_qa_stub PASS
+    run bash "$GATE"
+    [ "$status" -eq 0 ]
+    run jq -r '.sandbox_head_sha' "$PRIMARY/.autospec/explore-qa-gate.json"
+    [ "$output" = "$HEAD_SHA" ]
+    run jq -r '.sandbox_branch' "$PRIMARY/.autospec/explore-qa-gate.json"
+    [ "$output" = "sandbox-branch" ]
+}
+
+# ---------------------------------------------------------------------------
+# Worktree isolation: primary checkout must not be edited by the gate
+# ---------------------------------------------------------------------------
+
+@test "primary checkout stays clean (gate ran QA in a worktree, not here)" {
+    cd "$PRIMARY"
+    seed_mode
+    add_qa_config
+    make_qa_stub PASS
+    run bash "$GATE"
+    [ "$status" -eq 0 ]
+    # The only artifact written in the primary checkout is the gate JSON +
+    # the seeded mode/config. The stub's qa-verdict.json must land in the
+    # worktree, NOT in the primary .autospec/. Assert no qa-verdict.json here.
+    [ ! -f "$PRIMARY/.autospec/qa-verdict.json" ]
+}
+
+# ---------------------------------------------------------------------------
+# Output validates against the schema
+# ---------------------------------------------------------------------------
+
+@test "explore-qa-gate.json validates against schema (ajv if available)" {
+    cd "$PRIMARY"
+    seed_mode
+    add_qa_config
+    make_qa_stub PASS
+    run bash "$GATE"
+    [ "$status" -eq 0 ]
+    if command -v ajv >/dev/null 2>&1; then
+        run ajv validate --spec=draft2020 -s "$SCHEMA" -d "$PRIMARY/.autospec/explore-qa-gate.json"
+        [ "$status" -eq 0 ]
+    else
+        # Minimal structural check: all required keys present.
+        run jq -e 'has("verdict") and has("sandbox_branch") and has("sandbox_head_sha") and has("qa_verdict_path") and has("blocking_findings") and has("ran_at")' \
+            "$PRIMARY/.autospec/explore-qa-gate.json"
+        [ "$status" -eq 0 ]
+    fi
+}


### PR DESCRIPTION
Closes #1113

Adds the explore-qa-gate runner (Issue A of the explore-qa-gate spec).

## What
- `scripts/explore-qa-gate.sh` — reads `.autospec/explore-mode.json` `{branch, head_sha}`, stands the sandbox HEAD up in a **fresh throwaway worktree** (never the primary checkout), runs `autospec-qa --no-heal` against it, and persists `.autospec/explore-qa-gate.json`.
- `schemas/autospec-explore-qa-gate.schema.json` — pinned artifact schema `{verdict: PASS|PARTIAL|FAIL|skipped|error, sandbox_branch, sandbox_head_sha, qa_verdict_path, blocking_findings, ran_at}`.
- `tests/explore/test_explore_qa_gate_runner.bats` — 12 cases, real shell, stub `autospec-qa` on PATH.

## Verdict semantics
- **No sandbox** (`explore-mode.json` absent) → `code_health:explore_qa_gate_no_sandbox`, exit 2 (operator error).
- **No QA config** (`.autospec/test.yml` / autospec-qa config) → **fail-open SKIP**: `verdict:"skipped"`, `code_health:explore_qa_gate_skipped_no_config`, exit 0 — a repo with no QA setup is not penalized.
- **Missing autospec-qa / QA crash / jq error** → **fail-closed** `verdict:"error"`, block (exit 1).
- **QA FAIL / PARTIAL** → block (exit 1); **PASS** → exit 0.
- Records `sandbox_head_sha` for staleness.

## Isolation & hygiene
- Worktree created via `worktree-guard.sh create --base <head_sha>` (refuses primary checkout / dirty reuse); inline cleanup on every exit path (no RETURN traps).
- bash 3.2 safe, `set -u`, if/then/fi, no `git add -A`.

## Out of scope (later issues)
Loop wiring (`--qa-gate` flags), validate.sh gate, trio docs, goldens.

## Verification
- `bash -n scripts/explore-qa-gate.sh` clean; `bats tests/explore/test_explore_qa_gate_runner.bats` → 12/12 pass.
- Full `bash scripts/validate.sh` → OK (pre-existing token-baseline WARN only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)