### PR TITLE
feat(autospec-upgrade): compute-upgrade-steps.sh incremental-major planner

### DIFF
--- a/skills/autospec-upgrade/scripts/compute-upgrade-steps.sh
+++ b/skills/autospec-upgrade/scripts/compute-upgrade-steps.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# skills/autospec-upgrade/scripts/compute-upgrade-steps.sh
+#
+# Compute the ordered incremental-major upgrade hops for the detected stack.
+#
+# CLI:
+#   compute-upgrade-steps.sh --detect <detection.json> [--targets <targets.json>]
+#                            [--target-angular N] [--target-next N] [--target-react N]
+#
+# Reads the detection JSON ({frameworks:[],versions:{<fw>:"maj.min.patch"}}) and a
+# fixture-injected set of TARGET majors (no network), then emits, on stdout, a single
+# JSON object of strictly-sequential one-major hops:
+#   {"hops":[{"framework":"angular","from":20,"to":21}, ... ]}
+# Angular (and Next/React) never skip a major: 20 -> 23 yields 21, 22, 23.
+# A framework already at its target contributes no hops; all-at-latest -> {"hops":[]}.
+
+set -uo pipefail
+
+DETECT=""
+TARGETS_FILE=""
+# Indexed array of "fw=major" CLI overrides (bash 3.2 safe — no associative arrays).
+OVERRIDES=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --detect)  DETECT="${2:-}"; shift 2 ;;
+    --targets) TARGETS_FILE="${2:-}"; shift 2 ;;
+    --target-angular) OVERRIDES+=("angular=${2:-}"); shift 2 ;;
+    --target-next)    OVERRIDES+=("next=${2:-}");    shift 2 ;;
+    --target-react)   OVERRIDES+=("react=${2:-}");   shift 2 ;;
+    *) printf 'compute-upgrade-steps: unknown argument: %s\n' "$1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$DETECT" ] || [ ! -f "$DETECT" ]; then
+  printf 'compute-upgrade-steps: --detect <detection.json> is required and must exist\n' >&2
+  exit 2
+fi
+
+detect_json="$(cat "$DETECT")"
+
+# Base targets object from --targets file (default empty), then merge CLI overrides.
+targets_json='{}'
+if [ -n "$TARGETS_FILE" ]; then
+  if [ ! -f "$TARGETS_FILE" ]; then
+    printf 'compute-upgrade-steps: --targets file not found: %s\n' "$TARGETS_FILE" >&2
+    exit 2
+  fi
+  targets_json="$(cat "$TARGETS_FILE")"
+fi
+
+for ov in "${OVERRIDES[@]:-}"; do
+  [ -n "$ov" ] || continue
+  fw="${ov%%=*}"
+  maj="${ov#*=}"
+  case "$maj" in
+    ''|*[!0-9]*)
+      printf 'compute-upgrade-steps: --target-%s must be an integer major, got: %s\n' "$fw" "$maj" >&2
+      exit 2 ;;
+  esac
+  targets_json="$(printf '%s' "$targets_json" | jq -c --arg fw "$fw" --argjson maj "$maj" '. + {($fw): $maj}')"
+done
+
+# Strictly-sequential one-major hops per framework whose target exceeds its current major.
+jq -cn \
+  --argjson detect "$detect_json" \
+  --argjson targets "$targets_json" '
+  [ $detect.frameworks[]
+    | select(. != "unknown")
+    | . as $fw
+    | (($detect.versions[$fw] // "0") | tostring | split(".")[0] | tonumber) as $cur
+    | (($targets[$fw] // $cur)) as $tgt
+    | range($cur + 1; $tgt + 1)
+    | { framework: $fw, from: (. - 1), to: . }
+  ]
+  | { hops: . }
+'

--- a/skills/autospec-upgrade/tests/compute-upgrade-steps.bats
+++ b/skills/autospec-upgrade/tests/compute-upgrade-steps.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  STEPS="$REPO_ROOT/skills/autospec-upgrade/scripts/compute-upgrade-steps.sh"
+  FX="$BATS_TEST_DIRNAME/fixtures/compute-steps"
+}
+
+@test "compute-upgrade-steps.sh exists and is executable" {
+  [ -x "$STEPS" ]
+}
+
+@test "Angular 20 -> target 23 yields strictly sequential hops 21,22,23 (no skips)" {
+  command -v jq >/dev/null 2>&1 || skip "jq not available"
+  run bash "$STEPS" --detect "$FX/detect-angular20.json" --targets "$FX/targets.json"
+  [ "$status" -eq 0 ]
+  # The to-sequence must be exactly [21,22,23] — never skipping a major.
+  echo "$output" | jq -e '[.hops[] | select(.framework=="angular") | .to] == [21,22,23]'
+  # And each hop's from is the prior major (contiguous chain).
+  echo "$output" | jq -e '[.hops[] | select(.framework=="angular") | .from] == [20,21,22]'
+}
+
+@test "already-latest Angular yields an empty hop list" {
+  command -v jq >/dev/null 2>&1 || skip "jq not available"
+  run bash "$STEPS" --detect "$FX/detect-angular-latest.json" --targets "$FX/targets.json"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.hops == []'
+}
+
+@test "Next 13 -> 15 yields incremental one-major hops 14,15" {
+  command -v jq >/dev/null 2>&1 || skip "jq not available"
+  run bash "$STEPS" --detect "$FX/detect-next13.json" --targets "$FX/targets.json"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '[.hops[] | select(.framework=="next") | .to] == [14,15]'
+  # detect-next13 also has react@18 -> 19, one hop.
+  echo "$output" | jq -e '[.hops[] | select(.framework=="react") | .to] == [19]'
+}
+
+@test "React 17 -> 19 yields incremental one-major hops 18,19" {
+  command -v jq >/dev/null 2>&1 || skip "jq not available"
+  run bash "$STEPS" --detect "$FX/detect-react17.json" --targets "$FX/targets.json"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '[.hops[] | select(.framework=="react") | .to] == [18,19]'
+}
+
+@test "combined angular+react stack yields strictly incremental hops for both" {
+  command -v jq >/dev/null 2>&1 || skip "jq not available"
+  run bash "$STEPS" --detect "$FX/detect-combo.json" --targets "$FX/targets.json"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '[.hops[] | select(.framework=="angular") | .to] == [22,23]'
+  echo "$output" | jq -e '[.hops[] | select(.framework=="react") | .to] == [19]'
+}
+
+@test "--target-<fw> flag overrides the targets file" {
+  command -v jq >/dev/null 2>&1 || skip "jq not available"
+  run bash "$STEPS" --detect "$FX/detect-angular20.json" --target-angular 22
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '[.hops[] | select(.framework=="angular") | .to] == [21,22]'
+}
+
+@test "missing --detect exits non-zero" {
+  run bash "$STEPS" --targets "$FX/targets.json"
+  [ "$status" -ne 0 ]
+}

--- a/skills/autospec-upgrade/tests/fixtures/compute-steps/detect-angular-latest.json
+++ b/skills/autospec-upgrade/tests/fixtures/compute-steps/detect-angular-latest.json
@@ -1,0 +1,1 @@
+{"frameworks":["angular"],"versions":{"angular":"23.0.0"},"package_manager":"npm","runners":["karma"],"monorepo":false,"has_tests":true}

--- a/skills/autospec-upgrade/tests/fixtures/compute-steps/detect-angular20.json
+++ b/skills/autospec-upgrade/tests/fixtures/compute-steps/detect-angular20.json
@@ -1,0 +1,1 @@
+{"frameworks":["angular"],"versions":{"angular":"20.1.2"},"package_manager":"npm","runners":["karma"],"monorepo":false,"has_tests":true}

--- a/skills/autospec-upgrade/tests/fixtures/compute-steps/detect-combo.json
+++ b/skills/autospec-upgrade/tests/fixtures/compute-steps/detect-combo.json
@@ -1,0 +1,1 @@
+{"frameworks":["angular","react"],"versions":{"angular":"21.0.0","react":"18.0.0"},"package_manager":"npm","runners":["jest"],"monorepo":true,"has_tests":true}

--- a/skills/autospec-upgrade/tests/fixtures/compute-steps/detect-next13.json
+++ b/skills/autospec-upgrade/tests/fixtures/compute-steps/detect-next13.json
@@ -1,0 +1,1 @@
+{"frameworks":["next","react"],"versions":{"next":"13.4.0","react":"18.2.0"},"package_manager":"pnpm","runners":["jest"],"monorepo":false,"has_tests":true}

--- a/skills/autospec-upgrade/tests/fixtures/compute-steps/detect-react17.json
+++ b/skills/autospec-upgrade/tests/fixtures/compute-steps/detect-react17.json
@@ -1,0 +1,1 @@
+{"frameworks":["react"],"versions":{"react":"17.0.2"},"package_manager":"yarn","runners":["jest"],"monorepo":false,"has_tests":true}

--- a/skills/autospec-upgrade/tests/fixtures/compute-steps/targets.json
+++ b/skills/autospec-upgrade/tests/fixtures/compute-steps/targets.json
@@ -1,0 +1,1 @@
+{"angular":23,"next":15,"react":19}


### PR DESCRIPTION
Closes #1176

Adds `compute-upgrade-steps.sh`: from detection JSON + fixture-injected target majors (`--targets` file and/or `--target-<fw>` flags; no network), emits strictly-sequential one-major hops `{"hops":[{framework,from,to}...]}`. Angular/Next/React never skip a major (20→23 = 21,22,23); already-at-target → no hops; all-latest → `{"hops":[]}`.

## Verification
- `bats skills/autospec-upgrade/tests/compute-upgrade-steps.bats` — 8/8 (angular 21,22,23 no-skip; already-latest empty; next/react incremental; combined; flag override; missing --detect). Real jq, no network.
- `bash scripts/validate.sh` — exit 0.

**Format note:** the older shared-contract described "one target major per line"; this issue's AC/outline specifies a JSON `{hops:[{framework,from,to}]}` object. Implemented per the issue — flagged so #1180's engine consumes JSON hops (and for the #1185 audit). Also authored by the orchestrator after the dispatched implementer stranded during exploration.