### PR TITLE
feat(validate): run autospec-upgrade test suite + contract gate (#1211)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -2788,6 +2788,7 @@ main() {
     check_derive_trio_consistency
     check_claim_guard_contract
     check_autospec_harmonize_contract
+    check_autospec_upgrade_contract
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.
@@ -3866,6 +3867,31 @@ check_autospec_harmonize_contract() {
             || fail "$f: missing 'AskUserQuestion' pick gate reference (issue #1146)"
         grep -q '/autospec-define' "$f" \
             || fail "$f: missing '/autospec-define' handoff (issue #1146)"
+    done
+}
+
+check_autospec_upgrade_contract() {
+    info "autospec-upgrade contract: trio phase tokens + full bats suite (issue #1211/#1185)"
+    local skill_dir="skills/autospec-upgrade"
+    for f in "$skill_dir/SKILL.md" \
+              "$skill_dir/codex/prompt.md" \
+              "$skill_dir/opencode/agent.md"; do
+        [ -f "$f" ] || fail "$f: required trio file missing (issue #1211)"
+        for token in detect behavior-lock mutation codemod orchestrat; do
+            grep -qi "$token" "$f" \
+                || fail "$f: missing pipeline token '$token' (issue #1211)"
+        done
+    done
+    # Run the autospec-upgrade bats suite. Previously NO validate gate ran these
+    # tests, which is exactly why the #1185 behavior-lock landed-order regression
+    # (green in isolation, red once mutation-gate.sh landed) went undetected.
+    local t name
+    for t in "$skill_dir"/tests/*.bats; do
+        [ -f "$t" ] || continue
+        name="$(basename "$t")"
+        info "  running: $t"
+        bats "$t" >"/tmp/validate-upgrade-$name.log" 2>&1 \
+            || { cat "/tmp/validate-upgrade-$name.log" >&2; fail "$t: failed"; }
     done
 }
 


### PR DESCRIPTION
Closes #1211

Adds `check_autospec_upgrade_contract` to `scripts/validate.sh` (registered in the run list):
- Greps the autospec-upgrade trio (SKILL.md + codex + opencode) for the phase/pipeline tokens `detect`/`behavior-lock`/`mutation`/`codemod`/`orchestrat`.
- **Runs every `skills/autospec-upgrade/tests/*.bats`** (13 suites).

**Why:** validate previously ran NO autospec-upgrade tests — the systemic gap that let the #1185 behavior-lock landed-order regression hide (green in isolation, red once #1175's `mutation-gate.sh` sibling landed). validate now catches such regressions.

## Verification
- `bash scripts/validate.sh` — exit 0; output shows `autospec-upgrade contract: ...` + `running: skills/autospec-upgrade/tests/*.bats` for all 13 suites.

Note: the harmonize tests (tests/harmonize/) similarly have only a grep contract gate, not a bats run, in validate — a related observation outside this issue's scope; can be a future follow-up if desired.