### PR TITLE
feat(harmonize): validate contract gate + docs + dogfood

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Claude Code, OpenCode, or Codex CLI. Each links to its own README; see
 | [`autospec-release`](skills/autospec-release/README.md) | You want to know whether the current repo is ready to ship. | Runs the release-readiness loop across sweep, review, run, test, QA, docs sync, proof artifacts, and legacy cleanup. |
 | [`autospec-story`](skills/autospec-story/README.md) | You need a repo-level product and implementation-state overview. | Produces a cited Markdown story from local specs, docs, issues, PRs, and git history. |
 | [`autospec-fleet`](skills/autospec-fleet/README.md) | You want to supervise `autospec-run` across multiple repos. | Provides config schemas/linting, checkout planning, dry-run command generation, JSON status, and stop forwarding. |
+| [`autospec-harmonize`](skills/autospec-harmonize/README.md) | You want to discover design-token drift and produce a harmonized migration spec. | Runs a 6-stage pipeline (discover → generalize → variants → preview → pick → gen-migration-spec) and emits a dated spec ready for `/autospec-define`. |
 
 ### Run control and recovery
 
@@ -154,7 +155,7 @@ Sorted heaviest first. Regenerate with
 | `autospec-refine` | 3.1k | | `autospec-playwright` | 1.0k |
 | `autospec-classify` | 3.1k | | `autospec-stop` | 0.8k |
 | `autospec-explore` | 2.9k | | `autospec-rollover-status` | 0.5k |
-| `autospec-design` | 2.9k | | | |
+| `autospec-design` | 2.9k | | `autospec-harmonize` | 2.0k |
 | `autospec-continue` | 2.7k | | | |
 
 ## Install

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -142,6 +142,11 @@ task-oriented "I want to…" guidance, see [`README.md`](README.md).
 - Trigger: start a perpetual autonomous research + ship loop on an isolated sandbox branch — 7 researchers propose features from spec/code gaps, prior reports, codebase signals, open issues, source analysis, dependency health, and competitor research, then drain via `/autospec-run` with PRs targeting the sandbox branch (never `main`).
 - Keywords: `autospec-explore`, `explore and ship`, `autonomous research loop`, `discovery loop`
 
+### `autospec-harmonize`
+- Path: [`skills/autospec-harmonize`](skills/autospec-harmonize)
+- Trigger: discover design-token drift in a codebase, generalize a baseline, generate variants, preview them, pick one, and emit a dated migration spec ready for `/autospec-define`.
+- Keywords: `autospec-harmonize`, `harmonize design`, `design tokens`, `style drift`, `palette inconsistency`, `design migration spec`
+
 ## Adding a skill
 
 1. Create `skills/<skill-name>/SKILL.md`; keep the body concise and move large detail into `references/`.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -2787,6 +2787,7 @@ main() {
     check_block_expansion
     check_derive_trio_consistency
     check_claim_guard_contract
+    check_autospec_harmonize_contract
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.
@@ -3842,6 +3843,30 @@ check_claim_guard_contract() {
                      fail "$bf: failed (issue #1066/#1069)"; }
         done
     fi
+}
+
+# autospec-harmonize trio contract (issue #1146):
+# All three adapter files (SKILL.md, codex/prompt.md, opencode/agent.md) must
+# contain the 6 stage labels, --no-live-preview, the AskUserQuestion pick gate,
+# and the /autospec-define handoff.
+check_autospec_harmonize_contract() {
+    info "autospec-harmonize contract: trio stage labels + pick gate + handoff (issue #1146)"
+    local skill_dir="skills/autospec-harmonize"
+    for f in "$skill_dir/SKILL.md" \
+              "$skill_dir/codex/prompt.md" \
+              "$skill_dir/opencode/agent.md"; do
+        [ -f "$f" ] || fail "$f: required trio file missing (issue #1146)"
+        for token in discover generalize variants preview pick gen-migration-spec; do
+            grep -q "$token" "$f" \
+                || fail "$f: missing stage label '$token' (issue #1146)"
+        done
+        grep -q -- '--no-live-preview' "$f" \
+            || fail "$f: missing '--no-live-preview' (issue #1146)"
+        grep -q 'AskUserQuestion' "$f" \
+            || fail "$f: missing 'AskUserQuestion' pick gate reference (issue #1146)"
+        grep -q '/autospec-define' "$f" \
+            || fail "$f: missing '/autospec-define' handoff (issue #1146)"
+    done
 }
 
 main "$@"

--- a/skills/autospec-harmonize/scripts/extract-source.mjs
+++ b/skills/autospec-harmonize/scripts/extract-source.mjs
@@ -45,17 +45,38 @@ function walkSync(dir) {
       if (!SKIP_DIRS.has(entry.name)) {
         files.push(...walkSync(path.join(dir, entry.name)));
       }
-    } else if (/\.(css|scss)$/.test(entry.name)) {
+    } else if (/\.(css|scss|html|htm)$/.test(entry.name)) {
       files.push(path.join(dir, entry.name));
     }
   }
   return files;
 }
 
+/**
+ * Given the text of an HTML file, extract the contents of all
+ * <style>...</style> blocks and concatenate them.
+ */
+function extractStyleBlocks(html) {
+  const blocks = [];
+  const re = /<style[^>]*>([\s\S]*?)<\/style>/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    blocks.push(m[1]);
+  }
+  return blocks.join('\n');
+}
+
 function readAllCSS(root) {
   const files = walkSync(root);
   return files.map(f => {
-    try { return fs.readFileSync(f, 'utf8'); } catch { return ''; }
+    let text;
+    try { text = fs.readFileSync(f, 'utf8'); } catch { return ''; }
+    // For HTML/HTM files, extract only the <style> block contents so that
+    // the CSS token regexes don't match stray hex-like strings in markup.
+    if (/\.html?$/.test(f)) {
+      return extractStyleBlocks(text);
+    }
+    return text;
   }).join('\n');
 }
 

--- a/tests/harmonize/test_dogfood_fleet_gui.bats
+++ b/tests/harmonize/test_dogfood_fleet_gui.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+# tests/harmonize/test_dogfood_fleet_gui.bats
+#
+# Dogfood test: run the harmonize --source-only pipeline against the real
+# skills/autospec-fleet/gui directory (inline-styled single-file HTML GUI).
+# Asserts exit 0 and that discovered-tokens.json has a non-empty .inconsistencies
+# array — proving that extract-source.mjs can read <style> blocks in HTML files.
+#
+# Guards: node and jq must be available; LLM and Playwright are stubbed out.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  TARGET_GUI="$REPO_ROOT/skills/autospec-fleet/gui"
+  SCRIPTS_DIR="$REPO_ROOT/skills/autospec-harmonize/scripts"
+  TEST_TMPDIR="$(mktemp -d /tmp/autospec-dogfood-fleet-gui-XXXXXX)"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+@test "dogfood fleet-gui: harmonize --source-only exits 0 and produces discovered-tokens.json" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+
+  run env \
+    AUTOSPEC_SCRIPTS_DIR="$SCRIPTS_DIR" \
+    AUTOSPEC_HARMONIZE_LLM_STUB=1 \
+    AUTOSPEC_HARMONIZE_NO_PLAYWRIGHT=1 \
+    bash "$SCRIPTS_DIR/harmonize.sh" \
+      --root "$TARGET_GUI" \
+      --source-only \
+      --no-live-preview \
+      --variants minimal \
+      --out "$TEST_TMPDIR"
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMPDIR/discovered-tokens.json" ]
+}
+
+@test "dogfood fleet-gui: discovered-tokens.json has non-empty inconsistencies array" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+
+  env \
+    AUTOSPEC_SCRIPTS_DIR="$SCRIPTS_DIR" \
+    AUTOSPEC_HARMONIZE_LLM_STUB=1 \
+    AUTOSPEC_HARMONIZE_NO_PLAYWRIGHT=1 \
+    bash "$SCRIPTS_DIR/harmonize.sh" \
+      --root "$TARGET_GUI" \
+      --source-only \
+      --no-live-preview \
+      --variants minimal \
+      --out "$TEST_TMPDIR"
+
+  run jq '.inconsistencies | length >= 1' "$TEST_TMPDIR/discovered-tokens.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}


### PR DESCRIPTION
Closes #1146

- `check_autospec_harmonize_contract()` added to `scripts/validate.sh` and registered in the run list — asserts all 3 trio files name the 6 stages, `--no-live-preview`, the `AskUserQuestion` pick gate, and the `/autospec-define` handoff.
- `README.md` (skills + token-cost tables) + `SKILLS.md` get `autospec-harmonize` rows.
- Dogfood test against `skills/autospec-fleet/gui`.

**Scope note (justified):** `fleet/gui` is a single `index.html` with inline `<style>` and **no `.css` files**, so `--source-only` extraction found nothing and the dogfood AC ("inconsistencies non-empty") was unsatisfiable. `extract-source.mjs` is extended minimally to also read `<style>` blocks from `*.html`/`*.htm` — real single-file GUIs need this. Existing extract-source behavior + output shape unchanged.

## Verification
- `bash scripts/validate.sh` — exit 0; runs `validate: autospec-harmonize contract: ...`.
- `bats tests/harmonize/test_dogfood_fleet_gui.bats` — 2/2 (exit 0, non-empty inconsistencies on the real GUI).
- `bats tests/harmonize/test_extract_source.bats` — 7/7 (HTML extension didn't regress .css extraction).
- No doc/spec deleted.