### PR TITLE
feat(autospec-fab): FreeCAD headless harness lib + box fixture

### DIFF
--- a/skills/autospec-fab/fixtures/box/box.stl
+++ b/skills/autospec-fab/fixtures/box/box.stl
@@ -1,0 +1,86 @@
+solid box_20mm
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 20 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 20 20 20
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 0 20 20
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 20
+      vertex 20 0 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 20
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 0
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 20
+      vertex 0 20 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 0
+      vertex 0 20 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 20
+      vertex 0 0 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 20
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 0 20
+      vertex 20 20 20
+    endloop
+  endfacet
+endsolid box_20mm

--- a/skills/autospec-fab/scripts/freecad_harness.py
+++ b/skills/autospec-fab/scripts/freecad_harness.py
@@ -1,0 +1,191 @@
+"""
+freecad_harness.py — headless FreeCAD driver (stdlib only).
+
+Drives freecadcmd via subprocess; never imports FreeCAD or trimesh at module
+level so the file is safely importable on any Python 3 host.
+
+Public API
+----------
+resolve_freecadcmd()          -> str | None
+open_model(path)              -> subprocess.CompletedProcess
+export_stl(in_path, out_stl)  -> subprocess.CompletedProcess
+section(in_path, plane, out_path) -> subprocess.CompletedProcess
+render(in_path, view, out_png)    -> subprocess.CompletedProcess
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+def resolve_freecadcmd():
+    """Return the absolute path to freecadcmd, or None if not on PATH."""
+    return shutil.which("freecadcmd")
+
+
+def _require_freecadcmd():
+    """Return freecadcmd path or raise FileNotFoundError."""
+    cmd = resolve_freecadcmd()
+    if cmd is None:
+        raise FileNotFoundError(
+            "freecadcmd not found on PATH. "
+            "Install FreeCAD or prepend a $TMP/bin shim to $PATH."
+        )
+    return cmd
+
+
+# ---------------------------------------------------------------------------
+# Script builders — deterministic, no timestamps/random tokens
+# ---------------------------------------------------------------------------
+
+def _script_open(in_path):
+    """FreeCAD Python script: open a model and report its label."""
+    in_path = os.path.abspath(in_path)
+    return textwrap.dedent(f"""\
+        import FreeCAD
+        FreeCAD.units.setSchema(FreeCAD.Units.Millimeter)
+        doc = FreeCAD.open({in_path!r})
+        print("opened:", doc.Label)
+        FreeCAD.closeDocument(doc.Label)
+    """)
+
+
+def _script_export_stl(in_path, out_stl):
+    """FreeCAD Python script: export model to STL (mm, ASCII)."""
+    in_path = os.path.abspath(in_path)
+    out_stl = os.path.abspath(out_stl)
+    return textwrap.dedent(f"""\
+        import FreeCAD
+        import Mesh
+        FreeCAD.units.setSchema(FreeCAD.Units.Millimeter)
+        doc = FreeCAD.open({in_path!r})
+        objects = doc.Objects
+        if not objects:
+            raise RuntimeError("no objects in document: " + {in_path!r})
+        Mesh.export(objects, {out_stl!r})
+        print("exported:", {out_stl!r})
+        FreeCAD.closeDocument(doc.Label)
+    """)
+
+
+def _script_section(in_path, plane, out_path):
+    """FreeCAD Python script: cut a cross-section and export as DXF/SVG."""
+    in_path = os.path.abspath(in_path)
+    out_path = os.path.abspath(out_path)
+    # plane is a dict: {"normal": [nx,ny,nz], "origin": [ox,oy,oz]}
+    nx, ny, nz = plane.get("normal", [0, 0, 1])
+    ox, oy, oz = plane.get("origin", [0, 0, 0])
+    return textwrap.dedent(f"""\
+        import FreeCAD
+        import Part
+        FreeCAD.units.setSchema(FreeCAD.Units.Millimeter)
+        doc = FreeCAD.open({in_path!r})
+        shape = Part.makeCompound([o.Shape for o in doc.Objects
+                                   if hasattr(o, 'Shape')])
+        normal = FreeCAD.Vector({nx}, {ny}, {nz})
+        origin = FreeCAD.Vector({ox}, {oy}, {oz})
+        section = shape.section(Part.Plane(origin, normal))
+        section.exportDXF({out_path!r})
+        print("section:", {out_path!r})
+        FreeCAD.closeDocument(doc.Label)
+    """)
+
+
+def _script_render(in_path, view, out_png):
+    """FreeCAD Python script: headless render to PNG (seed-free, pinned args)."""
+    in_path = os.path.abspath(in_path)
+    out_png = os.path.abspath(out_png)
+    # view is a dict: {"camera": "iso"|"top"|"front"|"right", "width": int, "height": int}
+    camera = view.get("camera", "iso")
+    width = int(view.get("width", 800))
+    height = int(view.get("height", 600))
+    return textwrap.dedent(f"""\
+        import FreeCAD
+        import FreeCADGui
+        FreeCAD.units.setSchema(FreeCAD.Units.Millimeter)
+        FreeCADGui.showMainWindow()
+        doc = FreeCAD.open({in_path!r})
+        view = FreeCADGui.ActiveDocument.ActiveView
+        view.setAnimationEnabled(False)
+        camera = {camera!r}
+        if camera == "iso":
+            view.viewIsometric()
+        elif camera == "top":
+            view.viewTop()
+        elif camera == "front":
+            view.viewFront()
+        elif camera == "right":
+            view.viewRight()
+        view.fitAll()
+        view.saveImage({out_png!r}, {width}, {height}, "White")
+        print("rendered:", {out_png!r})
+        FreeCAD.closeDocument(doc.Label)
+    """)
+
+
+# ---------------------------------------------------------------------------
+# Runners
+# ---------------------------------------------------------------------------
+
+def _run_script(script_text, extra_args=None):
+    """Write script to a temp file, run freecadcmd, return CompletedProcess."""
+    cmd = resolve_freecadcmd()
+    if cmd is None:
+        # Return a sentinel CompletedProcess so callers get a clear error
+        # without crashing; stdout/stderr carry the diagnostic.
+        return subprocess.CompletedProcess(
+            args=["freecadcmd"],
+            returncode=127,
+            stdout="",
+            stderr="freecadcmd not found on PATH",
+        )
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", prefix="freecad_harness_", delete=False
+    ) as tf:
+        tf.write(script_text)
+        script_path = tf.name
+    try:
+        args = [cmd, script_path]
+        if extra_args:
+            args.extend(extra_args)
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.unlink(script_path)
+    return result
+
+
+def open_model(path):
+    """Open a FreeCAD model and return the subprocess result."""
+    return _run_script(_script_open(path))
+
+
+def export_stl(in_path, out_stl):
+    """Export a FreeCAD model to STL and return the subprocess result."""
+    return _run_script(_script_export_stl(in_path, out_stl))
+
+
+def section(in_path, plane, out_path):
+    """Cut a cross-section from a model and return the subprocess result.
+
+    plane: dict with keys "normal" ([nx,ny,nz]) and "origin" ([ox,oy,oz]).
+    out_path: destination .dxf file.
+    """
+    return _run_script(_script_section(in_path, plane, out_path))
+
+
+def render(in_path, view, out_png):
+    """Render a model to PNG and return the subprocess result.
+
+    view: dict with keys "camera" (iso/top/front/right), "width", "height".
+    """
+    return _run_script(_script_render(in_path, view, out_png))

--- a/skills/autospec-fab/tests/freecad_shim.py
+++ b/skills/autospec-fab/tests/freecad_shim.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# fake freecadcmd shim — records argv, writes sentinel output files.
+# Used by test_freecad_harness.py; installed into a $TMP/bin at test time.
+import os
+import re
+import sys
+
+argv_record = os.environ.get("FREECAD_ARGV_RECORD", "")
+if argv_record:
+    with open(argv_record, "a") as _f:
+        _f.write(" ".join(sys.argv[1:]) + "\n")
+
+if len(sys.argv) < 2:
+    sys.exit(0)
+
+script_file = sys.argv[1]
+if not os.path.isfile(script_file):
+    sys.exit(0)
+
+script = open(script_file).read()
+
+# export_stl: Mesh.export(objects, 'PATH') or Mesh.export(objects, "PATH")
+m = re.search(r"Mesh\.export\([^,]+,\s*['\"]([^'\"]+)['\"]\)", script)
+if m:
+    path = m.group(1)
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w") as f:
+        f.write("solid shim_cube\n")
+        f.write("  facet normal 0 0 1\n")
+        f.write("    outer loop\n")
+        f.write("      vertex 0 0 0\n")
+        f.write("      vertex 1 0 0\n")
+        f.write("      vertex 1 1 0\n")
+        f.write("    endloop\n")
+        f.write("  endfacet\n")
+        f.write("endsolid shim_cube\n")
+
+# section: section.exportDXF('PATH') or section.exportDXF("PATH")
+m = re.search(r"section\.exportDXF\(['\"]([^'\"]+)['\"]\)", script)
+if m:
+    path = m.group(1)
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w") as f:
+        f.write("DXF_SENTINEL\n")
+
+# render: view.saveImage('PATH', ...) or view.saveImage("PATH", ...)
+m = re.search(r"view\.saveImage\(['\"]([^'\"]+)['\"]", script)
+if m:
+    path = m.group(1)
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w") as f:
+        f.write("PNG_SENTINEL\n")
+
+sys.exit(0)

--- a/skills/autospec-fab/tests/test_freecad_harness.bats
+++ b/skills/autospec-fab/tests/test_freecad_harness.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# test_freecad_harness.bats — thin bats wrapper around the Python unittest suite.
+# Invoked by the validate.sh fab gate (check_autospec_fab_contract) which runs
+# every skills/autospec-fab/tests/*.bats file.
+
+# Resolve the repo root from this file's location (tests/ → skill/ → repo root)
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+
+@test "freecad_harness python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_freecad_harness.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_freecad_harness.py
+++ b/skills/autospec-fab/tests/test_freecad_harness.py
@@ -1,0 +1,343 @@
+"""
+test_freecad_harness.py — unittest for freecad_harness.py.
+
+Strategy: prepend a $TMP/bin directory containing a fake `freecadcmd`
+Python shim to PATH.  The shim (freecad_shim.py, installed as `freecadcmd`):
+  - Records its argv to a file (env var FREECAD_ARGV_RECORD).
+  - Reads the FreeCAD Python script it was given and parses output paths
+    from Mesh.export / exportDXF / saveImage calls.
+  - Writes minimal sentinel content to each output path.
+  - Exits 0.
+
+No real FreeCAD is needed.  Pure stdlib.
+"""
+
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+
+# ---------------------------------------------------------------------------
+# Ensure freecad_harness is importable regardless of invocation style.
+# ---------------------------------------------------------------------------
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import freecad_harness  # noqa: E402
+
+# Path to the shim script that lives next to this test file.
+_SHIM_SRC = os.path.join(_THIS_DIR, "freecad_shim.py")
+
+
+# ---------------------------------------------------------------------------
+# Shim installer
+# ---------------------------------------------------------------------------
+
+def _install_shim(tmp_bin, argv_record):
+    """Copy freecad_shim.py into tmp_bin as 'freecadcmd' and make it executable."""
+    shim_dst = os.path.join(tmp_bin, "freecadcmd")
+    shutil.copy2(_SHIM_SRC, shim_dst)
+    current = os.stat(shim_dst).st_mode
+    os.chmod(shim_dst, current | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return shim_dst
+
+
+# ---------------------------------------------------------------------------
+# Base class: shim PATH setup/teardown
+# ---------------------------------------------------------------------------
+
+class _HarnessBase(unittest.TestCase):
+
+    def setUp(self):
+        self._orig_path = os.environ.get("PATH", "")
+        self._tmpdir = tempfile.mkdtemp(prefix="fc_test_")
+        self._tmp_bin = os.path.join(self._tmpdir, "bin")
+        os.makedirs(self._tmp_bin)
+        self._argv_record = os.path.join(self._tmpdir, "argv.txt")
+        _install_shim(self._tmp_bin, self._argv_record)
+        os.environ["PATH"] = self._tmp_bin + os.pathsep + self._orig_path
+        os.environ["FREECAD_ARGV_RECORD"] = self._argv_record
+
+    def tearDown(self):
+        os.environ["PATH"] = self._orig_path
+        os.environ.pop("FREECAD_ARGV_RECORD", None)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _recorded_lines(self):
+        if not os.path.exists(self._argv_record):
+            return []
+        with open(self._argv_record) as f:
+            return [ln.rstrip() for ln in f if ln.strip()]
+
+
+# ---------------------------------------------------------------------------
+# resolve_freecadcmd
+# ---------------------------------------------------------------------------
+
+class TestResolveFreecadcmd(_HarnessBase):
+
+    def test_finds_shim_on_path(self):
+        result = freecad_harness.resolve_freecadcmd()
+        self.assertIsNotNone(result)
+        self.assertIn("freecadcmd", result)
+
+    def test_returns_none_when_absent(self):
+        os.environ["PATH"] = "/usr/bin:/bin"
+        result = freecad_harness.resolve_freecadcmd()
+        self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
+# open_model
+# ---------------------------------------------------------------------------
+
+class TestOpenModel(_HarnessBase):
+
+    def test_invokes_freecadcmd(self):
+        result = freecad_harness.open_model("/fake/model.FCStd")
+        self.assertEqual(result.returncode, 0,
+                         f"stderr: {result.stderr}")
+
+    def test_argv_record_has_entry(self):
+        freecad_harness.open_model("/fake/model.FCStd")
+        self.assertGreater(len(self._recorded_lines()), 0, "No argv recorded")
+
+    def test_script_contains_freecad_open(self):
+        script = freecad_harness._script_open("/model.FCStd")
+        self.assertIn("FreeCAD.open", script)
+
+    def test_script_pins_mm_units(self):
+        script = freecad_harness._script_open("/model.FCStd")
+        self.assertIn("Millimeter", script)
+
+    def test_script_no_random_tokens(self):
+        script = freecad_harness._script_open("/model.FCStd")
+        self.assertNotIn("import random", script)
+        self.assertNotIn("import time", script)
+        self.assertNotIn("uuid", script)
+        self.assertNotIn("strftime", script)
+
+
+# ---------------------------------------------------------------------------
+# export_stl
+# ---------------------------------------------------------------------------
+
+class TestExportSTL(_HarnessBase):
+
+    def test_invokes_freecadcmd(self):
+        out = os.path.join(self._tmpdir, "out.stl")
+        result = freecad_harness.export_stl("/fake/model.FCStd", out)
+        self.assertEqual(result.returncode, 0,
+                         f"stderr: {result.stderr}")
+
+    def test_produces_stl_at_requested_path(self):
+        out = os.path.join(self._tmpdir, "output.stl")
+        freecad_harness.export_stl("/fake/model.FCStd", out)
+        self.assertTrue(os.path.exists(out),
+                        f"Expected STL at {out}")
+
+    def test_stl_output_starts_with_solid(self):
+        out = os.path.join(self._tmpdir, "output.stl")
+        freecad_harness.export_stl("/fake/model.FCStd", out)
+        with open(out) as f:
+            first = f.read(20)
+        self.assertTrue(first.strip().startswith("solid"), repr(first))
+
+    def test_script_calls_mesh_export_with_output_path(self):
+        out_stl = "/my/output.stl"
+        script = freecad_harness._script_export_stl("/in.FCStd", out_stl)
+        self.assertIn("Mesh.export", script)
+        self.assertIn(out_stl, script)
+
+    def test_script_pins_mm_units(self):
+        script = freecad_harness._script_export_stl("/in.FCStd", "/out.stl")
+        self.assertIn("Millimeter", script)
+
+    def test_script_no_random_tokens(self):
+        script = freecad_harness._script_export_stl("/in.FCStd", "/out.stl")
+        self.assertNotIn("import random", script)
+        self.assertNotIn("import time", script)
+        self.assertNotIn("uuid", script)
+        self.assertNotIn("strftime", script)
+
+    def test_script_deterministic_for_same_inputs(self):
+        s1 = freecad_harness._script_export_stl("/in.FCStd", "/out.stl")
+        s2 = freecad_harness._script_export_stl("/in.FCStd", "/out.stl")
+        self.assertEqual(s1, s2)
+
+
+# ---------------------------------------------------------------------------
+# section
+# ---------------------------------------------------------------------------
+
+class TestSection(_HarnessBase):
+
+    def test_invokes_freecadcmd(self):
+        out = os.path.join(self._tmpdir, "section.dxf")
+        plane = {"normal": [0, 0, 1], "origin": [0, 0, 10]}
+        result = freecad_harness.section("/fake/model.FCStd", plane, out)
+        self.assertEqual(result.returncode, 0,
+                         f"stderr: {result.stderr}")
+
+    def test_script_contains_section_call(self):
+        plane = {"normal": [0, 0, 1], "origin": [0, 0, 10]}
+        script = freecad_harness._script_section("/in.FCStd", plane, "/out.dxf")
+        self.assertIn("shape.section", script)
+
+    def test_script_pins_mm_units(self):
+        plane = {"normal": [0, 0, 1], "origin": [0, 0, 0]}
+        script = freecad_harness._script_section("/in.FCStd", plane, "/out.dxf")
+        self.assertIn("Millimeter", script)
+
+    def test_script_embeds_plane_values(self):
+        plane = {"normal": [1, 0, 0], "origin": [5, 5, 5]}
+        script = freecad_harness._script_section("/in.FCStd", plane, "/out.dxf")
+        self.assertIn("1, 0, 0", script)
+        self.assertIn("5, 5, 5", script)
+
+    def test_script_no_random_tokens(self):
+        plane = {"normal": [0, 0, 1], "origin": [0, 0, 0]}
+        script = freecad_harness._script_section("/in.FCStd", plane, "/out.dxf")
+        self.assertNotIn("import random", script)
+        self.assertNotIn("import time", script)
+        self.assertNotIn("uuid", script)
+
+
+# ---------------------------------------------------------------------------
+# render
+# ---------------------------------------------------------------------------
+
+class TestRender(_HarnessBase):
+
+    def test_invokes_freecadcmd(self):
+        out = os.path.join(self._tmpdir, "render.png")
+        view = {"camera": "iso", "width": 800, "height": 600}
+        result = freecad_harness.render("/fake/model.FCStd", view, out)
+        self.assertEqual(result.returncode, 0,
+                         f"stderr: {result.stderr}")
+
+    def test_script_pins_camera_top(self):
+        view = {"camera": "top", "width": 1024, "height": 768}
+        script = freecad_harness._script_render("/in.FCStd", view, "/out.png")
+        self.assertIn("viewTop", script)
+        self.assertIn("1024", script)
+        self.assertIn("768", script)
+
+    def test_script_pins_camera_iso(self):
+        view = {"camera": "iso", "width": 800, "height": 600}
+        script = freecad_harness._script_render("/in.FCStd", view, "/out.png")
+        self.assertIn("viewIsometric", script)
+
+    def test_script_pins_mm_units(self):
+        view = {"camera": "iso", "width": 800, "height": 600}
+        script = freecad_harness._script_render("/in.FCStd", view, "/out.png")
+        self.assertIn("Millimeter", script)
+
+    def test_script_disables_animation(self):
+        view = {"camera": "iso", "width": 800, "height": 600}
+        script = freecad_harness._script_render("/in.FCStd", view, "/out.png")
+        self.assertIn("setAnimationEnabled(False)", script)
+
+    def test_script_no_random_tokens(self):
+        view = {"camera": "iso", "width": 800, "height": 600}
+        script = freecad_harness._script_render("/in.FCStd", view, "/out.png")
+        self.assertNotIn("import random", script)
+        self.assertNotIn("import time", script)
+        self.assertNotIn("uuid", script)
+        self.assertNotIn("strftime", script)
+
+    def test_script_deterministic(self):
+        view = {"camera": "iso", "width": 800, "height": 600}
+        s1 = freecad_harness._script_render("/in.FCStd", view, "/out.png")
+        s2 = freecad_harness._script_render("/in.FCStd", view, "/out.png")
+        self.assertEqual(s1, s2)
+
+
+# ---------------------------------------------------------------------------
+# absent freecadcmd — graceful degradation
+# ---------------------------------------------------------------------------
+
+class TestAbsentFreecadcmd(unittest.TestCase):
+
+    def setUp(self):
+        self._orig_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = "/usr/bin:/bin"
+
+    def tearDown(self):
+        os.environ["PATH"] = self._orig_path
+
+    def test_resolve_returns_none(self):
+        self.assertIsNone(freecad_harness.resolve_freecadcmd())
+
+    def test_export_stl_returncode_127(self):
+        result = freecad_harness.export_stl("/f.FCStd", "/f.stl")
+        self.assertEqual(result.returncode, 127)
+        self.assertIn("freecadcmd", result.stderr)
+
+    def test_open_model_returncode_127(self):
+        result = freecad_harness.open_model("/f.FCStd")
+        self.assertEqual(result.returncode, 127)
+
+    def test_section_returncode_127(self):
+        result = freecad_harness.section(
+            "/f.FCStd", {"normal": [0, 0, 1], "origin": [0, 0, 0]}, "/o.dxf"
+        )
+        self.assertEqual(result.returncode, 127)
+
+    def test_render_returncode_127(self):
+        result = freecad_harness.render(
+            "/f.FCStd", {"camera": "iso", "width": 800, "height": 600}, "/o.png"
+        )
+        self.assertEqual(result.returncode, 127)
+
+
+# ---------------------------------------------------------------------------
+# box fixture integrity
+# ---------------------------------------------------------------------------
+
+class TestBoxFixture(unittest.TestCase):
+
+    @property
+    def _stl_path(self):
+        here = os.path.dirname(os.path.abspath(__file__))
+        return os.path.normpath(
+            os.path.join(here, "..", "fixtures", "box", "box.stl")
+        )
+
+    def test_fixture_exists(self):
+        self.assertTrue(os.path.exists(self._stl_path),
+                        f"Missing: {self._stl_path}")
+
+    def test_fixture_is_ascii_stl(self):
+        with open(self._stl_path) as f:
+            content = f.read()
+        self.assertTrue(content.strip().startswith("solid"), content[:60])
+        self.assertIn("endsolid", content)
+
+    def test_fixture_has_12_triangles(self):
+        with open(self._stl_path) as f:
+            content = f.read()
+        count = content.count("facet normal")
+        self.assertEqual(count, 12,
+                         f"Expected 12 facets (cube = 6 faces x 2), got {count}")
+
+    def test_fixture_normals_are_unit_length(self):
+        import re
+        with open(self._stl_path) as f:
+            content = f.read()
+        normals = re.findall(
+            r"facet normal\s+([\-\d.]+)\s+([\-\d.]+)\s+([\-\d.]+)", content
+        )
+        self.assertEqual(len(normals), 12)
+        for nx, ny, nz in normals:
+            mag2 = float(nx)**2 + float(ny)**2 + float(nz)**2
+            self.assertAlmostEqual(mag2, 1.0, places=5,
+                                   msg=f"Non-unit normal: {nx} {ny} {nz}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1221

Adds `freecad_harness.py` — the FreeCAD-backend lib the deterministic stages + render build on:
- stdlib-only, **no top-level FreeCAD/trimesh import** (importable on bare python3); `resolve_freecadcmd()` + `open_model`/`export_stl`/`section`/`render` build **deterministic** FreeCAD scripts (pinned mm units, seed-free) and subprocess a PATH-resolved `freecadcmd`; absent `freecadcmd` → 127 sentinel (no importer crash).
- Watertight 20 mm `box.stl` fixture (12 facets) for downstream stages.
- 35-case python unittest with a `$TMP/bin` `freecadcmd` shim (real solver deferred to the container) + a thin **bats wrapper** so the fab validate gate runs the python suite.

## Verification
- `python3 -m unittest test_freecad_harness.py` — 35/35 OK; bats wrapper passes.
- `bash scripts/validate.sh` — exit 0 (fab gate ran scaffold + load-fab-config + freecad_harness wrappers).