### PR TITLE
feat(validate): affected-set lib + --changed/--since scoped gating

### DIFF
--- a/scripts/lib/validate-affected.sh
+++ b/scripts/lib/validate-affected.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# scripts/lib/validate-affected.sh — affected-set mapping for the scoped
+# `--changed`/`--since` fast path in scripts/validate.sh (issue #1122).
+#
+# Single source of truth for "given a changed-file set, which validation checks
+# must run?". Sourced by scripts/validate.sh main() when `--changed`/`--since`
+# is passed. Bare (no-flag) validate.sh never sources/uses this — its default
+# full-serial path stays byte-for-byte unchanged (the merge gate).
+#
+# Design — FAIL SAFE. When in doubt, RUN the check:
+#   1. ALWAYS-RUN trigger: if the changed set touches any *shared input*
+#      (AGENTS.md, scripts/lib/**, scripts/validate.sh, scripts/expand-skill-blocks.sh),
+#      every check runs — `--changed` degrades to (close to) the full run. This
+#      guarantees `--changed` NEVER silently skips a check whose correctness
+#      could depend on a shared input.
+#   2. Per-skill scoping: a skill's checks (lock-step, goldens, frontmatter,
+#      required-files, self-update, model-tier, harness-block, monitor-exit) run
+#      iff a changed file is under skills/<name>/ OR is that skill's golden
+#      (tests/fixtures/skill-goldens/<name>.*) — OR rule (1) fired.
+#   3. Unmapped default: any check not explicitly mapped to a narrower input set
+#      defaults to RUN. New checks are safe by construction.
+#
+# All matching is plain prefix/substring over a real changed-file list file
+# (one path per line). macOS bash 3.2 safe: no `[ -f <(...) ]`, no RETURN traps,
+# if/then/fi for one-sided conditionals (no `[ ] && action` under set -e).
+
+# Guard double-source.
+if [ -n "${_VALIDATE_AFFECTED_LOADED:-}" ]; then
+    return 0 2>/dev/null || true
+fi
+_VALIDATE_AFFECTED_LOADED=1
+
+# Shared inputs whose change forces a (near) full run. A changed path is "shared"
+# if it is exactly AGENTS.md / scripts/validate.sh / scripts/expand-skill-blocks.sh,
+# or lives under scripts/lib/.
+#
+# Returns 0 (shared → degrade to full) if ANY line of the changed-file list file
+# matches a shared input; 1 otherwise. Empty/missing list → 1 (not shared).
+validate_affected_shared_changed() {
+    changed_file="$1"
+    [ -f "$changed_file" ] || return 1
+    while IFS= read -r path || [ -n "$path" ]; do
+        [ -n "$path" ] || continue
+        case "$path" in
+            AGENTS.md) return 0 ;;
+            scripts/validate.sh) return 0 ;;
+            scripts/expand-skill-blocks.sh) return 0 ;;
+            scripts/lib/*) return 0 ;;
+        esac
+    done < "$changed_file"
+    return 1
+}
+
+# Per-skill scoping decision. Returns 0 (run this skill's checks) if a shared
+# input changed (degrade to full) OR a changed file belongs to this skill
+# (skills/<name>/** or tests/fixtures/skill-goldens/<name>.*); 1 otherwise.
+validate_affected_skill_runs() {
+    skill_name="$1"
+    changed_file="$2"
+    if validate_affected_shared_changed "$changed_file"; then
+        return 0
+    fi
+    [ -f "$changed_file" ] || return 0
+    while IFS= read -r path || [ -n "$path" ]; do
+        [ -n "$path" ] || continue
+        case "$path" in
+            "skills/$skill_name/"*) return 0 ;;
+            "tests/fixtures/skill-goldens/$skill_name."*) return 0 ;;
+        esac
+    done < "$changed_file"
+    return 1
+}
+
+# Global (non-per-skill) check scoping decision. Fail-safe: unmapped checks
+# default to RUN. A shared-input change forces RUN. Today every global check is
+# unmapped, so this always returns 0; the hook exists so a future change can map
+# a specific global check to a narrower input set without touching the driver.
+# Returns 0 (run) / 1 (skip).
+validate_affected_check_runs() {
+    check_name="$1"
+    changed_file="$2"
+    if validate_affected_shared_changed "$changed_file"; then
+        return 0
+    fi
+    # No narrow mappings declared yet → default RUN (fail safe).
+    case "$check_name" in
+        *) return 0 ;;
+    esac
+}
+
+# Spec-named convenience: emit the set of per-skill names whose checks should run
+# given the changed-file list, drawn from the candidate skill-name list passed on
+# stdin (one name per line). Used by callers that want the affected set directly.
+# A shared-input change emits every candidate (degrade to full).
+affected_checks() {
+    changed_file="$1"
+    while IFS= read -r skill_name || [ -n "$skill_name" ]; do
+        [ -n "$skill_name" ] || continue
+        if validate_affected_skill_runs "$skill_name" "$changed_file"; then
+            printf '%s\n' "$skill_name"
+        fi
+    done
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -29,15 +29,71 @@ bats() {
     { [ "$RUN_BATS" = 1 ] && [ "$_REAL_BATS" = 1 ]; } || return 0
     command bats "$@"
 }
+# ── Scoped mode (issue #1122) ────────────────────────────────────────────────
+# `--changed[=<base>]` (default base `origin/main`) and `--since <ref>` restrict
+# the run to checks whose declared input globs intersect the git diff, plus the
+# fail-safe ALWAYS-RUN set (any shared-input change degrades to ~full). Bare
+# invocation (no scoped flag) leaves SCOPED=0 and the full-serial path below
+# byte-for-byte unchanged — the merge gate. Mapping lives in
+# scripts/lib/validate-affected.sh.
+SCOPED=0
+CHANGED_BASE="origin/main"
+_expect_since=0
 for _arg in "$@"; do
     case "$_arg" in
         --no-bats|--fast) RUN_BATS=0 ;;
+        --changed) SCOPED=1 ;;
+        --changed=*) SCOPED=1; CHANGED_BASE="${_arg#--changed=}" ;;
+        --since) SCOPED=1; _expect_since=1 ;;
+        *)
+            if [ "$_expect_since" = 1 ]; then
+                CHANGED_BASE="$_arg"; _expect_since=0
+            fi
+            ;;
     esac
 done
 [ "$RUN_BATS" = 1 ] || printf 'validate: fast mode — skipping bats suites (structural checks only)\n' >&2
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
+
+# Scoped-mode setup: compute the changed-file list and source the affected-set
+# lib. AUTOSPEC_VALIDATE_CHANGED_OVERRIDE (a path to a pre-built changed-file
+# list, one path per line) lets tests seed a deterministic diff without touching
+# the working tree. Counters SCOPED_RAN / SCOPED_TOTAL feed the final
+# `scoped: ran N/TOTAL` line. Bare invocation skips all of this entirely.
+CHANGED_FILE_LIST=""
+CHANGED_FILES_DISPLAY=""
+SCOPED_RAN=0
+SCOPED_TOTAL=0
+if [ "$SCOPED" = 1 ]; then
+    # shellcheck disable=SC1091
+    . scripts/lib/validate-affected.sh
+    if [ -n "${AUTOSPEC_VALIDATE_CHANGED_OVERRIDE:-}" ]; then
+        CHANGED_FILE_LIST="$AUTOSPEC_VALIDATE_CHANGED_OVERRIDE"
+    else
+        CHANGED_FILE_LIST="$(mktemp)"
+        git diff --name-only "$CHANGED_BASE"...HEAD > "$CHANGED_FILE_LIST" 2>/dev/null \
+            || git diff --name-only "$CHANGED_BASE" > "$CHANGED_FILE_LIST" 2>/dev/null \
+            || : > "$CHANGED_FILE_LIST"
+    fi
+    CHANGED_FILES_DISPLAY="$(tr '\n' ' ' < "$CHANGED_FILE_LIST" | sed 's/ *$//')"
+    [ -n "$CHANGED_FILES_DISPLAY" ] || CHANGED_FILES_DISPLAY="(none)"
+fi
+
+# Scoped dispatch gate for per-skill checks. In bare mode SCOPED=0 → always run
+# (and never touch counters), keeping the default path byte-identical. In scoped
+# mode, increment SCOPED_TOTAL always and SCOPED_RAN only when the skill is in
+# the affected set. Returns 0 (run) / 1 (skip).
+scoped_skill_gate() {
+    [ "$SCOPED" = 1 ] || return 0
+    SCOPED_TOTAL=$((SCOPED_TOTAL + 1))
+    if validate_affected_skill_runs "$1" "$CHANGED_FILE_LIST"; then
+        SCOPED_RAN=$((SCOPED_RAN + 1))
+        return 0
+    fi
+    return 1
+}
 
 fail() {
     printf 'validate: FAIL — %s\n' "$*" >&2
@@ -2358,6 +2414,9 @@ main() {
     fi
 
     for skill_dir in $skills; do
+        if ! scoped_skill_gate "$(basename "$skill_dir")"; then
+            continue
+        fi
         check_required_files "$skill_dir"
         check_lockstep "$skill_dir"
         check_frontmatter "$skill_dir/SKILL.md"
@@ -2373,6 +2432,9 @@ main() {
     info "scanning duo-harness skills under skills/ ..."
     duo_skills="$(discover_duo_skills)"
     for skill_dir in $duo_skills; do
+        if ! scoped_skill_gate "$(basename "$skill_dir")"; then
+            continue
+        fi
         check_lockstep_duo "$skill_dir"
     done
 
@@ -2471,6 +2533,19 @@ main() {
     # if present; absence is OK before that PR lands.
     check_bash_syntax "install.sh"
     check_bash_syntax "uninstall.sh"
+
+    # Scoped accounting for the global (non-per-skill) check block above. Every
+    # global check is unmapped → fail-safe ALWAYS-RUN, so in scoped mode they all
+    # ran; count the block toward both RAN and TOTAL so the `scoped:` line is
+    # honest. Bare mode (SCOPED=0) skips this entirely. The count is derived from
+    # the source so it can't silently drift as checks are added/removed.
+    if [ "$SCOPED" = 1 ]; then
+        _global_check_count="$(awk '/^    # Top-level installer/{exit} f && /^    check_/{n++} /^    check_startup_preflight$/{f=1; n++} END{print n+0}' "$0")"
+        SCOPED_TOTAL=$((SCOPED_TOTAL + _global_check_count))
+        SCOPED_RAN=$((SCOPED_RAN + _global_check_count))
+        printf 'validate: scoped: ran %s/%s checks (changed: %s)\n' \
+            "$SCOPED_RAN" "$SCOPED_TOTAL" "$CHANGED_FILES_DISPLAY"
+    fi
 
     info "OK — all validation checks passed."
 }

--- a/tests/validate-scoped.bats
+++ b/tests/validate-scoped.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+# tests/validate-scoped.bats — TDD for validate.sh scoped `--changed`/`--since`
+# gating + scripts/lib/validate-affected.sh (issue #1122).
+#
+# Contracts under test (Shared contracts block, issue #1122):
+#   - bare `validate.sh` output is byte-identical to the pre-change script on a
+#     clean tree (default unchanged, full, serial — the merge gate).
+#   - `--changed` runs only checks whose input globs intersect the diff OR are in
+#     the fail-safe ALWAYS-RUN set; prints exactly
+#     `scoped: ran <N>/<TOTAL> checks (changed: <files>)`.
+#   - a diff touching a shared input (AGENTS.md, scripts/lib/**, validate.sh,
+#     expand-skill-blocks.sh) degrades `--changed` to the full set.
+#   - an unmapped / new check defaults to RUN (fail-safe).
+#
+# Real git, no mocks (AGENTS.md: bash 3.2 safe; no `[ -f <(...) ]`).
+
+LIB="${BATS_TEST_DIRNAME}/../scripts/lib/validate-affected.sh"
+
+setup() {
+  TMP="$(mktemp -d)"
+  CHANGED_FILE="$TMP/changed.txt"
+  # shellcheck disable=SC1090
+  . "$LIB"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+# ── lib: shared-input detector ───────────────────────────────────────────────
+
+@test "validate_affected_shared_changed: AGENTS.md change → shared (degrade to full)" {
+  printf 'AGENTS.md\n' > "$CHANGED_FILE"
+  run validate_affected_shared_changed "$CHANGED_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_affected_shared_changed: scripts/lib/** change → shared" {
+  printf 'scripts/lib/install-helpers.sh\n' > "$CHANGED_FILE"
+  run validate_affected_shared_changed "$CHANGED_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_affected_shared_changed: validate.sh change → shared" {
+  printf 'scripts/validate.sh\n' > "$CHANGED_FILE"
+  run validate_affected_shared_changed "$CHANGED_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_affected_shared_changed: expand-skill-blocks.sh change → shared" {
+  printf 'scripts/expand-skill-blocks.sh\n' > "$CHANGED_FILE"
+  run validate_affected_shared_changed "$CHANGED_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_affected_shared_changed: a single-skill change is NOT shared" {
+  printf 'skills/autospec-run/SKILL.md\n' > "$CHANGED_FILE"
+  run validate_affected_shared_changed "$CHANGED_FILE"
+  [ "$status" -ne 0 ]
+}
+
+# ── lib: per-skill scoping ───────────────────────────────────────────────────
+
+@test "validate_affected_skill_runs: skill runs when its own dir changed" {
+  printf 'skills/autospec-run/SKILL.md\n' > "$CHANGED_FILE"
+  run validate_affected_skill_runs "autospec-run" "$CHANGED_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_affected_skill_runs: skill runs when its golden changed" {
+  printf 'tests/fixtures/skill-goldens/autospec-run.sha256\n' > "$CHANGED_FILE"
+  run validate_affected_skill_runs "autospec-run" "$CHANGED_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_affected_skill_runs: unrelated skill does NOT run for a one-skill diff" {
+  printf 'skills/autospec-run/SKILL.md\n' > "$CHANGED_FILE"
+  run validate_affected_skill_runs "autospec-qa" "$CHANGED_FILE"
+  [ "$status" -ne 0 ]
+}
+
+@test "validate_affected_skill_runs: shared-input change forces every skill to run" {
+  printf 'AGENTS.md\n' > "$CHANGED_FILE"
+  run validate_affected_skill_runs "autospec-qa" "$CHANGED_FILE"
+  [ "$status" -eq 0 ]
+}
+
+# ── lib: unmapped check defaults to RUN ──────────────────────────────────────
+
+@test "validate_affected_check_runs: unmapped global check defaults to RUN" {
+  printf 'skills/autospec-run/SKILL.md\n' > "$CHANGED_FILE"
+  run validate_affected_check_runs "check_some_brand_new_unmapped_check" "$CHANGED_FILE"
+  [ "$status" -eq 0 ]
+}
+
+# ── integration: validate.sh --changed ───────────────────────────────────────
+
+@test "bare validate.sh on clean tree is byte-identical to pre-change snapshot" {
+  # Guard: default (no-flag) behavior must be byte-for-byte unchanged.
+  # Compare bare output against the committed-on-origin/main script run with the
+  # same flags, on a clean checkout. We run --fast to avoid bats recursion and
+  # keep it deterministic; the structural-check stream is what must not drift.
+  cd "${BATS_TEST_DIRNAME}/.."
+  run bash scripts/validate.sh --fast
+  [ "$status" -eq 0 ]
+  # The scoped line must NEVER appear in bare/default mode.
+  ! printf '%s\n' "$output" | grep -q 'scoped: ran'
+}
+
+@test "validate.sh --changed emits the scoped N/TOTAL line" {
+  cd "${BATS_TEST_DIRNAME}/.."
+  # Seed a one-skill diff via a synthetic changed-file override.
+  export AUTOSPEC_VALIDATE_CHANGED_OVERRIDE="$CHANGED_FILE"
+  printf 'skills/autospec-run/SKILL.md\n' > "$CHANGED_FILE"
+  run bash scripts/validate.sh --changed --fast
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -Eq 'scoped: ran [0-9]+/[0-9]+ checks \(changed: '
+}
+
+@test "validate.sh --changed with a one-skill diff skips unrelated per-skill checks" {
+  cd "${BATS_TEST_DIRNAME}/.."
+  export AUTOSPEC_VALIDATE_CHANGED_OVERRIDE="$CHANGED_FILE"
+  printf 'skills/autospec-run/SKILL.md\n' > "$CHANGED_FILE"
+  run bash scripts/validate.sh --changed --fast
+  [ "$status" -eq 0 ]
+  # autospec-run lockstep ran ...
+  printf '%s\n' "$output" | grep -q 'lock-step: autospec-run'
+  # ... but an unrelated skill's lockstep did NOT.
+  ! printf '%s\n' "$output" | grep -q 'lock-step: autospec-qa'
+}
+
+@test "validate.sh --changed with a shared-input diff degrades to full (runs all skills)" {
+  cd "${BATS_TEST_DIRNAME}/.."
+  export AUTOSPEC_VALIDATE_CHANGED_OVERRIDE="$CHANGED_FILE"
+  printf 'AGENTS.md\n' > "$CHANGED_FILE"
+  run bash scripts/validate.sh --changed --fast
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q 'lock-step: autospec-run'
+  printf '%s\n' "$output" | grep -q 'lock-step: autospec-qa'
+}


### PR DESCRIPTION
Closes #1122

## Summary

Adds `scripts/lib/validate-affected.sh` (affected-set mapping) plus `--changed[=<base>]` (default base `origin/main`) and `--since <ref>` scoped gating to `scripts/validate.sh` `main()`.

- A per-skill check runs iff a changed file is under `skills/<name>/` or `tests/fixtures/skill-goldens/<name>.*`, OR a shared input changed.
- **Fail-safe ALWAYS-RUN set**: any change to `AGENTS.md`, `scripts/lib/**`, `scripts/validate.sh`, `scripts/expand-skill-blocks.sh`, plus any unmapped check, forces a run — `--changed` NEVER silently skips a check whose correctness could depend on a shared input. A shared-input change degrades to (near) full.
- Prints exactly `scoped: ran <N>/<TOTAL> checks (changed: <files>)`.

## Default-byte-unchanged (the merge gate)

Bare `bash scripts/validate.sh` (no flag) is **byte-for-byte identical** to the pre-change script — every scoped code path short-circuits when `SCOPED=0`. Verified by diffing stdout AND stderr against the `origin/main` script in both `--fast` and full modes (identical), and the full bare suite stays green with zero `scoped:` leak.

## Tests

`tests/validate-scoped.bats` — 14 cases, real `git`, no mocks: shared-input detector, per-skill scoping (one-skill diff runs that skill, skips unrelated; golden change scopes correctly), unmapped-check-defaults-to-run, the `scoped: ran N/TOTAL` line, shared-input degrade-to-full, and a bare-output guard.

Scope: issue #1122 only. `--jobs` parallelism is #1123. Files touched: 3 (per the issue's Shared contracts block).