### PR TITLE
feat(autospec-upgrade): codemod-route.sh Angular routing + dispatcher

### DIFF
--- a/skills/autospec-upgrade/scripts/codemod-route.sh
+++ b/skills/autospec-upgrade/scripts/codemod-route.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# codemod-route.sh — shared codemod dispatcher for autospec-upgrade (issue #1177)
+#
+# Usage (CLI):
+#   codemod-route.sh <framework> <target_major> [--standalone]
+#
+# Usage (sourced):
+#   . codemod-route.sh
+#   route_codemod <framework> <target_major> [--standalone]
+#   route_angular_codemod <target_major> [--standalone]
+#
+# Design: this file is designed to be extended by #1178 (next) and #1179 (react).
+# Each issue adds exactly one function (route_next_codemod / route_react_codemod)
+# and one case arm in route_codemod(). No existing code needs to change.
+#
+# Exit codes:
+#   0  — codemod dispatched successfully
+#   1  — unknown framework (code_health:upgrade_unknown_framework)
+#   2  — missing required argument
+
+set -uo pipefail
+
+# ── Angular codemod (issue #1177) ─────────────────────────────────────────────
+#
+# Shells the OFFICIAL Angular CLI tooling only — never hand-rolls migrations.
+#   ng update @angular/core@<to> @angular/cli@<to>   (standard hop)
+#   ng generate @angular/core:standalone              (standalone mode, optional)
+
+route_angular_codemod() {
+  local target_major="$1"
+  local standalone="${2:-}"
+
+  if [ -z "$target_major" ]; then
+    printf 'codemod-route: route_angular_codemod requires <target_major>\n' >&2
+    return 2
+  fi
+
+  # Official Angular upgrade schematic — never hand-roll this
+  ng update "@angular/core@${target_major}" "@angular/cli@${target_major}"
+
+  # Optional: migrate to standalone components via the official schematic
+  if [ "$standalone" = "--standalone" ]; then
+    ng generate @angular/core:standalone
+  fi
+}
+
+# ── Shared dispatcher ─────────────────────────────────────────────────────────
+#
+# route_codemod <framework> <target_major> [--standalone]
+#
+# The case statement is structured for clean extension:
+#   #1178 adds a "next)" arm calling route_next_codemod
+#   #1179 adds a "react)" arm calling route_react_codemod
+
+route_codemod() {
+  local framework="${1:-}"
+  local target_major="${2:-}"
+  local standalone="${3:-}"
+
+  if [ -z "$framework" ]; then
+    printf 'codemod-route: <framework> argument is required\n' >&2
+    return 2
+  fi
+
+  if [ -z "$target_major" ]; then
+    printf 'codemod-route: <target_major> argument is required\n' >&2
+    return 2
+  fi
+
+  case "$framework" in
+    angular)
+      route_angular_codemod "$target_major" "$standalone"
+      ;;
+    # additional framework arms added by #1178 (next) / #1179 (react)
+    *)
+      printf 'codemod-route: unknown framework "%s" — code_health:upgrade_unknown_framework\n' \
+        "$framework" >&2
+      return 1
+      ;;
+  esac
+}
+
+# ── CLI entrypoint ────────────────────────────────────────────────────────────
+# Only runs when executed directly (not when sourced).
+
+_codemod_route_main() {
+  local framework="${1:-}"
+  local target_major="${2:-}"
+  local standalone="${3:-}"
+
+  if [ -z "$framework" ]; then
+    printf 'Usage: codemod-route.sh <framework> <target_major> [--standalone]\n' >&2
+    exit 2
+  fi
+
+  route_codemod "$framework" "$target_major" "$standalone"
+}
+
+# Detect sourced vs executed: in bash the source produces $BASH_SOURCE[0] != $0
+# In bash 3.2 (macOS), use $0 comparison; works for both bash and bats execution.
+_self="${BASH_SOURCE[0]:-$0}"
+if [ "$_self" = "$0" ]; then
+  _codemod_route_main "$@"
+fi

--- a/skills/autospec-upgrade/tests/codemod-route-angular.bats
+++ b/skills/autospec-upgrade/tests/codemod-route-angular.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# codemod-route-angular.bats — TDD suite for codemod-route.sh Angular routing (issue #1177)
+# No network access, no real installs. All ng calls mocked via $TMP/bin PATH shim.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/codemod-route.sh"
+
+# ── Setup / teardown ──────────────────────────────────────────────────────────
+
+setup() {
+  MOCK_BIN="$(mktemp -d /tmp/cr-mock-bin.XXXXXX)"
+  RECORDER="$MOCK_BIN/ng-calls.txt"
+  export MOCK_BIN RECORDER
+
+  # Fake ng: appends full argv (space-joined) to RECORDER, exits 0
+  cat > "$MOCK_BIN/ng" <<'MOCKEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$RECORDER"
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/ng"
+}
+
+teardown() {
+  rm -rf "$MOCK_BIN"
+}
+
+# ── Existence / executability ─────────────────────────────────────────────────
+
+@test "codemod-route.sh exists and is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+# ── Angular 17→18 hop via CLI ─────────────────────────────────────────────────
+
+@test "angular 18 hop: CLI invokes 'ng update @angular/core@18 @angular/cli@18'" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" angular 18
+  [ "$status" -eq 0 ]
+  grep -Fx "update @angular/core@18 @angular/cli@18" "$RECORDER"
+}
+
+@test "angular 18 hop: exactly one ng call (no extra invocations)" {
+  env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" angular 18
+  count="$(wc -l < "$RECORDER" | tr -d ' ')"
+  [ "$count" -eq 1 ]
+}
+
+# ── Angular hop via route_codemod function (sourced) ─────────────────────────
+
+@test "route_codemod angular 18: invokes ng update with correct packages" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    bash -c ". '$SCRIPT' && route_codemod angular 18"
+  [ "$status" -eq 0 ]
+  grep -Fx "update @angular/core@18 @angular/cli@18" "$RECORDER"
+}
+
+@test "route_codemod angular 17: invokes ng update @angular/core@17 @angular/cli@17" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    bash -c ". '$SCRIPT' && route_codemod angular 17"
+  [ "$status" -eq 0 ]
+  grep -Fx "update @angular/core@17 @angular/cli@17" "$RECORDER"
+}
+
+@test "route_angular_codemod 19: invokes ng update @angular/core@19 @angular/cli@19" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    bash -c ". '$SCRIPT' && route_angular_codemod 19"
+  [ "$status" -eq 0 ]
+  grep -Fx "update @angular/core@19 @angular/cli@19" "$RECORDER"
+}
+
+# ── Standalone mode ───────────────────────────────────────────────────────────
+
+@test "angular 18 --standalone: first call is ng update" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" angular 18 --standalone
+  [ "$status" -eq 0 ]
+  head -1 "$RECORDER" | grep -F "update @angular/core@18 @angular/cli@18"
+}
+
+@test "angular 18 --standalone: second call is 'ng generate @angular/core:standalone'" {
+  env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" angular 18 --standalone
+  sed -n '2p' "$RECORDER" | grep -F "generate @angular/core:standalone"
+}
+
+@test "angular 18 --standalone: exactly two ng calls total" {
+  env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" angular 18 --standalone
+  count="$(wc -l < "$RECORDER" | tr -d ' ')"
+  [ "$count" -eq 2 ]
+}
+
+@test "route_codemod angular 18 --standalone: invokes standalone schematic" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    bash -c ". '$SCRIPT' && route_codemod angular 18 --standalone"
+  [ "$status" -eq 0 ]
+  grep -F "generate @angular/core:standalone" "$RECORDER"
+}
+
+# ── Unknown framework errors ──────────────────────────────────────────────────
+
+@test "route_codemod unknown framework: exits non-zero" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" vue 3
+  [ "$status" -ne 0 ]
+}
+
+@test "route_codemod unknown framework: stderr mentions code_health:upgrade_unknown_framework" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" vue 3
+  [ "$status" -ne 0 ]
+  printf '%s\n' "$output" | grep -qi "upgrade_unknown_framework"
+}
+
+@test "route_codemod svelte 4: exits non-zero" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" svelte 4
+  [ "$status" -ne 0 ]
+}
+
+@test "route_codemod missing framework arg: exits non-zero" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+# ── No hand-rolled migrations (ng calls are exactly the official schematics) ──
+
+@test "angular hop: ng is invoked, not npm/npx/yarn for the upgrade itself" {
+  env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" angular 18
+
+  # The recorded call must start with 'update' (ng subcommand), not 'npm install' etc.
+  first_word="$(head -1 "$RECORDER" | cut -d' ' -f1)"
+  [ "$first_word" = "update" ]
+}


### PR DESCRIPTION
Closes #1177

Creates the shared `codemod-route.sh` (first of the codemod trio #1177/#1178/#1179):
- `route_codemod <framework> <target_major>` dispatcher (sourced or CLI), with an `angular)` arm + a clearly-commented placeholder so #1178 (next) / #1179 (react) add one function + one arm with NO existing-code changes; unknown framework → `code_health:upgrade_unknown_framework` (exit≠0).
- `route_angular_codemod`: official tooling only — `ng update @angular/core@<to> @angular/cli@<to>` per hop, `ng generate @angular/core:standalone` in `--standalone` mode. No hand-rolled migrations.

## Verification
- `bats skills/autospec-upgrade/tests/codemod-route-angular.bats` — 15/15 (exact `ng update` command, standalone schematic, unknown-framework error). `ng` mocked via $TMP/bin asserting exact argv.
- `bash scripts/validate.sh` — exit 0.