### PR TITLE
perf(cache): slim + cache-stabilize the reviewer prompt prefix (prompt-cache-reclaim Phase 1)

### DIFF
--- a/scripts/gen-reviewer-prompt.sh
+++ b/scripts/gen-reviewer-prompt.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # scripts/gen-reviewer-prompt.sh — compose Phase 4 fused guardian+LGTM reviewer prompt.
 #
-# Wraps bundle-static-context.sh --role reviewer (static cached prefix) with a
-# deterministic dynamic suffix derived from the PR diff and previous-iteration findings.
-# Zero LLM calls.
+# Wraps bundle-static-context.sh --role reviewer (the slim, byte-stable cached
+# prefix: reviewer-contract.md guardian rubric + RULE_ID table + the AGENTS.md
+# enforcement narrative) with a deterministic dynamic suffix derived from the PR
+# diff and previous-iteration findings. The suffix references the cached prefix
+# rubric rather than re-embedding the RULE_ID table. Zero LLM calls.
 #
 # Usage:
 #   scripts/gen-reviewer-prompt.sh --pr-diff <file> [--prev-findings <file>]
@@ -204,7 +206,7 @@ ${ISSUE_BODY:-"(Issue body not provided. Fetch it before applying issue-scope, T
 ## Fused guardian+LGTM review rubric
 
 **Part 1 — Guardian (contract compliance)** — skip if \`AUTOSPEC_NO_GUARDIAN=1\`:
-1. Read AGENTS.md \`## Implementation-quality contract\` for the RULE_ID table and directive map.
+1. Apply the RULE_ID table and corrective-directive map from the cached \`## Reviewer contract\` prefix above (no need to re-read AGENTS.md — the prefix already carries them).
 2. Read the issue body — note \`## Implementation scope\`, \`## Implementation outline\`, \`## Tests required\`, and any \`Guardian: skip-*\` lines.
 3. Read deterministic findings from lint-implementation.sh output (included above if present).
 4. Apply LLM-tier RULE_IDs (HALLUCINATED_API, DUPLICATE_CODE, DOC_OUT_OF_SYNC semantic pass, INVENTED_CONFIG). Collect as \`RULE_ID:<path>:<line>: <desc>\`. Honor \`Guardian: skip-*\` with \`INFO:\` lines.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -789,6 +789,80 @@ check_implementer_contract() {
     fi
 }
 
+# Reviewer-contract named-content invariants (prompt-cache reclaim Phase 1): the
+# curated reviewer-contract.md replaces the ~14KB autospec-run/SKILL.md in the
+# reviewer prefix. The contract MUST exist, stay <=24KB, carry exactly one
+# RULE_ID table header, and must not drift from AGENTS.md's canonical RULE_ID
+# set. The bundler MUST inject the contract for the reviewer role and MUST NOT
+# inject the autospec-run SKILL.md into that role any more.
+check_reviewer_contract() {
+    info "reviewer-contract: skills/autospec-run/prompts/reviewer-contract.md"
+    local contract="skills/autospec-run/prompts/reviewer-contract.md"
+    [ -f "$contract" ] \
+        || fail "$contract: file missing"
+
+    # Size guard: <=24576 bytes.
+    local size
+    size="$(wc -c < "$contract" | tr -d ' ')"
+    [ "$size" -le 24576 ] \
+        || fail "$contract: $size bytes exceeds 24576-byte (24KB) budget"
+
+    # Single RULE_ID table header (no duplicate re-extraction).
+    local header_count
+    header_count="$(grep -c '^### RULE_ID table' "$contract" || true)"
+    [ "$header_count" = "1" ] \
+        || fail "$contract: expected exactly 1 '### RULE_ID table' header, found $header_count"
+
+    # Drift gate: every RULE_ID named in AGENTS.md's canonical table must also be
+    # present in the contract (the reviewer must still enforce the full set).
+    [ -f AGENTS.md ] || fail "AGENTS.md missing at repo root"
+    local agents_rule_ids
+    agents_rule_ids="$(awk '
+        /^### RULE_ID table/ { in_table=1; next }
+        /^### / && in_table { exit }
+        /^## / && in_table { exit }
+        in_table && /^\| `[A-Z_]+`/ {
+            line=$0; sub(/^\| `/,"",line); sub(/`.*/,"",line); print line
+        }
+    ' AGENTS.md | sort -u)"
+    [ -n "$agents_rule_ids" ] || fail "AGENTS.md RULE_ID table yielded no RULE_IDs (parse drift)"
+    local rid
+    for rid in $agents_rule_ids; do
+        grep -q "$rid" "$contract" \
+            || fail "$contract: drift — AGENTS.md RULE_ID '$rid' missing from contract"
+    done
+
+    # The bundler must inject the contract for the reviewer role.
+    local bundler="skills/autospec-shared/scripts/bundle-static-context.sh"
+    [ -f "$bundler" ] || fail "$bundler: file missing"
+    grep -q 'REVIEWER_CONTRACT' "$bundler" \
+        || fail "$bundler: missing REVIEWER_CONTRACT injection variable"
+
+    # Behavioral negative: the reviewer-role output must NOT carry the verbose
+    # 'SKILL.md (reviewer role)' injection header (no full ~14KB SKILL.md), the
+    # RULE_ID table must appear EXACTLY once in the prefix, and the full LLM-tier
+    # RULE_ID set the fused reviewer applies must still be present.
+    local rev_out
+    rev_out="$(AUTOSPEC_REPO_ROOT="$REPO_ROOT" \
+        AUTOSPEC_MEMORY_DIR=/nonexistent-memory-dir \
+        AUTOSPEC_MANIFEST=/nonexistent-manifest.yml \
+        bash "$bundler" --role reviewer --issue-labels 'ctx:120k' 2>/dev/null)" \
+        || fail "$bundler: --role reviewer failed to run"
+    if printf '%s\n' "$rev_out" | grep -q 'SKILL.md (reviewer role)'; then
+        fail "$bundler: reviewer output still injects the SKILL.md (reviewer role) prefix"
+    fi
+    local rev_table_count
+    rev_table_count="$(printf '%s\n' "$rev_out" | grep -c '^### RULE_ID table' || true)"
+    [ "$rev_table_count" = "1" ] \
+        || fail "$bundler: reviewer prefix must carry the RULE_ID table exactly once (found $rev_table_count)"
+    local llm_rid
+    for llm_rid in HALLUCINATED_API DUPLICATE_CODE STRING_MATCH_DOMAIN_LOGIC \
+                   REPEATED_STRUCTURE_AS_CODE DOC_OUT_OF_SYNC INVENTED_CONFIG; do
+        printf '%s\n' "$rev_out" | grep -q "$llm_rid" \
+            || fail "$bundler: reviewer prefix dropped LLM-tier RULE_ID: $llm_rid"
+    done
+}
+
 # Usage-limit recovery helper invariants: autospec-run's quota recovery path
 # depends on this shell-only supervisor being installed and executable.
 check_usage_limit_helper() {
@@ -2569,6 +2643,7 @@ main() {
     check_lint_issue_helpers
     check_lint_implementation_helpers
     check_implementer_contract
+    check_reviewer_contract
     check_lint_heredoc_handling
     check_quality_differential
     check_usage_limit_helper

--- a/skills/autospec-run/prompts/reviewer-contract.md
+++ b/skills/autospec-run/prompts/reviewer-contract.md
@@ -1,0 +1,104 @@
+# Reviewer contract (autospec Phase 4 fused guardian+LGTM)
+
+This is the **reviewer-relevant extract** of the autospec project rules. It is
+the curated subset a reviewer ACTS on — the guardian rubric, the RULE_ID table
+the fused reviewer applies, the corrective-directive map, the per-issue opt-out
+grammar, and the verdict format. The full ~14KB `autospec-run/SKILL.md`
+monitor-loop machinery is intentionally NOT here: as a single-pass reviewer you
+audit one PR diff and you do not run the orchestrator's monitor phases, profile
+machinery, or invocation flags.
+
+Treat this contract as authoritative for HOW to review one PR. It is the acting
+digest for the guardian + LGTM verdict, not a replacement for the per-step
+review prompt assembled by `gen-reviewer-prompt.sh`.
+
+## Reviewer standards
+
+- **No verdict without the diff.** Apply every check against the actual PR diff
+  and the issue body's declared scope — never approve on prose alone.
+- **Honor declared opt-outs.** A valid `Guardian: skip-RULE_ID # <reason>` line
+  in the issue body downgrades that RULE_ID to an `INFO:` line; it does NOT block.
+- **Enforce TDD, no DB mocks, conventional commits, no unsafe git ops** as
+  AGENTS.md `## Engineering standards` requires.
+- **Bounded effort.** Max 25 tool calls total across both review parts. If the
+  budget is exhausted, append `RULE_ID:OUT_OF_SCOPE: reviewer budget exhausted;
+  PR needs human review` and proceed to the verdict.
+
+## Guardian rubric (Part 1 — contract compliance)
+
+Skip Part 1 entirely if `AUTOSPEC_NO_GUARDIAN=1` (log
+`WARN: guardian disabled by AUTOSPEC_NO_GUARDIAN`).
+
+1. Read AGENTS.md `## Implementation-quality contract` for the RULE_ID table and
+   directive map (the canonical copy; the table below mirrors it).
+2. Read the issue body — note `## Implementation scope`, `## Implementation
+   outline`, `## Tests required`, and any `Guardian: skip-*` lines.
+3. Read deterministic findings from `lint-implementation.sh` output (included in
+   the dynamic suffix if present).
+4. Apply the **LLM-tier** RULE_IDs against the diff: `HALLUCINATED_API`,
+   `DUPLICATE_CODE`, `STRING_MATCH_DOMAIN_LOGIC`, `REPEATED_STRUCTURE_AS_CODE`,
+   `DOC_OUT_OF_SYNC` (semantic pass), `INVENTED_CONFIG`. Collect findings as
+   `RULE_ID:<path>:<line>: <desc>`. Honor `Guardian: skip-*` with `INFO:` lines.
+
+### RULE_ID table
+
+| RULE_ID | Detector | Tier | Threshold / regex |
+|---|---|---|---|
+| `OUT_OF_SCOPE` | det | path-list compare | files touched ∉ issue body `## Implementation outline` paths |
+| `MISSING_TEST` | det | path-prefix scan | required test type from issue body `## Tests required` not present in diff under `tests/{unit,integration,smoke,e2e}/` |
+| `COMPLEXITY` | det | line/regex scan | function >50 LOC, file >500 LOC, nesting >4 |
+| `SECURITY` | det | regex match | `eval\(`, `exec\(`, `--no-verify`, `git reset --hard`, `rm -rf /`, AWS-key shape `AKIA[0-9A-Z]{16}`, GitHub-token shape `gh[pousr]_[A-Za-z0-9]{36,}`, private-key markers `-----BEGIN [A-Z ]*PRIVATE KEY-----` |
+| `TODO_LEFT` | det | regex on non-test diff | `\b(TODO\|XXX\|FIXME)\b` |
+| `MOCK_DB` | det | regex on test diff | `\b(mock\|stub)\b` near DB-symbol heuristics (`db\.`, `database`, `DataSource`, `pg`, `mysql`, `sqlite`) |
+| `HALLUCINATED_API` | LLM | semantic | symbol referenced in diff not defined in diff, not in pre-PR repo (verifiable via repo search), not in dependency manifests |
+| `DUPLICATE_CODE` | LLM | semantic | new code mirrors an existing helper (must cite `<path>:<line>`) |
+| `STRING_MATCH_DOMAIN_LOGIC` | LLM | semantic | code uses substring checks against free-form text to encode domain meaning, AND a proper-representation library is imported in the file |
+| `REPEATED_STRUCTURE_AS_CODE` | LLM | semantic | ≥5 branches in the same function/method sharing identical structural shape (same return shape, predicate signature, side-effect line) |
+| `DOC_OUT_OF_SYNC` | hybrid | det+LLM | det: any change to public surface (CLI flag, env var, exported function, config key) WITHOUT a touched doc file (`README*`, `AGENTS.md`, `docs/**`, `SKILL.md`); LLM: judges semantic accuracy when a doc IS touched |
+| `INVENTED_CONFIG` | LLM | semantic | flag/env-var/config-key introduced in diff not present in issue body or referenced spec |
+
+### Corrective directive map
+
+When a RULE_ID fires, the finding carries this single-line corrective directive
+so the implementer knows the fix on retry:
+
+| RULE_ID | Directive |
+|---|---|
+| `OUT_OF_SCOPE` | "Restrict diff to files listed in issue's ## Implementation outline. Revert other changes or amend the issue body." |
+| `MISSING_TEST` | "Add a test under tests/<TIER>/ for the listed required test type before re-pushing." |
+| `COMPLEXITY` | "Split functions >50 LOC, files >500 LOC, nesting >4. No copy-paste branches." |
+| `SECURITY` | "Remove the flagged pattern. NEVER hardcode secrets, NEVER use --no-verify or git reset --hard, validate input at boundaries." |
+| `TODO_LEFT` | "Remove TODO/XXX/FIXME from non-test code. File a follow-up issue if the work is genuinely deferred." |
+| `MOCK_DB` | "Remove DB mock/stub. Use the real DB per AGENTS.md ## Engineering standards." |
+| `HALLUCINATED_API` | "The flagged symbol does not exist. Verify identifier names against the pre-PR repo and dependency manifests." |
+| `DUPLICATE_CODE` | "Reuse the existing helper at <path>:<line> instead of re-implementing." |
+| `STRING_MATCH_DOMAIN_LOGIC` | "Replace substring checks with the proper domain primitive (AST/parsed URL/IP/date/schema)." |
+| `REPEATED_STRUCTURE_AS_CODE` | "Extract the N branches into a table + single dispatcher loop." |
+| `DOC_OUT_OF_SYNC` | "Update the doc file(s) covering the changed public surface in this same PR." |
+| `INVENTED_CONFIG` | "Remove the invented flag/env/key, or amend the issue body to introduce it as scope." |
+
+## Per-issue opt-out grammar
+
+The issue body MAY declare per-RULE_ID opt-outs with mandatory justification:
+
+```
+^Guardian:\s+(skip-[A-Z_]+(,\s*skip-[A-Z_]+)*)\s+#\s+\S.+$
+```
+
+- Justification (text after `#`) is **mandatory**. Bare `Guardian: skip-X` is
+  rejected (malformed; RULE stays active).
+- Skipped RULE_IDs are emitted as `INFO:RULE_ID...` (audit trail) but do NOT
+  block the merge.
+- Skips apply only to the PR derived from this issue; they do NOT cascade.
+
+## LGTM rubric (Part 2 — correctness review)
+
+5. Check correctness, edge cases, missing tests, and AGENTS.md compliance (TDD,
+   no mocks, conventional commits).
+6. Collect findings as a numbered list.
+
+## Verdict
+
+If Part 1 has ZERO blocking findings (`INFO:` lines are OK) AND Part 2 has no
+findings: return ONLY the token `LGTM`. Otherwise return a numbered findings
+list — RULE_ID findings first, then LGTM findings.

--- a/skills/autospec-shared/scripts/bundle-static-context.sh
+++ b/skills/autospec-shared/scripts/bundle-static-context.sh
@@ -16,13 +16,28 @@
 #   4. Lockstep paragraph
 #   5. Role-specific implementer scaffolding
 #
-# Composition order (reviewer/decomposer/classifier roles — unchanged):
+# Composition order (reviewer role — prompt-cache reclaim Phase 1 prefix slim):
+#   --- inside the CACHE BOUNDARY (byte-stable prefix, safe to cache) ---
+#   1. reviewer-contract.md (curated guardian rubric + RULE_ID table — NOT the
+#      ~14KB autospec-run/SKILL.md monitor-loop machinery)
+#   2. AGENTS.md ## Implementation-quality contract section (canonical RULE_ID)
+#   --- below the closing CACHE BOUNDARY (per-issue, NOT cached) ---
+#   3. Tag-filtered saved-memory files
+#   4. Lockstep paragraph
+#   5. Reviewer scaffolding
+#
+# Composition order (decomposer/classifier roles):
+#   --- inside the CACHE BOUNDARY ---
 #   1. SKILL.md (role's skill, verbatim)
-#   2. AGENTS.md (verbatim)
-#   3. RULE_ID table (extracted from AGENTS.md)
-#   4. Tag-filtered saved-memory files
-#   5. Lockstep paragraph
-#   6. Role-specific scaffolding
+#   2. AGENTS.md (verbatim)   [NO separate RULE_ID re-extraction — it already
+#      rides inside AGENTS.md; the duplicate block was dropped in Phase 1]
+#   --- below the closing CACHE BOUNDARY (per-issue) ---
+#   3. Tag-filtered saved-memory files
+#   4. Lockstep paragraph
+#   5. Role-specific scaffolding
+#
+# Memory injection is capped at AUTOSPEC_MAX_MEMORY_FILES (default 6) — only the
+# top-K most-specific tag matches are injected, so memory never busts the budget.
 #
 # Implementer prefix caching: the launch path SHOULD pass everything ABOVE the
 # closing <!-- CACHE BOUNDARY --> with cache_control: {type: ephemeral} where the
@@ -110,13 +125,19 @@ MANIFEST="${AUTOSPEC_MANIFEST:-$SCRIPTS_DIR/memory-tags.yml}"
 AGENTS_MD="$REPO_ROOT/AGENTS.md"
 # D3: the implementer role injects this curated contract instead of the 70KB SKILL.md.
 IMPLEMENTER_CONTRACT="$REPO_ROOT/skills/autospec-run/prompts/implementer-contract.md"
+# Phase 1 (prompt-cache reclaim): the reviewer role injects this curated contract
+# instead of the ~14KB autospec-run/SKILL.md.
+REVIEWER_CONTRACT="$REPO_ROOT/skills/autospec-run/prompts/reviewer-contract.md"
 
-# Role-to-skill mapping. The implementer role no longer injects a SKILL.md
-# (D3 prefix slim) — it injects implementer-contract.md instead.
+# Cap on injected saved-memory files (top-K most-specific tag matches).
+AUTOSPEC_MAX_MEMORY_FILES="${AUTOSPEC_MAX_MEMORY_FILES:-6}"
+
+# Role-to-skill mapping. The implementer and reviewer roles no longer inject a
+# SKILL.md (prefix slim) — they inject their curated *-contract.md instead.
 SKILL_MD=""
 case "$ROLE" in
   implementer) SKILL_MD="" ;;
-  reviewer)    SKILL_MD="$REPO_ROOT/skills/autospec-run/SKILL.md" ;;
+  reviewer)    SKILL_MD="" ;;
   decomposer)  SKILL_MD="$REPO_ROOT/skills/autospec-define/SKILL.md" ;;
   classifier)  SKILL_MD="$REPO_ROOT/skills/autospec-classify/SKILL.md" ;;
 esac
@@ -129,6 +150,11 @@ fi
 if [ "$ROLE" = "implementer" ]; then
   if [ ! -f "$IMPLEMENTER_CONTRACT" ]; then
     printf 'bundle-static-context.sh: implementer-contract.md not found: %s\n' "$IMPLEMENTER_CONTRACT" >&2
+    exit 1
+  fi
+elif [ "$ROLE" = "reviewer" ]; then
+  if [ ! -f "$REVIEWER_CONTRACT" ]; then
+    printf 'bundle-static-context.sh: reviewer-contract.md not found: %s\n' "$REVIEWER_CONTRACT" >&2
     exit 1
   fi
 elif [ ! -f "$SKILL_MD" ]; then
@@ -145,8 +171,11 @@ _raw_tokens=$(printf '%s' "$ISSUE_LABELS" | tr ',' ' ' | tr '[:upper:]' '[:lower
 _colon_tokens=$(printf '%s' "$_raw_tokens" | tr ':' ' ')
 issue_tokens=" ${_raw_tokens} ${_colon_tokens} "
 
-# Build list of matched memory file paths from manifest
-matched_memory=""
+# Build list of matched memory file paths from manifest. Each match is scored by
+# how many of its tags hit the issue tokens (more matches = more specific), so we
+# can keep only the top-K most-specific files (AUTOSPEC_MAX_MEMORY_FILES).
+# Intermediate lines are "<score>\t<path>"; ranked + capped below.
+scored_memory=""
 if [ -f "$MANIFEST" ] && [ -d "$MEMORY_DIR" ]; then
   current_file=""
   while IFS= read -r line; do
@@ -159,20 +188,32 @@ if [ -f "$MANIFEST" ] && [ -d "$MEMORY_DIR" ]; then
     if printf '%s' "$line" | grep -qE '^[[:space:]]+tags:' && [ -n "$current_file" ]; then
       tags_raw=$(printf '%s' "$line" | sed 's/.*\[//; s/\].*//')
       current_path="$MEMORY_DIR/$current_file"
-      match=0
+      match_count=0
       for tag in $(printf '%s' "$tags_raw" | tr ',' '\n' | tr -d ' []"'"'" | tr '[:upper:]' '[:lower:]'); do
         if printf '%s' "$issue_tokens" | grep -qw "$tag"; then
-          match=1
-          break
+          match_count=$((match_count + 1))
         fi
       done
-      if [ "$match" -eq 1 ] && [ -f "$current_path" ]; then
-        matched_memory="${matched_memory}${current_path}
+      if [ "$match_count" -gt 0 ] && [ -f "$current_path" ]; then
+        scored_memory="${scored_memory}${match_count}	${current_path}
 "
       fi
       current_file=""
     fi
   done < "$MANIFEST"
+fi
+
+# Rank by specificity (descending match score), break ties by path for a stable
+# byte-identical ordering, then cap to the top-K. Keeps only the path column.
+matched_memory=""
+if [ -n "$scored_memory" ]; then
+  matched_memory=$(printf '%s' "$scored_memory" \
+    | grep -v '^$' \
+    | sort -t'	' -k1,1nr -k2,2 \
+    | head -n "$AUTOSPEC_MAX_MEMORY_FILES" \
+    | cut -f2-)
+  [ -n "$matched_memory" ] && matched_memory="${matched_memory}
+"
 fi
 
 # ── emit helpers ──────────────────────────────────────────────────────────────
@@ -294,9 +335,48 @@ if [ "$ROLE" = "implementer" ]; then
   emit_memory
   emit_lockstep
   emit_scaffolding
+elif [ "$ROLE" = "reviewer" ]; then
+  # Phase 1 (prompt-cache reclaim): the reviewer prefix is byte-stable across
+  # issues. Only the curated reviewer-contract + the AGENTS.md quality-contract
+  # section (the rules a reviewer actually enforces) live inside the cache
+  # boundary; per-issue memory + scaffolding (and the PR diff, appended by
+  # gen-reviewer-prompt.sh) go BELOW the closing marker.
+
+  printf '<!-- CACHE BOUNDARY -->\n'
+
+  # 1. Curated reviewer contract (NOT the ~14KB SKILL.md monitor-loop machinery).
+  printf '## Reviewer contract\n\n'
+  cat "$REVIEWER_CONTRACT"
+  printf '\n'
+
+  # 2. AGENTS.md ## Implementation-quality contract section — the enforcement
+  #    narrative a reviewer applies (Enforcement, opt-out grammar, env-var
+  #    contract). The RULE_ID table + Corrective directive map subsections are
+  #    OMITTED here because reviewer-contract.md above already carries them
+  #    verbatim: the table must appear EXACTLY once in the cached prefix (no
+  #    duplicate re-extraction). validate.sh flags contract↔AGENTS.md drift.
+  printf '## AGENTS.md — Implementation-quality contract (enforcement)\n\n'
+  awk '
+    /^## Implementation-quality contract/ { in_sec=1; print; next }
+    /^## / && in_sec { exit }
+    /^### RULE_ID table/ && in_sec { skip=1; next }
+    /^### Corrective directive map/ && in_sec { skip=1; next }
+    /^### / && skip { skip=0 }
+    in_sec && !skip { print }
+  ' "$AGENTS_MD"
+  printf '\n'
+
+  printf '<!-- CACHE BOUNDARY -->\n'
+
+  # Below the boundary: per-issue, NOT part of the cached prefix.
+  emit_memory
+  emit_lockstep
+  emit_scaffolding
 else
-  # reviewer / decomposer / classifier: unchanged composition (everything inside
-  # the boundary; these roles do not yet use the byte-stable-prefix split).
+  # decomposer / classifier: SKILL.md + AGENTS.md verbatim inside the boundary.
+  # The duplicate '## RULE_ID table' re-extraction was dropped in Phase 1 — the
+  # canonical table already rides inside AGENTS.md verbatim. Per-issue memory +
+  # scaffolding move BELOW the closing marker.
   printf '<!-- CACHE BOUNDARY -->\n'
 
   # 1. SKILL.md verbatim
@@ -304,29 +384,16 @@ else
   cat "$SKILL_MD"
   printf '\n'
 
-  # 2. AGENTS.md verbatim
+  # 2. AGENTS.md verbatim (carries the canonical RULE_ID table — no duplicate
+  #    re-extraction).
   printf '## AGENTS.md\n\n'
   cat "$AGENTS_MD"
   printf '\n'
 
-  # 3. RULE_ID table extracted from AGENTS.md
-  printf '## RULE_ID table\n\n'
-  awk '
-    /^### RULE_ID table/ { in_table=1; next }
-    /^### / && in_table { exit }
-    /^## / && in_table { exit }
-    in_table { print }
-  ' "$AGENTS_MD"
-  printf '\n'
-
-  # 4. Tag-filtered saved-memory files
-  emit_memory
-
-  # 5. Lockstep paragraph
-  emit_lockstep
-
-  # 6. Role-specific scaffolding
-  emit_scaffolding
-
   printf '<!-- CACHE BOUNDARY -->\n'
+
+  # Below the boundary: per-issue, NOT part of the cached prefix.
+  emit_memory
+  emit_lockstep
+  emit_scaffolding
 fi

--- a/tests/bundle-static-context-reviewer.bats
+++ b/tests/bundle-static-context-reviewer.bats
@@ -15,10 +15,11 @@ SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/bundle-static-con
   printf '%s\n' "$output" | head -1 | grep -q "CACHE BOUNDARY"
 }
 
-@test "bundle-static-context.sh --role reviewer emits closing CACHE BOUNDARY marker" {
+@test "bundle-static-context.sh --role reviewer emits two CACHE BOUNDARY markers (prefix framed; per-issue content below the second)" {
   run "$SCRIPT" --role reviewer
   [ "$status" -eq 0 ]
-  printf '%s\n' "$output" | tail -1 | grep -q "CACHE BOUNDARY"
+  count="$(printf '%s\n' "$output" | grep -c 'CACHE BOUNDARY' || true)"
+  [ "$count" = "2" ]
 }
 
 @test "bundle-static-context.sh --role reviewer output contains Implementation-quality contract" {
@@ -49,4 +50,154 @@ SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/bundle-static-con
   out1=$("$SCRIPT" --role reviewer)
   out2=$("$SCRIPT" --role reviewer)
   [ "$out1" = "$out2" ]
+}
+
+# ── Phase 1 (prompt-cache reclaim): reviewer prefix slim + cache stabilization ──
+
+# Helper: emit only the cached prefix (everything up to and including the closing
+# CACHE BOUNDARY marker — i.e. the part the harness caches).
+_reviewer_prefix() {
+  "$SCRIPT" --role reviewer "$@" | awk '
+    /<!-- CACHE BOUNDARY -->/ { n++; print; if (n==2) exit; next }
+    { print }
+  '
+}
+
+@test "reviewer prefix no longer injects the full autospec-run SKILL.md" {
+  out="$("$SCRIPT" --role reviewer)"
+  # The verbose injection header used by the old composition must be gone.
+  if printf '%s\n' "$out" | grep -q 'SKILL.md (reviewer role)'; then
+    return 1
+  fi
+}
+
+@test "reviewer prefix no longer carries the monitor-loop bash" {
+  prefix="$(_reviewer_prefix)"
+  # A representative monitor-loop construct from autospec-run/SKILL.md.
+  if printf '%s\n' "$prefix" | grep -q 'heartbeat-write.sh'; then
+    return 1
+  fi
+}
+
+@test "reviewer prefix sources the reviewer-contract.md rubric" {
+  run "$SCRIPT" --role reviewer
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q 'Reviewer contract'
+  printf '%s\n' "$output" | grep -qi 'Guardian rubric'
+}
+
+@test "reviewer prefix contains the RULE_ID table exactly once" {
+  prefix="$(_reviewer_prefix)"
+  count="$(printf '%s\n' "$prefix" | grep -c '^### RULE_ID table' || true)"
+  [ "$count" = "1" ]
+}
+
+@test "reviewer prefix carries the full LLM-tier RULE_ID set the fused reviewer applies" {
+  prefix="$(_reviewer_prefix)"
+  for rid in HALLUCINATED_API DUPLICATE_CODE STRING_MATCH_DOMAIN_LOGIC \
+             REPEATED_STRUCTURE_AS_CODE DOC_OUT_OF_SYNC INVENTED_CONFIG; do
+    printf '%s\n' "$prefix" | grep -q "$rid" \
+      || { echo "missing RULE_ID in prefix: $rid"; return 1; }
+  done
+}
+
+@test "reviewer prefix carries every AGENTS.md canonical RULE_ID (no dropped rule)" {
+  agents="${BATS_TEST_DIRNAME}/../AGENTS.md"
+  prefix="$(_reviewer_prefix)"
+  rule_ids="$(awk '
+    /^### RULE_ID table/ { in_table=1; next }
+    /^### / && in_table { exit }
+    /^## / && in_table { exit }
+    in_table && /^\| `[A-Z_]+`/ {
+      line=$0; sub(/^\| `/,"",line); sub(/`.*/,"",line); print line
+    }
+  ' "$agents" | sort -u)"
+  [ -n "$rule_ids" ]
+  for rid in $rule_ids; do
+    printf '%s\n' "$prefix" | grep -q "$rid" \
+      || { echo "AGENTS.md RULE_ID dropped from reviewer prefix: $rid"; return 1; }
+  done
+}
+
+@test "reviewer per-issue memory + diff live BELOW the cache boundary" {
+  full="$("$SCRIPT" --role reviewer)"
+  prefix="$(_reviewer_prefix)"
+  # The saved-memory block is per-issue → must not be inside the cached prefix.
+  if printf '%s\n' "$prefix" | grep -q 'Project rules (saved memory)'; then
+    return 1
+  fi
+  # But it must still be present somewhere in the full output (below the boundary).
+  printf '%s\n' "$full" | grep -q 'Project rules (saved memory)'
+}
+
+@test "reviewer prefix is BYTE-IDENTICAL across two differing-issue dispatches" {
+  # The prefix is cached, so it must not vary with issue labels.
+  p1="$(_reviewer_prefix --issue-labels 'skill:autospec-run,ctx:120k')"
+  p2="$(_reviewer_prefix --issue-labels 'bug,ctx:32k,reasoning:deep')"
+  [ "$p1" = "$p2" ]
+}
+
+@test "reviewer prefix token estimate drops >=50% vs the full SKILL.md prefix" {
+  # wc-based token estimate: words ~= tokens (conservative). Compare the new slim
+  # prefix against the pre-Phase-1 baseline (full autospec-run/SKILL.md prefix).
+  skill_md="${BATS_TEST_DIRNAME}/../skills/autospec-run/SKILL.md"
+  agents="${BATS_TEST_DIRNAME}/../AGENTS.md"
+  old_tokens=$(cat "$skill_md" "$agents" | wc -w | tr -d ' ')
+  new_tokens=$(_reviewer_prefix | wc -w | tr -d ' ')
+  # Assert at least a 50% reduction.
+  [ "$new_tokens" -le $((old_tokens / 2)) ] \
+    || { echo "old=$old_tokens new=$new_tokens (need <= $((old_tokens/2)))"; return 1; }
+}
+
+# ── Memory-injection cap (AUTOSPEC_MAX_MEMORY_FILES, default 6) ──────────────────
+
+@test "memory injection is capped at AUTOSPEC_MAX_MEMORY_FILES" {
+  memdir="$(mktemp -d)"
+  manifest="$(mktemp)"
+  # Build 10 memory files all sharing the tag 'autospec-run' so all match.
+  : > "$manifest"
+  for i in $(seq 1 10); do
+    f="feedback_cap_$i.md"
+    printf 'CAP_MARKER_%02d body\n' "$i" > "$memdir/$f"
+    printf '%s:\n  tags: [autospec-run, cap]\n' "$f" >> "$manifest"
+  done
+  run env AUTOSPEC_MEMORY_DIR="$memdir" AUTOSPEC_MANIFEST="$manifest" \
+    AUTOSPEC_MAX_MEMORY_FILES=3 \
+    "$SCRIPT" --role reviewer --issue-labels 'autospec-run'
+  rm -rf "$memdir" "$manifest"
+  [ "$status" -eq 0 ]
+  injected="$(printf '%s\n' "$output" | grep -c 'CAP_MARKER_' || true)"
+  [ "$injected" -le 3 ] || { echo "injected=$injected (cap was 3)"; return 1; }
+}
+
+@test "memory cap defaults to 6 when AUTOSPEC_MAX_MEMORY_FILES unset" {
+  memdir="$(mktemp -d)"
+  manifest="$(mktemp)"
+  : > "$manifest"
+  for i in $(seq 1 10); do
+    f="feedback_cap_$i.md"
+    printf 'CAP_MARKER_%02d body\n' "$i" > "$memdir/$f"
+    printf '%s:\n  tags: [autospec-run, cap]\n' "$f" >> "$manifest"
+  done
+  run env -u AUTOSPEC_MAX_MEMORY_FILES AUTOSPEC_MEMORY_DIR="$memdir" \
+    AUTOSPEC_MANIFEST="$manifest" \
+    "$SCRIPT" --role reviewer --issue-labels 'autospec-run'
+  rm -rf "$memdir" "$manifest"
+  [ "$status" -eq 0 ]
+  injected="$(printf '%s\n' "$output" | grep -c 'CAP_MARKER_' || true)"
+  [ "$injected" -le 6 ] || { echo "injected=$injected (default cap 6)"; return 1; }
+}
+
+@test "decomposer/classifier roles drop the duplicate RULE_ID re-extraction block" {
+  # The standalone '## RULE_ID table' re-extraction header must be gone; the
+  # canonical table still rides inside AGENTS.md verbatim.
+  for role in decomposer classifier; do
+    out="$("$SCRIPT" --role "$role")"
+    if printf '%s\n' "$out" | grep -q '^## RULE_ID table'; then
+      echo "$role still emits duplicate '## RULE_ID table'"
+      return 1
+    fi
+    # Canonical RULE_IDs still reachable (via AGENTS.md verbatim).
+    printf '%s\n' "$out" | grep -q 'OUT_OF_SCOPE'
+  done
 }

--- a/tests/bundle-static-context.bats
+++ b/tests/bundle-static-context.bats
@@ -34,6 +34,24 @@ EOF
 | `OUT_OF_SCOPE` | det |
 EOF
 
+  # Fixture reviewer-contract.md (Phase 1: reviewer role injects this, not SKILL.md)
+  cat > "$FIXTURES_DIR/skills/autospec-run/prompts/reviewer-contract.md" <<'EOF'
+# Reviewer contract (test fixture)
+
+## Guardian rubric
+
+### RULE_ID table
+
+| RULE_ID | Detector |
+|---|---|
+| `OUT_OF_SCOPE` | det |
+| `MISSING_TEST` | det |
+
+## Verdict
+
+Return LGTM if clean.
+EOF
+
   # Fixture AGENTS.md with RULE_ID table
   cat > "$FIXTURES_DIR/AGENTS.md" <<'EOF'
 # AGENTS.md


### PR DESCRIPTION
Phase 1 of docs/specs/2026-06-16-prompt-cache-reclaim-design.md. Replaces the ~14KB autospec-run/SKILL.md + duplicate RULE_ID re-extraction in the reviewer prefix with a curated reviewer-contract.md (guardian rubric + single RULE_ID table); moves per-issue memory + diff below the cache boundary (byte-stable prefix); caps memory injection (AUTOSPEC_MAX_MEMORY_FILES). Adds check_reviewer_contract() drift gate (every AGENTS.md RULE_ID present). No autospec-run/define trio edited (Phase 2 deferred). validate.sh green. (Recovered + finished after the implementer stopped pre-commit.)