### PR TITLE
fix(explore): handoff timeout kills caller's process group + orphans watchdog sleep (validate.sh hung for hours)

### DIFF
--- a/scripts/autospec-explore.sh
+++ b/scripts/autospec-explore.sh
@@ -162,7 +162,13 @@ _explore_kill_tree() {
     local pid="$1" child
     local pgid
     pgid="$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
-    if [ -n "$pgid" ] && [ "$pgid" != "$$" ]; then
+    # Group-kill ONLY when this pid is its own process-group leader (pgid == pid),
+    # i.e. setsid gave the handoff a dedicated group we own. When setsid is absent
+    # (e.g. macOS) the handoff shares the CALLER's group; a `kill -TERM -$pgid`
+    # there would take down autospec-explore itself, the test runner, or the
+    # operator's shell. In that case fall back to killing the pid + its
+    # descendants individually (pgrep -P recursion below).
+    if [ -n "$pgid" ] && [ "$pgid" = "$pid" ]; then
         kill -TERM "-$pgid" 2>/dev/null || true
     fi
     for child in $(pgrep -P "$pid" 2>/dev/null || true); do
@@ -170,7 +176,7 @@ _explore_kill_tree() {
     done
     kill -TERM "$pid" 2>/dev/null || true
     sleep 1
-    if [ -n "$pgid" ] && [ "$pgid" != "$$" ]; then
+    if [ -n "$pgid" ] && [ "$pgid" = "$pid" ]; then
         kill -KILL "-$pgid" 2>/dev/null || true
     fi
     kill -KILL "$pid" 2>/dev/null || true
@@ -219,17 +225,25 @@ _explore_run_handoff() {
     pid=$!
     EXPLORE_CHILD_PIDS="${EXPLORE_CHILD_PIDS:+$EXPLORE_CHILD_PIDS }$pid"
 
+    # Redirect the watchdog's own descriptors away from the caller's stdout/stderr:
+    # otherwise its `sleep $HANDOFF_TIMEOUT_SEC` inherits and holds them open, and a
+    # caller that reads our output to EOF (e.g. bats `run`) blocks until the sleep
+    # finally exits — up to the full timeout.
     (
         sleep "$HANDOFF_TIMEOUT_SEC"
         if kill -0 "$pid" 2>/dev/null; then
             printf 'timeout after %ss\n' "$HANDOFF_TIMEOUT_SEC" > "$timeout_file"
             _explore_kill_tree "$pid"
         fi
-    ) &
+    ) >/dev/null 2>&1 &
     watchdog=$!
 
     wait "$pid"
     rc=$?
+    # Tear down the watchdog AND its sleep child. Killing only the subshell
+    # ($watchdog) orphans the `sleep $HANDOFF_TIMEOUT_SEC`, which then lingers for
+    # the full timeout instead of being reaped promptly.
+    pkill -P "$watchdog" 2>/dev/null || true
     kill "$watchdog" 2>/dev/null || true
     wait "$watchdog" 2>/dev/null || true
     _explore_remove_child_pid "$pid"


### PR DESCRIPTION
## Problem
On macOS (no GNU `timeout`/`setsid`), `_explore_run_handoff`'s fallback had two defects that made `validate.sh` hang for **3+ hours** and exit 144:

1. **Caller-group kill:** `_explore_kill_tree` ran `kill -TERM -$pgid` guarded only by `pgid != $$`. Without `setsid` the handoff shares the **caller's** process group, so this killed autospec-explore itself, the test runner (bats), and would kill the operator's shell in production. → group-kill only when `pgid == pid` (we own a dedicated group).
2. **Orphaned watchdog sleep:** `( sleep N; … ) &` inherited the caller's stdout and, on teardown, only the subshell was killed — orphaning `sleep N` for the full timeout while it held the inherited pipe, hanging `bats run`. → watchdog redirects to /dev/null + its sleep child is reaped via `pkill -P`.

## Proof
- `bash scripts/validate.sh`: **3+h hang → 316s, green**
- `test_explore_e2e.bats` 10/10 (incl. the previously-fatal timeout test), `test_explore_qa_gate_e2e.bats` 4/4, zero orphan sleeps.

Scripts only; no trio/goldens touched.