### PR TITLE
feat(harmonize): runtime computed-CSS extractor via Playwright

### DIFF
--- a/skills/autospec-harmonize/scripts/extract-runtime.mjs
+++ b/skills/autospec-harmonize/scripts/extract-runtime.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+// skills/autospec-harmonize/scripts/extract-runtime.mjs
+//
+// Runtime computed-CSS token-profile extractor for autospec-harmonize Stage 1.
+//
+// CLI: node extract-runtime.mjs --url <url> [--pages a,b]
+// Stdout: JSON token profile conforming to
+//         schemas/autospec-harmonize-token-profile.schema.json (source:"runtime")
+//
+// Lazily imports Playwright, crawls the route(s), reads getComputedStyle over
+// every element, converts rgb()->hex, and aggregates into the same token-profile
+// shape as extract-source.mjs. Screenshots each route to
+// .autospec/design/before/<route>.png. When Playwright is missing or the URL is
+// unreachable it prints `code_health:harmonize_runtime_unavailable` and exits 3.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const RUNTIME_UNAVAILABLE = 'code_health:harmonize_runtime_unavailable';
+
+// ---------------------------------------------------------------------------
+// CLI arg parsing
+// ---------------------------------------------------------------------------
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const result = { url: null, pages: null };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--url' && args[i + 1]) result.url = args[++i];
+    else if (args[i] === '--pages' && args[i + 1]) result.pages = args[++i];
+  }
+  return result;
+}
+
+/** Print a code_health line and exit 3 (the runtime-unavailable degradation path). */
+function failUnavailable(detail) {
+  process.stderr.write(`${RUNTIME_UNAVAILABLE}: ${detail}\n`);
+  process.exit(3);
+}
+
+// ---------------------------------------------------------------------------
+// Conversion + aggregation helpers (mirror extract-source.mjs output shape)
+// ---------------------------------------------------------------------------
+
+/** "rgb(26, 115, 232)" / "rgba(26,115,232,0.5)" -> "#1a73e8" (null if transparent/unparseable). */
+function rgbToHex(value) {
+  const v = (value || '').trim();
+  const m = /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i.exec(v);
+  if (!m) return null;
+  const alpha = /rgba\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*([\d.]+)\s*\)/i.exec(v);
+  if (alpha && Number(alpha[1]) === 0) return null; // fully transparent
+  const [r, g, b] = [m[1], m[2], m[3]].map(Number);
+  return '#' + [r, g, b].map(n => n.toString(16).padStart(2, '0')).join('').toLowerCase();
+}
+
+/** "16px" -> 16 (null otherwise). */
+function pxNum(value) {
+  const m = /^(\d+(?:\.\d+)?)px$/.exec((value || '').trim());
+  return m ? Number(m[1]) : null;
+}
+
+function detectInconsistencies(palette, typeScale, buttons) {
+  const result = [];
+  if (palette.length > 3) {
+    result.push({ category: 'palette', detail: `${palette.length} colors found; consider consolidating to a smaller set` });
+  }
+  if (typeScale.length > 4) {
+    result.push({ category: 'type_scale', detail: `${typeScale.length} distinct font sizes found` });
+  }
+  if (buttons.length > 1) {
+    result.push({ category: 'components', detail: `${buttons.length} button treatments found` });
+  }
+  return result;
+}
+
+/** Reduce per-element computed-style records to the token-profile sub-shapes. */
+function aggregate(records) {
+  const paletteCounts = new Map();
+  const type = new Set();
+  const spacing = new Set();
+  const radii = new Set();
+  const shadows = new Set();
+  const buttons = [];
+
+  for (const rec of records) {
+    for (const colorStr of [rec.color, rec.backgroundColor]) {
+      const hex = rgbToHex(colorStr);
+      if (hex) paletteCounts.set(hex, (paletteCounts.get(hex) ?? 0) + 1);
+    }
+    const fz = pxNum(rec.fontSize);
+    if (fz != null) type.add(fz);
+    for (const p of rec.paddings || []) {
+      const v = pxNum(p);
+      if (v != null && v > 0) spacing.add(v);
+    }
+    for (const rd of rec.radii || []) {
+      const v = pxNum(rd);
+      if (v != null && v > 0) radii.add(v);
+    }
+    if (rec.boxShadow && rec.boxShadow !== 'none') shadows.add(rec.boxShadow.trim());
+    if (rec.isButton) {
+      buttons.push({
+        selector: rec.selector || 'button',
+        rules: `color:${rec.color}; background:${rec.backgroundColor}; radius:${(rec.radii || [])[0] || ''}`.slice(0, 200),
+      });
+    }
+  }
+
+  const palette = Array.from(paletteCounts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([hex, count]) => ({ hex, count }));
+
+  return {
+    palette,
+    type_scale: Array.from(type).sort((a, b) => a - b).map(px => ({ px })),
+    spacing: Array.from(spacing).sort((a, b) => a - b).map(px => ({ px })),
+    radii: Array.from(radii).sort((a, b) => a - b).map(px => ({ px })),
+    shadows: Array.from(shadows).map(value => ({ value })),
+    buttons,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Page reader — runs in the browser context via $$eval.
+// ---------------------------------------------------------------------------
+function readComputedStyles(els) {
+  return els.slice(0, 5000).map(el => {
+    const cs = getComputedStyle(el);
+    const tag = el.tagName.toLowerCase();
+    const cls = (el.className && typeof el.className === 'string') ? el.className : '';
+    const isButton = tag === 'button' || /\b(btn|button|cta)\b/i.test(cls);
+    return {
+      color: cs.color,
+      backgroundColor: cs.backgroundColor,
+      fontSize: cs.fontSize,
+      paddings: [cs.paddingTop, cs.paddingRight, cs.paddingBottom, cs.paddingLeft],
+      radii: [cs.borderTopLeftRadius, cs.borderTopRightRadius, cs.borderBottomRightRadius, cs.borderBottomLeftRadius],
+      boxShadow: cs.boxShadow,
+      isButton,
+      selector: isButton ? (tag + (cls ? '.' + cls.trim().split(/\s+/).join('.') : '')) : null,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (!args.url) {
+    process.stderr.write('Usage: node extract-runtime.mjs --url <url> [--pages a,b]\n');
+    process.exit(1);
+  }
+
+  let playwright;
+  try {
+    playwright = await import('playwright');
+  } catch {
+    failUnavailable('playwright not installed (run: npm i -D playwright && npx playwright install chromium)');
+  }
+  const chromium = playwright.chromium || (playwright.default && playwright.default.chromium);
+  if (!chromium) failUnavailable('playwright chromium export unavailable');
+
+  let browser = null;
+  try {
+    browser = await chromium.launch();
+  } catch (e) {
+    failUnavailable(`browser launch failed: ${e && e.message ? e.message : e}`);
+  }
+  if (!browser) failUnavailable('browser launch returned null');
+
+  const routes = args.pages
+    ? args.pages.split(',').map(s => s.trim()).filter(Boolean)
+    : [''];
+
+  const beforeDir = path.join('.autospec', 'design', 'before');
+  fs.mkdirSync(beforeDir, { recursive: true });
+
+  const records = [];
+  try {
+    for (const route of routes) {
+      const page = await browser.newPage();
+      const target = route ? new URL(route, args.url).toString() : args.url;
+      await page.goto(target, { timeout: 8000, waitUntil: 'load' });
+      const recs = await page.$$eval('*', readComputedStyles);
+      records.push(...recs);
+      const safe = (route || 'index').replace(/[^a-zA-Z0-9_-]+/g, '_').replace(/^_+|_+$/g, '') || 'index';
+      try { await page.screenshot({ path: path.join(beforeDir, `${safe}.png`), fullPage: true }); } catch { /* screenshot is best-effort */ }
+      await page.close();
+    }
+  } catch (e) {
+    try { await browser.close(); } catch { /* ignore */ }
+    failUnavailable(`navigation failed: ${e && e.message ? e.message : e}`);
+  }
+  try { await browser.close(); } catch { /* ignore */ }
+
+  const agg = aggregate(records);
+  const inconsistencies = detectInconsistencies(agg.palette, agg.type_scale, agg.buttons);
+
+  const profile = {
+    source: 'runtime',
+    palette: agg.palette,
+    type_scale: agg.type_scale,
+    spacing: agg.spacing,
+    radii: agg.radii,
+    shadows: agg.shadows,
+    components: { button: agg.buttons },
+    inconsistencies,
+  };
+
+  process.stdout.write(JSON.stringify(profile, null, 2) + '\n');
+}
+
+main().catch(e => {
+  process.stderr.write(`${RUNTIME_UNAVAILABLE}: ${e && e.message ? e.message : e}\n`);
+  process.exit(3);
+});

--- a/skills/autospec-harmonize/test-targets/messy-app/index.html
+++ b/skills/autospec-harmonize/test-targets/messy-app/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Messy App — fixture</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <a class="nav-link" href="/">Home</a>
+    <a class="nav-link" href="/about">About</a>
+  </nav>
+
+  <section class="hero">
+    <h1>Welcome to Messy App</h1>
+    <button class="btn-primary">Get Started</button>
+    <button class="cta-button">Sign Up Free</button>
+  </section>
+
+  <div class="card">
+    <h2>Features</h2>
+    <p class="success">Everything is working great!</p>
+    <p class="error">But there are some issues too.</p>
+    <button class="btn-secondary">Learn More</button>
+    <span class="icon-badge">New</span>
+  </div>
+</body>
+</html>

--- a/tests/harmonize/test_extract_runtime.bats
+++ b/tests/harmonize/test_extract_runtime.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  EXTRACTOR="$REPO_ROOT/skills/autospec-harmonize/scripts/extract-runtime.mjs"
+  FIXTURE_DIR="$REPO_ROOT/skills/autospec-harmonize/test-targets/messy-app"
+  PROFILE_SCHEMA="$REPO_ROOT/schemas/autospec-harmonize-token-profile.schema.json"
+  TEST_TMPDIR="$(mktemp -d /tmp/autospec-extract-runtime-XXXXXX)"
+}
+
+teardown() {
+  # Kill any http server started during tests
+  if [ -n "${HTTP_SERVER_PID:-}" ]; then
+    kill "$HTTP_SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TEST_TMPDIR"
+}
+
+# Helper: check if Playwright is importable
+_playwright_available() {
+  node -e "require.resolve('playwright')" 2>/dev/null
+}
+
+# Helper: find a free port
+_free_port() {
+  python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()"
+}
+
+@test "missing Playwright exits 3 and prints harmonize_runtime_unavailable" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+
+  # Use a NODE_PATH that hides playwright, or rely on it being absent
+  run env NODE_PATH=/nonexistent node "$EXTRACTOR" --url "http://127.0.0.1:1" 2>&1
+  # Accept either: Playwright truly absent (exit 3) OR unreachable URL (exit 3)
+  # Both paths must emit harmonize_runtime_unavailable
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"harmonize_runtime_unavailable"* ]]
+}
+
+@test "unreachable URL exits 3 and prints harmonize_runtime_unavailable" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+
+  # Port 1 is always refused; if Playwright is absent we still get exit 3 + the line
+  run node "$EXTRACTOR" --url "http://127.0.0.1:1" 2>&1
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"harmonize_runtime_unavailable"* ]]
+}
+
+@test "missing --url exits non-zero" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+
+  run node "$EXTRACTOR" 2>&1
+  [ "$status" -ne 0 ]
+}
+
+@test "positive path: source == runtime and schema-valid (skips if Playwright absent)" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  _playwright_available || skip "playwright not installed"
+
+  # Serve the fixture directory on a free port
+  PORT="$(_free_port)"
+  python3 -m http.server "$PORT" --directory "$FIXTURE_DIR" >/dev/null 2>&1 &
+  HTTP_SERVER_PID=$!
+  # Give the server a moment to start
+  sleep 0.5
+
+  run node "$EXTRACTOR" --url "http://127.0.0.1:${PORT}"
+  kill "$HTTP_SERVER_PID" 2>/dev/null || true
+  HTTP_SERVER_PID=""
+
+  [ "$status" -eq 0 ]
+
+  command -v jq >/dev/null 2>&1 || skip "jq not available"
+  SOURCE="$(echo "$output" | jq -r '.source')"
+  [ "$SOURCE" = "runtime" ]
+
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available"
+  echo "$output" > "$TEST_TMPDIR/runtime-profile.json"
+  run ajv validate -s "$PROFILE_SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/runtime-profile.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "positive path: palette is non-empty array (skips if Playwright absent)" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+  _playwright_available || skip "playwright not installed"
+
+  PORT="$(_free_port)"
+  python3 -m http.server "$PORT" --directory "$FIXTURE_DIR" >/dev/null 2>&1 &
+  HTTP_SERVER_PID=$!
+  sleep 0.5
+
+  node "$EXTRACTOR" --url "http://127.0.0.1:${PORT}" > "$TEST_TMPDIR/profile.json"
+  kill "$HTTP_SERVER_PID" 2>/dev/null || true
+  HTTP_SERVER_PID=""
+
+  run jq '.palette | length' "$TEST_TMPDIR/profile.json"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+}


### PR DESCRIPTION
Closes #1139

Adds `skills/autospec-harmonize/scripts/extract-runtime.mjs` — runtime computed-CSS token extractor:
- Lazy `import('playwright')`; reads `getComputedStyle` over all elements, rgb()→hex, aggregates into the same token-profile shape as extract-source (`source:"runtime"`).
- Screenshots each route to `.autospec/design/before/<route>.png`.
- Degradation: missing Playwright **or** unreachable URL → `code_health:harmonize_runtime_unavailable` + exit 3.

## Verification
- `bats tests/harmonize/test_extract_runtime.bats` — 3 pass (both exit-3 degradation paths + usage), 2 positive-path tests skip cleanly (Playwright not installed here). Real served fixture, no mocks.
- `bash scripts/validate.sh` — exit 0.

Note: implemented by the orchestrator after the dispatched implementer subagent dropped on an API connection error mid-run (test + fixture were authored; the .mjs was finished and verified by the orchestrator).