### PR TITLE
docs(memory): add 8 session lessons

### DIFF
--- a/docs/memory/MEMORY.md
+++ b/docs/memory/MEMORY.md
@@ -33,6 +33,7 @@ older than 7 days AND the lesson is no longer load-bearing, archive it.
 - [Autospec design preferences](feedback_autospec_design_prefs.md) — small-LLM target (60-120k ctx), correctness>>speed, tight imperative triggers, conservative guardrails, lock-step rule sacred
 - [Autospec monitor exit modes + recovery](feedback_monitor_silent_exit.md) — Phase 4 monitor silent-exits on complex integration work; relaunch is part of the workflow; subprocess mocks for tmux/osascript prevent test stalls
 - [Autospec decomposer + lockstep gotchas](feedback_autospec_decomposer_gotchas.md) — first new-skill issue MUST include structural sections (Self-update + Model tier + adapter row); codex/prompt.md needs leading blank line for lockstep; decomposer should NOT apply needs-autospec-template
+- [lint BODY_TOO_LONG counts injected metadata](feedback_lint_body_too_long_counts_injected_metadata.md) — Phase 3.5/3.75 append Model-fit + Shared-contracts blocks after the ≤400-word trim, so every classified child trips needs-quality-bar; blanket BODY_TOO_LONG-only flags are benign
 - [Admin-merge denial during autospec](feedback_admin_merge_denial.md) — `gh pr merge --admin` blocked by harness hook; needs settings.json permission rule for Phase 4 to flow
 - [/autospec autonomy scope](feedback_autospec_autonomy_scope.md) — auto-merge spec PRs, collapse low-stakes brainstorm to default-locks, surface only run/defer/refine + destructive-remote actions
 - [Skill per capability](feedback_autospec_skill_per_capability.md) — operator-facing capabilities ship as top-level /autospec-<verb> skills; inline sub-modes are convenience shortcuts only
@@ -44,14 +45,22 @@ older than 7 days AND the lesson is no longer load-bearing, archive it.
 - [LLM validator + adaptive retry](feedback_llm_validator_adaptive_retry.md) — pair every LLM-output validator with a 5-attempt retry loop that feeds findings back as directives
 - [validate.sh has named-content checks](feedback_validate_sh_lockstep_checks.md) — renaming SKILL.md prose sections requires updating validate.sh checks too
 - [validate.sh lockstep duo gap](feedback_validate_sh_lockstep_duo_gap.md) — check_lockstep() must guard SKILL.md+codex/prompt.md duos, not just full trios
+- [Skill golden + derivation workflow](feedback_skill_golden_derivation_workflow.md) — editing any trio skill (esp. with autospec-block markers) needs re-derive codex/opencode AND regenerate tests/fixtures/skill-goldens sha256, or validate.sh fails closed
+- [Decompose: trio prose + goldens must be one issue](feedback_decompose_trio_prose_goldens_atomic.md) — never split "edit trio prose" and "regen goldens" into separate auto-implement issues; the prose-only intermediate fails validate closed (bit 3x in one run); combine into one implementer that Closes both
 - [jq test() regex metachar injection](feedback_jq_test_regex_metachar_injection.md) — interpolating host/user-derived values into jq test() is regex injection; dotted hostnames made claim self-clean delete the wrong worker's lock comment; use capture()+==
 - [Self-consistent test fixtures mask bugs](feedback_self_consistent_test_fixtures_mask_bugs.md) — tests that build fixtures with the SUT's own derivation expression can't catch a bug in it; the Claude transcript-slug `lstrip` bug shipped green for months. Pin against the real convention / live values; reproduce end-to-end
 
 # Infrastructure gotchas
 
+- [Installer excludes runtime libs](feedback_installer_excludes_runtime_libs.md) — install.sh drops scripts/lib/ runtime libs; autospec-explore hard-crashes on a clean install; ship-completeness doesn't catch it
+- [Explore codebase-signals false positives](feedback_explore_codebase_signals_false_positives.md) — TODO/FIXME grep matches prose, assets, and its own source; noise dominates ranking; constitution gate drops 0/45
+
 - [Heartbeat cross-repo collision](feedback_heartbeat_cross_repo_collision.md) — ~/.autospec/process-heartbeats/ is shared across repos; use path-scoped slug subdirs
 - [Bash RETURN trap leaks](feedback_bash_return_trap_leak.md) — RETURN traps leak into caller frames under set -u; use inline cleanup
 - [Bash set -e short-circuit aborts](feedback_bash_set_e_short_circuit.md) — `[ test ] && action` aborts under set -e when test fails; use if/then/fi for one-sided conditionals
+- [bash 3.2 process-sub + [ -f ] in tests](feedback_bash32_process_sub_test_file.md) — macOS bash 3.2 `[ -f <(...) ]` is false; bats tests must write to a real temp file before a --validate-file/[ -f ] helper
+- [Subagent cwd pinned to main checkout](feedback_subagent_cwd_pinned_to_main_checkout.md) — Agent subagents commit to the main checkout's branch, NOT the EnterWorktree worktree; do writes directly as the main agent, reserve subagents for read-only, or they contaminate parallel branches
+- [Per-session worktree isolation](feedback_per_session_worktree_isolation.md) — concurrent autospec/claude sessions stomp each other; start every edit in a fresh worktree off origin/main + pre-flight overlap scan + file/skill claim, never edit on a shared/in-flight branch
 - [OMC autopilot magic-keyword misfire](feedback_omc_autopilot_misfire.md) — system reminders containing "AUTOPILOT" auto-activate OMC autopilot mid-session; recover via state_write(active=false) + state_clear(skill-active)
 - [Mempalace miner flat-form gap](feedback_mempalace_miner_flat_form.md) — M3 miner matches both `metadata.type:` (spec) and `type:` (real CC files); fixture both variants
 - [Harness session-id env vars](reference_harness_session_id_envs.md) — `CLAUDE_CODE_SESSION_ID` is the stable per-session id (ps -o sess=0, no tty under tool calls); fallback chain for harness-neutral per-session locks; PPID fallback is unreliable

--- a/docs/memory/feedback_bash32_process_sub_test_file.md
+++ b/docs/memory/feedback_bash32_process_sub_test_file.md
@@ -1,0 +1,25 @@
+---
+name: feedback_bash32_process_sub_test_file
+description: "macOS bash 3.2 fails `[ -f <(...) ]` process substitution; bats tests that pass a script's output through a `--validate-file`/`[ -f ]` helper must write to a real temp file first"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: ba194365-30f2-4add-918a-ed7263b0d5dd
+---
+
+On macOS the system bash is 3.2.57. Process substitution `<(...)` yields a
+`/dev/fd/N` path that bash 3.2's `[ -f "$path" ]` test reports as **false**, so
+any helper guarded by `[ -f "${2:-}" ]` (e.g. `gap-json-lib.sh --validate-file`)
+rejects a process-substitution argument regardless of content. This is a
+test/platform incompatibility, not a SUT bug.
+
+**Why:** autospec bats tests run under the host's `/bin/bash` (3.2), and several
+scripts validate a file path with `[ -f ]`. A test like
+`run bash "$LIB" --validate-file <(printf '%s' "$line")` fails 100% on macOS.
+
+**How to apply:** in bats, write the value to a real temp file and validate that:
+`printf '%s' "$line" > "$TMP/x.json"; run bash "$LIB" --validate-file "$TMP/x.json"`.
+One-off `<(...)` in interactive verification commands or in LLM-runtime prompt
+examples is fine — the rule is only for committed shell that must run under
+bash 3.2 (test scripts, the scanner engine). Mind subshell variable loss in
+`... | while read` too (use EXIT not RETURN traps). Related: [[feedback_bash_return_trap_leak]], [[feedback_bash_set_e_short_circuit]].

--- a/docs/memory/feedback_decompose_trio_prose_goldens_atomic.md
+++ b/docs/memory/feedback_decompose_trio_prose_goldens_atomic.md
@@ -1,0 +1,33 @@
+---
+name: feedback_decompose_trio_prose_goldens_atomic
+description: "Never decompose a spec so \"trio prose edit\" and \"golden regen\" land in separate issues — validate fails closed on the prose-only intermediate; keep them one atomic issue"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 59916493-7c02-4311-889a-2cbeccc1c071
+---
+
+When `/autospec-define` decomposes a spec, the ≤3-files-touched cap tempts it to
+split a skill change into "edit the trio prose" (issue X) and "regenerate the
+sha256 goldens" (issue X+1). This is WRONG: `scripts/validate.sh`'s
+block-expansion golden gate + `check_lockstep` require the trio prose change and
+its regenerated goldens in the SAME commit, so the prose-only issue can never
+merge green on its own. The same applies to a trio whose new prose is gated by a
+NEW `check_*_contract` added in a later issue.
+
+**Why:** this bit three times in the 2026-06-16 multi-spec run — #1067/#1068
+(autospec-run), #1084/#1085 (autospec-explore), #1100/#1101 (define+split). Each
+time I had to recombine the split issues into one implementer that did prose +
+goldens (+ any new validate gate) atomically and closed both issue numbers.
+
+**How to apply:**
+1. At decompose time, keep "trio prose + its goldens (+ the validate gate that
+   asserts the new prose)" as ONE issue even if it exceeds 3 files — correctness
+   beats the file cap. Tell the decomposer this explicitly.
+2. If they're already split in the queue, dispatch ONE implementer for the pair,
+   instruct it to do prose + golden regen in one commit/PR, and `Closes #X` +
+   `Closes #X+1`.
+3. The drainer must never run the prose-only issue alone expecting green.
+
+Related: [[feedback_skill_golden_derivation_workflow]],
+[[feedback_validate_sh_lockstep_checks]], [[feedback_per_session_worktree_isolation]].

--- a/docs/memory/feedback_explore_codebase_signals_false_positives.md
+++ b/docs/memory/feedback_explore_codebase_signals_false_positives.md
@@ -1,0 +1,33 @@
+---
+name: feedback_explore_codebase_signals_false_positives
+description: "autospec-explore codebase-signals researcher greps (TODO|FIXME|XXX|HACK)[: ] which matches prose (\"TODO list CLI\", \"FIXME found\"), non-.md assets (.cast/.html), and its OWN source + lint tooling that documents the markers — these noise proposals dominate ranking and the constitution gate (45→45) drops none"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: c279ed81-38f7-4098-ab47-a0a192f0366f
+---
+
+A bounded `explore-research-cycle.sh` round (deterministic 4-source, no internet/LLM)
+on the autospec repo returned 8/8 top-ranked proposals as `codebase-signals` false
+positives: demo copy `"build me a TODO list CLI"` in docs/quickstart.cast +
+docs/site/index.html, the researcher's OWN comments in codebase-signals.sh, and
+lint-implementation.sh help text describing the TODO_LEFT check.
+
+Root cause `scripts/explore-research/codebase-signals.sh:30`:
+`git grep -n -I -E '(TODO|FIXME|XXX|HACK)[: ]' -- ':!*.md'` — the `[: ]` allows a
+trailing SPACE (so "TODO list"/"FIXME found" prose matches), only `*.md` is excluded
+(so `.cast`/`.html`/asset files slip), and nothing excludes the researcher's own dir or
+the lint tooling that documents the markers.
+
+**Why:** noise crowds out the genuine spec-drift / prior-report proposals (small +
+weight 0.7 → score 0.385 dominates), and the constitution gate is toothless here —
+`proposals_after_constitution: 45` dropped 0/45. Unsupervised auto-filing would have
+opened ~8 garbage "chore: address TODO in marketing copy" issues. This is the concrete
+argument for surface-before-file discipline on explore rounds.
+
+**How to apply:** tighten the marker regex to require a comment-marker shape
+(`(TODO|FIXME|XXX|HACK)(\(|:)`, not a bare space); exclude `scripts/explore-research/`,
+`scripts/lint-*.sh`, `docs/`, and non-source asset extensions (`.cast`,`.html`,`.svg`);
+and give the constitution a rule that culls low-value `chore: address <marker>` proposals
+(or down-weights self/doc matches). Related: [[feedback_installer_excludes_runtime_libs]]
+(the DOA install that hid this until now), [[feedback_self_consistent_test_fixtures_mask_bugs]].

--- a/docs/memory/feedback_installer_excludes_runtime_libs.md
+++ b/docs/memory/feedback_installer_excludes_runtime_libs.md
@@ -1,0 +1,30 @@
+---
+name: feedback_installer_excludes_runtime_libs
+description: "install.sh excludes scripts/lib/ as \"install-time-only\" but it also holds runtime libs (autospec-loop.sh, autospec-harness-detect.sh) that 9 runtime scripts source at $SCRIPT_DIR/lib/ — clean install ships them nowhere, so autospec-explore hard-crashes on launch"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: c279ed81-38f7-4098-ab47-a0a192f0366f
+---
+
+`scripts/lib/` is a MIXED directory: install-time-only helpers (`install-helpers.sh`,
+`claude-md-block.txt`) **and** runtime libs (`autospec-loop.sh`,
+`autospec-harness-detect.sh`). `install.sh copy_repo_scripts()` uses `find -maxdepth 1`
+and explicitly excludes `scripts/lib/` ("install-time-only helpers"); the explicit
+`runtime_skill_scripts` manifest (9 entries) omits the two runtime libs. Net: a clean
+install never lands `~/.autospec/scripts/lib/autospec-loop.sh`, yet 9 runtime scripts
+source it from `$SCRIPT_DIR/lib/` — `autospec-explore.sh:112/114` does so **un-guarded**
+(`. "$SCRIPT_DIR/lib/..."`) and hard-crashes, while `autospec-continue.sh:52` wraps the
+same source in `if [ -f ... ]` and degrades gracefully.
+
+**Why:** the test suite is green while the install is broken — `validate.sh` only checks
+scripts *reference* the lib and runs the loop's bats logic; `ship-completeness.bats` mirrors
+the manifest that *omits* the libs. Classic [[feedback_self_consistent_test_fixtures_mask_bugs]]
+blind spot: nothing asserts the installer actually copies runtime libs to the runtime tree.
+
+**How to apply:** (1) add a `copy_runtime_libs()` step (or extend the manifest) that copies
+`scripts/lib/autospec-loop.sh` + `autospec-harness-detect.sh` to `$AUTOSPEC_SCRIPTS_DIR/lib/`;
+(2) add a ship-completeness assertion that every `$SCRIPT_DIR/lib/<x>` sourced by an installed
+runtime script exists post-install; (3) make `autospec-explore.sh` guard its source like
+`autospec-continue.sh` does. Immediate unblock: `cp scripts/lib/autospec-{loop,harness-detect}.sh
+~/.autospec/scripts/lib/`. Related: [[feedback_skill_golden_derivation_workflow]].

--- a/docs/memory/feedback_lint_body_too_long_counts_injected_metadata.md
+++ b/docs/memory/feedback_lint_body_too_long_counts_injected_metadata.md
@@ -1,0 +1,29 @@
+---
+name: feedback_lint_body_too_long_counts_injected_metadata
+description: "lint-issue.sh BODY_TOO_LONG counts auto-injected Model-fit + Shared-contracts blocks, so every classified child trips needs-quality-bar even when the authored body is in budget"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 065dc9be-3716-42b0-9667-ccb4ac86d20e
+---
+
+In an autospec-define run (harmonize spec, issues #1137-1146), ALL 10 children
+got `needs-quality-bar` with the single finding `BODY_TOO_LONG` (457-514 words).
+Root cause: Phase 3 trims each child body to ≤400 words, then Phase 3.5 appends
+the `## Model fit` block and Phase 3.75 appends the `## Shared contracts` block
+(~104 words combined). `scripts/lint-issue.sh`'s word count includes those
+auto-injected metadata blocks, so the post-filing audit re-flags every child
+even though the implementer-load-bearing prose is within budget.
+
+**Why:** the 400-word cap exists to keep a 32B-class implementer's context small,
+but the injected blocks are autospec's own metadata, not authored implementer
+load — counting them defeats the cap's intent and makes `needs-quality-bar`
+noise on every decomposition.
+
+**How to apply:** treat a blanket `needs-quality-bar` whose ONLY finding is
+`BODY_TOO_LONG` as benign when the overflow equals the injected metadata; don't
+block the gate on it. Real fix (future self-improvement): have `lint-issue.sh`
+BODY_TOO_LONG exclude content between `<!-- autospec-classify:* -->` and
+`<!-- autospec-shared-contracts:* -->` markers from the word count, OR run the
+post-filing audit on the pre-injection body. Relates to
+[[feedback_decompose_trio_prose_goldens_atomic]].

--- a/docs/memory/feedback_per_session_worktree_isolation.md
+++ b/docs/memory/feedback_per_session_worktree_isolation.md
@@ -1,0 +1,40 @@
+---
+name: feedback_per_session_worktree_isolation
+description: "Concurrent autospec/claude sessions stomp each other; start every edit in a fresh worktree off origin/main + claim files, never edit on the shared/in-flight branch"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 59916493-7c02-4311-889a-2cbeccc1c071
+---
+
+When multiple autospec or claude sessions run against the same repo, they step
+on each other's code. In the 2026-06-15 session I edited the autospec-explore
+trio directly on the in-flight `feat/closeout-report-contract` branch; meanwhile
+`main` had advanced 15 commits (refactoring the very `SRC_WEIGHTS`→
+`DEFAULT_SRC_WEIGHTS` file I touched) and other live worktrees existed
+(`fix/explore-codebase-signals-precision`, `fix/installer-ships-runtime-libs`).
+Result: a conflicted PR and full rework onto a fresh branch.
+
+**Why:** the trio + golden + validate machinery makes every skill edit a
+multi-file atomic unit; two sessions touching the same skill = guaranteed
+lockstep/golden conflicts. Editing on someone else's branch or a stale base
+compounds it. The repo already ships the primitives to prevent this
+(`worktree-guard.sh` with in_primary_checkout / dirty / stale_base exits;
+path-scoped heartbeats; atomic cross-machine issue-claim).
+
+**How to apply:**
+1. Before ANY code edit, `git fetch origin` and create/enter a dedicated
+   worktree on a new branch off fresh `origin/main` — never the shared primary
+   checkout, never an unrelated in-flight feature branch. Run
+   `worktree-guard.sh assert` and refuse on stale_base.
+2. Pre-flight overlap scan: check open PRs + `git worktree list` + other
+   branches for in-flight edits to the same files/skill; if another live session
+   owns that skill, pick different work or coordinate.
+3. Prefer a file/skill-granular claim (lease with heartbeat TTL under a
+   path-scoped `~/.autospec/claims/…`) layered on the existing issue-claim
+   infra, so two sessions don't both edit one trio.
+4. Keep my work in its own branch/PR; stage only my files; leave others'
+   uncommitted changes untouched.
+
+Related: [[feedback_subagent_cwd_pinned_to_main_checkout]],
+[[feedback_heartbeat_cross_repo_collision]], [[reference_harness_session_id_envs]].

--- a/docs/memory/feedback_skill_golden_derivation_workflow.md
+++ b/docs/memory/feedback_skill_golden_derivation_workflow.md
@@ -1,0 +1,33 @@
+---
+name: feedback_skill_golden_derivation_workflow
+description: "Editing any autospec trio skill (esp. one with autospec-block markers) requires re-deriving codex/opencode AND regenerating tests/fixtures/skill-goldens sha256, or validate.sh fails closed"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: ba194365-30f2-4add-918a-ed7263b0d5dd
+---
+
+When adding or editing an autospec multi-harness skill, two coupled gates in
+`scripts/validate.sh` must both pass:
+
+1. **Lock-step (raw):** `strip_body(SKILL.md)` (= `awk '/^---$/{c++;next} c>=2'`)
+   must byte-equal `codex/prompt.md`, and equal `strip_body(opencode/agent.md)`.
+   opencode has its own 2-line frontmatter (`description:` + `mode: primary`).
+2. **Block-expansion golden:** for every skill, `tests/fixtures/skill-goldens/
+   <skill>.{SKILL.md,codex.prompt.md,opencode.agent.md}.sha256` must equal
+   `expand-skill-blocks.sh <src> | shasum -a 256 | cut -d' ' -f1`. SKILL.md
+   golden is required (fail-closed on missing); codex/opencode goldens required
+   when that member contains `<!-- autospec-block:... -->` markers.
+
+**Why:** a NEW skill fails validate.sh until goldens exist; editing a skill with
+block markers (e.g. autospec-run's `harness-adapter-core` / `startup-self-update`)
+changes the expanded bytes, so stale goldens fail.
+
+**How to apply (safe procedure):** edit SKILL.md only → re-derive
+`codex/prompt.md = strip_body(SKILL.md)` and `opencode/agent.md = <its frontmatter> +
+strip_body(SKILL.md)` → regenerate all 3 goldens with the expander+shasum →
+verify both lock-step diffs empty → run full `validate.sh` (slow, runs whole bats
+suite) expecting exit 0. New skills also need a `## Stop mode` heading in all
+three trio files, a `## Self-update mode` section, a Model-tier directive, and the
+adapter rows. Extends [[feedback_autospec_decomposer_gotchas]] and
+[[feedback_validate_sh_lockstep_checks]].

--- a/docs/memory/feedback_subagent_cwd_pinned_to_main_checkout.md
+++ b/docs/memory/feedback_subagent_cwd_pinned_to_main_checkout.md
@@ -1,0 +1,33 @@
+---
+name: feedback_subagent_cwd_pinned_to_main_checkout
+description: "Agent-tool subagents run with cwd pinned to the main repo checkout, NOT the EnterWorktree worktree — implementer subagents commit to whatever branch the main checkout is on, contaminating parallel work"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: ba194365-30f2-4add-918a-ed7263b0d5dd
+---
+
+When the session is in an `EnterWorktree` worktree and you dispatch an **Agent**
+subagent to write+commit code, the subagent's working directory is pinned to the
+**main repo checkout** (the original launch dir), not the active worktree — and
+the harness resets a subagent's `cd` back after each Bash call. So a build
+subagent commits to whatever branch the *main checkout* currently has checked
+out. If a parallel session/user has switched the main checkout to their own
+branch, the subagent's commit lands on THEIR branch (cross-contamination).
+
+**Why:** observed live — main checkout was on `feat/closeout-report-contract`
+(parallel work); a dispatched implementer's commit landed there instead of the
+intended worktree branch, on top of the user's uncommitted edits.
+
+**How to apply:**
+- For multi-track worktree work, do the file edits/commits **directly as the main
+  agent** (the main loop's cwd IS correctly pinned to the active worktree — a
+  `cd elsewhere` in Bash is auto-reset back to the worktree). Reserve subagents
+  for **read-only** tasks (reviewers/explorers never commit, so they're safe).
+- If you must use a writing subagent, have it `git rev-parse --abbrev-ref HEAD`
+  first and refuse if not on the expected branch.
+- Recovery when it lands on the wrong branch: `git cherry-pick <sha>` onto the
+  intended branch, then in the contaminated checkout `git reset --soft HEAD~1` +
+  selectively `git restore`/`rm` only the stray files (never disturb the owner's
+  uncommitted changes). Confirm with the user before touching a branch you don't
+  own. Relates to [[feedback_skill_golden_derivation_workflow]].


### PR DESCRIPTION
Adds project-memory lesson files that accumulated across sessions but were never committed (the local branch was stale; these are the only genuinely-new files vs main — the secaudit docs and autospec-run security-dimension change are already landed).

Lessons:
- bash 3.2 process-sub + `[ -f ]` in bats tests
- decompose: trio prose + goldens must be one issue
- explore codebase-signals false positives
- installer excludes runtime libs
- per-session worktree isolation
- skill golden + derivation workflow
- subagent cwd pinned to main checkout
- lint BODY_TOO_LONG counts injected metadata

Docs-only; indexed in `docs/memory/MEMORY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)