### PR TITLE
fix(validate): Phase 5.5 audit — honest scoped count + real byte-identical guard (#1124)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -2650,9 +2650,13 @@ main() {
     # global check is unmapped → fail-safe ALWAYS-RUN, so in scoped mode they all
     # ran; count the block toward both RAN and TOTAL so the `scoped:` line is
     # honest. Bare mode (SCOPED=0) skips this entirely. The count is derived from
-    # the source so it can't silently drift as checks are added/removed.
+    # the source so it can't silently drift as checks are added/removed. The
+    # range spans every global `check_*` CALL from check_startup_preflight through
+    # the trailing check_bash_syntax install/uninstall calls (also always-run), so
+    # TOTAL is not understated by those two — it terminates at this accounting
+    # block, not before the installer checks.
     if [ "$SCOPED" = 1 ]; then
-        _global_check_count="$(awk '/^    # Top-level installer/{exit} f && /^    check_/{n++} /^    check_startup_preflight$/{f=1; n++} END{print n+0}' "$0")"
+        _global_check_count="$(awk '/^    # Scoped accounting/{exit} f && /^    check_/{n++} /^    check_startup_preflight$/{f=1; n++} END{print n+0}' "$0")"
         SCOPED_TOTAL=$((SCOPED_TOTAL + _global_check_count))
         SCOPED_RAN=$((SCOPED_RAN + _global_check_count))
         printf 'validate: scoped: ran %s/%s checks (changed: %s)\n' \

--- a/tests/validate-scoped.bats
+++ b/tests/validate-scoped.bats
@@ -96,15 +96,34 @@ teardown() {
 # ── integration: validate.sh --changed ───────────────────────────────────────
 
 @test "bare validate.sh on clean tree is byte-identical to pre-change snapshot" {
-  # Guard: default (no-flag) behavior must be byte-for-byte unchanged.
-  # Compare bare output against the committed-on-origin/main script run with the
-  # same flags, on a clean checkout. We run --fast to avoid bats recursion and
-  # keep it deterministic; the structural-check stream is what must not drift.
+  # Guard: default (no-flag) behavior must be byte-for-byte unchanged. We
+  # actually materialize the pre-feature script (the parent of the first commit
+  # that touched scripts/lib/validate-affected.sh — i.e. before --changed/--jobs
+  # landed) and diff its bare --fast output against the current script's. Any
+  # byte difference in the structural-check stream (stdout or stderr) fails. We
+  # use --fast to avoid bats recursion and keep the comparison deterministic.
   cd "${BATS_TEST_DIRNAME}/.."
-  run bash scripts/validate.sh --fast
-  [ "$status" -eq 0 ]
+  # First commit that introduced the affected-set lib; its parent is the
+  # pre-feature snapshot. If history is unavailable (shallow clone), skip.
+  feat_commit="$(git log --reverse --format=%H -- scripts/lib/validate-affected.sh 2>/dev/null | head -1)"
+  [ -n "$feat_commit" ] || skip "validate-affected.sh history unavailable"
+  pre_ref="${feat_commit}~1"
+  pre_script="$TMP/validate-pre.sh"
+  git show "${pre_ref}:scripts/validate.sh" > "$pre_script" 2>/dev/null \
+    || skip "pre-feature validate.sh unavailable at ${pre_ref}"
+  # Run the pre-feature script from the scripts/ dir context (it resolves
+  # REPO_ROOT via dirname "$0"/..), then the current one, and diff both streams.
+  cp "$pre_script" scripts/.validate-pre-snapshot.sh
+  pre_out="$(bash scripts/.validate-pre-snapshot.sh --fast 2>"$TMP/pre.err")"; pre_rc=$?
+  pre_err="$(cat "$TMP/pre.err")"
+  rm -f scripts/.validate-pre-snapshot.sh
+  cur_out="$(bash scripts/validate.sh --fast 2>"$TMP/cur.err")"; cur_rc=$?
+  cur_err="$(cat "$TMP/cur.err")"
+  [ "$pre_rc" -eq "$cur_rc" ]
+  [ "$pre_out" = "$cur_out" ]
+  [ "$pre_err" = "$cur_err" ]
   # The scoped line must NEVER appear in bare/default mode.
-  ! printf '%s\n' "$output" | grep -q 'scoped: ran'
+  ! printf '%s\n' "$cur_out" | grep -q 'scoped: ran'
 }
 
 @test "validate.sh --changed emits the scoped N/TOTAL line" {
@@ -115,6 +134,37 @@ teardown() {
   run bash scripts/validate.sh --changed --fast
   [ "$status" -eq 0 ]
   printf '%s\n' "$output" | grep -Eq 'scoped: ran [0-9]+/[0-9]+ checks \(changed: '
+}
+
+@test "validate.sh --changed global count includes the always-run installer syntax checks" {
+  # Regression (Phase 5.5 audit, issue #1124): the scoped global-check count must
+  # cover EVERY unconditionally-run global check, including the two trailing
+  # check_bash_syntax install.sh / uninstall.sh calls. An empty diff runs zero
+  # per-skill checks, so RAN == TOTAL == the global block size, and that size must
+  # equal the number of global `check_*` CALL lines actually executed in main()
+  # (no off-by-N undercount that makes the ratio look more-skipped than reality).
+  cd "${BATS_TEST_DIRNAME}/.."
+  export AUTOSPEC_VALIDATE_CHANGED_OVERRIDE="$CHANGED_FILE"
+  : > "$CHANGED_FILE"   # empty diff → no skill runs, only the always-run globals
+  run bash scripts/validate.sh --changed --fast
+  [ "$status" -eq 0 ]
+  scoped_line="$(printf '%s\n' "$output" | grep -o 'scoped: ran [0-9]*/[0-9]* checks')"
+  ran="$(printf '%s\n' "$scoped_line" | sed -E 's#scoped: ran ([0-9]+)/[0-9]+ checks#\1#')"
+  total="$(printf '%s\n' "$scoped_line" | sed -E 's#scoped: ran [0-9]+/([0-9]+) checks#\1#')"
+  # Empty diff: zero per-skill checks run, so RAN is exactly the always-run global
+  # block; the skipped skills still inflate TOTAL (that's the point of N/TOTAL),
+  # so RAN <= TOTAL here, not necessarily equal.
+  [ "$ran" -le "$total" ]
+  # RAN must match the literal count of global check_* CALL lines executed: the
+  # block from check_startup_preflight through the trailing check_bash_syntax
+  # install/uninstall calls (every one is always-run in scoped mode).
+  expected="$(awk '/^    # Scoped accounting/{exit} f && /^    check_/{n++} /^    check_startup_preflight$/{f=1; n++} END{print n+0}' scripts/validate.sh)"
+  [ "$ran" -eq "$expected" ]
+  # The two trailing installer syntax checks must be inside that count (guards the
+  # off-by-2 the audit found): the count strictly exceeds the block that stops at
+  # the "# Top-level installer" comment.
+  pre_installer="$(awk '/^    # Top-level installer/{exit} f && /^    check_/{n++} /^    check_startup_preflight$/{f=1; n++} END{print n+0}' scripts/validate.sh)"
+  [ "$expected" -eq "$((pre_installer + 2))" ]
 }
 
 @test "validate.sh --changed with a one-skill diff skips unrelated per-skill checks" {


### PR DESCRIPTION
Closes #1124

## Phase 5.5 broad-integration audit — validate scoped+parallel (#1126 `--changed`, #1127 `--jobs`)

Ran the flows end-to-end (adversarial diffs in real git state, all flag combos, full pre-vs-post byte comparison), not just a read.

### Verdict: zero high-severity merge-risk gaps. The feature is correct and fail-safe.

**Seam #1 — fail-safe scoping (the headline concern): SOLID.** Constructed adversarial diffs and confirmed each forces the dependent check to run, never silently skipped:
- Change to `AGENTS.md` / `scripts/lib/**` / `scripts/validate.sh` / `scripts/expand-skill-blocks.sh` → degrades to full (`114/114`).
- Change to a golden fixture without its skill → that skill's checks run.
- Change to a non-skill script (`scripts/qa-cluster-dispatch.sh`) or a `tests/` file → every one of the 91 global checks (all unconditionally ALWAYS-RUN in scoped mode) still runs.
- A brand-new unmapped check defaults to RUN.
- Verified every per-skill worker reads only `$skill_dir`-relative files, so per-skill scoping (the only thing ever skipped) can never drop an external dependency. **No input whose change is silently dropped exists.**

**Seam #2 — scoped+parallel composition: SOLID.** `--changed --jobs 16` operates on exactly the scoped set; same verdict as serial.

**Seam #3 — default byte-equivalence: SOLID.** Materialized the pre-feature `validate.sh` and diffed bare output: `--fast` stdout+stderr byte-identical, and the full-run `validate:` structural stream byte-identical pre-vs-post. The merge gate did not drift.

**Seam #4 — parallel determinism + isolation: SOLID.** `--jobs 16` × 5 repeats → identical sha256, exit 0 each (no flake). Unit-tested the worker pool: FIFO drain loses no PIDs, all failures counted, sorted output, no temp collision (each worker → own temp file). A worker crash / mid-check abort (any non-zero exit) is surfaced via `.failed` → `fail` → exit 1, not swallowed.

### Two minor hardening fixes (in-scope)

1. **`scoped: ran N/TOTAL` count was understated by 2.** The awk deriving the global-check block stopped at the `# Top-level installer` comment, excluding the two always-run `check_bash_syntax install.sh/uninstall.sh` calls. Moved the terminator to the scoped-accounting block → TOTAL now counts every unconditionally-run global check (91, was 89). Never over-reported run; never violated fail-safe; the ratio is now exact. (low severity)

2. **The "byte-identical to pre-change snapshot" test didn't actually compare.** It only asserted exit 0 + no `scoped:` line, leaving the acceptance criterion unenforced. Strengthened it to `git show` the pre-feature script and diff bare `--fast` stdout+stderr+exit byte-for-byte. Added a regression test asserting the global count includes the trailing installer syntax checks. (medium-low test-quality)

### Verification

- `bash scripts/validate.sh` → green (only the pre-existing token-baseline WARN, present identically in the pre-feature baseline).
- `tests/validate-scoped.bats` → 15/15 green (incl. new regression + strengthened guard).
- `tests/validate-parallel.bats` → 22/22 green (unchanged).

No follow-up issues filed — no larger gaps found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)