### PR TITLE
feat(autospec-fab): slicer wall + overhang + section QA

### DIFF
--- a/skills/autospec-fab/scripts/stage_slicer.py
+++ b/skills/autospec-fab/scripts/stage_slicer.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""
+stage_slicer.py — slicer QA stage for autospec-fab.
+
+Uniform stage CLI:
+    stage_slicer.py --in <stl> --out <fragment.json>
+                    [--printer <printer.json>] [--config <fab.yml>]
+
+Checks performed:
+  1. WALL THICKNESS  — estimate minimum feature thickness from the STL bounding
+     box and face layout; flag thin walls below min_perimeters × nozzle_width.
+     Heuristic: for each axis-aligned direction, the extent of the mesh in that
+     axis is the "wall span". When the minimum axis extent (the shortest
+     dimension) is less than min_wall, that dimension is a thin-wall candidate.
+     This is intentionally simple and documented: it catches plates and slabs
+     whose smallest extent is sub-perimeter, which is the most common FDM
+     failure mode. It does NOT do expensive ray-casting.
+  2. OVERHANG ANGLE  — for every face, compute the face normal and measure its
+     angle from the build-Z axis (+Z). If the normal has a significant downward
+     Z component (i.e. the face points "downward") and the angle from vertical
+     exceeds max_overhang_deg, it is a steep overhang. A face is downward-facing
+     when its normal Z component is negative (nz < 0). The overhang angle is
+     measured as the angle between the face normal and the downward -Z axis:
+       overhang_deg = arccos(|nz| / |normal|) when nz < 0
+     If overhang_deg > max_overhang_deg → slicer_overhang finding.
+  3. SECTION QA      — report bounding-box extents and mid-plane section info at
+     XY/XZ/YZ mid-planes as a detail string (informational, not a hard gate).
+
+Exit codes:
+  0  — harness success (verdict in fragment "status", not exit code).
+  1  — harness/usage error (bad args, --in missing, etc.).
+
+Trimesh is optional: lazy-imported; stdlib ASCII parser is the default path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+from typing import List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Optional trimesh (never hard-required)
+# ---------------------------------------------------------------------------
+try:
+    import trimesh as _trimesh  # type: ignore
+except ImportError:
+    _trimesh = None  # type: ignore
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+Triangle = Tuple[Tuple[float, float, float], ...]
+
+# ---------------------------------------------------------------------------
+# Default printer profile
+# ---------------------------------------------------------------------------
+_DEFAULT_PRINTER = {
+    "nozzle_width": 0.4,
+    "layer_height": 0.2,
+    "min_perimeters": 3,
+    "max_overhang_deg": 45.0,
+}
+
+# ---------------------------------------------------------------------------
+# ASCII STL parser (reused from stage-geometry.py pattern)
+# ---------------------------------------------------------------------------
+_FACET_RE = re.compile(r"facet\s+normal", re.IGNORECASE)
+_VERTEX_RE = re.compile(
+    r"vertex\s+([\-+]?[0-9]*\.?[0-9]+(?:[eE][\-+]?[0-9]+)?)"
+    r"\s+([\-+]?[0-9]*\.?[0-9]+(?:[eE][\-+]?[0-9]+)?)"
+    r"\s+([\-+]?[0-9]*\.?[0-9]+(?:[eE][\-+]?[0-9]+)?)",
+    re.IGNORECASE,
+)
+_NORMAL_RE = re.compile(
+    r"facet\s+normal\s+([\-+]?[0-9]*\.?[0-9]+(?:[eE][\-+]?[0-9]+)?)"
+    r"\s+([\-+]?[0-9]*\.?[0-9]+(?:[eE][\-+]?[0-9]+)?)"
+    r"\s+([\-+]?[0-9]*\.?[0-9]+(?:[eE][\-+]?[0-9]+)?)",
+    re.IGNORECASE,
+)
+
+
+def _parse_stl_ascii(path: str) -> Tuple[List[Triangle], List[Tuple[float, float, float]]]:
+    """
+    Parse ASCII STL; return (triangles, normals).
+
+    normals[i] is the stated normal for triangles[i].  If the stated normal is
+    zero-length (e.g. auto-generated as 0 0 0) the computed normal is used.
+    """
+    triangles: List[Triangle] = []
+    normals: List[Tuple[float, float, float]] = []
+
+    with open(path, "r", errors="replace") as fh:
+        content = fh.read()
+
+    # Split on "facet normal" boundaries keeping the normal line
+    raw_blocks = _FACET_RE.split(content)
+    for block in raw_blocks[1:]:
+        # The normal values are at the start of this block (after the split)
+        nm = _NORMAL_RE.match("facet normal " + block.lstrip())
+        if nm:
+            nx, ny, nz = float(nm.group(1)), float(nm.group(2)), float(nm.group(3))
+        else:
+            nx, ny, nz = 0.0, 0.0, 0.0
+
+        vertices = _VERTEX_RE.findall(block)
+        if len(vertices) >= 3:
+            tri = tuple((float(x), float(y), float(z)) for x, y, z in vertices[:3])
+            triangles.append(tri)  # type: ignore[arg-type]
+
+            # If stated normal is degenerate, compute from vertices
+            mag = math.sqrt(nx * nx + ny * ny + nz * nz)
+            if mag < 1e-9:
+                nx, ny, nz = _compute_normal(tri)
+            normals.append((nx, ny, nz))
+
+    return triangles, normals
+
+
+def _compute_normal(tri: Triangle) -> Tuple[float, float, float]:
+    """Compute face normal from triangle vertices via cross product."""
+    v0, v1, v2 = tri
+    ax, ay, az = v1[0] - v0[0], v1[1] - v0[1], v1[2] - v0[2]
+    bx, by, bz = v2[0] - v0[0], v2[1] - v0[1], v2[2] - v0[2]
+    nx = ay * bz - az * by
+    ny = az * bx - ax * bz
+    nz = ax * by - ay * bx
+    mag = math.sqrt(nx * nx + ny * ny + nz * nz)
+    if mag < 1e-9:
+        return 0.0, 0.0, 1.0
+    return nx / mag, ny / mag, nz / mag
+
+
+def _parse_stl(path: str) -> Optional[Tuple[List[Triangle], List[Tuple[float, float, float]]]]:
+    """
+    Parse STL at *path* into (triangles, normals).
+
+    Tries trimesh first when available; falls back to stdlib ASCII parser.
+    Returns None on parse failure.
+    """
+    if _trimesh is not None:
+        try:
+            mesh = _trimesh.load_mesh(path)
+            tris = []
+            norms = []
+            for i, face in enumerate(mesh.faces):
+                v0 = tuple(float(c) for c in mesh.vertices[face[0]])
+                v1 = tuple(float(c) for c in mesh.vertices[face[1]])
+                v2 = tuple(float(c) for c in mesh.vertices[face[2]])
+                tri = (v0, v1, v2)
+                tris.append(tri)
+                fn = tuple(float(c) for c in mesh.face_normals[i])
+                norms.append(fn)
+            if tris:
+                return tris, norms
+        except Exception:
+            pass
+
+    try:
+        tris, norms = _parse_stl_ascii(path)
+        return (tris, norms) if tris else None
+    except Exception:
+        return None
+
+# ---------------------------------------------------------------------------
+# Printer profile loader
+# ---------------------------------------------------------------------------
+
+def _load_printer_profile(printer_path: Optional[str]) -> dict:
+    """
+    Load printer profile from a JSON file.
+
+    Returns defaults if printer_path is None or the file can't be read.
+    """
+    profile = dict(_DEFAULT_PRINTER)
+    if not printer_path:
+        return profile
+    try:
+        with open(printer_path) as f:
+            data = json.load(f)
+        for key in ("nozzle_width", "layer_height", "min_perimeters", "max_overhang_deg"):
+            if key in data:
+                profile[key] = float(data[key])
+    except Exception:
+        pass
+    return profile
+
+# ---------------------------------------------------------------------------
+# Wall thickness check
+# ---------------------------------------------------------------------------
+
+def check_wall_thickness(
+    triangles: List[Triangle],
+    min_wall: float,
+) -> Tuple[bool, str, Optional[float]]:
+    """
+    Estimate minimum feature thickness from bounding box extents.
+
+    Heuristic: the smallest axis-aligned extent of the mesh is the thinnest
+    feature dimension (catches thin plates/slabs — the dominant FDM failure
+    mode). Each axis extent is min→max vertex coordinate spread along that axis.
+
+    Returns (passes, detail, min_thickness_found).
+    passes=True when min_thickness >= min_wall.
+    """
+    if not triangles:
+        return True, "No triangles; skipping wall check", None
+
+    xs = [v[0] for tri in triangles for v in tri]
+    ys = [v[1] for tri in triangles for v in tri]
+    zs = [v[2] for tri in triangles for v in tri]
+
+    extent_x = max(xs) - min(xs)
+    extent_y = max(ys) - min(ys)
+    extent_z = max(zs) - min(zs)
+
+    min_extent = min(extent_x, extent_y, extent_z)
+
+    detail = (
+        f"Bounding extents: X={extent_x:.3f} Y={extent_y:.3f} Z={extent_z:.3f} mm; "
+        f"min_extent={min_extent:.3f} mm; min_wall={min_wall:.3f} mm"
+    )
+
+    if min_extent < min_wall:
+        return False, detail, min_extent
+    return True, detail, min_extent
+
+# ---------------------------------------------------------------------------
+# Overhang angle check
+# ---------------------------------------------------------------------------
+
+def check_overhang(
+    triangles: List[Triangle],
+    normals: List[Tuple[float, float, float]],
+    max_overhang_deg: float,
+) -> Tuple[bool, str, int]:
+    """
+    Scan faces for steep overhangs relative to build-Z (+Z axis).
+
+    A face is a candidate overhang when its normal has nz < 0 (faces downward)
+    AND its centroid Z is above the model's minimum Z (faces on the build plate
+    are excluded — a flat bottom is supported by definition).
+
+    The overhang angle is measured from vertical (build-Z):
+        For a downward face, overhang_from_vertical = 90 - arccos(|nz|/|N|)
+        Horizontal face → 0°; straight-down face → 90°.
+    Faces where overhang_from_vertical > max_overhang_deg are flagged.
+
+    Returns (passes, detail, steep_count).
+    """
+    if not triangles:
+        return True, "No geometry; skipping overhang check", 0
+
+    # Build-plate Z: faces at (or within tolerance of) model min-Z are supported
+    all_zs = [v[2] for tri in triangles for v in tri]
+    z_min = min(all_zs)
+    z_tol = max((max(all_zs) - z_min) * 0.01, 1e-4)
+
+    steep_count = 0
+    max_seen = 0.0
+
+    for tri, (nx, ny, nz) in zip(triangles, normals):
+        if nz >= 0:
+            continue  # upward or horizontal — not an overhang concern
+        # Centroid Z of this face
+        cz = (tri[0][2] + tri[1][2] + tri[2][2]) / 3.0
+        if cz <= z_min + z_tol:
+            continue  # bottom face — resting on build plate, not an overhang
+
+        mag = math.sqrt(nx * nx + ny * ny + nz * nz)
+        if mag < 1e-9:
+            continue
+        # overhang from vertical: 0° = horizontal face, 90° = straight down
+        cos_angle = abs(nz) / mag
+        cos_angle = min(1.0, cos_angle)  # clamp float noise
+        overhang_from_vertical = math.degrees(math.acos(cos_angle))
+        if overhang_from_vertical > max_overhang_deg:
+            steep_count += 1
+            if overhang_from_vertical > max_seen:
+                max_seen = overhang_from_vertical
+
+    if steep_count > 0:
+        detail = (
+            f"{steep_count} face(s) exceed overhang limit "
+            f"(max seen: {max_seen:.1f}°; limit: {max_overhang_deg:.1f}°)"
+        )
+        return False, detail, steep_count
+
+    detail = f"No faces exceed overhang limit of {max_overhang_deg:.1f}°"
+    return True, detail, 0
+
+# ---------------------------------------------------------------------------
+# Section QA (informational)
+# ---------------------------------------------------------------------------
+
+def section_info(triangles: List[Triangle]) -> str:
+    """
+    Produce section summary at key mid-planes (XY/XZ/YZ).
+
+    Counts faces whose centroid lies within ±10% of mesh extent from each
+    mid-plane. This is informational only — no hard gate.
+    """
+    if not triangles:
+        return "section: no geometry"
+
+    xs = [v[0] for tri in triangles for v in tri]
+    ys = [v[1] for tri in triangles for v in tri]
+    zs = [v[2] for tri in triangles for v in tri]
+
+    cx = (min(xs) + max(xs)) / 2
+    cy = (min(ys) + max(ys)) / 2
+    cz = (min(zs) + max(zs)) / 2
+
+    ex = (max(xs) - min(xs)) * 0.1 + 1e-9
+    ey = (max(ys) - min(ys)) * 0.1 + 1e-9
+    ez = (max(zs) - min(zs)) * 0.1 + 1e-9
+
+    xy_count = xz_count = yz_count = 0
+    for tri in triangles:
+        tx = sum(v[0] for v in tri) / 3
+        ty = sum(v[1] for v in tri) / 3
+        tz = sum(v[2] for v in tri) / 3
+        if abs(tz - cz) <= ez:
+            xy_count += 1
+        if abs(ty - cy) <= ey:
+            xz_count += 1
+        if abs(tx - cx) <= ex:
+            yz_count += 1
+
+    return (
+        f"section XY-mid: {xy_count} faces, "
+        f"XZ-mid: {xz_count} faces, "
+        f"YZ-mid: {yz_count} faces"
+    )
+
+# ---------------------------------------------------------------------------
+# Stage runner
+# ---------------------------------------------------------------------------
+
+def run_slicer_stage(stl_path: str, printer: dict) -> dict:
+    """
+    Run all slicer checks on *stl_path* and return a stage-record fragment.
+
+    Fragment shape:
+      { "stage": "slicer", "status": "pass|fail",
+        "detail": "...", "findings": [...] }
+    """
+    findings = []
+    status = "pass"
+    details = []
+
+    # Parse STL
+    parsed = _parse_stl(stl_path)
+    if parsed is None:
+        return {
+            "stage": "slicer",
+            "status": "fail",
+            "detail": f"Failed to parse STL: {os.path.basename(stl_path)}",
+            "findings": [{"code": "slicer_parse_error",
+                          "message": f"Could not parse {stl_path}"}],
+        }
+
+    triangles, normals = parsed
+    details.append(f"Parsed {len(triangles)} facets")
+
+    # Printer params
+    min_wall = float(printer["min_perimeters"]) * float(printer["nozzle_width"])
+    max_overhang_deg = float(printer["max_overhang_deg"])
+
+    # 1. Wall thickness check
+    wall_ok, wall_detail, min_thickness = check_wall_thickness(triangles, min_wall)
+    details.append(wall_detail)
+    if not wall_ok:
+        status = "fail"
+        findings.append({
+            "code": "slicer_thin_wall",
+            "message": (
+                f"Min feature thickness {min_thickness:.3f} mm < "
+                f"min_wall {min_wall:.3f} mm "
+                f"({int(printer['min_perimeters'])} perimeters × "
+                f"{printer['nozzle_width']} mm nozzle)"
+            ),
+        })
+
+    # 2. Overhang angle check
+    overhang_ok, overhang_detail, steep_count = check_overhang(triangles, normals, max_overhang_deg)
+    details.append(overhang_detail)
+    if not overhang_ok:
+        status = "fail"
+        findings.append({
+            "code": "slicer_overhang",
+            "message": (
+                f"{steep_count} face(s) exceed overhang limit "
+                f"of {max_overhang_deg:.1f}°; {overhang_detail}"
+            ),
+        })
+
+    # 3. Section QA (informational)
+    sec_detail = section_info(triangles)
+    details.append(sec_detail)
+
+    return {
+        "stage": "slicer",
+        "status": status,
+        "detail": "; ".join(details),
+        "findings": findings,
+    }
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="autospec-fab slicer stage: min wall + overhang + section QA"
+    )
+    parser.add_argument("--in", dest="in_path", required=True,
+                        help="Input STL file")
+    parser.add_argument("--out", required=True,
+                        help="Output fragment JSON path")
+    parser.add_argument("--model", dest="model_path", default=None,
+                        help="Per-model metadata JSON sidecar (optional, unused by this stage)")
+    parser.add_argument("--printer", dest="printer_path", default=None,
+                        help="Printer profile JSON with nozzle_width/min_perimeters/max_overhang_deg")
+    parser.add_argument("--config", dest="config_path", default=None,
+                        help="fab.yml path; printer block used if --printer not given")
+
+    args = parser.parse_args(argv)
+
+    # Resolve printer profile: --printer > --config printer block > defaults
+    printer = _load_printer_profile(args.printer_path)
+    if args.printer_path is None and args.config_path:
+        try:
+            # fab.yml is YAML; try yq/python-yaml; fall back to regex extraction
+            _load_printer_from_config(args.config_path, printer)
+        except Exception:
+            pass  # keep defaults
+
+    fragment = run_slicer_stage(args.in_path, printer)
+
+    out_dir = os.path.dirname(os.path.abspath(args.out))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(fragment, f, indent=2)
+        f.write("\n")
+
+    sys.exit(0)
+
+
+def _load_printer_from_config(config_path: str, printer: dict) -> None:
+    """
+    Best-effort: extract printer fields from fab.yml into *printer* dict.
+
+    Tries PyYAML first; falls back to simple regex line scanning.
+    Mutates *printer* in place.
+    """
+    try:
+        import yaml  # type: ignore
+        with open(config_path) as f:
+            data = yaml.safe_load(f)
+        p = data.get("printer", {}) or {}
+        for key in ("nozzle_width", "layer_height", "min_perimeters", "max_overhang_deg"):
+            if key in p:
+                printer[key] = float(p[key])
+        return
+    except ImportError:
+        pass
+
+    # Fallback: line-by-line key: value under a "printer:" block
+    in_printer = False
+    with open(config_path) as f:
+        for line in f:
+            stripped = line.rstrip()
+            if stripped.startswith("printer:"):
+                in_printer = True
+                continue
+            if in_printer:
+                if stripped and not stripped[0].isspace():
+                    break  # left printer block
+                for key in ("nozzle_width", "layer_height", "min_perimeters", "max_overhang_deg"):
+                    m = re.match(rf"\s+{key}\s*:\s*([0-9.]+)", stripped)
+                    if m:
+                        printer[key] = float(m.group(1))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/autospec-fab/tests/fixtures/slicer/printer.json
+++ b/skills/autospec-fab/tests/fixtures/slicer/printer.json
@@ -1,0 +1,6 @@
+{
+  "nozzle_width": 0.4,
+  "layer_height": 0.2,
+  "min_perimeters": 3,
+  "max_overhang_deg": 45
+}

--- a/skills/autospec-fab/tests/fixtures/slicer/steep_overhang.stl
+++ b/skills/autospec-fab/tests/fixtures/slicer/steep_overhang.stl
@@ -1,0 +1,93 @@
+solid steep-overhang
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 20 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 20 20 20
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 0 20 20
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 20
+      vertex 0 0 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 0
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 20
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 20
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 0 20 20
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 20
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 20
+      vertex 0 20 20
+    endloop
+  endfacet
+  facet normal 0 0.940 -0.342
+    outer loop
+      vertex 5 10 15
+      vertex 15 10 15
+      vertex 10 13 18
+    endloop
+  endfacet
+endsolid steep-overhang

--- a/skills/autospec-fab/tests/fixtures/slicer/thick_wall.stl
+++ b/skills/autospec-fab/tests/fixtures/slicer/thick_wall.stl
@@ -1,0 +1,86 @@
+solid thick-wall-box
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 20 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 20 20 20
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 0 20 20
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 20
+      vertex 0 0 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 0
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 20
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 20
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 0 20 20
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 20
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 20
+      vertex 0 20 20
+    endloop
+  endfacet
+endsolid thick-wall-box

--- a/skills/autospec-fab/tests/fixtures/slicer/thin_wall.stl
+++ b/skills/autospec-fab/tests/fixtures/slicer/thin_wall.stl
@@ -1,0 +1,86 @@
+solid thin-wall-plate
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 20 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.3
+      vertex 20 20 0.3
+      vertex 20 0 0.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0.3
+      vertex 0 20 0.3
+      vertex 20 20 0.3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 0 0.3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0.3
+      vertex 0 0 0.3
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 0
+      vertex 20 20 0.3
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 0.3
+      vertex 20 0 0.3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 0.3
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 0 20 0.3
+      vertex 20 20 0.3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 0.3
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 0.3
+      vertex 0 20 0.3
+    endloop
+  endfacet
+endsolid thin-wall-plate

--- a/skills/autospec-fab/tests/test_stage_slicer.bats
+++ b/skills/autospec-fab/tests/test_stage_slicer.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# test_stage_slicer.bats — thin bats wrapper around the Python unittest suite.
+# Invoked by validate.sh fab gate (check_autospec_fab_contract) which runs
+# every skills/autospec-fab/tests/*.bats file.
+
+# Resolve the repo root from this file's location (tests/ → skill/ → repo root)
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+
+@test "stage_slicer python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_stage_slicer.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_stage_slicer.py
+++ b/skills/autospec-fab/tests/test_stage_slicer.py
@@ -1,0 +1,213 @@
+"""
+test_stage_slicer.py — unittest for stage_slicer.py.
+
+Tests:
+  1. thick_wall.stl + printer.json  → status pass (wall >> min, no steep overhang)
+  2. thin_wall.stl  + printer.json  → status fail + finding slicer_thin_wall
+  3. steep_overhang.stl + printer.json → status fail + finding slicer_overhang
+  4. fragment validates release-gate stage-record shape (stage/status/detail/findings)
+  5. section detail present in fragment
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
+_FIXTURES_DIR = os.path.normpath(os.path.join(_THIS_DIR, "fixtures", "slicer"))
+
+_STAGE_SCRIPT = os.path.join(_SCRIPTS_DIR, "stage_slicer.py")
+
+_THICK_WALL_STL = os.path.join(_FIXTURES_DIR, "thick_wall.stl")
+_THIN_WALL_STL = os.path.join(_FIXTURES_DIR, "thin_wall.stl")
+_STEEP_OVERHANG_STL = os.path.join(_FIXTURES_DIR, "steep_overhang.stl")
+_PRINTER_JSON = os.path.join(_FIXTURES_DIR, "printer.json")
+
+
+def _run_stage(stl_path, extra_args=None):
+    """Run stage_slicer.py on *stl_path*, return (returncode, fragment_dict, stderr)."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+        out_path = tf.name
+    try:
+        cmd = [
+            sys.executable, _STAGE_SCRIPT,
+            "--in", stl_path,
+            "--out", out_path,
+            "--printer", _PRINTER_JSON,
+        ]
+        if extra_args:
+            cmd.extend(extra_args)
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        fragment = None
+        if os.path.exists(out_path):
+            with open(out_path) as f:
+                fragment = json.load(f)
+        return result.returncode, fragment, result.stderr
+    finally:
+        if os.path.exists(out_path):
+            os.unlink(out_path)
+
+
+def _finding_codes(fragment):
+    """Return set of code_health ids from fragment findings."""
+    return {f.get("code") for f in fragment.get("findings", [])}
+
+
+class TestFragmentShape(unittest.TestCase):
+    """Every fragment must match release-gate stage-record shape."""
+
+    def _assert_valid_fragment(self, fragment, stl_label):
+        self.assertIsInstance(fragment, dict, f"{stl_label}: fragment must be a dict")
+        for key in ("stage", "status", "detail", "findings"):
+            self.assertIn(key, fragment, f"{stl_label}: fragment missing '{key}'")
+        self.assertIn(
+            fragment["status"], {"pass", "fail", "warn", "skip"},
+            f"{stl_label}: invalid status {fragment['status']!r}",
+        )
+        self.assertIsInstance(fragment["findings"], list,
+                              f"{stl_label}: 'findings' must be a list")
+        self.assertEqual(fragment["stage"], "slicer",
+                         f"{stl_label}: stage name must be 'slicer'")
+
+    def test_thick_wall_fragment_shape(self):
+        _, fragment, _ = _run_stage(_THICK_WALL_STL)
+        self.assertIsNotNone(fragment)
+        self._assert_valid_fragment(fragment, "thick_wall")
+
+    def test_thin_wall_fragment_shape(self):
+        _, fragment, _ = _run_stage(_THIN_WALL_STL)
+        self.assertIsNotNone(fragment)
+        self._assert_valid_fragment(fragment, "thin_wall")
+
+    def test_steep_overhang_fragment_shape(self):
+        _, fragment, _ = _run_stage(_STEEP_OVERHANG_STL)
+        self.assertIsNotNone(fragment)
+        self._assert_valid_fragment(fragment, "steep_overhang")
+
+
+class TestThickWall(unittest.TestCase):
+    """thick_wall.stl is a 20×20×20mm box — walls >> min, no steep overhang."""
+
+    def setUp(self):
+        self.rc, self.fragment, self.stderr = _run_stage(_THICK_WALL_STL)
+
+    def test_exit_code_zero(self):
+        self.assertEqual(self.rc, 0,
+                         f"Expected exit 0 (harness success); stderr={self.stderr}")
+
+    def test_status_pass(self):
+        self.assertEqual(
+            self.fragment["status"], "pass",
+            f"Expected pass for thick-wall box; fragment={self.fragment}",
+        )
+
+    def test_no_thin_wall_finding(self):
+        codes = _finding_codes(self.fragment)
+        self.assertNotIn("slicer_thin_wall", codes,
+                         f"Unexpected slicer_thin_wall finding; findings={self.fragment['findings']}")
+
+    def test_no_overhang_finding(self):
+        codes = _finding_codes(self.fragment)
+        self.assertNotIn("slicer_overhang", codes,
+                         f"Unexpected slicer_overhang finding; findings={self.fragment['findings']}")
+
+    def test_section_detail_present(self):
+        self.assertIn("section", self.fragment["detail"].lower(),
+                      f"Expected 'section' in detail; detail={self.fragment['detail']!r}")
+
+
+class TestThinWall(unittest.TestCase):
+    """thin_wall.stl is a 0.3mm-thick plate — below min wall (3 × 0.4 = 1.2mm)."""
+
+    def setUp(self):
+        self.rc, self.fragment, self.stderr = _run_stage(_THIN_WALL_STL)
+
+    def test_exit_code_zero(self):
+        self.assertEqual(self.rc, 0,
+                         f"Expected exit 0 (harness success); stderr={self.stderr}")
+
+    def test_status_fail(self):
+        self.assertEqual(
+            self.fragment["status"], "fail",
+            f"Expected fail for thin wall; fragment={self.fragment}",
+        )
+
+    def test_finding_slicer_thin_wall(self):
+        codes = _finding_codes(self.fragment)
+        self.assertIn("slicer_thin_wall", codes,
+                      f"Expected slicer_thin_wall finding; findings={self.fragment['findings']}")
+
+
+class TestSteepOverhang(unittest.TestCase):
+    """steep_overhang.stl has a face whose normal points >45° from vertical downward."""
+
+    def setUp(self):
+        self.rc, self.fragment, self.stderr = _run_stage(_STEEP_OVERHANG_STL)
+
+    def test_exit_code_zero(self):
+        self.assertEqual(self.rc, 0,
+                         f"Expected exit 0 (harness success); stderr={self.stderr}")
+
+    def test_status_fail(self):
+        self.assertEqual(
+            self.fragment["status"], "fail",
+            f"Expected fail for steep overhang; fragment={self.fragment}",
+        )
+
+    def test_finding_slicer_overhang(self):
+        codes = _finding_codes(self.fragment)
+        self.assertIn("slicer_overhang", codes,
+                      f"Expected slicer_overhang finding; findings={self.fragment['findings']}")
+
+
+class TestMissingInArg(unittest.TestCase):
+    """Missing --in should exit non-zero (harness/usage error)."""
+
+    def test_missing_in_exits_nonzero(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+            out_path = tf.name
+        try:
+            result = subprocess.run(
+                [sys.executable, _STAGE_SCRIPT, "--out", out_path],
+                capture_output=True, text=True,
+            )
+            self.assertNotEqual(result.returncode, 0,
+                                "Expected non-zero exit when --in is missing")
+        finally:
+            if os.path.exists(out_path):
+                os.unlink(out_path)
+
+
+class TestDefaultPrinterProfile(unittest.TestCase):
+    """Without --printer, defaults (3×0.4=1.2mm min wall) still flag thin wall."""
+
+    def test_thin_wall_fails_without_printer_arg(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+            out_path = tf.name
+        try:
+            cmd = [
+                sys.executable, _STAGE_SCRIPT,
+                "--in", _THIN_WALL_STL,
+                "--out", out_path,
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0,
+                             f"Harness should exit 0; stderr={result.stderr}")
+            with open(out_path) as f:
+                fragment = json.load(f)
+            self.assertEqual(fragment["status"], "fail",
+                             f"Expected fail with default profile; fragment={fragment}")
+            codes = _finding_codes(fragment)
+            self.assertIn("slicer_thin_wall", codes,
+                          f"Expected slicer_thin_wall; findings={fragment['findings']}")
+        finally:
+            if os.path.exists(out_path):
+                os.unlink(out_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1228

Adds `stage_slicer.py`: min wall = `min_perimeters × nozzle_width` (printer profile) → `slicer_thin_wall`; overhang = downward faces past `max_overhang_deg` excluding build-plate faces → `slicer_overhang`; section info at mid-planes (informational). Stdlib (trimesh optional).

## Verification
- `python3 -m unittest test_stage_slicer.py` — 16/16; bats gates it. thick_wall→pass, thin_wall(0.3mm plate)→`slicer_thin_wall`, steep_overhang(70° face)→`slicer_overhang`.
- `bash scripts/validate.sh` — exit 0.

Note: wall heuristic is bbox min-extent (catches sub-perimeter plates — the dominant FDM failure; documented), not ray-cast. COMPLEXITY nesting flags = AST-FP class (#1245).