### PR TITLE
feat(autospec-fab): vacuum circuit QA (reachability + isolation + no-relief)

### DIFF
--- a/skills/autospec-fab/scripts/stage_circuit.py
+++ b/skills/autospec-fab/scripts/stage_circuit.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+stage_circuit.py — vacuum circuit QA stage for autospec-fab.
+
+Uniform stage CLI:
+    stage_circuit.py --in <stl|dir> --circuit <circuit.json> --out <fragment.json>
+
+The circuit graph is a SEPARATE input (--circuit) because
+autospec-fab-model.schema.json is additionalProperties:false and the channel
+graph does not belong in the per-model metadata sidecar.
+
+Circuit JSON schema:
+  {
+    "nodes":           [<node_id>, ...],
+    "edges":           [[<a>, <b>], ...],       // undirected channel segments
+    "inlets":          [<node_id>, ...],         // vacuum inlet nodes
+    "targets":         [<node_id>, ...],         // gaskets/cavities/ports each inlet must reach
+    "isolated_groups": [[<node_id>, ...], ...],  // node-sets that must stay mutually unreachable
+    "self_clamping":   true | false,             // true → shared-input branches allowed
+    "pump_type":       "low_flow" | "standard",
+    "relief_nodes":    [<node_id>, ...]          // relief valves / bleed ports / restrictors
+  }
+
+Checks performed:
+  1. REACHABILITY   — every inlet must reach every target via BFS over the
+                      undirected channel graph.
+                      Fail: code_health disconnected_flow; detail names the pair.
+  2. ISOLATION      — declared isolated_groups must remain mutually UNREACHABLE
+                      (no path between any node in group A and any node in group B),
+                      UNLESS self_clamping is true (shared-input branches waived).
+                      Fail: circuit_isolation_violation.
+  3. NO RELIEF ON   — if pump_type == "low_flow" and relief_nodes is non-empty,
+     LOW-FLOW PUMPS   the stage rejects the model.
+                      Fail: relief_on_low_flow.
+
+Exit codes:
+  0  — harness success (gate verdict is in fragment "status", not exit code).
+  1  — harness/usage error (bad args, unreadable files, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import deque
+from typing import Dict, List, Optional, Set, Tuple
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+STAGE_NAME = "vacuum-circuit"
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+AdjGraph = Dict[str, List[str]]
+Finding = Dict[str, str]
+Fragment = Dict
+
+
+# ---------------------------------------------------------------------------
+# Graph helpers (stdlib BFS — no external graph lib)
+# ---------------------------------------------------------------------------
+
+def _build_adjacency(nodes: List[str], edges: List[List[str]]) -> AdjGraph:
+    """Build an undirected adjacency dict from nodes + edge list."""
+    adj: AdjGraph = {n: [] for n in nodes}
+    for edge in edges:
+        if len(edge) < 2:
+            continue
+        a, b = edge[0], edge[1]
+        # Add nodes implicitly if not declared (defensive)
+        if a not in adj:
+            adj[a] = []
+        if b not in adj:
+            adj[b] = []
+        adj[a].append(b)
+        adj[b].append(a)
+    return adj
+
+
+def _bfs_reachable(adj: AdjGraph, start: str) -> Set[str]:
+    """Return the set of all nodes reachable from *start* via BFS."""
+    if start not in adj:
+        return {start}
+    visited: Set[str] = {start}
+    queue: deque[str] = deque([start])
+    while queue:
+        node = queue.popleft()
+        for neighbour in adj.get(node, []):
+            if neighbour not in visited:
+                visited.add(neighbour)
+                queue.append(neighbour)
+    return visited
+
+
+def _can_reach(adj: AdjGraph, src: str, dst: str) -> bool:
+    """Return True if *dst* is reachable from *src*."""
+    return dst in _bfs_reachable(adj, src)
+
+
+# ---------------------------------------------------------------------------
+# Check 1: reachability
+# ---------------------------------------------------------------------------
+
+def _check_reachability(
+    adj: AdjGraph,
+    inlets: List[str],
+    targets: List[str],
+) -> List[Finding]:
+    """Every inlet must reach every target. Returns findings for broken pairs."""
+    findings: List[Finding] = []
+    for inlet in inlets:
+        reachable = _bfs_reachable(adj, inlet)
+        for target in targets:
+            if target not in reachable:
+                findings.append({
+                    "code": "disconnected_flow",
+                    "detail": (
+                        f"inlet '{inlet}' cannot reach target '{target}': "
+                        "no path in channel graph"
+                    ),
+                })
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check 2: isolation
+# ---------------------------------------------------------------------------
+
+def _check_isolation(
+    adj: AdjGraph,
+    isolated_groups: List[List[str]],
+    self_clamping: bool,
+) -> List[Finding]:
+    """
+    Declared isolated_groups must remain mutually unreachable unless
+    self_clamping is True.
+
+    Returns findings for any cross-group path detected.
+    """
+    if self_clamping:
+        return []  # shared-input self-clamping branches are explicitly allowed
+
+    findings: List[Finding] = []
+    n = len(isolated_groups)
+    for i in range(n):
+        for j in range(i + 1, n):
+            group_a = isolated_groups[i]
+            group_b = isolated_groups[j]
+            # Check whether ANY node in group_a can reach ANY node in group_b
+            leaked_pair: Optional[Tuple[str, str]] = None
+            for node_a in group_a:
+                reachable_from_a = _bfs_reachable(adj, node_a)
+                for node_b in group_b:
+                    if node_b in reachable_from_a:
+                        leaked_pair = (node_a, node_b)
+                        break
+                if leaked_pair:
+                    break
+            if leaked_pair:
+                findings.append({
+                    "code": "circuit_isolation_violation",
+                    "detail": (
+                        f"isolated groups {group_a} and {group_b} are not "
+                        f"electrically/fluidically isolated: path found between "
+                        f"'{leaked_pair[0]}' and '{leaked_pair[1]}'"
+                    ),
+                })
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check 3: no relief on low-flow pumps
+# ---------------------------------------------------------------------------
+
+def _check_relief(pump_type: str, relief_nodes: List[str]) -> List[Finding]:
+    """
+    Reject relief valves / bleed ports / intentional restrictors on low-flow
+    vacuum pump models. The low-flow pump rule forbids these components.
+    """
+    if pump_type != "low_flow":
+        return []
+    if not relief_nodes:
+        return []
+    return [
+        {
+            "code": "relief_on_low_flow",
+            "detail": (
+                f"pump_type 'low_flow' forbids relief/bleed/restrictor nodes; "
+                f"found: {relief_nodes}"
+            ),
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Stage entry point
+# ---------------------------------------------------------------------------
+
+def run(circuit_path: str) -> Fragment:
+    """
+    Execute all circuit checks and return the stage fragment dict.
+
+    This is the public API; main() wraps it for CLI use.
+    """
+    # Load circuit graph
+    try:
+        with open(circuit_path) as fh:
+            circuit = json.load(fh)
+    except Exception as exc:
+        return {
+            "stage": STAGE_NAME,
+            "status": "fail",
+            "detail": f"failed to load circuit JSON: {exc}",
+            "findings": [{"code": "disconnected_flow", "detail": str(exc)}],
+        }
+
+    nodes: List[str] = circuit.get("nodes", [])
+    edges: List[List[str]] = circuit.get("edges", [])
+    inlets: List[str] = circuit.get("inlets", [])
+    targets: List[str] = circuit.get("targets", [])
+    isolated_groups: List[List[str]] = circuit.get("isolated_groups", [])
+    self_clamping: bool = bool(circuit.get("self_clamping", False))
+    pump_type: str = circuit.get("pump_type", "standard")
+    relief_nodes: List[str] = circuit.get("relief_nodes", [])
+
+    adj = _build_adjacency(nodes, edges)
+
+    all_findings: List[Finding] = []
+
+    # Check 1: reachability
+    all_findings.extend(_check_reachability(adj, inlets, targets))
+
+    # Check 2: isolation
+    all_findings.extend(_check_isolation(adj, isolated_groups, self_clamping))
+
+    # Check 3: no relief on low-flow pumps
+    all_findings.extend(_check_relief(pump_type, relief_nodes))
+
+    if all_findings:
+        codes = sorted({f["code"] for f in all_findings})
+        detail = "; ".join(f["detail"] for f in all_findings)
+        status = "fail"
+    else:
+        inlet_count = len(inlets)
+        target_count = len(targets)
+        detail = (
+            f"all {inlet_count} inlet(s) reach all {target_count} target(s); "
+            "isolation intact; pump configuration valid"
+        )
+        status = "pass"
+
+    return {
+        "stage": STAGE_NAME,
+        "status": status,
+        "detail": detail,
+        "findings": all_findings,
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="autospec-fab vacuum circuit QA stage",
+    )
+    parser.add_argument(
+        "--in", dest="stl", required=True,
+        help="path to STL file or directory (required for uniform CLI; "
+             "circuit verdict is driven by --circuit graph, not geometry)",
+    )
+    parser.add_argument(
+        "--circuit", required=True,
+        help="path to circuit graph JSON",
+    )
+    parser.add_argument(
+        "--out", required=True,
+        help="output path for stage fragment JSON",
+    )
+    args = parser.parse_args(argv)
+
+    fragment = run(args.circuit)
+
+    try:
+        with open(args.out, "w") as fh:
+            json.dump(fragment, fh, indent=2)
+    except Exception as exc:
+        print(f"stage_circuit: failed to write fragment: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/autospec-fab/tests/fixtures/circuit/broken-link.json
+++ b/skills/autospec-fab/tests/fixtures/circuit/broken-link.json
@@ -1,0 +1,14 @@
+{
+  "nodes": ["inlet_a", "junction_1", "junction_2", "gasket_x", "cavity_y"],
+  "edges": [
+    ["inlet_a", "junction_1"],
+    ["junction_1", "gasket_x"],
+    ["junction_2", "cavity_y"]
+  ],
+  "inlets": ["inlet_a"],
+  "targets": ["gasket_x", "cavity_y"],
+  "isolated_groups": [],
+  "self_clamping": false,
+  "pump_type": "standard",
+  "relief_nodes": []
+}

--- a/skills/autospec-fab/tests/fixtures/circuit/connected.json
+++ b/skills/autospec-fab/tests/fixtures/circuit/connected.json
@@ -1,0 +1,17 @@
+{
+  "nodes": ["inlet_a", "inlet_b", "junction_1", "junction_2", "gasket_x", "cavity_y", "port_z"],
+  "edges": [
+    ["inlet_a", "junction_1"],
+    ["inlet_b", "junction_1"],
+    ["junction_1", "junction_2"],
+    ["junction_2", "gasket_x"],
+    ["junction_2", "cavity_y"],
+    ["junction_2", "port_z"]
+  ],
+  "inlets": ["inlet_a", "inlet_b"],
+  "targets": ["gasket_x", "cavity_y", "port_z"],
+  "isolated_groups": [],
+  "self_clamping": false,
+  "pump_type": "standard",
+  "relief_nodes": []
+}

--- a/skills/autospec-fab/tests/fixtures/circuit/leaked-isolation.json
+++ b/skills/autospec-fab/tests/fixtures/circuit/leaked-isolation.json
@@ -1,0 +1,15 @@
+{
+  "nodes": ["inlet_a", "circuit_a_node", "bridge_node", "inlet_b", "circuit_b_node"],
+  "edges": [
+    ["inlet_a", "circuit_a_node"],
+    ["circuit_a_node", "bridge_node"],
+    ["bridge_node", "circuit_b_node"],
+    ["inlet_b", "circuit_b_node"]
+  ],
+  "inlets": ["inlet_a", "inlet_b"],
+  "targets": ["circuit_a_node", "circuit_b_node"],
+  "isolated_groups": [["inlet_a", "circuit_a_node"], ["inlet_b", "circuit_b_node"]],
+  "self_clamping": false,
+  "pump_type": "standard",
+  "relief_nodes": []
+}

--- a/skills/autospec-fab/tests/fixtures/circuit/relief-low-flow.json
+++ b/skills/autospec-fab/tests/fixtures/circuit/relief-low-flow.json
@@ -1,0 +1,14 @@
+{
+  "nodes": ["inlet_a", "junction_1", "gasket_x", "relief_valve_1"],
+  "edges": [
+    ["inlet_a", "junction_1"],
+    ["junction_1", "gasket_x"],
+    ["junction_1", "relief_valve_1"]
+  ],
+  "inlets": ["inlet_a"],
+  "targets": ["gasket_x"],
+  "isolated_groups": [],
+  "self_clamping": false,
+  "pump_type": "low_flow",
+  "relief_nodes": ["relief_valve_1"]
+}

--- a/skills/autospec-fab/tests/test_stage_circuit.bats
+++ b/skills/autospec-fab/tests/test_stage_circuit.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+# test_stage_circuit.bats — thin bats wrapper around the Python unittest suite.
+# Invoked by validate.sh check_autospec_fab_contract which runs every
+# skills/autospec-fab/tests/*.bats file.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+
+@test "stage_circuit python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_stage_circuit.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_stage_circuit.py
+++ b/skills/autospec-fab/tests/test_stage_circuit.py
@@ -1,0 +1,292 @@
+"""
+test_stage_circuit.py — unittest for stage_circuit.py.
+
+Tests:
+  1. connected fixture      → status pass (every inlet reaches every target,
+                               isolation intact, no relief on standard pump)
+  2. broken-link fixture    → status fail + code_health disconnected_flow
+                               (inlet_a cannot reach cavity_y via severed edge)
+  3. leaked-isolation fixture → status fail (path between isolated_groups,
+                               self_clamping false)
+  4. relief-low-flow fixture  → status fail (pump_type low_flow + relief_nodes
+                               present → relief/bleed forbidden)
+  5. fragment shape         → stage="vacuum-circuit", status in {pass,fail,warn,skip},
+                               keys: stage, status, detail, findings
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
+_FIXTURES_DIR = os.path.normpath(os.path.join(_THIS_DIR, "fixtures", "circuit"))
+
+_STAGE_SCRIPT = os.path.join(_SCRIPTS_DIR, "stage_circuit.py")
+
+# Reuse a small existing STL (any valid STL; circuit stage doesn't gate on geometry)
+_SHARED_STL = os.path.normpath(
+    os.path.join(_THIS_DIR, "fixtures", "port-good", "body.stl")
+)
+
+_CONNECTED_CIRCUIT    = os.path.join(_FIXTURES_DIR, "connected.json")
+_BROKEN_CIRCUIT       = os.path.join(_FIXTURES_DIR, "broken-link.json")
+_LEAKED_CIRCUIT       = os.path.join(_FIXTURES_DIR, "leaked-isolation.json")
+_RELIEF_LF_CIRCUIT    = os.path.join(_FIXTURES_DIR, "relief-low-flow.json")
+
+
+def _run_stage(circuit_path, extra_args=None):
+    """Run stage_circuit.py and return (returncode, fragment_dict, stderr)."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+        out_path = tf.name
+    try:
+        cmd = [
+            sys.executable, _STAGE_SCRIPT,
+            "--in", _SHARED_STL,
+            "--circuit", circuit_path,
+            "--out", out_path,
+        ]
+        if extra_args:
+            cmd.extend(extra_args)
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        fragment = None
+        if os.path.exists(out_path):
+            with open(out_path) as fh:
+                try:
+                    fragment = json.load(fh)
+                except json.JSONDecodeError:
+                    pass
+        return result.returncode, fragment, result.stderr
+    finally:
+        if os.path.exists(out_path):
+            os.unlink(out_path)
+
+
+def _finding_codes(fragment):
+    """Return set of code values from fragment findings list."""
+    return {f.get("code") for f in fragment.get("findings", [])}
+
+
+# ---------------------------------------------------------------------------
+# Fragment shape contract
+# ---------------------------------------------------------------------------
+
+class TestFragmentShape(unittest.TestCase):
+    """Every invocation emits a valid release-gate stage-record fragment."""
+
+    VALID_STATUSES = {"pass", "fail", "warn", "skip"}
+
+    def _assert_valid_fragment(self, fragment, label=""):
+        self.assertIsInstance(fragment, dict, f"{label} fragment is not a dict")
+        for key in ("stage", "status", "detail", "findings"):
+            self.assertIn(key, fragment, f"{label} fragment missing key '{key}'")
+        self.assertIn(
+            fragment["status"], self.VALID_STATUSES,
+            f"{label} invalid status: {fragment['status']!r}",
+        )
+        self.assertEqual(
+            fragment["stage"], "vacuum-circuit",
+            f"{label} stage name must be 'vacuum-circuit'",
+        )
+        self.assertIsInstance(fragment["findings"], list,
+                              f"{label} findings must be a list")
+
+    def test_connected_fragment_shape(self):
+        _, frag, _ = _run_stage(_CONNECTED_CIRCUIT)
+        self.assertIsNotNone(frag, "no fragment emitted for connected circuit")
+        self._assert_valid_fragment(frag, "connected")
+
+    def test_broken_fragment_shape(self):
+        _, frag, _ = _run_stage(_BROKEN_CIRCUIT)
+        self.assertIsNotNone(frag, "no fragment emitted for broken-link circuit")
+        self._assert_valid_fragment(frag, "broken-link")
+
+    def test_leaked_fragment_shape(self):
+        _, frag, _ = _run_stage(_LEAKED_CIRCUIT)
+        self.assertIsNotNone(frag, "no fragment emitted for leaked-isolation circuit")
+        self._assert_valid_fragment(frag, "leaked-isolation")
+
+    def test_relief_lf_fragment_shape(self):
+        _, frag, _ = _run_stage(_RELIEF_LF_CIRCUIT)
+        self.assertIsNotNone(frag, "no fragment emitted for relief-low-flow circuit")
+        self._assert_valid_fragment(frag, "relief-low-flow")
+
+
+# ---------------------------------------------------------------------------
+# Case 1: fully connected circuit → pass
+# ---------------------------------------------------------------------------
+
+class TestConnectedCircuit(unittest.TestCase):
+    """Every inlet reaches every target, isolation intact → pass."""
+
+    def test_connected_passes(self):
+        rc, frag, stderr = _run_stage(_CONNECTED_CIRCUIT)
+        self.assertEqual(rc, 0, f"harness error: {stderr}")
+        self.assertIsNotNone(frag)
+        self.assertEqual(
+            frag["status"], "pass",
+            f"expected pass, got {frag['status']!r}; detail={frag.get('detail')}",
+        )
+
+    def test_connected_no_disconnected_flow(self):
+        _, frag, _ = _run_stage(_CONNECTED_CIRCUIT)
+        self.assertIsNotNone(frag)
+        codes = _finding_codes(frag)
+        self.assertNotIn(
+            "disconnected_flow", codes,
+            "fully connected circuit must not produce disconnected_flow finding",
+        )
+
+    def test_connected_no_findings(self):
+        _, frag, _ = _run_stage(_CONNECTED_CIRCUIT)
+        self.assertIsNotNone(frag)
+        self.assertEqual(
+            frag["findings"], [],
+            f"fully connected circuit must have empty findings, got: {frag['findings']}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 2: broken inlet→gasket link → fail disconnected_flow
+# ---------------------------------------------------------------------------
+
+class TestBrokenLink(unittest.TestCase):
+    """A severed edge leaves inlet_a unable to reach cavity_y → fail."""
+
+    def test_broken_link_fails(self):
+        rc, frag, stderr = _run_stage(_BROKEN_CIRCUIT)
+        self.assertEqual(rc, 0, f"harness error: {stderr}")
+        self.assertIsNotNone(frag)
+        self.assertEqual(
+            frag["status"], "fail",
+            f"expected fail for broken-link, got {frag['status']!r}",
+        )
+
+    def test_broken_link_emits_disconnected_flow(self):
+        _, frag, _ = _run_stage(_BROKEN_CIRCUIT)
+        self.assertIsNotNone(frag)
+        codes = _finding_codes(frag)
+        self.assertIn(
+            "disconnected_flow", codes,
+            "broken inlet→target path must emit disconnected_flow finding",
+        )
+
+    def test_broken_link_detail_names_broken_pair(self):
+        """Detail string must name the unreachable inlet→target pair."""
+        _, frag, _ = _run_stage(_BROKEN_CIRCUIT)
+        self.assertIsNotNone(frag)
+        detail = frag.get("detail", "")
+        # The fixture has inlet_a that cannot reach cavity_y
+        self.assertIn(
+            "inlet_a", detail,
+            f"detail must name the broken inlet; got: {detail!r}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 3: cross-circuit isolation leak → fail
+# ---------------------------------------------------------------------------
+
+class TestLeakedIsolation(unittest.TestCase):
+    """Path between isolated_groups when self_clamping=false → fail."""
+
+    def test_leaked_isolation_fails(self):
+        rc, frag, stderr = _run_stage(_LEAKED_CIRCUIT)
+        self.assertEqual(rc, 0, f"harness error: {stderr}")
+        self.assertIsNotNone(frag)
+        self.assertEqual(
+            frag["status"], "fail",
+            f"expected fail for leaked-isolation, got {frag['status']!r}",
+        )
+
+    def test_leaked_isolation_emits_finding(self):
+        _, frag, _ = _run_stage(_LEAKED_CIRCUIT)
+        self.assertIsNotNone(frag)
+        # Must emit either disconnected_flow or circuit_isolation_violation
+        codes = _finding_codes(frag)
+        self.assertTrue(
+            codes & {"disconnected_flow", "circuit_isolation_violation"},
+            f"isolation leak must emit isolation finding; codes: {codes}",
+        )
+
+    def test_self_clamping_accepts_shared_input(self):
+        """When self_clamping=true the stage must accept cross-group paths."""
+        # Build a variant of leaked-isolation with self_clamping=true
+        with open(_LEAKED_CIRCUIT) as fh:
+            circuit = json.load(fh)
+        circuit["self_clamping"] = True
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", mode="w", delete=False
+        ) as tf:
+            json.dump(circuit, tf)
+            tmp_circuit = tf.name
+        try:
+            rc, frag, stderr = _run_stage(tmp_circuit)
+            self.assertEqual(rc, 0, f"harness error: {stderr}")
+            self.assertIsNotNone(frag)
+            # Isolation is waived; reachability still must pass (all nodes reachable)
+            # In this fixture every inlet reaches every target via the bridge,
+            # so overall status should be pass.
+            self.assertEqual(
+                frag["status"], "pass",
+                f"self_clamping=true should accept shared-input branches; "
+                f"got {frag['status']!r}; detail={frag.get('detail')}",
+            )
+        finally:
+            os.unlink(tmp_circuit)
+
+
+# ---------------------------------------------------------------------------
+# Case 4: relief/bleed node on low-flow pump → fail
+# ---------------------------------------------------------------------------
+
+class TestReliefLowFlow(unittest.TestCase):
+    """pump_type=low_flow + non-empty relief_nodes → fail."""
+
+    def test_relief_low_flow_fails(self):
+        rc, frag, stderr = _run_stage(_RELIEF_LF_CIRCUIT)
+        self.assertEqual(rc, 0, f"harness error: {stderr}")
+        self.assertIsNotNone(frag)
+        self.assertEqual(
+            frag["status"], "fail",
+            f"expected fail for relief-low-flow, got {frag['status']!r}",
+        )
+
+    def test_relief_low_flow_finding_code(self):
+        _, frag, _ = _run_stage(_RELIEF_LF_CIRCUIT)
+        self.assertIsNotNone(frag)
+        codes = _finding_codes(frag)
+        self.assertTrue(
+            codes & {"disconnected_flow", "relief_on_low_flow"},
+            f"relief on low-flow must emit a finding; codes: {codes}",
+        )
+
+    def test_standard_pump_with_relief_passes_pump_check(self):
+        """Relief nodes on a standard pump must NOT trigger the pump check."""
+        with open(_RELIEF_LF_CIRCUIT) as fh:
+            circuit = json.load(fh)
+        circuit["pump_type"] = "standard"
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", mode="w", delete=False
+        ) as tf:
+            json.dump(circuit, tf)
+            tmp_circuit = tf.name
+        try:
+            rc, frag, stderr = _run_stage(tmp_circuit)
+            self.assertEqual(rc, 0, f"harness error: {stderr}")
+            self.assertIsNotNone(frag)
+            # No pump-type violation; reachability is fine in this fixture
+            codes = _finding_codes(frag)
+            self.assertNotIn(
+                "relief_on_low_flow", codes,
+                "standard pump with relief nodes must NOT emit relief_on_low_flow",
+            )
+        finally:
+            os.unlink(tmp_circuit)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1225

Adds `stage_circuit.py`: stdlib-BFS over a `--circuit` channel graph (separate input — model schema is additionalProperties:false). Checks: every inlet reaches every target (`disconnected_flow`), isolated_groups stay mutually unreachable unless `self_clamping` (`circuit_isolation_violation`), and no relief/bleed/restrictor on `pump_type:low_flow` (`relief_on_low_flow`). Emits the release-gate fragment.

## Verification
- `python3 -m unittest test_stage_circuit.py` — 16/16; bats gates it. connected→pass, broken-link→`disconnected_flow`, leaked-isolation→`circuit_isolation_violation`, relief-low-flow→`relief_on_low_flow`; self_clamping waiver + standard-pump variants covered.
- `bash scripts/validate.sh` — exit 0.

Note: any COMPLEXITY nesting flags are the AST-false-positive class tracked in #1245.