### PR TITLE
feat(autospec-doc): activate architecture/flow diagrams (wire doc-style.mjs)

### DIFF
--- a/skills/autospec-doc/scripts/gen-audience-docs.mjs
+++ b/skills/autospec-doc/scripts/gen-audience-docs.mjs
@@ -36,6 +36,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isLogicFlowSection, generateExplainerDiagram } from './doc-style.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SHARED_SCRIPTS = path.resolve(__dirname, '../../autospec-shared/scripts');
@@ -329,7 +330,20 @@ function renderFeature(audience, feature, directive) {
     feature.summary ? `${feature.summary}` : `Reference documentation for ${feature.slug}.`,
     '',
   ];
-  for (const s of (feature.spec_sections || [])) lines.push(s, '');
+  for (const s of (feature.spec_sections || [])) {
+    lines.push(s, '');
+    // Track D (issue #1131): emit a palette-themed mermaid diagram for logic-flow sections.
+    const section = { heading: feature.title || feature.slug, body: s };
+    if (isLogicFlowSection(section)) {
+      const diagram = generateExplainerDiagram(section);
+      if (diagram) {
+        lines.push('```mermaid');
+        lines.push(diagram);
+        lines.push('```');
+        lines.push('');
+      }
+    }
+  }
   // Append the six LLM-targeted sections (issue #1129); empty fields are omitted.
   lines.push(...renderFeatureSections(audience, feature));
   // Append verified runnable examples (issue #1133); empty examples[] emits nothing.

--- a/skills/autospec-doc/tests/gen-audience-docs.test.mjs
+++ b/skills/autospec-doc/tests/gen-audience-docs.test.mjs
@@ -622,7 +622,85 @@ test('backward compat: legacy feature (summary+spec_sections only) produces byte
   }
 });
 
-// Test D6-4: batched ai-review parse round-trip
+// ── Track D: logic-flow diagram tests (issue #1131) ──────────────────────────
+
+// A feature whose spec_sections describe logic/flow (ordered steps + decision
+// language). The feature page must contain a mermaid fenced block with the
+// palette %%{init}%% header from doc-style.mjs.
+const FLOW_FEATURE = {
+  slug: 'flow-feature',
+  title: 'Flow Feature',
+  summary: 'Demonstrates logic-flow diagram emission.',
+  spec_sections: [
+    // This section satisfies isLogicFlowSection: ordered steps + decision
+    '1. Validate input record against schema.\n2. If valid, enqueue record for processing.\n3. Otherwise, emit INVALID_RECORD error and reject.',
+  ],
+};
+
+// A feature with a plain prose section — no ordered steps, no flow language.
+const NON_FLOW_FEATURE = {
+  slug: 'non-flow-feature',
+  title: 'Non Flow Feature',
+  summary: 'Has a plain prose section — no logic flow.',
+  spec_sections: [
+    'This feature stores configuration settings for the application.',
+  ],
+};
+
+test('Track D: logic-flow spec section yields a themed mermaid block in the feature page', async () => {
+  const result = await generateAudienceDocs({
+    features: [FLOW_FEATURE],
+    audiences: [FOUR_AUDIENCES[0]], // user audience
+  });
+  const page = result.files.find(f => f.path === 'docs/user/features/flow-feature.md');
+  assert.ok(page, 'feature page should exist');
+  // The mermaid block must contain the %%{init}%% header from mermaidInit()
+  assert.ok(
+    page.content.includes('%%{init:'),
+    'logic-flow section must yield a themed mermaid %%{init}%% block',
+  );
+  // Must be wrapped in a mermaid fenced code block
+  assert.ok(
+    page.content.includes('```mermaid'),
+    'logic-flow section must yield a ```mermaid fenced block',
+  );
+});
+
+test('Track D: non-flow spec section yields no mermaid block in the feature page', async () => {
+  const result = await generateAudienceDocs({
+    features: [NON_FLOW_FEATURE],
+    audiences: [FOUR_AUDIENCES[0]],
+  });
+  const page = result.files.find(f => f.path === 'docs/user/features/non-flow-feature.md');
+  assert.ok(page, 'non-flow feature page should exist');
+  assert.ok(
+    !page.content.includes('```mermaid'),
+    'non-flow section must NOT yield a mermaid block',
+  );
+});
+
+test('Track D: gen-audience-docs.mjs imports doc-style.mjs (no second palette source)', async () => {
+  const src = fs.readFileSync(path.join(SCRIPTS_DIR, 'gen-audience-docs.mjs'), 'utf8');
+  assert.ok(
+    /doc-style\.mjs/.test(src) && /\bimport\b/.test(src),
+    'gen-audience-docs.mjs must import from doc-style.mjs',
+  );
+  // Must call the two exported functions
+  assert.ok(/isLogicFlowSection/.test(src), 'must reference isLogicFlowSection');
+  assert.ok(/generateExplainerDiagram/.test(src), 'must reference generateExplainerDiagram');
+  // Must NOT hardcode palette hex values (single-source guard). Derive the hex
+  // list from PALETTE at runtime so this test file introduces no second source.
+  const { PALETTE } = await import(path.join(SCRIPTS_DIR, 'doc-style.mjs'));
+  const paletteHexes = Object.values(PALETTE).filter((v) => /^#[0-9a-fA-F]{3,8}$/.test(v));
+  const hardcoded = paletteHexes.filter((hex) => src.includes(hex));
+  assert.deepStrictEqual(
+    hardcoded,
+    [],
+    'gen-audience-docs.mjs must not hardcode palette hex values (single-source guard)',
+  );
+});
+
+// ── Test D6-4: batched ai-review parse round-trip
 //
 // Confirm that per-section confidence markers in the ai_review field are correctly
 // set on each page, and that the annotation contract (<!-- ai-reviewed: ... -->)


### PR DESCRIPTION
Closes #1131

Track D of epic #1128. Wires the previously-orphaned isLogicFlowSection/generateExplainerDiagram into gen-audience-docs; logic-flow sections now emit palette-themed mermaid. Single-source palette guard intact (test derives hexes from PALETTE, not literals).
Gate: gen-audience-docs.test.mjs (27/27) + validate.sh (OK).