### PR TITLE
feat(autospec-upgrade): codemod-route.sh React routing

### DIFF
--- a/skills/autospec-upgrade/scripts/codemod-route.sh
+++ b/skills/autospec-upgrade/scripts/codemod-route.sh
@@ -68,6 +68,30 @@ route_next_codemod() {
   fi
 }
 
+# ── React codemod (issue #1179) ──────────────────────────────────────────────
+#
+# Shells the OFFICIAL React codemod tooling only — never hand-rolls migrations.
+#   npx codemod react/19/migration-recipe   (standard React 19 hop)
+#   npx types-react-codemod preset-19       (types mode, optional)
+
+route_react_codemod() {
+  local target_major="$1"
+  local types="${2:-}"
+
+  if [ -z "$target_major" ]; then
+    printf 'codemod-route: route_react_codemod requires <target_major>\n' >&2
+    return 2
+  fi
+
+  if [ "$types" = "--types" ]; then
+    # Official types-react-codemod preset — never hand-roll this
+    npx types-react-codemod preset-19
+  else
+    # Official React migration recipe codemod — never hand-roll this
+    npx codemod react/19/migration-recipe
+  fi
+}
+
 # ── Shared dispatcher ─────────────────────────────────────────────────────────
 #
 # route_codemod <framework> <target_major> [--standalone]
@@ -98,7 +122,9 @@ route_codemod() {
     next)
       route_next_codemod "$target_major" "$standalone"
       ;;
-    # additional framework arms added by #1179 (react)
+    react)
+      route_react_codemod "$target_major" "$standalone"
+      ;;
     *)
       printf 'codemod-route: unknown framework "%s" — code_health:upgrade_unknown_framework\n' \
         "$framework" >&2

--- a/skills/autospec-upgrade/tests/codemod-route-react.bats
+++ b/skills/autospec-upgrade/tests/codemod-route-react.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# codemod-route-react.bats — TDD suite for codemod-route.sh React routing (issue #1179)
+# No network access, no real installs. All npx calls mocked via $TMP/bin PATH shim.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/codemod-route.sh"
+
+# ── Setup / teardown ──────────────────────────────────────────────────────────
+
+setup() {
+  MOCK_BIN="$(mktemp -d /tmp/cr-react-mock-bin.XXXXXX)"
+  RECORDER="$MOCK_BIN/npx-calls.txt"
+  export MOCK_BIN RECORDER
+
+  # Fake npx: appends full argv (space-joined) to RECORDER, exits 0
+  cat > "$MOCK_BIN/npx" <<'MOCKEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$RECORDER"
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/npx"
+}
+
+teardown() {
+  rm -rf "$MOCK_BIN"
+}
+
+# ── Existence / executability ─────────────────────────────────────────────────
+
+@test "codemod-route.sh exists and is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+# ── React 19 hop via CLI ──────────────────────────────────────────────────────
+
+@test "react hop: CLI invokes 'npx codemod react/19/migration-recipe'" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" react 19
+  [ "$status" -eq 0 ]
+  grep -F "codemod react/19/migration-recipe" "$RECORDER"
+}
+
+@test "react hop: exactly one npx call (no extra invocations)" {
+  env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" react 19
+  count="$(wc -l < "$RECORDER" | tr -d ' ')"
+  [ "$count" -eq 1 ]
+}
+
+# ── React 19 hop via route_codemod function (sourced) ────────────────────────
+
+@test "route_codemod react 19: invokes npx codemod react/19/migration-recipe" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    bash -c ". '$SCRIPT' && route_codemod react 19"
+  [ "$status" -eq 0 ]
+  grep -F "codemod react/19/migration-recipe" "$RECORDER"
+}
+
+@test "route_react_codemod 19: invokes npx codemod react/19/migration-recipe" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    bash -c ". '$SCRIPT' && route_react_codemod 19"
+  [ "$status" -eq 0 ]
+  grep -F "codemod react/19/migration-recipe" "$RECORDER"
+}
+
+# ── Types mode ────────────────────────────────────────────────────────────────
+
+@test "react --types: CLI invokes 'npx types-react-codemod preset-19'" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" react 19 --types
+  [ "$status" -eq 0 ]
+  grep -F "types-react-codemod preset-19" "$RECORDER"
+}
+
+@test "react --types: exactly one npx call" {
+  env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" react 19 --types
+  count="$(wc -l < "$RECORDER" | tr -d ' ')"
+  [ "$count" -eq 1 ]
+}
+
+@test "route_codemod react 19 --types: invokes types-react-codemod preset-19" {
+  run env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    bash -c ". '$SCRIPT' && route_codemod react 19 --types"
+  [ "$status" -eq 0 ]
+  grep -F "types-react-codemod preset-19" "$RECORDER"
+}
+
+# ── No hand-rolled migrations ─────────────────────────────────────────────────
+
+@test "react hop: npx is invoked with the official codemod package" {
+  env PATH="$MOCK_BIN:$PATH" RECORDER="$RECORDER" \
+    "$SCRIPT" react 19
+
+  # The recorded call must use the official codemod package
+  grep -F "codemod react/19/migration-recipe" "$RECORDER"
+}


### PR DESCRIPTION
Closes #1179

Completes the codemod trio (#1177/#1178/#1179): adds `route_react_codemod` + a `react)` dispatcher arm to the shared `codemod-route.sh`. Official recipe only — `npx codemod react/19/migration-recipe`, and `npx types-react-codemod preset-19` in `--types` mode. No hand-rolled migrations. Angular + next arms byte-identical.

## Verification
- `codemod-route-react.bats` 9/9 (exact `npx codemod react/19/migration-recipe` + `types-react-codemod preset-19`); `-next` 9/9 + `-angular` 15/15 (no shared-file regression) = 33/33. `npx` mocked via $TMP/bin.
- `bash scripts/validate.sh` — exit 0.