### PR TITLE
feat(harmonize): token-profile + variant JSON schemas

### DIFF
--- a/schemas/autospec-harmonize-token-profile.schema.json
+++ b/schemas/autospec-harmonize-token-profile.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-harmonize-token-profile.schema.json",
+  "title": "autospec-harmonize token profile",
+  "description": "Design tokens discovered from a repo (runtime computed-CSS or static source) by the autospec-harmonize discover stage.",
+  "type": "object",
+  "required": ["source", "palette", "type_scale", "spacing", "radii", "shadows", "components"],
+  "additionalProperties": false,
+  "properties": {
+    "source": {
+      "type": "string",
+      "enum": ["runtime", "source"],
+      "description": "How the tokens were extracted: runtime computed CSS via Playwright, or static source parsing."
+    },
+    "palette": {
+      "type": "array",
+      "description": "Discovered color tokens.",
+      "items": {
+        "type": "object",
+        "required": ["hex"],
+        "additionalProperties": false,
+        "properties": {
+          "hex": {
+            "type": "string",
+            "pattern": "^#[0-9a-fA-F]{6}$"
+          },
+          "role": { "type": "string" },
+          "count": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "type_scale": { "type": "array", "items": { "type": "object" } },
+    "spacing": { "type": "array", "items": { "type": "object" } },
+    "radii": { "type": "array", "items": { "type": "object" } },
+    "shadows": { "type": "array", "items": { "type": "object" } },
+    "components": {
+      "type": "object",
+      "description": "Per-component computed style summaries keyed by component name."
+    },
+    "inconsistencies": {
+      "type": "array",
+      "description": "Detected cross-page or cross-component token inconsistencies.",
+      "items": { "type": "object" }
+    }
+  }
+}

--- a/schemas/autospec-harmonize-variant.schema.json
+++ b/schemas/autospec-harmonize-variant.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-harmonize-variant.schema.json",
+  "title": "autospec-harmonize design variant",
+  "description": "A single generated design-language variant produced by the autospec-harmonize variants stage. The baseline variant is index 0.",
+  "type": "object",
+  "required": ["id", "label", "axis", "tokens", "design_md"],
+  "additionalProperties": false,
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "label": { "type": "string", "minLength": 1 },
+    "axis": {
+      "type": "string",
+      "enum": ["baseline", "minimal", "high-contrast", "dense", "bold", "vendor-blend"]
+    },
+    "vendor": { "type": "string" },
+    "wcag_min_ratio": { "type": "number", "minimum": 0 },
+    "tokens": {
+      "type": "object",
+      "required": ["palette", "type_scale", "spacing", "radii", "shadows"],
+      "additionalProperties": false,
+      "properties": {
+        "palette": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["hex"],
+            "additionalProperties": false,
+            "properties": {
+              "hex": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$" },
+              "role": { "type": "string" },
+              "count": { "type": "integer", "minimum": 0 }
+            }
+          }
+        },
+        "type_scale": { "type": "array", "items": { "type": "object" } },
+        "spacing": { "type": "array", "items": { "type": "object" } },
+        "radii": { "type": "array", "items": { "type": "object" } },
+        "shadows": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "design_md": { "type": "string", "minLength": 1 }
+  }
+}

--- a/tests/harmonize/test_schemas.bats
+++ b/tests/harmonize/test_schemas.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  PROFILE_SCHEMA="$REPO_ROOT/schemas/autospec-harmonize-token-profile.schema.json"
+  VARIANT_SCHEMA="$REPO_ROOT/schemas/autospec-harmonize-variant.schema.json"
+  TEST_TMPDIR="$(mktemp -d /tmp/autospec-harmonize-schemas-XXXXXX)"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+@test "token-profile schema accepts a minimal valid profile" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (install ajv-cli to run this test)"
+
+  cat > "$TEST_TMPDIR/profile-ok.json" <<'JSON'
+{
+  "source": "source",
+  "palette": [{ "hex": "#1a2b3c", "role": "primary", "count": 12 }],
+  "type_scale": [{ "px": 16 }],
+  "spacing": [{ "px": 8 }],
+  "radii": [{ "px": 4 }],
+  "shadows": [{ "value": "0 1px 2px rgba(0,0,0,0.1)" }],
+  "components": {}
+}
+JSON
+
+  run ajv validate -s "$PROFILE_SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/profile-ok.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "token-profile schema rejects a palette-less profile" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (install ajv-cli to run this test)"
+
+  cat > "$TEST_TMPDIR/profile-bad.json" <<'JSON'
+{
+  "source": "source",
+  "type_scale": [],
+  "spacing": [],
+  "radii": [],
+  "shadows": [],
+  "components": {}
+}
+JSON
+
+  run ajv validate -s "$PROFILE_SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/profile-bad.json"
+  [ "$status" -ne 0 ]
+}
+
+@test "variant schema accepts a baseline variant" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (install ajv-cli to run this test)"
+
+  cat > "$TEST_TMPDIR/variant-ok.json" <<'JSON'
+{
+  "id": "baseline",
+  "label": "Baseline",
+  "axis": "baseline",
+  "tokens": {
+    "palette": [{ "hex": "#1a2b3c" }],
+    "type_scale": [],
+    "spacing": [],
+    "radii": [],
+    "shadows": []
+  },
+  "design_md": "# Baseline\nDerived design language."
+}
+JSON
+
+  run ajv validate -s "$VARIANT_SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/variant-ok.json"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #1137

Adds the two shared JSON schemas for the autospec-harmonize epic:

- `schemas/autospec-harmonize-token-profile.schema.json` — requires `source` `palette` `type_scale` `spacing` `radii` `shadows` `components`; palette items require a `#rrggbb` `hex`; optional `inconsistencies`.
- `schemas/autospec-harmonize-variant.schema.json` — requires `id` `label` `axis` (enum) `tokens` `design_md`; optional `vendor` `wcag_min_ratio`.

Authored as draft-2020-12 to match every existing repo schema and the `ajv ... --spec=draft2020` test convention.

## Verification
- `bats tests/harmonize/test_schemas.bats` — 3/3 green (valid profile passes, palette-less profile rejected, baseline variant passes; real ajv, no mocks).
- `bash scripts/validate.sh` — exit 0, no schema regression.