### PR TITLE
docs(spec): trio derivation + prompt-cache reclaim (efficiency waves 2-3)

### DIFF
--- a/docs/specs/2026-06-16-prompt-cache-reclaim-design.md
+++ b/docs/specs/2026-06-16-prompt-cache-reclaim-design.md
@@ -1,0 +1,125 @@
+# Prompt-cache reclaim (reviewer slim + v2 cache + redundant-pass trims)
+
+## Summary
+
+The 2026-06-03 cost-efficiency spec (D3) slimmed and cache-stabilized the
+**implementer** prompt prefix, but the same disease was left untreated on every
+other LLM dispatch path. Concretely:
+
+- The **reviewer** prefix still injects the entire ~14 k-token `autospec-run/SKILL.md`
+  (almost all monitor-loop bash a reviewer never runs) + full ~6 k-token AGENTS.md
+  + a duplicate RULE_ID re-extraction, all inside ONE non-byte-stable
+  `<!-- CACHE BOUNDARY -->` → it misses the prompt cache every inner-loop iteration
+  (≤3/issue). ~30–45 k wasted tokens per review-heavy issue.
+- The **v2-flow implementer** (`phase4-implementer.md`, the documented default
+  path) does NOT route through the cache prefix at all — it re-reads issue body +
+  AGENTS.md/RULE_IDs in-context, so the shipped D3 benefit is unrealized on the
+  path that actually runs.
+- **Phase 3.75** shared-contracts is a full Tier-A pass whose steps 1–2 are
+  mechanical signature/path/name scans.
+- **Phase 5.5** round ≥2 re-audits the entire batch window, not just the new gap PRs.
+- Duplicate RULE_ID re-extraction also rides the decomposer/classifier paths;
+  tag-filtered memory injection has no per-dispatch cap.
+
+This spec reclaims those tokens — extending the existing cost specs to the roles
+and code paths they did not reach.
+
+## Concurrency phasing (REQUIRED)
+
+- **Phase 1 (ship now — non-contended shared scripts only):** the reviewer
+  prefix slim + cache stabilization (`bundle-static-context.sh`,
+  `gen-reviewer-prompt.sh`, a new `reviewer-contract.md` mirror of
+  `implementer-contract.md`), the duplicate-RULE_ID trim, and the memory-injection
+  cap. None of these touch the `autospec-run`/`autospec-define` trios.
+- **Phase 2 (DEFERRED until the queue is clear of concurrent run/define-trio
+  edits):** the v2-flow cache wiring (edits `phase4-implementer.md` +
+  `autospec-run` trio), Phase 3.75 deterministic-extract (edits `autospec-define`),
+  Phase 5.5 round-≥2 scoping (edits `autospec-run` trio). Filed
+  `deferred:concurrency` (NOT `auto-implement`).
+
+## Team personality
+- **Selected team:** Reliability/backend — backend dev, perf engineer, test engineer.
+- **Carry into child issues:** prove savings with a token before/after, not just
+  prose; the cache prefix must be BYTE-STABLE across dispatches (per-issue dynamic
+  content goes BELOW the `<!-- CACHE BOUNDARY -->`); no behavior change to review
+  verdicts — only prompt-assembly cost.
+
+## Review counter-team
+- **Selected counter-team:** Correctness + review-quality.
+- **Challenge:** does slimming the reviewer prefix drop context the reviewer
+  actually needs (a RULE_ID, an AGENTS.md rule it must enforce)? Does the
+  memory cap drop a feedback file that would have caught a bug? Is the cache
+  boundary truly stable, or does a stray per-issue token still bust it?
+
+## Architecture (Phase 1)
+
+```
+skills/autospec-shared/scripts/bundle-static-context.sh
+  reviewer role  ──► emit a SLIM, BYTE-STABLE cached prefix:
+     reviewer-contract.md (guardian rubric + RULE_ID table, static)
+   + the small subset of AGENTS.md a reviewer enforces
+   — NOT the full autospec-run/SKILL.md, NOT a duplicate RULE_ID block
+   per-issue memory + the diff move BELOW the <!-- CACHE BOUNDARY -->
+  decomposer/classifier roles ──► drop the duplicate RULE_ID re-extraction
+  all roles ──► cap injected memory to the top-K most-specific tag matches
+                (AUTOSPEC_MAX_MEMORY_FILES, default e.g. 6)
+
+skills/autospec-run/prompts/reviewer-contract.md   (NEW — mirrors implementer-contract.md)
+```
+
+## Phase 2 (deferred) design — captured, not shipped yet
+
+- **v2 cache wiring:** prepend the `gen-implementer-prompt.sh` cached prefix to
+  the `phase4-implementer.md` body (or have the orchestrator assemble it), so the
+  default v2 path realizes the D3 prefix-slim + cache.
+- **Phase 3.75 deterministic-extract:** a `extract-shared-contracts.sh` scanner
+  greps signatures/paths/names across issue bodies; a narrowed Tier-B call only
+  reconciles conflicts — or fold the synthesis into the decomposer's existing
+  context (it already holds all bodies), eliminating the standalone Tier-A pass.
+- **Phase 5.5 round-≥2 scoping:** scope the broad-review `--since` window on
+  round ≥2 to only the newly-filed gap PRs (round 1 stays full — preserves the
+  per-PR-LGTM-misses-integration value).
+
+## Testing (Phase 1)
+- `tests/bundle-static-context-reviewer.bats` (extend) — the reviewer prefix no
+  longer contains the monitor-loop bash / full SKILL.md; contains the
+  reviewer-contract rubric + RULE_ID table exactly once; per-issue memory + diff
+  are BELOW the cache boundary; the prefix is byte-identical across two dispatches
+  with different issue bodies (cache-stable).
+- A token-count assertion: reviewer prefix tokens drop from ~20 k toward ~5 k on
+  the fixture.
+- Memory-cap test: with many tag matches, ≤ `AUTOSPEC_MAX_MEMORY_FILES` files injected.
+
+## Acceptance (Phase 1 only)
+- [ ] `skills/autospec-run/prompts/reviewer-contract.md` ships (static guardian
+      rubric + RULE_ID table), mirroring `implementer-contract.md`.
+- [ ] `bundle-static-context.sh` reviewer role emits the slim, byte-stable cached
+      prefix (no full `autospec-run/SKILL.md`, no duplicate RULE_ID block);
+      per-issue memory + diff move below the cache boundary.
+- [ ] Duplicate RULE_ID re-extraction dropped on reviewer/decomposer/classifier
+      roles; memory injection capped at `AUTOSPEC_MAX_MEMORY_FILES`.
+- [ ] Reviewer prefix token count drops ≥50% on the fixture; prefix byte-stable
+      across two differing-issue dispatches.
+- [ ] No `autospec-run`/`autospec-define` trio file edited in Phase 1.
+- [ ] `bash scripts/validate.sh` green; reviewer/bundle bats pass.
+
+## Decomposition into child issues
+
+**Phase 1 (file as `auto-implement`, drain now):** 2 children + umbrella.
+1. **A — reviewer prefix slim + cache stabilization**: `reviewer-contract.md` +
+   `bundle-static-context.sh` reviewer role + `gen-reviewer-prompt.sh` + the
+   reviewer bats. Files: 3.
+2. **B — duplicate-RULE_ID trim + memory-injection cap** in
+   `bundle-static-context.sh` (decomposer/classifier/reviewer) + a cap test.
+   Depends A (same file). Files: 2.
+
+**Phase 2 (file as `deferred:concurrency`, do NOT drain):**
+3. C — v2-flow cache wiring (`phase4-implementer.md` + `autospec-run` trio).
+4. D — Phase 3.75 deterministic-extract (`autospec-define`).
+5. E — Phase 5.5 round-≥2 scoping (`autospec-run` trio).
+
+Plus a Phase 5.5 audit child for Phase 1.
+
+## Out of scope
+- Changing review verdict logic or the fused guardian+LGTM structure (D4 keeps it).
+- Re-deriving the implementer prefix (D3 already shipped it).

--- a/docs/specs/2026-06-16-trio-derivation-design.md
+++ b/docs/specs/2026-06-16-trio-derivation-design.md
@@ -1,0 +1,117 @@
+# Trio single-source derivation (`derive-trio.sh`)
+
+## Summary
+
+A multi-harness skill is three files — `SKILL.md` (authoritative), `codex/prompt.md`,
+`opencode/agent.md` — kept **byte-identical in the body** by hand. `codex/prompt.md`
+is just the SKILL.md body with frontmatter stripped; `opencode/agent.md` is the body
+with a frontmatter swap. They are pure mechanical transforms, yet they are
+hand-copied and re-hashed, which is the single biggest source of new-feature
+friction: the `autospec-run` trio alone is ~245 KB / ~61 k tokens of ~98% identical
+prose, ~30 of `validate.sh`'s checks exist only to police the copies, and the
+2026-06-16 run tripped `check_lockstep` and had to recombine prose+golden splits 3×.
+
+This spec introduces **`scripts/derive-trio.sh`** — generate `codex/prompt.md` and
+`opencode/agent.md` deterministically from `SKILL.md` — plus a skill-golden
+auto-regenerator, so the trio collapses to one source of truth and a derive step.
+
+## Concurrency phasing (REQUIRED — high blast radius)
+
+This change touches the maintenance model of **every** trio skill (~20). To avoid
+stomping concurrent sessions editing skill trios, it ships in two phases:
+
+- **Phase 1 (ship now — non-contended):** the standalone tools only — new files,
+  no existing-trio edits. `scripts/derive-trio.sh`, `scripts/gen-skill-goldens.sh`,
+  and their bats. Nothing migrates; the tools are opt-in.
+- **Phase 2 (DEFERRED until the queue is clear of concurrent trio edits):** wire
+  `derive-trio` into the decompose/validate flow, add the decomposer atomic-unit
+  exemption (edits `autospec-define`), and migrate the ~20 trios to be
+  generated. Tracked here; filed with a `deferred:concurrency` label (NOT
+  `auto-implement`) so no drainer picks them up until the operator promotes them.
+
+## Team personality
+- **Selected team:** Tooling/build — build engineer, maintainer, test engineer.
+- **Carry into child issues:** the derive transform must be EXACT (codex = body
+  frontmatter-stripped; opencode = body + opencode frontmatter); idempotent
+  (`derive-trio --check` exits non-zero iff a trio is out of sync, zero edits);
+  Phase 1 adds NO edits to any existing trio.
+
+## Review counter-team
+- **Selected counter-team:** Correctness + migration safety.
+- **Challenge:** does the generated codex/opencode byte-match the current
+  hand-maintained files for EVERY skill (else migration is a mass diff)? Does
+  `--check` exactly reproduce what `check_lockstep` enforces? Could a
+  frontmatter edge case (multi-doc, CRLF, trailing newline) corrupt a mirror?
+
+## Architecture
+
+```
+scripts/derive-trio.sh <skill-dir> [--in-place | --check | --stdout <member>]
+  SKILL.md ──strip frontmatter────────────────► codex/prompt.md
+           └─strip body + swap to opencode FM──► opencode/agent.md
+  --check : derive in-memory, diff vs the committed mirrors; exit 0 if identical,
+            non-zero + diff if drift (the deterministic equivalent of check_lockstep)
+
+scripts/gen-skill-goldens.sh [<skill>...]
+  for each markered trio member: expand-skill-blocks.sh <m> | shasum -a 256
+    > tests/fixtures/skill-goldens/<skill>.<suffix>.sha256
+  (the one-liner currently living only in feedback_skill_golden_derivation_workflow.md)
+```
+
+`derive-trio.sh` reuses the literal-substitution discipline already proven by
+`scripts/expand-skill-blocks.sh`. The opencode frontmatter delta is the only
+non-strip transform — capture it as a small declared template, not ad-hoc seds.
+
+## Phase 2 (deferred) design — captured, not shipped yet
+
+- **Validate integration:** `check_lockstep` becomes (or is backed by)
+  `derive-trio --check` so drift is reported as "run `derive-trio --in-place`",
+  and `check_block_expansion` is fed by `gen-skill-goldens.sh`.
+- **Decomposer atomic-unit exemption:** `autospec-define` Phase 3 + `sizing-check.sh`
+  treat a trio's members + their derived goldens as ONE logical change (the
+  ≤3-files cap stops forcing prose/golden splits — the recurring recombine tax,
+  per `feedback_decompose_trio_prose_goldens_atomic.md`). Once derive-trio is the
+  source of truth, an edit is "edit SKILL.md + run derive + regen goldens",
+  which the implementer can do in one commit.
+- **Migration:** for each of the ~20 trios, assert `derive-trio --check` already
+  passes (proving the generator matches the hand-maintained file), then mark the
+  skill as derive-managed. No prose changes — just adopting the generator.
+
+## Testing (Phase 1)
+- `tests/derive-trio.bats` — for a fixture skill, `--stdout codex` == the body
+  with frontmatter stripped; `--stdout opencode` == body + opencode frontmatter;
+  `--check` exits 0 when in sync, non-zero + diff when the mirror is edited;
+  `--in-place` writes both mirrors and is idempotent; **`--check` passes for
+  EVERY current `skills/*/` trio** (proves the generator already matches today's
+  hand-maintained mirrors — the migration-safety guard).
+- `tests/gen-skill-goldens.bats` — regenerates the sha256 for a markered skill
+  matching `check_block_expansion`; no-op when already current.
+
+## Acceptance (Phase 1 only)
+- [ ] `scripts/derive-trio.sh` ships with `--in-place`/`--check`/`--stdout <member>`;
+      exact codex (frontmatter-stripped) + opencode (frontmatter-swapped) transforms.
+- [ ] `scripts/gen-skill-goldens.sh` regenerates skill-golden sha256s matching
+      `check_block_expansion`'s expander.
+- [ ] `tests/derive-trio.bats` asserts `--check` passes for EVERY existing
+      `skills/*/` trio (generator already byte-matches today's mirrors).
+- [ ] `tests/gen-skill-goldens.bats` passes; `bash scripts/validate.sh` green.
+- [ ] NO existing trio file, `validate.sh`, or `autospec-define` is edited in
+      Phase 1 (deferred to Phase 2).
+
+## Decomposition into child issues
+
+**Phase 1 (file as `auto-implement`, drain now):** 2 children + umbrella.
+1. **A — `derive-trio.sh`** + `tests/derive-trio.bats` (incl. the all-trios
+   `--check` guard). Files: 2.
+2. **B — `gen-skill-goldens.sh`** + `tests/gen-skill-goldens.bats`. Files: 2.
+
+**Phase 2 (file as `deferred:concurrency`, do NOT drain until queue clear):**
+3. C — validate integration (`check_lockstep` via `derive-trio --check`).
+4. D — decomposer atomic-unit exemption (`autospec-define` + `sizing-check.sh`).
+5. E — migrate the ~20 trios to derive-managed.
+
+Plus a Phase 5.5 audit child for Phase 1.
+
+## Out of scope
+- Generating `SKILL.md` itself (it stays the authoritative human-authored source).
+- Non-trio skills.


### PR DESCRIPTION
Two efficiency design specs from the 2026-06-16 /autospec-explore analysis. Each is **phased for concurrency safety**: Phase 1 (non-contended new tools / shared-script edits) ships now; Phase 2 (the ~20-trio migration + autospec-run/define trio edits) is deferred until the concurrent harmonize/autodoc explore run drains. Doc-only.