### PR TITLE
feat(tooling): derive-trio.sh + gen-skill-goldens.sh (trio-derivation Phase 1)

### DIFF
--- a/scripts/derive-trio.sh
+++ b/scripts/derive-trio.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# derive-trio.sh — single-source derivation of a multi-harness skill trio.
+#
+# A multi-harness skill is three files kept byte-identical in the BODY by hand:
+#   SKILL.md          authoritative source: YAML frontmatter + body
+#   codex/prompt.md   the SKILL.md body with frontmatter stripped (NO frontmatter)
+#   opencode/agent.md its OWN frontmatter + the SKILL.md body
+# Both mirrors are pure mechanical transforms of SKILL.md's body. This script
+# regenerates them deterministically so the trio collapses to one source of
+# truth (SKILL.md) plus a derive step.
+#
+# CRITICAL transform contract (must byte-match validate.sh's check_lockstep):
+#   * codex/prompt.md  == strip_body(SKILL.md)            — no frontmatter at all
+#   * opencode/agent.md == <opencode's existing frontmatter> + strip_body(SKILL.md)
+# where strip_body drops the YAML frontmatter (and any later `---` HR line) per
+# the repo convention: awk '/^---$/{c++; next} c>=2'. Only the BODY of each
+# mirror is regenerated; each mirror's existing frontmatter is preserved exactly
+# (codex has none; opencode keeps its own mode:/name:/description:).
+#
+# Usage:
+#   derive-trio.sh <skill-dir> --check          # diff derived vs committed; exit 0 if in sync, non-zero + diff on drift
+#   derive-trio.sh <skill-dir> --in-place       # write both mirrors (idempotent)
+#   derive-trio.sh <skill-dir> --stdout codex   # print derived codex/prompt.md to stdout
+#   derive-trio.sh <skill-dir> --stdout opencode # print derived opencode/agent.md to stdout
+#   derive-trio.sh -h | --help
+#
+# Exit codes:
+#   0  success / --check in sync
+#   1  --check drift (one or more mirrors diverge from the derived bytes)
+#   2  usage error (bad args, missing/unreadable trio member)
+#
+# Conventions: set -u (no -e — we branch on diff exits explicitly); if/then/fi
+# for one-sided conditionals; no RETURN traps (repo bash 3.2 gotchas).
+set -u
+
+PROG="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+$PROG — derive codex/prompt.md and opencode/agent.md from SKILL.md.
+
+Usage:
+  $PROG <skill-dir> --check            Diff derived mirrors vs committed; exit 0
+                                       if identical, 1 + unified diff on drift.
+  $PROG <skill-dir> --in-place         Rewrite both mirrors from SKILL.md (idempotent).
+  $PROG <skill-dir> --stdout <member>  Print a derived member (codex|opencode) to stdout.
+  $PROG -h | --help                    Show this help.
+
+Transform:
+  codex/prompt.md   = SKILL.md body with frontmatter stripped (no frontmatter).
+  opencode/agent.md = opencode's existing frontmatter + SKILL.md body.
+EOF
+}
+
+die() {  # die <code> <message>
+    code="$1"; shift
+    printf '%s: %s\n' "$PROG" "$*" >&2
+    exit "$code"
+}
+
+# Strip YAML frontmatter (and any later `---` HR separator) per repo convention,
+# matching validate.sh's strip_body exactly. The body is everything after the
+# second `---` line; every `---` line is itself dropped.
+strip_body() {  # strip_body <file>
+    awk '/^---$/{c++; next} c>=2' "$1"
+}
+
+# Emit the leading frontmatter block of a file: every line up to and INCLUDING
+# the second `---` line. For opencode/agent.md this is its own preserved
+# frontmatter. If the file has fewer than two `---` lines, emits nothing.
+front_matter() {  # front_matter <file>
+    awk '{print} /^---$/{c++; if(c==2) exit}' "$1"
+}
+
+# Build the derived bytes for a given member into stdout.
+#   derive_member codex    <skill-dir>  -> strip_body(SKILL.md)
+#   derive_member opencode <skill-dir>  -> opencode frontmatter + strip_body(SKILL.md)
+derive_member() {  # derive_member <member> <skill-dir>
+    member="$1"; dir="$2"
+    skill="$dir/SKILL.md"
+    [ -f "$skill" ] || die 2 "missing SKILL.md in $dir"
+    [ -r "$skill" ] || die 2 "unreadable SKILL.md in $dir"
+    case "$member" in
+        codex)
+            strip_body "$skill"
+            ;;
+        opencode)
+            oc="$dir/opencode/agent.md"
+            [ -f "$oc" ] || die 2 "missing opencode/agent.md in $dir"
+            [ -r "$oc" ] || die 2 "unreadable opencode/agent.md in $dir"
+            front_matter "$oc"
+            strip_body "$skill"
+            ;;
+        *)
+            die 2 "unknown member '$member' (expected: codex | opencode)"
+            ;;
+    esac
+}
+
+# Diff a derived member against its committed file. Echoes the relative path of a
+# drifting member to stdout (and a unified diff to stderr) on mismatch; nothing
+# on a match. Never exits — the caller accumulates drift.
+check_member() {  # check_member <member> <skill-dir> <committed-file>
+    member="$1"; dir="$2"; committed="$3"
+    [ -f "$committed" ] || die 2 "missing $committed"
+    tmp="$(mktemp "${TMPDIR:-/tmp}/derive-trio.XXXXXX")" || die 2 "cannot create temp file"
+    derive_member "$member" "$dir" > "$tmp"
+    if ! diff -u "$committed" "$tmp" >/dev/null 2>&1; then
+        diff -u "$committed" "$tmp" >&2
+        printf '%s\n' "$committed"
+    fi
+    rm -f "$tmp"
+}
+
+# Atomically write derived bytes to a target via temp+mv.
+write_member() {  # write_member <member> <skill-dir> <target-file>
+    member="$1"; dir="$2"; target="$3"
+    target_dir="$(dirname "$target")"
+    [ -d "$target_dir" ] || die 2 "missing directory $target_dir for $target"
+    tmp="$(mktemp "${TMPDIR:-/tmp}/derive-trio.XXXXXX")" || die 2 "cannot create temp file"
+    if derive_member "$member" "$dir" > "$tmp"; then
+        mv "$tmp" "$target"
+    else
+        rc=$?
+        rm -f "$tmp"
+        exit "$rc"
+    fi
+}
+
+main() {
+    skill_dir=""
+    mode=""
+    member=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help) usage; exit 0 ;;
+            --check)    mode="check"; shift ;;
+            --in-place) mode="in-place"; shift ;;
+            --stdout)
+                mode="stdout"
+                shift
+                [ $# -gt 0 ] || die 2 "--stdout requires a member argument (codex|opencode)"
+                member="$1"; shift ;;
+            --) shift; break ;;
+            -*) die 2 "unknown option: $1" ;;
+            *)
+                if [ -n "$skill_dir" ]; then die 2 "unexpected extra argument: $1"; fi
+                skill_dir="$1"; shift ;;
+        esac
+    done
+    if [ $# -gt 0 ]; then
+        if [ -n "$skill_dir" ]; then die 2 "unexpected extra argument: $1"; fi
+        skill_dir="$1"; shift
+        [ $# -eq 0 ] || die 2 "unexpected extra argument: $1"
+    fi
+
+    [ -n "$skill_dir" ] || { usage >&2; die 2 "missing <skill-dir> argument"; }
+    [ -n "$mode" ] || { usage >&2; die 2 "missing mode (--check | --in-place | --stdout <member>)"; }
+    skill_dir="${skill_dir%/}"
+    [ -d "$skill_dir" ] || die 2 "not a directory: $skill_dir"
+    [ -f "$skill_dir/SKILL.md" ] || die 2 "not a skill directory (no SKILL.md): $skill_dir"
+
+    case "$mode" in
+        stdout)
+            derive_member "$member" "$skill_dir"
+            ;;
+        check)
+            drift=""
+            d="$(check_member codex "$skill_dir" "$skill_dir/codex/prompt.md")"
+            drift="${drift}${d:+$d
+}"
+            if [ -f "$skill_dir/opencode/agent.md" ]; then
+                d="$(check_member opencode "$skill_dir" "$skill_dir/opencode/agent.md")"
+                drift="${drift}${d:+$d
+}"
+            fi
+            if [ -n "$drift" ]; then
+                printf '%s: drift — run `%s %s --in-place`:\n%s' \
+                    "$PROG" "$PROG" "$skill_dir" "$drift" >&2
+                exit 1
+            fi
+            ;;
+        in-place)
+            write_member codex "$skill_dir" "$skill_dir/codex/prompt.md"
+            if [ -f "$skill_dir/opencode/agent.md" ]; then
+                write_member opencode "$skill_dir" "$skill_dir/opencode/agent.md"
+            fi
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/gen-skill-goldens.sh
+++ b/scripts/gen-skill-goldens.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# gen-skill-goldens.sh — regenerate the block-expansion golden sha256 snapshots.
+#
+# validate.sh's check_block_expansion gate expands every markered trio member
+# through scripts/expand-skill-blocks.sh and compares its sha256 against a
+# committed golden at tests/fixtures/skill-goldens/<skill>.<suffix>.sha256
+# (suffix one of: SKILL.md | codex.prompt.md | opencode.agent.md). This script
+# regenerates those goldens with the exact same expander + hash one-liner:
+#
+#   expand-skill-blocks.sh <member> | shasum -a 256 | cut -d' ' -f1 \
+#     > tests/fixtures/skill-goldens/<skill>.<suffix>.sha256
+#
+# A golden is written for SKILL.md whenever the skill has one, and for the
+# codex/opencode mirrors only when they carry an autospec-block marker (matching
+# check_block_expansion's "markered member requires a golden" rule). Writes are
+# idempotent: a golden whose content already matches is left untouched, so a
+# no-op run produces no diff.
+#
+# Usage:
+#   gen-skill-goldens.sh                 # regenerate goldens for every skill
+#   gen-skill-goldens.sh <skill>...      # only the named skills (bare names)
+#   gen-skill-goldens.sh -h | --help
+#
+# Exit codes:
+#   0  success
+#   2  usage error / missing expander
+#   3  a named skill does not exist
+#
+# Conventions: set -u (no -e — explicit checks); if/then/fi for one-sided
+# conditionals; no RETURN traps (repo bash 3.2 gotchas).
+set -u
+
+PROG="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+EXPANDER="$REPO_ROOT/scripts/expand-skill-blocks.sh"
+GOLDEN_DIR="$REPO_ROOT/tests/fixtures/skill-goldens"
+
+usage() {
+    cat <<EOF
+$PROG — regenerate block-expansion golden sha256 snapshots.
+
+Usage:
+  $PROG                 Regenerate goldens for every skill under skills/.
+  $PROG <skill>...      Regenerate goldens only for the named skills.
+  $PROG -h | --help     Show this help.
+
+For each markered trio member it writes
+  tests/fixtures/skill-goldens/<skill>.<suffix>.sha256
+matching validate.sh's check_block_expansion. SKILL.md always gets a golden;
+codex/opencode mirrors get one only when they carry an autospec-block marker.
+Idempotent: an already-current golden is left untouched.
+EOF
+}
+
+die() {  # die <code> <message>
+    code="$1"; shift
+    printf '%s: %s\n' "$PROG" "$*" >&2
+    exit "$code"
+}
+
+# Whether a file carries an autospec-block marker (so check_block_expansion
+# requires a golden for it).
+has_marker() {  # has_marker <file>
+    grep -q '<!-- autospec-block:' "$1" 2>/dev/null
+}
+
+# Regenerate one golden if needed. Echoes a one-line status. The hash one-liner
+# is byte-for-byte the one check_block_expansion runs: shasum -a 256 | cut.
+gen_one() {  # gen_one <skill> <src-file> <suffix>
+    skill="$1"; src="$2"; suffix="$3"
+    [ -f "$src" ] || return 0
+    golden="$GOLDEN_DIR/${skill}.${suffix}.sha256"
+    new_hash="$(bash "$EXPANDER" "$src" | shasum -a 256 | cut -d' ' -f1)"
+    if [ -f "$golden" ]; then
+        old_hash="$(tr -d '[:space:]' < "$golden")"
+        if [ "$old_hash" = "$new_hash" ]; then
+            return 0  # already current — no write, no diff
+        fi
+    fi
+    printf '%s\n' "$new_hash" > "$golden"
+    printf '%s: wrote %s\n' "$PROG" "$golden"
+}
+
+# Regenerate every applicable golden for one skill directory.
+gen_skill() {  # gen_skill <skill-dir>
+    dir="${1%/}"
+    skill="$(basename "$dir")"
+    # SKILL.md: always gets a golden when present (check_block_expansion fails
+    # closed on a missing SKILL.md golden).
+    gen_one "$skill" "$dir/SKILL.md" "SKILL.md"
+    # codex/opencode mirrors: golden only when the member is markered.
+    if [ -f "$dir/codex/prompt.md" ] && has_marker "$dir/codex/prompt.md"; then
+        gen_one "$skill" "$dir/codex/prompt.md" "codex.prompt.md"
+    fi
+    if [ -f "$dir/opencode/agent.md" ] && has_marker "$dir/opencode/agent.md"; then
+        gen_one "$skill" "$dir/opencode/agent.md" "opencode.agent.md"
+    fi
+}
+
+main() {
+    names=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help) usage; exit 0 ;;
+            --) shift; break ;;
+            -*) die 2 "unknown option: $1" ;;
+            *)  names="${names}${names:+ }$1"; shift ;;
+        esac
+    done
+    for arg in "$@"; do
+        names="${names}${names:+ }$arg"
+    done
+
+    [ -f "$EXPANDER" ] || die 2 "expander missing: $EXPANDER"
+    [ -d "$GOLDEN_DIR" ] || die 2 "golden dir missing: $GOLDEN_DIR"
+
+    if [ -n "$names" ]; then
+        for name in $names; do
+            dir="$REPO_ROOT/skills/$name"
+            [ -d "$dir" ] || die 3 "no such skill: skills/$name"
+            gen_skill "$dir"
+        done
+    else
+        for dir in "$REPO_ROOT"/skills/*/; do
+            [ -d "$dir" ] || continue
+            [ -f "$dir/SKILL.md" ] || continue
+            gen_skill "$dir"
+        done
+    fi
+}
+
+main "$@"

--- a/tests/derive-trio.bats
+++ b/tests/derive-trio.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+# Tests for scripts/derive-trio.sh — single-source trio derivation (trio-derivation
+# Phase 1). Covers the exact transform (codex = body frontmatter-stripped;
+# opencode = own frontmatter + body), --check drift detection, --in-place
+# idempotency, usage errors, and the migration-safety guard: --check must pass
+# for EVERY existing skills/*/ trio (proving the generator already byte-matches
+# today's hand-maintained mirrors).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/derive-trio.sh"
+    FIXTURE="$REPO_ROOT/skills/autospec-explore"   # a representative real trio
+    TMP="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+# Materialize a writable copy of a real trio under $TMP so we can mutate it.
+_copy_trio() {  # _copy_trio <src-skill-dir> <dest-dir>
+    src="$1"; dest="$2"
+    mkdir -p "$dest/codex" "$dest/opencode"
+    cp "$src/SKILL.md" "$dest/SKILL.md"
+    cp "$src/codex/prompt.md" "$dest/codex/prompt.md"
+    cp "$src/opencode/agent.md" "$dest/opencode/agent.md"
+}
+
+# --- transform: --stdout codex == committed codex/prompt.md ---
+@test "--stdout codex equals committed codex/prompt.md (frontmatter stripped)" {
+    run bash "$SCRIPT" "$FIXTURE" --stdout codex
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" > "$TMP/codex.out"
+    diff "$FIXTURE/codex/prompt.md" "$TMP/codex.out"
+}
+
+# --- transform: --stdout codex has NO YAML frontmatter ---
+@test "--stdout codex emits no frontmatter" {
+    run bash "$SCRIPT" "$FIXTURE" --stdout codex
+    [ "$status" -eq 0 ]
+    # first non-empty line must not be a --- frontmatter fence
+    first="$(printf '%s\n' "$output" | sed '/^$/d' | head -1)"
+    [ "$first" != "---" ]
+    # the SKILL.md body content is present
+    [[ "$output" == *"autospec-explore workflow"* ]]
+}
+
+# --- transform: --stdout opencode == committed opencode/agent.md ---
+@test "--stdout opencode equals committed opencode/agent.md (own frontmatter + body)" {
+    run bash "$SCRIPT" "$FIXTURE" --stdout opencode
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" > "$TMP/opencode.out"
+    diff "$FIXTURE/opencode/agent.md" "$TMP/opencode.out"
+}
+
+# --- transform: opencode preserves its OWN frontmatter, not SKILL.md's ---
+@test "--stdout opencode keeps opencode's own frontmatter (mode: primary)" {
+    run bash "$SCRIPT" "$FIXTURE" --stdout opencode
+    [ "$status" -eq 0 ]
+    # opencode/agent.md frontmatter declares mode: primary; SKILL.md has name:.
+    [[ "$output" == *"mode: primary"* ]]
+}
+
+# --- --check: in sync exits 0 ---
+@test "--check exits 0 when mirrors are in sync" {
+    run bash "$SCRIPT" "$FIXTURE" --check
+    [ "$status" -eq 0 ]
+}
+
+# --- --check: codex drift exits non-zero with a diff ---
+@test "--check exits non-zero and shows a diff when codex/prompt.md drifts" {
+    _copy_trio "$FIXTURE" "$TMP/skill"
+    printf '\nDRIFTED CODEX LINE\n' >> "$TMP/skill/codex/prompt.md"
+    run bash "$SCRIPT" "$TMP/skill" --check
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"DRIFTED CODEX LINE"* ]]
+}
+
+# --- --check: opencode drift exits non-zero ---
+@test "--check exits non-zero when opencode/agent.md drifts" {
+    _copy_trio "$FIXTURE" "$TMP/skill"
+    printf '\nDRIFTED OPENCODE LINE\n' >> "$TMP/skill/opencode/agent.md"
+    run bash "$SCRIPT" "$TMP/skill" --check
+    [ "$status" -ne 0 ]
+}
+
+# --- --in-place: writes both mirrors and is idempotent ---
+@test "--in-place repairs drift and a second run is a no-op (idempotent)" {
+    _copy_trio "$FIXTURE" "$TMP/skill"
+    printf '\nDRIFT\n' >> "$TMP/skill/codex/prompt.md"
+
+    run bash "$SCRIPT" "$TMP/skill" --in-place
+    [ "$status" -eq 0 ]
+    # now in sync
+    run bash "$SCRIPT" "$TMP/skill" --check
+    [ "$status" -eq 0 ]
+
+    # snapshot, run in-place again, must be byte-identical (idempotent)
+    sum1_c="$(shasum -a 256 < "$TMP/skill/codex/prompt.md")"
+    sum1_o="$(shasum -a 256 < "$TMP/skill/opencode/agent.md")"
+    run bash "$SCRIPT" "$TMP/skill" --in-place
+    [ "$status" -eq 0 ]
+    sum2_c="$(shasum -a 256 < "$TMP/skill/codex/prompt.md")"
+    sum2_o="$(shasum -a 256 < "$TMP/skill/opencode/agent.md")"
+    [ "$sum1_c" = "$sum2_c" ]
+    [ "$sum1_o" = "$sum2_o" ]
+}
+
+# --- --in-place: regenerates mirror bodies from SKILL.md while preserving the
+#     opencode frontmatter; result matches the committed mirrors. codex is fully
+#     derived (it has no frontmatter); opencode keeps its existing frontmatter,
+#     so we corrupt only its BODY (the real-world case: edit SKILL.md, re-derive).
+@test "--in-place regenerates mirror bodies and matches the committed mirrors" {
+    _copy_trio "$FIXTURE" "$TMP/skill"
+    # fully clobber codex (no frontmatter to preserve) and append drift to the
+    # opencode BODY (its frontmatter stays intact as the preserved source).
+    printf 'garbage\n' > "$TMP/skill/codex/prompt.md"
+    printf '\nDRIFTED OPENCODE BODY\n' >> "$TMP/skill/opencode/agent.md"
+    run bash "$SCRIPT" "$TMP/skill" --in-place
+    [ "$status" -eq 0 ]
+    diff "$FIXTURE/codex/prompt.md" "$TMP/skill/codex/prompt.md"
+    diff "$FIXTURE/opencode/agent.md" "$TMP/skill/opencode/agent.md"
+}
+
+# --- usage: no args -> exit 2 ---
+@test "no arguments exits 2" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 2 ]
+}
+
+# --- usage: missing mode -> exit 2 ---
+@test "skill dir without a mode exits 2" {
+    run bash "$SCRIPT" "$FIXTURE"
+    [ "$status" -eq 2 ]
+}
+
+# --- usage: non-directory -> exit 2 ---
+@test "nonexistent skill dir exits 2" {
+    run bash "$SCRIPT" "$TMP/does-not-exist" --check
+    [ "$status" -eq 2 ]
+}
+
+# --- usage: bad member -> exit 2 ---
+@test "unknown --stdout member exits 2" {
+    run bash "$SCRIPT" "$FIXTURE" --stdout bogus
+    [ "$status" -eq 2 ]
+}
+
+# --- usage: --help exits 0 and prints Usage ---
+@test "--help prints Usage and exits 0" {
+    run bash "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+# --- MIGRATION-SAFETY GUARD: --check passes for EVERY existing trio ---
+@test "--check passes for EVERY existing skills/*/ trio (migration-safety guard)" {
+    local checked=0 failed=""
+    for d in "$REPO_ROOT"/skills/*/; do
+        [ -f "$d/SKILL.md" ] || continue
+        [ -f "$d/codex/prompt.md" ] || continue
+        [ -f "$d/opencode/agent.md" ] || continue
+        checked=$((checked + 1))
+        if ! bash "$SCRIPT" "$d" --check >/dev/null 2>&1; then
+            failed="${failed} $(basename "$d")"
+        fi
+    done
+    # there must be at least one real trio to make the guard meaningful
+    [ "$checked" -gt 0 ]
+    if [ -n "$failed" ]; then
+        printf 'derive-trio --check drift for trios:%s\n' "$failed" >&2
+    fi
+    [ -z "$failed" ]
+}

--- a/tests/gen-skill-goldens.bats
+++ b/tests/gen-skill-goldens.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# Tests for scripts/gen-skill-goldens.sh — block-expansion golden regenerator
+# (trio-derivation Phase 1). Proves the regenerated sha256 matches the expander
+# one-liner that validate.sh's check_block_expansion runs, that a current run is
+# a no-op (no diff), and that usage errors fail closed.
+#
+# NOTE: tests that mutate tests/fixtures/skill-goldens/ snapshot the affected
+# file and restore it in teardown so the repo working tree is never left dirty.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/gen-skill-goldens.sh"
+    EXPANDER="$REPO_ROOT/scripts/expand-skill-blocks.sh"
+    GOLDEN_DIR="$REPO_ROOT/tests/fixtures/skill-goldens"
+    SKILL="autospec-explore"
+    GOLDEN="$GOLDEN_DIR/$SKILL.SKILL.md.sha256"
+    BACKUP="$BATS_TEST_TMPDIR/golden.backup"
+    cp "$GOLDEN" "$BACKUP"
+}
+
+teardown() {
+    # always restore the snapshot so the working tree stays clean
+    if [ -f "$BACKUP" ]; then
+        cp "$BACKUP" "$GOLDEN"
+    fi
+}
+
+# --- regenerated sha matches check_block_expansion's expander one-liner ---
+@test "regenerated SKILL.md golden equals expander | shasum one-liner" {
+    expected="$(bash "$EXPANDER" "$REPO_ROOT/skills/$SKILL/SKILL.md" | shasum -a 256 | cut -d' ' -f1)"
+    # clobber, regenerate, compare
+    printf 'deadbeef\n' > "$GOLDEN"
+    run bash "$SCRIPT" "$SKILL"
+    [ "$status" -eq 0 ]
+    got="$(tr -d '[:space:]' < "$GOLDEN")"
+    [ "$got" = "$expected" ]
+}
+
+# --- regenerated golden keeps the 64-hex + trailing-newline format ---
+@test "regenerated golden is 64 hex chars + a trailing newline (65 bytes)" {
+    printf 'deadbeef\n' > "$GOLDEN"
+    run bash "$SCRIPT" "$SKILL"
+    [ "$status" -eq 0 ]
+    bytes="$(wc -c < "$GOLDEN" | tr -d '[:space:]')"
+    [ "$bytes" -eq 65 ]
+    # content (sans whitespace) is 64 lowercase hex chars
+    hex="$(tr -d '[:space:]' < "$GOLDEN")"
+    [ "${#hex}" -eq 64 ]
+    [[ "$hex" =~ ^[0-9a-f]{64}$ ]]
+}
+
+# --- idempotent: a current golden is left untouched (no write) ---
+@test "no-op when the golden is already current (no diff)" {
+    # ensure current first
+    bash "$SCRIPT" "$SKILL" >/dev/null
+    before="$(shasum -a 256 < "$GOLDEN")"
+    run bash "$SCRIPT" "$SKILL"
+    [ "$status" -eq 0 ]
+    # an already-current golden produces no "wrote" line
+    [[ "$output" != *"wrote"* ]]
+    after="$(shasum -a 256 < "$GOLDEN")"
+    [ "$before" = "$after" ]
+}
+
+# --- whole-repo run is a clean no-op against the committed goldens ---
+@test "full run prints no 'wrote' lines for an in-sync repo" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    # If the committed goldens already match, the regenerator writes nothing.
+    [[ "$output" != *"wrote"* ]]
+}
+
+# --- usage: unknown skill -> exit 3 (fail closed) ---
+@test "unknown skill name exits 3" {
+    run bash "$SCRIPT" definitely-not-a-real-skill
+    [ "$status" -eq 3 ]
+}
+
+# --- usage: unknown option -> exit 2 ---
+@test "unknown option exits 2" {
+    run bash "$SCRIPT" --bogus
+    [ "$status" -eq 2 ]
+}
+
+# --- usage: --help exits 0 and prints Usage ---
+@test "--help prints Usage and exits 0" {
+    run bash "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}


### PR DESCRIPTION
Ships **Phase 1 only** of `docs/specs/2026-06-16-trio-derivation-design.md` —
the standalone, opt-in tools. NEW files only: no existing-trio, `validate.sh`,
or `autospec-define` edits (those are deferred to Phase 2 per the spec's
concurrency phasing).

## What

- **`scripts/derive-trio.sh <skill-dir> [--check | --in-place | --stdout <member>]`**
  regenerates the BODY of `codex/prompt.md` and `opencode/agent.md` from `SKILL.md`.
  - `codex/prompt.md` = `strip_body(SKILL.md)` (no frontmatter), byte-matching
    `validate.sh`'s `check_lockstep` awk convention (`/^---$/{c++; next} c>=2`).
  - `opencode/agent.md` = opencode's **own existing frontmatter** + the SKILL.md
    body. Only the body is regenerated; each mirror's frontmatter is preserved
    (codex has none; opencode keeps its `mode:`/`description:`).
  - `--check` is the deterministic equivalent of `check_lockstep`: derive
    in-memory, diff vs the committed mirrors (exit 0 in sync, 1 + unified diff
    on drift). `--in-place` writes both mirrors atomically and is idempotent.

- **`scripts/gen-skill-goldens.sh [<skill>...]`** regenerates the block-expansion
  golden sha256 snapshots with the exact one-liner `check_block_expansion` runs:
  `expand-skill-blocks.sh <m> | shasum -a 256 | cut -d' ' -f1 > tests/fixtures/skill-goldens/<skill>.<suffix>.sha256`.
  Markered-member rules preserved; idempotent (already-current goldens untouched).

## Tests

- `tests/derive-trio.bats` + `tests/gen-skill-goldens.bats` (22 tests).
- **Migration-safety guard:** `derive-trio --check` is asserted to pass for
  **EVERY** existing `skills/*/` trio — proving the generator already byte-matches
  all 24 hand-maintained mirrors today (zero divergences; clean Phase 2 migration).

## Gate

`bash scripts/validate.sh` green; both new bats suites pass; `--check` passes for
all 24 trios; `gen-skill-goldens.sh` is a clean no-op against committed goldens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)