### PR TITLE
fix(autospec-doc): ship full doc-orchestrator module closure (doc-scaffold + doc-coverage) and fix flat entry

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -918,7 +918,7 @@ skills/autospec-run/scripts/list-ready-issues.sh::list-ready-issues.sh \
 skills/autospec-run/scripts/post-token-report.sh::post-token-report.sh \
 skills/autospec-run/scripts/release-issue.sh::release-issue.sh \
 skills/autospec-resume/scripts/resume-scan.sh::resume-scan.sh \
-skills/autospec-doc/scripts/doc-orchestrator.mjs::doc-orchestrator.mjs \
+skills/autospec-doc/scripts/doc-orchestrator-entry.mjs::doc-orchestrator.mjs \
 skills/autospec-sweep/scripts/run.sh::autospec-sweep-run.sh \
 skills/autospec-sweep/scripts/wizard.sh::autospec-sweep-wizard.sh"
 
@@ -930,13 +930,24 @@ skills/autospec-sweep/scripts/wizard.sh::autospec-sweep-wizard.sh"
     #   <base>/autospec-doc/scripts/   (so ../../ reaches <base>/)
     # with the shared scripts mirrored at <base>/autospec-shared/scripts/.
     # We use $autospec_scripts_dir/../skills/ as <base>, giving:
-    #   ~/.autospec/skills/autospec-doc/scripts/       — the six module files
+    #   ~/.autospec/skills/autospec-doc/scripts/       — the module closure
     #   ~/.autospec/skills/autospec-shared/scripts/    — the shared deps mirror
-    # doc-orchestrator.mjs is ALSO copied to the flat $autospec_scripts_dir/ entry
-    # point (above) for backward-compatible invocations via ${AUTOSPEC_SCRIPTS_DIR}.
+    # A delegating shim (doc-orchestrator-entry.mjs) is installed flat at
+    # $autospec_scripts_dir/doc-orchestrator.mjs (above) for backward-compatible
+    # ${AUTOSPEC_SCRIPTS_DIR} invocations; it re-execs the subtree orchestrator. A
+    # flat copy of the real orchestrator can never resolve its two-level shared import.
+    #
+    # This list MUST contain doc-orchestrator.mjs's full transitive ./ import closure:
+    #   doc-orchestrator -> doc-config, doc-scaffold, gen-llms-full, gen-audience-docs, doc-coverage
+    #   doc-scaffold     -> doc-config
+    #   gen-audience-docs -> doc-style (+ ../../autospec-shared/scripts)
+    # Omitting any of these crashes the orchestrator at module-load (ERR_MODULE_NOT_FOUND).
+    # tests/ship-completeness.bats enforces this against the static import graph.
     autospec_doc_scripts="\
 skills/autospec-doc/scripts/doc-orchestrator.mjs \
 skills/autospec-doc/scripts/doc-config.mjs \
+skills/autospec-doc/scripts/doc-scaffold.mjs \
+skills/autospec-doc/scripts/doc-coverage.mjs \
 skills/autospec-doc/scripts/doc-style.mjs \
 skills/autospec-doc/scripts/gen-audience-docs.mjs \
 skills/autospec-doc/scripts/gen-llms-full.mjs \

--- a/skills/autospec-doc/scripts/doc-orchestrator-entry.mjs
+++ b/skills/autospec-doc/scripts/doc-orchestrator-entry.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Flat entry-point shim for the autospec-doc orchestrator.
+//
+// Installed as ${AUTOSPEC_SCRIPTS_DIR}/doc-orchestrator.mjs (the path skill
+// surfaces invoke by convention). The real orchestrator and its ES-module
+// closure (doc-config, doc-scaffold, gen-llms-full, gen-audience-docs,
+// doc-coverage, doc-style) live in the two-level subtree
+// ${AUTOSPEC_SCRIPTS_DIR}/../skills/autospec-doc/scripts/ — they MUST live there
+// so gen-audience-docs.mjs's path.resolve(__dirname, '../../autospec-shared/scripts')
+// resolves at runtime. A flat copy of the orchestrator can never satisfy that
+// closure, so the flat entry delegates here, preserving argv, stdio, and exit code.
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const real = path.resolve(here, '..', 'skills', 'autospec-doc', 'scripts', 'doc-orchestrator.mjs');
+const result = spawnSync(process.execPath, [real, ...process.argv.slice(2)], { stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/tests/ship-completeness.bats
+++ b/tests/ship-completeness.bats
@@ -152,3 +152,48 @@ is_shipped() {
     false
   }
 }
+
+# --- autospec-doc ES-module closure (the doc-orchestrator regression) ----------
+# The orchestrator's relative `./*.mjs` imports must ALL be shipped into the
+# subtree, else it crashes at module-load (ERR_MODULE_NOT_FOUND). The generic
+# ${AUTOSPEC_SCRIPTS_DIR} guard above can't see static ES imports, so check the
+# import graph directly. This is the bug where doc-scaffold.mjs + doc-coverage.mjs
+# were omitted from install.sh's autospec_doc_scripts closure list.
+
+@test "autospec-doc orchestrator import closure is fully shipped by install.sh" {
+  scripts_dir="$REPO_ROOT/skills/autospec-doc/scripts"
+  seen=" "
+  queue="doc-orchestrator.mjs"
+  closure=""
+  while [ -n "$queue" ]; do
+    next=""
+    for m in $queue; do
+      case "$seen" in *" $m "*) continue ;; esac
+      seen="$seen$m "
+      closure="$closure $m"
+      imports="$(grep -hoE "from '\./[a-z-]+\.mjs'" "$scripts_dir/$m" 2>/dev/null | sed "s#from '\./##;s#'##")"
+      next="$next $imports"
+    done
+    queue="$next"
+  done
+  shipped="$(grep -oE 'skills/autospec-doc/scripts/[a-z-]+\.mjs' "$REPO_ROOT/install.sh" | sed 's#.*/##' | sort -u)"
+  missing=""
+  for m in $closure; do
+    printf '%s\n' "$shipped" | grep -qx "$m" || missing="$missing $m"
+  done
+  [ -z "$missing" ] || { echo "Unshipped doc-orchestrator closure modules:$missing" >&2; false; }
+}
+
+@test "autospec-doc flat entry is the delegating shim (not the real orchestrator)" {
+  # The flat ${AUTOSPEC_SCRIPTS_DIR}/doc-orchestrator.mjs must be the shim, since a
+  # flat copy of the real orchestrator can't resolve gen-audience-docs' two-level
+  # ../../autospec-shared/scripts import.
+  run grep -qE 'skills/autospec-doc/scripts/doc-orchestrator-entry\.mjs::doc-orchestrator\.mjs' "$REPO_ROOT/install.sh"
+  [ "$status" -eq 0 ]
+  [ -f "$REPO_ROOT/skills/autospec-doc/scripts/doc-orchestrator-entry.mjs" ]
+  # The shim builds the subtree path from segments and re-execs it.
+  run grep -qE "spawnSync" "$REPO_ROOT/skills/autospec-doc/scripts/doc-orchestrator-entry.mjs"
+  [ "$status" -eq 0 ]
+  run grep -qE "autospec-doc" "$REPO_ROOT/skills/autospec-doc/scripts/doc-orchestrator-entry.mjs"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Problem

`/autospec-doc` is unrunnable for every non-`init` subcommand — the installed
orchestrator crashes at module-load:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../doc-scaffold.mjs'
  imported from .../doc-orchestrator.mjs
```

Two install bugs, both in `install.sh`:

1. **Incomplete module closure.** `doc-orchestrator.mjs` statically imports
   `doc-config`, `doc-scaffold`, `gen-llms-full`, `gen-audience-docs`,
   `doc-coverage`; `doc-scaffold` imports `doc-config`; `gen-audience-docs`
   imports `doc-style` (+ `../../autospec-shared/scripts`). The
   `autospec_doc_scripts` list shipped only 6 of the 8 modules — **`doc-scaffold.mjs`
   and `doc-coverage.mjs` were missing**, so the subtree orchestrator dies on import.

2. **Broken flat entry point.** The flat `${AUTOSPEC_SCRIPTS_DIR}/doc-orchestrator.mjs`
   — the path skill surfaces invoke by convention — was a *copy* of the real
   orchestrator. A flat copy can never resolve `gen-audience-docs.mjs`'s two-level
   `path.resolve(__dirname, '../../autospec-shared/scripts')`, so the flat path
   crashes even with the closure complete.

The modules themselves are fine — running `doc-orchestrator.mjs` from the repo
checkout works. It's purely a shipping bug.

## Fix

- `install.sh`: add `doc-scaffold.mjs` + `doc-coverage.mjs` to the closure list.
- Replace the flat entry with a **delegating shim** (`doc-orchestrator-entry.mjs`)
  that re-execs the subtree orchestrator, preserving argv / stdio / exit code.
- `tests/ship-completeness.bats`: new guard that computes the orchestrator's
  transitive `./*.mjs` import closure and asserts `install.sh` ships all of it,
  plus that the flat entry is the shim. The existing `${AUTOSPEC_SCRIPTS_DIR}`
  guard couldn't catch this — it doesn't see static ES imports.

## Verification

Ran the **real installer** into a throwaway `HOME` (`install.sh --harness claude
--update`, 26/26 pairs OK), then:

- flat `${AUTOSPEC_SCRIPTS_DIR}/doc-orchestrator.mjs --help` → exit 0
- subtree `doc-orchestrator.mjs --help` → exit 0
- flat shim `--audit` in a real repo → runs the full pipeline to the expected
  `no documentation: config found ... Run /autospec-doc init first` message
- `bats tests/ship-completeness.bats` → 5/5 pass (incl. the 2 new guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
