### PR TITLE
fix(autospec-fab): docs test fails on clean checkout (gitignored build/ fixtures)

### DIFF
--- a/skills/autospec-fab/tests/fixtures/docs/hand-edited/FITTINGS_AND_SCREWS.md
+++ b/skills/autospec-fab/tests/fixtures/docs/hand-edited/FITTINGS_AND_SCREWS.md
@@ -1,7 +1,0 @@
-# Fittings and Screws
-
-Per the current models cyclone_inlet and dust_deputy:
-
-- 3x 1/4 NPT plug
-- 2x hose barb
-- 8x M4 screw

--- a/skills/autospec-fab/tests/fixtures/docs/hand-edited/MANIFEST.md
+++ b/skills/autospec-fab/tests/fixtures/docs/hand-edited/MANIFEST.md
@@ -1,8 +1,0 @@
-# Manifest
-
-Models in this catalog:
-
-- cyclone_inlet — primary vacuum manifold
-- dust_deputy — secondary separator
-
-Fittings: 3 NPT, 2 hose.

--- a/skills/autospec-fab/tests/fixtures/docs/hand-edited/README.md
+++ b/skills/autospec-fab/tests/fixtures/docs/hand-edited/README.md
@@ -1,5 +1,0 @@
-# Vacuum Manifold Catalog
-
-This repo generates printable manifolds: cyclone_inlet and dust_deputy.
-
-Run the generator to produce build/ artifacts.

--- a/skills/autospec-fab/tests/fixtures/docs/hand-edited/baseline.json
+++ b/skills/autospec-fab/tests/fixtures/docs/hand-edited/baseline.json
@@ -1,7 +1,0 @@
-{
-  "build/BOM.md": "566f8cacc7076f32a81df7e0b1207bd45bf291b823dcbc037d03a588f940dc61",
-  "build/datasheet.pdf": "2cc762e4cb855e1b91621751ce7a28be169af90f244a72570e9ba8487acae578",
-  "build/renders/contact_sheet.txt": "eda4e8b1aa48bf20f15edc9cfcd8bc6fa1e22368817dc99b644843d0cc0a8057",
-  "build/stls/manifolds/cyclone_inlet.stl": "b5845b491d4cf34d5718ca8c1734327ba38f6f33a256146ecefe798a93c61f00",
-  "build/stls/manifolds/dust_deputy.stl": "a6d9443c95f83b869382b1db0cb065caf41842fd3d4a1881f3ea0a49c854c4f3"
-}

--- a/skills/autospec-fab/tests/fixtures/docs/hand-edited/facts.json
+++ b/skills/autospec-fab/tests/fixtures/docs/hand-edited/facts.json
@@ -1,7 +1,0 @@
-{
-  "models": ["cyclone_inlet", "dust_deputy"],
-  "fitting_counts": {
-    "npt": 3,
-    "hose": 2
-  }
-}

--- a/skills/autospec-fab/tests/fixtures/docs/in-sync/FITTINGS_AND_SCREWS.md
+++ b/skills/autospec-fab/tests/fixtures/docs/in-sync/FITTINGS_AND_SCREWS.md
@@ -1,7 +1,0 @@
-# Fittings and Screws
-
-Per the current models cyclone_inlet and dust_deputy:
-
-- 3x 1/4 NPT plug
-- 2x hose barb
-- 8x M4 screw

--- a/skills/autospec-fab/tests/fixtures/docs/in-sync/MANIFEST.md
+++ b/skills/autospec-fab/tests/fixtures/docs/in-sync/MANIFEST.md
@@ -1,8 +1,0 @@
-# Manifest
-
-Models in this catalog:
-
-- cyclone_inlet — primary vacuum manifold
-- dust_deputy — secondary separator
-
-Fittings: 3 NPT, 2 hose.

--- a/skills/autospec-fab/tests/fixtures/docs/in-sync/README.md
+++ b/skills/autospec-fab/tests/fixtures/docs/in-sync/README.md
@@ -1,5 +1,0 @@
-# Vacuum Manifold Catalog
-
-This repo generates printable manifolds: cyclone_inlet and dust_deputy.
-
-Run the generator to produce build/ artifacts.

--- a/skills/autospec-fab/tests/fixtures/docs/in-sync/baseline.json
+++ b/skills/autospec-fab/tests/fixtures/docs/in-sync/baseline.json
@@ -1,7 +1,0 @@
-{
-  "build/BOM.md": "566f8cacc7076f32a81df7e0b1207bd45bf291b823dcbc037d03a588f940dc61",
-  "build/datasheet.pdf": "2cc762e4cb855e1b91621751ce7a28be169af90f244a72570e9ba8487acae578",
-  "build/renders/contact_sheet.txt": "eda4e8b1aa48bf20f15edc9cfcd8bc6fa1e22368817dc99b644843d0cc0a8057",
-  "build/stls/manifolds/cyclone_inlet.stl": "b5845b491d4cf34d5718ca8c1734327ba38f6f33a256146ecefe798a93c61f00",
-  "build/stls/manifolds/dust_deputy.stl": "a6d9443c95f83b869382b1db0cb065caf41842fd3d4a1881f3ea0a49c854c4f3"
-}

--- a/skills/autospec-fab/tests/fixtures/docs/in-sync/facts.json
+++ b/skills/autospec-fab/tests/fixtures/docs/in-sync/facts.json
@@ -1,7 +1,0 @@
-{
-  "models": ["cyclone_inlet", "dust_deputy"],
-  "fitting_counts": {
-    "npt": 3,
-    "hose": 2
-  }
-}

--- a/skills/autospec-fab/tests/fixtures/docs/stale-manifest/FITTINGS_AND_SCREWS.md
+++ b/skills/autospec-fab/tests/fixtures/docs/stale-manifest/FITTINGS_AND_SCREWS.md
@@ -1,7 +1,0 @@
-# Fittings and Screws
-
-Per the current models cyclone_inlet and dust_deputy:
-
-- 3x 1/4 NPT plug
-- 2x hose barb
-- 8x M4 screw

--- a/skills/autospec-fab/tests/fixtures/docs/stale-manifest/MANIFEST.md
+++ b/skills/autospec-fab/tests/fixtures/docs/stale-manifest/MANIFEST.md
@@ -1,7 +1,0 @@
-# Manifest
-
-Models in this catalog:
-
-- cyclone_inlet — primary vacuum manifold
-
-Fittings: 3 NPT, 2 hose.

--- a/skills/autospec-fab/tests/fixtures/docs/stale-manifest/README.md
+++ b/skills/autospec-fab/tests/fixtures/docs/stale-manifest/README.md
@@ -1,5 +1,0 @@
-# Vacuum Manifold Catalog
-
-This repo generates printable manifolds: cyclone_inlet and dust_deputy.
-
-Run the generator to produce build/ artifacts.

--- a/skills/autospec-fab/tests/fixtures/docs/stale-manifest/baseline.json
+++ b/skills/autospec-fab/tests/fixtures/docs/stale-manifest/baseline.json
@@ -1,7 +1,0 @@
-{
-  "build/BOM.md": "566f8cacc7076f32a81df7e0b1207bd45bf291b823dcbc037d03a588f940dc61",
-  "build/datasheet.pdf": "2cc762e4cb855e1b91621751ce7a28be169af90f244a72570e9ba8487acae578",
-  "build/renders/contact_sheet.txt": "eda4e8b1aa48bf20f15edc9cfcd8bc6fa1e22368817dc99b644843d0cc0a8057",
-  "build/stls/manifolds/cyclone_inlet.stl": "b5845b491d4cf34d5718ca8c1734327ba38f6f33a256146ecefe798a93c61f00",
-  "build/stls/manifolds/dust_deputy.stl": "a6d9443c95f83b869382b1db0cb065caf41842fd3d4a1881f3ea0a49c854c4f3"
-}

--- a/skills/autospec-fab/tests/fixtures/docs/stale-manifest/facts.json
+++ b/skills/autospec-fab/tests/fixtures/docs/stale-manifest/facts.json
@@ -1,7 +1,0 @@
-{
-  "models": ["cyclone_inlet", "dust_deputy"],
-  "fitting_counts": {
-    "npt": 3,
-    "hose": 2
-  }
-}

--- a/skills/autospec-fab/tests/test_stage_docs.py
+++ b/skills/autospec-fab/tests/test_stage_docs.py
@@ -1,20 +1,31 @@
 """
 test_stage_docs.py — unittest for stage_docs.py.
 
-Real file diffs, no mocks. Drives the stage via its uniform CLI against three
-committed fixtures under fixtures/docs/:
+Real file diffs, no mocks. Drives the stage via its uniform CLI against model
+dirs that each test MATERIALIZES AT RUNTIME under a tempfile.mkdtemp(). Nothing
+here reads any committed fixture or any committed build/ artifact, so the suite
+passes on a clean checkout (where build/ is gitignored and absent).
 
-  1. in-sync/        → status pass  (all generated artifacts match baseline.json;
-                       all hand docs reference every current fact).
-  2. stale-manifest/ → status fail + finding docs_stale
-                       (MANIFEST.md omits the current model 'dust_deputy';
-                        generated artifacts still match baseline).
-  3. hand-edited/    → status fail + finding hand_edited_generated
-                       (a build/ STL was hand-edited so its sha256 no longer
-                        matches baseline.json; hand docs are still in sync).
-  4. fragment shape  → required stage-record keys + valid status enum.
+Each scenario builds a fresh model dir containing:
+  - hand docs MANIFEST.md / README.md / FITTINGS_AND_SCREWS.md (inline content)
+  - facts.json with two models (cyclone_inlet, dust_deputy)
+  - build/ artifacts with deterministic bytes
+  - baseline.json = {relpath: sha256(materialized file)} computed in-code, so
+    the regen baseline is correct by construction.
+
+Scenarios:
+  1. in-sync        → status pass  (artifacts match baseline; docs reference both models).
+  2. stale-manifest → status fail + docs_stale (MANIFEST omits dust_deputy);
+                      NO hand_edited_generated (artifacts still match baseline).
+  3. hand-edited    → status fail + hand_edited_generated (one build artifact
+                      mutated after baseline so its sha256 no longer matches).
+  4. missing artifact → status fail + hand_edited_generated (a baseline-tracked
+                      build artifact deleted → guard fails closed on absence).
+  5. fragment shape → required stage-record keys + valid status enum.
+  6. exit codes     → verdict in status (exit 0); missing --in is usage error.
 """
 
+import hashlib
 import json
 import os
 import shutil
@@ -25,17 +36,78 @@ import unittest
 
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 _SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
-_FIXTURES_DIR = os.path.normpath(os.path.join(_THIS_DIR, "fixtures", "docs"))
-
 _STAGE_SCRIPT = os.path.join(_SCRIPTS_DIR, "stage_docs.py")
 
-_IN_SYNC = os.path.join(_FIXTURES_DIR, "in-sync")
-_STALE = os.path.join(_FIXTURES_DIR, "stale-manifest")
-_HAND_EDITED = os.path.join(_FIXTURES_DIR, "hand-edited")
+_MODELS = ("cyclone_inlet", "dust_deputy")
+
+# Deterministic build/ artifacts (relpath -> bytes). Parent dirs created on write.
+_BUILD_ARTIFACTS = {
+    "build/BOM.md": b"# Bill of Materials\ncyclone_inlet x1\ndust_deputy x1\n",
+    "build/datasheet.pdf": b"%PDF-1.4\n%fake-deterministic-pdf-bytes\n%%EOF\n",
+    "build/renders/contact_sheet.txt": b"contact sheet: cyclone_inlet, dust_deputy\n",
+    "build/stls/manifolds/cyclone_inlet.stl": b"solid cyclone_inlet\nendsolid\n",
+    "build/stls/manifolds/dust_deputy.stl": b"solid dust_deputy\nendsolid\n",
+}
+
+
+def _sha256_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def _write_file(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as fh:
+        fh.write(data)
+
+
+def _hand_docs(include_models):
+    """Return {filename: text} for the three hand docs.
+
+    Each doc references every model name in `include_models`. Omitting a model
+    from MANIFEST (via a smaller include list) makes that doc stale.
+    """
+    refs = ", ".join(include_models)
+    all_refs = ", ".join(_MODELS)
+    return {
+        "MANIFEST.md": f"# Manifest\nModels: {refs}\n",
+        "README.md": f"# Cyclone Kit\nIncludes models: {all_refs}\n",
+        "FITTINGS_AND_SCREWS.md": f"# Fittings\nFor models: {all_refs}\n",
+    }
+
+
+def _materialize_model_dir(manifest_models=_MODELS):
+    """Build a fresh tmp model dir with hand docs, facts.json, build/ artifacts,
+    and a baseline.json correct by construction. Returns the model dir path.
+
+    Caller is responsible for cleanup (shutil.rmtree of the parent tmp).
+    """
+    model_dir = tempfile.mkdtemp(prefix="stage_docs_")
+
+    # Hand docs (MANIFEST may omit models when manifest_models is shorter).
+    docs = _hand_docs(manifest_models)
+    for name, text in docs.items():
+        _write_file(os.path.join(model_dir, name), text.encode("utf-8"))
+
+    # facts.json — current model list.
+    _write_file(
+        os.path.join(model_dir, "facts.json"),
+        json.dumps({"models": list(_MODELS)}).encode("utf-8"),
+    )
+
+    # build/ artifacts + baseline (sha256 by construction).
+    baseline = {}
+    for rel, data in _BUILD_ARTIFACTS.items():
+        _write_file(os.path.join(model_dir, rel), data)
+        baseline[rel] = _sha256_bytes(data)
+    _write_file(
+        os.path.join(model_dir, "baseline.json"),
+        json.dumps(baseline).encode("utf-8"),
+    )
+    return model_dir
 
 
 def _run_stage(model_dir, baseline=None):
-    """Run stage_docs.py --in <dir> --out <tmp> [--baseline <dir>].
+    """Run stage_docs.py --in <dir> --out <tmp> --baseline <baseline>.
 
     Returns (returncode, fragment_dict_or_None, stderr).
     """
@@ -65,7 +137,17 @@ def _finding_codes(fragment):
     return {f.get("code") for f in fragment.get("findings", [])}
 
 
-class TestFragmentShape(unittest.TestCase):
+class _MaterializedModelMixin:
+    """Provides a self.model_dir materialized in setUp and cleaned up after."""
+
+    manifest_models = _MODELS
+
+    def setUp(self):
+        self.model_dir = _materialize_model_dir(self.manifest_models)
+        self.addCleanup(shutil.rmtree, self.model_dir, ignore_errors=True)
+
+
+class TestFragmentShape(_MaterializedModelMixin, unittest.TestCase):
     _VALID_STATUSES = {"pass", "fail", "warn", "skip"}
 
     def _assert_valid_fragment(self, fragment, expected_stage="docs"):
@@ -80,30 +162,44 @@ class TestFragmentShape(unittest.TestCase):
         self.assertIsInstance(fragment["findings"], list)
 
     def test_in_sync_fragment_shape(self):
-        _, fragment, _ = _run_stage(_IN_SYNC)
+        _, fragment, _ = _run_stage(self.model_dir)
         self.assertIsNotNone(fragment)
         self._assert_valid_fragment(fragment)
 
     def test_stale_fragment_shape(self):
-        _, fragment, _ = _run_stage(_STALE)
+        # Mutate MANIFEST to omit a model, then run.
+        _write_file(
+            os.path.join(self.model_dir, "MANIFEST.md"),
+            b"# Manifest\nModels: cyclone_inlet\n",
+        )
+        _, fragment, _ = _run_stage(self.model_dir)
         self.assertIsNotNone(fragment)
         self._assert_valid_fragment(fragment)
 
     def test_hand_edited_fragment_shape(self):
-        _, fragment, _ = _run_stage(_HAND_EDITED)
+        # Mutate a build artifact so it diverges from baseline, then run.
+        victim = os.path.join(self.model_dir,
+                              "build/stls/manifolds/cyclone_inlet.stl")
+        with open(victim, "ab") as fh:
+            fh.write(b"hand edit\n")
+        _, fragment, _ = _run_stage(self.model_dir)
         self.assertIsNotNone(fragment)
         self._assert_valid_fragment(fragment)
 
 
-class TestInSync(unittest.TestCase):
+class TestInSync(_MaterializedModelMixin, unittest.TestCase):
     """All artifacts match baseline + all docs fresh → pass."""
 
     def setUp(self):
-        self.rc, self.fragment, self.stderr = _run_stage(_IN_SYNC)
+        super().setUp()
+        self.rc, self.fragment, self.stderr = _run_stage(self.model_dir)
 
-    def test_fixture_exists(self):
-        self.assertTrue(os.path.isdir(_IN_SYNC))
-        self.assertTrue(os.path.exists(os.path.join(_IN_SYNC, "baseline.json")))
+    def test_baseline_materialized(self):
+        self.assertTrue(os.path.exists(
+            os.path.join(self.model_dir, "baseline.json")))
+        # build/ artifacts exist on disk (materialized, not committed).
+        for rel in _BUILD_ARTIFACTS:
+            self.assertTrue(os.path.exists(os.path.join(self.model_dir, rel)))
 
     def test_exit_code_zero(self):
         self.assertEqual(self.rc, 0, f"Expected exit 0; stderr={self.stderr}")
@@ -117,11 +213,15 @@ class TestInSync(unittest.TestCase):
                          f"Expected no findings; fragment={self.fragment}")
 
 
-class TestStaleManifest(unittest.TestCase):
-    """MANIFEST omits a current model → fail + docs_stale."""
+class TestStaleManifest(_MaterializedModelMixin, unittest.TestCase):
+    """MANIFEST omits a current model → fail + docs_stale (artifacts still match)."""
+
+    # MANIFEST references only cyclone_inlet → omits dust_deputy.
+    manifest_models = ("cyclone_inlet",)
 
     def setUp(self):
-        self.rc, self.fragment, self.stderr = _run_stage(_STALE)
+        super().setUp()
+        self.rc, self.fragment, self.stderr = _run_stage(self.model_dir)
 
     def test_exit_code_zero(self):
         self.assertEqual(self.rc, 0, f"Expected exit 0; stderr={self.stderr}")
@@ -136,22 +236,28 @@ class TestStaleManifest(unittest.TestCase):
                       f"Expected docs_stale; findings={self.fragment['findings']}")
 
     def test_not_hand_edited(self):
-        # Generated artifacts in this fixture still match baseline.
+        # Generated artifacts match the runtime baseline by construction.
         codes = _finding_codes(self.fragment)
         self.assertNotIn("hand_edited_generated", codes)
 
     def test_names_stale_doc_and_fact(self):
-        # The finding should name the stale doc + missing fact (MANIFEST/dust_deputy).
+        # The finding should name the stale doc + missing fact.
         blob = json.dumps(self.fragment)
         self.assertIn("MANIFEST", blob)
         self.assertIn("dust_deputy", blob)
 
 
-class TestHandEdited(unittest.TestCase):
+class TestHandEdited(_MaterializedModelMixin, unittest.TestCase):
     """A build/ artifact's bytes differ from baseline → fail + hand_edited_generated."""
 
     def setUp(self):
-        self.rc, self.fragment, self.stderr = _run_stage(_HAND_EDITED)
+        super().setUp()
+        # After baseline is written, mutate one build artifact's bytes.
+        victim = os.path.join(self.model_dir,
+                              "build/stls/manifolds/cyclone_inlet.stl")
+        with open(victim, "ab") as fh:
+            fh.write(b"hand edit\n")
+        self.rc, self.fragment, self.stderr = _run_stage(self.model_dir)
 
     def test_exit_code_zero(self):
         self.assertEqual(self.rc, 0, f"Expected exit 0; stderr={self.stderr}")
@@ -171,6 +277,25 @@ class TestHandEdited(unittest.TestCase):
         self.assertIn("cyclone_inlet.stl", blob)
 
 
+class TestMissingGeneratedArtifact(_MaterializedModelMixin, unittest.TestCase):
+    """A baseline-listed generated artifact that is ABSENT on disk must trip
+    hand_edited_generated — proving the guard fails closed on a missing file,
+    not only on a content mismatch."""
+
+    def test_deleted_generated_artifact_fails(self):
+        baseline_path = os.path.join(self.model_dir, "baseline.json")
+        with open(baseline_path) as f:
+            baseline = json.load(f)
+        victim = sorted(baseline.keys())[0]
+        os.unlink(os.path.join(self.model_dir, victim))
+
+        rc, fragment, _ = _run_stage(self.model_dir, baseline=baseline_path)
+        self.assertEqual(rc, 0, "verdict lives in status, not exit code")
+        self.assertEqual(fragment["status"], "fail")
+        self.assertIn("hand_edited_generated", _finding_codes(fragment),
+                      "a deleted baseline-tracked artifact must fail closed")
+
+
 class TestMissingInArg(unittest.TestCase):
     """Omitting --in should exit non-zero (usage error)."""
 
@@ -187,34 +312,6 @@ class TestMissingInArg(unittest.TestCase):
         finally:
             if os.path.exists(out_path):
                 os.unlink(out_path)
-
-
-class TestMissingGeneratedArtifact(unittest.TestCase):
-    """A baseline-listed generated artifact that is ABSENT on disk (e.g. a
-    deleted/never-regenerated file) must trip hand_edited_generated — proving
-    the guard fails closed on a missing file, not only on a content mismatch."""
-
-    def test_deleted_generated_artifact_fails(self):
-        tmp = tempfile.mkdtemp()
-        try:
-            model_dir = os.path.join(tmp, "model")
-            shutil.copytree(_IN_SYNC, model_dir)
-            baseline_path = os.path.join(model_dir, "baseline.json")
-            with open(baseline_path) as f:
-                baseline = json.load(f)
-            # Pick a generated artifact the baseline tracks and delete it.
-            tracked = sorted(baseline.keys() if isinstance(baseline, dict)
-                             else [e["path"] for e in baseline])
-            victim = tracked[0]
-            os.unlink(os.path.join(model_dir, victim))
-
-            rc, fragment, _ = _run_stage(model_dir, baseline=baseline_path)
-            self.assertEqual(rc, 0, "verdict lives in status, not exit code")
-            self.assertEqual(fragment["status"], "fail")
-            self.assertIn("hand_edited_generated", _finding_codes(fragment),
-                          "a deleted baseline-tracked artifact must fail closed")
-        finally:
-            shutil.rmtree(tmp, ignore_errors=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Bug:** #1233 (PR #1255) merged with a docs-stage test that depends on fixture artifacts under `build/`, which is gitignored (`.gitignore:16`). `git add` silently skipped them, so **zero** build/ fixtures were committed. The test passed in #1255's validate only because the untracked files were still on disk in that worktree — on any clean checkout they're absent, the NO_HANDEDIT guard reports the generated artifacts 'missing', and **main's validate gate is RED**.

**Fix:** make `test_stage_docs.py` self-contained / gitignore-proof — `_materialize_model_dir()` builds a fresh tmp model dir at runtime (inline hand docs + facts.json + deterministic build/ artifacts + a baseline.json computed by sha256 to match by construction). No committed file under `build/` is read. Removes the now-unreferenced committed fixture dirs.

## Verification (on a clean checkout)
- `python3 -m unittest test_stage_docs.py` — 18/18 (in-sync pass, stale→docs_stale + asserts no hand_edited_generated, hand-edited→hand_edited_generated, missing-artifact→hand_edited_generated, fragment shape).
- `bash scripts/validate.sh` — **exit 0** (gate green again).

Caught while building #1234 (the engine), whose validate was blocked by this. Class of bug worth a lint: a test that reads committed files under a gitignored path.