### PR TITLE
feat(autospec-fab): gasket leak sim + model-schema QA-fields fix

### DIFF
--- a/schemas/autospec-fab-model.schema.json
+++ b/schemas/autospec-fab-model.schema.json
@@ -48,7 +48,10 @@
             "description": "Port connection type."
           },
           "size": { "type": "string", "description": "Thread or diameter designation (e.g. 1/4, 25mm)." },
-          "clearance_mm": { "type": "number", "description": "Minimum tool-access clearance in mm." }
+          "clearance_mm": { "type": "number", "description": "Minimum tool-access clearance in mm." },
+          "tap_access": { "type": "boolean", "description": "NPT port: tap/wrench access is preserved (vacuum-fitting QA, #1224)." },
+          "thread_depth_mm": { "type": "number", "description": "NPT port: usable thread depth in mm (vacuum-fitting QA)." },
+          "standalone_tower": { "type": "boolean", "description": "Port is a narrow standalone tower/ear/boss rather than integrated into the body (vacuum-fitting QA rejects true)." }
         }
       }
     },
@@ -65,7 +68,9 @@
           "surrounding_wall_mm": {
             "type": "number",
             "description": "Minimum plastic wall surrounding the gasket groove in mm (gate requires ≥5 mm)."
-          }
+          },
+          "seal_face_continuous": { "type": "boolean", "description": "Groove seal face is continuous/closed (gasket-leak QA rejects a broken seal face)." },
+          "exposed_side": { "type": "boolean", "description": "Groove side is open to the exterior (gasket-leak QA rejects true — exposed gasket side)." }
         }
       }
     }

--- a/skills/autospec-fab/scripts/stage_gasket.py
+++ b/skills/autospec-fab/scripts/stage_gasket.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+stage_gasket.py — gasket leak-sim QA stage for autospec-fab.
+
+Uniform stage CLI:
+    stage_gasket.py --in <stl|dir> --model <metadata.json> --out <fragment.json>
+
+Checks performed (per gasket in model metadata):
+  1. SURROUNDING WALL      — gasket.surrounding_wall_mm must be ≥ 5 mm.
+                             Fails with code_health exposed_gasket (thin wall)
+                             when < 5 or not declared.
+  2. SEAL-FACE CONTINUITY  — gasket.seal_face_continuous must be true.
+                             Fails with exposed_gasket (broken seal face) when
+                             false or absent.
+  3. EXPOSED SIDE          — gasket.exposed_side must be false (or absent).
+                             Fails with exposed_gasket (exposed side) when true.
+
+All three checks use declared metadata fields as the primary signal.
+The stdlib STL geometry probe is loaded opportunistically for cross-checking
+but never required; trimesh is optional (lazy try/except).
+
+Exit codes:
+  0  — harness success (gate verdict is in fragment "status", not exit code).
+  1  — harness/usage error (bad args, unreadable files, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Optional trimesh
+# ---------------------------------------------------------------------------
+try:
+    import trimesh as _trimesh  # type: ignore
+except ImportError:
+    _trimesh = None  # type: ignore
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MIN_SURROUNDING_WALL_MM: float = 5.0  # minimum plastic outside groove (mm)
+STAGE_NAME = "gasket"
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+Triangle = Tuple[
+    Tuple[float, float, float],
+    Tuple[float, float, float],
+    Tuple[float, float, float],
+]
+Finding = Dict[str, str]
+Fragment = Dict
+
+# ---------------------------------------------------------------------------
+# ASCII STL parser (stdlib — same pattern as stage_fitting.py)
+# ---------------------------------------------------------------------------
+
+_FACET_RE = re.compile(r"facet\s+normal", re.IGNORECASE)
+_VERTEX_RE = re.compile(
+    r"vertex\s+([\-+]?[0-9]*\.?[0-9]+(?:[eE][\-+]?[0-9]+)?)"
+    r"\s+([\-+]?[0-9]*\.?[0-9]+(?:[eE][\-+]?[0-9]+)?)"
+    r"\s+([\-+]?[0-9]*\.?[0-9]+(?:[eE][\-+]?[0-9]+)?)",
+    re.IGNORECASE,
+)
+
+
+def _parse_stl_ascii(path: str) -> List[Triangle]:
+    """Parse ASCII STL → list of triangles (each: 3 (x,y,z) tuples)."""
+    triangles: List[Triangle] = []
+    with open(path, "r", errors="replace") as fh:
+        content = fh.read()
+    for block in _FACET_RE.split(content)[1:]:
+        verts = _VERTEX_RE.findall(block)
+        if len(verts) >= 3:
+            tri = tuple(
+                (float(x), float(y), float(z)) for x, y, z in verts[:3]
+            )
+            triangles.append(tri)  # type: ignore[arg-type]
+    return triangles
+
+
+def _parse_stl(path: str) -> Optional[List[Triangle]]:
+    """
+    Parse STL at *path*.  Tries trimesh first (binary STL support) when
+    available; falls back to stdlib ASCII parser.  Returns None on failure.
+    """
+    if _trimesh is not None:
+        try:
+            mesh = _trimesh.load_mesh(path)
+            tris: List[Triangle] = []
+            for face in mesh.faces:
+                v0 = tuple(float(c) for c in mesh.vertices[face[0]])
+                v1 = tuple(float(c) for c in mesh.vertices[face[1]])
+                v2 = tuple(float(c) for c in mesh.vertices[face[2]])
+                tris.append((v0, v1, v2))  # type: ignore[arg-type]
+            return tris or None
+        except Exception:
+            pass
+    try:
+        tris = _parse_stl_ascii(path)
+        return tris or None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Geometry probe — bounding-box extents
+# ---------------------------------------------------------------------------
+
+def _bounding_box(triangles: List[Triangle]) -> Tuple[float, float, float]:
+    """Return (x_range, y_range, z_range) bounding-box extents in mm."""
+    xs = [v[0] for tri in triangles for v in tri]
+    ys = [v[1] for tri in triangles for v in tri]
+    zs = [v[2] for tri in triangles for v in tri]
+    return (
+        max(xs) - min(xs),
+        max(ys) - min(ys),
+        max(zs) - min(zs),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-gasket checks
+# ---------------------------------------------------------------------------
+
+def _check_gasket(
+    gasket: dict,
+    _triangles: Optional[List[Triangle]],
+) -> List[Finding]:
+    """
+    Run all checks for a single gasket dict.
+
+    Returns a (possibly empty) list of Finding dicts; empty means all pass.
+    The triangles argument is available for optional geometry cross-checks
+    but none are required — metadata fields are the authoritative signal.
+    """
+    findings: List[Finding] = []
+    gid = gasket.get("id", "<unknown>")
+
+    # --- Rule 1: surrounding wall ≥ 5 mm -----------------------------------
+    wall = gasket.get("surrounding_wall_mm")
+    if wall is None or wall < MIN_SURROUNDING_WALL_MM:
+        actual = wall if wall is not None else "not declared"
+        findings.append({
+            "code": "exposed_gasket",
+            "gasket": gid,
+            "detail": (
+                f"gasket '{gid}' surrounding_wall_mm {actual} mm "
+                f"< required {MIN_SURROUNDING_WALL_MM} mm (thin wall)"
+            ),
+        })
+
+    # --- Rule 2: seal-face continuity --------------------------------------
+    if not gasket.get("seal_face_continuous", False):
+        findings.append({
+            "code": "exposed_gasket",
+            "gasket": gid,
+            "detail": (
+                f"gasket '{gid}' seal_face_continuous is false or absent "
+                "(broken seal face — pressure boundary not closed)"
+            ),
+        })
+
+    # --- Rule 3: exposed side ----------------------------------------------
+    if gasket.get("exposed_side", False):
+        findings.append({
+            "code": "exposed_gasket",
+            "gasket": gid,
+            "detail": (
+                f"gasket '{gid}' exposed_side is true "
+                "(groove side open to exterior — rejected)"
+            ),
+        })
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Stage entry point
+# ---------------------------------------------------------------------------
+
+def _resolve_stl(path: str) -> Optional[str]:
+    """
+    Resolve *path* to a single STL file path.
+    If *path* is a directory, return the first *.stl found (case-insensitive).
+    """
+    if os.path.isfile(path):
+        return path
+    if os.path.isdir(path):
+        for name in sorted(os.listdir(path)):
+            if name.lower().endswith(".stl"):
+                return os.path.join(path, name)
+    return None
+
+
+def run(stl_path: str, model_path: str) -> Fragment:
+    """
+    Execute all gasket checks and return the stage fragment dict.
+
+    This is the public API; main() wraps it for CLI use.
+    """
+    all_findings: List[Finding] = []
+
+    # Load model metadata
+    try:
+        with open(model_path) as fh:
+            model = json.load(fh)
+    except Exception as exc:
+        return {
+            "stage": STAGE_NAME,
+            "status": "fail",
+            "detail": f"failed to load model metadata: {exc}",
+            "findings": [{"code": "exposed_gasket", "detail": str(exc)}],
+        }
+
+    gaskets: List[dict] = model.get("gaskets", [])
+
+    # Load STL best-effort (None if unavailable) for optional cross-checks
+    resolved = _resolve_stl(stl_path)
+    triangles: Optional[List[Triangle]] = None
+    if resolved:
+        triangles = _parse_stl(resolved)
+
+    for gasket in gaskets:
+        gasket_findings = _check_gasket(gasket, triangles)
+        all_findings.extend(gasket_findings)
+
+    if all_findings:
+        gasket_ids = sorted({f.get("gasket", "") for f in all_findings if f.get("gasket")})
+        detail = (
+            f"gasket QA failed on gasket(s) {gasket_ids}: "
+            + "; ".join(f["detail"] for f in all_findings)
+        )
+        status = "fail"
+    else:
+        gasket_count = len(gaskets)
+        detail = f"all {gasket_count} gasket(s) passed leak-sim QA"
+        status = "pass"
+
+    return {
+        "stage": STAGE_NAME,
+        "status": status,
+        "detail": detail,
+        "findings": all_findings,
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="autospec-fab gasket leak-sim QA stage",
+    )
+    parser.add_argument("--in", dest="stl", required=True,
+                        help="path to STL file or directory containing STL")
+    parser.add_argument("--model", required=True,
+                        help="path to model metadata JSON sidecar")
+    parser.add_argument("--out", required=True,
+                        help="output path for stage fragment JSON")
+    args = parser.parse_args(argv)
+
+    fragment = run(args.stl, args.model)
+
+    try:
+        with open(args.out, "w") as fh:
+            json.dump(fragment, fh, indent=2)
+    except Exception as exc:
+        print(f"stage_gasket: failed to write fragment: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/autospec-fab/tests/fixtures/gasket-enclosed/body.stl
+++ b/skills/autospec-fab/tests/fixtures/gasket-enclosed/body.stl
@@ -1,0 +1,86 @@
+solid gasket-enclosed-body
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 40 0 0
+      vertex 40 40 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 40 40 0
+      vertex 0 40 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 40 40 20
+      vertex 40 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 0 40 20
+      vertex 40 40 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 40 0 0
+      vertex 40 0 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 40 0 20
+      vertex 0 0 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 40 0
+      vertex 40 40 20
+      vertex 40 40 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 40 0
+      vertex 0 40 20
+      vertex 40 40 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 40 0
+      vertex 0 40 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 40 20
+      vertex 0 0 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 40 0 0
+      vertex 40 40 20
+      vertex 40 40 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 40 0 0
+      vertex 40 0 20
+      vertex 40 40 20
+    endloop
+  endfacet
+endsolid gasket-enclosed-body

--- a/skills/autospec-fab/tests/fixtures/gasket-enclosed/model.json
+++ b/skills/autospec-fab/tests/fixtures/gasket-enclosed/model.json
@@ -1,0 +1,16 @@
+{
+  "material": "PETG",
+  "print_orientation": "flat",
+  "load_critical": false,
+  "flow_critical": true,
+  "dims": { "x_mm": 40, "y_mm": 40, "z_mm": 20 },
+  "gaskets": [
+    {
+      "id": "g1",
+      "groove": "o-ring",
+      "surrounding_wall_mm": 8.0,
+      "seal_face_continuous": true,
+      "exposed_side": false
+    }
+  ]
+}

--- a/skills/autospec-fab/tests/fixtures/gasket-exposed/body.stl
+++ b/skills/autospec-fab/tests/fixtures/gasket-exposed/body.stl
@@ -1,0 +1,86 @@
+solid gasket-exposed-body
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 20 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 10
+      vertex 20 20 10
+      vertex 20 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 10
+      vertex 0 20 10
+      vertex 20 20 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 0 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 10
+      vertex 0 0 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 10
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 0 20 10
+      vertex 20 20 10
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 0
+      vertex 0 20 10
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 10
+      vertex 0 0 10
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 10
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 0 10
+      vertex 20 20 10
+    endloop
+  endfacet
+endsolid gasket-exposed-body

--- a/skills/autospec-fab/tests/fixtures/gasket-exposed/model.json
+++ b/skills/autospec-fab/tests/fixtures/gasket-exposed/model.json
@@ -1,0 +1,16 @@
+{
+  "material": "PETG",
+  "print_orientation": "flat",
+  "load_critical": false,
+  "flow_critical": true,
+  "dims": { "x_mm": 20, "y_mm": 20, "z_mm": 10 },
+  "gaskets": [
+    {
+      "id": "g1",
+      "groove": "o-ring",
+      "surrounding_wall_mm": 6.0,
+      "seal_face_continuous": false,
+      "exposed_side": true
+    }
+  ]
+}

--- a/skills/autospec-fab/tests/fixtures/gasket-thin/body.stl
+++ b/skills/autospec-fab/tests/fixtures/gasket-thin/body.stl
@@ -1,0 +1,86 @@
+solid gasket-thin-body
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 20 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 10
+      vertex 20 20 10
+      vertex 20 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 10
+      vertex 0 20 10
+      vertex 20 20 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 0 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 10
+      vertex 0 0 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 10
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 0 20 10
+      vertex 20 20 10
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 0
+      vertex 0 20 10
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 10
+      vertex 0 0 10
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 10
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 0 10
+      vertex 20 20 10
+    endloop
+  endfacet
+endsolid gasket-thin-body

--- a/skills/autospec-fab/tests/fixtures/gasket-thin/model.json
+++ b/skills/autospec-fab/tests/fixtures/gasket-thin/model.json
@@ -1,0 +1,16 @@
+{
+  "material": "PETG",
+  "print_orientation": "flat",
+  "load_critical": false,
+  "flow_critical": true,
+  "dims": { "x_mm": 20, "y_mm": 20, "z_mm": 10 },
+  "gaskets": [
+    {
+      "id": "g1",
+      "groove": "o-ring",
+      "surrounding_wall_mm": 3.0,
+      "seal_face_continuous": true,
+      "exposed_side": false
+    }
+  ]
+}

--- a/skills/autospec-fab/tests/test_stage_gasket.bats
+++ b/skills/autospec-fab/tests/test_stage_gasket.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+# test_stage_gasket.bats — thin bats wrapper around the Python unittest suite.
+# Invoked by validate.sh check_autospec_fab_contract which runs every
+# skills/autospec-fab/tests/*.bats file.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+
+@test "stage_gasket python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_stage_gasket.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_stage_gasket.py
+++ b/skills/autospec-fab/tests/test_stage_gasket.py
@@ -1,0 +1,253 @@
+"""
+test_stage_gasket.py — unittest for stage_gasket.py.
+
+Tests:
+  1. gasket-enclosed fixture → status pass (surrounding_wall≥5, seal continuous,
+                               not exposed)
+  2. gasket-thin fixture     → status fail + finding exposed_gasket (wall < 5 mm)
+  3. gasket-exposed fixture  → status fail + finding exposed_gasket (exposed_side
+                               true + broken seal face)
+  4. fragment shape          → stage="gasket", status in {pass,fail,warn,skip},
+                               keys: stage, status, detail, findings
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
+_FIXTURES_DIR = os.path.normpath(os.path.join(_THIS_DIR, "fixtures"))
+
+_STAGE_SCRIPT = os.path.join(_SCRIPTS_DIR, "stage_gasket.py")
+
+_ENCLOSED_STL   = os.path.join(_FIXTURES_DIR, "gasket-enclosed", "body.stl")
+_ENCLOSED_MODEL = os.path.join(_FIXTURES_DIR, "gasket-enclosed", "model.json")
+
+_THIN_STL   = os.path.join(_FIXTURES_DIR, "gasket-thin", "body.stl")
+_THIN_MODEL = os.path.join(_FIXTURES_DIR, "gasket-thin", "model.json")
+
+_EXPOSED_STL   = os.path.join(_FIXTURES_DIR, "gasket-exposed", "body.stl")
+_EXPOSED_MODEL = os.path.join(_FIXTURES_DIR, "gasket-exposed", "model.json")
+
+
+def _run_stage(stl_path, model_path, extra_args=None):
+    """Run stage_gasket.py and return (returncode, fragment_dict, stderr)."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+        out_path = tf.name
+    try:
+        cmd = [
+            sys.executable, _STAGE_SCRIPT,
+            "--in", stl_path,
+            "--model", model_path,
+            "--out", out_path,
+        ]
+        if extra_args:
+            cmd.extend(extra_args)
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        fragment = None
+        if os.path.exists(out_path):
+            with open(out_path) as fh:
+                fragment = json.load(fh)
+        return result.returncode, fragment, result.stderr
+    finally:
+        if os.path.exists(out_path):
+            os.unlink(out_path)
+
+
+def _finding_codes(fragment):
+    """Return set of code_health ids from fragment findings list."""
+    return {f.get("code") for f in fragment.get("findings", [])}
+
+
+class TestFragmentShape(unittest.TestCase):
+    """Every invocation emits a valid release-gate stage-record fragment."""
+
+    def _assert_valid_fragment(self, fragment):
+        self.assertIsInstance(fragment, dict)
+        for key in ("stage", "status", "detail", "findings"):
+            self.assertIn(key, fragment, f"fragment missing key '{key}'")
+        self.assertIn(
+            fragment["status"], {"pass", "fail", "warn", "skip"},
+            f"invalid status: {fragment['status']!r}",
+        )
+        self.assertEqual(fragment["stage"], "gasket")
+        self.assertIsInstance(fragment["findings"], list)
+
+    def test_enclosed_fragment_shape(self):
+        _, frag, _ = _run_stage(_ENCLOSED_STL, _ENCLOSED_MODEL)
+        self.assertIsNotNone(frag, "no fragment emitted for enclosed gasket")
+        self._assert_valid_fragment(frag)
+
+    def test_thin_fragment_shape(self):
+        _, frag, _ = _run_stage(_THIN_STL, _THIN_MODEL)
+        self.assertIsNotNone(frag, "no fragment emitted for thin-wall gasket")
+        self._assert_valid_fragment(frag)
+
+    def test_exposed_fragment_shape(self):
+        _, frag, _ = _run_stage(_EXPOSED_STL, _EXPOSED_MODEL)
+        self.assertIsNotNone(frag, "no fragment emitted for exposed-side gasket")
+        self._assert_valid_fragment(frag)
+
+
+class TestEnclosedGasket(unittest.TestCase):
+    """Well-enclosed gasket groove with ≥5 mm wall, continuous seal → pass."""
+
+    def test_enclosed_passes(self):
+        rc, frag, stderr = _run_stage(_ENCLOSED_STL, _ENCLOSED_MODEL)
+        self.assertEqual(rc, 0, f"harness error: {stderr}")
+        self.assertIsNotNone(frag)
+        self.assertEqual(
+            frag["status"], "pass",
+            f"expected pass, got {frag['status']!r}; detail={frag.get('detail')}",
+        )
+
+    def test_enclosed_no_exposed_gasket(self):
+        _, frag, _ = _run_stage(_ENCLOSED_STL, _ENCLOSED_MODEL)
+        self.assertIsNotNone(frag)
+        codes = _finding_codes(frag)
+        self.assertNotIn(
+            "exposed_gasket", codes,
+            "compliant enclosed gasket must not produce exposed_gasket finding",
+        )
+
+
+class TestThinWallGasket(unittest.TestCase):
+    """Gasket with surrounding_wall_mm < 5 → fail + exposed_gasket."""
+
+    def test_thin_wall_fails(self):
+        rc, frag, stderr = _run_stage(_THIN_STL, _THIN_MODEL)
+        self.assertEqual(rc, 0, f"harness error: {stderr}")
+        self.assertIsNotNone(frag)
+        self.assertEqual(
+            frag["status"], "fail",
+            f"expected fail for thin-wall gasket, got {frag['status']!r}",
+        )
+
+    def test_thin_wall_emits_exposed_gasket(self):
+        _, frag, _ = _run_stage(_THIN_STL, _THIN_MODEL)
+        self.assertIsNotNone(frag)
+        self.assertIn(
+            "exposed_gasket", _finding_codes(frag),
+            "thin-wall gasket must emit exposed_gasket finding",
+        )
+
+
+class TestExposedSideGasket(unittest.TestCase):
+    """Gasket with exposed_side true or broken seal face → fail + exposed_gasket."""
+
+    def test_exposed_side_fails(self):
+        rc, frag, stderr = _run_stage(_EXPOSED_STL, _EXPOSED_MODEL)
+        self.assertEqual(rc, 0, f"harness error: {stderr}")
+        self.assertIsNotNone(frag)
+        self.assertEqual(
+            frag["status"], "fail",
+            f"expected fail for exposed-side gasket, got {frag['status']!r}",
+        )
+
+    def test_exposed_side_emits_exposed_gasket(self):
+        _, frag, _ = _run_stage(_EXPOSED_STL, _EXPOSED_MODEL)
+        self.assertIsNotNone(frag)
+        self.assertIn(
+            "exposed_gasket", _finding_codes(frag),
+            "exposed-side gasket must emit exposed_gasket finding",
+        )
+
+
+class TestInlineModels(unittest.TestCase):
+    """Boundary/inline model checks without fixture files."""
+
+    def test_wall_exactly_5mm_passes(self):
+        """surrounding_wall_mm == 5.0 is on the boundary → should pass."""
+        model = {
+            "material": "PETG",
+            "print_orientation": "flat",
+            "load_critical": False,
+            "flow_critical": True,
+            "gaskets": [
+                {
+                    "id": "g1",
+                    "groove": "o-ring",
+                    "surrounding_wall_mm": 5.0,
+                    "seal_face_continuous": True,
+                    "exposed_side": False,
+                }
+            ],
+        }
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", mode="w", delete=False
+        ) as tf:
+            json.dump(model, tf)
+            tmp_model = tf.name
+        try:
+            rc, frag, stderr = _run_stage(_ENCLOSED_STL, tmp_model)
+            self.assertEqual(rc, 0, f"harness error: {stderr}")
+            self.assertIsNotNone(frag)
+            self.assertEqual(
+                frag["status"], "pass",
+                "surrounding_wall_mm==5.0 must pass (boundary inclusive)",
+            )
+        finally:
+            os.unlink(tmp_model)
+
+    def test_broken_seal_face_alone_fails(self):
+        """seal_face_continuous false with adequate wall → fail exposed_gasket."""
+        model = {
+            "material": "PETG",
+            "print_orientation": "flat",
+            "load_critical": False,
+            "flow_critical": True,
+            "gaskets": [
+                {
+                    "id": "g1",
+                    "groove": "o-ring",
+                    "surrounding_wall_mm": 8.0,
+                    "seal_face_continuous": False,
+                    "exposed_side": False,
+                }
+            ],
+        }
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", mode="w", delete=False
+        ) as tf:
+            json.dump(model, tf)
+            tmp_model = tf.name
+        try:
+            rc, frag, stderr = _run_stage(_ENCLOSED_STL, tmp_model)
+            self.assertEqual(rc, 0, f"harness error: {stderr}")
+            self.assertIsNotNone(frag)
+            self.assertEqual(frag["status"], "fail",
+                             "broken seal face must fail even with good wall")
+            self.assertIn("exposed_gasket", _finding_codes(frag))
+        finally:
+            os.unlink(tmp_model)
+
+    def test_no_gaskets_passes(self):
+        """Model with empty gaskets list → pass (nothing to reject)."""
+        model = {
+            "material": "PETG",
+            "print_orientation": "flat",
+            "load_critical": False,
+            "flow_critical": False,
+            "gaskets": [],
+        }
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", mode="w", delete=False
+        ) as tf:
+            json.dump(model, tf)
+            tmp_model = tf.name
+        try:
+            rc, frag, stderr = _run_stage(_ENCLOSED_STL, tmp_model)
+            self.assertEqual(rc, 0, f"harness error: {stderr}")
+            self.assertIsNotNone(frag)
+            self.assertEqual(frag["status"], "pass",
+                             "empty gaskets list must pass")
+        finally:
+            os.unlink(tmp_model)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1226

Adds `stage_gasket.py`: per gasket — `surrounding_wall_mm`≥5, `seal_face_continuous`, not `exposed_side`; violation → `code_health: exposed_gasket`. Stdlib STL probe (trimesh optional). Fixtures enclosed/thin/exposed; 12-test unittest + bats.

**Cross-stage integration fix:** `autospec-fab-model.schema.json`'s `ports[].items`/`gaskets[].items` were `additionalProperties:false` WITHOUT the QA fields the #1224/#1226 stages read — so a real QA sidecar (`tap_access`/`thread_depth_mm`/`standalone_tower`/`seal_face_continuous`/`exposed_side`) was **rejected by the metadata stage #1223** (verified ajv_rc 1→0 after the fix). Added them as named optional fields. This unblocks a model both passing metadata validation AND carrying the QA attributes — a latent Phase-5.5 break caught early.

## Verification
- `python3 -m unittest test_stage_gasket.py` — 12/12; bats gates it. enclosed→pass, thin(<5mm)→`exposed_gasket`, exposed-side/broken-seal→`exposed_gasket`.
- gasket + port QA sidecars now validate against the model schema (ajv exit 0); schema bats 6/6 unregressed.
- `bash scripts/validate.sh` — exit 0.