### PR TITLE
fix(autospec-upgrade): Phase 5.5 audit remediation — behavior-lock mutation-gate resolution (#1185)

### DIFF
--- a/skills/autospec-upgrade/scripts/behavior-lock.sh
+++ b/skills/autospec-upgrade/scripts/behavior-lock.sh
@@ -104,12 +104,18 @@ fi
 
 # ── Resolve helper paths ──────────────────────────────────────────────────────
 
-# mutation-gate.sh: look in same scripts/ dir first, then PATH
+# mutation-gate.sh resolution: prefer an explicit AUTOSPEC_SCRIPTS_DIR (set by the
+# orchestrator / installed location), then PATH, then the co-located source sibling.
+# AUTOSPEC_SCRIPTS_DIR/PATH must win over the source sibling so the orchestrator's
+# configured gate — and a test's $TMP/bin mock — are honored rather than silently
+# bypassed by the in-tree sibling (Phase 5.5 audit #1185).
 MUTATION_GATE=""
-if [ -x "$SCRIPT_DIR/mutation-gate.sh" ]; then
-  MUTATION_GATE="$SCRIPT_DIR/mutation-gate.sh"
+if [ -n "${AUTOSPEC_SCRIPTS_DIR:-}" ] && [ -x "${AUTOSPEC_SCRIPTS_DIR}/mutation-gate.sh" ]; then
+  MUTATION_GATE="${AUTOSPEC_SCRIPTS_DIR}/mutation-gate.sh"
 elif command -v mutation-gate.sh >/dev/null 2>&1; then
   MUTATION_GATE="mutation-gate.sh"
+elif [ -x "$SCRIPT_DIR/mutation-gate.sh" ]; then
+  MUTATION_GATE="$SCRIPT_DIR/mutation-gate.sh"
 fi
 
 # ── Step 1: characterize — run autospec-test + autospec-playwright ────────────


### PR DESCRIPTION
Closes #1185

**Phase 5.5 broad integration audit** of the merged autospec-upgrade epic (#1172–1184). The audit ran the *full* upgrade bats suite together and found **4 failures** that every per-issue run + per-issue validate missed:

### Finding (HIGH, fixed here)
`behavior-lock.bats`' 4 'locked' tests were green when #1174 landed (`mutation-gate.sh` didn't exist → behavior-lock's stub path), then silently went **RED** once #1175 added the real `mutation-gate.sh` sibling: behavior-lock resolved `$SCRIPT_DIR/mutation-gate.sh` (real sibling) **before** the PATH/$TMP/bin mock, so the test's mock was bypassed and the real gate's unmocked `npx stryker` failed. Fix: resolve mutation-gate via `AUTOSPEC_SCRIPTS_DIR` → PATH → in-tree sibling (consistent with the engine/orchestrator; the orchestrator's configured gate and a test mock now win over the source sibling).

### Other audited seams — CLEAN
- compute-steps JSON `{hops}` consumed correctly by the engine (#1180).
- engine tag idempotency (post-upgrade tag skip) + bounded fix-loop + last-green-tag.
- tag-upgrade post-tag-withhold reads the mutation-proof gate.
- detect unknown-stack → `frameworks:["unknown"]` exit 0 (per AC; flagged for the engine to treat as 'do not upgrade').

### Coverage gap → follow-up #1211
`validate.sh` does not run `skills/autospec-upgrade/tests/`, which is *why* this hid. Filed #1211 (operator review) to wire the upgrade tests + a contract gate into validate.

## Verification
- `bats skills/autospec-upgrade/tests/` (full suite together) — **239/239 green** (was 235/239). behavior-lock 12/12.
- `bash scripts/validate.sh` — exit 0.