### PR TITLE
Promote autospec-explore round 1: enrich /autospec-doc for LLM learning

### DIFF
--- a/docs/specs/2026-06-16-explore-autodoc-improve-round-1-design.md
+++ b/docs/specs/2026-06-16-explore-autodoc-improve-round-1-design.md
@@ -1,0 +1,141 @@
+# Design spec — make `/autospec-doc` actually teach an LLM the project
+
+- **Sandbox branch:** `autospec/explore/2026-06-16-autodoc-improve`
+- **Round:** 1
+- **Driver:** `/autospec-explore` (focused, single-skill investigation)
+- **Operator complaint:** the auto-documentation skill "seems a bit lacking and
+  was missing critical information for the LLMs to learn."
+
+## Result first
+
+The complaint is correct, and it has **two independent root causes** — both
+must be addressed or the docs stay thin:
+
+1. **Content-model poverty (design gap).** Even when the generators run, a
+   feature page is just `title + summary + spec_sections (prose) + an AI
+   confidence marker`. The categories an LLM needs to *learn* a system — data
+   models/schemas, invariants/constraints, error semantics, config/env/CLI
+   reference, the "why"/rationale, and cross-feature dependencies — are **never
+   captured**. `gen-audience-docs.mjs:158-244` emits only the summary and the
+   provided prose sections.
+
+2. **Pipeline incompleteness (implementation gap).** The high-signal artifacts
+   that exist on paper are not wired:
+   - `.llm-manifest.json` is a **legacy stub**: `modules`, `cli_entry_points`,
+     `http_endpoints`, `faq` are all `[]` and `concepts` holds a literal
+     `"<name>"` placeholder (dated 2026-05-22). The symbol map an LLM/RAG would
+     navigate by is empty.
+   - `doc-style.mjs` exports `generateExplainerDiagram()` and
+     `isLogicFlowSection()` but **no generator imports it** — only the test does.
+     Architecture/flow diagrams are dead code.
+   - `verify-examples.mjs` is fully built, but `gen-audience-docs.mjs` never
+     emits `<!-- example -->` blocks for it to run, so no verified runnable
+     examples (with captured `output`) ever reach the docs or `llms-full.txt`.
+   - `llms.txt` does not follow the llmstxt.org shape (duplicate `# autospec`
+     H1, no per-link descriptions, no routing), and `llms-full.txt` has no
+     navigable index, no per-section summaries, no token-budget annotations, and
+     no source-file→doc reverse routing.
+
+Net: an LLM reading today's output gets *what* a feature is named and a one-line
+summary, but not *how it works, how it fails, how to configure it, or why it
+exists* — exactly the "critical information … to learn" the operator flagged.
+
+## Evidence
+
+| Claim | Evidence |
+|---|---|
+| Page content is summary + prose only | `gen-audience-docs.mjs:158-244` (renderIndex/getting-started/tutorial/feature) |
+| Diagram generator orphaned | `gen-audience-docs.mjs` imports only `gen-docs-from-spec`, `ai-review-doc`, `scan-doc-scope`; `doc-style.mjs` imported only by `doc-style.test.mjs` |
+| Manifest is an empty stub | `docs/.llm-manifest.json`: empty `modules/cli_entry_points/http_endpoints/faq`, `concepts[0].name == "<name>"` |
+| Examples never emitted into pages | `verify-examples.mjs` parses/executes `<!-- example -->` blocks; generators never produce them |
+| `llms.txt` off-standard | duplicate H1 at lines 1 & 5; no per-link descriptions/routing |
+| Much of the skill is still stubbed | `SKILL.md:20-24` "scaffold contract"; generators "filled in by #917-#924" |
+
+## Improvement tracks (severity-first)
+
+### Track A — Enrich the content model *(severity: correctness)* — the direct fix
+Extend the feature/config schema (`doc-config.mjs`) and the audience renderers
+(`gen-audience-docs.mjs`) to emit structured, LLM-targeted sections per feature,
+each audience-scoped:
+- `## Data model` — schemas/types for the feature's inputs/outputs.
+- `## Invariants & constraints` — what must hold; pairs with the project's
+  existing invariant/guard discipline.
+- `## Errors & failure modes` — error taxonomy: cause → recovery, what fails
+  silently vs. loudly.
+- `## Configuration` — CLI flags, env vars, config keys (admin + developer).
+- `## Why` — rationale / design decision / alternatives rejected (developer).
+- `## Related features` — cross-links from a `depends_on` edge (dependency graph).
+
+Acceptance criteria:
+- [ ] `doc-config.mjs` accepts and validates the new per-feature fields
+  (`data_model`, `invariants`, `errors`, `config_reference`, `rationale`,
+  `depends_on`) with safe defaults when absent (backward compatible).
+- [ ] `gen-audience-docs.mjs` renders each present field as its own H2 section,
+  audience-gated per the table above, and omits empty sections.
+- [ ] A fixture feature carrying all new fields round-trips into the four
+  audience pages with the expected headings (unit test).
+- [ ] No regression: a feature with only `summary`/`spec_sections` produces
+  byte-identical output to today.
+
+### Track B — Populate `.llm-manifest.json` with real symbol data *(severity: correctness)*
+Make the manifest the navigable symbol map it is specified to be.
+
+Acceptance criteria:
+- [ ] `gen-llms-full.mjs` populates `modules[]` (name + summary + public_api +
+  doc path), `cli_entry_points[]`, and `concepts[]`/glossary from the generated
+  corpus and `<!-- autospec-concept: -->` markers — no literal `<name>` stub.
+- [ ] Each manifest entry carries `source_anchor` provenance and an
+  `approx_tokens` size hint.
+- [ ] A fixture corpus produces a manifest with non-empty `modules` and
+  `concepts` and zero placeholder strings (unit test).
+
+### Track C — Wire verified runnable examples end-to-end *(severity: stability)*
+Close the loop between example authoring, execution, and LLM-facing output.
+
+Acceptance criteria:
+- [ ] `gen-audience-docs.mjs` emits `<!-- example -->` fenced blocks from a
+  `feature.examples[]` field.
+- [ ] `verify-examples.mjs` runs them and the captured ` ```output ` block plus
+  `<!-- example-verified: <sha> <iso> -->` marker survive concatenation into
+  `llms-full.txt` (not stripped).
+- [ ] A fixture example executes, its output is embedded, and the verified
+  marker appears in both the page and `llms-full.txt` (unit test).
+
+### Track D — Activate architecture/flow diagrams (kill the dead code) *(severity: operability)*
+Import and call the orphaned `doc-style.mjs` diagram functions.
+
+Acceptance criteria:
+- [ ] `gen-audience-docs.mjs` imports `doc-style.mjs` and calls
+  `isLogicFlowSection()` / `generateExplainerDiagram()` for logic-flow sections,
+  emitting palette-themed mermaid diagrams.
+- [ ] A logic-flow fixture section yields a themed mermaid block; a non-flow
+  section yields none (unit test).
+- [ ] No second palette source is introduced (existing single-source guard
+  still passes).
+
+### Track E — Make `llms.txt` a real index + `llms-full.txt` navigable *(severity: operability)*
+Conform to the llmstxt.org convention and add LLM-navigation affordances.
+
+Acceptance criteria:
+- [ ] `llms.txt`: single H1, blockquote summary, curated link sections each with
+  a one-line description; no duplicate heading.
+- [ ] `llms-full.txt`: a top table-of-contents with anchors, a 1–2 line summary
+  before each section, per-section `approx_tokens` annotation, a
+  source-file→doc reverse-routing block, and a `generated_at`+`commit` freshness
+  stamp.
+- [ ] Generation is deterministic and idempotent (re-run on unchanged corpus is
+  a no-op diff).
+
+## Out of scope (this round)
+- Completing the still-stubbed Phase 4 self-heal / Phase 5.5 completeness / sweep
+  + define redirects (#922-#924). Tracks A–E raise content quality on the
+  generation path that already runs; the wiring is a separate program.
+- Per-audience `llms-full-<audience>.txt` splits (future, once A–E land).
+
+## Verification
+- `bash scripts/validate.sh` stays green (lockstep trio + goldens regenerated for
+  any `SKILL.md` prose touched).
+- New unit tests under `skills/autospec-doc/tests/` for each track.
+- A smoke generation against a fixture repo shows all six new section types,
+  a populated manifest, an executed example, a themed diagram, and a navigable
+  `llms-full.txt`.

--- a/skills/autospec-doc/scripts/doc-config.mjs
+++ b/skills/autospec-doc/scripts/doc-config.mjs
@@ -304,6 +304,45 @@ export function resolveAutoRegenerate({ config = {}, issueBody = '', withDocsFla
   return { generate: false, reason: 'default-off' };
 }
 
+// ── normalizeFeature ──────────────────────────────────────────────────────────
+//
+// Coerces the six new LLM-targeted fields (issue #1129) to empty-safe defaults
+// so downstream renderers never encounter undefined. Absent fields stay '' / [].
+// Existing fields (slug, title, summary, spec_sections, code_entry_points, …)
+// are preserved verbatim — this function only adds the new keys when missing.
+//
+// Shared-contracts field names (pinned; consumers MUST use these verbatim):
+//   data_model      string (markdown) | default ''
+//   invariants      string (markdown) | default ''
+//   errors          string (markdown) | default ''
+//   config_reference string (markdown) | default ''
+//   rationale       string (markdown) | default ''
+//   depends_on      array of feature-id strings | default []
+//   examples        array of example entries     | default []
+
+/**
+ * normalizeFeature(feature) → feature with six new LLM fields defaulted.
+ *
+ * @param {object} feature  Raw feature object from config / test fixtures.
+ * @returns {object}  Same object reference enriched with empty-safe defaults.
+ */
+export function normalizeFeature(feature) {
+  if (!feature || typeof feature !== 'object') return feature;
+  // String fields: coerce present non-string values; keep '' for absent.
+  const STR_FIELDS = ['data_model', 'invariants', 'errors', 'config_reference', 'rationale'];
+  for (const field of STR_FIELDS) {
+    feature[field] = (feature[field] != null) ? String(feature[field]) : '';
+  }
+  // Array fields: coerce present non-array values; keep [] for absent.
+  if (!Array.isArray(feature.depends_on)) {
+    feature.depends_on = (feature.depends_on != null) ? [feature.depends_on] : [];
+  }
+  if (!Array.isArray(feature.examples)) {
+    feature.examples = (feature.examples != null) ? [feature.examples] : [];
+  }
+  return feature;
+}
+
 // ── loadConfig ─────────────────────────────────────────────────────────────────
 
 /**

--- a/skills/autospec-doc/scripts/gen-audience-docs.mjs
+++ b/skills/autospec-doc/scripts/gen-audience-docs.mjs
@@ -36,6 +36,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isLogicFlowSection, generateExplainerDiagram } from './doc-style.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SHARED_SCRIPTS = path.resolve(__dirname, '../../autospec-shared/scripts');
@@ -329,7 +330,20 @@ function renderFeature(audience, feature, directive) {
     feature.summary ? `${feature.summary}` : `Reference documentation for ${feature.slug}.`,
     '',
   ];
-  for (const s of (feature.spec_sections || [])) lines.push(s, '');
+  for (const s of (feature.spec_sections || [])) {
+    lines.push(s, '');
+    // Track D (issue #1131): emit a palette-themed mermaid diagram for logic-flow sections.
+    const section = { heading: feature.title || feature.slug, body: s };
+    if (isLogicFlowSection(section)) {
+      const diagram = generateExplainerDiagram(section);
+      if (diagram) {
+        lines.push('```mermaid');
+        lines.push(diagram);
+        lines.push('```');
+        lines.push('');
+      }
+    }
+  }
   // Append the six LLM-targeted sections (issue #1129); empty fields are omitted.
   lines.push(...renderFeatureSections(audience, feature));
   // Append verified runnable examples (issue #1133); empty examples[] emits nothing.

--- a/skills/autospec-doc/scripts/gen-audience-docs.mjs
+++ b/skills/autospec-doc/scripts/gen-audience-docs.mjs
@@ -281,6 +281,40 @@ function renderFeatureSections(audience, feature) {
   return lines;
 }
 
+// ── renderExamples — emit <!-- example --> fenced blocks (issue #1133) ──────────
+//
+// Emits one `<!-- example -->` + fenced code block per entry in
+// feature.examples[].  Empty / absent arrays emit nothing.
+//
+// Entry shape: { lang?: string, command: string }
+//   lang     defaults to 'bash' when absent or empty.
+//   command  the executable text placed verbatim inside the fence.
+//
+// Marker format is pinned verbatim by the #1133 shared contract:
+//   <!-- example -->
+//   ```<lang>
+//   <command>
+//   ```
+//
+// verifyExamples (verify-examples.mjs) recognises exactly this tag+fence
+// sequence and stamps an adjacent output block + <!-- example-verified: -->
+// marker after a successful run.
+
+function renderExamples(feature) {
+  const examples = feature.examples;
+  if (!examples || examples.length === 0) return [];
+  const lines = [];
+  for (const entry of examples) {
+    const lang = (entry.lang && entry.lang.trim()) ? entry.lang.trim() : 'bash';
+    lines.push('<!-- example -->');
+    lines.push(`\`\`\`${lang}`);
+    lines.push(entry.command);
+    lines.push('```');
+    lines.push('');
+  }
+  return lines;
+}
+
 function renderFeature(audience, feature, directive) {
   const globs = featureSrcGlobs(feature);
   const lines = [
@@ -298,6 +332,8 @@ function renderFeature(audience, feature, directive) {
   for (const s of (feature.spec_sections || [])) lines.push(s, '');
   // Append the six LLM-targeted sections (issue #1129); empty fields are omitted.
   lines.push(...renderFeatureSections(audience, feature));
+  // Append verified runnable examples (issue #1133); empty examples[] emits nothing.
+  lines.push(...renderExamples(feature));
   if (directive) lines.push(`<!-- regen-directive: ${directive} -->`, '');
   return lines.join('\n');
 }

--- a/skills/autospec-doc/scripts/gen-audience-docs.mjs
+++ b/skills/autospec-doc/scripts/gen-audience-docs.mjs
@@ -224,6 +224,63 @@ function renderTutorial(audience, feature, directive) {
   return lines.join('\n');
 }
 
+// ── renderFeatureSections — six LLM-targeted H2 blocks (issue #1129) ──────────
+//
+// Audience gating (pinned in shared-contracts):
+//   config_reference → [admin, developer]
+//   rationale        → [developer]
+//   all others       → all audiences
+//
+// Empty fields ('' / []) are silently omitted — no blank H2 is emitted.
+//
+// Section order is fixed: Data model → Invariants → Errors → Configuration →
+// Why → Related features.
+
+const SECTION_AUDIENCE_GATE = {
+  config_reference: ['admin', 'developer'],
+  rationale:        ['developer'],
+};
+
+function renderFeatureSections(audience, feature) {
+  const lines = [];
+
+  function maybeSection(heading, fieldValue) {
+    if (!fieldValue || (typeof fieldValue === 'string' && fieldValue.trim() === '')) return;
+    if (Array.isArray(fieldValue) && fieldValue.length === 0) return;
+    lines.push(`## ${heading}`, '');
+    if (Array.isArray(fieldValue)) {
+      for (const item of fieldValue) lines.push(`- ${item}`);
+      lines.push('');
+    } else {
+      lines.push(String(fieldValue), '');
+    }
+  }
+
+  // data_model — all audiences
+  maybeSection('Data model', feature.data_model || '');
+
+  // invariants — all audiences
+  maybeSection('Invariants & constraints', feature.invariants || '');
+
+  // errors — all audiences
+  maybeSection('Errors & failure modes', feature.errors || '');
+
+  // config_reference — admin + developer only
+  if (SECTION_AUDIENCE_GATE.config_reference.includes(audience.name)) {
+    maybeSection('Configuration', feature.config_reference || '');
+  }
+
+  // rationale — developer only
+  if (SECTION_AUDIENCE_GATE.rationale.includes(audience.name)) {
+    maybeSection('Why', feature.rationale || '');
+  }
+
+  // depends_on — all audiences
+  maybeSection('Related features', feature.depends_on || []);
+
+  return lines;
+}
+
 function renderFeature(audience, feature, directive) {
   const globs = featureSrcGlobs(feature);
   const lines = [
@@ -239,6 +296,8 @@ function renderFeature(audience, feature, directive) {
     '',
   ];
   for (const s of (feature.spec_sections || [])) lines.push(s, '');
+  // Append the six LLM-targeted sections (issue #1129); empty fields are omitted.
+  lines.push(...renderFeatureSections(audience, feature));
   if (directive) lines.push(`<!-- regen-directive: ${directive} -->`, '');
   return lines.join('\n');
 }

--- a/skills/autospec-doc/scripts/gen-llms-full.mjs
+++ b/skills/autospec-doc/scripts/gen-llms-full.mjs
@@ -66,55 +66,224 @@ function chunkMarker(chunkNum, charCount) {
   return `<!-- llms-chunk: chunk=${chunkNum} approx_tokens=${approxTokens} -->`;
 }
 
+// ── Internal helpers (Track E) ────────────────────────────────────────────────
+
+/**
+ * Derive a URL-safe anchor slug from a heading string.
+ * Mirrors GitHub-flavored Markdown anchor rules: lowercase, spaces→hyphens,
+ * strip non-alphanumeric-hyphen chars.
+ */
+function slugify(text) {
+  return text.toLowerCase().replace(/[^\w\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-');
+}
+
+/**
+ * Extract the first H1 text from a page's content, falling back to the
+ * path's basename.
+ */
+function pageTitle(page) {
+  const m = (page.content || '').match(/^#\s+(.+)/m);
+  return m ? m[1].trim() : path.basename(page.path, '.md');
+}
+
+/**
+ * Extract a one-line summary for a page: the first non-empty, non-heading
+ * line after the H1 (or the H1 text itself if nothing follows).
+ */
+function pageSummary(page) {
+  const lines = (page.content || '').split('\n');
+  let pastH1 = false;
+  for (const ln of lines) {
+    if (!pastH1) { if (/^#\s+/.test(ln)) pastH1 = true; continue; }
+    const t = ln.trim();
+    if (t && !/^#+\s/.test(t) && !t.startsWith('<!--')) return t;
+  }
+  return pageTitle(page);
+}
+
+/**
+ * Group sorted pages by their audience, returning
+ * Array<{ audience: string, pages: page[] }> in deterministic order.
+ */
+function groupByAudience(sorted) {
+  const map = new Map();
+  for (const page of sorted) {
+    if (!map.has(page.audience)) map.set(page.audience, []);
+    map.get(page.audience).push(page);
+  }
+  return [...map.entries()].map(([audience, pages]) => ({ audience, pages }));
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /**
- * Generate a deterministic, byte-stable llms-full.txt string from page objects.
+ * Generate a deterministic llms.txt string conforming to llmstxt.org:
+ *   - single H1 title
+ *   - blockquote one-line summary
+ *   - one H2 section per audience with described links
  *
  * @param {{
- *   pages: Array<{ audience: string, feature: string|null, path: string, content: string }>
+ *   pages: Array<{ audience: string, feature: string|null, path: string, content: string }>,
+ *   title?: string,
+ *   summary?: string,
  * }} opts
  * @returns {string}
  */
-export function generateLlmsFull({ pages = [] } = {}) {
+export function generateLlmsIndex({ pages = [], title = 'autospec', summary = 'Multi-harness LLM-driven CI/CD skill family for autonomous feature decomposition, implementation, and review.' } = {}) {
+  // Sort deterministically by path.
+  const sorted = [...pages].sort((a, b) => a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
+  const groups = groupByAudience(sorted);
+
+  const parts = [];
+
+  // Single H1
+  parts.push(`# ${title}`);
+  parts.push('');
+
+  // Blockquote summary
+  parts.push(`> ${summary}`);
+  parts.push('');
+
+  if (groups.length === 0) {
+    // No pages — emit a placeholder note section
+    parts.push('## Documentation');
+    parts.push('');
+    parts.push('No documentation pages have been generated yet.');
+    parts.push('');
+  } else {
+    // One H2 section per audience, with described links
+    for (const { audience, pages: grpPages } of groups) {
+      const sectionTitle = audience.charAt(0).toUpperCase() + audience.slice(1);
+      parts.push(`## ${sectionTitle} Documentation`);
+      parts.push('');
+      for (const pg of grpPages) {
+        const t = pageTitle(pg);
+        const desc = pageSummary(pg);
+        parts.push(`- [${t}](${pg.path}): ${desc}`);
+      }
+      parts.push('');
+    }
+  }
+
+  return parts.join('\n');
+}
+
+/**
+ * Write llms.txt to outputPath. Idempotent: skips write if byte-equal.
+ *
+ * @param {{
+ *   pages: Array<object>,
+ *   outputPath: string,
+ *   title?: string,
+ *   summary?: string,
+ * }} opts
+ * @returns {Promise<{ written: boolean, path: string }>}
+ */
+export async function writeLlmsIndex({ pages, outputPath, title, summary }) {
+  const content = generateLlmsIndex({ pages, title, summary });
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+
+  let existing = null;
+  try { existing = fs.readFileSync(outputPath, 'utf8'); } catch {}
+
+  const written = existing !== content;
+  if (written) fs.writeFileSync(outputPath, content, 'utf8');
+
+  return { written, path: outputPath };
+}
+
+/**
+ * Generate a deterministic, byte-stable llms-full.txt string from page objects.
+ * Track E additions: top ToC with anchors, per-section summary + approx_tokens,
+ * reverse-routing block, generated_at + commit freshness stamp.
+ *
+ * @param {{
+ *   pages: Array<{ audience: string, feature: string|null, path: string, content: string }>,
+ *   generatedAt?: string,   // ISO timestamp; omit to use current time (non-idempotent)
+ *   commit?: string,        // git commit hash; omit to skip
+ * }} opts
+ * @returns {string}
+ */
+export function generateLlmsFull({ pages = [], generatedAt, commit } = {}) {
   if (!pages || pages.length === 0) return '';
 
   // Sort deterministically by path so output is stable regardless of input order.
   const sorted = [...pages].sort((a, b) => a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
 
-  const parts = [];
-  let accChars = 0;
+  // ── Track E: build ToC entries ──────────────────────────────────────────────
+  // Each page gets an anchor derived from its path slug.
+  const tocEntries = sorted.map(page => {
+    const title = pageTitle(page);
+    const anchor = slugify(page.path.replace(/[/\\]/g, '-').replace(/\.md$/, ''));
+    return { page, title, anchor };
+  });
+
+  const headerParts = [];
+
+  // Top-level freshness stamp (generated_at + commit) — only emitted when
+  // generatedAt is explicitly provided so that callers without a fixed stamp
+  // stay byte-stable across calls.
+  if (generatedAt) {
+    headerParts.push(`<!-- generated_at=${generatedAt}${commit ? ` commit=${commit}` : ''} -->`);
+    headerParts.push('');
+  }
+
+  // Table of Contents
+  headerParts.push('## Table of Contents');
+  headerParts.push('');
+  for (const { title, anchor } of tocEntries) {
+    headerParts.push(`- [${title}](#${anchor})`);
+  }
+  headerParts.push('');
+
+  // Reverse-routing block: source_anchor → doc path mapping
+  headerParts.push('<!-- reverse-routing');
+  for (const page of sorted) {
+    const src = `${page.path}#L1`;
+    headerParts.push(`  ${src} -> ${page.path}`);
+  }
+  headerParts.push('-->');
+  headerParts.push('');
+
+  // ── Page blocks ─────────────────────────────────────────────────────────────
+  const pageParts = [];
+  let accChars = headerParts.join('\n').length;
   let chunkNum = 1;
 
-  for (const page of sorted) {
+  for (const { page, anchor } of tocEntries) {
     const open  = openDelimiter(page.audience, page.feature);
     const close = closeDelimiter(page.audience, page.feature);
     const body  = (page.content || '').trimEnd();
+    const tokens = approxTokens(body);
+
+    // Per-section summary + approx_tokens annotation (Track E)
+    const summary = pageSummary(page);
+    const sectionHeader = `<!-- section-summary: ${summary} approx_tokens=${tokens} id=${anchor} -->`;
 
     // Emit chunk marker BEFORE this page if we would cross the budget boundary.
-    // We check accChars > 0 to avoid a spurious marker at the very start.
     if (accChars > 0 && (accChars + open.length + body.length) > TOKEN_BUDGET_CHARS * chunkNum) {
       const marker = chunkMarker(chunkNum, accChars);
-      parts.push(marker);
+      pageParts.push(marker);
       accChars += marker.length + 1;
       chunkNum++;
     }
 
-    const block = [open, body, close, ''].join('\n');
-    parts.push(block);
+    const block = [sectionHeader, open, body, close, ''].join('\n');
+    pageParts.push(block);
     accChars += block.length;
 
     // Also emit a marker AFTER this page if the page itself was large enough to
     // cross the next budget boundary (handles single-page inputs > TOKEN_BUDGET_CHARS).
     while (accChars > TOKEN_BUDGET_CHARS * chunkNum) {
       const marker = chunkMarker(chunkNum, accChars);
-      parts.push(marker);
+      pageParts.push(marker);
       accChars += marker.length + 1;
       chunkNum++;
     }
   }
 
-  return parts.join('\n');
+  return headerParts.join('\n') + pageParts.join('\n');
 }
 
 /**

--- a/skills/autospec-doc/scripts/gen-llms-full.mjs
+++ b/skills/autospec-doc/scripts/gen-llms-full.mjs
@@ -118,22 +118,48 @@ export function generateLlmsFull({ pages = [] } = {}) {
 }
 
 /**
- * Fill modules, concepts, and faq in a manifest object from page content.
- * Non-destructive: existing entries are kept; duplicates skipped.
+ * Approximate token count for a string using the 4-chars/token heuristic.
+ * @param {string} text
+ * @returns {number}
+ */
+function approxTokens(text) {
+  return Math.max(1, Math.round((text || '').length / 4));
+}
+
+/**
+ * Fill modules, concepts, cli_entry_points, and faq in a manifest object from
+ * page content.  Non-destructive: existing entries are kept; duplicates skipped.
  *
  * Extraction rules:
- *   modules  — one entry per page, path = page.path, summary = first H1 heading
- *   concepts — <!-- autospec-concept: <name> --> markers; next non-empty line = definition
- *   faq      — ### Q: <question> / next non-empty line = answer
+ *   modules          — one entry per page; name = H1 text; summary = first
+ *                      non-heading paragraph line; public_api = backtick
+ *                      command/function tokens on lines inside ## CLI / ## API
+ *                      sections; doc = page.path; source_anchor = "<path>#L1";
+ *                      approx_tokens = chars/4 heuristic on full page content.
+ *   cli_entry_points — slash-command tokens (`/word-word`) found anywhere in
+ *                      the page, deduplicated.
+ *   concepts         — <!-- autospec-concept: <name> --> markers; next
+ *                      non-empty line = definition; source_anchor = line ref;
+ *                      approx_tokens = definition char/4; literal "<name>"
+ *                      placeholder is ALWAYS skipped.
+ *   faq              — ### Q: <question> / next non-empty line = answer.
  *
- * @param {object} manifest - object with modules, concepts, faq arrays (mutated in place)
+ * @param {object} manifest - object with modules, cli_entry_points, concepts,
+ *                            faq arrays (mutated in place)
  * @param {Array<{ path: string, content: string }>} pages
  * @returns {void}
  */
 export function fillManifest(manifest, pages = []) {
-  const existingModPaths   = new Set((manifest.modules  || []).map(m => m.path));
-  const existingConceptNames = new Set((manifest.concepts || []).map(c => c.name));
-  const existingFaqQs      = new Set((manifest.faq      || []).map(f => f.question));
+  if (!Array.isArray(manifest.modules))         manifest.modules = [];
+  if (!Array.isArray(manifest.cli_entry_points)) manifest.cli_entry_points = [];
+  if (!Array.isArray(manifest.concepts))         manifest.concepts = [];
+  if (!Array.isArray(manifest.faq))              manifest.faq = [];
+
+  const existingModPaths     = new Set(manifest.modules.map(m => m.path || m.doc));
+  const existingConceptNames = new Set(manifest.concepts.map(c => c.name));
+  const existingFaqQs        = new Set(manifest.faq.map(f => f.question));
+  const existingCliCmds      = new Set(manifest.cli_entry_points.map(e =>
+    typeof e === 'string' ? e : e.command));
 
   for (const page of pages) {
     const content = page.content || '';
@@ -141,10 +167,60 @@ export function fillManifest(manifest, pages = []) {
 
     // ── modules: one entry per page keyed by path ────────────────────────────
     if (!existingModPaths.has(page.path)) {
-      const h1 = lines.find(l => /^#\s+/.test(l));
-      const summary = h1 ? h1.replace(/^#+\s+/, '').trim() : path.basename(page.path, '.md');
-      manifest.modules.push({ path: page.path, summary, public_api: [], depends_on: [] });
+      // name = first H1 text (strip leading #s)
+      const h1Line  = lines.find(l => /^#\s+/.test(l));
+      const name    = h1Line ? h1Line.replace(/^#+\s+/, '').trim()
+                             : path.basename(page.path, '.md');
+
+      // summary = first non-empty, non-heading line after the H1
+      let summary = name;
+      let pastH1 = !h1Line; // if no H1, start scanning from line 0
+      for (const ln of lines) {
+        if (!pastH1) { if (/^#\s+/.test(ln)) { pastH1 = true; } continue; }
+        const t = ln.trim();
+        if (t && !/^#+\s/.test(t) && !t.startsWith('<!--')) {
+          summary = t;
+          break;
+        }
+      }
+
+      // public_api = backtick tokens from ## CLI / ## API sub-sections
+      const public_api = [];
+      let inApiSection = false;
+      for (const ln of lines) {
+        if (/^##\s+(CLI|API|Public API|Commands)/i.test(ln)) {
+          inApiSection = true;
+          continue;
+        }
+        if (/^##\s+/.test(ln)) { inApiSection = false; continue; }
+        if (!inApiSection) continue;
+        // extract all `token` spans
+        const ticks = [...ln.matchAll(/`([^`]+)`/g)].map(m2 => m2[1]);
+        for (const tok of ticks) {
+          if (!public_api.includes(tok)) public_api.push(tok);
+        }
+      }
+
+      manifest.modules.push({
+        name,
+        summary,
+        public_api,
+        doc:           page.path,
+        path:          page.path,
+        source_anchor: `${page.path}#L1`,
+        approx_tokens: approxTokens(content),
+      });
       existingModPaths.add(page.path);
+    }
+
+    // ── cli_entry_points: /slash-command tokens anywhere in page ─────────────
+    const slashCmds = [...content.matchAll(/`(\/[\w-]+(?:\s+[\w-]+)?)`/g)]
+      .map(m2 => m2[1]);
+    for (const cmd of slashCmds) {
+      if (!existingCliCmds.has(cmd)) {
+        manifest.cli_entry_points.push(cmd);
+        existingCliCmds.add(cmd);
+      }
     }
 
     // ── concepts: <!-- autospec-concept: <name> --> ──────────────────────────
@@ -152,6 +228,8 @@ export function fillManifest(manifest, pages = []) {
       const m = lines[i].match(/<!--\s*autospec-concept:\s*(.+?)\s*-->/);
       if (!m) continue;
       const name = m[1].trim();
+      // Skip the literal template placeholder "<name>"
+      if (name === '<name>') continue;
       if (existingConceptNames.has(name)) continue;
       // Definition is the next non-empty line after the marker.
       let definition = '';
@@ -159,7 +237,12 @@ export function fillManifest(manifest, pages = []) {
         const def = lines[j].trim();
         if (def) { definition = def; break; }
       }
-      manifest.concepts.push({ name, definition, source_anchor: `${page.path}#L${i + 1}` });
+      manifest.concepts.push({
+        name,
+        definition,
+        source_anchor: `${page.path}#L${i + 1}`,
+        approx_tokens: approxTokens(definition),
+      });
       existingConceptNames.add(name);
     }
 

--- a/skills/autospec-doc/tests/gen-audience-docs.test.mjs
+++ b/skills/autospec-doc/tests/gen-audience-docs.test.mjs
@@ -622,7 +622,85 @@ test('backward compat: legacy feature (summary+spec_sections only) produces byte
   }
 });
 
-// Test D6-4: batched ai-review parse round-trip
+// ── Track D: logic-flow diagram tests (issue #1131) ──────────────────────────
+
+// A feature whose spec_sections describe logic/flow (ordered steps + decision
+// language). The feature page must contain a mermaid fenced block with the
+// palette %%{init}%% header from doc-style.mjs.
+const FLOW_FEATURE = {
+  slug: 'flow-feature',
+  title: 'Flow Feature',
+  summary: 'Demonstrates logic-flow diagram emission.',
+  spec_sections: [
+    // This section satisfies isLogicFlowSection: ordered steps + decision
+    '1. Validate input record against schema.\n2. If valid, enqueue record for processing.\n3. Otherwise, emit INVALID_RECORD error and reject.',
+  ],
+};
+
+// A feature with a plain prose section — no ordered steps, no flow language.
+const NON_FLOW_FEATURE = {
+  slug: 'non-flow-feature',
+  title: 'Non Flow Feature',
+  summary: 'Has a plain prose section — no logic flow.',
+  spec_sections: [
+    'This feature stores configuration settings for the application.',
+  ],
+};
+
+test('Track D: logic-flow spec section yields a themed mermaid block in the feature page', async () => {
+  const result = await generateAudienceDocs({
+    features: [FLOW_FEATURE],
+    audiences: [FOUR_AUDIENCES[0]], // user audience
+  });
+  const page = result.files.find(f => f.path === 'docs/user/features/flow-feature.md');
+  assert.ok(page, 'feature page should exist');
+  // The mermaid block must contain the %%{init}%% header from mermaidInit()
+  assert.ok(
+    page.content.includes('%%{init:'),
+    'logic-flow section must yield a themed mermaid %%{init}%% block',
+  );
+  // Must be wrapped in a mermaid fenced code block
+  assert.ok(
+    page.content.includes('```mermaid'),
+    'logic-flow section must yield a ```mermaid fenced block',
+  );
+});
+
+test('Track D: non-flow spec section yields no mermaid block in the feature page', async () => {
+  const result = await generateAudienceDocs({
+    features: [NON_FLOW_FEATURE],
+    audiences: [FOUR_AUDIENCES[0]],
+  });
+  const page = result.files.find(f => f.path === 'docs/user/features/non-flow-feature.md');
+  assert.ok(page, 'non-flow feature page should exist');
+  assert.ok(
+    !page.content.includes('```mermaid'),
+    'non-flow section must NOT yield a mermaid block',
+  );
+});
+
+test('Track D: gen-audience-docs.mjs imports doc-style.mjs (no second palette source)', async () => {
+  const src = fs.readFileSync(path.join(SCRIPTS_DIR, 'gen-audience-docs.mjs'), 'utf8');
+  assert.ok(
+    /doc-style\.mjs/.test(src) && /\bimport\b/.test(src),
+    'gen-audience-docs.mjs must import from doc-style.mjs',
+  );
+  // Must call the two exported functions
+  assert.ok(/isLogicFlowSection/.test(src), 'must reference isLogicFlowSection');
+  assert.ok(/generateExplainerDiagram/.test(src), 'must reference generateExplainerDiagram');
+  // Must NOT hardcode palette hex values (single-source guard). Derive the hex
+  // list from PALETTE at runtime so this test file introduces no second source.
+  const { PALETTE } = await import(path.join(SCRIPTS_DIR, 'doc-style.mjs'));
+  const paletteHexes = Object.values(PALETTE).filter((v) => /^#[0-9a-fA-F]{3,8}$/.test(v));
+  const hardcoded = paletteHexes.filter((hex) => src.includes(hex));
+  assert.deepStrictEqual(
+    hardcoded,
+    [],
+    'gen-audience-docs.mjs must not hardcode palette hex values (single-source guard)',
+  );
+});
+
+// ── Test D6-4: batched ai-review parse round-trip
 //
 // Confirm that per-section confidence markers in the ai_review field are correctly
 // set on each page, and that the annotation contract (<!-- ai-reviewed: ... -->)

--- a/skills/autospec-doc/tests/gen-audience-docs.test.mjs
+++ b/skills/autospec-doc/tests/gen-audience-docs.test.mjs
@@ -450,6 +450,178 @@ test('§D6: exactly ONE batched ai-review call per audience (not per section)', 
   assert.equal(confidences[0], 'high', 'stub=high should annotate all pages as high');
 });
 
+// ── Tests for six new LLM-targeted H2 sections (issue #1129) ─────────────────
+
+// Feature fixture with all six new fields populated.
+const ENRICHED_FEATURE = {
+  slug: 'pipeline',
+  title: 'Pipeline',
+  summary: 'Moves data through stages.',
+  spec_sections: ['Overview of pipeline stages.'],
+  data_model: '`Record { id, payload, ts }` — the unit of work.',
+  invariants: 'Records are immutable once enqueued.',
+  errors: '`QUEUE_FULL` — backpressure exceeded; `INVALID_RECORD` — schema mismatch.',
+  config_reference: '`pipeline.maxQueue` (default 1000) — maximum in-flight records.',
+  rationale: 'The pipeline decouples producers from consumers to allow backpressure.',
+  depends_on: ['auth', 'export-pipeline'],
+};
+
+// Legacy feature — only has summary + spec_sections (no new fields).
+const LEGACY_FEATURE = {
+  slug: 'export-pipeline',
+  title: 'Export Pipeline',
+  summary: 'Streams records out to downstream sinks.',
+  spec_sections: ['The export pipeline batches records and flushes to sinks.'],
+  code_entry_points: ['src/export/pipeline.mjs', 'src/export/sink.mjs'],
+};
+
+test('enriched feature: feature page contains all six H2 sections for all-audience fields', async () => {
+  const result = await generateAudienceDocs({
+    features: [ENRICHED_FEATURE],
+    audiences: FOUR_AUDIENCES,
+  });
+  for (const aud of FOUR_AUDIENCES) {
+    const page = result.files.find(f => f.path === `${aud.path}/features/pipeline.md`);
+    assert.ok(page, `${aud.name}: features/pipeline.md should exist`);
+    assert.ok(page.content.includes('## Data model'),
+      `${aud.name}: feature page should have ## Data model`);
+    assert.ok(page.content.includes('## Invariants & constraints'),
+      `${aud.name}: feature page should have ## Invariants & constraints`);
+    assert.ok(page.content.includes('## Errors & failure modes'),
+      `${aud.name}: feature page should have ## Errors & failure modes`);
+    assert.ok(page.content.includes('## Related features'),
+      `${aud.name}: feature page should have ## Related features`);
+  }
+});
+
+test('enriched feature: config_reference appears only for admin and developer audiences', async () => {
+  const result = await generateAudienceDocs({
+    features: [ENRICHED_FEATURE],
+    audiences: FOUR_AUDIENCES,
+  });
+  for (const aud of FOUR_AUDIENCES) {
+    const page = result.files.find(f => f.path === `${aud.path}/features/pipeline.md`);
+    assert.ok(page, `${aud.name}: features/pipeline.md should exist`);
+    if (aud.name === 'admin' || aud.name === 'developer') {
+      assert.ok(page.content.includes('## Configuration'),
+        `${aud.name}: feature page should have ## Configuration`);
+    } else {
+      assert.ok(!page.content.includes('## Configuration'),
+        `${aud.name}: feature page must NOT have ## Configuration (not gated for ${aud.name})`);
+    }
+  }
+});
+
+test('enriched feature: rationale appears only for developer audience', async () => {
+  const result = await generateAudienceDocs({
+    features: [ENRICHED_FEATURE],
+    audiences: FOUR_AUDIENCES,
+  });
+  for (const aud of FOUR_AUDIENCES) {
+    const page = result.files.find(f => f.path === `${aud.path}/features/pipeline.md`);
+    assert.ok(page, `${aud.name}: features/pipeline.md should exist`);
+    if (aud.name === 'developer') {
+      assert.ok(page.content.includes('## Why'),
+        `${aud.name}: feature page should have ## Why`);
+    } else {
+      assert.ok(!page.content.includes('## Why'),
+        `${aud.name}: feature page must NOT have ## Why`);
+    }
+  }
+});
+
+test('enriched feature: section content is rendered into the page body', async () => {
+  const result = await generateAudienceDocs({
+    features: [ENRICHED_FEATURE],
+    audiences: [FOUR_AUDIENCES[1]], // developer — sees all sections
+  });
+  const page = result.files.find(f => f.path === 'docs/developer/features/pipeline.md');
+  assert.ok(page, 'developer feature page should exist');
+  assert.ok(page.content.includes(ENRICHED_FEATURE.data_model),
+    'data_model content should appear in page');
+  assert.ok(page.content.includes(ENRICHED_FEATURE.invariants),
+    'invariants content should appear in page');
+  assert.ok(page.content.includes(ENRICHED_FEATURE.errors),
+    'errors content should appear in page');
+  assert.ok(page.content.includes(ENRICHED_FEATURE.config_reference),
+    'config_reference content should appear in page');
+  assert.ok(page.content.includes(ENRICHED_FEATURE.rationale),
+    'rationale content should appear in page');
+  // depends_on renders feature ids
+  for (const dep of ENRICHED_FEATURE.depends_on) {
+    assert.ok(page.content.includes(dep),
+      `depends_on entry '${dep}' should appear in page`);
+  }
+});
+
+test('empty new fields are omitted — no blank H2 headings emitted', async () => {
+  const partialFeature = {
+    slug: 'partial',
+    title: 'Partial',
+    summary: 'Has only some new fields.',
+    data_model: 'A partial data model.',
+    // invariants, errors, config_reference, rationale, depends_on all absent
+  };
+  const result = await generateAudienceDocs({
+    features: [partialFeature],
+    audiences: FOUR_AUDIENCES,
+  });
+  for (const aud of FOUR_AUDIENCES) {
+    const page = result.files.find(f => f.path === `${aud.path}/features/partial.md`);
+    assert.ok(page, `${aud.name}: features/partial.md should exist`);
+    // data_model is present → should render
+    assert.ok(page.content.includes('## Data model'),
+      `${aud.name}: ## Data model should appear for partial feature`);
+    // absent fields → no heading
+    assert.ok(!page.content.includes('## Invariants & constraints'),
+      `${aud.name}: ## Invariants & constraints must not appear when field absent`);
+    assert.ok(!page.content.includes('## Errors & failure modes'),
+      `${aud.name}: ## Errors & failure modes must not appear when field absent`);
+    assert.ok(!page.content.includes('## Related features'),
+      `${aud.name}: ## Related features must not appear when field absent`);
+    assert.ok(!page.content.includes('## Configuration'),
+      `${aud.name}: ## Configuration must not appear when field absent`);
+    assert.ok(!page.content.includes('## Why'),
+      `${aud.name}: ## Why must not appear when field absent`);
+  }
+});
+
+test('backward compat: legacy feature (summary+spec_sections only) produces byte-identical output', async () => {
+  // Generate without new fields — establish baseline.
+  const baseline = await generateAudienceDocs({
+    features: [LEGACY_FEATURE],
+    audiences: FOUR_AUDIENCES,
+    aiReviewStub: 'high',
+  });
+  // Generate again — should be identical (idempotent + no new sections).
+  const second = await generateAudienceDocs({
+    features: [LEGACY_FEATURE],
+    audiences: FOUR_AUDIENCES,
+    aiReviewStub: 'high',
+  });
+  for (const file of baseline.files) {
+    const match = second.files.find(f => f.path === file.path);
+    assert.ok(match, `${file.path}: should appear in second run`);
+    assert.equal(match.content, file.content,
+      `${file.path}: legacy feature must produce byte-identical output on re-run`);
+  }
+  // Confirm no new section headings leaked into legacy output.
+  for (const file of second.files) {
+    assert.ok(!file.content.includes('## Data model'),
+      `${file.path}: legacy feature must not emit ## Data model`);
+    assert.ok(!file.content.includes('## Invariants & constraints'),
+      `${file.path}: legacy feature must not emit ## Invariants & constraints`);
+    assert.ok(!file.content.includes('## Errors & failure modes'),
+      `${file.path}: legacy feature must not emit ## Errors & failure modes`);
+    assert.ok(!file.content.includes('## Configuration'),
+      `${file.path}: legacy feature must not emit ## Configuration`);
+    assert.ok(!file.content.includes('## Why'),
+      `${file.path}: legacy feature must not emit ## Why`);
+    assert.ok(!file.content.includes('## Related features'),
+      `${file.path}: legacy feature must not emit ## Related features`);
+  }
+});
+
 // Test D6-4: batched ai-review parse round-trip
 //
 // Confirm that per-section confidence markers in the ai_review field are correctly

--- a/skills/autospec-doc/tests/gen-llms-full.test.mjs
+++ b/skills/autospec-doc/tests/gen-llms-full.test.mjs
@@ -242,3 +242,123 @@ test('chunk markers include a boundary token count annotation', () => {
   const chunkNum = parseInt(markerMatch[1], 10);
   assert.ok(chunkNum >= 1, 'chunk number must be >= 1');
 });
+
+// ── Track B new tests (issue #1130) ───────────────────────────────────────────
+
+// Fixture corpus for Track B: contains an H1, a cli marker, and a concept marker
+const TRACK_B_PAGES = [
+  {
+    audience: 'developer',
+    feature: 'autospec-run',
+    path: 'docs/developer/features/autospec-run.md',
+    content: [
+      '# autospec-run',
+      '',
+      'The main entry point for running the autospec pipeline.',
+      '',
+      '<!-- autospec-concept: lock-step rule -->',
+      'Every phase-1 change locks all related trios simultaneously.',
+      '',
+      '<!-- autospec-concept: worktree isolation -->',
+      'Each implementation runs in an isolated git worktree.',
+      '',
+      '## CLI',
+      '`/autospec-run` — run the implementation loop',
+    ].join('\n'),
+  },
+  {
+    audience: 'developer',
+    feature: 'autospec-define',
+    path: 'docs/developer/features/autospec-define.md',
+    content: [
+      '# autospec-define',
+      '',
+      'Plan a feature and decompose into GitHub issues.',
+    ].join('\n'),
+  },
+];
+
+// ── Test 13: modules[] carry name, summary, source_anchor, approx_tokens ──────
+
+test('fillManifest: modules carry name, source_anchor, and approx_tokens', () => {
+  const manifest = { modules: [], cli_entry_points: [], http_endpoints: [], concepts: [], faq: [] };
+  fillManifest(manifest, TRACK_B_PAGES);
+  assert.ok(manifest.modules.length > 0, 'modules must be non-empty');
+  for (const mod of manifest.modules) {
+    assert.ok(typeof mod.name === 'string' && mod.name.length > 0,
+      `module must have name field; got ${JSON.stringify(mod)}`);
+    assert.ok(typeof mod.summary === 'string' && mod.summary.length > 0,
+      `module must have summary; got ${JSON.stringify(mod)}`);
+    assert.ok(typeof mod.source_anchor === 'string' && mod.source_anchor.includes('#L'),
+      `module must have source_anchor with #L; got ${JSON.stringify(mod)}`);
+    assert.ok(typeof mod.approx_tokens === 'number' && mod.approx_tokens > 0,
+      `module must have approx_tokens > 0; got ${JSON.stringify(mod)}`);
+    assert.ok(Array.isArray(mod.public_api),
+      `module must have public_api array; got ${JSON.stringify(mod)}`);
+    assert.ok(typeof mod.doc === 'string',
+      `module must have doc field; got ${JSON.stringify(mod)}`);
+  }
+});
+
+// ── Test 14: concepts[] carry source_anchor and approx_tokens ─────────────────
+
+test('fillManifest: concepts carry source_anchor and approx_tokens', () => {
+  const manifest = { modules: [], cli_entry_points: [], http_endpoints: [], concepts: [], faq: [] };
+  fillManifest(manifest, TRACK_B_PAGES);
+  assert.ok(manifest.concepts.length >= 2, 'expected at least 2 concepts from fixture');
+  for (const concept of manifest.concepts) {
+    assert.ok(typeof concept.source_anchor === 'string' && concept.source_anchor.includes('#L'),
+      `concept must have source_anchor with #L; got ${JSON.stringify(concept)}`);
+    assert.ok(typeof concept.approx_tokens === 'number' && concept.approx_tokens > 0,
+      `concept must have approx_tokens > 0; got ${JSON.stringify(concept)}`);
+  }
+});
+
+// ── Test 15: no literal <name> placeholder in manifest output ──────────────────
+
+test('fillManifest: no literal <name> placeholder survives in any field', () => {
+  // Inject a page that contains the literal placeholder string in a concept marker
+  const pagesWithPlaceholder = [
+    ...TRACK_B_PAGES,
+    {
+      audience: 'developer',
+      feature: 'bad',
+      path: 'docs/developer/features/bad.md',
+      content: '# Bad page\n\n<!-- autospec-concept: <name> -->\nShould be skipped.\n',
+    },
+  ];
+  const manifest = { modules: [], cli_entry_points: [], http_endpoints: [], concepts: [], faq: [] };
+  fillManifest(manifest, pagesWithPlaceholder);
+  const conceptNames = manifest.concepts.map(c => c.name);
+  assert.ok(!conceptNames.includes('<name>'),
+    `literal <name> placeholder must not appear in concepts; got ${JSON.stringify(conceptNames)}`);
+  // Also check no field in manifest JSON contains literal <name>
+  const json = JSON.stringify(manifest);
+  assert.ok(!json.includes('"<name>"'),
+    `literal "<name>" must not appear in manifest JSON; found: ${json.slice(0, 200)}`);
+});
+
+// ── Test 16: cli_entry_points[] non-empty when pages have CLI sections ─────────
+
+test('fillManifest: cli_entry_points extracted from pages', () => {
+  const manifest = { modules: [], cli_entry_points: [], http_endpoints: [], concepts: [], faq: [] };
+  fillManifest(manifest, TRACK_B_PAGES);
+  // TRACK_B_PAGES has a CLI section with `/autospec-run`; cli_entry_points should be populated
+  assert.ok(Array.isArray(manifest.cli_entry_points),
+    'cli_entry_points must be an array');
+  // The fixture has CLI content — at least one entry is expected
+  assert.ok(manifest.cli_entry_points.length > 0,
+    `cli_entry_points must be non-empty for pages with CLI sections; got ${JSON.stringify(manifest.cli_entry_points)}`);
+});
+
+// ── Test 17: fixture corpus produces zero placeholder strings ─────────────────
+
+test('fillManifest: fixture corpus produces non-empty modules and concepts, zero placeholders', () => {
+  const manifest = { modules: [], cli_entry_points: [], http_endpoints: [], concepts: [], faq: [] };
+  fillManifest(manifest, TRACK_B_PAGES);
+  assert.ok(manifest.modules.length > 0, 'modules must be non-empty');
+  assert.ok(manifest.concepts.length > 0, 'concepts must be non-empty');
+  const json = JSON.stringify(manifest);
+  assert.ok(!json.includes('<name>'),
+    `no <name> placeholder must survive; manifest JSON: ${json.slice(0, 300)}`);
+});

--- a/skills/autospec-doc/tests/gen-llms-full.test.mjs
+++ b/skills/autospec-doc/tests/gen-llms-full.test.mjs
@@ -14,6 +14,18 @@
 //  10. generateLlmsFull: deterministic sort — changing page order does not change output
 //  11. writeLlmsFull: writes file to disk; second identical run reports written=false
 //  12. chunk markers contain the correct token-budget boundary annotation
+//  Track E (issue #1132):
+//  18. generateLlmsIndex: single H1 in output
+//  19. generateLlmsIndex: blockquote summary present
+//  20. generateLlmsIndex: described link sections (each link has a description)
+//  21. generateLlmsIndex: no duplicate headings
+//  22. generateLlmsIndex: empty pages → well-formed minimal output
+//  23. generateLlmsFull: top ToC with anchors present
+//  24. generateLlmsFull: per-section summary before each section
+//  25. generateLlmsFull: per-section approx_tokens annotation
+//  26. generateLlmsFull: reverse-routing block present
+//  27. generateLlmsFull: generated_at + commit stamp present
+//  28. generateLlmsFull: re-run idempotency (no-op diff with fixed stamp)
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -25,7 +37,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPTS_DIR = path.resolve(__dirname, '../scripts');
 
-const { generateLlmsFull, writeLlmsFull, fillManifest } =
+const { generateLlmsFull, writeLlmsFull, fillManifest, generateLlmsIndex, writeLlmsIndex } =
   await import(path.join(SCRIPTS_DIR, 'gen-llms-full.mjs'));
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -361,4 +373,164 @@ test('fillManifest: fixture corpus produces non-empty modules and concepts, zero
   const json = JSON.stringify(manifest);
   assert.ok(!json.includes('<name>'),
     `no <name> placeholder must survive; manifest JSON: ${json.slice(0, 300)}`);
+});
+
+// ── Track E tests (issue #1132) ───────────────────────────────────────────────
+
+// Fixture for Track E: pages with varied features + sections
+const TRACK_E_PAGES = [
+  {
+    audience: 'user',
+    feature: 'export-pipeline',
+    path: 'docs/user/features/export-pipeline.md',
+    content: [
+      '# Export Pipeline',
+      '',
+      'Streams records out to downstream sinks.',
+      '',
+      '## Overview',
+      '',
+      'The export pipeline processes batches of records.',
+    ].join('\n'),
+  },
+  {
+    audience: 'developer',
+    feature: 'auth',
+    path: 'docs/developer/features/auth.md',
+    content: [
+      '# Authentication',
+      '',
+      'Token-based login architecture.',
+      '',
+      '## Overview',
+      '',
+      'Supports OAuth2 and API keys.',
+    ].join('\n'),
+  },
+  {
+    audience: 'user',
+    feature: null,
+    path: 'docs/user/index.md',
+    content: [
+      '# User Guide',
+      '',
+      'Entry point for user-facing documentation.',
+    ].join('\n'),
+  },
+];
+
+// ── Test 18: generateLlmsIndex — single H1 in output ──────────────────────────
+
+test('generateLlmsIndex: output contains exactly one H1 heading', () => {
+  const output = generateLlmsIndex({ pages: TRACK_E_PAGES });
+  assert.ok(typeof output === 'string', 'should return a string');
+  const h1Matches = output.match(/^# .+/gm);
+  assert.ok(h1Matches !== null, 'output must contain at least one H1');
+  assert.strictEqual(h1Matches.length, 1, `output must have exactly one H1; got ${h1Matches.length}: ${JSON.stringify(h1Matches)}`);
+});
+
+// ── Test 19: generateLlmsIndex — blockquote summary present ───────────────────
+
+test('generateLlmsIndex: output contains a blockquote summary line', () => {
+  const output = generateLlmsIndex({ pages: TRACK_E_PAGES });
+  assert.ok(output.includes('\n> '), 'output must contain a blockquote line (> ...)');
+});
+
+// ── Test 20: generateLlmsIndex — described links (each link has a description) ─
+
+test('generateLlmsIndex: each link entry has a one-line description', () => {
+  const output = generateLlmsIndex({ pages: TRACK_E_PAGES });
+  // llmstxt.org: links in sections look like:  - [Title](url): Description
+  const linkLines = output.split('\n').filter(l => /^- \[.+\]\(.+\):/.test(l));
+  assert.ok(linkLines.length > 0, `output must contain at least one described link; output:\n${output}`);
+  for (const line of linkLines) {
+    // After the colon there must be non-empty description text
+    const descPart = line.replace(/^- \[.+\]\(.+\):\s*/, '').trim();
+    assert.ok(descPart.length > 0, `link line must have a non-empty description: "${line}"`);
+  }
+});
+
+// ── Test 21: generateLlmsIndex — no duplicate headings ────────────────────────
+
+test('generateLlmsIndex: no duplicate headings in output', () => {
+  const output = generateLlmsIndex({ pages: TRACK_E_PAGES });
+  const headings = output.split('\n').filter(l => /^#{1,6} /.test(l));
+  const seen = new Set();
+  for (const h of headings) {
+    assert.ok(!seen.has(h), `duplicate heading found: "${h}"`);
+    seen.add(h);
+  }
+});
+
+// ── Test 22: generateLlmsIndex — empty pages → well-formed minimal output ──────
+
+test('generateLlmsIndex: empty pages array returns a well-formed string', () => {
+  let result;
+  assert.doesNotThrow(() => { result = generateLlmsIndex({ pages: [] }); });
+  assert.ok(typeof result === 'string', 'should return a string');
+  // Must still have a single H1
+  const h1Matches = result.match(/^# .+/gm);
+  assert.ok(h1Matches !== null && h1Matches.length === 1, 'empty-pages output must still have exactly one H1');
+});
+
+// ── Test 23: generateLlmsFull — top ToC with anchors present ──────────────────
+
+test('generateLlmsFull (Track E): top ToC with anchors present', () => {
+  const output = generateLlmsFull({ pages: TRACK_E_PAGES });
+  // ToC section: ## Table of Contents or similar, with anchor links [text](#anchor)
+  assert.ok(output.includes('Table of Contents') || output.includes('## Contents'),
+    'output must contain a table of contents section');
+  // Anchors look like (#something)
+  assert.ok(/\(#[a-z0-9-]+\)/.test(output),
+    'ToC must contain at least one anchor link like (#section-name)');
+});
+
+// ── Test 24: generateLlmsFull — per-section summary before each section ────────
+
+test('generateLlmsFull (Track E): per-section summary (1-2 lines) before each section', () => {
+  const output = generateLlmsFull({ pages: TRACK_E_PAGES });
+  // A summary comment block looks like: <!-- summary: ... --> or plain text before the delimiter
+  // We check that summary annotations appear somewhere in the output
+  assert.ok(
+    output.includes('<!-- section-summary:') || output.includes('<!-- summary:'),
+    'output must contain per-section summary annotations'
+  );
+});
+
+// ── Test 25: generateLlmsFull — per-section approx_tokens annotation ──────────
+
+test('generateLlmsFull (Track E): per-section approx_tokens annotation present', () => {
+  const output = generateLlmsFull({ pages: TRACK_E_PAGES });
+  assert.ok(
+    /approx_tokens=\d+/.test(output),
+    'output must contain per-section approx_tokens=N annotations'
+  );
+});
+
+// ── Test 26: generateLlmsFull — reverse-routing block present ─────────────────
+
+test('generateLlmsFull (Track E): reverse-routing block (source→doc mapping) present', () => {
+  const output = generateLlmsFull({ pages: TRACK_E_PAGES });
+  assert.ok(
+    output.includes('<!-- reverse-routing') || output.includes('## Source Routing') || output.includes('source-routing'),
+    'output must contain a reverse-routing block mapping source files to docs'
+  );
+});
+
+// ── Test 27: generateLlmsFull — generated_at + commit stamp present ───────────
+
+test('generateLlmsFull (Track E): generated_at and commit stamp present', () => {
+  const output = generateLlmsFull({ pages: TRACK_E_PAGES, generatedAt: '2026-06-16T00:00:00Z', commit: 'abc1234' });
+  assert.ok(output.includes('generated_at'), 'output must contain generated_at stamp');
+  assert.ok(output.includes('2026-06-16T00:00:00Z'), 'output must contain the provided generated_at value');
+  assert.ok(output.includes('abc1234'), 'output must contain the commit hash');
+});
+
+// ── Test 28: generateLlmsFull — re-run idempotency with fixed stamp ───────────
+
+test('generateLlmsFull (Track E): re-run with same inputs produces identical output (idempotent)', () => {
+  const opts = { pages: TRACK_E_PAGES, generatedAt: '2026-06-16T00:00:00Z', commit: 'abc1234' };
+  const run1 = generateLlmsFull(opts);
+  const run2 = generateLlmsFull(opts);
+  assert.strictEqual(run1, run2, 'two runs with identical inputs must produce byte-identical output');
 });

--- a/skills/autospec-doc/tests/verify-examples.test.mjs
+++ b/skills/autospec-doc/tests/verify-examples.test.mjs
@@ -312,3 +312,139 @@ test('CLI exits 0 and rewrites the file on a passing-example fixture (fake-pass)
   assert.match(out, /```output/);
   assert.match(out, /example-verified:/);
 });
+
+// ── Track C: gen-audience-docs examples[] emission + llms-full.txt survival ───
+// Issue #1133: gen-audience-docs.mjs must emit <!-- example --> fenced blocks
+// from feature.examples[]; the output block and verified marker must survive
+// generateLlmsFull concatenation unaltered.
+
+import { generateLlmsFull } from '../scripts/gen-llms-full.mjs';
+// generateAudienceDocs is the entry point for Track A+C together
+const { generateAudienceDocs } = await import(
+  path.resolve(__dirname, '../scripts/gen-audience-docs.mjs')
+);
+// EXAMPLE_TAG is already destructured from MOD above; no re-import needed.
+
+// Minimal audience fixture for Track C tests
+const TRACK_C_AUDIENCE = [
+  { name: 'developer', path: 'docs/developer', focus: 'APIs, architecture, extending' },
+];
+
+// Feature with an examples[] array — the new Track C field
+const FEATURE_WITH_EXAMPLES = {
+  slug: 'greet',
+  title: 'Greeter',
+  summary: 'Emits a greeting.',
+  spec_sections: [],
+  code_entry_points: [],
+  examples: [
+    { lang: 'bash', command: 'echo hello-world' },
+    { lang: 'bash', command: 'echo second-example' },
+  ],
+};
+
+// Feature with no examples[] — backward compat must be unaffected
+const FEATURE_NO_EXAMPLES = {
+  slug: 'plain',
+  title: 'Plain feature',
+  summary: 'No examples.',
+  spec_sections: [],
+  code_entry_points: [],
+};
+
+test('Track C: gen-audience-docs emits <!-- example --> blocks for each feature.examples[] entry', async () => {
+  const result = await generateAudienceDocs({
+    features: [FEATURE_WITH_EXAMPLES],
+    audiences: TRACK_C_AUDIENCE,
+  });
+  // The feature page should contain EXAMPLE_TAG for each entry
+  const featurePage = result.files.find(f => f.path.includes('features/greet.md'));
+  assert.ok(featurePage, 'feature page greet.md must be generated');
+  const tagCount = (featurePage.content.match(/<!-- example -->/g) || []).length;
+  assert.strictEqual(tagCount, 2, 'one <!-- example --> tag per examples[] entry');
+  // Each command should appear in a fenced block after the tag
+  assert.match(featurePage.content, /<!-- example -->\n```bash\necho hello-world\n```/);
+  assert.match(featurePage.content, /<!-- example -->\n```bash\necho second-example\n```/);
+});
+
+test('Track C: feature with no examples[] emits no <!-- example --> blocks (backward compat)', async () => {
+  const result = await generateAudienceDocs({
+    features: [FEATURE_NO_EXAMPLES],
+    audiences: TRACK_C_AUDIENCE,
+  });
+  const featurePage = result.files.find(f => f.path.includes('features/plain.md'));
+  assert.ok(featurePage, 'feature page plain.md must be generated');
+  assert.doesNotMatch(featurePage.content, /<!-- example -->/,
+    'no example tag when examples[] is absent');
+});
+
+test('Track C: output block and example-verified marker survive generateLlmsFull concatenation', () => {
+  // Build a page that already has a verified example (simulate post-verify-examples state)
+  const verifiedPage = [
+    '# Greeter (developer)',
+    '',
+    '<!-- example -->',
+    '```bash',
+    'echo hello-world',
+    '```',
+    '<!-- example-verified: deadbeef 2026-06-16 -->',
+    '',
+    '```output',
+    'hello-world',
+    '```',
+    '',
+  ].join('\n');
+
+  const llmsFull = generateLlmsFull({
+    pages: [{ audience: 'developer', feature: 'greet', path: 'docs/developer/features/greet.md', content: verifiedPage }],
+  });
+
+  // The marker must survive intact
+  assert.match(llmsFull, /<!-- example-verified: deadbeef 2026-06-16 -->/,
+    'example-verified marker must survive llms-full concat');
+  // The output block must survive intact
+  assert.match(llmsFull, /```output\nhello-world\n```/,
+    'output fence block must survive llms-full concat');
+  // The example tag must survive intact
+  assert.match(llmsFull, /<!-- example -->/,
+    '<!-- example --> tag must survive llms-full concat');
+});
+
+test('Track C: end-to-end — example in gen-audience-docs page + verify + llms-full survival', async () => {
+  // 1. Generate the docs page with examples
+  const result = await generateAudienceDocs({
+    features: [FEATURE_WITH_EXAMPLES],
+    audiences: TRACK_C_AUDIENCE,
+  });
+  const featurePage = result.files.find(f => f.path.includes('features/greet.md'));
+  assert.ok(featurePage, 'feature page must exist');
+
+  // 2. Run verifyExamples with a fake executor (no real sandbox needed)
+  const fakeExec = async ({ command }) => ({
+    stdout: `${command}-output\n`,
+    stderr: '',
+    code: 0,
+  });
+  const verified = await verifyExamples({
+    content: featurePage.content,
+    headSha: 'cafe1234',
+    isoDate: '2026-06-16',
+    exec: fakeExec,
+  });
+  assert.strictEqual(verified.failed.length, 0, 'no failures from fake executor');
+  assert.ok(verified.verified >= 1, 'at least one example verified');
+  // Marker must be in the stamped page
+  assert.match(verified.content, /<!-- example-verified: cafe1234 2026-06-16 -->/,
+    'marker must appear in verified page content');
+  // Output block must be in the stamped page
+  assert.match(verified.content, /```output/, 'output block must appear in verified page');
+
+  // 3. Concatenate via generateLlmsFull and confirm marker/output survive
+  const llmsFull = generateLlmsFull({
+    pages: [{ audience: 'developer', feature: 'greet', path: featurePage.path, content: verified.content }],
+  });
+  assert.match(llmsFull, /<!-- example-verified: cafe1234 2026-06-16 -->/,
+    'marker must survive into llms-full.txt');
+  assert.match(llmsFull, /```output/,
+    'output block must survive into llms-full.txt');
+});


### PR DESCRIPTION
Promotes sandbox `autospec/explore/2026-06-16-autodoc-improve` into main.

Five tracks + Phase 5.5 integration audit, all verified on the sandbox:
- A #1150 enriched content model (6 audience-gated sections)
- B #1151 populated .llm-manifest.json
- C #1154 verified runnable examples flow into llms-full.txt
- D #1156 activated mermaid diagrams (wired orphaned doc-style.mjs)
- E #1158 llmstxt.org index + navigable llms-full.txt
- #1134 broad integration audit: CLEAN (109/109 unit, 21/21 composition, validate OK)

Diff is scoped to skills/autospec-doc/* + the round-1 design spec.