### PR TITLE
feat(validate): adopt derive-trio --check as the canonical trio-drift gate (trio-derivation Phase 2)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -220,6 +220,32 @@ check_required_files() {
     done
 }
 
+# Derive-trio drift gate (trio-derivation Phase 2, decomposition children C+E).
+# This ADOPTS scripts/derive-trio.sh --check as the canonical trio-drift
+# mechanism: for every multi-harness skill under skills/, the committed
+# codex/prompt.md and opencode/agent.md mirrors must be byte-identical to what
+# derive-trio regenerates from SKILL.md. check_lockstep (the byte-diff above)
+# stays as the low-level invariant; this is its derive-aware companion that, on
+# drift, emits the actionable single-command fix:
+#   run: scripts/derive-trio.sh --in-place skills/<name> && scripts/gen-skill-goldens.sh <name>
+# (re-derive the mirrors, then regenerate the skill-golden sha256s).
+#
+# Since --check already passes universally today, this gate is a no-op on a
+# clean tree; it makes derive-trio canonical going forward (no trio FILE changes
+# are part of this adoption). Uses the trio-discovery convention (SKILL.md +
+# opencode/agent.md + codex/prompt.md), matching discover_skills.
+check_derive_trio_consistency() {
+    info "derive-trio --check (canonical trio-drift gate)"
+    derive="scripts/derive-trio.sh"
+    [ -f "$derive" ] || fail "$derive: missing (trio-derivation Phase 1 must be merged first)"
+    for skill_dir in $(discover_skills); do
+        name="$(basename "$skill_dir")"
+        if ! bash "$derive" "$skill_dir" --check; then
+            fail "$name: trio mirrors drift from SKILL.md — run: $derive --in-place $skill_dir && scripts/gen-skill-goldens.sh $name"
+        fi
+    done
+}
+
 # Stop mode invariants (introduced by the autospec-stop mechanism): every
 # multi-harness skill trio must carry a `## Stop mode` heading in all three
 # trio files (SKILL.md, opencode/agent.md, codex/prompt.md). Parallels
@@ -2714,6 +2740,7 @@ main() {
     check_define_spec_worktree_routing
     check_token_baseline_fresh
     check_block_expansion
+    check_derive_trio_consistency
     check_claim_guard_contract
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax

--- a/tests/unit/test_validate_derive_trio.bats
+++ b/tests/unit/test_validate_derive_trio.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# tests/unit/test_validate_derive_trio.bats — exercise the
+# check_derive_trio_consistency() gate added to scripts/validate.sh
+# (trio-derivation Phase 2, decomposition children C + E).
+#
+# Contract:
+#   * The function exists and is wired into main()'s global check list.
+#   * It passes against the real repo as-is (every trio's --check is green —
+#     this is the "migration/adoption" assertion: derive-trio is now canonical).
+#   * When a trio mirror (codex/prompt.md or opencode/agent.md) is hand-edited
+#     out of sync, validate.sh fails AND the diagnostic names the skill and the
+#     exact fix command:
+#       run: scripts/derive-trio.sh --in-place skills/<name> && \
+#            scripts/gen-skill-goldens.sh <name>
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    VALIDATE="$REPO_ROOT/scripts/validate.sh"
+    SCRATCH="$(mktemp -d)"
+    export SCRATCH
+}
+
+teardown() {
+    if [ -n "${SCRATCH:-}" ] && [ -d "$SCRATCH" ]; then
+        rm -rf "$SCRATCH"
+    fi
+}
+
+# ---- presence / wiring ---------------------------------------------------
+
+@test "validate.sh: defines check_derive_trio_consistency" {
+    run grep -q '^check_derive_trio_consistency()' "$VALIDATE"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate.sh: wires check_derive_trio_consistency into main()" {
+    run grep -Eq '^[[:space:]]+check_derive_trio_consistency$' "$VALIDATE"
+    [ "$status" -eq 0 ]
+}
+
+# ---- clean tree passes ---------------------------------------------------
+
+@test "validate.sh: passes against the real repo as-is (derive-trio --check green for all trios)" {
+    run bash "$VALIDATE"
+    [ "$status" -eq 0 ]
+}
+
+# ---- drift in a trio mirror fails with the friendly fix command ----------
+#
+# check_derive_trio_consistency is exercised IN ISOLATION here. In the full
+# main() run order the per-skill check_lockstep byte-diff fires first and exits
+# on drift, so it would shadow this check's diagnostic; that shadowing is fine
+# (both enforce the same invariant) — this gate's job is to emit the actionable
+# single-command fix, which we assert by driving the function directly against a
+# drifted scratch skills/ tree. We source the function out of validate.sh so the
+# test tracks the real implementation (no copy-paste) and provide the fail/info
+# helpers it depends on, with `fail` writing the message to a real temp file
+# (bash-3.2 safe; no process-substitution into [ -f ]).
+
+# Build a hermetic skills/ tree containing one real trio under $SCRATCH and run
+# check_derive_trio_consistency from there. Captures combined output; returns the
+# function's exit status. The fail message lands in $SCRATCH/fail.out.
+_run_derive_check_in_scratch() {
+    mkdir -p "$SCRATCH/skills" "$SCRATCH/scripts"
+    cp -R "$REPO_ROOT/skills/autospec-explore" "$SCRATCH/skills/autospec-explore"
+    cp "$REPO_ROOT/scripts/derive-trio.sh" "$SCRATCH/scripts/derive-trio.sh"
+    # Extract the function body verbatim from validate.sh (def line to its closing
+    # brace at column 0) so the test asserts the SHIPPED implementation.
+    awk '/^check_derive_trio_consistency\(\) \{/{p=1} p{print} p&&/^\}/{exit}' \
+        "$VALIDATE" > "$SCRATCH/fn.sh"
+    (
+        cd "$SCRATCH"
+        # shellcheck disable=SC1091
+        set +e
+        fail() { printf 'validate: FAIL — %s\n' "$*" > "$SCRATCH/fail.out"; cat "$SCRATCH/fail.out" >&2; exit 1; }
+        info() { printf 'validate: %s\n' "$*"; }
+        discover_skills() { for d in skills/*/; do
+            [ -d "$d" ] || continue
+            if [ -f "$d/SKILL.md" ] && [ -f "$d/opencode/agent.md" ] && [ -f "$d/codex/prompt.md" ]; then
+                printf '%s\n' "${d%/}"
+            fi
+        done; }
+        # shellcheck source=/dev/null
+        . "$SCRATCH/fn.sh"
+        check_derive_trio_consistency
+    )
+}
+
+@test "check_derive_trio_consistency: passes on a clean scratch trio" {
+    run _run_derive_check_in_scratch
+    [ "$status" -eq 0 ]
+}
+
+# ---- valid cross-dir: resolves trio paths via its own discovery -----------
+#
+# check_derive_trio_consistency() must not assume validate.sh was invoked from
+# the repo root: it resolves the trio via discover_skills globbing skills/*/
+# relative to its own CWD plus a relative scripts/derive-trio.sh, never an
+# absolute repo path. _run_derive_check_in_scratch cd's into $SCRATCH (created
+# by mktemp -d, distinct from $REPO_ROOT) and runs the check there against a
+# clean hermetic trio, so a green exit proves the cross-dir resolution. We also
+# assert no fail.out was written — the absence of the fail diagnostic confirms
+# the check found and passed the scratch trio rather than erroring on a missing
+# absolute path.
+@test "check_derive_trio_consistency: passes when run from a working dir other than the repo root (valid cross-dir)" {
+    # Guard: the scratch CWD the helper uses must differ from the repo root, so
+    # a green result genuinely exercises the cross-dir path-resolution behavior.
+    [ "$SCRATCH" != "$REPO_ROOT" ]
+    run _run_derive_check_in_scratch
+    [ "$status" -eq 0 ]
+    [ ! -f "$SCRATCH/fail.out" ]
+}
+
+@test "check_derive_trio_consistency: fails with the fix command when a codex mirror drifts" {
+    mkdir -p "$SCRATCH/skills" "$SCRATCH/scripts"
+    cp -R "$REPO_ROOT/skills/autospec-explore" "$SCRATCH/skills/autospec-explore"
+    cp "$REPO_ROOT/scripts/derive-trio.sh" "$SCRATCH/scripts/derive-trio.sh"
+    printf '\nHAND-EDITED DRIFT LINE\n' >> "$SCRATCH/skills/autospec-explore/codex/prompt.md"
+    run _run_derive_check_in_scratch
+    [ "$status" -ne 0 ]
+    [ -f "$SCRATCH/fail.out" ]
+    grep -F 'autospec-explore' "$SCRATCH/fail.out" >/dev/null
+    grep -F 'scripts/derive-trio.sh --in-place skills/autospec-explore' "$SCRATCH/fail.out" >/dev/null
+    grep -F 'scripts/gen-skill-goldens.sh autospec-explore' "$SCRATCH/fail.out" >/dev/null
+}
+
+@test "check_derive_trio_consistency: fails with the fix command when an opencode mirror drifts" {
+    mkdir -p "$SCRATCH/skills" "$SCRATCH/scripts"
+    cp -R "$REPO_ROOT/skills/autospec-explore" "$SCRATCH/skills/autospec-explore"
+    cp "$REPO_ROOT/scripts/derive-trio.sh" "$SCRATCH/scripts/derive-trio.sh"
+    printf '\nHAND-EDITED OPENCODE DRIFT\n' >> "$SCRATCH/skills/autospec-explore/opencode/agent.md"
+    run _run_derive_check_in_scratch
+    [ "$status" -ne 0 ]
+    [ -f "$SCRATCH/fail.out" ]
+    grep -F 'autospec-explore' "$SCRATCH/fail.out" >/dev/null
+    grep -F 'scripts/derive-trio.sh --in-place skills/autospec-explore' "$SCRATCH/fail.out" >/dev/null
+}


### PR DESCRIPTION
## Summary

Implements the final Phase-2 item of the trio-derivation spec (decomposition children **C** + **E**) as one small, additive change: a derive-aware drift gate in `scripts/validate.sh`.

- Adds `check_derive_trio_consistency()`: for every multi-harness skill trio under `skills/`, runs `scripts/derive-trio.sh <skill-dir> --check`; on drift it `fail`s with a message that names the skill **and** the exact single-command fix:

  ```
  run: scripts/derive-trio.sh --in-place skills/<name> && scripts/gen-skill-goldens.sh <name>
  ```

- **Child E (adoption):** makes `derive-trio --check` the canonical trio-drift mechanism going forward. `--check` already passes universally today, so the gate is a no-op on a clean tree and needs **no trio FILE changes**.
- **Child C (friendly fix):** surfaces the actionable re-derive + regen-goldens command on drift.
- `check_lockstep` (the low-level byte-diff) stays exactly as-is — this is its derive-aware companion, not a replacement.

### Scoping
The check is a global (non-per-skill) gate. Under `--changed`/`--since` it is unmapped and therefore fail-safe **ALWAYS-RUNs**, and it is auto-counted by `main()`'s scoped accounting — so no `scripts/lib/validate-affected.sh` mapping was needed.

## Tests
`tests/unit/test_validate_derive_trio.bats`:
- function presence + `main()` wiring
- clean-tree green path (the migration/adoption assertion: every trio's `--check` is green)
- drift path (hand-editing a `codex/prompt.md` or `opencode/agent.md` mirror out of sync makes the check fail and emit the fix command naming the skill). Drift cases drive the function in isolation, since `check_lockstep` shadows it in full-`main()` order.

## Verification
- `bash scripts/validate.sh` → green (exit 0); the new gate ran and passed.
- `bash scripts/validate.sh --changed=origin/main` → green (`scoped: ran 93/118`); the global gate ran.
- New bats suite green.

Refs `docs/specs/2026-06-16-trio-derivation-design.md` — Phase 2, decomposition children **C + E**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)