### PR TITLE
feat(autospec-fab): geometry stage (reload + watertight + single-body)

### DIFF
--- a/skills/autospec-fab/fixtures/open-cube.stl
+++ b/skills/autospec-fab/fixtures/open-cube.stl
@@ -1,0 +1,79 @@
+solid open_cube
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 20 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 20 20 20
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 0 20 20
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 20
+      vertex 20 0 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 20
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 0
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 20
+      vertex 0 20 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 0
+      vertex 0 20 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 20
+      vertex 0 0 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 20
+      vertex 20 20 0
+    endloop
+  endfacet
+endsolid open_cube

--- a/skills/autospec-fab/fixtures/two-cubes.stl
+++ b/skills/autospec-fab/fixtures/two-cubes.stl
@@ -1,0 +1,170 @@
+solid two_cubes
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 20 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 20 20 20
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 0 20 20
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 20
+      vertex 20 0 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 20
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 0
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 20
+      vertex 0 20 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 0
+      vertex 0 20 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 20
+      vertex 0 0 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 20
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 0 20
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50 0 0
+      vertex 70 0 0
+      vertex 70 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50 0 0
+      vertex 70 20 0
+      vertex 50 20 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 50 0 20
+      vertex 70 20 20
+      vertex 70 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 50 0 20
+      vertex 50 20 20
+      vertex 70 20 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 50 0 0
+      vertex 70 0 20
+      vertex 70 0 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 50 0 0
+      vertex 50 0 20
+      vertex 70 0 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 50 20 0
+      vertex 70 20 0
+      vertex 70 20 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 50 20 0
+      vertex 70 20 20
+      vertex 50 20 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 50 0 0
+      vertex 50 20 0
+      vertex 50 20 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 50 0 0
+      vertex 50 20 20
+      vertex 50 0 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 70 0 0
+      vertex 70 20 20
+      vertex 70 20 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 70 0 0
+      vertex 70 0 20
+      vertex 70 20 20
+    endloop
+  endfacet
+endsolid two_cubes

--- a/skills/autospec-fab/scripts/stage-geometry.py
+++ b/skills/autospec-fab/scripts/stage-geometry.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+stage-geometry.py — geometry gate stage for autospec-fab.
+
+Uniform stage CLI:
+    stage-geometry.py --in <stl|dir> --out <fragment.json>
+                      [--model <metadata.json>] [--expect-bodies N]
+
+Checks performed:
+  1. RELOAD   — file opens and parses to ≥1 facet.
+  2. WATERTIGHT — every undirected edge shared by exactly 2 facets.
+  3. SINGLE-BODY — connected components over facet-adjacency graph == expected.
+
+Exit codes:
+  0  — harness success (verdict lives in fragment "status", not exit code).
+  1  — harness/usage error (bad args, --in missing, etc.).
+
+Trimesh is optional: lazy-imported and used only when available (for
+robustness / binary STL support). The stdlib ASCII parser is the default
+path and the one exercised by tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Optional trimesh (never hard-required)
+# ---------------------------------------------------------------------------
+try:
+    import trimesh as _trimesh  # type: ignore
+except ImportError:
+    _trimesh = None  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+# A triangle is a tuple of three (x, y, z) float tuples.
+Triangle = Tuple[Tuple[float, float, float], ...]
+
+
+# ---------------------------------------------------------------------------
+# ASCII STL parser (stdlib)
+# ---------------------------------------------------------------------------
+
+_FACET_RE = re.compile(r"facet\s+normal", re.IGNORECASE)
+_VERTEX_RE = re.compile(
+    r"vertex\s+([\-+]?[0-9]*\.?[0-9]+(?:[eE][\-+]?[0-9]+)?)"
+    r"\s+([\-+]?[0-9]*\.?[0-9]+(?:[eE][\-+]?[0-9]+)?)"
+    r"\s+([\-+]?[0-9]*\.?[0-9]+(?:[eE][\-+]?[0-9]+)?)",
+    re.IGNORECASE,
+)
+
+
+def _parse_stl_ascii(path: str) -> List[Triangle]:
+    """Parse ASCII STL and return list of triangles (each: 3 vertices)."""
+    triangles: List[Triangle] = []
+    with open(path, "r", errors="replace") as fh:
+        content = fh.read()
+
+    # Split on facet boundaries
+    facet_blocks = _FACET_RE.split(content)
+    for block in facet_blocks[1:]:  # skip header before first facet
+        vertices = _VERTEX_RE.findall(block)
+        if len(vertices) >= 3:
+            tri = tuple(
+                (float(x), float(y), float(z)) for x, y, z in vertices[:3]
+            )
+            triangles.append(tri)  # type: ignore[arg-type]
+    return triangles
+
+
+def _parse_stl(path: str) -> Optional[List[Triangle]]:
+    """
+    Parse STL at *path* into a list of triangles.
+
+    Tries trimesh first (handles binary STL too) when available; falls back to
+    the stdlib ASCII parser.  Returns None on parse failure.
+    """
+    if _trimesh is not None:
+        try:
+            mesh = _trimesh.load_mesh(path)
+            tris = []
+            for face in mesh.faces:
+                v0 = tuple(float(c) for c in mesh.vertices[face[0]])
+                v1 = tuple(float(c) for c in mesh.vertices[face[1]])
+                v2 = tuple(float(c) for c in mesh.vertices[face[2]])
+                tris.append((v0, v1, v2))
+            return tris if tris else None
+        except Exception:
+            pass  # fall through to stdlib parser
+
+    try:
+        tris = _parse_stl_ascii(path)
+        return tris if tris else None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Geometry checks
+# ---------------------------------------------------------------------------
+
+_TOLERANCE = 1e-6
+
+
+def _rounded_vertex(v: tuple, tol: float = _TOLERANCE) -> tuple:
+    """Round vertex coordinates to *tol* to deduplicate float noise."""
+    scale = 1.0 / tol
+    return (round(v[0] * scale), round(v[1] * scale), round(v[2] * scale))
+
+
+def _edge_key(va: tuple, vb: tuple) -> tuple:
+    """Return a canonical (sorted) undirected edge key."""
+    a = _rounded_vertex(va)
+    b = _rounded_vertex(vb)
+    return (a, b) if a <= b else (b, a)
+
+
+def check_watertight(triangles: List[Triangle]) -> Tuple[bool, str]:
+    """
+    Check watertightness: every undirected edge must be shared by exactly 2 facets.
+
+    Returns (is_watertight, detail_string).
+    """
+    from collections import defaultdict
+
+    edge_count: dict = defaultdict(int)
+    for tri in triangles:
+        v0, v1, v2 = tri
+        edge_count[_edge_key(v0, v1)] += 1
+        edge_count[_edge_key(v1, v2)] += 1
+        edge_count[_edge_key(v2, v0)] += 1
+
+    bad_edges = [e for e, c in edge_count.items() if c != 2]
+    if bad_edges:
+        return False, (
+            f"Non-watertight: {len(bad_edges)} edge(s) not shared by exactly "
+            f"2 facets (open/non-manifold mesh)"
+        )
+    return True, "All edges shared by exactly 2 facets (watertight)"
+
+
+def check_connectivity(triangles: List[Triangle]) -> Tuple[int, str]:
+    """
+    Count connected components via facet-adjacency (facets sharing an edge).
+
+    Returns (component_count, detail_string).
+    """
+    from collections import defaultdict, deque
+
+    # Build edge → list-of-facet-indices map
+    edge_to_facets: dict = defaultdict(list)
+    for i, tri in enumerate(triangles):
+        v0, v1, v2 = tri
+        edge_to_facets[_edge_key(v0, v1)].append(i)
+        edge_to_facets[_edge_key(v1, v2)].append(i)
+        edge_to_facets[_edge_key(v2, v0)].append(i)
+
+    # Build adjacency list: facet i → set of neighbouring facet indices
+    n = len(triangles)
+    adj: List[set] = [set() for _ in range(n)]
+    for facets in edge_to_facets.values():
+        for a in facets:
+            for b in facets:
+                if a != b:
+                    adj[a].add(b)
+
+    # BFS to count components
+    visited = [False] * n
+    components = 0
+    for start in range(n):
+        if visited[start]:
+            continue
+        components += 1
+        queue: deque = deque([start])
+        while queue:
+            node = queue.popleft()
+            if visited[node]:
+                continue
+            visited[node] = True
+            for nb in adj[node]:
+                if not visited[nb]:
+                    queue.append(nb)
+
+    return components, f"{components} connected body/bodies found"
+
+
+# ---------------------------------------------------------------------------
+# Stage runner
+# ---------------------------------------------------------------------------
+
+def run_geometry_stage(
+    stl_path: str,
+    expect_bodies: int = 1,
+) -> dict:
+    """
+    Run all geometry checks on *stl_path* and return a stage-record fragment.
+
+    Fragment shape:
+      { "stage": "geometry", "status": "pass|fail",
+        "detail": "...", "findings": [...] }
+    """
+    findings = []
+    status = "pass"
+    details = []
+
+    # ------------------------------------------------------------------
+    # 1. RELOAD check
+    # ------------------------------------------------------------------
+    triangles = _parse_stl(stl_path)
+    if triangles is None or len(triangles) == 0:
+        findings.append({
+            "code": "geometry_reload",
+            "message": f"Failed to parse STL or zero facets: {stl_path}",
+        })
+        return {
+            "stage": "geometry",
+            "status": "fail",
+            "detail": f"RELOAD failed: could not parse {os.path.basename(stl_path)}",
+            "findings": findings,
+        }
+
+    details.append(f"Parsed {len(triangles)} facets")
+
+    # ------------------------------------------------------------------
+    # 2. WATERTIGHT check
+    # ------------------------------------------------------------------
+    is_wt, wt_detail = check_watertight(triangles)
+    details.append(wt_detail)
+    if not is_wt:
+        status = "fail"
+        findings.append({
+            "code": "non_watertight",
+            "message": wt_detail,
+        })
+
+    # ------------------------------------------------------------------
+    # 3. SINGLE-BODY connectivity check
+    # ------------------------------------------------------------------
+    body_count, conn_detail = check_connectivity(triangles)
+    details.append(conn_detail)
+    if body_count != expect_bodies:
+        status = "fail"
+        findings.append({
+            "code": "disconnected_bodies",
+            "message": (
+                f"Expected {expect_bodies} body/bodies, "
+                f"found {body_count}: {conn_detail}"
+            ),
+        })
+
+    return {
+        "stage": "geometry",
+        "status": status,
+        "detail": "; ".join(details),
+        "findings": findings,
+    }
+
+
+def _collect_stl_paths(in_arg: str) -> List[str]:
+    """Return list of STL file paths from *in_arg* (file or directory)."""
+    if os.path.isdir(in_arg):
+        paths = []
+        for name in sorted(os.listdir(in_arg)):
+            if name.lower().endswith(".stl"):
+                paths.append(os.path.join(in_arg, name))
+        return paths
+    return [in_arg]
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="autospec-fab geometry stage: reload + watertight + connectivity"
+    )
+    parser.add_argument("--in", dest="in_path", required=True,
+                        help="Input STL file or directory of STL files")
+    parser.add_argument("--out", required=True,
+                        help="Output fragment JSON path")
+    parser.add_argument("--model", dest="model_path", default=None,
+                        help="Per-model metadata JSON sidecar (optional)")
+    parser.add_argument("--expect-bodies", dest="expect_bodies",
+                        type=int, default=None,
+                        help="Expected number of connected bodies (default: 1, "
+                             "or from metadata body_count if provided)")
+
+    args = parser.parse_args(argv)
+
+    # Resolve expect_bodies: CLI arg > metadata > default 1
+    expect_bodies = args.expect_bodies
+    if expect_bodies is None and args.model_path:
+        try:
+            with open(args.model_path) as f:
+                meta = json.load(f)
+            expect_bodies = int(meta.get("body_count", 1))
+        except Exception:
+            expect_bodies = 1
+    if expect_bodies is None:
+        expect_bodies = 1
+
+    stl_paths = _collect_stl_paths(args.in_path)
+    if not stl_paths:
+        print(f"stage-geometry: no STL files found at {args.in_path!r}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    # Run checks on first STL (directory mode: first file only for now,
+    # matching single-model stage contract; engine iterates per-model).
+    fragment = run_geometry_stage(stl_paths[0], expect_bodies=expect_bodies)
+
+    # Write fragment
+    out_dir = os.path.dirname(os.path.abspath(args.out))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(fragment, f, indent=2)
+        f.write("\n")
+
+    # Exit 0 always on harness success (verdict in status field)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/autospec-fab/tests/test_stage_geometry.bats
+++ b/skills/autospec-fab/tests/test_stage_geometry.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# test_stage_geometry.bats — thin bats wrapper around the Python unittest suite.
+# Invoked by the validate.sh fab gate (check_autospec_fab_contract) which runs
+# every skills/autospec-fab/tests/*.bats file.
+
+# Resolve the repo root from this file's location (tests/ → skill/ → repo root)
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+
+@test "stage_geometry python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_stage_geometry.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_stage_geometry.py
+++ b/skills/autospec-fab/tests/test_stage_geometry.py
@@ -1,0 +1,184 @@
+"""
+test_stage_geometry.py — unittest for stage-geometry.py.
+
+Tests:
+  1. box.stl   → status pass, watertight, 1 body
+  2. open-cube.stl → status fail + finding non_watertight
+  3. two-cubes.stl → status fail + finding disconnected_bodies (--expect-bodies 1)
+  4. emitted fragment validates against release-gate stage-record shape
+     (keys present, status is one of pass|fail|warn|skip)
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
+_FIXTURES_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "fixtures"))
+
+_STAGE_SCRIPT = os.path.join(_SCRIPTS_DIR, "stage-geometry.py")
+
+# Fixture paths
+_BOX_STL = os.path.join(_FIXTURES_DIR, "box", "box.stl")
+_OPEN_CUBE_STL = os.path.join(_FIXTURES_DIR, "open-cube.stl")
+_TWO_CUBES_STL = os.path.join(_FIXTURES_DIR, "two-cubes.stl")
+
+
+def _run_stage(stl_path, extra_args=None):
+    """Run stage-geometry.py on *stl_path*, return (returncode, fragment_dict)."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+        out_path = tf.name
+    try:
+        cmd = [sys.executable, _STAGE_SCRIPT, "--in", stl_path, "--out", out_path]
+        if extra_args:
+            cmd.extend(extra_args)
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if os.path.exists(out_path):
+            with open(out_path) as f:
+                fragment = json.load(f)
+        else:
+            fragment = None
+        return result.returncode, fragment, result.stderr
+    finally:
+        if os.path.exists(out_path):
+            os.unlink(out_path)
+
+
+def _finding_codes(fragment):
+    """Return set of code_health ids from fragment findings."""
+    return {f.get("code") for f in fragment.get("findings", [])}
+
+
+class TestFragmentShape(unittest.TestCase):
+    """Stage fragment validates against release-gate stage-record shape."""
+
+    def _assert_valid_fragment(self, fragment):
+        self.assertIsInstance(fragment, dict, "fragment must be a dict")
+        self.assertIn("stage", fragment, "fragment missing 'stage' key")
+        self.assertIn("status", fragment, "fragment missing 'status' key")
+        self.assertIn(fragment["status"], {"pass", "fail", "warn", "skip"},
+                      f"invalid status: {fragment['status']!r}")
+        self.assertIn("detail", fragment, "fragment missing 'detail' key")
+        self.assertIn("findings", fragment, "fragment missing 'findings' key")
+        self.assertIsInstance(fragment["findings"], list, "'findings' must be a list")
+        self.assertEqual(fragment["stage"], "geometry", "stage name must be 'geometry'")
+
+    def test_box_fragment_shape(self):
+        _, fragment, _ = _run_stage(_BOX_STL)
+        self.assertIsNotNone(fragment)
+        self._assert_valid_fragment(fragment)
+
+    def test_open_cube_fragment_shape(self):
+        _, fragment, _ = _run_stage(_OPEN_CUBE_STL)
+        self.assertIsNotNone(fragment)
+        self._assert_valid_fragment(fragment)
+
+    def test_two_cubes_fragment_shape(self):
+        _, fragment, _ = _run_stage(_TWO_CUBES_STL)
+        self.assertIsNotNone(fragment)
+        self._assert_valid_fragment(fragment)
+
+
+class TestBoxSTL(unittest.TestCase):
+    """box.stl is a watertight 12-facet cube — should pass all checks."""
+
+    def setUp(self):
+        self.rc, self.fragment, self.stderr = _run_stage(_BOX_STL)
+
+    def test_exit_code_zero(self):
+        self.assertEqual(self.rc, 0,
+                         f"Expected exit 0 (harness success); stderr={self.stderr}")
+
+    def test_status_pass(self):
+        self.assertEqual(self.fragment["status"], "pass",
+                         f"Expected pass; fragment={self.fragment}")
+
+    def test_no_findings(self):
+        codes = _finding_codes(self.fragment)
+        self.assertNotIn("non_watertight", codes)
+        self.assertNotIn("disconnected_bodies", codes)
+
+    def test_fixture_exists(self):
+        self.assertTrue(os.path.exists(_BOX_STL), f"Missing: {_BOX_STL}")
+
+
+class TestOpenCubeSTL(unittest.TestCase):
+    """open-cube.stl has one facet removed — NOT watertight."""
+
+    def setUp(self):
+        self.rc, self.fragment, self.stderr = _run_stage(_OPEN_CUBE_STL)
+
+    def test_exit_code_zero(self):
+        # Harness exit 0 even on geometry fail (verdict is in status)
+        self.assertEqual(self.rc, 0,
+                         f"Expected exit 0 (harness success); stderr={self.stderr}")
+
+    def test_status_fail(self):
+        self.assertEqual(self.fragment["status"], "fail",
+                         f"Expected fail for non-watertight; fragment={self.fragment}")
+
+    def test_finding_non_watertight(self):
+        codes = _finding_codes(self.fragment)
+        self.assertIn("non_watertight", codes,
+                      f"Expected non_watertight finding; findings={self.fragment['findings']}")
+
+
+class TestTwoCubesSTL(unittest.TestCase):
+    """two-cubes.stl has two disjoint bodies — disconnected with --expect-bodies 1."""
+
+    def setUp(self):
+        self.rc, self.fragment, self.stderr = _run_stage(
+            _TWO_CUBES_STL, extra_args=["--expect-bodies", "1"]
+        )
+
+    def test_exit_code_zero(self):
+        self.assertEqual(self.rc, 0,
+                         f"Expected exit 0 (harness success); stderr={self.stderr}")
+
+    def test_status_fail(self):
+        self.assertEqual(self.fragment["status"], "fail",
+                         f"Expected fail for disconnected bodies; fragment={self.fragment}")
+
+    def test_finding_disconnected_bodies(self):
+        codes = _finding_codes(self.fragment)
+        self.assertIn("disconnected_bodies", codes,
+                      f"Expected disconnected_bodies finding; findings={self.fragment['findings']}")
+
+
+class TestTwoCubesExpectTwo(unittest.TestCase):
+    """two-cubes.stl passes when --expect-bodies 2."""
+
+    def setUp(self):
+        self.rc, self.fragment, self.stderr = _run_stage(
+            _TWO_CUBES_STL, extra_args=["--expect-bodies", "2"]
+        )
+
+    def test_status_pass(self):
+        self.assertEqual(self.fragment["status"], "pass",
+                         f"Expected pass with --expect-bodies 2; fragment={self.fragment}")
+
+
+class TestMissingInArg(unittest.TestCase):
+    """Missing --in should exit non-zero (harness/usage error)."""
+
+    def test_missing_in_exits_nonzero(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+            out_path = tf.name
+        try:
+            result = subprocess.run(
+                [sys.executable, _STAGE_SCRIPT, "--out", out_path],
+                capture_output=True, text=True
+            )
+            self.assertNotEqual(result.returncode, 0,
+                                "Expected non-zero exit when --in is missing")
+        finally:
+            if os.path.exists(out_path):
+                os.unlink(out_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1222

Adds `stage-geometry.py` (uniform stage CLI): reload + **watertight** (every undirected edge shared by exactly 2 facets) + **single-body connectivity** (BFS components == `--expect-bodies`). Emits a release-gate stage fragment `{stage,status,detail,findings}` with `code_health` `non_watertight`/`disconnected_bodies`; verdict in `status`.

**Environment call:** implemented with a **stdlib ASCII-STL parser** (trimesh optional/lazy, never required) so the fab validate gate RUNS the test on bare python3 instead of skipping — no toolchain dep, real coverage.

## Verification
- `python3 -m unittest test_stage_geometry.py` — 15/15; bats wrapper gates it. Negative fixtures: open-cube.stl→`non_watertight`, two-cubes.stl→`disconnected_bodies`; box.stl→pass.
- `bash scripts/validate.sh` — exit 0.