### PR TITLE
feat(autospec-upgrade): tag-upgrade.sh + upgrade-report.json

### DIFF
--- a/skills/autospec-upgrade/scripts/tag-upgrade.sh
+++ b/skills/autospec-upgrade/scripts/tag-upgrade.sh
@@ -111,62 +111,45 @@ do_pre() {
 
 # ── Mode: post ────────────────────────────────────────────────────────────────
 
-do_post() {
-  if [ -z "$FRAMEWORK" ]; then
-    printf 'tag-upgrade: --framework is required\n' >&2
-    exit 3
+# Evaluate the mutation-proof gate at $1. Return 0 if the post tag may be
+# created, 1 if it must be withheld (prints reason), 2 if the proof is
+# missing/malformed. Uses if/then/else to distinguish JSON false from a missing
+# "passed" key (jq `false // x` would wrongly treat false as absent).
+gate_evaluate() {
+  local proof="$1"
+  if [ ! -f "$proof" ]; then
+    printf 'tag-upgrade: proof file not found: %s\n' "$proof" >&2
+    return 2
   fi
-  if [ -z "$VERSION" ]; then
-    printf 'tag-upgrade: --version is required\n' >&2
-    exit 3
-  fi
-
-  # Resolve proof file: default to .autospec/mutation-proof.json
-  if [ -z "$PROOF_FILE" ]; then
-    PROOF_FILE="$AUTOSPEC_DIR/mutation-proof.json"
-  fi
-
-  if [ ! -f "$PROOF_FILE" ]; then
-    printf 'tag-upgrade: proof file not found: %s\n' "$PROOF_FILE" >&2
-    exit 2
-  fi
-
-  # Read passed flag from proof
-  # Use if/then/else to distinguish JSON false from missing key
   local passed
-  passed="$(jq -r 'if has("passed") then (if .passed then "true" else "false" end) else "null" end' "$PROOF_FILE" 2>/dev/null)"
+  passed="$(jq -r 'if has("passed") then (if .passed then "true" else "false" end) else "null" end' "$proof" 2>/dev/null)"
   if [ "$passed" = "null" ] || [ -z "$passed" ]; then
-    printf 'tag-upgrade: proof file missing "passed" field: %s\n' "$PROOF_FILE" >&2
-    exit 2
+    printf 'tag-upgrade: proof file missing "passed" field: %s\n' "$proof" >&2
+    return 2
   fi
-
-  # Read scores for regression check
-  local baseline_score post_score
-  baseline_score="$(jq -r '.baseline.score // "null"' "$PROOF_FILE" 2>/dev/null)"
-  post_score="$(jq -r '.post_upgrade.score // "null"' "$PROOF_FILE" 2>/dev/null)"
-
-  # Gate check 1: passed must be true
   if [ "$passed" != "true" ]; then
-    printf 'tag-upgrade: WITHHELD post tag — mutation gate not passed (passed=%s)\n' \
-      "$passed" >&2
-    exit 1
+    printf 'tag-upgrade: WITHHELD post tag — mutation gate not passed (passed=%s)\n' "$passed" >&2
+    return 1
   fi
-
-  # Gate check 2: post_upgrade.score must be >= baseline.score (if both present)
+  local baseline_score post_score bs_int ps_int
+  baseline_score="$(jq -r '.baseline.score // "null"' "$proof" 2>/dev/null)"
+  post_score="$(jq -r '.post_upgrade.score // "null"' "$proof" 2>/dev/null)"
   if [ "$baseline_score" != "null" ] && [ "$post_score" != "null" ]; then
-    # Strip any decimal for integer comparison
-    local bs_int ps_int
     bs_int="$(printf '%s' "$baseline_score" | grep -o '^[0-9]*')"
     ps_int="$(printf '%s' "$post_score" | grep -o '^[0-9]*')"
-    if [ -n "$bs_int" ] && [ -n "$ps_int" ]; then
-      if [ "$ps_int" -lt "$bs_int" ]; then
-        printf 'tag-upgrade: WITHHELD post tag — post_upgrade score %s is below baseline %s\n' \
-          "$ps_int" "$bs_int" >&2
-        exit 1
-      fi
+    if [ -n "$bs_int" ] && [ -n "$ps_int" ] && [ "$ps_int" -lt "$bs_int" ]; then
+      printf 'tag-upgrade: WITHHELD post tag — post_upgrade score %s is below baseline %s\n' "$ps_int" "$bs_int" >&2
+      return 1
     fi
   fi
+  return 0
+}
 
+do_post() {
+  if [ -z "$FRAMEWORK" ]; then printf 'tag-upgrade: --framework is required\n' >&2; exit 3; fi
+  if [ -z "$VERSION" ];   then printf 'tag-upgrade: --version is required\n'   >&2; exit 3; fi
+  if [ -z "$PROOF_FILE" ]; then PROOF_FILE="$AUTOSPEC_DIR/mutation-proof.json"; fi
+  gate_evaluate "$PROOF_FILE" || exit $?
   local tag_name="post-upgrade-${FRAMEWORK}-${VERSION}"
   git tag "$tag_name"
   printf 'tag-upgrade: created tag %s\n' "$tag_name"
@@ -174,6 +157,21 @@ do_post() {
 }
 
 # ── Mode: report ──────────────────────────────────────────────────────────────
+
+# Build one per-hop report entry JSON from the CLI-provided fields.
+build_hop_entry() {
+  local codemods_json="[]" manual_fixes_json="[]"
+  if [ -n "$CODEMODS" ];     then codemods_json="$(jq -n --arg c "$CODEMODS" '[$c]')"; fi
+  if [ -n "$MANUAL_FIXES" ]; then manual_fixes_json="$(jq -n --arg m "$MANUAL_FIXES" '[$m]')"; fi
+  jq -n \
+    --arg framework "$FRAMEWORK" \
+    --arg from "$FROM_VER" \
+    --arg to "$TO_VER" \
+    --argjson codemods "$codemods_json" \
+    --argjson manual_fixes "$manual_fixes_json" \
+    --arg residual_risk "${RESIDUAL_RISK:-}" \
+    '{framework:$framework, from:$from, to:$to, codemods:$codemods, manual_fixes:$manual_fixes, residual_risk:$residual_risk}'
+}
 
 do_report() {
   if [ -z "$FRAMEWORK" ]; then
@@ -191,31 +189,8 @@ do_report() {
 
   local report_file="$AUTOSPEC_DIR/$REPORT_FILENAME"
 
-  # Build codemods array
-  local codemods_json="[]"
-  if [ -n "$CODEMODS" ]; then
-    codemods_json="$(jq -n --arg c "$CODEMODS" '[$c]')"
-  fi
-
-  # Build manual_fixes array
-  local manual_fixes_json="[]"
-  if [ -n "$MANUAL_FIXES" ]; then
-    manual_fixes_json="$(jq -n --arg m "$MANUAL_FIXES" '[$m]')"
-  fi
-
-  # Build residual_risk string
-  local residual_risk_val="${RESIDUAL_RISK:-}"
-
-  # Build the new hop entry
   local new_entry
-  new_entry="$(jq -n \
-    --arg framework "$FRAMEWORK" \
-    --arg from "$FROM_VER" \
-    --arg to "$TO_VER" \
-    --argjson codemods "$codemods_json" \
-    --argjson manual_fixes "$manual_fixes_json" \
-    --arg residual_risk "$residual_risk_val" \
-    '{framework:$framework, from:$from, to:$to, codemods:$codemods, manual_fixes:$manual_fixes, residual_risk:$residual_risk}')"
+  new_entry="$(build_hop_entry)"
 
   # Read existing report or start fresh array
   local existing="[]"

--- a/skills/autospec-upgrade/scripts/tag-upgrade.sh
+++ b/skills/autospec-upgrade/scripts/tag-upgrade.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# tag-upgrade.sh — pre/post upgrade tagging + structured upgrade-report.json
+#
+# Usage:
+#   tag-upgrade.sh pre  --framework <fw> --version <ver> [--out <dir>]
+#   tag-upgrade.sh post --framework <fw> --version <ver>
+#                       [--proof <mutation-proof.json>] [--out <dir>]
+#   tag-upgrade.sh report --framework <fw> --from <ver> --to <ver>
+#                         [--codemods <cmd>] [--manual-fixes <note>]
+#                         [--residual-risk <text>] [--out <dir>]
+#
+# Modes:
+#   pre     Create tag pre-upgrade-<fw>-<ver> at the start of a hop.
+#   post    Create tag post-upgrade-<fw>-<ver> ONLY when the mutation gate
+#           passed: proof.passed == true AND proof.post_upgrade.score >=
+#           proof.baseline.score.  Withholds and exits non-zero otherwise.
+#   report  Append a per-hop entry to <out>/.autospec/upgrade-report.json.
+#           The file is an array; each entry has framework/from/to/codemods/
+#           manual_fixes/residual_risk.  Idempotent append (merge strategy).
+#
+# Tag format:
+#   pre-upgrade-<fw>-<ver>   fw ∈ angular|next|react
+#   post-upgrade-<fw>-<ver>
+#
+# Exit codes:
+#   0  — success
+#   1  — post tag withheld (gate failed / score regressed)
+#   2  — proof file missing or unparseable
+#   3  — argument / environment error
+
+set -uo pipefail
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+REPORT_FILENAME="upgrade-report.json"
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+die() {
+  printf 'tag-upgrade: %s\n' "$*" >&2
+  exit 3
+}
+
+# ── Argument parsing ───────────────────────────────────────────────────────────
+
+MODE=""
+FRAMEWORK=""
+VERSION=""
+FROM_VER=""
+TO_VER=""
+PROOF_FILE=""
+OUT_DIR=""
+CODEMODS=""
+MANUAL_FIXES=""
+RESIDUAL_RISK=""
+
+if [ $# -gt 0 ]; then
+  MODE="$1"
+  shift
+fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --framework)   FRAMEWORK="$2";    shift 2 ;;
+    --framework=*) FRAMEWORK="${1#--framework=}"; shift ;;
+    --version)     VERSION="$2";      shift 2 ;;
+    --version=*)   VERSION="${1#--version=}";     shift ;;
+    --from)        FROM_VER="$2";     shift 2 ;;
+    --from=*)      FROM_VER="${1#--from=}";       shift ;;
+    --to)          TO_VER="$2";       shift 2 ;;
+    --to=*)        TO_VER="${1#--to=}";           shift ;;
+    --proof)       PROOF_FILE="$2";   shift 2 ;;
+    --proof=*)     PROOF_FILE="${1#--proof=}";    shift ;;
+    --out)         OUT_DIR="$2";      shift 2 ;;
+    --out=*)       OUT_DIR="${1#--out=}";         shift ;;
+    --codemods)    CODEMODS="$2";     shift 2 ;;
+    --codemods=*)  CODEMODS="${1#--codemods=}";   shift ;;
+    --manual-fixes)  MANUAL_FIXES="$2";  shift 2 ;;
+    --manual-fixes=*) MANUAL_FIXES="${1#--manual-fixes=}"; shift ;;
+    --residual-risk)  RESIDUAL_RISK="$2"; shift 2 ;;
+    --residual-risk=*) RESIDUAL_RISK="${1#--residual-risk=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
+# ── Resolve output directory ───────────────────────────────────────────────────
+
+if [ -z "$OUT_DIR" ]; then
+  OUT_DIR="$(pwd)"
+fi
+AUTOSPEC_DIR="$OUT_DIR/.autospec"
+mkdir -p "$AUTOSPEC_DIR"
+
+# ── Mode: pre ─────────────────────────────────────────────────────────────────
+
+do_pre() {
+  if [ -z "$FRAMEWORK" ]; then
+    printf 'tag-upgrade: --framework is required\n' >&2
+    exit 3
+  fi
+  if [ -z "$VERSION" ]; then
+    printf 'tag-upgrade: --version is required\n' >&2
+    exit 3
+  fi
+
+  local tag_name="pre-upgrade-${FRAMEWORK}-${VERSION}"
+  git tag "$tag_name"
+  printf 'tag-upgrade: created tag %s\n' "$tag_name"
+  exit 0
+}
+
+# ── Mode: post ────────────────────────────────────────────────────────────────
+
+do_post() {
+  if [ -z "$FRAMEWORK" ]; then
+    printf 'tag-upgrade: --framework is required\n' >&2
+    exit 3
+  fi
+  if [ -z "$VERSION" ]; then
+    printf 'tag-upgrade: --version is required\n' >&2
+    exit 3
+  fi
+
+  # Resolve proof file: default to .autospec/mutation-proof.json
+  if [ -z "$PROOF_FILE" ]; then
+    PROOF_FILE="$AUTOSPEC_DIR/mutation-proof.json"
+  fi
+
+  if [ ! -f "$PROOF_FILE" ]; then
+    printf 'tag-upgrade: proof file not found: %s\n' "$PROOF_FILE" >&2
+    exit 2
+  fi
+
+  # Read passed flag from proof
+  # Use if/then/else to distinguish JSON false from missing key
+  local passed
+  passed="$(jq -r 'if has("passed") then (if .passed then "true" else "false" end) else "null" end' "$PROOF_FILE" 2>/dev/null)"
+  if [ "$passed" = "null" ] || [ -z "$passed" ]; then
+    printf 'tag-upgrade: proof file missing "passed" field: %s\n' "$PROOF_FILE" >&2
+    exit 2
+  fi
+
+  # Read scores for regression check
+  local baseline_score post_score
+  baseline_score="$(jq -r '.baseline.score // "null"' "$PROOF_FILE" 2>/dev/null)"
+  post_score="$(jq -r '.post_upgrade.score // "null"' "$PROOF_FILE" 2>/dev/null)"
+
+  # Gate check 1: passed must be true
+  if [ "$passed" != "true" ]; then
+    printf 'tag-upgrade: WITHHELD post tag — mutation gate not passed (passed=%s)\n' \
+      "$passed" >&2
+    exit 1
+  fi
+
+  # Gate check 2: post_upgrade.score must be >= baseline.score (if both present)
+  if [ "$baseline_score" != "null" ] && [ "$post_score" != "null" ]; then
+    # Strip any decimal for integer comparison
+    local bs_int ps_int
+    bs_int="$(printf '%s' "$baseline_score" | grep -o '^[0-9]*')"
+    ps_int="$(printf '%s' "$post_score" | grep -o '^[0-9]*')"
+    if [ -n "$bs_int" ] && [ -n "$ps_int" ]; then
+      if [ "$ps_int" -lt "$bs_int" ]; then
+        printf 'tag-upgrade: WITHHELD post tag — post_upgrade score %s is below baseline %s\n' \
+          "$ps_int" "$bs_int" >&2
+        exit 1
+      fi
+    fi
+  fi
+
+  local tag_name="post-upgrade-${FRAMEWORK}-${VERSION}"
+  git tag "$tag_name"
+  printf 'tag-upgrade: created tag %s\n' "$tag_name"
+  exit 0
+}
+
+# ── Mode: report ──────────────────────────────────────────────────────────────
+
+do_report() {
+  if [ -z "$FRAMEWORK" ]; then
+    printf 'tag-upgrade: --framework is required for report\n' >&2
+    exit 3
+  fi
+  if [ -z "$FROM_VER" ]; then
+    printf 'tag-upgrade: --from is required for report\n' >&2
+    exit 3
+  fi
+  if [ -z "$TO_VER" ]; then
+    printf 'tag-upgrade: --to is required for report\n' >&2
+    exit 3
+  fi
+
+  local report_file="$AUTOSPEC_DIR/$REPORT_FILENAME"
+
+  # Build codemods array
+  local codemods_json="[]"
+  if [ -n "$CODEMODS" ]; then
+    codemods_json="$(jq -n --arg c "$CODEMODS" '[$c]')"
+  fi
+
+  # Build manual_fixes array
+  local manual_fixes_json="[]"
+  if [ -n "$MANUAL_FIXES" ]; then
+    manual_fixes_json="$(jq -n --arg m "$MANUAL_FIXES" '[$m]')"
+  fi
+
+  # Build residual_risk string
+  local residual_risk_val="${RESIDUAL_RISK:-}"
+
+  # Build the new hop entry
+  local new_entry
+  new_entry="$(jq -n \
+    --arg framework "$FRAMEWORK" \
+    --arg from "$FROM_VER" \
+    --arg to "$TO_VER" \
+    --argjson codemods "$codemods_json" \
+    --argjson manual_fixes "$manual_fixes_json" \
+    --arg residual_risk "$residual_risk_val" \
+    '{framework:$framework, from:$from, to:$to, codemods:$codemods, manual_fixes:$manual_fixes, residual_risk:$residual_risk}')"
+
+  # Read existing report or start fresh array
+  local existing="[]"
+  if [ -f "$report_file" ]; then
+    existing="$(cat "$report_file")"
+    # Validate it's an array; reset if not
+    if ! printf '%s' "$existing" | jq -e 'type == "array"' > /dev/null 2>&1; then
+      existing="[]"
+    fi
+  fi
+
+  # Append new entry and write
+  local updated
+  updated="$(printf '%s\n%s\n' "$existing" "$new_entry" | jq -s '.[0] + [.[1]]')"
+  printf '%s\n' "$updated" > "$report_file"
+
+  printf 'tag-upgrade: report written to %s\n' "$report_file"
+  exit 0
+}
+
+# ── Dispatch ───────────────────────────────────────────────────────────────────
+
+case "$MODE" in
+  pre)    do_pre ;;
+  post)   do_post ;;
+  report) do_report ;;
+  "")     die "mode (pre|post|report) is required as first argument" ;;
+  *)      die "unknown mode: ${MODE}; expected pre|post|report" ;;
+esac

--- a/skills/autospec-upgrade/tests/fixtures/tag-upgrade/proof-failing.json
+++ b/skills/autospec-upgrade/tests/fixtures/tag-upgrade/proof-failing.json
@@ -1,0 +1,7 @@
+{
+  "baseline": {"score": 80},
+  "post_upgrade": {"score": 70},
+  "threshold": 70,
+  "passed": false,
+  "gated_at": "2026-06-18T00:00:00Z"
+}

--- a/skills/autospec-upgrade/tests/fixtures/tag-upgrade/proof-passing.json
+++ b/skills/autospec-upgrade/tests/fixtures/tag-upgrade/proof-passing.json
@@ -1,0 +1,7 @@
+{
+  "baseline": {"score": 75},
+  "post_upgrade": {"score": 80},
+  "threshold": 70,
+  "passed": true,
+  "gated_at": "2026-06-18T00:00:00Z"
+}

--- a/skills/autospec-upgrade/tests/tag-upgrade.bats
+++ b/skills/autospec-upgrade/tests/tag-upgrade.bats
@@ -1,0 +1,302 @@
+#!/usr/bin/env bats
+# tag-upgrade.bats — TDD suite for tag-upgrade.sh (issue #1182)
+# No real git. All git calls mocked via $MOCK_BIN PATH shim recording invocations.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/tag-upgrade.sh"
+FIXTURE_DIR="${BATS_TEST_DIRNAME}/fixtures/tag-upgrade"
+
+# ── Setup / teardown ──────────────────────────────────────────────────────────
+
+setup() {
+  TEST_ROOT="$(mktemp -d /tmp/tu-test-root.XXXXXX)"
+  MOCK_BIN="$(mktemp -d /tmp/tu-mock-bin.XXXXXX)"
+  AUTOSPEC_DIR="$TEST_ROOT/.autospec"
+  TAGS_FILE="$MOCK_BIN/tags-recorded.txt"
+  mkdir -p "$AUTOSPEC_DIR"
+  touch "$TAGS_FILE"
+  export TEST_ROOT MOCK_BIN AUTOSPEC_DIR TAGS_FILE
+
+  # Install git mock that records tag names
+  cat > "$MOCK_BIN/git" <<'GITEOF'
+#!/usr/bin/env bash
+# Fake git — records "git tag <name>" calls to $TAGS_FILE; silently passes anything else
+if [ "$1" = "tag" ] && [ -n "$2" ]; then
+  printf '%s\n' "$2" >> "$TAGS_FILE"
+  exit 0
+fi
+exit 0
+GITEOF
+  chmod +x "$MOCK_BIN/git"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT" "$MOCK_BIN"
+}
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+tag_was_created() {
+  local tag="$1"
+  grep -qx "$tag" "$TAGS_FILE"
+}
+
+tag_was_not_created() {
+  local tag="$1"
+  ! grep -qx "$tag" "$TAGS_FILE"
+}
+
+# ── Existence / executability ─────────────────────────────────────────────────
+
+@test "tag-upgrade.sh exists and is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+# ── pre mode: tag format ──────────────────────────────────────────────────────
+
+@test "pre: creates tag named pre-upgrade-angular-17" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" pre --framework angular --version 17 --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  tag_was_created "pre-upgrade-angular-17"
+}
+
+@test "pre: creates tag named pre-upgrade-next-15" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" pre --framework next --version 15 --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  tag_was_created "pre-upgrade-next-15"
+}
+
+@test "pre: creates tag named pre-upgrade-react-19" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" pre --framework react --version 19 --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  tag_was_created "pre-upgrade-react-19"
+}
+
+@test "pre: does NOT create a post tag" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" pre --framework angular --version 17 --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  tag_was_not_created "post-upgrade-angular-17"
+}
+
+@test "pre: exits non-zero when --framework is missing" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" pre --version 17 --out "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+}
+
+@test "pre: exits non-zero when --version is missing" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" pre --framework angular --out "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+}
+
+# ── post mode: tag format (proof passes) ──────────────────────────────────────
+
+@test "post: creates tag named post-upgrade-angular-17 when proof passes" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" post --framework angular --version 17 \
+      --proof "$FIXTURE_DIR/proof-passing.json" --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  tag_was_created "post-upgrade-angular-17"
+}
+
+@test "post: creates tag named post-upgrade-next-15 when proof passes" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" post --framework next --version 15 \
+      --proof "$FIXTURE_DIR/proof-passing.json" --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  tag_was_created "post-upgrade-next-15"
+}
+
+@test "post: creates tag named post-upgrade-react-19 when proof passes" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" post --framework react --version 19 \
+      --proof "$FIXTURE_DIR/proof-passing.json" --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  tag_was_created "post-upgrade-react-19"
+}
+
+@test "post: does NOT create a pre tag" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" post --framework angular --version 17 \
+      --proof "$FIXTURE_DIR/proof-passing.json" --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  tag_was_not_created "pre-upgrade-angular-17"
+}
+
+# ── post mode: WITHHOLD tag when proof fails ──────────────────────────────────
+
+@test "post: WITHHOLDS tag when proof passed=false" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" post --framework angular --version 17 \
+      --proof "$FIXTURE_DIR/proof-failing.json" --out "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+  tag_was_not_created "post-upgrade-angular-17"
+}
+
+@test "post: WITHHOLDS tag when post_upgrade.score < baseline.score (inline proof)" {
+  local proof_file="$TEST_ROOT/proof-regressed.json"
+  printf '{"baseline":{"score":80},"post_upgrade":{"score":70},"passed":true}\n' \
+    > "$proof_file"
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" post --framework react --version 19 \
+      --proof "$proof_file" --out "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+  tag_was_not_created "post-upgrade-react-19"
+}
+
+@test "post: WITHHOLDS tag when passed=false even if score >= baseline" {
+  local proof_file="$TEST_ROOT/proof-explicit-false.json"
+  printf '{"baseline":{"score":70},"post_upgrade":{"score":80},"passed":false}\n' \
+    > "$proof_file"
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" post --framework next --version 15 \
+      --proof "$proof_file" --out "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+  tag_was_not_created "post-upgrade-next-15"
+}
+
+@test "post: output mentions withheld when gate fails" {
+  run bash -c "env PATH=\"$MOCK_BIN:\$PATH\" \
+    \"$SCRIPT\" post --framework angular --version 17 \
+      --proof \"$FIXTURE_DIR/proof-failing.json\" --out \"$TEST_ROOT\" 2>&1"
+  [ "$status" -ne 0 ]
+  printf '%s\n' "$output" | grep -qi 'withheld\|below\|failed\|not tagged'
+}
+
+@test "post: exits non-zero when proof file is missing" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" post --framework angular --version 17 \
+      --proof "$TEST_ROOT/nonexistent-proof.json" --out "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+}
+
+@test "post: exits non-zero when --framework is missing" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" post --version 17 \
+      --proof "$FIXTURE_DIR/proof-passing.json" --out "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+}
+
+@test "post: exits non-zero when --version is missing" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" post --framework angular \
+      --proof "$FIXTURE_DIR/proof-passing.json" --out "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+}
+
+# ── report mode: emits upgrade-report.json with documented fields ─────────────
+
+@test "report: emits .autospec/upgrade-report.json" {
+  run env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" report \
+      --framework angular --from 16 --to 17 \
+      --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_ROOT/.autospec/upgrade-report.json" ]
+}
+
+@test "report: upgrade-report.json contains framework field" {
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" report \
+      --framework angular --from 16 --to 17 \
+      --out "$TEST_ROOT"
+  jq -e '.[0] | has("framework")' "$TEST_ROOT/.autospec/upgrade-report.json"
+}
+
+@test "report: upgrade-report.json contains from field" {
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" report \
+      --framework angular --from 16 --to 17 \
+      --out "$TEST_ROOT"
+  jq -e '.[0] | has("from")' "$TEST_ROOT/.autospec/upgrade-report.json"
+}
+
+@test "report: upgrade-report.json contains to field" {
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" report \
+      --framework angular --from 16 --to 17 \
+      --out "$TEST_ROOT"
+  jq -e '.[0] | has("to")' "$TEST_ROOT/.autospec/upgrade-report.json"
+}
+
+@test "report: upgrade-report.json contains codemods field (array)" {
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" report \
+      --framework angular --from 16 --to 17 \
+      --out "$TEST_ROOT"
+  jq -e '.[0].codemods | type == "array"' "$TEST_ROOT/.autospec/upgrade-report.json"
+}
+
+@test "report: upgrade-report.json contains manual_fixes field (array)" {
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" report \
+      --framework angular --from 16 --to 17 \
+      --out "$TEST_ROOT"
+  jq -e '.[0].manual_fixes | type == "array"' "$TEST_ROOT/.autospec/upgrade-report.json"
+}
+
+@test "report: upgrade-report.json contains residual_risk field" {
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" report \
+      --framework angular --from 16 --to 17 \
+      --out "$TEST_ROOT"
+  jq -e '.[0] | has("residual_risk")' "$TEST_ROOT/.autospec/upgrade-report.json"
+}
+
+@test "report: upgrade-report.json framework value matches --framework arg" {
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" report \
+      --framework next --from 14 --to 15 \
+      --out "$TEST_ROOT"
+  local fw
+  fw="$(jq -r '.[0].framework' "$TEST_ROOT/.autospec/upgrade-report.json")"
+  [ "$fw" = "next" ]
+}
+
+@test "report: upgrade-report.json from/to values match args" {
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" report \
+      --framework react --from 18 --to 19 \
+      --out "$TEST_ROOT"
+  local from to
+  from="$(jq -r '.[0].from' "$TEST_ROOT/.autospec/upgrade-report.json")"
+  to="$(jq -r '.[0].to' "$TEST_ROOT/.autospec/upgrade-report.json")"
+  [ "$from" = "18" ]
+  [ "$to" = "19" ]
+}
+
+@test "report: appends a second hop when called twice" {
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" report --framework angular --from 15 --to 16 --out "$TEST_ROOT"
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" report --framework angular --from 16 --to 17 --out "$TEST_ROOT"
+  local count
+  count="$(jq 'length' "$TEST_ROOT/.autospec/upgrade-report.json")"
+  [ "$count" -eq 2 ]
+}
+
+@test "report: accepts optional --codemods and includes in output" {
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" report \
+      --framework angular --from 16 --to 17 \
+      --codemods "ng update @angular/core" \
+      --out "$TEST_ROOT"
+  local cmd
+  cmd="$(jq -r '.[0].codemods[0]' "$TEST_ROOT/.autospec/upgrade-report.json")"
+  [ "$cmd" = "ng update @angular/core" ]
+}
+
+@test "report: accepts optional --residual-risk and includes in output" {
+  env PATH="$MOCK_BIN:$PATH" \
+    "$SCRIPT" report \
+      --framework angular --from 16 --to 17 \
+      --residual-risk "Manual review needed for lazy-loaded modules" \
+      --out "$TEST_ROOT"
+  local risk
+  risk="$(jq -r '.[0].residual_risk' "$TEST_ROOT/.autospec/upgrade-report.json")"
+  [ "$risk" = "Manual review needed for lazy-loaded modules" ]
+}


### PR DESCRIPTION
Closes #1182

Adds `tag-upgrade.sh`:
- `pre` → `pre-upgrade-<fw>-<ver>`; `post` → `post-upgrade-<fw>-<ver>` **only when the mutation gate passed** (reads `.autospec/mutation-proof.json`: `passed==true` AND `post_upgrade.score >= baseline.score`) — withholds the post tag + exits≠0 on regression.
- `report` → `.autospec/upgrade-report.json` (per-hop `framework/from/to/codemods/manual_fixes/residual_risk`).
- git PATH-resolved + mocked; correctly distinguishes `passed:false` from a missing key (jq `false // "null"` gotcha).

## Verification
- `bats skills/autospec-upgrade/tests/tag-upgrade.bats` — 30/30 (pre/post tag format x3 frameworks; post withheld on passed:false AND on score regression; report fields). `git` mocked via $TMP/bin; no real git (no leaked tags).
- `bash scripts/validate.sh` — exit 0.

Note: pre/post tag creation also exists inline in #1180's engine; tag-upgrade.sh is the standalone helper #1184's orchestrator wires. Minor tag-logic overlap flagged for the #1185 audit.