### PR TITLE
feat(autospec-upgrade): mutation-gate.sh Stryker adapter (baseline + gate)

### DIFF
--- a/skills/autospec-upgrade/scripts/mutation-gate.sh
+++ b/skills/autospec-upgrade/scripts/mutation-gate.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# mutation-gate.sh — Stryker mutation-testing adapter for autospec-upgrade
+#
+# Usage:
+#   mutation-gate.sh --baseline [--detect <file>] [--runner <runner>] [--out <dir>]
+#   mutation-gate.sh --gate <threshold> [--detect <file>] [--runner <runner>] [--out <dir>]
+#
+# Modes:
+#   --baseline              Run Stryker, parse mutation score, write it as the
+#                           baseline into <out>/.autospec/mutation-proof.json.
+#                           Exits non-zero if Stryker produces no parseable score.
+#   --gate <threshold>      Run Stryker, parse post-upgrade score.  Fails (exit != 0)
+#                           when post-upgrade score < recorded baseline OR when
+#                           post-upgrade score < explicit <threshold>.  Reports
+#                           surviving mutants on failure.  Updates mutation-proof.json
+#                           with post_upgrade, threshold, and passed fields.
+#
+# Options:
+#   --detect <file>  Path to upgrade-detect.sh JSON (runners[] used for mapping).
+#   --runner <name>  Explicit runner override: jest | vitest | karma.
+#   --out <dir>      Output directory that contains (or will contain) .autospec/.
+#                    Default: current working directory.
+#
+# mutation-proof.json shapes:
+#   After --baseline:
+#     {"baseline":{"score":<number>},"recorded_at":"<ISO8601>"}
+#   After --gate:
+#     {"baseline":{"score":<number>},"post_upgrade":{"score":<number>},
+#      "threshold":<number>,"passed":<bool>,"gated_at":"<ISO8601>"}
+#
+# Exit codes:
+#   0  — success (baseline recorded, or gate passed)
+#   1  — gate failed (post-upgrade score < baseline or below threshold)
+#   2  — Stryker produced no parseable mutation score
+#   3  — argument / environment error
+
+set -uo pipefail
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+PROOF_FILENAME="mutation-proof.json"
+
+# ── Argument parsing ───────────────────────────────────────────────────────────
+
+MODE=""          # "baseline" or "gate"
+THRESHOLD=""     # numeric threshold for --gate
+DETECT_FILE=""
+RUNNER_OVERRIDE=""
+OUT_DIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --baseline)
+      MODE="baseline"
+      shift
+      ;;
+    --gate)
+      MODE="gate"
+      THRESHOLD="$2"
+      shift 2
+      ;;
+    --gate=*)
+      MODE="gate"
+      THRESHOLD="${1#--gate=}"
+      shift
+      ;;
+    --detect)
+      DETECT_FILE="$2"
+      shift 2
+      ;;
+    --detect=*)
+      DETECT_FILE="${1#--detect=}"
+      shift
+      ;;
+    --runner)
+      RUNNER_OVERRIDE="$2"
+      shift 2
+      ;;
+    --runner=*)
+      RUNNER_OVERRIDE="${1#--runner=}"
+      shift
+      ;;
+    --out)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --out=*)
+      OUT_DIR="${1#--out=}"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+# ── Validate mode ──────────────────────────────────────────────────────────────
+
+if [ -z "$MODE" ]; then
+  printf 'mutation-gate: --baseline or --gate <threshold> is required\n' >&2
+  exit 3
+fi
+
+if [ "$MODE" = "gate" ] && [ -z "$THRESHOLD" ]; then
+  printf 'mutation-gate: --gate requires a numeric threshold argument\n' >&2
+  exit 3
+fi
+
+# ── Resolve output directory ───────────────────────────────────────────────────
+
+if [ -z "$OUT_DIR" ]; then
+  OUT_DIR="$(pwd)/.autospec"
+fi
+mkdir -p "$OUT_DIR"
+
+PROOF_FILE="$OUT_DIR/$PROOF_FILENAME"
+
+# ── Detect runner ──────────────────────────────────────────────────────────────
+# Priority: --runner flag > first entry in detect JSON > default "jest"
+
+detect_runner() {
+  local runner="jest"
+
+  if [ -n "$RUNNER_OVERRIDE" ]; then
+    runner="$RUNNER_OVERRIDE"
+  elif [ -n "$DETECT_FILE" ] && [ -f "$DETECT_FILE" ]; then
+    local first_runner
+    first_runner="$(jq -r '.runners[0] // "jest"' "$DETECT_FILE" 2>/dev/null || printf 'jest')"
+    if [ -n "$first_runner" ] && [ "$first_runner" != "null" ]; then
+      runner="$first_runner"
+    fi
+  fi
+
+  printf '%s' "$runner"
+}
+
+# ── Map runner to Stryker testRunner value ────────────────────────────────────
+# Supported: jest → jest, vitest → vitest, karma → karma
+# Fallback: jest
+
+map_stryker_runner() {
+  local runner="$1"
+  case "$runner" in
+    jest)    printf 'jest' ;;
+    vitest)  printf 'vitest' ;;
+    karma)   printf 'karma' ;;
+    *)       printf 'jest' ;;
+  esac
+}
+
+# ── Write Stryker config ───────────────────────────────────────────────────────
+
+write_stryker_config() {
+  local stryker_runner="$1"
+  local cfg_file="$OUT_DIR/stryker.config.json"
+  printf '{"testRunner":"%s","coverageAnalysis":"perTest"}\n' "$stryker_runner" > "$cfg_file"
+  printf '%s' "$cfg_file"
+}
+
+# ── Run Stryker and parse mutation score ───────────────────────────────────────
+# Returns: sets MUTATION_SCORE variable; exits non-zero if unparseable
+
+run_stryker_and_parse() {
+  local cfg_file="$1"
+  local stryker_out
+  # Run stryker; capture combined stdout+stderr
+  stryker_out="$(npx stryker run --configFile "$cfg_file" 2>&1)" || {
+    printf 'mutation-gate: npx stryker run exited non-zero\n' >&2
+    printf '%s\n' "$stryker_out" >&2
+    return 1
+  }
+
+  # Parse "Mutation score: <N>%" from output (case-insensitive, integer or decimal)
+  local raw_score
+  raw_score="$(printf '%s\n' "$stryker_out" | grep -i 'mutation score' | grep -o '[0-9]*\.[0-9]*\|[0-9]\+' | head -1)"
+
+  if [ -z "$raw_score" ]; then
+    printf 'mutation-gate: Stryker produced no parseable mutation score\n' >&2
+    printf '%s\n' "$stryker_out" >&2
+    return 2
+  fi
+
+  # Strip decimal for integer comparison (floor)
+  MUTATION_SCORE="$(printf '%s' "$raw_score" | grep -o '^[0-9]*')"
+  printf '%s\n' "$stryker_out" >&2
+
+  # Capture surviving mutant count for reporting
+  SURVIVING_MUTANTS="$(printf '%s\n' "$stryker_out" | grep -i 'survived' | grep -o '[0-9]\+' | head -1)"
+  SURVIVING_MUTANTS="${SURVIVING_MUTANTS:-unknown}"
+}
+
+# ── ISO8601 timestamp ──────────────────────────────────────────────────────────
+
+iso_now() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || printf 'unknown'
+}
+
+# ── --baseline mode ────────────────────────────────────────────────────────────
+
+do_baseline() {
+  local runner
+  runner="$(detect_runner)"
+  local stryker_runner
+  stryker_runner="$(map_stryker_runner "$runner")"
+  local cfg_file
+  cfg_file="$(write_stryker_config "$stryker_runner")"
+
+  MUTATION_SCORE=""
+  SURVIVING_MUTANTS=""
+  run_stryker_and_parse "$cfg_file" || exit $?
+
+  local recorded_at
+  recorded_at="$(iso_now)"
+
+  # Write baseline proof
+  printf '{"baseline":{"score":%s},"recorded_at":"%s"}\n' \
+    "$MUTATION_SCORE" "$recorded_at" > "$PROOF_FILE"
+
+  printf 'mutation-gate: baseline recorded — score=%s%% → %s\n' \
+    "$MUTATION_SCORE" "$PROOF_FILE"
+  exit 0
+}
+
+# ── --gate mode ────────────────────────────────────────────────────────────────
+
+do_gate() {
+  # Validate threshold is numeric
+  case "$THRESHOLD" in
+    ''|*[!0-9]*)
+      printf 'mutation-gate: threshold must be a non-negative integer, got: %s\n' "$THRESHOLD" >&2
+      exit 3
+      ;;
+  esac
+
+  # Require existing proof file with a baseline score
+  if [ ! -f "$PROOF_FILE" ]; then
+    printf 'mutation-gate: mutation-proof.json not found at %s; run --baseline first\n' "$PROOF_FILE" >&2
+    exit 3
+  fi
+
+  local baseline_score
+  baseline_score="$(jq -r '.baseline.score // empty' "$PROOF_FILE" 2>/dev/null)"
+  if [ -z "$baseline_score" ] || [ "$baseline_score" = "null" ]; then
+    printf 'mutation-gate: mutation-proof.json has no baseline.score; run --baseline first\n' >&2
+    exit 3
+  fi
+
+  local runner
+  runner="$(detect_runner)"
+  local stryker_runner
+  stryker_runner="$(map_stryker_runner "$runner")"
+  local cfg_file
+  cfg_file="$(write_stryker_config "$stryker_runner")"
+
+  MUTATION_SCORE=""
+  SURVIVING_MUTANTS=""
+  run_stryker_and_parse "$cfg_file" || exit $?
+
+  local post_score="$MUTATION_SCORE"
+  local gated_at
+  gated_at="$(iso_now)"
+
+  # Determine pass/fail
+  local passed=true
+  local fail_reason=""
+
+  if [ "$post_score" -lt "$baseline_score" ]; then
+    passed=false
+    fail_reason="post-upgrade score ${post_score}% is below baseline ${baseline_score}%"
+  fi
+
+  if [ "$post_score" -lt "$THRESHOLD" ]; then
+    passed=false
+    if [ -n "$fail_reason" ]; then
+      fail_reason="${fail_reason} and below threshold ${THRESHOLD}%"
+    else
+      fail_reason="post-upgrade score ${post_score}% is below threshold ${THRESHOLD}%"
+    fi
+  fi
+
+  # Write updated proof (preserve baseline, add post_upgrade fields)
+  local passed_json
+  if [ "$passed" = "true" ]; then
+    passed_json="true"
+  else
+    passed_json="false"
+  fi
+
+  # Read existing proof and merge — use jq to combine fields
+  local merged
+  merged="$(jq -n \
+    --argjson existing "$(cat "$PROOF_FILE")" \
+    --argjson post_score "$post_score" \
+    --argjson threshold "$THRESHOLD" \
+    --argjson passed "$passed_json" \
+    --arg gated_at "$gated_at" \
+    '$existing + {post_upgrade:{score:$post_score},threshold:$threshold,passed:$passed,gated_at:$gated_at}')"
+  printf '%s\n' "$merged" > "$PROOF_FILE"
+
+  if [ "$passed" = "false" ]; then
+    printf 'mutation-gate: GATE FAILED — %s (surviving mutants: %s)\n' \
+      "$fail_reason" "$SURVIVING_MUTANTS" >&2
+    exit 1
+  fi
+
+  printf 'mutation-gate: gate passed — post-upgrade score=%s%% baseline=%s%% threshold=%s%%\n' \
+    "$post_score" "$baseline_score" "$THRESHOLD"
+  exit 0
+}
+
+# ── Dispatch ───────────────────────────────────────────────────────────────────
+
+case "$MODE" in
+  baseline) do_baseline ;;
+  gate)     do_gate ;;
+esac

--- a/skills/autospec-upgrade/scripts/mutation-gate.sh
+++ b/skills/autospec-upgrade/scripts/mutation-gate.sh
@@ -223,52 +223,59 @@ do_baseline() {
 
 # ── --gate mode ────────────────────────────────────────────────────────────────
 
-do_gate() {
-  # Validate threshold is numeric
+# Validate --gate inputs and echo the recorded baseline score on stdout.
+# Returns 3 on any error (NEVER `exit` here — this runs in a command
+# substitution, so exit would only kill the subshell and be swallowed).
+read_gate_baseline() {
   case "$THRESHOLD" in
     ''|*[!0-9]*)
       printf 'mutation-gate: threshold must be a non-negative integer, got: %s\n' "$THRESHOLD" >&2
-      exit 3
-      ;;
+      return 3 ;;
   esac
-
-  # Require existing proof file with a baseline score
   if [ ! -f "$PROOF_FILE" ]; then
     printf 'mutation-gate: mutation-proof.json not found at %s; run --baseline first\n' "$PROOF_FILE" >&2
-    exit 3
+    return 3
   fi
-
-  local baseline_score
-  baseline_score="$(jq -r '.baseline.score // empty' "$PROOF_FILE" 2>/dev/null)"
-  if [ -z "$baseline_score" ] || [ "$baseline_score" = "null" ]; then
+  local bs
+  bs="$(jq -r '.baseline.score // empty' "$PROOF_FILE" 2>/dev/null)"
+  if [ -z "$bs" ] || [ "$bs" = "null" ]; then
     printf 'mutation-gate: mutation-proof.json has no baseline.score; run --baseline first\n' >&2
-    exit 3
+    return 3
   fi
+  printf '%s' "$bs"
+}
 
-  local runner
-  runner="$(detect_runner)"
-  local stryker_runner
-  stryker_runner="$(map_stryker_runner "$runner")"
+# Merge the post-upgrade verdict into the proof, preserving the baseline.
+# Args: post_score threshold passed(true|false) gated_at
+write_gate_proof() {
+  local merged
+  merged="$(jq -n \
+    --argjson existing "$(cat "$PROOF_FILE")" \
+    --argjson post_score "$1" \
+    --argjson threshold "$2" \
+    --argjson passed "$3" \
+    --arg gated_at "$4" \
+    '$existing + {post_upgrade:{score:$post_score},threshold:$threshold,passed:$passed,gated_at:$gated_at}')"
+  printf '%s\n' "$merged" > "$PROOF_FILE"
+}
+
+do_gate() {
+  local baseline_score
+  baseline_score="$(read_gate_baseline)" || exit $?
+
   local cfg_file
-  cfg_file="$(write_stryker_config "$stryker_runner")"
+  cfg_file="$(write_stryker_config "$(map_stryker_runner "$(detect_runner)")")"
 
   MUTATION_SCORE=""
   SURVIVING_MUTANTS=""
   run_stryker_and_parse "$cfg_file" || exit $?
-
   local post_score="$MUTATION_SCORE"
-  local gated_at
-  gated_at="$(iso_now)"
 
-  # Determine pass/fail
-  local passed=true
-  local fail_reason=""
-
+  local passed=true fail_reason=""
   if [ "$post_score" -lt "$baseline_score" ]; then
     passed=false
     fail_reason="post-upgrade score ${post_score}% is below baseline ${baseline_score}%"
   fi
-
   if [ "$post_score" -lt "$THRESHOLD" ]; then
     passed=false
     if [ -n "$fail_reason" ]; then
@@ -278,31 +285,13 @@ do_gate() {
     fi
   fi
 
-  # Write updated proof (preserve baseline, add post_upgrade fields)
-  local passed_json
-  if [ "$passed" = "true" ]; then
-    passed_json="true"
-  else
-    passed_json="false"
-  fi
-
-  # Read existing proof and merge — use jq to combine fields
-  local merged
-  merged="$(jq -n \
-    --argjson existing "$(cat "$PROOF_FILE")" \
-    --argjson post_score "$post_score" \
-    --argjson threshold "$THRESHOLD" \
-    --argjson passed "$passed_json" \
-    --arg gated_at "$gated_at" \
-    '$existing + {post_upgrade:{score:$post_score},threshold:$threshold,passed:$passed,gated_at:$gated_at}')"
-  printf '%s\n' "$merged" > "$PROOF_FILE"
+  write_gate_proof "$post_score" "$THRESHOLD" "$passed" "$(iso_now)"
 
   if [ "$passed" = "false" ]; then
     printf 'mutation-gate: GATE FAILED — %s (surviving mutants: %s)\n' \
       "$fail_reason" "$SURVIVING_MUTANTS" >&2
     exit 1
   fi
-
   printf 'mutation-gate: gate passed — post-upgrade score=%s%% baseline=%s%% threshold=%s%%\n' \
     "$post_score" "$baseline_score" "$THRESHOLD"
   exit 0

--- a/skills/autospec-upgrade/tests/fixtures/mutation-gate/detect-jest.json
+++ b/skills/autospec-upgrade/tests/fixtures/mutation-gate/detect-jest.json
@@ -1,0 +1,1 @@
+{"frameworks":["react"],"versions":{"react":"18.2.0"},"package_manager":"npm","runners":["jest"],"monorepo":false,"has_tests":true}

--- a/skills/autospec-upgrade/tests/fixtures/mutation-gate/detect-karma.json
+++ b/skills/autospec-upgrade/tests/fixtures/mutation-gate/detect-karma.json
@@ -1,0 +1,1 @@
+{"frameworks":["angular"],"versions":{"angular":"17.0.0"},"package_manager":"npm","runners":["karma"],"monorepo":false,"has_tests":true}

--- a/skills/autospec-upgrade/tests/fixtures/mutation-gate/detect-vitest.json
+++ b/skills/autospec-upgrade/tests/fixtures/mutation-gate/detect-vitest.json
@@ -1,0 +1,1 @@
+{"frameworks":["react"],"versions":{"react":"18.2.0"},"package_manager":"npm","runners":["vitest"],"monorepo":false,"has_tests":true}

--- a/skills/autospec-upgrade/tests/mutation-gate.bats
+++ b/skills/autospec-upgrade/tests/mutation-gate.bats
@@ -1,0 +1,357 @@
+#!/usr/bin/env bats
+# mutation-gate.bats — TDD suite for mutation-gate.sh (issue #1175)
+# No network access, no real installs. All subprocess calls mocked via $TMP/bin PATH shim.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/mutation-gate.sh"
+FIXTURE_DIR="${BATS_TEST_DIRNAME}/fixtures/mutation-gate"
+
+# ── Setup / teardown ──────────────────────────────────────────────────────────
+
+setup() {
+  TEST_ROOT="$(mktemp -d /tmp/mg-test-root.XXXXXX)"
+  MOCK_BIN="$(mktemp -d /tmp/mg-mock-bin.XXXXXX)"
+  AUTOSPEC_DIR="$TEST_ROOT/.autospec"
+  mkdir -p "$AUTOSPEC_DIR"
+  export TEST_ROOT MOCK_BIN AUTOSPEC_DIR
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT" "$MOCK_BIN"
+}
+
+# ── Helper: install a mock npx that emits a Stryker-style report ──────────────
+# MOCK_STRYKER_SCORE env var controls the reported mutation score (default 80).
+
+install_npx_mock() {
+  local score="${MOCK_STRYKER_SCORE:-80}"
+  cat > "$MOCK_BIN/npx" <<MOCK
+#!/usr/bin/env bash
+# Fake npx — emits a Stryker-style report when called as "npx stryker run"
+if [ "\$1" = "stryker" ] && [ "\$2" = "run" ]; then
+  printf 'Ran 100 tests\\n'
+  printf 'Mutation score: %s%%\\n' "\${MOCK_STRYKER_SCORE:-${score}}"
+  printf 'Killed: 80 Survived: %s Timeout: 0 No coverage: 0\\n' "\$(( 100 - \${MOCK_STRYKER_SCORE:-${score}} ))"
+  exit 0
+fi
+# Pass through anything else
+exec "\$@"
+MOCK
+  chmod +x "$MOCK_BIN/npx"
+}
+
+# ── Existence / executability ─────────────────────────────────────────────────
+
+@test "mutation-gate.sh exists and is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+# ── --baseline mode: records valid mutation-proof.json ───────────────────────
+
+@test "baseline: exit 0 when Stryker succeeds" {
+  install_npx_mock
+  run env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=80 \
+    "$SCRIPT" --baseline --out "$AUTOSPEC_DIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "baseline: writes .autospec/mutation-proof.json" {
+  install_npx_mock
+  env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=75 \
+    "$SCRIPT" --baseline --out "$AUTOSPEC_DIR"
+  local proof="$AUTOSPEC_DIR/mutation-proof.json"
+  [ -f "$proof" ]
+}
+
+@test "baseline: mutation-proof.json has numeric baseline.score" {
+  install_npx_mock
+  env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=75 \
+    "$SCRIPT" --baseline --out "$AUTOSPEC_DIR"
+  local proof="$AUTOSPEC_DIR/mutation-proof.json"
+  [ -f "$proof" ]
+  # .baseline.score must be a number (jq -e exits 0 only for truthy non-null)
+  jq -e '.baseline.score | type == "number"' "$proof"
+}
+
+@test "baseline: mutation-proof.json baseline.score matches mocked Stryker score" {
+  install_npx_mock
+  env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=73 \
+    "$SCRIPT" --baseline --out "$AUTOSPEC_DIR"
+  local proof="$AUTOSPEC_DIR/mutation-proof.json"
+  local score
+  score="$(jq -r '.baseline.score' "$proof")"
+  [ "$score" = "73" ]
+}
+
+@test "baseline: default out dir is .autospec/ under current directory" {
+  install_npx_mock
+  # Run from TEST_ROOT without --out; expect .autospec/mutation-proof.json relative to cwd
+  local proof="$TEST_ROOT/.autospec/mutation-proof.json"
+  mkdir -p "$TEST_ROOT/.autospec"
+  env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=80 \
+    bash -c "cd '$TEST_ROOT' && '$SCRIPT' --baseline"
+  [ -f "$proof" ]
+}
+
+# ── --gate mode: pass when post-upgrade score >= baseline ────────────────────
+
+@test "gate: exit 0 when post-upgrade score equals baseline" {
+  install_npx_mock
+  # Write a baseline proof first
+  printf '{"baseline":{"score":80}}\n' > "$AUTOSPEC_DIR/mutation-proof.json"
+  run env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=80 \
+    "$SCRIPT" --gate 70 --out "$AUTOSPEC_DIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "gate: exit 0 when post-upgrade score exceeds baseline" {
+  install_npx_mock
+  printf '{"baseline":{"score":75}}\n' > "$AUTOSPEC_DIR/mutation-proof.json"
+  run env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=85 \
+    "$SCRIPT" --gate 70 --out "$AUTOSPEC_DIR"
+  [ "$status" -eq 0 ]
+}
+
+# ── --gate mode: fail when post-upgrade score < baseline ─────────────────────
+
+@test "gate: exit non-zero when post-upgrade score is below baseline" {
+  install_npx_mock
+  # baseline=80, post-upgrade score=70 → should fail
+  printf '{"baseline":{"score":80}}\n' > "$AUTOSPEC_DIR/mutation-proof.json"
+  run env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=70 \
+    "$SCRIPT" --gate 70 --out "$AUTOSPEC_DIR"
+  [ "$status" -ne 0 ]
+}
+
+@test "gate: exit non-zero when post-upgrade score is well below baseline" {
+  install_npx_mock
+  printf '{"baseline":{"score":90}}\n' > "$AUTOSPEC_DIR/mutation-proof.json"
+  run env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=60 \
+    "$SCRIPT" --gate 50 --out "$AUTOSPEC_DIR"
+  [ "$status" -ne 0 ]
+}
+
+@test "gate: output mentions surviving mutants when gate fails" {
+  install_npx_mock
+  printf '{"baseline":{"score":80}}\n' > "$AUTOSPEC_DIR/mutation-proof.json"
+  run env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=70 \
+    "$SCRIPT" --gate 70 --out "$AUTOSPEC_DIR"
+  [ "$status" -ne 0 ]
+  printf '%s\n' "$output" | grep -qi 'surviv'
+}
+
+# ── --gate mode: fail when score is below explicit threshold even if >= baseline
+
+@test "gate: exit non-zero when score below explicit threshold despite >= baseline" {
+  install_npx_mock
+  # baseline=60, score=65 (>= baseline), but threshold=70 → should fail
+  printf '{"baseline":{"score":60}}\n' > "$AUTOSPEC_DIR/mutation-proof.json"
+  run env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=65 \
+    "$SCRIPT" --gate 70 --out "$AUTOSPEC_DIR"
+  [ "$status" -ne 0 ]
+}
+
+# ── --gate mode: writes post_upgrade score to mutation-proof.json ─────────────
+
+@test "gate: writes post_upgrade.score into mutation-proof.json on pass" {
+  install_npx_mock
+  printf '{"baseline":{"score":70}}\n' > "$AUTOSPEC_DIR/mutation-proof.json"
+  env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=80 \
+    "$SCRIPT" --gate 70 --out "$AUTOSPEC_DIR"
+  local proof="$AUTOSPEC_DIR/mutation-proof.json"
+  jq -e '.post_upgrade.score | type == "number"' "$proof"
+}
+
+@test "gate: mutation-proof.json contains threshold and passed fields" {
+  install_npx_mock
+  printf '{"baseline":{"score":70}}\n' > "$AUTOSPEC_DIR/mutation-proof.json"
+  env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=80 \
+    "$SCRIPT" --gate 70 --out "$AUTOSPEC_DIR"
+  local proof="$AUTOSPEC_DIR/mutation-proof.json"
+  jq -e 'has("threshold") and has("passed")' "$proof"
+}
+
+@test "gate: mutation-proof.json passed field is true on pass" {
+  install_npx_mock
+  printf '{"baseline":{"score":70}}\n' > "$AUTOSPEC_DIR/mutation-proof.json"
+  env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=80 \
+    "$SCRIPT" --gate 70 --out "$AUTOSPEC_DIR"
+  local proof="$AUTOSPEC_DIR/mutation-proof.json"
+  jq -e '.passed == true' "$proof"
+}
+
+@test "gate: mutation-proof.json passed field is false on failure" {
+  install_npx_mock
+  printf '{"baseline":{"score":80}}\n' > "$AUTOSPEC_DIR/mutation-proof.json"
+  run env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=70 \
+    "$SCRIPT" --gate 70 --out "$AUTOSPEC_DIR"
+  [ "$status" -ne 0 ]
+  local proof="$AUTOSPEC_DIR/mutation-proof.json"
+  jq -e '.passed == false' "$proof"
+}
+
+# ── runner mapping: jest → jest testRunner ────────────────────────────────────
+
+@test "runner-map: jest detect file maps to jest testRunner in Stryker invocation" {
+  # Install a recording npx that captures its arguments
+  cat > "$MOCK_BIN/npx" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MOCK_BIN/npx-args.txt"
+printf 'Mutation score: 80%%\n'
+exit 0
+MOCK
+  chmod +x "$MOCK_BIN/npx"
+
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --baseline --runner jest --out "$AUTOSPEC_DIR"
+
+  # The script must invoke npx stryker run with jest config/runner
+  grep -q "stryker" "$MOCK_BIN/npx-args.txt"
+}
+
+@test "runner-map: vitest detect file maps to vitest testRunner" {
+  cat > "$MOCK_BIN/npx" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MOCK_BIN/npx-args.txt"
+printf 'Mutation score: 80%%\n'
+exit 0
+MOCK
+  chmod +x "$MOCK_BIN/npx"
+
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --baseline --runner vitest --out "$AUTOSPEC_DIR"
+
+  grep -q "stryker" "$MOCK_BIN/npx-args.txt"
+}
+
+@test "runner-map: karma detect file maps to karma testRunner" {
+  cat > "$MOCK_BIN/npx" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MOCK_BIN/npx-args.txt"
+printf 'Mutation score: 80%%\n'
+exit 0
+MOCK
+  chmod +x "$MOCK_BIN/npx"
+
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --baseline --runner karma --out "$AUTOSPEC_DIR"
+
+  grep -q "stryker" "$MOCK_BIN/npx-args.txt"
+}
+
+# ── runner mapping: --detect file auto-detects runner ────────────────────────
+
+@test "runner-map: --detect jest fixture produces jest testRunner config" {
+  cat > "$MOCK_BIN/npx" <<'MOCK'
+#!/usr/bin/env bash
+# Capture all args to a file for inspection
+printf '%s\n' "$@" > "$MOCK_BIN/npx-args.txt"
+printf 'Mutation score: 80%%\n'
+exit 0
+MOCK
+  chmod +x "$MOCK_BIN/npx"
+
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --baseline --detect "$FIXTURE_DIR/detect-jest.json" --out "$AUTOSPEC_DIR"
+
+  # Must have invoked stryker
+  grep -q "stryker" "$MOCK_BIN/npx-args.txt"
+  # Stryker config file should exist and reference jest
+  local cfg="$AUTOSPEC_DIR/stryker.config.json"
+  [ -f "$cfg" ]
+  jq -e '.testRunner == "jest"' "$cfg"
+}
+
+@test "runner-map: --detect vitest fixture produces vitest testRunner config" {
+  cat > "$MOCK_BIN/npx" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MOCK_BIN/npx-args.txt"
+printf 'Mutation score: 80%%\n'
+exit 0
+MOCK
+  chmod +x "$MOCK_BIN/npx"
+
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --baseline --detect "$FIXTURE_DIR/detect-vitest.json" --out "$AUTOSPEC_DIR"
+
+  local cfg="$AUTOSPEC_DIR/stryker.config.json"
+  [ -f "$cfg" ]
+  jq -e '.testRunner == "vitest"' "$cfg"
+}
+
+@test "runner-map: --detect karma fixture produces karma testRunner config" {
+  cat > "$MOCK_BIN/npx" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MOCK_BIN/npx-args.txt"
+printf 'Mutation score: 80%%\n'
+exit 0
+MOCK
+  chmod +x "$MOCK_BIN/npx"
+
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --baseline --detect "$FIXTURE_DIR/detect-karma.json" --out "$AUTOSPEC_DIR"
+
+  local cfg="$AUTOSPEC_DIR/stryker.config.json"
+  [ -f "$cfg" ]
+  jq -e '.testRunner == "karma"' "$cfg"
+}
+
+# ── error: baseline absent when --gate invoked without prior --baseline ───────
+
+@test "gate: exit non-zero when mutation-proof.json has no baseline" {
+  install_npx_mock
+  # Write a proof file missing the baseline.score field
+  printf '{"recorded_at":"2026-06-18"}\n' > "$AUTOSPEC_DIR/mutation-proof.json"
+  run env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=80 \
+    "$SCRIPT" --gate 70 --out "$AUTOSPEC_DIR"
+  [ "$status" -ne 0 ]
+}
+
+@test "gate: exit non-zero when mutation-proof.json is missing entirely" {
+  install_npx_mock
+  run env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=80 \
+    "$SCRIPT" --gate 70 --out "$AUTOSPEC_DIR"
+  [ "$status" -ne 0 ]
+}
+
+# ── error: unparseable Stryker output exits non-zero ─────────────────────────
+
+@test "baseline: exit non-zero when Stryker produces no parseable score" {
+  # npx mock that succeeds but emits no score line
+  cat > "$MOCK_BIN/npx" <<'MOCK'
+#!/usr/bin/env bash
+printf 'Stryker ran but something went wrong. No score available.\n'
+exit 0
+MOCK
+  chmod +x "$MOCK_BIN/npx"
+
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --baseline --out "$AUTOSPEC_DIR"
+  [ "$status" -ne 0 ]
+}
+
+# ── proof JSON shape contract ─────────────────────────────────────────────────
+
+@test "proof-shape: baseline-only proof has exactly baseline.score (number)" {
+  install_npx_mock
+  env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=82 \
+    "$SCRIPT" --baseline --out "$AUTOSPEC_DIR"
+  local proof="$AUTOSPEC_DIR/mutation-proof.json"
+  # Must have baseline.score as a number
+  jq -e '.baseline.score | type == "number"' "$proof"
+  # Must NOT have post_upgrade yet (only baseline mode was run)
+  jq -e 'has("post_upgrade") | not' "$proof"
+}
+
+@test "proof-shape: gate proof has baseline.score, post_upgrade.score, threshold, passed" {
+  install_npx_mock
+  printf '{"baseline":{"score":70}}\n' > "$AUTOSPEC_DIR/mutation-proof.json"
+  env PATH="$MOCK_BIN:$PATH" MOCK_STRYKER_SCORE=80 \
+    "$SCRIPT" --gate 70 --out "$AUTOSPEC_DIR"
+  local proof="$AUTOSPEC_DIR/mutation-proof.json"
+  jq -e '
+    (.baseline.score | type == "number") and
+    (.post_upgrade.score | type == "number") and
+    (.threshold | type == "number") and
+    (.passed | type == "boolean")
+  ' "$proof"
+}


### PR DESCRIPTION
Closes #1175

Adds `mutation-gate.sh`: runner→Stryker testRunner mapping (jest/vitest/karma); `--baseline` records `baseline.score` into `.autospec/mutation-proof.json`; `--gate <threshold>` records the post-upgrade score and fails when it's below the recorded baseline OR the explicit threshold (reports surviving mutants). Never invents a score.

## Verification
- `bats skills/autospec-upgrade/tests/mutation-gate.bats` — 27/27 (baseline records, gate passes ≥baseline / fails below, runner mapping x3, no-score→fail, proof shape). `npx stryker` mocked via $TMP/bin.
- `bash scripts/validate.sh` — exit 0.

**Integration note:** the upgrade epic's `.autospec/mutation-proof.json` (Stryker *score*: `baseline.score`/`post_upgrade.score`) shares a filename with the QA `schemas/autospec-mutation-proof.schema.json` (workflow-breakage proof) but is a distinct artifact/shape per the upgrade shared-contract. Flagged for the #1185 audit; this PR follows the upgrade contract and is compatible with #1174's stub.