### PR TITLE
feat(autospec-fab): .autospec/fab.yml loader + contract doc

### DIFF
--- a/skills/autospec-fab/README.md
+++ b/skills/autospec-fab/README.md
@@ -35,6 +35,75 @@ Target repos opt in via `.autospec/fab.yml`.
 | [`autospec-qa`](../autospec-qa/README.md) | Post-gate no-mock smoke + proof artifacts. |
 | [`autospec-doc`](../autospec-doc/README.md) | Docs/PDF sync and `NO_HANDEDIT_GENERATED` guard. |
 
+## .autospec/fab.yml
+
+Target repositories opt in to `autospec-fab` by placing a `.autospec/fab.yml`
+file at their root. The loader `skills/autospec-fab/scripts/load-fab-config.sh`
+parses this file and emits normalized JSON with defaults applied.
+
+### Shape
+
+```yaml
+# Entrypoint command that regenerates all STL artifacts from source.
+# REQUIRED for --validate.
+generator: "rm -rf build && .venv/bin/python src/generate.py"
+
+# Directories to scan for output STL files.
+# Default: ["build/stls/manifolds/"]
+stl_roots:
+  - "build/stls/manifolds/"
+  - "catalog/manifolds/"
+
+# FDM printer profile used by the slicer stage.
+# All fields default if the printer key is absent.
+printer:
+  nozzle_width: 0.4      # default: 0.4 mm
+  layer_height: 0.2      # default: 0.2 mm
+  min_perimeters: 3      # default: 3
+  max_overhang_deg: 45   # default: 45 degrees
+
+# Path template to per-model metadata sidecar JSON files.
+# Optional; null if absent.
+metadata_sidecar: "manifolds/{name}/metadata.json"
+
+# List of models to gate. REQUIRED (non-empty) for --validate.
+models:
+  - name: "inlet_manifold"
+    stl: "build/stls/manifolds/inlet_manifold.stl"
+    metadata: "manifolds/inlet_manifold/metadata.json"
+    printable: true
+    load_critical: true   # gates FEA stage
+    flow_critical: false  # gates CFD stage
+```
+
+### Required keys (--validate mode)
+
+| Key | Requirement |
+| --- | --- |
+| `generator` | Must be present and non-empty |
+| `models` | Must be a non-empty list |
+
+### Defaults applied at load time
+
+| Key | Default value |
+| --- | --- |
+| `generator` | `rm -rf build && .venv/bin/python src/generate.py` |
+| `stl_roots` | `["build/stls/manifolds/"]` |
+| `printer.nozzle_width` | `0.4` |
+| `printer.layer_height` | `0.2` |
+| `printer.min_perimeters` | `3` |
+| `printer.max_overhang_deg` | `45` |
+
+### Loader CLI
+
+```bash
+# Emit normalized JSON (defaults applied):
+skills/autospec-fab/scripts/load-fab-config.sh .autospec/fab.yml
+
+# Strict validation (exits non-zero on missing required keys):
+skills/autospec-fab/scripts/load-fab-config.sh --validate .autospec/fab.yml
+```
+
 ## License
 
 MIT - see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autospec-fab/scripts/load-fab-config.sh
+++ b/skills/autospec-fab/scripts/load-fab-config.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# load-fab-config.sh — parse .autospec/fab.yml → normalized JSON on stdout.
+#
+# Usage:
+#   load-fab-config.sh [--validate] <path-to-fab.yml>
+#
+# Flags:
+#   --validate   Strict mode: exit non-zero (with message to stderr) when a
+#                required key is missing or models list is empty.
+#
+# Output:
+#   Normalized JSON to stdout with defaults applied:
+#     generator      default: "rm -rf build && .venv/bin/python src/generate.py"
+#     stl_roots      default: ["build/stls/manifolds/"]
+#     printer        defaults: nozzle_width=0.4, layer_height=0.2,
+#                              min_perimeters=3, max_overhang_deg=45
+#     metadata_sidecar  (passed through as-is; null if absent)
+#     models[]       (passed through as-is)
+#
+# Required by --validate: generator (non-empty), models (non-empty list).
+#
+# Exit codes:
+#   0  success
+#   1  usage / file-not-found / parse error / --validate failure
+
+set -uo pipefail
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+DEFAULT_GENERATOR="rm -rf build && .venv/bin/python src/generate.py"
+DEFAULT_STL_ROOTS='["build/stls/manifolds/"]'
+DEFAULT_NOZZLE_WIDTH="0.4"
+DEFAULT_LAYER_HEIGHT="0.2"
+DEFAULT_MIN_PERIMETERS="3"
+DEFAULT_MAX_OVERHANG_DEG="45"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+VALIDATE=0
+FAB_YML=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --validate)
+      VALIDATE=1
+      shift
+      ;;
+    -*)
+      printf 'load-fab-config: unknown flag: %s\n' "$1" >&2
+      exit 1
+      ;;
+    *)
+      FAB_YML="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$FAB_YML" ]; then
+  printf 'Usage: load-fab-config.sh [--validate] <path-to-fab.yml>\n' >&2
+  exit 1
+fi
+
+# ── Dependency checks ─────────────────────────────────────────────────────────
+
+if ! command -v yq >/dev/null 2>&1; then
+  printf 'load-fab-config: yq is required but not found in PATH\n' >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'load-fab-config: jq is required but not found in PATH\n' >&2
+  exit 1
+fi
+
+# ── File existence ────────────────────────────────────────────────────────────
+
+if [ ! -f "$FAB_YML" ]; then
+  printf 'load-fab-config: file not found: %s\n' "$FAB_YML" >&2
+  exit 1
+fi
+
+# ── Parse YAML → raw JSON via yq ─────────────────────────────────────────────
+
+RAW_JSON=""
+RAW_JSON="$(yq -o=json '.' "$FAB_YML" 2>&1)" || {
+  printf 'load-fab-config: failed to parse %s: %s\n' "$FAB_YML" "$RAW_JSON" >&2
+  exit 1
+}
+
+# ── Extract fields with defaults ──────────────────────────────────────────────
+
+# generator: use value from file if present and non-null/non-empty, else default
+GENERATOR="$(printf '%s' "$RAW_JSON" | jq -r '.generator // empty' 2>/dev/null || true)"
+if [ -z "$GENERATOR" ] || [ "$GENERATOR" = "null" ]; then
+  GENERATOR="$DEFAULT_GENERATOR"
+fi
+
+# stl_roots: use value from file if present and non-empty array, else default
+STL_ROOTS_LEN="$(printf '%s' "$RAW_JSON" | jq 'if .stl_roots and (.stl_roots | length) > 0 then 1 else 0 end' 2>/dev/null || printf '0')"
+if [ "$STL_ROOTS_LEN" -eq 1 ]; then
+  STL_ROOTS="$(printf '%s' "$RAW_JSON" | jq -c '.stl_roots')"
+else
+  STL_ROOTS="$DEFAULT_STL_ROOTS"
+fi
+
+# printer fields with per-key defaults
+PRINTER_NOZZLE="$(printf '%s' "$RAW_JSON" | jq -r '.printer.nozzle_width // empty' 2>/dev/null || true)"
+if [ -z "$PRINTER_NOZZLE" ] || [ "$PRINTER_NOZZLE" = "null" ]; then
+  PRINTER_NOZZLE="$DEFAULT_NOZZLE_WIDTH"
+fi
+
+PRINTER_LAYER="$(printf '%s' "$RAW_JSON" | jq -r '.printer.layer_height // empty' 2>/dev/null || true)"
+if [ -z "$PRINTER_LAYER" ] || [ "$PRINTER_LAYER" = "null" ]; then
+  PRINTER_LAYER="$DEFAULT_LAYER_HEIGHT"
+fi
+
+PRINTER_MIN_PERIM="$(printf '%s' "$RAW_JSON" | jq -r '.printer.min_perimeters // empty' 2>/dev/null || true)"
+if [ -z "$PRINTER_MIN_PERIM" ] || [ "$PRINTER_MIN_PERIM" = "null" ]; then
+  PRINTER_MIN_PERIM="$DEFAULT_MIN_PERIMETERS"
+fi
+
+PRINTER_MAX_OVERHANG="$(printf '%s' "$RAW_JSON" | jq -r '.printer.max_overhang_deg // empty' 2>/dev/null || true)"
+if [ -z "$PRINTER_MAX_OVERHANG" ] || [ "$PRINTER_MAX_OVERHANG" = "null" ]; then
+  PRINTER_MAX_OVERHANG="$DEFAULT_MAX_OVERHANG_DEG"
+fi
+
+# metadata_sidecar: pass through (may be null/absent)
+METADATA_SIDECAR="$(printf '%s' "$RAW_JSON" | jq -c '.metadata_sidecar // null')"
+
+# models: pass through (may be absent/null → empty array)
+MODELS_LEN="$(printf '%s' "$RAW_JSON" | jq 'if .models and (.models | type) == "array" then (.models | length) else 0 end' 2>/dev/null || printf '0')"
+if [ "$MODELS_LEN" -gt 0 ]; then
+  MODELS="$(printf '%s' "$RAW_JSON" | jq -c '.models')"
+else
+  MODELS="[]"
+fi
+
+# ── --validate strict checks ──────────────────────────────────────────────────
+
+if [ "$VALIDATE" -eq 1 ]; then
+  ERRORS=0
+
+  # Check generator is explicitly present in the file (not just defaulted)
+  FILE_GEN="$(printf '%s' "$RAW_JSON" | jq -r '.generator // empty' 2>/dev/null || true)"
+  if [ -z "$FILE_GEN" ] || [ "$FILE_GEN" = "null" ]; then
+    printf 'load-fab-config: --validate failed: required key "generator" is missing or empty\n' >&2
+    ERRORS=1
+  fi
+
+  # Check models is a non-empty list
+  if [ "$MODELS_LEN" -eq 0 ]; then
+    printf 'load-fab-config: --validate failed: "models" must be a non-empty list\n' >&2
+    ERRORS=1
+  fi
+
+  if [ "$ERRORS" -ne 0 ]; then
+    exit 1
+  fi
+fi
+
+# ── Emit normalized JSON ──────────────────────────────────────────────────────
+
+jq -cn \
+  --arg generator "$GENERATOR" \
+  --argjson stl_roots "$STL_ROOTS" \
+  --argjson nozzle_width "$PRINTER_NOZZLE" \
+  --argjson layer_height "$PRINTER_LAYER" \
+  --argjson min_perimeters "$PRINTER_MIN_PERIM" \
+  --argjson max_overhang_deg "$PRINTER_MAX_OVERHANG" \
+  --argjson metadata_sidecar "$METADATA_SIDECAR" \
+  --argjson models "$MODELS" \
+  '{
+    generator: $generator,
+    stl_roots: $stl_roots,
+    printer: {
+      nozzle_width: $nozzle_width,
+      layer_height: $layer_height,
+      min_perimeters: $min_perimeters,
+      max_overhang_deg: $max_overhang_deg
+    },
+    metadata_sidecar: $metadata_sidecar,
+    models: $models
+  }'

--- a/skills/autospec-fab/tests/fixtures/complete-fab.yml
+++ b/skills/autospec-fab/tests/fixtures/complete-fab.yml
@@ -1,0 +1,27 @@
+generator: "rm -rf build && .venv/bin/python src/generate.py"
+
+stl_roots:
+  - "build/stls/manifolds/"
+  - "catalog/manifolds/"
+
+printer:
+  nozzle_width: 0.6
+  layer_height: 0.3
+  min_perimeters: 4
+  max_overhang_deg: 40
+
+metadata_sidecar: "manifolds/{name}/metadata.json"
+
+models:
+  - name: "inlet_manifold"
+    stl: "build/stls/manifolds/inlet_manifold.stl"
+    metadata: "manifolds/inlet_manifold/metadata.json"
+    printable: true
+    load_critical: true
+    flow_critical: false
+  - name: "outlet_cap"
+    stl: "build/stls/manifolds/outlet_cap.stl"
+    metadata: "manifolds/outlet_cap/metadata.json"
+    printable: true
+    load_critical: false
+    flow_critical: true

--- a/skills/autospec-fab/tests/fixtures/empty-models-fab.yml
+++ b/skills/autospec-fab/tests/fixtures/empty-models-fab.yml
@@ -1,0 +1,12 @@
+generator: "rm -rf build && .venv/bin/python src/generate.py"
+
+stl_roots:
+  - "build/stls/manifolds/"
+
+printer:
+  nozzle_width: 0.4
+  layer_height: 0.2
+  min_perimeters: 3
+  max_overhang_deg: 45
+
+models: []

--- a/skills/autospec-fab/tests/fixtures/missing-generator-fab.yml
+++ b/skills/autospec-fab/tests/fixtures/missing-generator-fab.yml
@@ -1,0 +1,16 @@
+stl_roots:
+  - "build/stls/manifolds/"
+
+printer:
+  nozzle_width: 0.4
+  layer_height: 0.2
+  min_perimeters: 3
+  max_overhang_deg: 45
+
+models:
+  - name: "test_part"
+    stl: "build/stls/manifolds/test_part.stl"
+    metadata: "manifolds/test_part/metadata.json"
+    printable: true
+    load_critical: false
+    flow_critical: false

--- a/skills/autospec-fab/tests/fixtures/no-printer-fab.yml
+++ b/skills/autospec-fab/tests/fixtures/no-printer-fab.yml
@@ -1,0 +1,12 @@
+generator: "rm -rf build && .venv/bin/python src/generate.py"
+
+stl_roots:
+  - "build/stls/manifolds/"
+
+models:
+  - name: "test_part"
+    stl: "build/stls/manifolds/test_part.stl"
+    metadata: "manifolds/test_part/metadata.json"
+    printable: true
+    load_critical: false
+    flow_critical: false

--- a/skills/autospec-fab/tests/load-fab-config.bats
+++ b/skills/autospec-fab/tests/load-fab-config.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# load-fab-config.bats — TDD tests for skills/autospec-fab/scripts/load-fab-config.sh
+# Real yq required; tests skip if yq is absent.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+FIXTURE_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/fixtures" && pwd)"
+SCRIPT="$SCRIPT_DIR/load-fab-config.sh"
+
+setup() {
+    if ! command -v yq >/dev/null 2>&1; then
+        skip "yq not found — install yq to run these tests"
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        skip "jq not found — install jq to run these tests"
+    fi
+    [ -f "$SCRIPT" ] || skip "load-fab-config.sh not yet created (TDD red)"
+}
+
+# ── 1. Complete fixture loads with expected keys/values ───────────────────────
+
+@test "complete fab.yml: generator is present in normalized JSON" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/complete-fab.yml"
+    [ "$status" -eq 0 ]
+    result="$(printf '%s' "$output" | jq -r '.generator')"
+    [ "$result" = "rm -rf build && .venv/bin/python src/generate.py" ]
+}
+
+@test "complete fab.yml: stl_roots has 2 entries" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/complete-fab.yml"
+    [ "$status" -eq 0 ]
+    count="$(printf '%s' "$output" | jq '.stl_roots | length')"
+    [ "$count" -eq 2 ]
+}
+
+@test "complete fab.yml: printer.nozzle_width is 0.6" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/complete-fab.yml"
+    [ "$status" -eq 0 ]
+    val="$(printf '%s' "$output" | jq '.printer.nozzle_width')"
+    [ "$val" = "0.6" ]
+}
+
+@test "complete fab.yml: printer.layer_height is 0.3" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/complete-fab.yml"
+    [ "$status" -eq 0 ]
+    val="$(printf '%s' "$output" | jq '.printer.layer_height')"
+    [ "$val" = "0.3" ]
+}
+
+@test "complete fab.yml: printer.min_perimeters is 4" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/complete-fab.yml"
+    [ "$status" -eq 0 ]
+    val="$(printf '%s' "$output" | jq '.printer.min_perimeters')"
+    [ "$val" -eq 4 ]
+}
+
+@test "complete fab.yml: printer.max_overhang_deg is 40" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/complete-fab.yml"
+    [ "$status" -eq 0 ]
+    val="$(printf '%s' "$output" | jq '.printer.max_overhang_deg')"
+    [ "$val" -eq 40 ]
+}
+
+@test "complete fab.yml: models list has 2 entries" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/complete-fab.yml"
+    [ "$status" -eq 0 ]
+    count="$(printf '%s' "$output" | jq '.models | length')"
+    [ "$count" -eq 2 ]
+}
+
+@test "complete fab.yml: first model has name inlet_manifold" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/complete-fab.yml"
+    [ "$status" -eq 0 ]
+    name="$(printf '%s' "$output" | jq -r '.models[0].name')"
+    [ "$name" = "inlet_manifold" ]
+}
+
+@test "complete fab.yml: metadata_sidecar is present" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/complete-fab.yml"
+    [ "$status" -eq 0 ]
+    val="$(printf '%s' "$output" | jq -r '.metadata_sidecar')"
+    [ -n "$val" ]
+    [ "$val" != "null" ]
+}
+
+# ── 2. --validate: missing generator exits non-zero ───────────────────────────
+
+@test "missing generator: --validate exits non-zero" {
+    run bash "$SCRIPT" --validate "$FIXTURE_DIR/missing-generator-fab.yml"
+    [ "$status" -ne 0 ]
+}
+
+@test "missing generator: --validate error mentions generator" {
+    run bash "$SCRIPT" --validate "$FIXTURE_DIR/missing-generator-fab.yml"
+    [ "$status" -ne 0 ]
+    printf '%s' "$output" | grep -qi "generator"
+}
+
+# ── 3. --validate: empty/missing models exits non-zero ────────────────────────
+
+@test "empty models list: --validate exits non-zero" {
+    run bash "$SCRIPT" --validate "$FIXTURE_DIR/empty-models-fab.yml"
+    [ "$status" -ne 0 ]
+}
+
+@test "empty models list: --validate error mentions models" {
+    run bash "$SCRIPT" --validate "$FIXTURE_DIR/empty-models-fab.yml"
+    [ "$status" -ne 0 ]
+    printf '%s' "$output" | grep -qi "models"
+}
+
+# ── 4. Defaults applied when printer is absent ────────────────────────────────
+
+@test "no-printer fab.yml: default nozzle_width is 0.4" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/no-printer-fab.yml"
+    [ "$status" -eq 0 ]
+    val="$(printf '%s' "$output" | jq '.printer.nozzle_width')"
+    [ "$val" = "0.4" ]
+}
+
+@test "no-printer fab.yml: default layer_height is 0.2" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/no-printer-fab.yml"
+    [ "$status" -eq 0 ]
+    val="$(printf '%s' "$output" | jq '.printer.layer_height')"
+    [ "$val" = "0.2" ]
+}
+
+@test "no-printer fab.yml: default min_perimeters is 3" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/no-printer-fab.yml"
+    [ "$status" -eq 0 ]
+    val="$(printf '%s' "$output" | jq '.printer.min_perimeters')"
+    [ "$val" -eq 3 ]
+}
+
+@test "no-printer fab.yml: default max_overhang_deg is 45" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/no-printer-fab.yml"
+    [ "$status" -eq 0 ]
+    val="$(printf '%s' "$output" | jq '.printer.max_overhang_deg')"
+    [ "$val" -eq 45 ]
+}
+
+@test "no-printer fab.yml: default stl_roots contains build/stls/manifolds/" {
+    run bash "$SCRIPT" "$FIXTURE_DIR/no-printer-fab.yml"
+    [ "$status" -eq 0 ]
+    first="$(printf '%s' "$output" | jq -r '.stl_roots[0]')"
+    [ "$first" = "build/stls/manifolds/" ]
+}
+
+# ── 5. Valid complete fab.yml passes --validate ───────────────────────────────
+
+@test "complete fab.yml: --validate exits 0" {
+    run bash "$SCRIPT" --validate "$FIXTURE_DIR/complete-fab.yml"
+    [ "$status" -eq 0 ]
+}
+
+# ── 6. Missing file exits non-zero ────────────────────────────────────────────
+
+@test "nonexistent file exits non-zero" {
+    run bash "$SCRIPT" "/nonexistent/path/fab.yml"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Closes #1220

Adds `load-fab-config.sh`: `yq`-parses `.autospec/fab.yml` → normalized JSON with defaults (generator, stl_roots, printer nozzle/layer/min_perimeters/max_overhang); `--validate` fails on missing `generator` or empty `models[]`. Documents the fab.yml shape in README.

## Verification
- `bats skills/autospec-fab/tests/load-fab-config.bats` — 20/20 (load+defaults+validate-failures). Real yq, no mocks.
- `bash scripts/validate.sh` — exit 0 (fab gate ran scaffold.bats + load-fab-config.bats).