### PR TITLE
fix(harmonize): Phase 5.5 audit remediation (#1147)

### DIFF
--- a/skills/autospec-harmonize/scripts/design-variants.mjs
+++ b/skills/autospec-harmonize/scripts/design-variants.mjs
@@ -145,6 +145,10 @@ function makeMinimal(baseline) {
     return { ...entry, hex: hslToHex(h, 0, l) };
   });
 
+  // Desaturating the accent changes its luminance, so recompute the contrast
+  // annotation from THIS variant's palette — never inherit the baseline's stale
+  // wcag_min_ratio (Phase 5.5 audit #1147 finding F1).
+  v.wcag_min_ratio = minForegroundContrast(v.tokens.palette);
   v.design_md = '# Minimal Variant\n\nShadows removed; accent desaturated for a clean, decoration-free aesthetic.';
   return v;
 }

--- a/skills/autospec-harmonize/scripts/extract-source.mjs
+++ b/skills/autospec-harmonize/scripts/extract-source.mjs
@@ -120,9 +120,16 @@ function extractSpacing(css) {
 /** Extract border-radius px values → sorted unique {px} objects. */
 function extractRadii(css) {
   const vals = new Set();
-  const re = /border-radius\s*:\s*(\d+(?:\.\d+)?)px/gi;
+  // border-radius may be a multi-value shorthand (e.g. "4px 8px 12px 16px");
+  // capture every px corner value, matching the runtime extractor's per-corner
+  // read (Phase 5.5 audit #1147 finding F4).
+  const re = /border-radius\s*:\s*([^;}{]+)/gi;
   let m;
-  while ((m = re.exec(css)) !== null) vals.add(Number(m[1]));
+  while ((m = re.exec(css)) !== null) {
+    const pxRe = /(\d+(?:\.\d+)?)px/g;
+    let p;
+    while ((p = pxRe.exec(m[1])) !== null) vals.add(Number(p[1]));
+  }
   return Array.from(vals).sort((a, b) => a - b).map(px => ({ px }));
 }
 

--- a/tests/harmonize/test_extract_source.bats
+++ b/tests/harmonize/test_extract_source.bats
@@ -88,3 +88,17 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "$output" = "true" ]
 }
+
+@test "extract-source captures all corners of a border-radius shorthand (audit #1147 F4)" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+
+  RADIUS_DIR="$(mktemp -d /tmp/autospec-radii-XXXXXX)"
+  printf '.card { border-radius: 4px 8px 12px 16px; }\n' > "$RADIUS_DIR/s.css"
+  node "$EXTRACTOR" --root "$RADIUS_DIR" > "$RADIUS_DIR/profile.json"
+  # All four distinct corner values must be captured (was: only the first).
+  run jq -e '[.radii[].px] == [4,8,12,16]' "$RADIUS_DIR/profile.json"
+  rm -rf "$RADIUS_DIR"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}

--- a/tests/harmonize/test_variants.bats
+++ b/tests/harmonize/test_variants.bats
@@ -180,3 +180,38 @@ teardown() {
     [ "$status" -eq 0 ]
   done
 }
+
+@test "minimal variant recomputes wcag_min_ratio from its own palette (audit #1147 F1)" {
+  command -v node >/dev/null 2>&1 || skip "node not available"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available"
+
+  # A baseline whose chromatic accent is the binding (minimum-contrast) foreground.
+  # 'minimal' fully desaturates the accent, which changes its luminance and thus
+  # the minimum foreground-vs-bg contrast — so the variant's wcag_min_ratio MUST
+  # differ from the baseline's. Before the fix, minimal inherited the baseline's
+  # stale value (clone), so this asserted inequality fails.
+  cat > "$TEST_TMPDIR/binding.json" <<'EOF'
+{
+  "id": "baseline", "label": "B", "axis": "baseline",
+  "tokens": {
+    "palette": [
+      {"hex": "#ffffff", "role": "bg"},
+      {"hex": "#595959", "role": "text"},
+      {"hex": "#1aa3a3", "role": "accent"},
+      {"hex": "#0044cc", "role": "primary"}
+    ],
+    "type_scale": [{"px": 16}], "spacing": [{"px": 8}], "radii": [{"px": 4}],
+    "shadows": [{"value": "x"}]
+  },
+  "design_md": "# B"
+}
+EOF
+  node "$VARIANTS" --baseline "$TEST_TMPDIR/binding.json" --axes minimal > "$TEST_TMPDIR/out.json"
+  BASE=$(jq -r '.[] | select(.axis=="baseline") | .wcag_min_ratio' "$TEST_TMPDIR/out.json")
+  MIN=$(jq -r  '.[] | select(.axis=="minimal")  | .wcag_min_ratio' "$TEST_TMPDIR/out.json")
+  # Both present and numeric
+  [ -n "$BASE" ] && [ "$BASE" != "null" ]
+  [ -n "$MIN" ]  && [ "$MIN"  != "null" ]
+  # Recomputed, not inherited: the minimal palette's contrast differs from baseline's.
+  [ "$(node -e "process.stdout.write(String($MIN !== $BASE))")" = "true" ]
+}


### PR DESCRIPTION
Closes #1147

Phase 5.5 broad **integration audit** of the merged autospec-harmonize epic (PRs #1137–1146). 3/6 audited seams were fully clean (token-profile contract, harmonize.sh wiring, degradation reachability). Findings + remediation:

### Fixed in this PR
- **F1 (medium)** — `makeMinimal` cloned the baseline's `wcag_min_ratio` and desaturated the accent but never recomputed, so `design-preview` annotated the minimal card with the baseline's stale contrast. Now recomputes from the minimal variant's own palette. Regression test (#10 in test_variants.bats) uses a baseline whose chromatic accent binds the minimum foreground contrast, asserting minimal's ratio ≠ baseline's. *(Exactly the cross-stage bug per-PR LGTMs miss.)*
- **F4 (low)** — `extract-source.mjs` captured only the first px of a `border-radius` shorthand vs the runtime extractor's 4 corners (backend parity skew). Now captures all corner values; regression test on `border-radius: 4px 8px 12px 16px`.

### AC status
- `bash scripts/validate.sh` — exit 0, `check_autospec_harmonize_contract` green.
- `bats tests/harmonize` — fully green (59 prior + 2 new regression tests).
- All 3 `code_health:harmonize_*` identifiers are each exercised by a degradation test.
- Runtime/source extractors emit the same top-level token-profile shape (verified); F4 closes the one sub-shape skew.

### Low-severity follow-ups (filed separately, not auto-drained)
- **F2** — `design-generalize` emits the baseline variant without `wcag_min_ratio` (latent; `design-variants` always backfills it today).
- **F5** — axis transforms + the deterministic baseline are emitted unvalidated against the variant schema (only the LLM path validates); a future stray key could ship silently. Needs a runtime-ajv design decision.

See the follow-up tracker for F2/F5.