### PR TITLE
feat(autospec-upgrade): codemod-route.sh Next.js routing

### DIFF
--- a/skills/autospec-upgrade/scripts/codemod-route.sh
+++ b/skills/autospec-upgrade/scripts/codemod-route.sh
@@ -44,6 +44,30 @@ route_angular_codemod() {
   fi
 }
 
+# ── Next.js codemod (issue #1178) ────────────────────────────────────────────
+#
+# Shells the OFFICIAL Next.js codemod tooling only — never hand-rolls migrations.
+#   npx @next/codemod upgrade                  (standard version hop)
+#   npx @next/codemod next-async-request-api   (async request API migration)
+
+route_next_codemod() {
+  local target_major="$1"
+  local async_request_api="${2:-}"
+
+  if [ -z "$target_major" ]; then
+    printf 'codemod-route: route_next_codemod requires <target_major>\n' >&2
+    return 2
+  fi
+
+  if [ "$async_request_api" = "--async-request-api" ]; then
+    # Official Next.js async request API migration codemod — never hand-roll this
+    npx @next/codemod next-async-request-api
+  else
+    # Official Next.js upgrade codemod — never hand-roll this
+    npx @next/codemod upgrade
+  fi
+}
+
 # ── Shared dispatcher ─────────────────────────────────────────────────────────
 #
 # route_codemod <framework> <target_major> [--standalone]
@@ -71,7 +95,10 @@ route_codemod() {
     angular)
       route_angular_codemod "$target_major" "$standalone"
       ;;
-    # additional framework arms added by #1178 (next) / #1179 (react)
+    next)
+      route_next_codemod "$target_major" "$standalone"
+      ;;
+    # additional framework arms added by #1179 (react)
     *)
       printf 'codemod-route: unknown framework "%s" — code_health:upgrade_unknown_framework\n' \
         "$framework" >&2

--- a/skills/autospec-upgrade/tests/codemod-route-next.bats
+++ b/skills/autospec-upgrade/tests/codemod-route-next.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# codemod-route-next.bats — TDD suite for codemod-route.sh Next.js routing (issue #1178)
+# No network access, no real installs. All npx calls mocked via $TMP/bin PATH shim.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/codemod-route.sh"
+
+# ── Setup / teardown ──────────────────────────────────────────────────────────
+
+setup() {
+  MOCK_BIN="$(mktemp -d /tmp/cr-next-mock-bin.XXXXXX)"
+  RECORDER="$MOCK_BIN/npx-calls.txt"
+  export MOCK_BIN RECORDER
+
+  # Fake npx: appends full argv (space-joined) to RECORDER, exits 0
+  cat > "$MOCK_BIN/npx" <<'MOCKEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$RECORDER"
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/npx"
+}
+
+teardown() {
+  rm -rf "$MOCK_BIN"
+}
+
+# ── Existence / executability ─────────────────────────────────────────────────
+
+@test "codemod-route.sh exists and is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+# ── Next.js hop via CLI ───────────────────────────────────────────────────────
+
+@test "next hop: CLI invokes 'npx @next/codemod upgrade'" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" next 15
+  [ "$status" -eq 0 ]
+  grep -F "@next/codemod upgrade" "$RECORDER"
+}
+
+@test "next hop: exactly one npx call (no extra invocations)" {
+  env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" next 15
+  count="$(wc -l < "$RECORDER" | tr -d ' ')"
+  [ "$count" -eq 1 ]
+}
+
+# ── Next.js hop via route_codemod function (sourced) ─────────────────────────
+
+@test "route_codemod next 15: invokes npx @next/codemod upgrade" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    bash -c ". '$SCRIPT' && route_codemod next 15"
+  [ "$status" -eq 0 ]
+  grep -F "@next/codemod upgrade" "$RECORDER"
+}
+
+@test "route_next_codemod 15: invokes npx @next/codemod upgrade" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    bash -c ". '$SCRIPT' && route_next_codemod 15"
+  [ "$status" -eq 0 ]
+  grep -F "@next/codemod upgrade" "$RECORDER"
+}
+
+# ── Async-request-api mode ────────────────────────────────────────────────────
+
+@test "next --async-request-api: CLI invokes 'npx @next/codemod next-async-request-api'" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" next 15 --async-request-api
+  [ "$status" -eq 0 ]
+  grep -F "@next/codemod next-async-request-api" "$RECORDER"
+}
+
+@test "next --async-request-api: exactly one npx call" {
+  env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" next 15 --async-request-api
+  count="$(wc -l < "$RECORDER" | tr -d ' ')"
+  [ "$count" -eq 1 ]
+}
+
+@test "route_codemod next 15 --async-request-api: invokes next-async-request-api codemod" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    bash -c ". '$SCRIPT' && route_codemod next 15 --async-request-api"
+  [ "$status" -eq 0 ]
+  grep -F "@next/codemod next-async-request-api" "$RECORDER"
+}
+
+# ── No hand-rolled migrations ─────────────────────────────────────────────────
+
+@test "next hop: npx is invoked, not ng/npm-install for the upgrade itself" {
+  env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" next 15
+
+  # The recorded call must include @next/codemod (official codemod package)
+  grep -F "@next/codemod" "$RECORDER"
+}


### PR DESCRIPTION
Closes #1178

Extends the shared `codemod-route.sh` (codemod trio, after #1177): adds `route_next_codemod` + a `next)` dispatcher arm. Official Next codemod only — `npx @next/codemod upgrade` for the bump, `npx @next/codemod next-async-request-api` in `--async-request-api` mode. No hand-rolled migrations. Angular arm byte-identical; #1179 react placeholder retained.

## Verification
- `bats codemod-route-next.bats` — 9/9 (exact `npx @next/codemod upgrade` + `next-async-request-api`); `codemod-route-angular.bats` — 15/15 (no shared-file regression). `npx` mocked via $TMP/bin.
- `bash scripts/validate.sh` — exit 0.