### PR TITLE
feat(autospec-fab): dust leak/airflow QA (openings + monotonic area + gate-slot/PVC reject)

### DIFF
--- a/skills/autospec-fab/scripts/stage_dust.py
+++ b/skills/autospec-fab/scripts/stage_dust.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+stage_dust.py — dust leak/airflow QA stage for autospec-fab.
+
+Uniform stage CLI:
+    stage_dust.py --in <stl|dir> --duct <duct.json> --out <fragment.json>
+
+The duct descriptor is a SEPARATE input (--duct) because
+autospec-fab-model.schema.json is additionalProperties:false and the duct
+cross-section sweep does not belong in the per-model metadata sidecar.
+
+Duct JSON schema:
+  {
+    "ducts": [
+      {
+        "id":                <string>,
+        "opening_mm":        <float>,   // nominal full-size opening diameter/span
+        "min_opening_mm":    <float>,   // required minimum (full-size, unobstructed)
+        "cross_section_mm2": [<float>, ...],  // area sweep from inlet to outlet
+        "connected":         true|false,
+        "printed_gate_slot": true|false,
+        "pvc_as_duct":       true|false
+      }, ...
+    ],
+    "nominal_full_size_mm2": <float>   // expected unobstructed area (reference)
+  }
+
+Checks performed (per duct):
+  1. FULL-SIZE OPENING  — opening_mm >= min_opening_mm.
+                          Fail: disconnected_flow; detail names the duct.
+  2. CROSS-SECTION PINCH — any area in the sweep drops below
+                           PINCH_FRACTION (0.6) * inlet area → obstruction.
+                           Fail: disconnected_flow (detail: "pinched/blocked").
+  3. CONNECTIVITY       — connected == false → disconnected duct.
+                          Fail: disconnected_flow.
+  4. PRINTED GATE SLOT  — printed_gate_slot == true → hard reject.
+                          Fail: disconnected_flow (detail: "printed gate slot").
+  5. PVC AS DUCT        — pvc_as_duct == true → hard reject (PVC must not be
+                          used as the printed airflow duct).
+                          Fail: disconnected_flow (detail: "PVC as printed duct").
+
+Exit codes:
+  0  — harness success (gate verdict is in fragment "status", not exit code).
+  1  — harness/usage error (bad args, unreadable files, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Dict, List, Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+STAGE_NAME = "dust-airflow"
+
+# A cross-section area dropping below this fraction of the inlet area is
+# considered a pinch/obstruction (blocked/constricted duct).
+PINCH_FRACTION = 0.6
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+Finding = Dict[str, str]
+Fragment = Dict
+
+
+# ---------------------------------------------------------------------------
+# Per-duct checks
+# ---------------------------------------------------------------------------
+
+def _check_opening(duct: Dict) -> List[Finding]:
+    """opening_mm must be >= min_opening_mm (full-size, unobstructed)."""
+    duct_id = duct.get("id", "<unknown>")
+    opening = float(duct.get("opening_mm", 0.0))
+    min_opening = float(duct.get("min_opening_mm", 0.0))
+    if opening < min_opening:
+        return [{
+            "code": "disconnected_flow",
+            "detail": (
+                f"duct '{duct_id}': opening {opening} mm is below required "
+                f"minimum {min_opening} mm — port is undersized/blocked"
+            ),
+        }]
+    return []
+
+
+def _check_cross_section(duct: Dict) -> List[Finding]:
+    """
+    Sweep cross_section_mm2; any area below PINCH_FRACTION of the inlet area
+    is a pinch (obstruction/constriction).
+    """
+    duct_id = duct.get("id", "<unknown>")
+    sweep: List[float] = [float(a) for a in duct.get("cross_section_mm2", [])]
+    if len(sweep) < 2:
+        return []  # not enough data to detect a pinch
+
+    inlet_area = sweep[0]
+    if inlet_area <= 0.0:
+        return []
+
+    threshold = PINCH_FRACTION * inlet_area
+    for i, area in enumerate(sweep):
+        if area < threshold:
+            return [{
+                "code": "disconnected_flow",
+                "detail": (
+                    f"duct '{duct_id}': cross-section at index {i} is "
+                    f"{area:.1f} mm² — below {PINCH_FRACTION:.0%} of inlet area "
+                    f"{inlet_area:.1f} mm² (threshold {threshold:.1f} mm²); "
+                    "duct is pinched/blocked"
+                ),
+            }]
+    return []
+
+
+def _check_connectivity(duct: Dict) -> List[Finding]:
+    """connected must be true; false means a disconnected duct."""
+    duct_id = duct.get("id", "<unknown>")
+    if not duct.get("connected", True):
+        return [{
+            "code": "disconnected_flow",
+            "detail": (
+                f"duct '{duct_id}': duct is not connected — "
+                "disconnected ducts are a hard reject"
+            ),
+        }]
+    return []
+
+
+def _check_gate_slot(duct: Dict) -> List[Finding]:
+    """Printed gate slots are forbidden in dust collection paths."""
+    duct_id = duct.get("id", "<unknown>")
+    if duct.get("printed_gate_slot", False):
+        return [{
+            "code": "disconnected_flow",
+            "detail": (
+                f"duct '{duct_id}': printed gate slot detected — "
+                "printed gate slots are prohibited in dust collection ducts"
+            ),
+        }]
+    return []
+
+
+def _check_pvc_as_duct(duct: Dict) -> List[Finding]:
+    """PVC must not be used as the printed airflow duct."""
+    duct_id = duct.get("id", "<unknown>")
+    if duct.get("pvc_as_duct", False):
+        return [{
+            "code": "disconnected_flow",
+            "detail": (
+                f"duct '{duct_id}': PVC declared as the printed airflow duct — "
+                "PVC must not be used as the printed duct; use a proper printed "
+                "hose/duct/socket opening"
+            ),
+        }]
+    return []
+
+
+def _check_duct(duct: Dict) -> List[Finding]:
+    """Run all checks for a single duct entry; return combined findings."""
+    findings: List[Finding] = []
+    findings.extend(_check_opening(duct))
+    findings.extend(_check_cross_section(duct))
+    findings.extend(_check_connectivity(duct))
+    findings.extend(_check_gate_slot(duct))
+    findings.extend(_check_pvc_as_duct(duct))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Stage entry point
+# ---------------------------------------------------------------------------
+
+def run(duct_path: str) -> Fragment:
+    """
+    Execute all dust/airflow checks and return the stage fragment dict.
+
+    This is the public API; main() wraps it for CLI use.
+    """
+    try:
+        with open(duct_path) as fh:
+            descriptor = json.load(fh)
+    except Exception as exc:
+        return {
+            "stage": STAGE_NAME,
+            "status": "fail",
+            "detail": f"failed to load duct JSON: {exc}",
+            "findings": [{"code": "disconnected_flow", "detail": str(exc)}],
+        }
+
+    ducts: List[Dict] = descriptor.get("ducts", [])
+
+    all_findings: List[Finding] = []
+    for duct in ducts:
+        all_findings.extend(_check_duct(duct))
+
+    if all_findings:
+        detail = "; ".join(f["detail"] for f in all_findings)
+        status = "fail"
+    else:
+        duct_count = len(ducts)
+        detail = (
+            f"all {duct_count} duct(s) pass: full-size openings verified, "
+            "cross-sections clear of pinches, all ducts connected, "
+            "no printed gate slots, no PVC-as-duct"
+        )
+        status = "pass"
+
+    return {
+        "stage": STAGE_NAME,
+        "status": status,
+        "detail": detail,
+        "findings": all_findings,
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="autospec-fab dust leak/airflow QA stage",
+    )
+    parser.add_argument(
+        "--in", dest="stl", required=True,
+        help="path to STL file or directory (required for uniform stage CLI; "
+             "dust verdict is driven by --duct descriptor, not raw geometry)",
+    )
+    parser.add_argument(
+        "--duct", required=True,
+        help="path to duct descriptor JSON",
+    )
+    parser.add_argument(
+        "--out", required=True,
+        help="output path for stage fragment JSON",
+    )
+    args = parser.parse_args(argv)
+
+    fragment = run(args.duct)
+
+    try:
+        with open(args.out, "w") as fh:
+            json.dump(fragment, fh, indent=2)
+    except Exception as exc:
+        print(f"stage_dust: failed to write fragment: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/autospec-fab/tests/fixtures/dust/blocked.json
+++ b/skills/autospec-fab/tests/fixtures/dust/blocked.json
@@ -1,0 +1,14 @@
+{
+  "ducts": [
+    {
+      "id": "blocked_duct",
+      "opening_mm": 50.0,
+      "min_opening_mm": 96.0,
+      "cross_section_mm2": [1963.0, 1950.0, 1960.0],
+      "connected": false,
+      "printed_gate_slot": false,
+      "pvc_as_duct": false
+    }
+  ],
+  "nominal_full_size_mm2": 7854.0
+}

--- a/skills/autospec-fab/tests/fixtures/dust/clean.json
+++ b/skills/autospec-fab/tests/fixtures/dust/clean.json
@@ -1,0 +1,23 @@
+{
+  "ducts": [
+    {
+      "id": "main_duct",
+      "opening_mm": 100.0,
+      "min_opening_mm": 96.0,
+      "cross_section_mm2": [7854.0, 7800.0, 7850.0, 7900.0],
+      "connected": true,
+      "printed_gate_slot": false,
+      "pvc_as_duct": false
+    },
+    {
+      "id": "branch_duct",
+      "opening_mm": 63.5,
+      "min_opening_mm": 60.0,
+      "cross_section_mm2": [3167.0, 3150.0, 3160.0, 3170.0],
+      "connected": true,
+      "printed_gate_slot": false,
+      "pvc_as_duct": false
+    }
+  ],
+  "nominal_full_size_mm2": 7854.0
+}

--- a/skills/autospec-fab/tests/fixtures/dust/gate-slot.json
+++ b/skills/autospec-fab/tests/fixtures/dust/gate-slot.json
@@ -1,0 +1,14 @@
+{
+  "ducts": [
+    {
+      "id": "gate_slot_duct",
+      "opening_mm": 100.0,
+      "min_opening_mm": 96.0,
+      "cross_section_mm2": [7854.0, 7800.0, 7850.0],
+      "connected": true,
+      "printed_gate_slot": true,
+      "pvc_as_duct": false
+    }
+  ],
+  "nominal_full_size_mm2": 7854.0
+}

--- a/skills/autospec-fab/tests/fixtures/dust/pinched.json
+++ b/skills/autospec-fab/tests/fixtures/dust/pinched.json
@@ -1,0 +1,14 @@
+{
+  "ducts": [
+    {
+      "id": "pinched_duct",
+      "opening_mm": 100.0,
+      "min_opening_mm": 96.0,
+      "cross_section_mm2": [7854.0, 7800.0, 3000.0, 7850.0],
+      "connected": true,
+      "printed_gate_slot": false,
+      "pvc_as_duct": false
+    }
+  ],
+  "nominal_full_size_mm2": 7854.0
+}

--- a/skills/autospec-fab/tests/fixtures/dust/pvc.json
+++ b/skills/autospec-fab/tests/fixtures/dust/pvc.json
@@ -1,0 +1,14 @@
+{
+  "ducts": [
+    {
+      "id": "pvc_duct",
+      "opening_mm": 100.0,
+      "min_opening_mm": 96.0,
+      "cross_section_mm2": [7854.0, 7800.0, 7850.0],
+      "connected": true,
+      "printed_gate_slot": false,
+      "pvc_as_duct": true
+    }
+  ],
+  "nominal_full_size_mm2": 7854.0
+}

--- a/skills/autospec-fab/tests/test_stage_dust.bats
+++ b/skills/autospec-fab/tests/test_stage_dust.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+# test_stage_dust.bats — thin bats wrapper around the Python unittest suite.
+# Invoked by validate.sh check_autospec_fab_contract which runs every
+# skills/autospec-fab/tests/*.bats file.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+
+@test "stage_dust python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_stage_dust.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_stage_dust.py
+++ b/skills/autospec-fab/tests/test_stage_dust.py
@@ -1,0 +1,207 @@
+"""
+test_stage_dust.py — unittest for stage_dust.py.
+
+Tests:
+  1. clean fixture        → status pass (full-size openings, monotonic area,
+                             connected, no gate-slot, no PVC)
+  2. pinched fixture      → status fail (cross-section drops below 0.6× nominal
+                             area mid-path)
+  3. blocked fixture      → status fail (opening_mm < min_opening_mm AND
+                             connected false)
+  4. gate-slot fixture    → status fail (printed_gate_slot true)
+  5. pvc fixture          → status fail (pvc_as_duct true)
+  6. fragment shape       → stage="dust-airflow", status in {pass,fail,warn,skip},
+                             keys: stage, status, detail, findings
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
+_FIXTURES_DIR = os.path.normpath(os.path.join(_THIS_DIR, "fixtures", "dust"))
+
+_STAGE_SCRIPT = os.path.join(_SCRIPTS_DIR, "stage_dust.py")
+
+# Reuse a small existing STL (dust stage doesn't gate on geometry unless STL probe)
+_SHARED_STL = os.path.normpath(
+    os.path.join(_THIS_DIR, "fixtures", "port-good", "body.stl")
+)
+
+_CLEAN_DUCT     = os.path.join(_FIXTURES_DIR, "clean.json")
+_PINCHED_DUCT   = os.path.join(_FIXTURES_DIR, "pinched.json")
+_BLOCKED_DUCT   = os.path.join(_FIXTURES_DIR, "blocked.json")
+_GATE_SLOT_DUCT = os.path.join(_FIXTURES_DIR, "gate-slot.json")
+_PVC_DUCT       = os.path.join(_FIXTURES_DIR, "pvc.json")
+
+
+def _run_stage(duct_path, extra_args=None):
+    """Run stage_dust.py and return (returncode, fragment_dict, stderr)."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+        out_path = tf.name
+    try:
+        cmd = [
+            sys.executable, _STAGE_SCRIPT,
+            "--in", _SHARED_STL,
+            "--duct", duct_path,
+            "--out", out_path,
+        ]
+        if extra_args:
+            cmd.extend(extra_args)
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        fragment = None
+        if os.path.exists(out_path):
+            with open(out_path) as fh:
+                try:
+                    fragment = json.load(fh)
+                except json.JSONDecodeError:
+                    pass
+        return result.returncode, fragment, result.stderr
+    finally:
+        if os.path.exists(out_path):
+            os.unlink(out_path)
+
+
+def _finding_codes(fragment):
+    """Return set of code values from fragment findings list."""
+    return {f.get("code") for f in fragment.get("findings", [])}
+
+
+# ---------------------------------------------------------------------------
+# Fragment shape contract
+# ---------------------------------------------------------------------------
+
+class TestFragmentShape(unittest.TestCase):
+    """Every invocation emits a valid release-gate stage-record fragment."""
+
+    VALID_STATUSES = {"pass", "fail", "warn", "skip"}
+    REQUIRED_KEYS = {"stage", "status", "detail", "findings"}
+
+    def test_clean_fragment_shape(self):
+        rc, fragment, stderr = _run_stage(_CLEAN_DUCT)
+        self.assertEqual(rc, 0, f"stage exited non-zero: {stderr}")
+        self.assertIsNotNone(fragment, "fragment JSON not written")
+        self.assertEqual(fragment.get("stage"), "dust-airflow")
+        self.assertIn(fragment.get("status"), self.VALID_STATUSES)
+        self.assertGreaterEqual(
+            set(fragment.keys()), self.REQUIRED_KEYS,
+            f"missing keys: {self.REQUIRED_KEYS - set(fragment.keys())}",
+        )
+        self.assertIsInstance(fragment.get("findings"), list)
+
+
+# ---------------------------------------------------------------------------
+# Passing case
+# ---------------------------------------------------------------------------
+
+class TestCleanDuct(unittest.TestCase):
+    """Full-size, connected, monotonic, no gate-slot, no PVC → pass."""
+
+    def test_status_pass(self):
+        rc, fragment, stderr = _run_stage(_CLEAN_DUCT)
+        self.assertEqual(rc, 0, f"stage exited non-zero: {stderr}")
+        self.assertIsNotNone(fragment)
+        self.assertEqual(fragment.get("status"), "pass",
+                         f"expected pass, got: {fragment}")
+
+    def test_no_findings(self):
+        _rc, fragment, _stderr = _run_stage(_CLEAN_DUCT)
+        self.assertIsNotNone(fragment)
+        self.assertEqual(fragment.get("findings"), [],
+                         f"expected empty findings, got: {fragment.get('findings')}")
+
+
+# ---------------------------------------------------------------------------
+# Pinched cross-section
+# ---------------------------------------------------------------------------
+
+class TestPinchedDuct(unittest.TestCase):
+    """Cross-section drops to <60% of nominal inlet area mid-path → fail."""
+
+    def test_status_fail(self):
+        _rc, fragment, _stderr = _run_stage(_PINCHED_DUCT)
+        self.assertIsNotNone(fragment)
+        self.assertEqual(fragment.get("status"), "fail",
+                         f"expected fail for pinched duct: {fragment}")
+
+    def test_finding_code(self):
+        _rc, fragment, _stderr = _run_stage(_PINCHED_DUCT)
+        self.assertIsNotNone(fragment)
+        codes = _finding_codes(fragment)
+        self.assertTrue(
+            codes & {"disconnected_flow", "dust_obstructed"},
+            f"expected disconnected_flow or dust_obstructed in findings, got: {codes}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Blocked port / disconnected duct
+# ---------------------------------------------------------------------------
+
+class TestBlockedDuct(unittest.TestCase):
+    """opening_mm < min_opening_mm AND connected=false → fail."""
+
+    def test_status_fail(self):
+        _rc, fragment, _stderr = _run_stage(_BLOCKED_DUCT)
+        self.assertIsNotNone(fragment)
+        self.assertEqual(fragment.get("status"), "fail",
+                         f"expected fail for blocked duct: {fragment}")
+
+    def test_finding_code_disconnected(self):
+        _rc, fragment, _stderr = _run_stage(_BLOCKED_DUCT)
+        self.assertIsNotNone(fragment)
+        codes = _finding_codes(fragment)
+        self.assertIn("disconnected_flow", codes,
+                      f"expected disconnected_flow in findings, got: {codes}")
+
+
+# ---------------------------------------------------------------------------
+# Printed gate slot
+# ---------------------------------------------------------------------------
+
+class TestGateSlotDuct(unittest.TestCase):
+    """printed_gate_slot=true → hard reject."""
+
+    def test_status_fail(self):
+        _rc, fragment, _stderr = _run_stage(_GATE_SLOT_DUCT)
+        self.assertIsNotNone(fragment)
+        self.assertEqual(fragment.get("status"), "fail",
+                         f"expected fail for gate-slot duct: {fragment}")
+
+    def test_finding_present(self):
+        _rc, fragment, _stderr = _run_stage(_GATE_SLOT_DUCT)
+        self.assertIsNotNone(fragment)
+        self.assertTrue(
+            len(fragment.get("findings", [])) > 0,
+            "expected at least one finding for printed gate slot",
+        )
+
+
+# ---------------------------------------------------------------------------
+# PVC as printed duct
+# ---------------------------------------------------------------------------
+
+class TestPvcDuct(unittest.TestCase):
+    """pvc_as_duct=true → hard reject."""
+
+    def test_status_fail(self):
+        _rc, fragment, _stderr = _run_stage(_PVC_DUCT)
+        self.assertIsNotNone(fragment)
+        self.assertEqual(fragment.get("status"), "fail",
+                         f"expected fail for PVC duct: {fragment}")
+
+    def test_finding_present(self):
+        _rc, fragment, _stderr = _run_stage(_PVC_DUCT)
+        self.assertIsNotNone(fragment)
+        self.assertTrue(
+            len(fragment.get("findings", [])) > 0,
+            "expected at least one finding for PVC-as-duct",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1227

Adds `stage_dust.py`: per duct (via separate `--duct` descriptor) — full-size `opening_mm`≥`min_opening_mm`, no cross-section pinch (sweep area never <0.6× inlet), `connected`, and reject `printed_gate_slot`/`pvc_as_duct`. Failure → `code_health: disconnected_flow` (distinct detail per rule). Stdlib (trimesh optional).

## Verification
- `python3 -m unittest test_stage_dust.py` — 11/11; bats gates it. clean→pass, pinched→fail, blocked(undersize+disconnected)→fail, gate-slot→fail, pvc→fail.
- `bash scripts/validate.sh` — exit 0.

Note: COMPLEXITY nesting flags (if any) = AST-FP class tracked in #1245.