### PR TITLE
feat(autospec-doc): populate .llm-manifest.json with real symbol data

### DIFF
--- a/skills/autospec-doc/scripts/gen-llms-full.mjs
+++ b/skills/autospec-doc/scripts/gen-llms-full.mjs
@@ -118,22 +118,48 @@ export function generateLlmsFull({ pages = [] } = {}) {
 }
 
 /**
- * Fill modules, concepts, and faq in a manifest object from page content.
- * Non-destructive: existing entries are kept; duplicates skipped.
+ * Approximate token count for a string using the 4-chars/token heuristic.
+ * @param {string} text
+ * @returns {number}
+ */
+function approxTokens(text) {
+  return Math.max(1, Math.round((text || '').length / 4));
+}
+
+/**
+ * Fill modules, concepts, cli_entry_points, and faq in a manifest object from
+ * page content.  Non-destructive: existing entries are kept; duplicates skipped.
  *
  * Extraction rules:
- *   modules  — one entry per page, path = page.path, summary = first H1 heading
- *   concepts — <!-- autospec-concept: <name> --> markers; next non-empty line = definition
- *   faq      — ### Q: <question> / next non-empty line = answer
+ *   modules          — one entry per page; name = H1 text; summary = first
+ *                      non-heading paragraph line; public_api = backtick
+ *                      command/function tokens on lines inside ## CLI / ## API
+ *                      sections; doc = page.path; source_anchor = "<path>#L1";
+ *                      approx_tokens = chars/4 heuristic on full page content.
+ *   cli_entry_points — slash-command tokens (`/word-word`) found anywhere in
+ *                      the page, deduplicated.
+ *   concepts         — <!-- autospec-concept: <name> --> markers; next
+ *                      non-empty line = definition; source_anchor = line ref;
+ *                      approx_tokens = definition char/4; literal "<name>"
+ *                      placeholder is ALWAYS skipped.
+ *   faq              — ### Q: <question> / next non-empty line = answer.
  *
- * @param {object} manifest - object with modules, concepts, faq arrays (mutated in place)
+ * @param {object} manifest - object with modules, cli_entry_points, concepts,
+ *                            faq arrays (mutated in place)
  * @param {Array<{ path: string, content: string }>} pages
  * @returns {void}
  */
 export function fillManifest(manifest, pages = []) {
-  const existingModPaths   = new Set((manifest.modules  || []).map(m => m.path));
-  const existingConceptNames = new Set((manifest.concepts || []).map(c => c.name));
-  const existingFaqQs      = new Set((manifest.faq      || []).map(f => f.question));
+  if (!Array.isArray(manifest.modules))         manifest.modules = [];
+  if (!Array.isArray(manifest.cli_entry_points)) manifest.cli_entry_points = [];
+  if (!Array.isArray(manifest.concepts))         manifest.concepts = [];
+  if (!Array.isArray(manifest.faq))              manifest.faq = [];
+
+  const existingModPaths     = new Set(manifest.modules.map(m => m.path || m.doc));
+  const existingConceptNames = new Set(manifest.concepts.map(c => c.name));
+  const existingFaqQs        = new Set(manifest.faq.map(f => f.question));
+  const existingCliCmds      = new Set(manifest.cli_entry_points.map(e =>
+    typeof e === 'string' ? e : e.command));
 
   for (const page of pages) {
     const content = page.content || '';
@@ -141,10 +167,60 @@ export function fillManifest(manifest, pages = []) {
 
     // ── modules: one entry per page keyed by path ────────────────────────────
     if (!existingModPaths.has(page.path)) {
-      const h1 = lines.find(l => /^#\s+/.test(l));
-      const summary = h1 ? h1.replace(/^#+\s+/, '').trim() : path.basename(page.path, '.md');
-      manifest.modules.push({ path: page.path, summary, public_api: [], depends_on: [] });
+      // name = first H1 text (strip leading #s)
+      const h1Line  = lines.find(l => /^#\s+/.test(l));
+      const name    = h1Line ? h1Line.replace(/^#+\s+/, '').trim()
+                             : path.basename(page.path, '.md');
+
+      // summary = first non-empty, non-heading line after the H1
+      let summary = name;
+      let pastH1 = !h1Line; // if no H1, start scanning from line 0
+      for (const ln of lines) {
+        if (!pastH1) { if (/^#\s+/.test(ln)) { pastH1 = true; } continue; }
+        const t = ln.trim();
+        if (t && !/^#+\s/.test(t) && !t.startsWith('<!--')) {
+          summary = t;
+          break;
+        }
+      }
+
+      // public_api = backtick tokens from ## CLI / ## API sub-sections
+      const public_api = [];
+      let inApiSection = false;
+      for (const ln of lines) {
+        if (/^##\s+(CLI|API|Public API|Commands)/i.test(ln)) {
+          inApiSection = true;
+          continue;
+        }
+        if (/^##\s+/.test(ln)) { inApiSection = false; continue; }
+        if (!inApiSection) continue;
+        // extract all `token` spans
+        const ticks = [...ln.matchAll(/`([^`]+)`/g)].map(m2 => m2[1]);
+        for (const tok of ticks) {
+          if (!public_api.includes(tok)) public_api.push(tok);
+        }
+      }
+
+      manifest.modules.push({
+        name,
+        summary,
+        public_api,
+        doc:           page.path,
+        path:          page.path,
+        source_anchor: `${page.path}#L1`,
+        approx_tokens: approxTokens(content),
+      });
       existingModPaths.add(page.path);
+    }
+
+    // ── cli_entry_points: /slash-command tokens anywhere in page ─────────────
+    const slashCmds = [...content.matchAll(/`(\/[\w-]+(?:\s+[\w-]+)?)`/g)]
+      .map(m2 => m2[1]);
+    for (const cmd of slashCmds) {
+      if (!existingCliCmds.has(cmd)) {
+        manifest.cli_entry_points.push(cmd);
+        existingCliCmds.add(cmd);
+      }
     }
 
     // ── concepts: <!-- autospec-concept: <name> --> ──────────────────────────
@@ -152,6 +228,8 @@ export function fillManifest(manifest, pages = []) {
       const m = lines[i].match(/<!--\s*autospec-concept:\s*(.+?)\s*-->/);
       if (!m) continue;
       const name = m[1].trim();
+      // Skip the literal template placeholder "<name>"
+      if (name === '<name>') continue;
       if (existingConceptNames.has(name)) continue;
       // Definition is the next non-empty line after the marker.
       let definition = '';
@@ -159,7 +237,12 @@ export function fillManifest(manifest, pages = []) {
         const def = lines[j].trim();
         if (def) { definition = def; break; }
       }
-      manifest.concepts.push({ name, definition, source_anchor: `${page.path}#L${i + 1}` });
+      manifest.concepts.push({
+        name,
+        definition,
+        source_anchor: `${page.path}#L${i + 1}`,
+        approx_tokens: approxTokens(definition),
+      });
       existingConceptNames.add(name);
     }
 

--- a/skills/autospec-doc/tests/gen-llms-full.test.mjs
+++ b/skills/autospec-doc/tests/gen-llms-full.test.mjs
@@ -242,3 +242,123 @@ test('chunk markers include a boundary token count annotation', () => {
   const chunkNum = parseInt(markerMatch[1], 10);
   assert.ok(chunkNum >= 1, 'chunk number must be >= 1');
 });
+
+// ── Track B new tests (issue #1130) ───────────────────────────────────────────
+
+// Fixture corpus for Track B: contains an H1, a cli marker, and a concept marker
+const TRACK_B_PAGES = [
+  {
+    audience: 'developer',
+    feature: 'autospec-run',
+    path: 'docs/developer/features/autospec-run.md',
+    content: [
+      '# autospec-run',
+      '',
+      'The main entry point for running the autospec pipeline.',
+      '',
+      '<!-- autospec-concept: lock-step rule -->',
+      'Every phase-1 change locks all related trios simultaneously.',
+      '',
+      '<!-- autospec-concept: worktree isolation -->',
+      'Each implementation runs in an isolated git worktree.',
+      '',
+      '## CLI',
+      '`/autospec-run` — run the implementation loop',
+    ].join('\n'),
+  },
+  {
+    audience: 'developer',
+    feature: 'autospec-define',
+    path: 'docs/developer/features/autospec-define.md',
+    content: [
+      '# autospec-define',
+      '',
+      'Plan a feature and decompose into GitHub issues.',
+    ].join('\n'),
+  },
+];
+
+// ── Test 13: modules[] carry name, summary, source_anchor, approx_tokens ──────
+
+test('fillManifest: modules carry name, source_anchor, and approx_tokens', () => {
+  const manifest = { modules: [], cli_entry_points: [], http_endpoints: [], concepts: [], faq: [] };
+  fillManifest(manifest, TRACK_B_PAGES);
+  assert.ok(manifest.modules.length > 0, 'modules must be non-empty');
+  for (const mod of manifest.modules) {
+    assert.ok(typeof mod.name === 'string' && mod.name.length > 0,
+      `module must have name field; got ${JSON.stringify(mod)}`);
+    assert.ok(typeof mod.summary === 'string' && mod.summary.length > 0,
+      `module must have summary; got ${JSON.stringify(mod)}`);
+    assert.ok(typeof mod.source_anchor === 'string' && mod.source_anchor.includes('#L'),
+      `module must have source_anchor with #L; got ${JSON.stringify(mod)}`);
+    assert.ok(typeof mod.approx_tokens === 'number' && mod.approx_tokens > 0,
+      `module must have approx_tokens > 0; got ${JSON.stringify(mod)}`);
+    assert.ok(Array.isArray(mod.public_api),
+      `module must have public_api array; got ${JSON.stringify(mod)}`);
+    assert.ok(typeof mod.doc === 'string',
+      `module must have doc field; got ${JSON.stringify(mod)}`);
+  }
+});
+
+// ── Test 14: concepts[] carry source_anchor and approx_tokens ─────────────────
+
+test('fillManifest: concepts carry source_anchor and approx_tokens', () => {
+  const manifest = { modules: [], cli_entry_points: [], http_endpoints: [], concepts: [], faq: [] };
+  fillManifest(manifest, TRACK_B_PAGES);
+  assert.ok(manifest.concepts.length >= 2, 'expected at least 2 concepts from fixture');
+  for (const concept of manifest.concepts) {
+    assert.ok(typeof concept.source_anchor === 'string' && concept.source_anchor.includes('#L'),
+      `concept must have source_anchor with #L; got ${JSON.stringify(concept)}`);
+    assert.ok(typeof concept.approx_tokens === 'number' && concept.approx_tokens > 0,
+      `concept must have approx_tokens > 0; got ${JSON.stringify(concept)}`);
+  }
+});
+
+// ── Test 15: no literal <name> placeholder in manifest output ──────────────────
+
+test('fillManifest: no literal <name> placeholder survives in any field', () => {
+  // Inject a page that contains the literal placeholder string in a concept marker
+  const pagesWithPlaceholder = [
+    ...TRACK_B_PAGES,
+    {
+      audience: 'developer',
+      feature: 'bad',
+      path: 'docs/developer/features/bad.md',
+      content: '# Bad page\n\n<!-- autospec-concept: <name> -->\nShould be skipped.\n',
+    },
+  ];
+  const manifest = { modules: [], cli_entry_points: [], http_endpoints: [], concepts: [], faq: [] };
+  fillManifest(manifest, pagesWithPlaceholder);
+  const conceptNames = manifest.concepts.map(c => c.name);
+  assert.ok(!conceptNames.includes('<name>'),
+    `literal <name> placeholder must not appear in concepts; got ${JSON.stringify(conceptNames)}`);
+  // Also check no field in manifest JSON contains literal <name>
+  const json = JSON.stringify(manifest);
+  assert.ok(!json.includes('"<name>"'),
+    `literal "<name>" must not appear in manifest JSON; found: ${json.slice(0, 200)}`);
+});
+
+// ── Test 16: cli_entry_points[] non-empty when pages have CLI sections ─────────
+
+test('fillManifest: cli_entry_points extracted from pages', () => {
+  const manifest = { modules: [], cli_entry_points: [], http_endpoints: [], concepts: [], faq: [] };
+  fillManifest(manifest, TRACK_B_PAGES);
+  // TRACK_B_PAGES has a CLI section with `/autospec-run`; cli_entry_points should be populated
+  assert.ok(Array.isArray(manifest.cli_entry_points),
+    'cli_entry_points must be an array');
+  // The fixture has CLI content — at least one entry is expected
+  assert.ok(manifest.cli_entry_points.length > 0,
+    `cli_entry_points must be non-empty for pages with CLI sections; got ${JSON.stringify(manifest.cli_entry_points)}`);
+});
+
+// ── Test 17: fixture corpus produces zero placeholder strings ─────────────────
+
+test('fillManifest: fixture corpus produces non-empty modules and concepts, zero placeholders', () => {
+  const manifest = { modules: [], cli_entry_points: [], http_endpoints: [], concepts: [], faq: [] };
+  fillManifest(manifest, TRACK_B_PAGES);
+  assert.ok(manifest.modules.length > 0, 'modules must be non-empty');
+  assert.ok(manifest.concepts.length > 0, 'concepts must be non-empty');
+  const json = JSON.stringify(manifest);
+  assert.ok(!json.includes('<name>'),
+    `no <name> placeholder must survive; manifest JSON: ${json.slice(0, 300)}`);
+});


### PR DESCRIPTION
Closes #1130

Track B of epic #1128. Fills the manifest symbol map (modules/cli_entry_points/concepts) from the corpus + autospec-concept markers; zero placeholders.
Gate: `node --test skills/autospec-doc/tests/gen-llms-full.test.mjs` (17/17) + `bash scripts/validate.sh` (OK).