### PR TITLE
feat(autospec-fab): docs freshness + NO_HANDEDIT_GENERATED guard stage

### DIFF
--- a/skills/autospec-fab/scripts/stage_docs.py
+++ b/skills/autospec-fab/scripts/stage_docs.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+stage_docs.py — docs/PDF freshness + NO_HANDEDIT_GENERATED guard for autospec-fab.
+
+Uniform stage CLI:
+    stage_docs.py --in <model-dir|build-dir> --out <fragment.json>
+                  [--baseline <regen-baseline.json>]
+                  [--model <sidecar.json>]   (accepted for symmetry, ignored)
+
+Two independent checks, both expressed in the release-gate fragment status:
+
+  1. NO_HANDEDIT_GENERATED guard
+     Generated artifacts are never hand-edited. A *regen baseline* — a manifest
+     mapping each generated artifact's repo-relative path to the sha256 of a
+     clean regenerated copy — is produced by a clean `rm -rf build && generate`
+     run. This stage recomputes the sha256 of every baseline entry under --in
+     and compares it to the recorded hash. Generated artifacts are: anything
+     under build/, plus BOM.md, *.pdf, and renders / section images / contact
+     sheets (which all live under build/). Any current hash that differs from
+     the baseline (or a baseline path that has gone missing) is a hand edit →
+     status fail + finding code_health 'hand_edited_generated' (names the file).
+
+  2. Hand-doc freshness
+     The hand-maintained docs MANIFEST.md / README.md / FITTINGS_AND_SCREWS.md
+     must stay in sync with current geometry facts. Facts are modelled as a
+     small facts.json (current model list + fitting counts). Freshness is a
+     simple, documented inclusion check: each hand doc must contain every
+     current fact token (model names) as a substring. A doc that omits a current
+     model (e.g. a stale MANIFEST) → status fail + finding 'docs_stale' (names
+     the doc + the missing fact).
+
+All checks in sync → status pass. Exit 0 always carries the verdict in the
+fragment status; exit non-zero only on harness/usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from typing import List, Optional
+
+
+HAND_DOCS = ("MANIFEST.md", "README.md", "FITTINGS_AND_SCREWS.md")
+
+
+# ---------------------------------------------------------------------------
+# Fragment helpers
+# ---------------------------------------------------------------------------
+
+def _make_finding(code: str, message: str) -> dict:
+    return {"code": code, "message": message}
+
+
+def _make_fragment(status: str, detail: str, findings: List[dict]) -> dict:
+    return {
+        "stage": "docs",
+        "status": status,
+        "detail": detail,
+        "findings": findings,
+    }
+
+
+def _sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# NO_HANDEDIT_GENERATED guard
+# ---------------------------------------------------------------------------
+
+def check_no_handedit(model_dir: str, baseline_path: str) -> List[dict]:
+    """Compare each baseline artifact's current sha256 to the recorded hash.
+
+    Returns a list of 'hand_edited_generated' findings (empty when clean).
+    """
+    if not baseline_path or not os.path.exists(baseline_path):
+        return [_make_finding(
+            "hand_edited_generated",
+            f"Regen baseline not found: {baseline_path!r}; cannot verify "
+            "generated artifacts were not hand-edited",
+        )]
+    with open(baseline_path) as fh:
+        baseline = json.load(fh)
+
+    findings: List[dict] = []
+    for rel, expected in sorted(baseline.items()):
+        full = os.path.join(model_dir, rel)
+        if not os.path.exists(full):
+            findings.append(_make_finding(
+                "hand_edited_generated",
+                f"Generated artifact missing (expected from regen): {rel}",
+            ))
+            continue
+        actual = _sha256_file(full)
+        if actual != expected:
+            findings.append(_make_finding(
+                "hand_edited_generated",
+                f"Generated artifact hand-edited (sha256 differs from regen "
+                f"baseline): {rel}",
+            ))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Hand-doc freshness
+# ---------------------------------------------------------------------------
+
+def _expected_fact_tokens(facts: dict) -> List[str]:
+    """Current geometry facts every hand doc must reference (model names)."""
+    return [str(m) for m in facts.get("models", [])]
+
+
+def check_docs_fresh(model_dir: str, facts: dict) -> List[dict]:
+    """Each hand doc must reference every current fact token (substring).
+
+    Returns a list of 'docs_stale' findings (empty when fresh).
+    """
+    tokens = _expected_fact_tokens(facts)
+    findings: List[dict] = []
+    for doc in HAND_DOCS:
+        doc_path = os.path.join(model_dir, doc)
+        if not os.path.exists(doc_path):
+            findings.append(_make_finding(
+                "docs_stale", f"Hand doc missing: {doc}"))
+            continue
+        with open(doc_path, encoding="utf-8") as fh:
+            text = fh.read()
+        for token in tokens:
+            if token not in text:
+                findings.append(_make_finding(
+                    "docs_stale",
+                    f"{doc} is stale: omits current fact {token!r}",
+                ))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Stage runner
+# ---------------------------------------------------------------------------
+
+def _load_facts(model_dir: str) -> Optional[dict]:
+    facts_path = os.path.join(model_dir, "facts.json")
+    if not os.path.exists(facts_path):
+        return None
+    with open(facts_path) as fh:
+        return json.load(fh)
+
+
+def run_docs_stage(model_dir: str, baseline_path: str) -> dict:
+    """Run both checks and return a stage-record fragment."""
+    if not os.path.isdir(model_dir):
+        return _make_fragment(
+            "fail", f"Input dir not found: {model_dir}",
+            [_make_finding("docs_stale", f"Input dir not found: {model_dir}")])
+
+    facts = _load_facts(model_dir)
+    if facts is None:
+        return _make_fragment(
+            "fail", f"facts.json not found under {model_dir}",
+            [_make_finding("docs_stale", "facts.json missing; cannot verify "
+                           "hand-doc freshness")])
+
+    findings = check_no_handedit(model_dir, baseline_path)
+    findings += check_docs_fresh(model_dir, facts)
+
+    if findings:
+        return _make_fragment(
+            "fail",
+            f"docs gate failed: {len(findings)} finding(s) "
+            f"({', '.join(sorted({f['code'] for f in findings}))})",
+            findings)
+    return _make_fragment(
+        "pass",
+        "Hand docs in sync with current facts; generated artifacts match "
+        "regen baseline (no hand edits)",
+        [])
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="autospec-fab docs stage: hand-doc freshness + "
+                    "NO_HANDEDIT_GENERATED guard")
+    parser.add_argument("--in", dest="in_path", required=True,
+                        help="Model directory (contains build/, hand docs, "
+                             "facts.json, baseline.json)")
+    parser.add_argument("--out", required=True, help="Output fragment JSON path")
+    parser.add_argument("--baseline", dest="baseline", default=None,
+                        help="Regen baseline manifest (path->sha256). "
+                             "Defaults to <in>/baseline.json")
+    parser.add_argument("--model", dest="model_path", default=None,
+                        help="Per-model sidecar (accepted for CLI symmetry; "
+                             "not used by this stage)")
+
+    args = parser.parse_args(argv)
+
+    baseline = args.baseline or os.path.join(args.in_path, "baseline.json")
+    fragment = run_docs_stage(args.in_path, baseline)
+
+    out_dir = os.path.dirname(os.path.abspath(args.out))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(args.out, "w") as fh:
+        json.dump(fragment, fh, indent=2)
+        fh.write("\n")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/autospec-fab/tests/fixtures/docs/hand-edited/FITTINGS_AND_SCREWS.md
+++ b/skills/autospec-fab/tests/fixtures/docs/hand-edited/FITTINGS_AND_SCREWS.md
@@ -1,0 +1,7 @@
+# Fittings and Screws
+
+Per the current models cyclone_inlet and dust_deputy:
+
+- 3x 1/4 NPT plug
+- 2x hose barb
+- 8x M4 screw

--- a/skills/autospec-fab/tests/fixtures/docs/hand-edited/MANIFEST.md
+++ b/skills/autospec-fab/tests/fixtures/docs/hand-edited/MANIFEST.md
@@ -1,0 +1,8 @@
+# Manifest
+
+Models in this catalog:
+
+- cyclone_inlet — primary vacuum manifold
+- dust_deputy — secondary separator
+
+Fittings: 3 NPT, 2 hose.

--- a/skills/autospec-fab/tests/fixtures/docs/hand-edited/README.md
+++ b/skills/autospec-fab/tests/fixtures/docs/hand-edited/README.md
@@ -1,0 +1,5 @@
+# Vacuum Manifold Catalog
+
+This repo generates printable manifolds: cyclone_inlet and dust_deputy.
+
+Run the generator to produce build/ artifacts.

--- a/skills/autospec-fab/tests/fixtures/docs/hand-edited/baseline.json
+++ b/skills/autospec-fab/tests/fixtures/docs/hand-edited/baseline.json
@@ -1,0 +1,7 @@
+{
+  "build/BOM.md": "566f8cacc7076f32a81df7e0b1207bd45bf291b823dcbc037d03a588f940dc61",
+  "build/datasheet.pdf": "2cc762e4cb855e1b91621751ce7a28be169af90f244a72570e9ba8487acae578",
+  "build/renders/contact_sheet.txt": "eda4e8b1aa48bf20f15edc9cfcd8bc6fa1e22368817dc99b644843d0cc0a8057",
+  "build/stls/manifolds/cyclone_inlet.stl": "b5845b491d4cf34d5718ca8c1734327ba38f6f33a256146ecefe798a93c61f00",
+  "build/stls/manifolds/dust_deputy.stl": "a6d9443c95f83b869382b1db0cb065caf41842fd3d4a1881f3ea0a49c854c4f3"
+}

--- a/skills/autospec-fab/tests/fixtures/docs/hand-edited/facts.json
+++ b/skills/autospec-fab/tests/fixtures/docs/hand-edited/facts.json
@@ -1,0 +1,7 @@
+{
+  "models": ["cyclone_inlet", "dust_deputy"],
+  "fitting_counts": {
+    "npt": 3,
+    "hose": 2
+  }
+}

--- a/skills/autospec-fab/tests/fixtures/docs/in-sync/FITTINGS_AND_SCREWS.md
+++ b/skills/autospec-fab/tests/fixtures/docs/in-sync/FITTINGS_AND_SCREWS.md
@@ -1,0 +1,7 @@
+# Fittings and Screws
+
+Per the current models cyclone_inlet and dust_deputy:
+
+- 3x 1/4 NPT plug
+- 2x hose barb
+- 8x M4 screw

--- a/skills/autospec-fab/tests/fixtures/docs/in-sync/MANIFEST.md
+++ b/skills/autospec-fab/tests/fixtures/docs/in-sync/MANIFEST.md
@@ -1,0 +1,8 @@
+# Manifest
+
+Models in this catalog:
+
+- cyclone_inlet — primary vacuum manifold
+- dust_deputy — secondary separator
+
+Fittings: 3 NPT, 2 hose.

--- a/skills/autospec-fab/tests/fixtures/docs/in-sync/README.md
+++ b/skills/autospec-fab/tests/fixtures/docs/in-sync/README.md
@@ -1,0 +1,5 @@
+# Vacuum Manifold Catalog
+
+This repo generates printable manifolds: cyclone_inlet and dust_deputy.
+
+Run the generator to produce build/ artifacts.

--- a/skills/autospec-fab/tests/fixtures/docs/in-sync/baseline.json
+++ b/skills/autospec-fab/tests/fixtures/docs/in-sync/baseline.json
@@ -1,0 +1,7 @@
+{
+  "build/BOM.md": "566f8cacc7076f32a81df7e0b1207bd45bf291b823dcbc037d03a588f940dc61",
+  "build/datasheet.pdf": "2cc762e4cb855e1b91621751ce7a28be169af90f244a72570e9ba8487acae578",
+  "build/renders/contact_sheet.txt": "eda4e8b1aa48bf20f15edc9cfcd8bc6fa1e22368817dc99b644843d0cc0a8057",
+  "build/stls/manifolds/cyclone_inlet.stl": "b5845b491d4cf34d5718ca8c1734327ba38f6f33a256146ecefe798a93c61f00",
+  "build/stls/manifolds/dust_deputy.stl": "a6d9443c95f83b869382b1db0cb065caf41842fd3d4a1881f3ea0a49c854c4f3"
+}

--- a/skills/autospec-fab/tests/fixtures/docs/in-sync/facts.json
+++ b/skills/autospec-fab/tests/fixtures/docs/in-sync/facts.json
@@ -1,0 +1,7 @@
+{
+  "models": ["cyclone_inlet", "dust_deputy"],
+  "fitting_counts": {
+    "npt": 3,
+    "hose": 2
+  }
+}

--- a/skills/autospec-fab/tests/fixtures/docs/stale-manifest/FITTINGS_AND_SCREWS.md
+++ b/skills/autospec-fab/tests/fixtures/docs/stale-manifest/FITTINGS_AND_SCREWS.md
@@ -1,0 +1,7 @@
+# Fittings and Screws
+
+Per the current models cyclone_inlet and dust_deputy:
+
+- 3x 1/4 NPT plug
+- 2x hose barb
+- 8x M4 screw

--- a/skills/autospec-fab/tests/fixtures/docs/stale-manifest/MANIFEST.md
+++ b/skills/autospec-fab/tests/fixtures/docs/stale-manifest/MANIFEST.md
@@ -1,0 +1,7 @@
+# Manifest
+
+Models in this catalog:
+
+- cyclone_inlet — primary vacuum manifold
+
+Fittings: 3 NPT, 2 hose.

--- a/skills/autospec-fab/tests/fixtures/docs/stale-manifest/README.md
+++ b/skills/autospec-fab/tests/fixtures/docs/stale-manifest/README.md
@@ -1,0 +1,5 @@
+# Vacuum Manifold Catalog
+
+This repo generates printable manifolds: cyclone_inlet and dust_deputy.
+
+Run the generator to produce build/ artifacts.

--- a/skills/autospec-fab/tests/fixtures/docs/stale-manifest/baseline.json
+++ b/skills/autospec-fab/tests/fixtures/docs/stale-manifest/baseline.json
@@ -1,0 +1,7 @@
+{
+  "build/BOM.md": "566f8cacc7076f32a81df7e0b1207bd45bf291b823dcbc037d03a588f940dc61",
+  "build/datasheet.pdf": "2cc762e4cb855e1b91621751ce7a28be169af90f244a72570e9ba8487acae578",
+  "build/renders/contact_sheet.txt": "eda4e8b1aa48bf20f15edc9cfcd8bc6fa1e22368817dc99b644843d0cc0a8057",
+  "build/stls/manifolds/cyclone_inlet.stl": "b5845b491d4cf34d5718ca8c1734327ba38f6f33a256146ecefe798a93c61f00",
+  "build/stls/manifolds/dust_deputy.stl": "a6d9443c95f83b869382b1db0cb065caf41842fd3d4a1881f3ea0a49c854c4f3"
+}

--- a/skills/autospec-fab/tests/fixtures/docs/stale-manifest/facts.json
+++ b/skills/autospec-fab/tests/fixtures/docs/stale-manifest/facts.json
@@ -1,0 +1,7 @@
+{
+  "models": ["cyclone_inlet", "dust_deputy"],
+  "fitting_counts": {
+    "npt": 3,
+    "hose": 2
+  }
+}

--- a/skills/autospec-fab/tests/test_stage_docs.bats
+++ b/skills/autospec-fab/tests/test_stage_docs.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# test_stage_docs.bats — thin bats wrapper around the Python unittest suite.
+# Invoked by the validate.sh fab gate (check_autospec_fab_contract) which runs
+# every skills/autospec-fab/tests/*.bats file.
+
+# Resolve the repo root from this file's location (tests/ → skill/ → repo root)
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+
+@test "stage_docs python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_stage_docs.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_stage_docs.py
+++ b/skills/autospec-fab/tests/test_stage_docs.py
@@ -1,0 +1,192 @@
+"""
+test_stage_docs.py — unittest for stage_docs.py.
+
+Real file diffs, no mocks. Drives the stage via its uniform CLI against three
+committed fixtures under fixtures/docs/:
+
+  1. in-sync/        → status pass  (all generated artifacts match baseline.json;
+                       all hand docs reference every current fact).
+  2. stale-manifest/ → status fail + finding docs_stale
+                       (MANIFEST.md omits the current model 'dust_deputy';
+                        generated artifacts still match baseline).
+  3. hand-edited/    → status fail + finding hand_edited_generated
+                       (a build/ STL was hand-edited so its sha256 no longer
+                        matches baseline.json; hand docs are still in sync).
+  4. fragment shape  → required stage-record keys + valid status enum.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
+_FIXTURES_DIR = os.path.normpath(os.path.join(_THIS_DIR, "fixtures", "docs"))
+
+_STAGE_SCRIPT = os.path.join(_SCRIPTS_DIR, "stage_docs.py")
+
+_IN_SYNC = os.path.join(_FIXTURES_DIR, "in-sync")
+_STALE = os.path.join(_FIXTURES_DIR, "stale-manifest")
+_HAND_EDITED = os.path.join(_FIXTURES_DIR, "hand-edited")
+
+
+def _run_stage(model_dir, baseline=None):
+    """Run stage_docs.py --in <dir> --out <tmp> [--baseline <dir>].
+
+    Returns (returncode, fragment_dict_or_None, stderr).
+    """
+    if baseline is None:
+        baseline = os.path.join(model_dir, "baseline.json")
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+        out_path = tf.name
+    try:
+        cmd = [
+            sys.executable, _STAGE_SCRIPT,
+            "--in", model_dir,
+            "--out", out_path,
+            "--baseline", baseline,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        fragment = None
+        if os.path.exists(out_path) and os.path.getsize(out_path) > 0:
+            with open(out_path) as f:
+                fragment = json.load(f)
+        return result.returncode, fragment, result.stderr
+    finally:
+        if os.path.exists(out_path):
+            os.unlink(out_path)
+
+
+def _finding_codes(fragment):
+    return {f.get("code") for f in fragment.get("findings", [])}
+
+
+class TestFragmentShape(unittest.TestCase):
+    _VALID_STATUSES = {"pass", "fail", "warn", "skip"}
+
+    def _assert_valid_fragment(self, fragment, expected_stage="docs"):
+        self.assertIsInstance(fragment, dict, "fragment must be a dict")
+        self.assertIn("stage", fragment)
+        self.assertEqual(fragment["stage"], expected_stage)
+        self.assertIn("status", fragment)
+        self.assertIn(fragment["status"], self._VALID_STATUSES,
+                      f"invalid status: {fragment['status']!r}")
+        self.assertIn("detail", fragment)
+        self.assertIn("findings", fragment)
+        self.assertIsInstance(fragment["findings"], list)
+
+    def test_in_sync_fragment_shape(self):
+        _, fragment, _ = _run_stage(_IN_SYNC)
+        self.assertIsNotNone(fragment)
+        self._assert_valid_fragment(fragment)
+
+    def test_stale_fragment_shape(self):
+        _, fragment, _ = _run_stage(_STALE)
+        self.assertIsNotNone(fragment)
+        self._assert_valid_fragment(fragment)
+
+    def test_hand_edited_fragment_shape(self):
+        _, fragment, _ = _run_stage(_HAND_EDITED)
+        self.assertIsNotNone(fragment)
+        self._assert_valid_fragment(fragment)
+
+
+class TestInSync(unittest.TestCase):
+    """All artifacts match baseline + all docs fresh → pass."""
+
+    def setUp(self):
+        self.rc, self.fragment, self.stderr = _run_stage(_IN_SYNC)
+
+    def test_fixture_exists(self):
+        self.assertTrue(os.path.isdir(_IN_SYNC))
+        self.assertTrue(os.path.exists(os.path.join(_IN_SYNC, "baseline.json")))
+
+    def test_exit_code_zero(self):
+        self.assertEqual(self.rc, 0, f"Expected exit 0; stderr={self.stderr}")
+
+    def test_status_pass(self):
+        self.assertEqual(self.fragment["status"], "pass",
+                         f"Expected pass; fragment={self.fragment}")
+
+    def test_no_findings(self):
+        self.assertEqual(self.fragment["findings"], [],
+                         f"Expected no findings; fragment={self.fragment}")
+
+
+class TestStaleManifest(unittest.TestCase):
+    """MANIFEST omits a current model → fail + docs_stale."""
+
+    def setUp(self):
+        self.rc, self.fragment, self.stderr = _run_stage(_STALE)
+
+    def test_exit_code_zero(self):
+        self.assertEqual(self.rc, 0, f"Expected exit 0; stderr={self.stderr}")
+
+    def test_status_fail(self):
+        self.assertEqual(self.fragment["status"], "fail",
+                         f"Expected fail; fragment={self.fragment}")
+
+    def test_finding_docs_stale(self):
+        codes = _finding_codes(self.fragment)
+        self.assertIn("docs_stale", codes,
+                      f"Expected docs_stale; findings={self.fragment['findings']}")
+
+    def test_not_hand_edited(self):
+        # Generated artifacts in this fixture still match baseline.
+        codes = _finding_codes(self.fragment)
+        self.assertNotIn("hand_edited_generated", codes)
+
+    def test_names_stale_doc_and_fact(self):
+        # The finding should name the stale doc + missing fact (MANIFEST/dust_deputy).
+        blob = json.dumps(self.fragment)
+        self.assertIn("MANIFEST", blob)
+        self.assertIn("dust_deputy", blob)
+
+
+class TestHandEdited(unittest.TestCase):
+    """A build/ artifact's bytes differ from baseline → fail + hand_edited_generated."""
+
+    def setUp(self):
+        self.rc, self.fragment, self.stderr = _run_stage(_HAND_EDITED)
+
+    def test_exit_code_zero(self):
+        self.assertEqual(self.rc, 0, f"Expected exit 0; stderr={self.stderr}")
+
+    def test_status_fail(self):
+        self.assertEqual(self.fragment["status"], "fail",
+                         f"Expected fail; fragment={self.fragment}")
+
+    def test_finding_hand_edited(self):
+        codes = _finding_codes(self.fragment)
+        self.assertIn("hand_edited_generated", codes,
+                      f"Expected hand_edited_generated; findings={self.fragment['findings']}")
+
+    def test_names_the_file(self):
+        # The guard must name the offending generated file.
+        blob = json.dumps(self.fragment)
+        self.assertIn("cyclone_inlet.stl", blob)
+
+
+class TestMissingInArg(unittest.TestCase):
+    """Omitting --in should exit non-zero (usage error)."""
+
+    def test_missing_in_exits_nonzero(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+            out_path = tf.name
+        try:
+            result = subprocess.run(
+                [sys.executable, _STAGE_SCRIPT, "--out", out_path],
+                capture_output=True, text=True,
+            )
+            self.assertNotEqual(result.returncode, 0,
+                                "Expected non-zero exit when --in is missing")
+        finally:
+            if os.path.exists(out_path):
+                os.unlink(out_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/autospec-fab/tests/test_stage_docs.py
+++ b/skills/autospec-fab/tests/test_stage_docs.py
@@ -17,6 +17,7 @@ committed fixtures under fixtures/docs/:
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -186,6 +187,34 @@ class TestMissingInArg(unittest.TestCase):
         finally:
             if os.path.exists(out_path):
                 os.unlink(out_path)
+
+
+class TestMissingGeneratedArtifact(unittest.TestCase):
+    """A baseline-listed generated artifact that is ABSENT on disk (e.g. a
+    deleted/never-regenerated file) must trip hand_edited_generated — proving
+    the guard fails closed on a missing file, not only on a content mismatch."""
+
+    def test_deleted_generated_artifact_fails(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            model_dir = os.path.join(tmp, "model")
+            shutil.copytree(_IN_SYNC, model_dir)
+            baseline_path = os.path.join(model_dir, "baseline.json")
+            with open(baseline_path) as f:
+                baseline = json.load(f)
+            # Pick a generated artifact the baseline tracks and delete it.
+            tracked = sorted(baseline.keys() if isinstance(baseline, dict)
+                             else [e["path"] for e in baseline])
+            victim = tracked[0]
+            os.unlink(os.path.join(model_dir, victim))
+
+            rc, fragment, _ = _run_stage(model_dir, baseline=baseline_path)
+            self.assertEqual(rc, 0, "verdict lives in status, not exit code")
+            self.assertEqual(fragment["status"], "fail")
+            self.assertIn("hand_edited_generated", _finding_codes(fragment),
+                          "a deleted baseline-tracked artifact must fail closed")
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1233

Adds `stage_docs.py`: **NO_HANDEDIT guard** — sha256 of every generated artifact (build/, BOM.md, *.pdf, renders/section/contact-sheets) vs a regen `baseline.json`; mismatch/missing → `code_health: hand_edited_generated`. **Doc freshness** — hand docs (MANIFEST/README/FITTINGS) must reference every current fact token from `facts.json`; stale → `docs_stale`. Real file diffs, no mocks.

## Verification
- `python3 -m unittest test_stage_docs.py` — 17/17; bats gates it. in-sync→pass, stale-manifest→`docs_stale`, hand-edited build artifact→`hand_edited_generated`.
- <400 LOC, funcs <50; `bash scripts/validate.sh` — exit 0.

Note: COMPLEXITY nesting/cyclomatic-proxy flags (if any) = the benign artifact class tracked in #1245.