### PR TITLE
feat(autospec-fab): metadata stage (validate model sidecars vs schema)

### DIFF
--- a/skills/autospec-fab/scripts/stage_metadata.py
+++ b/skills/autospec-fab/scripts/stage_metadata.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+stage_metadata.py — metadata schema-validation stage for autospec-fab.
+
+Uniform stage CLI:
+    stage_metadata.py --model <sidecar.json> --out <fragment.json>
+                      [--in <stl|dir>]   (accepted for symmetry, ignored)
+
+Checks performed:
+  1. LOCATE sidecar — if absent → status fail, finding metadata_missing.
+  2. VALIDATE sidecar against autospec-fab-model.schema.json via ajv CLI.
+     ajv exit 0  → status pass.
+     ajv non-zero → status fail, finding metadata_invalid + ajv stderr detail.
+  3. ajv absent from PATH → status skip with clear detail (no crash).
+
+Exit codes:
+  0 — harness success (verdict lives in fragment "status", not exit code).
+  1 — harness/usage error (bad args, --out missing, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from typing import List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Schema resolution
+# ---------------------------------------------------------------------------
+
+def _schema_path() -> str:
+    """Resolve schemas/autospec-fab-model.schema.json from the repo root."""
+    # script lives at skills/autospec-fab/scripts/stage_metadata.py
+    # repo root is three levels up
+    scripts_dir = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.normpath(os.path.join(scripts_dir, "..", "..", ".."))
+    return os.path.join(repo_root, "schemas", "autospec-fab-model.schema.json")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_finding(code: str, message: str) -> dict:
+    return {"code": code, "message": message}
+
+
+def _make_fragment(status: str, detail: str, findings: List[dict]) -> dict:
+    return {
+        "stage": "metadata",
+        "status": status,
+        "detail": detail,
+        "findings": findings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Check: sidecar exists
+# ---------------------------------------------------------------------------
+
+def check_sidecar_present(model_path: str) -> Optional[dict]:
+    """Return a fail fragment if the sidecar is absent, else None."""
+    if not os.path.exists(model_path):
+        finding = _make_finding(
+            "metadata_missing",
+            f"Metadata sidecar not found: {model_path}",
+        )
+        return _make_fragment(
+            "fail",
+            f"Sidecar absent: {model_path}",
+            [finding],
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Check: ajv validation
+# ---------------------------------------------------------------------------
+
+def check_schema_valid(model_path: str, schema_path: str) -> dict:
+    """
+    Validate *model_path* against *schema_path* via the ajv CLI.
+
+    Returns a stage-record fragment.
+    """
+    ajv_bin = shutil.which("ajv")
+    if ajv_bin is None:
+        return _make_fragment(
+            "skip",
+            "ajv CLI not found on PATH; schema validation skipped",
+            [],
+        )
+
+    cmd = [ajv_bin, "validate", "-s", schema_path, "--spec=draft2020", "-d", model_path]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+    except OSError as exc:
+        return _make_fragment(
+            "skip",
+            f"ajv execution failed: {exc}",
+            [],
+        )
+
+    if result.returncode == 0:
+        return _make_fragment("pass", "Sidecar validates against autospec-fab-model schema", [])
+
+    detail_msg = (result.stdout + result.stderr).strip()
+    finding = _make_finding(
+        "metadata_invalid",
+        f"Schema validation failed: {detail_msg}",
+    )
+    return _make_fragment(
+        "fail",
+        f"Sidecar failed schema validation: {detail_msg[:200]}",
+        [finding],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage runner
+# ---------------------------------------------------------------------------
+
+def run_metadata_stage(model_path: str) -> dict:
+    """Run the metadata stage and return a stage-record fragment."""
+    absent = check_sidecar_present(model_path)
+    if absent is not None:
+        return absent
+
+    schema = _schema_path()
+    return check_schema_valid(model_path, schema)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="autospec-fab metadata stage: schema-validate per-model sidecar"
+    )
+    parser.add_argument(
+        "--in", dest="in_path", default=None,
+        help="Input STL file or directory (accepted for CLI symmetry; not used by this stage)",
+    )
+    parser.add_argument(
+        "--model", dest="model_path", required=True,
+        help="Per-model metadata JSON sidecar to validate",
+    )
+    parser.add_argument(
+        "--out", required=True,
+        help="Output fragment JSON path",
+    )
+
+    args = parser.parse_args(argv)
+
+    fragment = run_metadata_stage(args.model_path)
+
+    out_dir = os.path.dirname(os.path.abspath(args.out))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(args.out, "w") as fh:
+        json.dump(fragment, fh, indent=2)
+        fh.write("\n")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/autospec-fab/tests/fixtures/model-invalid.json
+++ b/skills/autospec-fab/tests/fixtures/model-invalid.json
@@ -1,0 +1,6 @@
+{
+  "print_orientation": "flat",
+  "load_critical": false,
+  "flow_critical": true,
+  "dims": { "x_mm": 80, "y_mm": 60, "z_mm": 40 }
+}

--- a/skills/autospec-fab/tests/fixtures/model-valid.json
+++ b/skills/autospec-fab/tests/fixtures/model-valid.json
@@ -1,0 +1,14 @@
+{
+  "material": "PETG",
+  "print_orientation": "flat",
+  "load_critical": false,
+  "flow_critical": true,
+  "dims": { "x_mm": 80, "y_mm": 60, "z_mm": 40 },
+  "ports": [
+    { "id": "inlet", "type": "npt", "size": "1/4", "clearance_mm": 6.0 },
+    { "id": "outlet", "type": "hose", "size": "25mm", "clearance_mm": 8.0 }
+  ],
+  "gaskets": [
+    { "id": "main_seal", "groove": "o-ring", "surrounding_wall_mm": 5.5 }
+  ]
+}

--- a/skills/autospec-fab/tests/test_stage_metadata.bats
+++ b/skills/autospec-fab/tests/test_stage_metadata.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# test_stage_metadata.bats — thin bats wrapper around the Python unittest suite.
+# Invoked by the validate.sh fab gate (check_autospec_fab_contract) which runs
+# every skills/autospec-fab/tests/*.bats file.
+
+# Resolve the repo root from this file's location (tests/ → skill/ → repo root)
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+
+@test "stage_metadata python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_stage_metadata.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_stage_metadata.py
+++ b/skills/autospec-fab/tests/test_stage_metadata.py
@@ -1,0 +1,201 @@
+"""
+test_stage_metadata.py — unittest for stage_metadata.py.
+
+Tests:
+  1. valid sidecar (model-valid.json)   → status pass
+  2. invalid sidecar (model-invalid.json, missing material) → status fail + metadata_invalid
+  3. absent sidecar (nonexistent path)  → status fail + metadata_missing (no ajv needed)
+  4. fragment shape: required keys + valid status enum
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
+_FIXTURES_DIR = os.path.normpath(os.path.join(_THIS_DIR, "fixtures"))
+
+_STAGE_SCRIPT = os.path.join(_SCRIPTS_DIR, "stage_metadata.py")
+
+_VALID_SIDECAR = os.path.join(_FIXTURES_DIR, "model-valid.json")
+_INVALID_SIDECAR = os.path.join(_FIXTURES_DIR, "model-invalid.json")
+_ABSENT_SIDECAR = os.path.join(_FIXTURES_DIR, "nonexistent-model.json")
+
+_AJV_AVAILABLE = shutil.which("ajv") is not None
+
+
+def _run_stage(model_path):
+    """Run stage_metadata.py --model <path> --out <tmp>, return (rc, fragment, stderr)."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+        out_path = tf.name
+    try:
+        cmd = [sys.executable, _STAGE_SCRIPT, "--model", model_path, "--out", out_path]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        fragment = None
+        if os.path.exists(out_path):
+            with open(out_path) as f:
+                fragment = json.load(f)
+        return result.returncode, fragment, result.stderr
+    finally:
+        if os.path.exists(out_path):
+            os.unlink(out_path)
+
+
+def _finding_codes(fragment):
+    return {f.get("code") for f in fragment.get("findings", [])}
+
+
+# ---------------------------------------------------------------------------
+# Fragment shape
+# ---------------------------------------------------------------------------
+
+class TestFragmentShape(unittest.TestCase):
+    """Every emitted fragment has the required stage-record keys."""
+
+    _VALID_STATUSES = {"pass", "fail", "warn", "skip"}
+
+    def _assert_valid_fragment(self, fragment, expected_stage="metadata"):
+        self.assertIsInstance(fragment, dict, "fragment must be a dict")
+        self.assertIn("stage", fragment)
+        self.assertIn("status", fragment)
+        self.assertIn(fragment["status"], self._VALID_STATUSES,
+                      f"invalid status: {fragment['status']!r}")
+        self.assertIn("detail", fragment)
+        self.assertIn("findings", fragment)
+        self.assertIsInstance(fragment["findings"], list)
+        self.assertEqual(fragment["stage"], expected_stage)
+
+    def test_valid_sidecar_fragment_shape(self):
+        if not _AJV_AVAILABLE:
+            self.skipTest("ajv not on PATH — skip ajv-dependent shape check")
+        _, fragment, _ = _run_stage(_VALID_SIDECAR)
+        self.assertIsNotNone(fragment)
+        self._assert_valid_fragment(fragment)
+
+    def test_invalid_sidecar_fragment_shape(self):
+        if not _AJV_AVAILABLE:
+            self.skipTest("ajv not on PATH — skip ajv-dependent shape check")
+        _, fragment, _ = _run_stage(_INVALID_SIDECAR)
+        self.assertIsNotNone(fragment)
+        self._assert_valid_fragment(fragment)
+
+    def test_absent_sidecar_fragment_shape(self):
+        # No ajv needed — sidecar-missing check runs before ajv
+        _, fragment, _ = _run_stage(_ABSENT_SIDECAR)
+        self.assertIsNotNone(fragment)
+        self._assert_valid_fragment(fragment)
+
+
+# ---------------------------------------------------------------------------
+# Valid sidecar → pass
+# ---------------------------------------------------------------------------
+
+class TestValidSidecar(unittest.TestCase):
+    """model-valid.json has all required fields → should pass."""
+
+    def setUp(self):
+        if not _AJV_AVAILABLE:
+            self.skipTest("ajv not on PATH — skip ajv-dependent test")
+        self.rc, self.fragment, self.stderr = _run_stage(_VALID_SIDECAR)
+
+    def test_fixture_exists(self):
+        self.assertTrue(os.path.exists(_VALID_SIDECAR), f"Missing: {_VALID_SIDECAR}")
+
+    def test_exit_code_zero(self):
+        self.assertEqual(self.rc, 0, f"Expected exit 0; stderr={self.stderr}")
+
+    def test_status_pass(self):
+        self.assertEqual(self.fragment["status"], "pass",
+                         f"Expected pass; fragment={self.fragment}")
+
+    def test_no_findings(self):
+        codes = _finding_codes(self.fragment)
+        self.assertNotIn("metadata_invalid", codes)
+        self.assertNotIn("metadata_missing", codes)
+
+
+# ---------------------------------------------------------------------------
+# Invalid sidecar → fail + metadata_invalid
+# ---------------------------------------------------------------------------
+
+class TestInvalidSidecar(unittest.TestCase):
+    """model-invalid.json is missing 'material' → should fail with metadata_invalid."""
+
+    def setUp(self):
+        if not _AJV_AVAILABLE:
+            self.skipTest("ajv not on PATH — skip ajv-dependent test")
+        self.rc, self.fragment, self.stderr = _run_stage(_INVALID_SIDECAR)
+
+    def test_fixture_exists(self):
+        self.assertTrue(os.path.exists(_INVALID_SIDECAR), f"Missing: {_INVALID_SIDECAR}")
+
+    def test_exit_code_zero(self):
+        self.assertEqual(self.rc, 0, f"Expected exit 0; stderr={self.stderr}")
+
+    def test_status_fail(self):
+        self.assertEqual(self.fragment["status"], "fail",
+                         f"Expected fail; fragment={self.fragment}")
+
+    def test_finding_metadata_invalid(self):
+        codes = _finding_codes(self.fragment)
+        self.assertIn("metadata_invalid", codes,
+                      f"Expected metadata_invalid finding; findings={self.fragment['findings']}")
+
+
+# ---------------------------------------------------------------------------
+# Absent sidecar → fail + metadata_missing  (no ajv required)
+# ---------------------------------------------------------------------------
+
+class TestAbsentSidecar(unittest.TestCase):
+    """Pointing --model at a nonexistent path → fail + metadata_missing."""
+
+    def setUp(self):
+        # This test does NOT need ajv — the missing-file check runs before ajv.
+        self.rc, self.fragment, self.stderr = _run_stage(_ABSENT_SIDECAR)
+
+    def test_sidecar_truly_absent(self):
+        self.assertFalse(os.path.exists(_ABSENT_SIDECAR),
+                         f"Fixture should not exist: {_ABSENT_SIDECAR}")
+
+    def test_exit_code_zero(self):
+        self.assertEqual(self.rc, 0, f"Expected exit 0; stderr={self.stderr}")
+
+    def test_status_fail(self):
+        self.assertEqual(self.fragment["status"], "fail",
+                         f"Expected fail for absent sidecar; fragment={self.fragment}")
+
+    def test_finding_metadata_missing(self):
+        codes = _finding_codes(self.fragment)
+        self.assertIn("metadata_missing", codes,
+                      f"Expected metadata_missing finding; findings={self.fragment['findings']}")
+
+
+# ---------------------------------------------------------------------------
+# Missing --model arg → non-zero exit (harness/usage error)
+# ---------------------------------------------------------------------------
+
+class TestMissingModelArg(unittest.TestCase):
+    """Omitting --model should exit non-zero (usage error)."""
+
+    def test_missing_model_exits_nonzero(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+            out_path = tf.name
+        try:
+            result = subprocess.run(
+                [sys.executable, _STAGE_SCRIPT, "--out", out_path],
+                capture_output=True, text=True,
+            )
+            self.assertNotEqual(result.returncode, 0,
+                                "Expected non-zero exit when --model is missing")
+        finally:
+            if os.path.exists(out_path):
+                os.unlink(out_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1223

Adds `stage_metadata.py`: validates each model sidecar against `autospec-fab-model.schema.json` via PATH-resolved `ajv` (`--spec=draft2020`). Missing → `metadata_missing`; schema violation → `metadata_invalid` (+ ajv detail); ajv absent → `skip`; valid → pass. Emits the release-gate stage fragment (verdict in status).

## Verification
- `python3 -m unittest test_stage_metadata.py` — 16/16; bats wrapper gates it. valid→pass, invalid(missing material)→`metadata_invalid`, absent→`metadata_missing`.
- `bash scripts/validate.sh` — exit 0.