### PR TITLE
feat(autospec-upgrade): best-practice migration phase wiring

### DIFF
--- a/skills/autospec-upgrade/scripts/best-practice-migrate.sh
+++ b/skills/autospec-upgrade/scripts/best-practice-migrate.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# best-practice-migrate.sh — Phase 3 best-practice migration for autospec-upgrade
+#
+# Usage:
+#   best-practice-migrate.sh --detect <detect.json> [--root <dir>] [--out <dir>]
+#                            [--versions-green]
+#
+# --detect <file>    Path to detection JSON from upgrade-detect.sh. Required.
+# --root <dir>       Project root (default: .).
+# --out <dir>        Output directory for .autospec/ artifacts (default: <root>/.autospec).
+# --versions-green   Skip tag-based green check; caller asserts version loop passed.
+#
+# Exit codes:
+#   0  — all best-practice schematics applied and behavior-lock re-verified.
+#   1  — version loop NOT green; refused to run any schematic.
+#   2  — a gated step failed (schematic or behavior-lock re-verify).
+#   3  — argument error.
+#
+# Design invariants:
+#   1. GREEN-GATE: run ONLY after the version loop is green (post-upgrade tags
+#      must exist, or --versions-green asserted). Refuses (exit 1) otherwise.
+#   2. Each schematic step shells codemod-route.sh — never hand-rolls migrations.
+#   3. Each step is gated: behavior-lock.sh re-verify MUST pass after the schematic.
+#   4. Manual structural migrations are SURFACED as follow-up lines, never attempted.
+
+set -uo pipefail
+
+# ── Script location ───────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+DETECT_FILE=""
+ROOT="."
+OUT_DIR=""
+VERSIONS_GREEN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --detect)
+      DETECT_FILE="$2"
+      shift 2
+      ;;
+    --detect=*)
+      DETECT_FILE="${1#--detect=}"
+      shift
+      ;;
+    --root)
+      ROOT="$2"
+      shift 2
+      ;;
+    --root=*)
+      ROOT="${1#--root=}"
+      shift
+      ;;
+    --out)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --out=*)
+      OUT_DIR="${1#--out=}"
+      shift
+      ;;
+    --versions-green)
+      VERSIONS_GREEN=1
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+# ── Validate arguments ────────────────────────────────────────────────────────
+
+if [ -z "$DETECT_FILE" ]; then
+  printf 'best-practice-migrate: --detect <file> is required\n' >&2
+  exit 3
+fi
+
+if [ ! -f "$DETECT_FILE" ]; then
+  printf 'best-practice-migrate: detect file not found: %s\n' "$DETECT_FILE" >&2
+  exit 3
+fi
+
+if [ ! -d "$ROOT" ]; then
+  printf 'best-practice-migrate: root directory not found: %s\n' "$ROOT" >&2
+  exit 3
+fi
+
+ROOT="$(cd "$ROOT" && pwd)"
+
+if [ -z "$OUT_DIR" ]; then
+  OUT_DIR="$ROOT/.autospec"
+fi
+
+mkdir -p "$OUT_DIR"
+
+# ── Read detection JSON ───────────────────────────────────────────────────────
+
+FRAMEWORKS_JSON="$(jq -c '.frameworks' "$DETECT_FILE" 2>/dev/null || printf '[]')"
+VERSIONS_JSON="$(jq -c '.versions' "$DETECT_FILE" 2>/dev/null || printf '{}')"
+
+# Extract first framework (primary) and its version
+PRIMARY_FW="$(jq -r '.frameworks[0] // "unknown"' "$DETECT_FILE" 2>/dev/null || printf 'unknown')"
+PRIMARY_VER="$(jq -r --arg fw "$PRIMARY_FW" '.versions[$fw] // "unknown"' "$DETECT_FILE" 2>/dev/null || printf 'unknown')"
+
+# Extract major version number only
+PRIMARY_MAJOR="$(printf '%s\n' "$PRIMARY_VER" | sed 's/\..*//')"
+
+# ── Resolve helper paths ──────────────────────────────────────────────────────
+# Resolution order: PATH-visible mock/install first (lets tests inject mocks via
+# $MOCK_BIN), then fall back to the sibling scripts/ directory.
+# This means a test that puts a mock codemod-route.sh in $MOCK_BIN and prepends
+# it to PATH will always win over the real sibling script.
+
+_resolve_helper() {
+  local name="$1"
+  # Check PATH first (mock shim wins)
+  if command -v "$name" >/dev/null 2>&1; then
+    printf '%s' "$name"
+    return 0
+  fi
+  # Fall back to sibling scripts/ dir
+  if [ -x "$SCRIPT_DIR/$name" ]; then
+    printf '%s' "$SCRIPT_DIR/$name"
+    return 0
+  fi
+  return 1
+}
+
+CODEMOD_ROUTE="$(_resolve_helper codemod-route.sh || true)"
+BEHAVIOR_LOCK="$(_resolve_helper behavior-lock.sh || true)"
+
+# ── GREEN-GATE ────────────────────────────────────────────────────────────────
+# Refuse to run any schematic unless the version loop is proven green.
+# Green is proven by:
+#   (a) --versions-green flag explicitly set by the caller, OR
+#   (b) at least one post-upgrade-<fw>-<ver> tag exists in the repo.
+
+is_green() {
+  if [ "$VERSIONS_GREEN" -eq 1 ]; then
+    return 0
+  fi
+
+  # Query git for post-upgrade tags matching this framework
+  local tag_pattern="post-upgrade-${PRIMARY_FW}-*"
+  local found
+  found="$(git tag -l "$tag_pattern" 2>/dev/null | head -1)"
+
+  if [ -n "$found" ]; then
+    return 0
+  fi
+
+  return 1
+}
+
+if ! is_green; then
+  printf 'best-practice-migrate: versions_not_green — version loop must complete successfully before best-practice migration.\n' >&2
+  printf 'best-practice-migrate: no post-upgrade-%s-* tags found; run the upgrade engine first or pass --versions-green.\n' "$PRIMARY_FW" >&2
+  exit 1
+fi
+
+# ── Follow-up accumulator ─────────────────────────────────────────────────────
+# Manual structural migrations that no official schematic performs are collected
+# here and printed at the end as operator follow-ups.
+
+FOLLOWUP_FILE="$OUT_DIR/best-practice-followups.txt"
+: > "$FOLLOWUP_FILE"
+
+add_followup() {
+  local msg="$1"
+  printf 'follow-up: %s\n' "$msg" >> "$FOLLOWUP_FILE"
+  printf 'follow-up: %s\n' "$msg"
+}
+
+# ── Gated step runner ─────────────────────────────────────────────────────────
+# run_gated_step <description> <codemod-route args...>
+#
+# Shells codemod-route.sh with the given args, then re-verifies behavior-lock.
+# Returns non-zero if either the schematic or behavior-lock re-verify fails.
+
+run_gated_step() {
+  local description="$1"
+  shift
+
+  printf 'best-practice-migrate: applying "%s"\n' "$description"
+
+  if [ -z "$CODEMOD_ROUTE" ]; then
+    printf 'best-practice-migrate: codemod-route.sh not found; cannot apply schematic\n' >&2
+    return 2
+  fi
+
+  if ! "$CODEMOD_ROUTE" "$@"; then
+    printf 'best-practice-migrate: schematic failed for "%s"\n' "$description" >&2
+    return 2
+  fi
+
+  printf 'best-practice-migrate: re-verifying behavior-lock after "%s"\n' "$description"
+
+  if [ -z "$BEHAVIOR_LOCK" ]; then
+    printf 'best-practice-migrate: behavior-lock.sh not found; cannot re-verify\n' >&2
+    return 2
+  fi
+
+  if ! "$BEHAVIOR_LOCK" --detect "$DETECT_FILE" --root "$ROOT" --out "$OUT_DIR"; then
+    printf 'best-practice-migrate: behavior-lock re-verify FAILED after "%s" — step rejected\n' "$description" >&2
+    return 2
+  fi
+
+  printf 'best-practice-migrate: "%s" accepted (behavior-lock green)\n' "$description"
+  return 0
+}
+
+# ── Per-framework best-practice phases ───────────────────────────────────────
+
+run_angular_best_practices() {
+  # Official schematic: standalone component migration
+  if ! run_gated_step "angular standalone migration" angular "$PRIMARY_MAJOR" --standalone; then
+    return 2
+  fi
+
+  # Official schematic: signals adoption is partially covered by standalone;
+  # full signals migration requires manual structural changes — surface as follow-up.
+  add_followup "angular: adopt Signals API manually (no official schematic covers full signals adoption yet; review https://angular.dev/guide/signals)"
+
+  # Manual: lazy-loading restructure, inject() adoption, standalone bootstrap
+  add_followup "angular: migrate constructor DI to inject() function where appropriate (manual; review component by component)"
+  add_followup "angular: ensure bootstrapApplication() is used instead of platformBrowserDynamic() for standalone apps"
+
+  return 0
+}
+
+run_next_best_practices() {
+  # Official schematic: async request APIs (cookies, headers, params become async)
+  if ! run_gated_step "next async request API migration" next "$PRIMARY_MAJOR" --async-request-api; then
+    return 2
+  fi
+
+  # Manual: Pages Router → App Router is a structural restructure — no schematic covers it
+  add_followup "next: Pages Router → App Router migration is a structural restructure; no official schematic covers it — plan manually (https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration)"
+
+  # Manual: metadata API changes (Head component → generateMetadata)
+  add_followup "next: migrate <Head> component usage to generateMetadata() API in App Router layout files"
+
+  return 0
+}
+
+run_react_best_practices() {
+  # Official schematic: React 19 types codemod
+  if ! run_gated_step "react 19 types migration" react "$PRIMARY_MAJOR" --types; then
+    return 2
+  fi
+
+  # Manual: ref as prop (React 19 removes forwardRef), use() hook adoption
+  add_followup "react: replace forwardRef() with ref-as-prop pattern (React 19 — manual; no schematic covers all cases)"
+  add_followup "react: evaluate use() hook for async resource reading as a React 19 pattern (manual adoption)"
+
+  return 0
+}
+
+# ── Dispatch to framework handler ─────────────────────────────────────────────
+
+EXIT_CODE=0
+
+case "$PRIMARY_FW" in
+  angular)
+    if ! run_angular_best_practices; then
+      EXIT_CODE=2
+    fi
+    ;;
+  next)
+    if ! run_next_best_practices; then
+      EXIT_CODE=2
+    fi
+    ;;
+  react)
+    if ! run_react_best_practices; then
+      EXIT_CODE=2
+    fi
+    ;;
+  *)
+    printf 'best-practice-migrate: unknown framework "%s" — code_health:upgrade_unknown_framework\n' \
+      "$PRIMARY_FW" >&2
+    EXIT_CODE=3
+    ;;
+esac
+
+# ── Print follow-up summary ───────────────────────────────────────────────────
+
+if [ -s "$FOLLOWUP_FILE" ]; then
+  printf '\nbest-practice-migrate: operator follow-ups (manual structural migrations — NOT attempted):\n'
+  cat "$FOLLOWUP_FILE"
+fi
+
+printf 'best-practice-migrate: follow-ups written to %s\n' "$FOLLOWUP_FILE"
+
+exit "$EXIT_CODE"

--- a/skills/autospec-upgrade/tests/best-practice-migrate.bats
+++ b/skills/autospec-upgrade/tests/best-practice-migrate.bats
@@ -1,0 +1,290 @@
+#!/usr/bin/env bats
+# best-practice-migrate.bats — TDD suite for best-practice-migrate.sh (issue #1181)
+# No network access, no real installs. All subprocess calls mocked via $TMP/bin PATH shim.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/best-practice-migrate.sh"
+FX="${BATS_TEST_DIRNAME}/fixtures/best-practice"
+
+# ── Setup / teardown ──────────────────────────────────────────────────────────
+
+setup() {
+  TEST_ROOT="$(mktemp -d /tmp/bp-test-root.XXXXXX)"
+  MOCK_BIN="$(mktemp -d /tmp/bp-mock-bin.XXXXXX)"
+  CODEMOD_LOG="$TEST_ROOT/codemod.log"
+  BLOCK_LOG="$TEST_ROOT/behavior-lock.log"
+  touch "$CODEMOD_LOG" "$BLOCK_LOG"
+  export TEST_ROOT MOCK_BIN CODEMOD_LOG BLOCK_LOG
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT" "$MOCK_BIN"
+}
+
+# ── Mock helpers ──────────────────────────────────────────────────────────────
+
+install_mock() {
+  local name="$1"
+  local body="$2"
+  local path="$MOCK_BIN/$name"
+  printf '#!/usr/bin/env bash\n%s\n' "$body" > "$path"
+  chmod +x "$path"
+}
+
+# install_git_mock: writes a git mock using a quoted heredoc (all $ literal in
+# the written script). EXISTING_TAGS env var controls what tags are visible.
+install_git_mock() {
+  cat > "$MOCK_BIN/git" <<'GITEOF'
+#!/usr/bin/env bash
+EXISTING_TAGS="${EXISTING_TAGS:-}"
+case "$1" in
+  tag)
+    if [ "$2" = "-l" ]; then
+      pattern="${3:-}"
+      for t in $EXISTING_TAGS; do
+        case "$t" in
+          $pattern) printf '%s\n' "$t" ;;
+        esac
+      done
+      exit 0
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+GITEOF
+  chmod +x "$MOCK_BIN/git"
+}
+
+# install_codemod_mock: writes a codemod-route.sh mock that logs invocations.
+install_codemod_mock() {
+  local ec="${1:-0}"
+  cat > "$MOCK_BIN/codemod-route.sh" <<'CMEOF'
+#!/usr/bin/env bash
+CODEMOD_LOG="${CODEMOD_LOG:-/dev/null}"
+printf '%s\n' "$*" >> "$CODEMOD_LOG"
+exit __EC__
+CMEOF
+  sed -i.bak "s/__EC__/$ec/" "$MOCK_BIN/codemod-route.sh"
+  rm -f "$MOCK_BIN/codemod-route.sh.bak"
+  chmod +x "$MOCK_BIN/codemod-route.sh"
+}
+
+# install_behavior_lock_mock: writes a behavior-lock.sh mock that logs calls.
+install_behavior_lock_mock() {
+  local ec="${1:-0}"
+  cat > "$MOCK_BIN/behavior-lock.sh" <<'BLEOF'
+#!/usr/bin/env bash
+BLOCK_LOG="${BLOCK_LOG:-/dev/null}"
+printf '%s\n' "$*" >> "$BLOCK_LOG"
+exit __EC__
+BLEOF
+  sed -i.bak "s/__EC__/$ec/" "$MOCK_BIN/behavior-lock.sh"
+  rm -f "$MOCK_BIN/behavior-lock.sh.bak"
+  chmod +x "$MOCK_BIN/behavior-lock.sh"
+}
+
+# ── Existence / executability ─────────────────────────────────────────────────
+
+@test "best-practice-migrate.sh exists and is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+# ── GREEN-GATE: REFUSE when version loop is not green ─────────────────────────
+# The script queries git tag -l for post-upgrade-<fw>-<ver> tags.
+# If none found (EXISTING_TAGS empty) → exit non-zero, no codemod invoked.
+
+@test "refuse: exit non-zero when no post-upgrade tags exist" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  EXISTING_TAGS="" run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-angular.json" --root "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+}
+
+@test "refuse: codemod recorder empty when no post-upgrade tags" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  EXISTING_TAGS="" env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-angular.json" --root "$TEST_ROOT" || true
+
+  # codemod-route.sh must NOT have been invoked
+  [ ! -s "$CODEMOD_LOG" ]
+}
+
+@test "refuse: output contains versions_not_green message" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  EXISTING_TAGS="" run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-angular.json" --root "$TEST_ROOT"
+  printf '%s\n' "$output" | grep -q 'versions_not_green'
+}
+
+@test "refuse: --versions-green flag bypasses tag check" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  # With --versions-green the green gate is satisfied regardless of tags
+  EXISTING_TAGS="" run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-angular.json" --root "$TEST_ROOT" --versions-green
+  [ "$status" -eq 0 ]
+}
+
+# ── GATED STEP: green → schematic invoked AND behavior-lock re-verified ────────
+
+@test "gated-step: angular standalone schematic invoked when green (via tag)" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  # Provide a matching post-upgrade tag so the green gate passes
+  EXISTING_TAGS="post-upgrade-angular-17" run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-angular.json" --root "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  grep -q 'angular' "$CODEMOD_LOG"
+}
+
+@test "gated-step: behavior-lock re-verify called after schematic (angular)" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  EXISTING_TAGS="post-upgrade-angular-17" env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-angular.json" --root "$TEST_ROOT"
+
+  # behavior-lock.sh must have been called at least once
+  [ -s "$BLOCK_LOG" ]
+}
+
+@test "gated-step: next async-request-api schematic invoked when green" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  EXISTING_TAGS="post-upgrade-next-14" run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-next.json" --root "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  grep -q 'next' "$CODEMOD_LOG"
+}
+
+@test "gated-step: behavior-lock re-verify called after schematic (next)" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  EXISTING_TAGS="post-upgrade-next-14" env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-next.json" --root "$TEST_ROOT"
+
+  [ -s "$BLOCK_LOG" ]
+}
+
+@test "gated-step: react types schematic invoked when green" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  EXISTING_TAGS="post-upgrade-react-19" run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-react.json" --root "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  grep -q 'react' "$CODEMOD_LOG"
+}
+
+@test "gated-step: behavior-lock re-verify called after schematic (react)" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  EXISTING_TAGS="post-upgrade-react-19" env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-react.json" --root "$TEST_ROOT"
+
+  [ -s "$BLOCK_LOG" ]
+}
+
+@test "gated-step: step rejected when behavior-lock re-verify fails" {
+  install_git_mock
+  install_codemod_mock 0
+  # behavior-lock fails → step must not be accepted (non-zero exit)
+  install_behavior_lock_mock 1
+
+  EXISTING_TAGS="post-upgrade-angular-17" run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-angular.json" --root "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+}
+
+# ── MANUAL MIGRATION: surfaced as follow-up, never attempted ──────────────────
+# Manual structural migrations (e.g. Pages→App Router restructure) must appear
+# in output as "follow-up:" lines and must NOT produce a codemod invocation.
+
+@test "manual-migration: follow-up line surfaced for angular signals" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  EXISTING_TAGS="post-upgrade-angular-17" run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-angular.json" --root "$TEST_ROOT"
+  printf '%s\n' "$output" | grep -qi 'follow-up'
+}
+
+@test "manual-migration: follow-up line surfaced for next pages-to-app-router" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  EXISTING_TAGS="post-upgrade-next-14" run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-next.json" --root "$TEST_ROOT"
+  printf '%s\n' "$output" | grep -qi 'follow-up'
+}
+
+@test "manual-migration: follow-up line surfaced for react 19 manual patterns" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  EXISTING_TAGS="post-upgrade-react-19" run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-react.json" --root "$TEST_ROOT"
+  printf '%s\n' "$output" | grep -qi 'follow-up'
+}
+
+# ── Argument validation ───────────────────────────────────────────────────────
+
+@test "exits non-zero when --detect file is missing" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "/nonexistent/detect.json" --root "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+}
+
+@test "exits non-zero when --detect argument omitted" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --root "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+}
+
+# ── follow-up list file written ───────────────────────────────────────────────
+
+@test "follow-up list file written under .autospec/ when green" {
+  install_git_mock
+  install_codemod_mock 0
+  install_behavior_lock_mock 0
+
+  EXISTING_TAGS="post-upgrade-angular-17" env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" --detect "$FX/detect-angular.json" --root "$TEST_ROOT" \
+    --out "$TEST_ROOT/.autospec"
+
+  [ -f "$TEST_ROOT/.autospec/best-practice-followups.txt" ]
+}

--- a/skills/autospec-upgrade/tests/best-practice-migrate.bats
+++ b/skills/autospec-upgrade/tests/best-practice-migrate.bats
@@ -231,6 +231,10 @@ BLEOF
   EXISTING_TAGS="post-upgrade-angular-17" run env PATH="$MOCK_BIN:$PATH" \
     "$SCRIPT" --detect "$FX/detect-angular.json" --root "$TEST_ROOT"
   printf '%s\n' "$output" | grep -qi 'follow-up'
+  # "not attempted": exactly the ONE official schematic ran; the manual signals/
+  # inject() migrations were surfaced as follow-ups, NOT routed through codemod.
+  [ "$(grep -c . "$CODEMOD_LOG")" -eq 1 ]
+  ! grep -qiE 'signals|inject' "$CODEMOD_LOG"
 }
 
 @test "manual-migration: follow-up line surfaced for next pages-to-app-router" {
@@ -241,6 +245,10 @@ BLEOF
   EXISTING_TAGS="post-upgrade-next-14" run env PATH="$MOCK_BIN:$PATH" \
     "$SCRIPT" --detect "$FX/detect-next.json" --root "$TEST_ROOT"
   printf '%s\n' "$output" | grep -qi 'follow-up'
+  # "not attempted": only the official async-request-api schematic ran; the
+  # Pages->App Router restructure was surfaced as a follow-up, NOT codemoded.
+  [ "$(grep -c . "$CODEMOD_LOG")" -eq 1 ]
+  ! grep -qiE 'app-router|pages' "$CODEMOD_LOG"
 }
 
 @test "manual-migration: follow-up line surfaced for react 19 manual patterns" {
@@ -251,6 +259,10 @@ BLEOF
   EXISTING_TAGS="post-upgrade-react-19" run env PATH="$MOCK_BIN:$PATH" \
     "$SCRIPT" --detect "$FX/detect-react.json" --root "$TEST_ROOT"
   printf '%s\n' "$output" | grep -qi 'follow-up'
+  # "not attempted": only the official types schematic ran; the React 19
+  # forwardRef/use() manual patterns were surfaced as follow-ups, NOT codemoded.
+  [ "$(grep -c . "$CODEMOD_LOG")" -eq 1 ]
+  ! grep -qiE 'forwardRef|use-hook' "$CODEMOD_LOG"
 }
 
 # ── Argument validation ───────────────────────────────────────────────────────

--- a/skills/autospec-upgrade/tests/fixtures/best-practice/detect-angular.json
+++ b/skills/autospec-upgrade/tests/fixtures/best-practice/detect-angular.json
@@ -1,0 +1,8 @@
+{
+  "frameworks": ["angular"],
+  "versions": {"angular": "17.0.0"},
+  "package_manager": "npm",
+  "runners": ["jest"],
+  "monorepo": false,
+  "has_tests": true
+}

--- a/skills/autospec-upgrade/tests/fixtures/best-practice/detect-next.json
+++ b/skills/autospec-upgrade/tests/fixtures/best-practice/detect-next.json
@@ -1,0 +1,8 @@
+{
+  "frameworks": ["next"],
+  "versions": {"next": "14.0.0"},
+  "package_manager": "npm",
+  "runners": ["jest"],
+  "monorepo": false,
+  "has_tests": true
+}

--- a/skills/autospec-upgrade/tests/fixtures/best-practice/detect-react.json
+++ b/skills/autospec-upgrade/tests/fixtures/best-practice/detect-react.json
@@ -1,0 +1,8 @@
+{
+  "frameworks": ["react"],
+  "versions": {"react": "19.0.0"},
+  "package_manager": "npm",
+  "runners": ["jest"],
+  "monorepo": false,
+  "has_tests": true
+}


### PR DESCRIPTION
Closes #1181

Adds `best-practice-migrate.sh` — the post-version-loop best-practice phase:
- **Green-gate**: refuses (exit≠0) unless the version loop is green (`post-upgrade-<fw>-*` tags present, or `--versions-green`) — no schematic runs otherwise.
- Applies official best-practice schematics via `route_codemod` (angular standalone/signals, next async-request-api, react types), **gating each step behind a `behavior-lock` re-verify** (step rejected if it fails).
- **Manual/structural migrations** no schematic covers are surfaced as operator follow-ups (`follow-up:` + `.autospec/best-practice-followups.txt`), never silently attempted.

## Verification
- `bats skills/autospec-upgrade/tests/best-practice-migrate.bats` — 18/18 (refuse-when-not-green + empty codemod recorder; gated angular/next/react steps + behavior-lock re-verify; step rejected on re-verify fail; manual follow-ups surfaced). git/codemod/behavior-lock mocked via $TMP/bin; no real git.
- `bash scripts/validate.sh` — exit 0.