### PR TITLE
feat(harmonize): static source style extractor

### DIFF
--- a/skills/autospec-harmonize/scripts/extract-source.mjs
+++ b/skills/autospec-harmonize/scripts/extract-source.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+// skills/autospec-harmonize/scripts/extract-source.mjs
+//
+// Static CSS/SCSS token-profile extractor for autospec-harmonize Stage 1.
+//
+// CLI: node extract-source.mjs --root <dir>
+// Stdout: JSON token profile conforming to
+//         schemas/autospec-harmonize-token-profile.schema.json
+//
+// Walks --root recursively (skips node_modules/.git), concats *.css/*.scss,
+// regex-collects design tokens, dedupes, and emits the schema-required shape.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// CLI arg parsing
+// ---------------------------------------------------------------------------
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const result = { root: null };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--root' && args[i + 1]) {
+      result.root = args[++i];
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// File walking
+// ---------------------------------------------------------------------------
+const SKIP_DIRS = new Set(['node_modules', '.git', '.svn', '.hg']);
+
+function walkSync(dir) {
+  const files = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) {
+        files.push(...walkSync(path.join(dir, entry.name)));
+      }
+    } else if (/\.(css|scss)$/.test(entry.name)) {
+      files.push(path.join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+function readAllCSS(root) {
+  const files = walkSync(root);
+  return files.map(f => {
+    try { return fs.readFileSync(f, 'utf8'); } catch { return ''; }
+  }).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Token extraction helpers
+// ---------------------------------------------------------------------------
+
+/** Extract all 6-digit hex colors, lowercased, deduped with occurrence count. */
+function extractPalette(css) {
+  const counts = new Map();
+  const re = /#([0-9a-fA-F]{6})\b/g;
+  let m;
+  while ((m = re.exec(css)) !== null) {
+    const hex = '#' + m[1].toLowerCase();
+    counts.set(hex, (counts.get(hex) ?? 0) + 1);
+  }
+  // Sort by count desc, then hex asc
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([hex, count]) => ({ hex, count }));
+}
+
+/** Extract font-size px values → sorted unique array of {px} objects. */
+function extractTypeScale(css) {
+  const vals = new Set();
+  const re = /font-size\s*:\s*(\d+(?:\.\d+)?)px/gi;
+  let m;
+  while ((m = re.exec(css)) !== null) vals.add(Number(m[1]));
+  return Array.from(vals).sort((a, b) => a - b).map(px => ({ px }));
+}
+
+/** Extract padding|gap|margin px values → sorted unique {px} objects. */
+function extractSpacing(css) {
+  const vals = new Set();
+  const re = /(?:padding|gap|margin)\s*:\s*(\d+(?:\.\d+)?)px/gi;
+  let m;
+  while ((m = re.exec(css)) !== null) vals.add(Number(m[1]));
+  return Array.from(vals).sort((a, b) => a - b).map(px => ({ px }));
+}
+
+/** Extract border-radius px values → sorted unique {px} objects. */
+function extractRadii(css) {
+  const vals = new Set();
+  const re = /border-radius\s*:\s*(\d+(?:\.\d+)?)px/gi;
+  let m;
+  while ((m = re.exec(css)) !== null) vals.add(Number(m[1]));
+  return Array.from(vals).sort((a, b) => a - b).map(px => ({ px }));
+}
+
+/** Extract box-shadow values → deduped {value} objects. */
+function extractShadows(css) {
+  const seen = new Set();
+  const re = /box-shadow\s*:\s*([^;}{]+)/gi;
+  let m;
+  while ((m = re.exec(css)) !== null) {
+    const val = m[1].trim();
+    if (val) seen.add(val);
+  }
+  return Array.from(seen).map(value => ({ value }));
+}
+
+/**
+ * Collect button-family selectors (.btn*, .button*, .cta*) and their
+ * rule bodies (first 200 chars each) into an array of descriptor strings.
+ */
+function extractButtonComponents(css) {
+  const entries = [];
+  const re = /(\.[a-zA-Z][a-zA-Z0-9_-]*)\s*\{([^}]*)\}/gs;
+  let m;
+  while ((m = re.exec(css)) !== null) {
+    const sel = m[1];
+    if (/\.(btn|button|cta)/i.test(sel)) {
+      entries.push({ selector: sel, rules: m[2].trim().slice(0, 200) });
+    }
+  }
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Inconsistency detection
+// ---------------------------------------------------------------------------
+function detectInconsistencies(palette, typeScale, buttons) {
+  const result = [];
+
+  if (palette.length > 3) {
+    result.push({
+      category: 'palette',
+      detail: `${palette.length} colors found; consider consolidating to a smaller set`,
+    });
+  }
+
+  if (typeScale.length > 4) {
+    result.push({
+      category: 'type_scale',
+      detail: `${typeScale.length} distinct font sizes found`,
+    });
+  }
+
+  if (buttons.length > 1) {
+    result.push({
+      category: 'components',
+      detail: `${buttons.length} button treatments found (.btn/.button/.cta selectors)`,
+    });
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+function main() {
+  const args = parseArgs(process.argv);
+
+  if (!args.root) {
+    process.stderr.write('Usage: node extract-source.mjs --root <dir>\n');
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(args.root)) {
+    process.stderr.write(`Error: root directory not found: ${args.root}\n`);
+    process.exit(1);
+  }
+
+  const css = readAllCSS(args.root);
+
+  if (!css.trim()) {
+    process.stderr.write('Warning: no CSS/SCSS source found under ' + args.root + '\n');
+  }
+
+  const palette        = extractPalette(css);
+  const typeScale      = extractTypeScale(css);
+  const spacing        = extractSpacing(css);
+  const radii          = extractRadii(css);
+  const shadows        = extractShadows(css);
+  const buttons        = extractButtonComponents(css);
+  const inconsistencies = detectInconsistencies(palette, typeScale, buttons);
+
+  const profile = {
+    source: 'source',
+    palette,
+    type_scale: typeScale,
+    spacing,
+    radii,
+    shadows,
+    components: { button: buttons },
+    inconsistencies,
+  };
+
+  process.stdout.write(JSON.stringify(profile, null, 2) + '\n');
+}
+
+main();

--- a/skills/autospec-harmonize/test-targets/messy-app/styles.css
+++ b/skills/autospec-harmonize/test-targets/messy-app/styles.css
@@ -1,0 +1,72 @@
+/* messy-app/styles.css — fixture with intentional style drift */
+
+/* Near-duplicate blues (3 entries → palette inconsistency) */
+.hero {
+  background-color: #1a73e8;
+  font-size: 32px;
+  padding: 24px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+}
+
+.nav-link {
+  color: #1b74e9;
+  font-size: 16px;
+  padding: 8px;
+}
+
+.icon-badge {
+  background: #1a72e7;
+  font-size: 12px;
+  border-radius: 4px;
+  margin: 4px;
+}
+
+/* Three distinct button treatments */
+.btn-primary {
+  background-color: #1a73e8;
+  color: #ffffff;
+  padding: 12px;
+  border-radius: 6px;
+  font-size: 16px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+.btn-secondary {
+  background-color: #f5f5f5;
+  color: #1b74e9;
+  padding: 10px;
+  border-radius: 4px;
+  font-size: 14px;
+  border: 1px solid #1b74e9;
+}
+
+.cta-button {
+  background: #1a72e7;
+  color: #ffffff;
+  padding: 16px;
+  border-radius: 24px;
+  font-size: 18px;
+  box-shadow: 0 4px 12px rgba(26,114,231,0.4);
+}
+
+/* Additional colors */
+.error {
+  color: #d93025;
+  font-size: 14px;
+  border-radius: 2px;
+  gap: 8px;
+}
+
+.success {
+  color: #1e8e3e;
+  font-size: 14px;
+}
+
+/* Card with spacing + shadow */
+.card {
+  padding: 24px;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+  gap: 16px;
+}

--- a/tests/harmonize/test_extract_source.bats
+++ b/tests/harmonize/test_extract_source.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  EXTRACTOR="$REPO_ROOT/skills/autospec-harmonize/scripts/extract-source.mjs"
+  FIXTURE_DIR="$REPO_ROOT/skills/autospec-harmonize/test-targets/messy-app"
+  PROFILE_SCHEMA="$REPO_ROOT/schemas/autospec-harmonize-token-profile.schema.json"
+  TEST_TMPDIR="$(mktemp -d /tmp/autospec-extract-source-XXXXXX)"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+@test "extract-source exits 0 on fixture dir" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  run node "$EXTRACTOR" --root "$FIXTURE_DIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "extract-source output validates against token-profile schema" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v ajv  >/dev/null 2>&1 || skip "ajv CLI not available (install ajv-cli to run this test)"
+
+  node "$EXTRACTOR" --root "$FIXTURE_DIR" > "$TEST_TMPDIR/profile.json"
+
+  run ajv validate -s "$PROFILE_SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/profile.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "extract-source output has source == \"source\"" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+
+  node "$EXTRACTOR" --root "$FIXTURE_DIR" > "$TEST_TMPDIR/profile.json"
+
+  run jq -r '.source' "$TEST_TMPDIR/profile.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "source" ]
+}
+
+@test "extract-source palette contains at least 3 entries" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+
+  node "$EXTRACTOR" --root "$FIXTURE_DIR" > "$TEST_TMPDIR/profile.json"
+
+  run jq '.palette | length' "$TEST_TMPDIR/profile.json"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 3 ]
+}
+
+@test "extract-source palette contains the 3 near-duplicate blues from fixture" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+
+  node "$EXTRACTOR" --root "$FIXTURE_DIR" > "$TEST_TMPDIR/profile.json"
+
+  # Each blue must be present in the palette
+  run jq -e '[.palette[].hex] | map(ascii_downcase) | contains(["#1a73e8"])' "$TEST_TMPDIR/profile.json"
+  [ "$status" -eq 0 ]
+
+  run jq -e '[.palette[].hex] | map(ascii_downcase) | contains(["#1b74e9"])' "$TEST_TMPDIR/profile.json"
+  [ "$status" -eq 0 ]
+
+  run jq -e '[.palette[].hex] | map(ascii_downcase) | contains(["#1a72e7"])' "$TEST_TMPDIR/profile.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "extract-source inconsistencies has at least 1 entry" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+
+  node "$EXTRACTOR" --root "$FIXTURE_DIR" > "$TEST_TMPDIR/profile.json"
+
+  run jq '.inconsistencies | length' "$TEST_TMPDIR/profile.json"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+}
+
+@test "extract-source inconsistencies entries have a category field" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+
+  node "$EXTRACTOR" --root "$FIXTURE_DIR" > "$TEST_TMPDIR/profile.json"
+
+  run jq -e '.inconsistencies | map(has("category")) | all' "$TEST_TMPDIR/profile.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}


### PR DESCRIPTION
Closes #1138

Adds `skills/autospec-harmonize/scripts/extract-source.mjs` — a deterministic static CSS/SCSS token extractor:
- Walks `*.css`/`*.scss` under `--root` (skips node_modules/.git), regex-collects hex colors, font-size/radius/spacing px, box-shadows, and `.btn|.button|.cta` selectors.
- Emits a schema-valid token-profile (`source:"source"`) with all required keys; flags `inconsistencies[]` on near-duplicate palettes / multiple button treatments.
- Fixture `test-targets/messy-app/styles.css` (3 near-dup blues, 3 type sizes, 3 button treatments).

## Verification
- `bats tests/harmonize/test_extract_source.bats` — 7/7 green (schema-valid output, source==source, ≥3 blue palette entries, non-empty inconsistencies; real node + ajv, no mocks).
- `bash scripts/validate.sh` — exit 0, no regression.