### PR TITLE
feat(harmonize): directional + vendor-blend variant transforms

### DIFF
--- a/skills/autospec-harmonize/scripts/design-variants.mjs
+++ b/skills/autospec-harmonize/scripts/design-variants.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+// skills/autospec-harmonize/scripts/design-variants.mjs
+//
+// Stage 3 — Variants: given a baseline variant, emit an array of design
+// variants for requested axes. Baseline is always index 0.
+//
+// CLI: node design-variants.mjs --baseline <file>
+//        --axes minimal,high-contrast,dense,bold[,vendor-blend]
+//        [--vendor-file <f>]   (bypasses fetch-vendor.sh in tests)
+// Stdout: JSON array of variants conforming to
+//         schemas/autospec-harmonize-variant.schema.json
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { hexToRgb, rgbToHsl, hexToHsl, isChromatic } from './lib/color.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// WCAG relative luminance (linearized sRGB) — NOT HSL-L
+// ---------------------------------------------------------------------------
+
+/** sRGB channel [0,255] → linear light value. */
+function linearize(c) {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+/** WCAG relative luminance of a "#rrggbb" hex. */
+function wcagLuminance(hex) {
+  const [r, g, b] = hexToRgb(hex);
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+/** WCAG contrast ratio between two hex colors. */
+function contrastRatio(hexA, hexB) {
+  const L1 = wcagLuminance(hexA);
+  const L2 = wcagLuminance(hexB);
+  const lighter = Math.max(L1, L2);
+  const darker  = Math.min(L1, L2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** Pick the background entry: the one tagged role:"bg", else the lightest hex. */
+function pickBackground(palette) {
+  if (!palette.length) return null;
+  const tagged = palette.find(e => e.role === 'bg');
+  if (tagged) return tagged;
+  return palette.reduce((a, b) => (wcagLuminance(b.hex) > wcagLuminance(a.hex) ? b : a));
+}
+
+/**
+ * Readability metric: the minimum WCAG contrast of each foreground color
+ * against the background. Contrast is inherently foreground-vs-background, so
+ * this — not min-pairwise-across-all-colors — is what "high contrast" must
+ * improve. The high-contrast transform pushes foregrounds away from the bg
+ * luminance, which monotonically raises this value (no fudge floor needed).
+ */
+function minForegroundContrast(palette) {
+  const bg = pickBackground(palette);
+  if (!bg) return 1;
+  const fg = palette.filter(e => e !== bg);
+  if (!fg.length) return 1;
+  let min = Infinity;
+  for (const e of fg) {
+    const r = contrastRatio(e.hex, bg.hex);
+    if (r < min) min = r;
+  }
+  return min === Infinity ? 1 : min;
+}
+
+// ---------------------------------------------------------------------------
+// Hex utilities
+// ---------------------------------------------------------------------------
+
+/** [r,g,b] in [0,255] → "#rrggbb" */
+function rgbToHex(r, g, b) {
+  return '#' + [r, g, b].map(v => Math.round(Math.max(0, Math.min(255, v)))
+    .toString(16).padStart(2, '0')).join('');
+}
+
+/** HSL [h∈[0,360), s∈[0,1], l∈[0,1]] → "#rrggbb" */
+function hslToHex(h, s, l) {
+  // Standard HSL→RGB conversion
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs((h / 60) % 2 - 1));
+  const m = l - c / 2;
+  let r = 0, g = 0, b = 0;
+  if (h < 60)       { r = c; g = x; b = 0; }
+  else if (h < 120) { r = x; g = c; b = 0; }
+  else if (h < 180) { r = 0; g = c; b = x; }
+  else if (h < 240) { r = 0; g = x; b = c; }
+  else if (h < 300) { r = x; g = 0; b = c; }
+  else              { r = c; g = 0; b = x; }
+  return rgbToHex((r + m) * 255, (g + m) * 255, (b + m) * 255);
+}
+
+/** Deep-clone a JSON-serializable object. */
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const result = { baseline: null, axes: [], vendorFile: null };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--baseline' && args[i + 1]) {
+      result.baseline = args[++i];
+    } else if (args[i] === '--axes' && args[i + 1] !== undefined) {
+      const raw = args[++i].trim();
+      result.axes = raw ? raw.split(',').map(a => a.trim()).filter(Boolean) : [];
+    } else if (args[i] === '--vendor-file' && args[i + 1]) {
+      result.vendorFile = args[++i];
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Axis transforms
+// ---------------------------------------------------------------------------
+
+/** minimal: drop shadows, desaturate accent role. */
+function makeMinimal(baseline) {
+  const v = clone(baseline);
+  v.id    = 'minimal';
+  v.label = 'Minimal — reduced decoration';
+  v.axis  = 'minimal';
+
+  // Drop shadows
+  v.tokens.shadows = [];
+
+  // Desaturate accent palette entry
+  v.tokens.palette = v.tokens.palette.map(entry => {
+    if (entry.role !== 'accent') return entry;
+    const [h, , l] = hexToHsl(entry.hex);
+    // Fully desaturate (s→0), keep lightness
+    return { ...entry, hex: hslToHex(h, 0, l) };
+  });
+
+  v.design_md = '# Minimal Variant\n\nShadows removed; accent desaturated for a clean, decoration-free aesthetic.';
+  return v;
+}
+
+/** high-contrast: push dark colors darker, light colors lighter; recompute wcag_min_ratio. */
+function makeHighContrast(baseline) {
+  const v = clone(baseline);
+  v.id    = 'high-contrast';
+  v.label = 'High-Contrast — WCAG-AA+ accessibility';
+  v.axis  = 'high-contrast';
+
+  // Contrast is foreground-vs-background. Push the background further toward
+  // its own extreme, and push every foreground color AWAY from the background
+  // luminance (light bg → darken foregrounds; dark bg → lighten them). This
+  // raises each foreground-vs-bg contrast monotonically.
+  const bg = pickBackground(v.tokens.palette);
+  const bgLight = bg ? wcagLuminance(bg.hex) >= 0.5 : true;
+  v.tokens.palette = v.tokens.palette.map(entry => {
+    const [h, s, l] = hexToHsl(entry.hex);
+    let newL;
+    if (entry === bg) {
+      newL = bgLight ? Math.min(1, l + 0.15) : Math.max(0, l - 0.15);
+    } else {
+      newL = bgLight ? Math.max(0, l - 0.20) : Math.min(1, l + 0.20);
+    }
+    return { ...entry, hex: hslToHex(h, s, newL) };
+  });
+
+  v.wcag_min_ratio = minForegroundContrast(v.tokens.palette);
+  v.design_md = '# High-Contrast Variant\n\nPalette colors pushed apart for WCAG-AA+ contrast.';
+  return v;
+}
+
+/** dense: multiply spacing & radii px by 0.75. */
+function makeDense(baseline) {
+  const v = clone(baseline);
+  v.id    = 'dense';
+  v.label = 'Dense — compact spacing';
+  v.axis  = 'dense';
+
+  v.tokens.spacing = v.tokens.spacing.map(s => ({ ...s, px: s.px * 0.75 }));
+  v.tokens.radii   = v.tokens.radii.map(r => ({ ...r, px: r.px * 0.75 }));
+
+  v.design_md = '# Dense Variant\n\nSpacing and radii reduced to 75% for compact layouts.';
+  return v;
+}
+
+/** bold: heavier font weights + bump type_scale by ~2px. */
+function makeBold(baseline) {
+  const v = clone(baseline);
+  v.id    = 'bold';
+  v.label = 'Bold — strong typographic presence';
+  v.axis  = 'bold';
+
+  v.tokens.type_scale = v.tokens.type_scale.map(t => {
+    const bumped = { ...t };
+    if (typeof bumped.px === 'number') bumped.px = bumped.px + 2;
+    // Add/increase font weight
+    bumped.weight = typeof bumped.weight === 'number'
+      ? Math.min(900, bumped.weight + 100)
+      : 700;
+    return bumped;
+  });
+
+  v.design_md = '# Bold Variant\n\nType scale bumped up 2px per step; weights increased for strong typographic presence.';
+  return v;
+}
+
+/** vendor-blend: channel-wise 50% lerp between baseline hex and vendor hex. */
+function blendHex(baseHex, vendorHex) {
+  const [br, bg, bb] = hexToRgb(baseHex);
+  const [vr, vg, vb] = hexToRgb(vendorHex);
+  // Midpoint — strictly between when channels differ
+  const r = Math.round((br + vr) / 2);
+  const g = Math.round((bg + vg) / 2);
+  const b = Math.round((bb + vb) / 2);
+  return rgbToHex(r, g, b);
+}
+
+function makeVendorBlend(baseline, vendorPalette) {
+  const v = clone(baseline);
+  v.id     = 'vendor-blend';
+  v.label  = 'Vendor-Blend — 50% palette merge with vendor brand';
+  v.axis   = 'vendor-blend';
+  v.vendor = 'vendor';
+
+  // Build a map from role → vendor hex (prefer role match, else index match)
+  const vendorByRole = {};
+  for (const entry of vendorPalette) {
+    if (entry.role) vendorByRole[entry.role] = entry.hex;
+  }
+
+  v.tokens.palette = v.tokens.palette.map((entry, idx) => {
+    // Find vendor counterpart: by role first, then by index
+    const vendorHex = entry.role && vendorByRole[entry.role]
+      ? vendorByRole[entry.role]
+      : vendorPalette[idx]?.hex ?? null;
+
+    if (!vendorHex) return entry;
+    return { ...entry, hex: blendHex(entry.hex, vendorHex) };
+  });
+
+  v.design_md = '# Vendor-Blend Variant\n\nPalette is a 50% channel-wise blend between the baseline and vendor brand colors.';
+  return v;
+}
+
+// ---------------------------------------------------------------------------
+// Vendor fetch
+// ---------------------------------------------------------------------------
+
+function fetchVendor(vendorFile, scriptDir) {
+  // Test mode: vendor file provided directly
+  if (vendorFile) {
+    if (!fs.existsSync(vendorFile)) return null;
+    try {
+      const data = JSON.parse(fs.readFileSync(vendorFile, 'utf8'));
+      return data.palette ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  // Normal mode: call fetch-vendor.sh
+  const fetchScript = path.join(scriptDir, 'fetch-vendor.sh');
+  if (!fs.existsSync(fetchScript)) return null;
+
+  const tmpOut = `/tmp/autospec-vendor-${Date.now()}.json`;
+  try {
+    const result = spawnSync(
+      'bash',
+      [fetchScript, '--vendor', 'default', '--out', tmpOut],
+      { stdio: ['ignore', 'pipe', 'pipe'], timeout: 30000 }
+    );
+    if (result.status !== 0) return null;
+    if (!fs.existsSync(tmpOut)) return null;
+    const data = JSON.parse(fs.readFileSync(tmpOut, 'utf8'));
+    fs.unlinkSync(tmpOut);
+    return data.palette ?? null;
+  } catch {
+    if (fs.existsSync(tmpOut)) {
+      try { fs.unlinkSync(tmpOut); } catch { /* ignore */ }
+    }
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  if (!args.baseline) {
+    process.stderr.write('Usage: node design-variants.mjs --baseline <file> --axes <axes> [--vendor-file <f>]\n');
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(args.baseline)) {
+    process.stderr.write(`Error: baseline file not found: ${args.baseline}\n`);
+    process.exit(1);
+  }
+
+  let baseline;
+  try {
+    baseline = JSON.parse(fs.readFileSync(args.baseline, 'utf8'));
+  } catch (e) {
+    process.stderr.write(`Error: could not parse baseline JSON: ${e.message}\n`);
+    process.exit(1);
+  }
+
+  // Recompute baseline wcag_min_ratio with the same foreground-vs-bg metric the
+  // variants use, so comparisons are apples-to-apples regardless of what value
+  // the upstream baseline carried.
+  baseline.wcag_min_ratio = minForegroundContrast(baseline.tokens.palette);
+
+  const variants = [baseline];
+
+  for (const axis of args.axes) {
+    switch (axis) {
+      case 'minimal':
+        variants.push(makeMinimal(baseline));
+        break;
+
+      case 'high-contrast':
+        variants.push(makeHighContrast(baseline));
+        break;
+
+      case 'dense':
+        variants.push(makeDense(baseline));
+        break;
+
+      case 'bold':
+        variants.push(makeBold(baseline));
+        break;
+
+      case 'vendor-blend': {
+        const vendorPalette = fetchVendor(args.vendorFile, __dirname);
+        if (!vendorPalette) {
+          process.stderr.write('code_health:harmonize_vendor_fetch_failed\n');
+          // Drop only vendor-blend; continue with other axes
+          continue;
+        }
+        variants.push(makeVendorBlend(baseline, vendorPalette));
+        break;
+      }
+
+      default:
+        process.stderr.write(`Warning: unknown axis "${axis}" — skipped\n`);
+    }
+  }
+
+  process.stdout.write(JSON.stringify(variants, null, 2) + '\n');
+}
+
+main();

--- a/skills/autospec-harmonize/scripts/design-variants.mjs
+++ b/skills/autospec-harmonize/scripts/design-variants.mjs
@@ -295,69 +295,61 @@ function fetchVendor(vendorFile, scriptDir) {
 // Main
 // ---------------------------------------------------------------------------
 
-function main() {
-  const args = parseArgs(process.argv);
+/** Directional axes that are a pure function of the baseline (no I/O). */
+const SIMPLE_AXES = {
+  minimal: makeMinimal,
+  'high-contrast': makeHighContrast,
+  dense: makeDense,
+  bold: makeBold,
+};
 
-  if (!args.baseline) {
-    process.stderr.write('Usage: node design-variants.mjs --baseline <file> --axes <axes> [--vendor-file <f>]\n');
+/** Read + parse the baseline variant file; exit 1 on missing/invalid input. */
+function loadBaseline(file) {
+  if (!fs.existsSync(file)) {
+    process.stderr.write(`Error: baseline file not found: ${file}\n`);
     process.exit(1);
   }
-
-  if (!fs.existsSync(args.baseline)) {
-    process.stderr.write(`Error: baseline file not found: ${args.baseline}\n`);
-    process.exit(1);
-  }
-
-  let baseline;
   try {
-    baseline = JSON.parse(fs.readFileSync(args.baseline, 'utf8'));
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
   } catch (e) {
     process.stderr.write(`Error: could not parse baseline JSON: ${e.message}\n`);
     process.exit(1);
   }
+}
 
+/** Build the variant array (baseline at index 0) for the requested axes. */
+function buildVariants(baseline, axes, vendorFile) {
+  const variants = [baseline];
+  for (const axis of axes) {
+    if (SIMPLE_AXES[axis]) {
+      variants.push(SIMPLE_AXES[axis](baseline));
+    } else if (axis === 'vendor-blend') {
+      const vendorPalette = fetchVendor(vendorFile, __dirname);
+      if (!vendorPalette) {
+        // Drop only vendor-blend; other axes survive.
+        process.stderr.write('code_health:harmonize_vendor_fetch_failed\n');
+        continue;
+      }
+      variants.push(makeVendorBlend(baseline, vendorPalette));
+    } else {
+      process.stderr.write(`Warning: unknown axis "${axis}" — skipped\n`);
+    }
+  }
+  return variants;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (!args.baseline) {
+    process.stderr.write('Usage: node design-variants.mjs --baseline <file> --axes <axes> [--vendor-file <f>]\n');
+    process.exit(1);
+  }
+  const baseline = loadBaseline(args.baseline);
   // Recompute baseline wcag_min_ratio with the same foreground-vs-bg metric the
   // variants use, so comparisons are apples-to-apples regardless of what value
   // the upstream baseline carried.
   baseline.wcag_min_ratio = minForegroundContrast(baseline.tokens.palette);
-
-  const variants = [baseline];
-
-  for (const axis of args.axes) {
-    switch (axis) {
-      case 'minimal':
-        variants.push(makeMinimal(baseline));
-        break;
-
-      case 'high-contrast':
-        variants.push(makeHighContrast(baseline));
-        break;
-
-      case 'dense':
-        variants.push(makeDense(baseline));
-        break;
-
-      case 'bold':
-        variants.push(makeBold(baseline));
-        break;
-
-      case 'vendor-blend': {
-        const vendorPalette = fetchVendor(args.vendorFile, __dirname);
-        if (!vendorPalette) {
-          process.stderr.write('code_health:harmonize_vendor_fetch_failed\n');
-          // Drop only vendor-blend; continue with other axes
-          continue;
-        }
-        variants.push(makeVendorBlend(baseline, vendorPalette));
-        break;
-      }
-
-      default:
-        process.stderr.write(`Warning: unknown axis "${axis}" — skipped\n`);
-    }
-  }
-
-  process.stdout.write(JSON.stringify(variants, null, 2) + '\n');
+  process.stdout.write(JSON.stringify(buildVariants(baseline, args.axes, args.vendorFile), null, 2) + '\n');
 }
 
 main();

--- a/skills/autospec-harmonize/scripts/fetch-vendor.sh
+++ b/skills/autospec-harmonize/scripts/fetch-vendor.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# skills/autospec-harmonize/scripts/fetch-vendor.sh
+#
+# Wrapper for fetching a vendor palette from the autospec-design catalog.
+# Usage: fetch-vendor.sh --vendor <name> --out <file>
+#
+# On success: writes JSON to <file>, exits 0.
+# On failure: prints code_health:harmonize_vendor_fetch_failed to stderr, exits 1.
+
+set -euo pipefail
+
+VENDOR_NAME=""
+OUT_FILE=""
+
+# Parse args
+i=0
+args=("$@")
+while [ $i -lt ${#args[@]} ]; do
+  if [ "${args[$i]}" = "--vendor" ]; then
+    i=$((i + 1))
+    VENDOR_NAME="${args[$i]}"
+  elif [ "${args[$i]}" = "--out" ]; then
+    i=$((i + 1))
+    OUT_FILE="${args[$i]}"
+  fi
+  i=$((i + 1))
+done
+
+if [ -z "$VENDOR_NAME" ] || [ -z "$OUT_FILE" ]; then
+  printf 'code_health:harmonize_vendor_fetch_failed\n' >&2
+  exit 1
+fi
+
+# Locate autospec-design fetch script (if present in known relative paths)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DESIGN_FETCH="$REPO_ROOT/skills/autospec-design/scripts/fetch-catalog.sh"
+
+if [ -f "$DESIGN_FETCH" ]; then
+  if "$DESIGN_FETCH" --vendor "$VENDOR_NAME" --out "$OUT_FILE"; then
+    exit 0
+  else
+    printf 'code_health:harmonize_vendor_fetch_failed\n' >&2
+    exit 1
+  fi
+fi
+
+# Fallback: attempt curl to a catalog URL (environment-configurable)
+CATALOG_URL="${AUTOSPEC_VENDOR_CATALOG_URL:-}"
+if [ -n "$CATALOG_URL" ]; then
+  if curl -fsSL "${CATALOG_URL}/${VENDOR_NAME}.json" -o "$OUT_FILE" 2>/dev/null; then
+    exit 0
+  else
+    printf 'code_health:harmonize_vendor_fetch_failed\n' >&2
+    exit 1
+  fi
+fi
+
+# No fetch path available
+printf 'code_health:harmonize_vendor_fetch_failed\n' >&2
+exit 1

--- a/tests/harmonize/test_variants.bats
+++ b/tests/harmonize/test_variants.bats
@@ -1,0 +1,182 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  VARIANTS="$REPO_ROOT/skills/autospec-harmonize/scripts/design-variants.mjs"
+  FETCH_VENDOR="$REPO_ROOT/skills/autospec-harmonize/scripts/fetch-vendor.sh"
+  VARIANT_SCHEMA="$REPO_ROOT/schemas/autospec-harmonize-variant.schema.json"
+  TEST_TMPDIR="$(mktemp -d /tmp/autospec-variants-XXXXXX)"
+
+  # Write a minimal baseline variant JSON fixture
+  cat > "$TEST_TMPDIR/baseline.json" <<'EOF'
+{
+  "id": "baseline",
+  "label": "Baseline — faithful consolidation",
+  "axis": "baseline",
+  "wcag_min_ratio": 3.5,
+  "tokens": {
+    "palette": [
+      {"hex": "#ffffff", "role": "bg"},
+      {"hex": "#111111", "role": "text"},
+      {"hex": "#1a73e8", "role": "primary"},
+      {"hex": "#d93025", "role": "accent"}
+    ],
+    "type_scale": [
+      {"px": 12}, {"px": 14}, {"px": 16}, {"px": 20}, {"px": 32}
+    ],
+    "spacing": [
+      {"px": 8}, {"px": 16}, {"px": 24}
+    ],
+    "radii": [
+      {"px": 4}, {"px": 8}
+    ],
+    "shadows": [
+      {"value": "0 1px 3px rgba(0,0,0,0.2)"}
+    ]
+  },
+  "design_md": "# Baseline\n\nBaseline design system."
+}
+EOF
+
+  # Vendor fixture with clearly different palette (orange/green tones)
+  cat > "$TEST_TMPDIR/vendor.json" <<'EOF'
+{
+  "palette": [
+    {"hex": "#ff6600", "role": "primary"},
+    {"hex": "#00aa44", "role": "accent"},
+    {"hex": "#f5f5f5", "role": "bg"},
+    {"hex": "#222222", "role": "text"}
+  ]
+}
+EOF
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+@test "design-variants exits 0 with baseline only (no axes)" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  run node "$VARIANTS" --baseline "$TEST_TMPDIR/baseline.json" --axes ""
+  [ "$status" -eq 0 ]
+}
+
+@test "design-variants output is a JSON array with baseline at index 0" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+  run node "$VARIANTS" --baseline "$TEST_TMPDIR/baseline.json" --axes "minimal"
+  [ "$status" -eq 0 ]
+  echo "$output" > "$TEST_TMPDIR/variants.json"
+  run jq 'type' "$TEST_TMPDIR/variants.json"
+  [ "$output" = '"array"' ]
+  run jq '.[0].axis' "$TEST_TMPDIR/variants.json"
+  [ "$output" = '"baseline"' ]
+}
+
+@test "high-contrast variant wcag_min_ratio exceeds baseline" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+  node "$VARIANTS" --baseline "$TEST_TMPDIR/baseline.json" --axes "high-contrast" \
+    > "$TEST_TMPDIR/hc.json"
+  # baseline index 0 has wcag_min_ratio; high-contrast is index 1
+  BASELINE_WCAG=$(jq '.[0].wcag_min_ratio' "$TEST_TMPDIR/hc.json")
+  HC_WCAG=$(jq '.[1].wcag_min_ratio' "$TEST_TMPDIR/hc.json")
+  # Use node to compare floats
+  run node -e "process.exit(($HC_WCAG > $BASELINE_WCAG) ? 0 : 1)"
+  [ "$status" -eq 0 ]
+}
+
+@test "high-contrast variant has axis == high-contrast" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+  node "$VARIANTS" --baseline "$TEST_TMPDIR/baseline.json" --axes "high-contrast" \
+    > "$TEST_TMPDIR/hc.json"
+  run jq -r '.[1].axis' "$TEST_TMPDIR/hc.json"
+  [ "$output" = "high-contrast" ]
+}
+
+@test "dense variant last spacing element is strictly smaller than baseline last spacing" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+  node "$VARIANTS" --baseline "$TEST_TMPDIR/baseline.json" --axes "dense" \
+    > "$TEST_TMPDIR/dense.json"
+  BASELINE_LAST=$(jq '.[0].tokens.spacing[-1].px' "$TEST_TMPDIR/dense.json")
+  DENSE_LAST=$(jq '.[1].tokens.spacing[-1].px' "$TEST_TMPDIR/dense.json")
+  run node -e "process.exit(($DENSE_LAST < $BASELINE_LAST) ? 0 : 1)"
+  [ "$status" -eq 0 ]
+}
+
+@test "vendor-blend palette hex channels lie strictly between baseline and vendor" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+  node "$VARIANTS" --baseline "$TEST_TMPDIR/baseline.json" --axes "vendor-blend" \
+    --vendor-file "$TEST_TMPDIR/vendor.json" \
+    > "$TEST_TMPDIR/vb.json"
+  # Check that the blended primary hex (#1a73e8 blended with #ff6600)
+  # Each channel must be strictly between baseline and vendor channels
+  # baseline primary: #1a73e8 = R=26,G=115,B=232
+  # vendor primary:   #ff6600 = R=255,G=102,B=0
+  # blended: R must be between 26 and 255, G between 102 and 115, B between 0 and 232
+  BLENDED_PRIMARY=$(jq -r '[.[1].tokens.palette[] | select(.role=="primary")][0].hex' "$TEST_TMPDIR/vb.json")
+  run node -e "
+    const hex = '$BLENDED_PRIMARY';
+    const r = parseInt(hex.slice(1,3),16);
+    const g = parseInt(hex.slice(3,5),16);
+    const b = parseInt(hex.slice(5,7),16);
+    // baseline primary R=26,G=115,B=232  vendor primary R=255,G=102,B=0
+    const ok = r > 26 && r < 255 && g > 102 && g < 115 && b > 0 && b < 232;
+    process.exit(ok ? 0 : 1);
+  "
+  [ "$status" -eq 0 ]
+}
+
+@test "vendor-blend axis == vendor-blend" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+  node "$VARIANTS" --baseline "$TEST_TMPDIR/baseline.json" --axes "vendor-blend" \
+    --vendor-file "$TEST_TMPDIR/vendor.json" \
+    > "$TEST_TMPDIR/vb.json"
+  run jq -r '.[1].axis' "$TEST_TMPDIR/vb.json"
+  [ "$output" = "vendor-blend" ]
+}
+
+@test "vendor fetch failure prints code_health signal and others survive, exit 0" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+  # No --vendor-file, fetch-vendor.sh will fail → vendor-blend is dropped
+  # Request minimal + vendor-blend; minimal should still appear
+  run node "$VARIANTS" --baseline "$TEST_TMPDIR/baseline.json" --axes "minimal,vendor-blend"
+  [ "$status" -eq 0 ]
+  # stderr should contain code_health signal
+  [[ "$output $stderr" == *"harmonize_vendor_fetch_failed"* ]] || \
+    echo "$output" | grep -q "harmonize_vendor_fetch_failed" || \
+    { run bash -c "node '$VARIANTS' --baseline '$TEST_TMPDIR/baseline.json' --axes 'minimal,vendor-blend' 2>&1"; \
+      [[ "$output" == *"harmonize_vendor_fetch_failed"* ]]; }
+  # The array must still be emitted with baseline + minimal (no vendor-blend)
+  run bash -c "node '$VARIANTS' --baseline '$TEST_TMPDIR/baseline.json' --axes 'minimal,vendor-blend' 2>/dev/null"
+  [ "$status" -eq 0 ]
+  echo "$output" > "$TEST_TMPDIR/fail.json"
+  run jq 'type' "$TEST_TMPDIR/fail.json"
+  [ "$output" = '"array"' ]
+  # minimal should be present
+  run jq '[.[] | select(.axis=="minimal")] | length' "$TEST_TMPDIR/fail.json"
+  [ "$output" -ge 1 ]
+  # vendor-blend should NOT be present
+  run jq '[.[] | select(.axis=="vendor-blend")] | length' "$TEST_TMPDIR/fail.json"
+  [ "$output" -eq 0 ]
+}
+
+@test "all variants validate against schema (ajv)" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v ajv  >/dev/null 2>&1 || skip "ajv CLI not available"
+  node "$VARIANTS" --baseline "$TEST_TMPDIR/baseline.json" \
+    --axes "minimal,high-contrast,dense,bold" \
+    > "$TEST_TMPDIR/all.json"
+  # Validate each variant individually
+  COUNT=$(jq 'length' "$TEST_TMPDIR/all.json")
+  for i in $(seq 0 $((COUNT - 1))); do
+    jq ".[$i]" "$TEST_TMPDIR/all.json" > "$TEST_TMPDIR/variant_$i.json"
+    run ajv validate -s "$VARIANT_SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/variant_$i.json"
+    [ "$status" -eq 0 ]
+  done
+}


### PR DESCRIPTION
Closes #1142

Adds `design-variants.mjs` + `fetch-vendor.sh`:
- Axes: `minimal`/`high-contrast`/`dense`/`bold`/`vendor-blend`; baseline at index 0.
- **high-contrast** uses `wcag_min_ratio` = min **foreground-vs-background** WCAG contrast (linearized-sRGB relative luminance), and pushes foregrounds away from the background luminance → contrast genuinely increases (fixture: baseline **4.5 → 9.3**). No fudge floor.
- **dense** ×0.75 spacing/radii; **bold** heavier weights +1 type step; **minimal** drops shadows + neutralizes accent.
- **vendor-blend**: channel-wise 50% lerp (each blended channel strictly between baseline & vendor); `fetch-vendor.sh` failure prints `code_health:harmonize_vendor_fetch_failed` and drops only that variant (others survive, exit 0).

## Verification
- `bats tests/harmonize/test_variants.bats` — 9/9 green (real node + ajv, fixture vendor file, no mocks).
- `bash scripts/validate.sh` — exit 0.

Note: the dispatched implementer's first pass measured wcag as min-pairwise-across-all-colors and added a `+0.01` floor that *faked* the high-contrast AC (pre-floor value was 2.1 < baseline 3.5). The orchestrator rewrote the metric + transform so the AC passes for the right reason, and removed the floor.