### PR TITLE
feat(autospec-fab): model + release-gate JSON schemas + bats

### DIFF
--- a/schemas/autospec-fab-model.schema.json
+++ b/schemas/autospec-fab-model.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-fab-model.schema.json",
+  "title": "autospec-fab model sidecar",
+  "description": "Per-model metadata sidecar describing geometry, material, ports, gaskets, and gate flags for the autospec-fab pipeline.",
+  "type": "object",
+  "required": ["material", "print_orientation", "load_critical", "flow_critical"],
+  "additionalProperties": false,
+  "properties": {
+    "material": {
+      "type": "string",
+      "description": "Filament or resin material designation (e.g. PETG, ABS, ASA)."
+    },
+    "print_orientation": {
+      "type": "string",
+      "description": "Recommended print orientation (e.g. flat, upright, side)."
+    },
+    "load_critical": {
+      "type": "boolean",
+      "description": "True when the part bears structural load and must pass FEA stage."
+    },
+    "flow_critical": {
+      "type": "boolean",
+      "description": "True when the part is in the vacuum/air-flow circuit and must pass CFD stage."
+    },
+    "dims": {
+      "type": "object",
+      "description": "Bounding-box dimensions in millimetres.",
+      "additionalProperties": false,
+      "properties": {
+        "x_mm": { "type": "number" },
+        "y_mm": { "type": "number" },
+        "z_mm": { "type": "number" }
+      }
+    },
+    "ports": {
+      "type": "array",
+      "description": "Fluid/vacuum port definitions (NPT, hose, socket).",
+      "items": {
+        "type": "object",
+        "required": ["id", "type"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string", "description": "Unique port identifier within this model." },
+          "type": {
+            "type": "string",
+            "enum": ["npt", "hose", "socket"],
+            "description": "Port connection type."
+          },
+          "size": { "type": "string", "description": "Thread or diameter designation (e.g. 1/4, 25mm)." },
+          "clearance_mm": { "type": "number", "description": "Minimum tool-access clearance in mm." }
+        }
+      }
+    },
+    "gaskets": {
+      "type": "array",
+      "description": "Gasket / O-ring groove definitions.",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string", "description": "Unique gasket identifier within this model." },
+          "groove": { "type": "string", "description": "Groove profile type (e.g. o-ring, flat, dovetail)." },
+          "surrounding_wall_mm": {
+            "type": "number",
+            "description": "Minimum plastic wall surrounding the gasket groove in mm (gate requires ≥5 mm)."
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/autospec-fab-release-gate.schema.json
+++ b/schemas/autospec-fab-release-gate.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-fab-release-gate.schema.json",
+  "title": "autospec-fab release-gate",
+  "description": "Aggregated release-gate report for the autospec-fab pipeline (.autospec/fab/release-gate.json). Stages are written by individual stage scripts and aggregated by the engine.",
+  "type": "object",
+  "required": ["schema_version", "stages"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": 1,
+      "description": "Schema version; always 1 for this revision."
+    },
+    "name": {
+      "type": "string",
+      "description": "Optional model name this gate report is for (set by the engine, #1234)."
+    },
+    "geometry_hash": {
+      "type": "string",
+      "description": "Optional geometry hash of the model (engine #1234) feeding the FEA/CFD freshness cache."
+    },
+    "stages": {
+      "type": "array",
+      "description": "Ordered list of stage records, one per fab pipeline stage.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["stage", "status"],
+        "additionalProperties": false,
+        "properties": {
+          "stage": {
+            "type": "string",
+            "description": "Stage name (e.g. geometry, metadata, vacuum-fitting)."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pass", "fail", "warn", "skip"],
+            "description": "Outcome of the stage run."
+          },
+          "detail": {
+            "type": "string",
+            "description": "Human-readable summary of the stage outcome."
+          },
+          "findings": {
+            "type": "array",
+            "description": "Structured findings emitted by the stage (code_health ids etc.).",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      }
+    },
+    "freshness": {
+      "type": "object",
+      "description": "Geometry-hash cache state used to decide whether FEA/CFD results are still fresh.",
+      "additionalProperties": true
+    },
+    "fea_results": {
+      "type": "object",
+      "description": "CalculiX FEA results summary for load-critical parts.",
+      "additionalProperties": true
+    },
+    "cfd_results": {
+      "type": "object",
+      "description": "OpenFOAM CFD results summary for flow-critical parts.",
+      "additionalProperties": true
+    },
+    "vision_findings": {
+      "type": "array",
+      "description": "Advisory observations from the vision stage (never blocking).",
+      "items": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/tests/fab/test_schemas.bats
+++ b/tests/fab/test_schemas.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  MODEL_SCHEMA="$REPO_ROOT/schemas/autospec-fab-model.schema.json"
+  GATE_SCHEMA="$REPO_ROOT/schemas/autospec-fab-release-gate.schema.json"
+  TEST_TMPDIR="$(mktemp -d /tmp/autospec-fab-schemas-XXXXXX)"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+@test "fab-model schema accepts a minimal valid model sidecar" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (install ajv-cli to run this test)"
+
+  cat > "$TEST_TMPDIR/model-ok.json" <<'JSON'
+{
+  "material": "PETG",
+  "print_orientation": "flat",
+  "load_critical": false,
+  "flow_critical": true,
+  "dims": { "x_mm": 80, "y_mm": 60, "z_mm": 40 },
+  "ports": [
+    { "id": "inlet", "type": "npt", "size": "1/4", "clearance_mm": 6.0 }
+  ],
+  "gaskets": [
+    { "id": "main_seal", "groove": "o-ring", "surrounding_wall_mm": 5.5 }
+  ]
+}
+JSON
+
+  run ajv validate -s "$MODEL_SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/model-ok.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "fab-model schema rejects a sidecar missing required field material" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (install ajv-cli to run this test)"
+
+  cat > "$TEST_TMPDIR/model-bad.json" <<'JSON'
+{
+  "print_orientation": "flat",
+  "load_critical": false,
+  "flow_critical": true
+}
+JSON
+
+  run ajv validate -s "$MODEL_SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/model-bad.json"
+  [ "$status" -ne 0 ]
+}
+
+@test "fab-release-gate schema accepts a minimal valid release-gate" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (install ajv-cli to run this test)"
+
+  cat > "$TEST_TMPDIR/gate-ok.json" <<'JSON'
+{
+  "schema_version": 1,
+  "stages": [
+    { "stage": "geometry", "status": "pass", "detail": "Watertight and single body" }
+  ]
+}
+JSON
+
+  run ajv validate -s "$GATE_SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/gate-ok.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "fab-release-gate schema rejects a stage with an invalid status enum value" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (install ajv-cli to run this test)"
+
+  cat > "$TEST_TMPDIR/gate-bad-status.json" <<'JSON'
+{
+  "schema_version": 1,
+  "stages": [
+    { "stage": "geometry", "status": "error" }
+  ]
+}
+JSON
+
+  run ajv validate -s "$GATE_SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/gate-bad-status.json"
+  [ "$status" -ne 0 ]
+}
+
+@test "fab-release-gate schema rejects a gate with empty stages array" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (install ajv-cli to run this test)"
+
+  cat > "$TEST_TMPDIR/gate-empty-stages.json" <<'JSON'
+{
+  "schema_version": 1,
+  "stages": []
+}
+JSON
+
+  run ajv validate -s "$GATE_SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/gate-empty-stages.json"
+  [ "$status" -ne 0 ]
+}
+
+@test "fab-release-gate schema rejects a gate missing stages entirely" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (install ajv-cli to run this test)"
+
+  cat > "$TEST_TMPDIR/gate-no-stages.json" <<'JSON'
+{
+  "schema_version": 1
+}
+JSON
+
+  run ajv validate -s "$GATE_SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/gate-no-stages.json"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Closes #1219

Adds the two shared autospec-fab schemas (draft-2020-12, repo style):
- `autospec-fab-model.schema.json` — per-model metadata sidecar (required `material`/`print_orientation`/`load_critical`/`flow_critical`; optional `dims`/`ports[]`/`gaskets[]` with typed items).
- `autospec-fab-release-gate.schema.json` — `.autospec/fab/release-gate.json` (required `schema_version`=1 + `stages[]` of `{stage,status:pass|fail|warn|skip,detail?,findings?}`; optional `freshness`/`fea_results`/`cfd_results`/`vision_findings` + optional `name`/`geometry_hash`).

**Contract reconciliation:** the issue body wanted `name`/`geometry_hash` required; the shared-contracts block omitted them. Made them **optional** (superset) so the engine (#1234) can write them without tripping `additionalProperties:false` — avoids a latent Phase-5.5 integration trap.

## Verification
- `bats tests/fab/test_schemas.bats` — 6/6 (valid+invalid for each schema; a gate with name/geometry_hash validates). Real ajv, `--spec=draft2020`.
- `bash scripts/validate.sh` — exit 0.