### PR TITLE
feat(autospec-fab): vision advisory stage (non-blocking, adversarial-verified)

### DIFF
--- a/skills/autospec-fab/scripts/stage_vision.py
+++ b/skills/autospec-fab/scripts/stage_vision.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+stage_vision.py — ADVISORY vision stage for autospec-fab.
+
+Uniform stage CLI:
+    stage_vision.py --in <contact-sheet.html | render-dir> --out <fragment.json>
+                    [--rules <rules-file>] [--model <metadata.json>]
+
+Behaviour (design spec §Release-gate stage 13 + decision 4 — "vision advises,
+geometry gates"):
+  1. Resolve the vision command from $AUTOSPEC_FAB_VISION_CMD, else PATH
+     (shutil.which). Mocked via $TMP/bin in tests; real vision deferred to the
+     pinned container. Absent -> status "skip", empty vision_findings.
+  2. Resolve the contact sheet (the --in path itself, or contact-sheet.html
+     inside the given render dir). Missing -> status "skip".
+  3. JUDGE pass: subprocess the vision command with the contact sheet + the STL
+     Modeling Rules; parse its JSON {"observations":[...]} into candidate
+     advisory observations [{view?, observation, severity(info|warn), rule?}].
+  4. ADVERSARIAL VERIFY: each raw observation is NOT trusted blindly. A light
+     second pass re-queries the vision command in --verify mode with the
+     candidate observation on stdin; only observations the command CONFIRMS are
+     recorded. This filters hallucinated/low-confidence findings. (Documented
+     and deliberately simple — the point is observations are filtered.)
+  5. Emit the release-gate fragment. The confirmed observations go into the
+     advisory **vision_findings** list, NEVER into the blocking findings[].
+     status: "warn" if any confirmed observation is warn-severity, else "pass".
+     The vision stage is ADVISORY: it NEVER emits "fail", even when it observes
+     a hard-reject-flavoured defect (geometry gates block; vision only advises).
+
+Exit codes: 0 — harness success (verdict lives in fragment "status"); 1 — usage
+error. Stdlib only; the vision toolchain is external + PATH/env-resolved.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+STAGE_NAME = "vision"
+_VALID_SEVERITIES = ("info", "warn")
+
+
+def resolve_vision_cmd() -> str | None:
+    """
+    Resolve the vision CLI: $AUTOSPEC_FAB_VISION_CMD first, else PATH lookup.
+
+    Returns an absolute/usable command path, or None when no vision tool is
+    available (tests mock this via $TMP/bin; real vision is deferred).
+    """
+    env_cmd = os.environ.get("AUTOSPEC_FAB_VISION_CMD")
+    if env_cmd:
+        if os.path.isfile(env_cmd) and os.access(env_cmd, os.X_OK):
+            return env_cmd
+        resolved = shutil.which(env_cmd)
+        if resolved:
+            return resolved
+        return None
+    return shutil.which("fab-vision")
+
+
+def resolve_contact_sheet(in_path: str) -> str | None:
+    """
+    Resolve the contact-sheet artifact from --in.
+
+    --in may be the contact-sheet.html file itself, or a render dir containing
+    one. Returns the sheet path, or None if no contact sheet is found.
+    """
+    if os.path.isfile(in_path):
+        return in_path
+    if os.path.isdir(in_path):
+        candidate = os.path.join(in_path, "contact-sheet.html")
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def _run_cmd(argv: list, stdin_text: str | None = None):
+    """Run the vision command; return CompletedProcess or None on OSError."""
+    try:
+        return subprocess.run(
+            argv,
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+
+
+def _normalize_observation(raw: dict) -> dict | None:
+    """
+    Coerce a raw vision observation into the advisory shape, or None if invalid.
+
+    Shape: {observation, severity(info|warn), view?, rule?}. Any unknown
+    severity is clamped to "warn" so an advisory finding is never silently
+    upgraded to a blocking severity.
+    """
+    if not isinstance(raw, dict):
+        return None
+    text = raw.get("observation")
+    if not isinstance(text, str) or not text.strip():
+        return None
+    severity = raw.get("severity")
+    if severity not in _VALID_SEVERITIES:
+        severity = "warn"
+    ob = {"observation": text.strip(), "severity": severity}
+    if isinstance(raw.get("view"), str) and raw["view"]:
+        ob["view"] = raw["view"]
+    if isinstance(raw.get("rule"), str) and raw["rule"]:
+        ob["rule"] = raw["rule"]
+    return ob
+
+
+def judge_contact_sheet(cmd: str, sheet: str, rules: str | None) -> list:
+    """
+    JUDGE pass: ask the vision command to review the sheet against the rules.
+
+    Invokes `<cmd> <sheet> [<rules>]`; parses stdout JSON
+    {"observations":[...]} into normalized candidate observations. Any parse or
+    subprocess failure yields an empty candidate list (advisory: never raise).
+    """
+    argv = [cmd, sheet]
+    if rules:
+        argv.append(rules)
+    proc = _run_cmd(argv)
+    if proc is None or proc.returncode != 0:
+        return []
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except (ValueError, TypeError):
+        return []
+    raw_list = payload.get("observations") if isinstance(payload, dict) else None
+    if not isinstance(raw_list, list):
+        return []
+    out = []
+    for raw in raw_list:
+        ob = _normalize_observation(raw)
+        if ob is not None:
+            out.append(ob)
+    return out
+
+
+def _confirm_observation(cmd: str, sheet: str, rules: str | None,
+                         observation: dict) -> bool:
+    """
+    Adversarial second pass: re-query the vision command to confirm ONE
+    observation before recording it.
+
+    Invokes `<cmd> --verify <sheet> [<rules>]` with the candidate observation
+    as JSON on stdin; the command answers {"confirmed": bool}. A missing or
+    malformed verdict is treated as NOT confirmed (conservative: an unverified
+    observation is dropped rather than trusted blindly).
+    """
+    argv = [cmd, "--verify", sheet]
+    if rules:
+        argv.append(rules)
+    proc = _run_cmd(argv, stdin_text=json.dumps(observation))
+    if proc is None or proc.returncode != 0:
+        return False
+    try:
+        verdict = json.loads(proc.stdout or "{}")
+    except (ValueError, TypeError):
+        return False
+    return isinstance(verdict, dict) and verdict.get("confirmed") is True
+
+
+def verify_observations(cmd: str, sheet: str, rules: str | None,
+                        candidates: list) -> list:
+    """Keep only observations the adversarial verify pass confirms."""
+    return [ob for ob in candidates
+            if _confirm_observation(cmd, sheet, rules, ob)]
+
+
+def _skip_fragment(detail: str) -> dict:
+    """Advisory fragment for the vision-unavailable / no-sheet case."""
+    return {
+        "stage": STAGE_NAME,
+        "status": "skip",
+        "detail": detail,
+        "findings": [],
+        "vision_findings": [],
+    }
+
+
+def _advisory_status(findings: list) -> str:
+    """
+    Map confirmed advisory findings to a NON-BLOCKING status.
+
+    "warn" if any confirmed observation is warn-severity, else "pass". This
+    function deliberately CANNOT return "fail": the vision stage only advises.
+    """
+    if any(f.get("severity") == "warn" for f in findings):
+        return "warn"
+    return "pass"
+
+
+def run_vision_stage(in_path: str, rules: str | None) -> dict:
+    """
+    Run the advisory vision stage and return a release-gate fragment.
+
+    Fragment shape: {stage, status, detail, findings, vision_findings}. The
+    confirmed advisory observations live in vision_findings; the blocking
+    findings[] is ALWAYS empty (geometry gates block, vision only advises).
+    """
+    cmd = resolve_vision_cmd()
+    if cmd is None:
+        return _skip_fragment(
+            "vision command not available; vision advisory deferred "
+            "(real vision deferred to the pinned container)")
+
+    sheet = resolve_contact_sheet(in_path)
+    if sheet is None:
+        return _skip_fragment(
+            "no contact sheet at --in; vision advisory deferred")
+
+    candidates = judge_contact_sheet(cmd, sheet, rules)
+    confirmed = verify_observations(cmd, sheet, rules, candidates)
+
+    status = _advisory_status(confirmed)
+    detail = (
+        f"vision advisory: {len(confirmed)} confirmed observation(s) "
+        f"of {len(candidates)} candidate(s) (adversarially verified); "
+        f"sheet: {sheet}"
+    )
+    return {
+        "stage": STAGE_NAME,
+        "status": status,
+        "detail": detail,
+        "findings": [],            # blocking list — vision NEVER populates it
+        "vision_findings": confirmed,
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="autospec-fab advisory vision stage (non-blocking)"
+    )
+    parser.add_argument("--in", dest="in_path", required=True,
+                        help="Contact-sheet HTML, or render dir containing one")
+    parser.add_argument("--out", required=True,
+                        help="Output release-gate fragment JSON path")
+    parser.add_argument("--rules", dest="rules_path", default=None,
+                        help="STL Modeling Rules file passed to the vision cmd")
+    parser.add_argument("--model", dest="model_path", default=None,
+                        help="Per-model metadata sidecar (optional, unused)")
+
+    args = parser.parse_args(argv)
+
+    fragment = run_vision_stage(args.in_path, args.rules_path)
+
+    out_dir = os.path.dirname(os.path.abspath(args.out))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(fragment, f, indent=2)
+        f.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/autospec-fab/tests/test_stage_vision.bats
+++ b/skills/autospec-fab/tests/test_stage_vision.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# test_stage_vision.bats — thin bats wrapper around the Python unittest suite.
+# Invoked by validate.sh fab gate (check_autospec_fab_contract) which runs
+# every skills/autospec-fab/tests/*.bats file.
+
+# Resolve the repo root from this file's location (tests/ → skill/ → repo root)
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+
+@test "stage_vision python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_stage_vision.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_stage_vision.py
+++ b/skills/autospec-fab/tests/test_stage_vision.py
@@ -1,0 +1,274 @@
+"""
+test_stage_vision.py — unittest for stage_vision.py (advisory vision stage).
+
+Strategy: prepend a $TMP/bin directory containing a fake vision CLI shim to
+PATH (and point $AUTOSPEC_FAB_VISION_CMD at it). The shim emits a known
+advisory observation on its first ("judge") pass and a confirm/reject verdict
+on its second ("--verify") pass — both env-controllable:
+
+  VISION_OBS       observation text the judge pass emits (default a generic one)
+  VISION_SEV       severity of that observation: "info" | "warn" (default warn)
+  VISION_VIEW      optional view label
+  VISION_RULE      optional rule id (e.g. exposed_gasket)
+  VISION_CONFIRM   "1" (default) the verify pass confirms; "0" it rejects
+
+No real vision model is needed. Pure stdlib + the PATH/env shim.
+
+Assertions:
+  (a) the shim's finding is RECORDED in vision_findings.
+  (b) the stage stays NON-BLOCKING: even when the shim emits an alarming /
+      "reject"-flavoured observation (a hard-reject code at warn severity) the
+      status is NEVER "fail" — at most "warn".
+  (c) vision absent -> status "skip", empty vision_findings.
+  (d) the observation lands in vision_findings, NOT the blocking findings[].
+  (e) fragment shape: {stage, status, detail, findings, vision_findings}.
+  (f) the adversarial verify pass actually filters: a rejected observation is
+      dropped from vision_findings.
+"""
+
+import json
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import stage_vision  # noqa: E402
+
+# A vision CLI shim with two passes:
+#   judge pass:  argv = [shim, <sheet>, <rules>]        -> emits observations
+#   verify pass: argv = [shim, "--verify", <sheet>, <rules>] with the candidate
+#                observation JSON on stdin -> emits {"confirmed": bool}
+# This mirrors the adversarial second-pass: every observation must be
+# re-confirmed before it is recorded.
+_VISION_SHIM = r'''#!/usr/bin/env python3
+import json, os, sys
+
+obs_text = os.environ.get("VISION_OBS", "surface looks acceptable")
+sev = os.environ.get("VISION_SEV", "warn")
+view = os.environ.get("VISION_VIEW", "")
+rule = os.environ.get("VISION_RULE", "")
+confirm = os.environ.get("VISION_CONFIRM", "1") == "1"
+
+if len(sys.argv) >= 2 and sys.argv[1] == "--verify":
+    # second pass: confirm or reject the candidate observation.
+    try:
+        json.load(sys.stdin)
+    except Exception:
+        pass
+    json.dump({"confirmed": confirm}, sys.stdout)
+    sys.exit(0)
+
+ob = {"observation": obs_text, "severity": sev}
+if view:
+    ob["view"] = view
+if rule:
+    ob["rule"] = rule
+json.dump({"observations": [ob]}, sys.stdout)
+sys.exit(0)
+'''
+
+
+def _install_vision_shim(tmp_bin):
+    dst = os.path.join(tmp_bin, "fab-vision")
+    with open(dst, "w") as f:
+        f.write(_VISION_SHIM)
+    mode = os.stat(dst).st_mode
+    os.chmod(dst, mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return dst
+
+
+class _VisionBase(unittest.TestCase):
+
+    def setUp(self):
+        self._orig_path = os.environ.get("PATH", "")
+        self._orig_cmd = os.environ.get("AUTOSPEC_FAB_VISION_CMD")
+        self._tmpdir = tempfile.mkdtemp(prefix="vision_test_")
+        self._tmp_bin = os.path.join(self._tmpdir, "bin")
+        os.makedirs(self._tmp_bin)
+        shim = _install_vision_shim(self._tmp_bin)
+        os.environ["PATH"] = self._tmp_bin + os.pathsep + self._orig_path
+        os.environ["AUTOSPEC_FAB_VISION_CMD"] = shim
+        for k in ("VISION_OBS", "VISION_SEV", "VISION_VIEW",
+                  "VISION_RULE", "VISION_CONFIRM"):
+            os.environ.pop(k, None)
+        # A stand-in contact sheet; the shim never reads it.
+        self._render_dir = os.path.join(self._tmpdir, "renders", "widget")
+        os.makedirs(self._render_dir)
+        self._sheet = os.path.join(self._render_dir, "contact-sheet.html")
+        with open(self._sheet, "w") as f:
+            f.write("<html><body>contact sheet</body></html>\n")
+        self._rules = os.path.join(self._tmpdir, "rules.md")
+        with open(self._rules, "w") as f:
+            f.write("# STL Modeling Rules\n- exposed_gasket bad\n")
+        self._out = os.path.join(self._tmpdir, "fragment.json")
+
+    def tearDown(self):
+        os.environ["PATH"] = self._orig_path
+        if self._orig_cmd is None:
+            os.environ.pop("AUTOSPEC_FAB_VISION_CMD", None)
+        else:
+            os.environ["AUTOSPEC_FAB_VISION_CMD"] = self._orig_cmd
+        for k in ("VISION_OBS", "VISION_SEV", "VISION_VIEW",
+                  "VISION_RULE", "VISION_CONFIRM"):
+            os.environ.pop(k, None)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _run(self, in_path=None):
+        argv = [
+            "--in", in_path or self._sheet,
+            "--out", self._out,
+            "--rules", self._rules,
+        ]
+        rc = stage_vision.main(argv)
+        with open(self._out) as f:
+            frag = json.load(f)
+        return rc, frag
+
+
+class TestFindingRecorded(_VisionBase):
+
+    def test_observation_recorded_in_vision_findings(self):
+        os.environ["VISION_OBS"] = "left gasket groove appears exposed"
+        os.environ["VISION_SEV"] = "warn"
+        os.environ["VISION_VIEW"] = "left"
+        os.environ["VISION_RULE"] = "exposed_gasket"
+        rc, frag = self._run()
+        self.assertEqual(rc, 0)
+        vf = frag["vision_findings"]
+        self.assertEqual(len(vf), 1)
+        self.assertEqual(vf[0]["observation"],
+                         "left gasket groove appears exposed")
+        self.assertEqual(vf[0]["severity"], "warn")
+        self.assertEqual(vf[0]["view"], "left")
+        self.assertEqual(vf[0]["rule"], "exposed_gasket")
+
+    def test_warn_observation_sets_warn_status(self):
+        os.environ["VISION_SEV"] = "warn"
+        _, frag = self._run()
+        self.assertEqual(frag["status"], "warn")
+
+    def test_info_only_observation_passes(self):
+        os.environ["VISION_SEV"] = "info"
+        _, frag = self._run()
+        self.assertEqual(frag["status"], "pass")
+        self.assertEqual(len(frag["vision_findings"]), 1)
+
+
+class TestNonBlocking(_VisionBase):
+
+    def test_never_fails_even_on_alarming_observation(self):
+        # An alarming, hard-reject-flavoured observation at warn severity.
+        os.environ["VISION_OBS"] = ("REJECT: NPT tap is completely blocked, "
+                                    "release must not ship")
+        os.environ["VISION_SEV"] = "warn"
+        os.environ["VISION_RULE"] = "blocked_npt"
+        _, frag = self._run()
+        # advisory: at most warn, NEVER fail.
+        self.assertNotEqual(frag["status"], "fail")
+        self.assertEqual(frag["status"], "warn")
+
+    def test_blocking_findings_list_stays_empty(self):
+        # Even an alarming observation must NOT enter the blocking findings[].
+        os.environ["VISION_OBS"] = "disconnected body visible"
+        os.environ["VISION_SEV"] = "warn"
+        os.environ["VISION_RULE"] = "disconnected_bodies"
+        _, frag = self._run()
+        self.assertEqual(frag["findings"], [])
+        # ...it lands in the advisory list instead.
+        rules = [v.get("rule") for v in frag["vision_findings"]]
+        self.assertIn("disconnected_bodies", rules)
+
+    def test_status_is_never_fail_for_any_severity(self):
+        for sev in ("info", "warn"):
+            with self.subTest(sev=sev):
+                os.environ["VISION_SEV"] = sev
+                _, frag = self._run()
+                self.assertNotEqual(frag["status"], "fail")
+
+
+class TestAdversarialVerify(_VisionBase):
+
+    def test_rejected_observation_is_dropped(self):
+        os.environ["VISION_OBS"] = "hallucinated overhang"
+        os.environ["VISION_SEV"] = "warn"
+        os.environ["VISION_CONFIRM"] = "0"  # verify pass rejects it
+        _, frag = self._run()
+        self.assertEqual(frag["vision_findings"], [])
+        # nothing confirmed -> nothing to warn about.
+        self.assertEqual(frag["status"], "pass")
+
+    def test_confirmed_observation_is_kept(self):
+        os.environ["VISION_OBS"] = "real overhang"
+        os.environ["VISION_SEV"] = "warn"
+        os.environ["VISION_CONFIRM"] = "1"
+        _, frag = self._run()
+        self.assertEqual(len(frag["vision_findings"]), 1)
+
+
+class TestVisionAbsent(unittest.TestCase):
+
+    def test_skip_when_vision_cmd_absent(self):
+        orig_path = os.environ.get("PATH", "")
+        orig_cmd = os.environ.get("AUTOSPEC_FAB_VISION_CMD")
+        tmpdir = tempfile.mkdtemp(prefix="vision_absent_")
+        try:
+            os.environ["PATH"] = "/nonexistent-bin-dir"
+            os.environ.pop("AUTOSPEC_FAB_VISION_CMD", None)
+            sheet = os.path.join(tmpdir, "contact-sheet.html")
+            with open(sheet, "w") as f:
+                f.write("<html></html>\n")
+            out = os.path.join(tmpdir, "frag.json")
+            rc = stage_vision.main(["--in", sheet, "--out", out])
+            self.assertEqual(rc, 0)
+            with open(out) as f:
+                frag = json.load(f)
+            self.assertEqual(frag["status"], "skip")
+            self.assertEqual(frag["vision_findings"], [])
+            self.assertIn("deferred", frag["detail"])
+        finally:
+            os.environ["PATH"] = orig_path
+            if orig_cmd is not None:
+                os.environ["AUTOSPEC_FAB_VISION_CMD"] = orig_cmd
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestInputResolution(_VisionBase):
+
+    def test_render_dir_input_resolves_to_contact_sheet(self):
+        # --in may be the render dir; the stage finds contact-sheet.html.
+        os.environ["VISION_SEV"] = "info"
+        rc, frag = self._run(in_path=self._render_dir)
+        self.assertEqual(rc, 0)
+        self.assertEqual(frag["status"], "pass")
+
+    def test_missing_contact_sheet_skips(self):
+        os.environ["VISION_SEV"] = "warn"
+        empty = os.path.join(self._tmpdir, "empty")
+        os.makedirs(empty)
+        rc, frag = self._run(in_path=empty)
+        self.assertEqual(rc, 0)
+        self.assertEqual(frag["status"], "skip")
+
+
+class TestFragmentShape(_VisionBase):
+
+    def test_fragment_keys(self):
+        os.environ["VISION_SEV"] = "warn"
+        _, frag = self._run()
+        self.assertEqual(frag["stage"], "vision")
+        self.assertIn(frag["status"], ("pass", "warn", "skip"))
+        self.assertNotEqual(frag["status"], "fail")
+        self.assertIsInstance(frag["detail"], str)
+        self.assertIsInstance(frag["findings"], list)
+        self.assertIsInstance(frag["vision_findings"], list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1232

Adds `stage_vision.py`: sends the contact sheet + STL rules to a PATH/env-resolved vision command (`$AUTOSPEC_FAB_VISION_CMD`; mocked via $TMP/bin; real vision deferred), two-pass **adversarial verify** (drops unconfirmed observations), records confirmed observations into the advisory `vision_findings[]`.

**Locked decision honored — vision is NON-BLOCKING:** `_advisory_status()` can only return warn/pass/skip, never `fail`; blocking `findings[]` stays empty. Verified empirically: an alarming "REJECT" observation → status `warn`, 0 blocking findings, 1 vision_finding.

## Verification
- `python3 -m unittest test_stage_vision.py` — 12/12; bats gates it. alarming-obs→warn(not fail)+in vision_findings not findings[]; rejected-obs dropped; vision-absent→skip.
- <400 LOC, funcs <50; `bash scripts/validate.sh` — exit 0.

Note: real vision deferred to container; COMPLEXITY nesting flags = AST-FP class (#1245).