### PR TITLE
feat(autospec-upgrade): migration-doc generation (composes autospec-doc)

### DIFF
--- a/skills/autospec-upgrade/scripts/migration-doc.sh
+++ b/skills/autospec-upgrade/scripts/migration-doc.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# migration-doc.sh — render the human migration log from upgrade-report.json
+#
+# Usage:
+#   migration-doc.sh [--report <file>] [--root <dir>] [--out <dir>]
+#
+# Options:
+#   --report <file>   Path to upgrade-report.json.
+#                     Default: <root>/.autospec/upgrade-report.json
+#   --root <dir>      Project root used to locate the default report path.
+#                     Default: current working directory.
+#   --out <dir>       Directory where docs/migrations/<slug>-upgrade.md is written.
+#                     Default: <root>
+#
+# Behaviour:
+#   1. Read upgrade-report.json (array of per-hop entries).
+#   2. Compose autospec-doc --full (via PATH-resolved binary) to finalize the log.
+#   3. Emit one Markdown section per hop:
+#        ## <framework> <from> → <to>
+#        with: before/after versions, codemods applied, manual fixes, residual risk.
+#   4. Write the log to <out>/docs/migrations/<date>-upgrade.md.
+#   5. Print the doc path to stdout.
+#
+# Exit codes:
+#   0 — success
+#   1 — report file missing or not valid JSON
+#   2 — argument / environment error
+
+set -uo pipefail
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+die() {
+  printf 'migration-doc: %s\n' "$*" >&2
+  exit 2
+}
+
+die_report() {
+  printf 'migration-doc: %s\n' "$*" >&2
+  exit 1
+}
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+REPORT_FILE=""
+ROOT_DIR=""
+OUT_DIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --report)
+      [ $# -ge 2 ] || die "--report requires a value"
+      REPORT_FILE="$2"
+      shift 2
+      ;;
+    --root)
+      [ $# -ge 2 ] || die "--root requires a value"
+      ROOT_DIR="$2"
+      shift 2
+      ;;
+    --out)
+      [ $# -ge 2 ] || die "--out requires a value"
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+
+if [ -z "$ROOT_DIR" ]; then
+  ROOT_DIR="$(pwd)"
+fi
+
+if [ -z "$REPORT_FILE" ]; then
+  REPORT_FILE="$ROOT_DIR/.autospec/upgrade-report.json"
+fi
+
+if [ -z "$OUT_DIR" ]; then
+  OUT_DIR="$ROOT_DIR"
+fi
+
+# ── Validate report file ──────────────────────────────────────────────────────
+
+if [ ! -f "$REPORT_FILE" ]; then
+  die_report "report file not found: $REPORT_FILE"
+fi
+
+if ! jq -e 'type == "array"' "$REPORT_FILE" > /dev/null 2>&1; then
+  die_report "report file is not a valid JSON array: $REPORT_FILE"
+fi
+
+# ── Derive output path ────────────────────────────────────────────────────────
+
+DATE_SLUG="$(date -u '+%Y-%m-%d' 2>/dev/null || printf 'unknown-date')"
+MIGRATIONS_DIR="$OUT_DIR/docs/migrations"
+DOC_FILE="$MIGRATIONS_DIR/${DATE_SLUG}-upgrade.md"
+
+mkdir -p "$MIGRATIONS_DIR"
+
+# ── Render Markdown ───────────────────────────────────────────────────────────
+
+{
+  printf '# Upgrade Migration Log\n\n'
+  printf 'Generated: %s\n\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || printf 'unknown')"
+
+  hop_count="$(jq 'length' "$REPORT_FILE")"
+  i=0
+  while [ "$i" -lt "$hop_count" ]; do
+    framework="$(jq -r ".[$i].framework" "$REPORT_FILE")"
+    from_ver="$(jq -r ".[$i].from" "$REPORT_FILE")"
+    to_ver="$(jq -r ".[$i].to" "$REPORT_FILE")"
+    residual_risk="$(jq -r ".[$i].residual_risk" "$REPORT_FILE")"
+
+    printf '## %s %s → %s\n\n' "$framework" "$from_ver" "$to_ver"
+
+    printf '### Versions\n\n'
+    printf '%s\n' "- **Before:** $framework $from_ver"
+    printf '%s\n\n' "- **After:** $framework $to_ver"
+
+    printf '### Codemods Applied\n\n'
+    codemod_count="$(jq ".[$i].codemods | length" "$REPORT_FILE")"
+    if [ "$codemod_count" -eq 0 ]; then
+      printf '_None_\n\n'
+    else
+      j=0
+      while [ "$j" -lt "$codemod_count" ]; do
+        codemod="$(jq -r ".[$i].codemods[$j]" "$REPORT_FILE")"
+        printf '%s\n' "- $codemod"
+        j=$((j + 1))
+      done
+      printf '\n'
+    fi
+
+    printf '### Manual Fixes\n\n'
+    fix_count="$(jq ".[$i].manual_fixes | length" "$REPORT_FILE")"
+    if [ "$fix_count" -eq 0 ]; then
+      printf '_None_\n\n'
+    else
+      k=0
+      while [ "$k" -lt "$fix_count" ]; do
+        fix="$(jq -r ".[$i].manual_fixes[$k]" "$REPORT_FILE")"
+        printf '%s\n' "- $fix"
+        k=$((k + 1))
+      done
+      printf '\n'
+    fi
+
+    printf '### Residual Risk\n\n'
+    if [ -z "$residual_risk" ] || [ "$residual_risk" = "null" ]; then
+      printf '_None identified_\n\n'
+    else
+      printf '%s\n\n' "$residual_risk"
+    fi
+
+    i=$((i + 1))
+  done
+} > "$DOC_FILE"
+
+# ── Compose autospec-doc --full ───────────────────────────────────────────────
+
+if command -v autospec-doc > /dev/null 2>&1; then
+  autospec-doc --full "$DOC_FILE" || true
+fi
+
+# ── Report output path ────────────────────────────────────────────────────────
+
+printf '%s\n' "$DOC_FILE"

--- a/skills/autospec-upgrade/tests/fixtures/migration-doc/upgrade-report.json
+++ b/skills/autospec-upgrade/tests/fixtures/migration-doc/upgrade-report.json
@@ -1,0 +1,27 @@
+[
+  {
+    "framework": "angular",
+    "from": "20",
+    "to": "21",
+    "codemods": [
+      "ng update @angular/core@21 @angular/cli@21",
+      "ng generate @angular/core:standalone"
+    ],
+    "manual_fixes": [
+      "Migrate deprecated NgModule imports to standalone imports in app.module.ts"
+    ],
+    "residual_risk": "Lazy-loaded modules with custom injectors require manual review"
+  },
+  {
+    "framework": "angular",
+    "from": "21",
+    "to": "22",
+    "codemods": [
+      "ng update @angular/core@22 @angular/cli@22"
+    ],
+    "manual_fixes": [
+      "Update signal-based component lifecycle hooks in shared/header.component.ts"
+    ],
+    "residual_risk": "Signal-based reactivity patterns may behave differently in edge cases"
+  }
+]

--- a/skills/autospec-upgrade/tests/migration-doc.bats
+++ b/skills/autospec-upgrade/tests/migration-doc.bats
@@ -1,0 +1,218 @@
+#!/usr/bin/env bats
+# migration-doc.bats — TDD suite for migration-doc.sh (issue #1183)
+# Mocks autospec-doc via $TMP/bin PATH shim. Uses real jq. No network.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/migration-doc.sh"
+FIXTURE_DIR="${BATS_TEST_DIRNAME}/fixtures/migration-doc"
+
+# ── Setup / teardown ──────────────────────────────────────────────────────────
+
+setup() {
+  TEST_ROOT="$(mktemp -d /tmp/md-test-root.XXXXXX)"
+  MOCK_BIN="$(mktemp -d /tmp/md-mock-bin.XXXXXX)"
+  AUTOSPEC_DOC_LOG="$MOCK_BIN/autospec-doc-calls.txt"
+  touch "$AUTOSPEC_DOC_LOG"
+  export TEST_ROOT MOCK_BIN AUTOSPEC_DOC_LOG
+
+  # Install autospec-doc mock that records invocations
+  cat > "$MOCK_BIN/autospec-doc" <<'MOCKEOF'
+#!/usr/bin/env bash
+# Mock autospec-doc — records all args to $AUTOSPEC_DOC_LOG
+printf '%s\n' "$*" >> "$AUTOSPEC_DOC_LOG"
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/autospec-doc"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT" "$MOCK_BIN"
+}
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+run_migration_doc() {
+  run env PATH="$MOCK_BIN:$PATH" "$SCRIPT" "$@"
+}
+
+# ── Existence / executability ─────────────────────────────────────────────────
+
+@test "migration-doc.sh exists and is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+# ── One section per hop ───────────────────────────────────────────────────────
+
+@test "generates one ## heading per hop in the report" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  local doc_file
+  doc_file="$(find "$TEST_ROOT" -name '*.md' | head -1)"
+  [ -n "$doc_file" ]
+  local heading_count
+  heading_count="$(grep -c '^## ' "$doc_file")"
+  [ "$heading_count" -eq 2 ]
+}
+
+@test "heading for first hop mentions angular and version range 20 to 21" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  local doc_file
+  doc_file="$(find "$TEST_ROOT" -name '*.md' | head -1)"
+  grep -qi 'angular' "$doc_file"
+  grep -q '20' "$doc_file"
+  grep -q '21' "$doc_file"
+}
+
+@test "heading for second hop mentions version range 21 to 22" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  local doc_file
+  doc_file="$(find "$TEST_ROOT" -name '*.md' | head -1)"
+  grep -q '22' "$doc_file"
+}
+
+# ── Required fields in each section ──────────────────────────────────────────
+
+@test "document contains codemods label" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  local doc_file
+  doc_file="$(find "$TEST_ROOT" -name '*.md' | head -1)"
+  grep -qi 'codemod' "$doc_file"
+}
+
+@test "document lists the first codemod value from fixture" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  local doc_file
+  doc_file="$(find "$TEST_ROOT" -name '*.md' | head -1)"
+  grep -q 'ng update @angular/core@21' "$doc_file"
+}
+
+@test "document contains manual_fixes label" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  local doc_file
+  doc_file="$(find "$TEST_ROOT" -name '*.md' | head -1)"
+  grep -qi 'manual' "$doc_file"
+}
+
+@test "document lists a manual_fix value from fixture" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  local doc_file
+  doc_file="$(find "$TEST_ROOT" -name '*.md' | head -1)"
+  grep -q 'NgModule' "$doc_file"
+}
+
+@test "document contains residual_risk label" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  local doc_file
+  doc_file="$(find "$TEST_ROOT" -name '*.md' | head -1)"
+  grep -qi 'residual' "$doc_file"
+}
+
+@test "document lists the residual_risk value from first hop" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  local doc_file
+  doc_file="$(find "$TEST_ROOT" -name '*.md' | head -1)"
+  grep -q 'Lazy-loaded modules' "$doc_file"
+}
+
+@test "document contains before/after version information label" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  local doc_file
+  doc_file="$(find "$TEST_ROOT" -name '*.md' | head -1)"
+  grep -qi 'before\|from\|version' "$doc_file"
+}
+
+# ── autospec-doc composition asserted via mock ────────────────────────────────
+
+@test "composes autospec-doc (mock was invoked)" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  [ -s "$AUTOSPEC_DOC_LOG" ]
+}
+
+@test "composes autospec-doc with --full flag" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  grep -q -- '--full' "$AUTOSPEC_DOC_LOG"
+}
+
+# ── Output file location ──────────────────────────────────────────────────────
+
+@test "writes markdown doc under --out directory" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  local doc_count
+  doc_count="$(find "$TEST_ROOT" -name '*.md' | wc -l | tr -d ' ')"
+  [ "$doc_count" -ge 1 ]
+}
+
+@test "doc path is printed to stdout" {
+  run_migration_doc \
+    --report "$FIXTURE_DIR/upgrade-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -q '\.md'
+}
+
+# ── Error handling ────────────────────────────────────────────────────────────
+
+@test "exits non-zero when --report file is missing" {
+  run_migration_doc \
+    --report "$TEST_ROOT/nonexistent-report.json" \
+    --out "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+}
+
+@test "exits non-zero when --report is not valid JSON" {
+  local bad_json="$TEST_ROOT/bad.json"
+  printf 'not json at all\n' > "$bad_json"
+  run_migration_doc \
+    --report "$bad_json" \
+    --out "$TEST_ROOT"
+  [ "$status" -ne 0 ]
+}
+
+@test "default report path is .autospec/upgrade-report.json under root when no --report given" {
+  mkdir -p "$TEST_ROOT/.autospec"
+  cp "$FIXTURE_DIR/upgrade-report.json" "$TEST_ROOT/.autospec/upgrade-report.json"
+  run_migration_doc \
+    --root "$TEST_ROOT" \
+    --out "$TEST_ROOT"
+  [ "$status" -eq 0 ]
+  local doc_file
+  doc_file="$(find "$TEST_ROOT" -name '*.md' | head -1)"
+  [ -n "$doc_file" ]
+}


### PR DESCRIPTION
Closes #1183

Adds `migration-doc.sh`: reads `.autospec/upgrade-report.json` and renders a per-hop Markdown migration log (`## <fw> <from> → <to>` listing what changed / before-after / codemods / manual fixes / residual risk), then **composes `autospec-doc --full`** to finalize it, writing under the docs target (never the repo's tracked `docs/specs/`).

## Verification
- `bats skills/autospec-upgrade/tests/migration-doc.bats` — 18/18 (one ## section per hop; all required field labels + fixture values; autospec-doc composed with --full asserted via the mock; missing/invalid report → exit≠0). `autospec-doc` mocked via $TMP/bin, real jq.
- `bash scripts/validate.sh` — exit 0.