### PR TITLE
feat(autospec-fab): render harness + 17-view contact sheet stage

### DIFF
--- a/skills/autospec-fab/scripts/render_views.py
+++ b/skills/autospec-fab/scripts/render_views.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+render_views.py — the deterministic required-view table for autospec-fab render QA.
+
+The fab design spec (§Release-gate stage 12, "render QA + 16-view contact sheet")
+requires every printable model be rendered from a fixed, named set of >=16 view
+angles so the vision stage (#1232) and human reviewers can inspect every port,
+socket, gasket, lug, and overhang:
+
+  - the 6 orthographic axis views (front/back/left/right/top/bottom),
+  - the 8 corner (45 degree) diagonals exposing edges/ports between two faces,
+  - >=2 slicer-like / print-orientation rotated views.
+
+The table is a fixed ordered list (NOT a set) so both the count and the names
+are deterministic and testable. Each entry carries a FreeCAD camera dict
+(camera/azimuth/elevation/width/height) consumed by freecad_harness.render();
+the real camera math is applied inside FreeCAD (mocked in tests), so unknown
+camera names degrade to an isometric view rather than failing.
+"""
+
+_W = 800
+_H = 600
+
+
+def _v(name, kind, camera, azimuth=0.0, elevation=0.0):
+    """Build one view-table entry (name + classification + camera dict)."""
+    return {
+        "name": name,
+        "kind": kind,
+        "camera": {
+            "camera": camera,
+            "azimuth": float(azimuth),
+            "elevation": float(elevation),
+            "width": _W,
+            "height": _H,
+        },
+    }
+
+
+# 6 orthographic axis views.
+_AXIS = [
+    _v("front", "axis", "front", 0, 0),
+    _v("back", "axis", "back", 180, 0),
+    _v("left", "axis", "left", 90, 0),
+    _v("right", "axis", "right", -90, 0),
+    _v("top", "axis", "top", 0, 90),
+    _v("bottom", "axis", "bottom", 0, -90),
+]
+
+# 8 corner (45 degree) diagonals: the four upper and four lower corners.
+_DIAGONAL = [
+    _v("iso-front-right-top", "diagonal", "iso", 45, 35),
+    _v("iso-back-right-top", "diagonal", "iso", 135, 35),
+    _v("iso-back-left-top", "diagonal", "iso", 225, 35),
+    _v("iso-front-left-top", "diagonal", "iso", 315, 35),
+    _v("iso-front-right-bottom", "diagonal", "iso", 45, -35),
+    _v("iso-back-right-bottom", "diagonal", "iso", 135, -35),
+    _v("iso-back-left-bottom", "diagonal", "iso", 225, -35),
+    _v("iso-front-left-bottom", "diagonal", "iso", 315, -35),
+]
+
+# Slicer-like rotated / print-orientation views: looking at the part as it sits
+# on the build plate plus a tipped orientation that exposes overhang undersides.
+_SLICER = [
+    _v("slicer-build-plate-top", "slicer", "top", 0, 90),
+    _v("slicer-rotated-45", "slicer", "iso", 30, 20),
+    _v("slicer-overhang-underside", "slicer", "iso", 0, -60),
+]
+
+# The authoritative ordered table. Order is load-bearing (contact-sheet layout).
+REQUIRED_VIEWS = _AXIS + _DIAGONAL + _SLICER

--- a/skills/autospec-fab/scripts/stage_render.py
+++ b/skills/autospec-fab/scripts/stage_render.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+stage_render.py — render QA + contact-sheet stage for autospec-fab.
+
+Uniform stage CLI:
+    stage_render.py --in <stl> --out <fragment.json>
+                    [--model <metadata.json>] [--render-dir <dir>]
+
+Behaviour (design spec §Release-gate stage 12):
+  1. Enumerate the deterministic required view table (render_views.REQUIRED_VIEWS:
+     6 axis + 8 corner diagonals + >=3 slicer/print-orientation views, >=16 total).
+  2. For each view, call freecad_harness.render() — which subprocesses the
+     PATH-resolved freecadcmd (mocked via $TMP/bin in tests) — to emit one
+     per-view PNG into the render dir (default .autospec/fab/renders/<model>/).
+  3. Assemble ONE deterministic contact sheet WITHOUT any image library: an HTML
+     grid (contact-sheet.html) with one <img> per view in table order. This is a
+     real artifact the vision stage (#1232) can consume; real PNG compositing
+     (PIL) is deferred to the pinned container.
+  4. Emit the release-gate fragment {stage,status,detail,findings}:
+       - freecadcmd absent  -> status "skip" (no renderer available).
+       - all views rendered -> status "pass".
+       - any view PNG missing -> status "fail" + finding render_incomplete.
+
+Exit codes: 0 — harness success (verdict lives in fragment "status"); 1 — usage
+error. Stdlib only; never imports PIL/trimesh.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import sys
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+import freecad_harness  # noqa: E402
+from render_views import REQUIRED_VIEWS  # noqa: E402
+
+
+def _model_slug(stl_path: str) -> str:
+    """Derive a render-subdir slug from the STL filename (sans extension)."""
+    base = os.path.basename(stl_path)
+    stem = os.path.splitext(base)[0]
+    return stem or "model"
+
+
+def _png_path(render_dir: str, slug: str, view_name: str) -> str:
+    """Absolute per-view PNG path: <render_dir>/<slug>/<view_name>.png."""
+    return os.path.join(render_dir, slug, view_name + ".png")
+
+
+def render_all_views(stl_path: str, render_dir: str, slug: str) -> list:
+    """
+    Render every required view via the harness; return per-view result records.
+
+    Each record: {"name", "kind", "png", "rendered"(bool)}. "rendered" is True
+    only when the harness exited 0 AND the PNG file exists on disk afterwards.
+    """
+    results = []
+    for view in REQUIRED_VIEWS:
+        png = _png_path(render_dir, slug, view["name"])
+        os.makedirs(os.path.dirname(png), exist_ok=True)
+        proc = freecad_harness.render(stl_path, view["camera"], png)
+        ok = (proc.returncode == 0) and os.path.isfile(png)
+        results.append({
+            "name": view["name"],
+            "kind": view["kind"],
+            "png": png,
+            "rendered": ok,
+        })
+    return results
+
+
+def build_contact_sheet(render_dir: str, slug: str, results: list) -> str:
+    """
+    Assemble a deterministic HTML contact sheet referencing every view PNG.
+
+    No image library: a fixed CSS grid with one labelled <img> per view, in the
+    table order from results. Each <img src> is a relative basename so the sheet
+    is portable alongside the PNGs. Returns the absolute sheet path.
+    """
+    cells = []
+    for r in results:
+        rel = html.escape(os.path.basename(r["png"]))
+        label = html.escape(r["name"])
+        marker = "" if r["rendered"] else " (MISSING)"
+        cells.append(
+            f'<figure><img src="{rel}" alt="{label}" width="320">'
+            f"<figcaption>{label}{marker}</figcaption></figure>"
+        )
+    body = "\n".join(cells)
+    sheet_html = (
+        "<!doctype html>\n"
+        '<html><head><meta charset="utf-8">\n'
+        f"<title>contact sheet: {html.escape(slug)}</title>\n"
+        "<style>body{margin:0;font-family:sans-serif}"
+        ".grid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;padding:8px}"
+        "figure{margin:0}img{width:100%;border:1px solid #ccc}"
+        "figcaption{font-size:12px;text-align:center}</style>\n"
+        "</head><body>\n"
+        f'<h1>{html.escape(slug)} — {len(results)} views</h1>\n'
+        f'<div class="grid">\n{body}\n</div>\n'
+        "</body></html>\n"
+    )
+    sheet = os.path.join(render_dir, slug, "contact-sheet.html")
+    os.makedirs(os.path.dirname(sheet), exist_ok=True)
+    with open(sheet, "w") as f:
+        f.write(sheet_html)
+    return sheet
+
+
+def _skip_fragment() -> dict:
+    """Fragment for the renderer-absent case (deferred real renders)."""
+    return {
+        "stage": "render",
+        "status": "skip",
+        "detail": ("freecadcmd not on PATH; render QA skipped "
+                   "(real renders deferred to the pinned container)"),
+        "findings": [],
+    }
+
+
+def run_render_stage(stl_path: str, render_dir: str) -> dict:
+    """
+    Run the render stage and return a release-gate fragment.
+
+    Fragment shape: {stage:"render", status, detail, findings}.
+    """
+    if freecad_harness.resolve_freecadcmd() is None:
+        return _skip_fragment()
+
+    slug = _model_slug(stl_path)
+    results = render_all_views(stl_path, render_dir, slug)
+    sheet = build_contact_sheet(render_dir, slug, results)
+
+    missing = [r["name"] for r in results if not r["rendered"]]
+    detail = (f"{len(results) - len(missing)}/{len(results)} views rendered; "
+              f"contact sheet: {sheet}")
+
+    if missing:
+        return {
+            "stage": "render",
+            "status": "fail",
+            "detail": detail,
+            "findings": [{
+                "code": "render_incomplete",
+                "message": ("missing render(s) for view(s): "
+                            + ", ".join(missing)),
+            }],
+        }
+    return {
+        "stage": "render",
+        "status": "pass",
+        "detail": detail,
+        "findings": [],
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="autospec-fab render stage: 16+ view contact sheet"
+    )
+    parser.add_argument("--in", dest="in_path", required=True,
+                        help="Input STL file")
+    parser.add_argument("--out", required=True,
+                        help="Output release-gate fragment JSON path")
+    parser.add_argument("--model", dest="model_path", default=None,
+                        help="Per-model metadata sidecar (optional, unused)")
+    parser.add_argument("--render-dir", dest="render_dir", default=None,
+                        help="Render output dir (default .autospec/fab/renders)")
+
+    args = parser.parse_args(argv)
+
+    render_dir = args.render_dir or os.path.join(
+        ".autospec", "fab", "renders")
+
+    fragment = run_render_stage(args.in_path, render_dir)
+
+    out_dir = os.path.dirname(os.path.abspath(args.out))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(fragment, f, indent=2)
+        f.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/autospec-fab/tests/test_stage_render.bats
+++ b/skills/autospec-fab/tests/test_stage_render.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# test_stage_render.bats — thin bats wrapper around the Python unittest suite.
+# Invoked by validate.sh fab gate (check_autospec_fab_contract) which runs
+# every skills/autospec-fab/tests/*.bats file.
+
+# Resolve the repo root from this file's location (tests/ → skill/ → repo root)
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+
+@test "stage_render python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_stage_render.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_stage_render.py
+++ b/skills/autospec-fab/tests/test_stage_render.py
@@ -1,0 +1,227 @@
+"""
+test_stage_render.py — unittest for stage_render.py.
+
+Strategy: prepend a $TMP/bin directory containing a fake `freecadcmd` Python
+shim to PATH. The shim records the output PNG path of every render it is asked
+to perform (one per required view) and writes sentinel PNG bytes there. The
+stage assembles a deterministic HTML contact sheet referencing every view PNG.
+
+No real FreeCAD / PIL / trimesh is needed. Pure stdlib + the PATH shim.
+
+Assertions:
+  (a) ALL required view angles (>=16, by name) were requested.
+  (b) The contact-sheet artifact is assembled and references every view PNG.
+  (c) A missing-view case -> status fail with finding render_incomplete.
+  (d) Fragment shape: {stage:"render", status, detail, findings}.
+"""
+
+import json
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import stage_render  # noqa: E402
+
+# A render shim that emits one PNG per view and records each requested PNG path.
+# It parses the FreeCAD script's view.saveImage('PATH', ...) call exactly like
+# the real freecad_shim, but additionally records the basename (the view name).
+_RENDER_SHIM = r'''#!/usr/bin/env python3
+import os, re, sys
+record = os.environ.get("RENDER_VIEW_RECORD", "")
+skip = os.environ.get("RENDER_SKIP_VIEW", "")
+if len(sys.argv) < 2 or not os.path.isfile(sys.argv[1]):
+    sys.exit(0)
+script = open(sys.argv[1]).read()
+m = re.search(r"view\.saveImage\(['\"]([^'\"]+)['\"]", script)
+if m:
+    path = m.group(1)
+    name = os.path.splitext(os.path.basename(path))[0]
+    if record:
+        with open(record, "a") as f:
+            f.write(name + "\n")
+    if not (skip and name == skip):
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(b"PNG_SENTINEL")
+sys.exit(0)
+'''
+
+
+def _install_render_shim(tmp_bin):
+    dst = os.path.join(tmp_bin, "freecadcmd")
+    with open(dst, "w") as f:
+        f.write(_RENDER_SHIM)
+    mode = os.stat(dst).st_mode
+    os.chmod(dst, mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return dst
+
+
+class _RenderBase(unittest.TestCase):
+
+    def setUp(self):
+        self._orig_path = os.environ.get("PATH", "")
+        self._tmpdir = tempfile.mkdtemp(prefix="render_test_")
+        self._tmp_bin = os.path.join(self._tmpdir, "bin")
+        os.makedirs(self._tmp_bin)
+        self._record = os.path.join(self._tmpdir, "views.txt")
+        _install_render_shim(self._tmp_bin)
+        os.environ["PATH"] = self._tmp_bin + os.pathsep + self._orig_path
+        os.environ["RENDER_VIEW_RECORD"] = self._record
+        os.environ.pop("RENDER_SKIP_VIEW", None)
+        # A trivial STL stand-in; the shim never reads it.
+        self._stl = os.path.join(self._tmpdir, "widget.stl")
+        with open(self._stl, "w") as f:
+            f.write("solid widget\nendsolid widget\n")
+        self._out = os.path.join(self._tmpdir, "fragment.json")
+        self._render_dir = os.path.join(self._tmpdir, "renders")
+
+    def tearDown(self):
+        os.environ["PATH"] = self._orig_path
+        os.environ.pop("RENDER_VIEW_RECORD", None)
+        os.environ.pop("RENDER_SKIP_VIEW", None)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _recorded_views(self):
+        if not os.path.exists(self._record):
+            return []
+        with open(self._record) as f:
+            return [ln.strip() for ln in f if ln.strip()]
+
+    def _run(self):
+        rc = stage_render.main([
+            "--in", self._stl,
+            "--out", self._out,
+            "--render-dir", self._render_dir,
+        ])
+        with open(self._out) as f:
+            frag = json.load(f)
+        return rc, frag
+
+
+class TestViewTable(unittest.TestCase):
+
+    def test_at_least_16_views(self):
+        self.assertGreaterEqual(len(stage_render.REQUIRED_VIEWS), 16)
+
+    def test_view_names_unique_and_ordered(self):
+        names = [v["name"] for v in stage_render.REQUIRED_VIEWS]
+        self.assertEqual(len(names), len(set(names)))
+        # deterministic order: the table is a fixed list, not a set
+        self.assertEqual(names, [v["name"] for v in stage_render.REQUIRED_VIEWS])
+
+    def test_has_six_axis_views(self):
+        names = {v["name"] for v in stage_render.REQUIRED_VIEWS}
+        for axis in ("front", "back", "left", "right", "top", "bottom"):
+            self.assertIn(axis, names)
+
+    def test_has_eight_corner_diagonals(self):
+        diagonals = [v for v in stage_render.REQUIRED_VIEWS
+                     if v.get("kind") == "diagonal"]
+        self.assertGreaterEqual(len(diagonals), 8)
+
+    def test_has_slicer_rotated_views(self):
+        slicer = [v for v in stage_render.REQUIRED_VIEWS
+                  if v.get("kind") == "slicer"]
+        self.assertGreaterEqual(len(slicer), 2)
+
+
+class TestAllViewsRequested(_RenderBase):
+
+    def test_every_required_view_requested(self):
+        rc, frag = self._run()
+        self.assertEqual(rc, 0)
+        requested = set(self._recorded_views())
+        expected = {v["name"] for v in stage_render.REQUIRED_VIEWS}
+        self.assertEqual(requested, expected,
+                         msg=f"missing: {expected - requested}")
+
+    def test_status_pass_when_complete(self):
+        _, frag = self._run()
+        self.assertEqual(frag["status"], "pass")
+        self.assertEqual(frag["findings"], [])
+
+
+class TestContactSheet(_RenderBase):
+
+    def test_sheet_assembled_and_referenced_in_detail(self):
+        _, frag = self._run()
+        sheet = os.path.join(self._render_dir, "widget", "contact-sheet.html")
+        self.assertTrue(os.path.isfile(sheet), "contact sheet not written")
+        self.assertIn("contact-sheet.html", frag["detail"])
+
+    def test_sheet_references_every_view(self):
+        self._run()
+        sheet = os.path.join(self._render_dir, "widget", "contact-sheet.html")
+        with open(sheet) as f:
+            html = f.read()
+        for v in stage_render.REQUIRED_VIEWS:
+            self.assertIn(v["name"] + ".png", html,
+                          msg=f"{v['name']} not referenced in sheet")
+
+    def test_sheet_is_deterministic(self):
+        self._run()
+        sheet = os.path.join(self._render_dir, "widget", "contact-sheet.html")
+        with open(sheet) as f:
+            first = f.read()
+        # re-run into the same dir; identical bytes
+        self._run()
+        with open(sheet) as f:
+            second = f.read()
+        self.assertEqual(first, second)
+
+
+class TestMissingView(_RenderBase):
+
+    def test_missing_view_fails_render_incomplete(self):
+        os.environ["RENDER_SKIP_VIEW"] = "top"
+        rc, frag = self._run()
+        self.assertEqual(rc, 0)  # verdict-in-status, exit 0
+        self.assertEqual(frag["status"], "fail")
+        codes = [f["code"] for f in frag["findings"]]
+        self.assertIn("render_incomplete", codes)
+
+
+class TestFragmentShape(_RenderBase):
+
+    def test_fragment_keys(self):
+        _, frag = self._run()
+        self.assertEqual(frag["stage"], "render")
+        self.assertIn(frag["status"], ("pass", "fail", "warn", "skip"))
+        self.assertIsInstance(frag["detail"], str)
+        self.assertIsInstance(frag["findings"], list)
+
+
+class TestFreecadAbsent(unittest.TestCase):
+
+    def test_skip_when_freecadcmd_absent(self):
+        orig = os.environ.get("PATH", "")
+        tmpdir = tempfile.mkdtemp(prefix="render_noskip_")
+        try:
+            os.environ["PATH"] = "/nonexistent-bin-dir"
+            stl = os.path.join(tmpdir, "m.stl")
+            with open(stl, "w") as f:
+                f.write("solid m\nendsolid m\n")
+            out = os.path.join(tmpdir, "frag.json")
+            rc = stage_render.main([
+                "--in", stl, "--out", out,
+                "--render-dir", os.path.join(tmpdir, "r"),
+            ])
+            self.assertEqual(rc, 0)
+            with open(out) as f:
+                frag = json.load(f)
+            self.assertEqual(frag["status"], "skip")
+        finally:
+            os.environ["PATH"] = orig
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1231

Adds `stage_render.py` + `render_views.py`: 17 deterministic named views (6 axis + 8 corner diagonals + 3 slicer/print-orientation), each rendered via PATH-resolved `freecad_harness.render()` (freecadcmd mocked via $TMP/bin; real renders deferred), montaged into `contact-sheet.html` (CSS grid, no PIL) under `.autospec/fab/renders/<model>/`. All views → pass; missing view → `render_incomplete`; freecadcmd absent → skip.

## Verification
- `python3 -m unittest test_stage_render.py` — 13/13; bats gates it. All 17 view angles requested (asserted by name) + sheet references every view + missing-view→fail + byte-deterministic sheet.
- files <400 LOC, funcs <50; `bash scripts/validate.sh` — exit 0.

Note: real PNG montage/renders deferred to the FreeCAD container; COMPLEXITY nesting flags = AST-FP class (#1245).