### PR TITLE
fix(autospec-doc): real LLM-artifact content (prose summaries, source→doc routing, real public_api)

### DIFF
--- a/docs/specs/2026-06-17-autodoc-content-fidelity-design.md
+++ b/docs/specs/2026-06-17-autodoc-content-fidelity-design.md
@@ -1,0 +1,48 @@
+# Design spec — round 2: raise `/autospec-doc` LLM-artifact content fidelity
+
+- **Branch:** `feat/autodoc-fidelity`
+- **Follows:** round 1 (`docs/specs/2026-06-16-explore-autodoc-improve-round-1-design.md`)
+- **Trigger:** the round-1 preview shipped complete *structure* but placeholder-grade
+  *content* in the LLM artifacts. This round closes that gap.
+
+## Result first
+
+Three content-fidelity defects in `skills/autospec-doc/scripts/gen-llms-full.mjs`,
+all fixed scripts+tests only (no SKILL.md/trio change):
+
+1. **Descriptions were the `src:` glob, not prose.** `pageSummary` and
+   `fillManifest`'s summary loop skipped only lines that *individually* start with
+   `<!--`, so the multi-line `autospec-doc-scope` comment's interior `src: [...]`
+   line was returned as the "summary." Fixed: a shared `firstProseLine()` that
+   skips whole comment blocks and the italic audience-boilerplate line, reaching
+   the real feature summary. This corrects `llms.txt` link descriptions, manifest
+   `summary`, and `llms-full.txt` per-section summaries at once.
+
+2. **`reverse-routing` was doc→itself identity** (`docs/x.md#L1 -> docs/x.md`).
+   Fixed: `parseScopeSrc()` reads each page's scope `src:` list and the block now
+   emits the intended **source_file → docs** map (`src/foo.mjs -> docs/.../foo.md`),
+   sorted and deterministic.
+
+3. **Manifest `public_api` was empty** on audience pages (only `## CLI/API`
+   backticks were scanned). Fixed: `extractExports()` reads each page's real
+   `code_entry_points` under a `repoRoot` and records ESM exports
+   (`function/const/let/var/class` + `export { … }`) and module-level Python
+   `def/class`; backtick tokens remain a supplement. `fillManifest` gains an
+   optional `{ repoRoot = process.cwd() }`.
+
+## Out of scope
+- Reshaping `modules[]` away from one-entry-per-page (kept for backward
+  compatibility; `public_api` now carries the real code surface instead).
+- Glossary auto-extraction beyond existing `<!-- autospec-concept: -->` markers.
+- Mermaid node-label polish (Track D heuristic).
+
+## Acceptance criteria
+- [ ] `llms.txt` link descriptions and manifest `summary` are the feature prose, never `src: [`.
+- [ ] `reverse-routing` maps source files to docs; no `#L1 -> ` identity lines.
+- [ ] `fillManifest(manifest, pages, { repoRoot })` populates `public_api` from real exports; non-exported symbols excluded.
+- [ ] `generateLlmsFull` stays byte-identical across runs on the same input.
+- [ ] `node --test skills/autospec-doc/tests/gen-llms-full.test.mjs` passes; `bash scripts/validate.sh` exits 0.
+
+## Verification
+- Primary: `node --test skills/autospec-doc/tests/gen-llms-full.test.mjs`
+- Full: `bash scripts/validate.sh` + a regenerated preview showing prose descriptions, source→doc routing, and populated `public_api`.

--- a/skills/autospec-doc/scripts/gen-llms-full.mjs
+++ b/skills/autospec-doc/scripts/gen-llms-full.mjs
@@ -87,18 +87,68 @@ function pageTitle(page) {
 }
 
 /**
- * Extract a one-line summary for a page: the first non-empty, non-heading
- * line after the H1 (or the H1 text itself if nothing follows).
+ * Extract the first real prose line of a page: skip the H1, any multi-line HTML
+ * comment block (e.g. the autospec-doc-scope comment whose interior `src:` line
+ * must NOT be mistaken for prose), other headings, and the italic audience
+ * boilerplate line (`_Reference for the … audience._`). Returns null if none.
+ */
+function firstProseLine(content) {
+  const lines = (content || '').split('\n');
+  let pastH1 = false;
+  let inComment = false;
+  for (const ln of lines) {
+    const t = ln.trim();
+    if (inComment) { if (t.includes('-->')) inComment = false; continue; }
+    if (t.startsWith('<!--')) { if (!t.includes('-->')) inComment = true; continue; }
+    if (!pastH1) { if (/^#\s+/.test(t)) pastH1 = true; continue; }
+    if (!t) continue;
+    if (/^#+\s/.test(t)) continue;          // headings
+    if (/^_.*_$/.test(t)) continue;         // italic audience boilerplate
+    return t;
+  }
+  return null;
+}
+
+/**
+ * Extract a one-line summary for a page: the first real prose line (see
+ * firstProseLine), falling back to the H1 title.
  */
 function pageSummary(page) {
-  const lines = (page.content || '').split('\n');
-  let pastH1 = false;
-  for (const ln of lines) {
-    if (!pastH1) { if (/^#\s+/.test(ln)) pastH1 = true; continue; }
-    const t = ln.trim();
-    if (t && !/^#+\s/.test(t) && !t.startsWith('<!--')) return t;
+  return firstProseLine(page.content) || pageTitle(page);
+}
+
+/**
+ * Parse the `src: [...]` list out of a page's first autospec-doc-scope comment.
+ * These are the feature's code_entry_points — used for source→doc reverse
+ * routing and real public_api extraction. Returns [] when no scope/src present.
+ */
+function parseScopeSrc(content) {
+  const block = (content || '').match(/<!--\s*autospec-doc-scope:[\s\S]*?-->/);
+  if (!block) return [];
+  const srcM = block[0].match(/src:\s*\[([^\]]*)\]/);
+  if (!srcM) return [];
+  return [...srcM[1].matchAll(/"([^"]+)"|'([^']+)'/g)].map(m => m[1] || m[2]);
+}
+
+/**
+ * Best-effort extraction of the public symbol surface of a source file: ESM
+ * exports (function/const/let/var/class + `export { … }`) and module-level
+ * Python def/class. Returns [] when the file is absent, a glob, or unreadable.
+ */
+function extractExports(absPath) {
+  let src;
+  try { src = fs.readFileSync(absPath, 'utf8'); } catch { return []; }
+  const out = [];
+  // Accept only valid identifiers — guards against matching `export { … }` that
+  // appears inside this file's own JSDoc/comments or string literals.
+  const push = (n) => { const s = (n || '').trim(); if (/^[A-Za-z_$][\w$]*$/.test(s) && !out.includes(s)) out.push(s); };
+  for (const m of src.matchAll(/export\s+(?:async\s+)?function\s+([A-Za-z0-9_$]+)/g)) push(m[1]);
+  for (const m of src.matchAll(/export\s+(?:const|let|var|class)\s+([A-Za-z0-9_$]+)/g)) push(m[1]);
+  for (const m of src.matchAll(/export\s*\{([^}]+)\}/g)) {
+    for (const part of m[1].split(',')) push(part.split(/\s+as\s+/)[0]);
   }
-  return pageTitle(page);
+  for (const m of src.matchAll(/^(?:def|class)\s+([A-Za-z0-9_]+)/gm)) push(m[1]);
+  return out;
 }
 
 /**
@@ -237,11 +287,20 @@ export function generateLlmsFull({ pages = [], generatedAt, commit } = {}) {
   }
   headerParts.push('');
 
-  // Reverse-routing block: source_anchor → doc path mapping
-  headerParts.push('<!-- reverse-routing');
+  // Reverse-routing block: source_file → doc paths. Built from each page's
+  // autospec-doc-scope `src:` list so an LLM can answer "where are the docs for
+  // src/foo.mjs?". Pages without a scope contribute nothing (no identity noise).
+  const routeMap = new Map();
   for (const page of sorted) {
-    const src = `${page.path}#L1`;
-    headerParts.push(`  ${src} -> ${page.path}`);
+    for (const src of parseScopeSrc(page.content)) {
+      if (!routeMap.has(src)) routeMap.set(src, new Set());
+      routeMap.get(src).add(page.path);
+    }
+  }
+  headerParts.push('<!-- reverse-routing');
+  for (const src of [...routeMap.keys()].sort()) {
+    const docs = [...routeMap.get(src)].sort().join(', ');
+    headerParts.push(`  ${src} -> ${docs}`);
   }
   headerParts.push('-->');
   headerParts.push('');
@@ -300,9 +359,11 @@ function approxTokens(text) {
  * page content.  Non-destructive: existing entries are kept; duplicates skipped.
  *
  * Extraction rules:
- *   modules          — one entry per page; name = H1 text; summary = first
- *                      non-heading paragraph line; public_api = backtick
- *                      command/function tokens on lines inside ## CLI / ## API
+ *   modules          — one entry per page; name = H1 text; summary = first real
+ *                      prose line (the scope comment + audience boilerplate are
+ *                      skipped); public_api = real exported symbols read from the
+ *                      page's code_entry_points (scope `src:`) under repoRoot,
+ *                      supplemented by backtick tokens inside ## CLI / ## API
  *                      sections; doc = page.path; source_anchor = "<path>#L1";
  *                      approx_tokens = chars/4 heuristic on full page content.
  *   cli_entry_points — slash-command tokens (`/word-word`) found anywhere in
@@ -318,7 +379,7 @@ function approxTokens(text) {
  * @param {Array<{ path: string, content: string }>} pages
  * @returns {void}
  */
-export function fillManifest(manifest, pages = []) {
+export function fillManifest(manifest, pages = [], { repoRoot = process.cwd() } = {}) {
   if (!Array.isArray(manifest.modules))         manifest.modules = [];
   if (!Array.isArray(manifest.cli_entry_points)) manifest.cli_entry_points = [];
   if (!Array.isArray(manifest.concepts))         manifest.concepts = [];
@@ -341,33 +402,23 @@ export function fillManifest(manifest, pages = []) {
       const name    = h1Line ? h1Line.replace(/^#+\s+/, '').trim()
                              : path.basename(page.path, '.md');
 
-      // summary = first non-empty, non-heading line after the H1
-      let summary = name;
-      let pastH1 = !h1Line; // if no H1, start scanning from line 0
-      for (const ln of lines) {
-        if (!pastH1) { if (/^#\s+/.test(ln)) { pastH1 = true; } continue; }
-        const t = ln.trim();
-        if (t && !/^#+\s/.test(t) && !t.startsWith('<!--')) {
-          summary = t;
-          break;
-        }
-      }
+      // summary = first real prose line (skips the scope comment + boilerplate)
+      const summary = firstProseLine(content) || name;
 
-      // public_api = backtick tokens from ## CLI / ## API sub-sections
+      // public_api = real exported symbols from the page's code_entry_points,
+      // supplemented by backtick tokens in any ## CLI / ## API sub-section.
       const public_api = [];
+      const addApi = (n) => { const s = (n || '').trim(); if (s && !public_api.includes(s)) public_api.push(s); };
+      for (const src of parseScopeSrc(content)) {
+        if (/[*?[\]]/.test(src)) continue;   // skip globs — only read literal paths
+        for (const sym of extractExports(path.resolve(repoRoot, src))) addApi(sym);
+      }
       let inApiSection = false;
       for (const ln of lines) {
-        if (/^##\s+(CLI|API|Public API|Commands)/i.test(ln)) {
-          inApiSection = true;
-          continue;
-        }
+        if (/^##\s+(CLI|API|Public API|Commands)/i.test(ln)) { inApiSection = true; continue; }
         if (/^##\s+/.test(ln)) { inApiSection = false; continue; }
         if (!inApiSection) continue;
-        // extract all `token` spans
-        const ticks = [...ln.matchAll(/`([^`]+)`/g)].map(m2 => m2[1]);
-        for (const tok of ticks) {
-          if (!public_api.includes(tok)) public_api.push(tok);
-        }
+        for (const m2 of ln.matchAll(/`([^`]+)`/g)) addApi(m2[1]);
       }
 
       manifest.modules.push({

--- a/skills/autospec-doc/tests/gen-llms-full.test.mjs
+++ b/skills/autospec-doc/tests/gen-llms-full.test.mjs
@@ -534,3 +534,79 @@ test('generateLlmsFull (Track E): re-run with same inputs produces identical out
   const run2 = generateLlmsFull(opts);
   assert.strictEqual(run1, run2, 'two runs with identical inputs must produce byte-identical output');
 });
+
+// ── Round 2 (content fidelity): real summaries, source→doc routing, real public_api ──
+
+// A page shaped like real generator output: H1, H2, a MULTI-LINE autospec-doc-scope
+// comment whose interior `src:` line previously leaked in as the "summary", an italic
+// audience-boilerplate line, then the real feature summary prose.
+const SCOPED_PAGE = {
+  audience: 'developer',
+  feature: 'export-pipeline',
+  path: 'docs/developer/features/export-pipeline.md',
+  content: [
+    '# Export Pipeline (developer)',
+    '',
+    '## Export Pipeline',
+    '',
+    '<!-- autospec-doc-scope:',
+    '  src: ["src/export/pipeline.mjs"]',
+    '  reason: "export-pipeline reference for developer"',
+    '  generated: true',
+    '-->',
+    '',
+    '_Reference for the **developer** audience (architecture, APIs, extending)._',
+    '',
+    'Streams records out to downstream sinks with bounded back-pressure.',
+    '',
+  ].join('\n'),
+};
+
+test('R2: llms.txt link description is the real feature summary, not the src glob', () => {
+  const idx = generateLlmsIndex({ pages: [SCOPED_PAGE] });
+  assert.ok(idx.includes('Streams records out to downstream sinks with bounded back-pressure.'),
+    'description must be the real prose summary');
+  assert.ok(!/src:\s*\[/.test(idx), 'description must NOT be the src: [...] glob');
+});
+
+test('R2: manifest module summary is the real prose, not the src glob', () => {
+  const manifest = { schema_version: '1.0', modules: [], cli_entry_points: [], concepts: [], faq: [] };
+  fillManifest(manifest, [SCOPED_PAGE]);
+  const mod = manifest.modules.find(m => m.path === SCOPED_PAGE.path);
+  assert.ok(mod, 'module entry exists');
+  assert.strictEqual(mod.summary, 'Streams records out to downstream sinks with bounded back-pressure.');
+  assert.ok(!mod.summary.includes('src:'), 'summary must not contain the src glob');
+});
+
+test('R2: reverse-routing maps source files to docs, not doc-to-itself identity', () => {
+  const out = generateLlmsFull({ pages: [SCOPED_PAGE] });
+  assert.ok(out.includes('src/export/pipeline.mjs -> docs/developer/features/export-pipeline.md'),
+    'reverse-routing must map the source file to the doc that references it');
+  assert.ok(!/docs\/developer\/features\/export-pipeline\.md#L1 -> /.test(out),
+    'reverse-routing must NOT emit the identity doc#L1 -> doc form');
+});
+
+test('R2: manifest public_api is extracted from the real code_entry_points source', () => {
+  const repoRoot = makeTmpDir();
+  fs.mkdirSync(path.join(repoRoot, 'src', 'export'), { recursive: true });
+  fs.writeFileSync(path.join(repoRoot, 'src', 'export', 'pipeline.mjs'), [
+    'export function flushBatch() {}',
+    'export const MAX_RETRIES = 5;',
+    'export class Sink {}',
+    'function privateHelper() {}',
+  ].join('\n'));
+  const manifest = { schema_version: '1.0', modules: [], cli_entry_points: [], concepts: [], faq: [] };
+  fillManifest(manifest, [SCOPED_PAGE], { repoRoot });
+  const mod = manifest.modules.find(m => m.path === SCOPED_PAGE.path);
+  assert.ok(mod, 'module entry exists');
+  for (const sym of ['flushBatch', 'MAX_RETRIES', 'Sink']) {
+    assert.ok(mod.public_api.includes(sym), `public_api must include exported ${sym}`);
+  }
+  assert.ok(!mod.public_api.includes('privateHelper'), 'non-exported symbols must be excluded');
+});
+
+test('R2: generateLlmsFull stays deterministic with scoped pages', () => {
+  const a = generateLlmsFull({ pages: [SCOPED_PAGE] });
+  const b = generateLlmsFull({ pages: [SCOPED_PAGE] });
+  assert.strictEqual(a, b, 'scoped-page output must be byte-identical across runs');
+});


### PR DESCRIPTION
Round 2 — closes the content-fidelity gaps flagged in the round-1 promotion preview. Scripts+tests only (gen-llms-full.mjs).

- **Summaries**: `firstProseLine()` skips the multi-line scope comment + audience boilerplate → `llms.txt`/manifest/section summaries carry the real feature prose, not the `src: [...]` glob.
- **reverse-routing**: now maps `source_file -> docs` (from each page's scope `src:`), replacing the `doc#L1 -> doc` identity noise.
- **public_api**: extracted from the real `code_entry_points` exports (ESM + Python), guarded to valid identifiers; `fillManifest` gains optional `repoRoot`.

Spec: docs/specs/2026-06-17-autodoc-content-fidelity-design.md
Gate: gen-llms-full.test.mjs 33/33 (5 new R2 tests) · full doc suite 114/114 · validate.sh OK.