### PR TITLE
feat(autospec-fab): stl-release-gate.py engine (orchestrates all 12 stages)

### DIFF
--- a/skills/autospec-fab/scripts/release_gate_stages.py
+++ b/skills/autospec-fab/scripts/release_gate_stages.py
@@ -1,0 +1,68 @@
+"""release_gate_stages.py — STAGE_ORDER table + script resolver for the engine.
+
+Extracted from stl-release-gate.py to keep each module small (repo lints file
+size + function length hard). Single source of truth for the 12-stage fab
+composition order and how the engine locates each stage script.
+
+Stage order matches skills/autospec-fab/SKILL.md (§Release-gate / phase
+contract). Every stage is BLOCKING except `vision`, which is ADVISORY: its
+status never blocks the gate; its observations flow to release-gate.json
+["vision_findings"].
+
+The real geometry stage lives at `stage-geometry.py` (hyphenated); the rest are
+`stage_<name>.py`. Resolution tries the listed filename first, then the
+alternate naming convention, so the engine works whether stage authors used a
+hyphen or an underscore.
+"""
+
+import os
+
+# Ordered list of {name, script, blocking}. `name` is the schema stage name;
+# `script` is the canonical filename; `blocking=False` only for vision.
+STAGE_ORDER = [
+    {"name": "geometry", "script": "stage-geometry.py", "blocking": True},
+    {"name": "metadata", "script": "stage_metadata.py", "blocking": True},
+    {"name": "vacuum-fitting", "script": "stage_fitting.py", "blocking": True},
+    {"name": "vacuum-circuit", "script": "stage_circuit.py", "blocking": True},
+    {"name": "gasket", "script": "stage_gasket.py", "blocking": True},
+    {"name": "dust-airflow", "script": "stage_dust.py", "blocking": True},
+    {"name": "slicer", "script": "stage_slicer.py", "blocking": True},
+    {"name": "fea", "script": "stage_fea.py", "blocking": True},
+    {"name": "cfd", "script": "stage_cfd.py", "blocking": True},
+    {"name": "render", "script": "stage_render.py", "blocking": True},
+    {"name": "vision", "script": "stage_vision.py", "blocking": False},
+    {"name": "docs", "script": "stage_docs.py", "blocking": True},
+]
+
+
+def _candidate_dirs(stages_dir):
+    """Resolution order: --stages-dir, $AUTOSPEC_FAB_STAGES_DIR, engine dir."""
+    dirs = []
+    if stages_dir:
+        dirs.append(stages_dir)
+    env_dir = os.environ.get("AUTOSPEC_FAB_STAGES_DIR")
+    if env_dir:
+        dirs.append(env_dir)
+    dirs.append(os.path.dirname(os.path.abspath(__file__)))
+    return dirs
+
+
+def _filename_variants(script):
+    """Yield the canonical name plus the alternate hyphen/underscore form."""
+    variants = [script]
+    if script.startswith("stage-"):
+        variants.append("stage_" + script[len("stage-"):].replace("-", "_"))
+    elif script.startswith("stage_"):
+        alt = "stage-" + script[len("stage_"):].replace("_", "-")
+        variants.append(alt)
+    return variants
+
+
+def resolve_stage_script(script, stages_dir):
+    """Return an absolute path to the stage script, or None if not found."""
+    for directory in _candidate_dirs(stages_dir):
+        for name in _filename_variants(script):
+            path = os.path.join(directory, name)
+            if os.path.isfile(path):
+                return path
+    return None

--- a/skills/autospec-fab/scripts/stl-release-gate.py
+++ b/skills/autospec-fab/scripts/stl-release-gate.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""stl-release-gate.py — the autospec-fab RELEASE-GATE ENGINE.
+
+Sequences the 12 fab stages in composition order, runs each with the uniform
+stage CLI (`--in <stl> --model <metadata> --out <fragment>`), aggregates their
+per-stage fragments into a schema-valid `.autospec/fab/release-gate.json`, and
+decides the overall verdict.
+
+Verdict / exit code:
+  - The gate FAILS (exit non-zero) if ANY blocking stage fragment has
+    status "fail".
+  - The vision stage is ADVISORY (blocking=False): its warn/fail never blocks;
+    its observations are surfaced in release-gate.json["vision_findings"].
+  - "skip" never fails. A green gate (all blocking stages pass/skip) exits 0.
+
+Each stage script exits non-zero only on a HARNESS error (the gate verdict is
+expressed in the fragment "status", not the stage exit code). A harness error
+in a blocking stage is treated as a blocking failure.
+
+The written gate is schema-validated with the `ajv` CLI when present; if ajv is
+absent, validation is skipped with a warning (the engine never crashes on a
+missing validator).
+
+CLI:
+    stl-release-gate.py --in <stl> --model <metadata.json>
+                        --out <release-gate.json> [--stages-dir <dir>]
+
+Stage scripts resolve from (in priority order): --stages-dir,
+$AUTOSPEC_FAB_STAGES_DIR, then the engine's own scripts directory.
+
+Stdlib only; runs on bare python3 in the fab gate.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from release_gate_stages import STAGE_ORDER, resolve_stage_script
+
+# Keys the schema permits on a stage record; the engine strips everything else
+# off each fragment before aggregating (fragments may carry extras like
+# vision_findings or harness-internal keys).
+_STAGE_KEYS = ("stage", "status", "detail", "findings")
+
+
+def _geometry_hash(stl_path):
+    """Return the sha256 hex digest of the STL file (or "" if unreadable)."""
+    try:
+        h = hashlib.sha256()
+        with open(stl_path, "rb") as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return ""
+
+
+def _model_name(model_path):
+    """Best-effort model name from the metadata sidecar (or "")."""
+    try:
+        with open(model_path, encoding="utf-8") as f:
+            data = json.load(f)
+        name = data.get("name")
+        return name if isinstance(name, str) else ""
+    except (OSError, ValueError):
+        return ""
+
+
+def _run_stage(stage, stl_path, model_path, stages_dir):
+    """Run one stage; return (fragment_dict, harness_ok).
+
+    fragment_dict is the raw JSON the stage wrote (or a synthetic error
+    fragment if the stage produced none). harness_ok is False when the stage
+    crashed or emitted no usable fragment.
+    """
+    script = resolve_stage_script(stage["script"], stages_dir)
+    if script is None:
+        return ({"stage": stage["name"], "status": "fail",
+                 "detail": "stage script not found: %s" % stage["script"],
+                 "findings": []}, False)
+
+    tmp_out = tempfile.NamedTemporaryFile(
+        prefix="fab-frag-", suffix=".json", delete=False)
+    tmp_out.close()
+    try:
+        argv = [sys.executable, script,
+                "--in", stl_path, "--model", model_path, "--out", tmp_out.name]
+        proc = subprocess.run(argv, capture_output=True, text=True)
+        fragment = _load_fragment(tmp_out.name, stage["name"])
+        harness_ok = proc.returncode == 0 and fragment is not None
+        if fragment is None:
+            detail = "no fragment emitted (rc=%d): %s" % (
+                proc.returncode, (proc.stderr or "").strip()[:200])
+            fragment = {"stage": stage["name"], "status": "fail",
+                        "detail": detail, "findings": []}
+        return (fragment, harness_ok)
+    finally:
+        try:
+            os.unlink(tmp_out.name)
+        except OSError:
+            pass
+
+
+def _load_fragment(path, stage_name):
+    """Load a stage fragment JSON; return None if missing/invalid."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    data.setdefault("stage", stage_name)
+    return data
+
+
+def _clean_stage_record(fragment, stage_name):
+    """Project a fragment down to the schema-permitted stage-record keys."""
+    record = {"stage": fragment.get("stage", stage_name),
+              "status": fragment.get("status", "fail")}
+    if "detail" in fragment:
+        record["detail"] = fragment["detail"]
+    findings = fragment.get("findings")
+    if isinstance(findings, list):
+        record["findings"] = findings
+    else:
+        record["findings"] = []
+    return record
+
+
+def run_gate(stl_path, model_path, stages_dir):
+    """Run every stage in order; return (gate_dict, blocking_failed: bool)."""
+    stages = []
+    vision_findings = []
+    blocking_failed = False
+
+    for stage in STAGE_ORDER:
+        fragment, harness_ok = _run_stage(stage, stl_path, model_path, stages_dir)
+        record = _clean_stage_record(fragment, stage["name"])
+        stages.append(record)
+
+        if stage["name"] == "vision":
+            vf = fragment.get("vision_findings")
+            if isinstance(vf, list):
+                vision_findings.extend(vf)
+
+        if stage["blocking"]:
+            if record["status"] == "fail" or not harness_ok:
+                blocking_failed = True
+
+    gate = {
+        "schema_version": 1,
+        "name": _model_name(model_path),
+        "geometry_hash": _geometry_hash(stl_path),
+        "stages": stages,
+        "vision_findings": vision_findings,
+    }
+    return gate, blocking_failed
+
+
+def _ajv_validate(schema_path, out_path):
+    """Validate the written gate with ajv; return True on valid/skip."""
+    if shutil.which("ajv") is None:
+        print("WARN: ajv not on PATH; skipping schema validation",
+              file=sys.stderr)
+        return True
+    proc = subprocess.run(
+        ["ajv", "validate", "-s", schema_path, "--spec=draft2020",
+         "-d", out_path],
+        capture_output=True, text=True)
+    if proc.returncode != 0:
+        print("ERROR: release-gate.json failed schema validation:",
+              file=sys.stderr)
+        print((proc.stdout or "") + (proc.stderr or ""), file=sys.stderr)
+        return False
+    return True
+
+
+def _schema_path():
+    """Locate the release-gate schema relative to the engine's repo root."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.abspath(os.path.join(here, "..", "..", ".."))
+    return os.path.join(
+        repo_root, "schemas", "autospec-fab-release-gate.schema.json")
+
+
+def _summary(gate, blocking_failed):
+    """One-line-per-stage human summary for stderr."""
+    lines = ["release-gate: %s" % (gate.get("name") or "<unnamed>")]
+    for s in gate["stages"]:
+        lines.append("  %-14s %s" % (s["stage"], s["status"]))
+    if gate["vision_findings"]:
+        lines.append("  vision advisory findings: %d"
+                     % len(gate["vision_findings"]))
+    lines.append("verdict: %s"
+                 % ("FAIL (blocking stage failed)" if blocking_failed
+                    else "PASS (green gate)"))
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="autospec-fab release-gate engine: sequence stages and "
+                    "emit a schema-valid release-gate.json")
+    parser.add_argument("--in", dest="in_path", required=True,
+                        help="STL file (or model dir) to gate")
+    parser.add_argument("--model", dest="model_path", required=True,
+                        help="per-model metadata sidecar JSON")
+    parser.add_argument("--out", required=True,
+                        help="output release-gate.json path")
+    parser.add_argument("--stages-dir", dest="stages_dir", default=None,
+                        help="override directory holding stage scripts")
+    args = parser.parse_args(argv)
+
+    gate, blocking_failed = run_gate(
+        args.in_path, args.model_path, args.stages_dir)
+
+    out_dir = os.path.dirname(os.path.abspath(args.out))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(gate, f, indent=2)
+        f.write("\n")
+
+    schema_valid = _ajv_validate(_schema_path(), args.out)
+    print(_summary(gate, blocking_failed), file=sys.stderr)
+
+    if not schema_valid:
+        # A gate that fails its own schema is an engine bug; fail loudly.
+        return 2
+    return 1 if blocking_failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/autospec-fab/tests/test_release_gate.bats
+++ b/skills/autospec-fab/tests/test_release_gate.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# test_release_gate.bats — thin bats wrapper around the Python unittest suite.
+# Invoked by the validate.sh fab gate (check_autospec_fab_contract) which runs
+# every skills/autospec-fab/tests/*.bats file.
+
+# Resolve the repo root from this file's location (tests/ → skill/ → repo root)
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+
+@test "release_gate engine python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_release_gate.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_release_gate.py
+++ b/skills/autospec-fab/tests/test_release_gate.py
@@ -1,0 +1,244 @@
+"""test_release_gate.py — unittest suite for the stl-release-gate.py ENGINE.
+
+The engine (skills/autospec-fab/scripts/stl-release-gate.py) sequences the 12
+fab stages, aggregates their per-stage fragments into a schema-valid
+.autospec/fab/release-gate.json, and decides the verdict:
+  - any BLOCKING stage fragment with status "fail" -> non-zero exit;
+  - the vision stage is ADVISORY: its warn/fail never blocks, its observations
+    go to release-gate.json["vision_findings"].
+
+Stages are stubbed via a --stages-dir of tiny python stub scripts whose
+emitted status / detail / findings / vision_findings are driven by environment
+variables, so each test can shape the per-stage verdict deterministically.
+
+Runs on bare python3 (stdlib only). Schema validation uses the real `ajv` CLI
+when present (assertions guarded by command -v ajv / shutil.which).
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS_DIR = os.path.abspath(os.path.join(HERE, "..", "scripts"))
+sys.path.insert(0, SCRIPTS_DIR)
+from release_gate_stages import STAGE_ORDER  # noqa: E402  (engine's own table)
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", "..", ".."))
+ENGINE = os.path.join(SCRIPTS_DIR, "stl-release-gate.py")
+SCHEMA = os.path.join(REPO_ROOT, "schemas", "autospec-fab-release-gate.schema.json")
+
+# The 12 stage names in composition order; must match the engine's STAGE_ORDER.
+STAGE_NAMES = [
+    "geometry", "metadata", "vacuum-fitting", "vacuum-circuit", "gasket",
+    "dust-airflow", "slicer", "fea", "cfd", "render", "vision", "docs",
+]
+
+# A stub stage script. It writes a release-gate fragment to --out. Its status,
+# detail, findings, and vision_findings are read from per-stage env vars so the
+# test harness can shape each stage's verdict:
+#   AUTOSPEC_STUB_STATUS_<stage>          -> status (default "pass")
+#   AUTOSPEC_STUB_FINDINGS_<stage>        -> JSON array for findings (default [])
+#   AUTOSPEC_STUB_VISION_<stage>          -> JSON array for vision_findings
+# stage names are uppercased and non-alnum -> "_" for the env var suffix.
+STUB_SOURCE = r'''#!/usr/bin/env python3
+import argparse, json, os, sys
+
+# This stub derives WHICH stage it is from its own filename (argv[0]) using the
+# engine's own script->stage-name map, injected as SCRIPT_TO_STAGE below. That
+# lets one stub body serve all 12 stages; the engine picks which file to run.
+SCRIPT_TO_STAGE = __SCRIPT_TO_STAGE__
+
+def _stage_from_argv0():
+    base = os.path.basename(sys.argv[0])
+    return SCRIPT_TO_STAGE.get(base, base)
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--in", dest="in_path", required=True)
+    p.add_argument("--model", dest="model_path", default=None)
+    p.add_argument("--out", required=True)
+    # tolerate any extra stage-specific flags the engine might pass
+    args, _unknown = p.parse_known_args()
+    stage = _stage_from_argv0()
+    key = "".join(c if c.isalnum() else "_" for c in stage).upper()
+    status = os.environ.get("AUTOSPEC_STUB_STATUS_" + key, "pass")
+    findings = json.loads(os.environ.get("AUTOSPEC_STUB_FINDINGS_" + key, "[]"))
+    fragment = {
+        "stage": stage,
+        "status": status,
+        "detail": stage + " stub: " + status,
+        "findings": findings,
+    }
+    vision = os.environ.get("AUTOSPEC_STUB_VISION_" + key)
+    if vision is not None:
+        fragment["vision_findings"] = json.loads(vision)
+    # exercise the "engine strips non-schema keys" path
+    fragment["_stub_extra"] = "should-be-dropped-by-engine"
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(fragment, f)
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def _build_stub_dir(base):
+    """Create a --stages-dir of stub stage scripts mirroring the real names."""
+    sdir = os.path.join(base, "stages")
+    os.makedirs(sdir, exist_ok=True)
+    # Build the canonical script-filename -> stage-name map from the engine's
+    # own STAGE_ORDER (plus the alternate hyphen/underscore filename variant),
+    # so each stub knows which stage it stands in for regardless of which
+    # filename the engine resolves. A single stub body then serves all stages.
+    script_to_stage = {}
+    for st in STAGE_ORDER:
+        script = st["script"]
+        script_to_stage[script] = st["name"]
+        if script.startswith("stage-"):
+            alt = "stage_" + script[len("stage-"):].replace("-", "_")
+        else:
+            alt = "stage-" + script[len("stage_"):].replace("_", "-")
+        script_to_stage[alt] = st["name"]
+    body = STUB_SOURCE.replace("__SCRIPT_TO_STAGE__", repr(script_to_stage))
+    for fname in script_to_stage:
+        path = os.path.join(sdir, fname)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(body)
+        os.chmod(path, 0o755)
+    return sdir
+
+
+def _env_for(status_overrides=None, findings_overrides=None, vision_overrides=None):
+    env = dict(os.environ)
+    status_overrides = status_overrides or {}
+    findings_overrides = findings_overrides or {}
+    vision_overrides = vision_overrides or {}
+    for stage in STAGE_NAMES:
+        key = "".join(c if c.isalnum() else "_" for c in stage).upper()
+        env["AUTOSPEC_STUB_STATUS_" + key] = status_overrides.get(stage, "pass")
+        if stage in findings_overrides:
+            env["AUTOSPEC_STUB_FINDINGS_" + key] = json.dumps(findings_overrides[stage])
+        if stage in vision_overrides:
+            env["AUTOSPEC_STUB_VISION_" + key] = json.dumps(vision_overrides[stage])
+    return env
+
+
+class ReleaseGateEngineTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="relgate-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.stl = os.path.join(self.tmp, "model.stl")
+        with open(self.stl, "w", encoding="utf-8") as f:
+            f.write("solid m\nendsolid m\n")
+        self.model = os.path.join(self.tmp, "model.json")
+        with open(self.model, "w", encoding="utf-8") as f:
+            json.dump({"name": "DogfoodManifold"}, f)
+        self.out = os.path.join(self.tmp, "release-gate.json")
+        self.stages_dir = _build_stub_dir(self.tmp)
+
+    def _run(self, env, extra_args=None):
+        argv = [
+            sys.executable, ENGINE,
+            "--in", self.stl,
+            "--model", self.model,
+            "--out", self.out,
+            "--stages-dir", self.stages_dir,
+        ]
+        if extra_args:
+            argv += extra_args
+        return subprocess.run(argv, env=env, capture_output=True, text=True)
+
+    def _read_gate(self):
+        with open(self.out, encoding="utf-8") as f:
+            return json.load(f)
+
+    def _ajv_validate(self):
+        proc = subprocess.run(
+            ["ajv", "validate", "-s", SCHEMA, "--spec=draft2020", "-d", self.out],
+            capture_output=True, text=True,
+        )
+        return proc
+
+    # ---- all-pass: schema-valid green gate, exit 0 -----------------------
+    def test_all_pass_green_gate(self):
+        proc = self._run(_env_for())
+        self.assertEqual(proc.returncode, 0,
+                         "all-pass should exit 0; stderr=%s" % proc.stderr)
+        self.assertTrue(os.path.exists(self.out))
+        gate = self._read_gate()
+        self.assertEqual(gate["schema_version"], 1)
+        self.assertEqual(gate["name"], "DogfoodManifold")
+        self.assertIn("geometry_hash", gate)
+        self.assertEqual([s["stage"] for s in gate["stages"]], STAGE_NAMES)
+        for s in gate["stages"]:
+            self.assertEqual(s["status"], "pass")
+            self.assertEqual(set(s.keys()), {"stage", "status", "detail", "findings"})
+            self.assertNotIn("_stub_extra", s)
+        if shutil.which("ajv"):
+            v = self._ajv_validate()
+            self.assertEqual(v.returncode, 0,
+                             "gate must be schema-valid; ajv: %s %s" % (v.stdout, v.stderr))
+
+    # ---- one hard-reject: blocking fail -> non-zero exit -----------------
+    def test_one_hard_reject_nonzero(self):
+        env = _env_for(
+            status_overrides={"geometry": "fail"},
+            findings_overrides={"geometry": [{"code": "non_watertight"}]},
+        )
+        proc = self._run(env)
+        self.assertNotEqual(proc.returncode, 0,
+                            "blocking fail must exit non-zero")
+        gate = self._read_gate()
+        geo = next(s for s in gate["stages"] if s["stage"] == "geometry")
+        self.assertEqual(geo["status"], "fail")
+        self.assertEqual(geo["findings"], [{"code": "non_watertight"}])
+        if shutil.which("ajv"):
+            self.assertEqual(self._ajv_validate().returncode, 0)
+
+    # ---- vision is advisory: warn never blocks ---------------------------
+    def test_vision_non_blocking(self):
+        env = _env_for(
+            status_overrides={"vision": "warn"},
+            vision_overrides={"vision": [{"code": "blocked_npt", "note": "looks blocked"}]},
+        )
+        proc = self._run(env)
+        self.assertEqual(proc.returncode, 0,
+                         "vision warn must NOT block; stderr=%s" % proc.stderr)
+        gate = self._read_gate()
+        vis = next(s for s in gate["stages"] if s["stage"] == "vision")
+        self.assertEqual(vis["status"], "warn")
+        self.assertEqual(
+            gate["vision_findings"],
+            [{"code": "blocked_npt", "note": "looks blocked"}],
+        )
+        if shutil.which("ajv"):
+            self.assertEqual(self._ajv_validate().returncode, 0)
+
+    # ---- vision fail also does not block ---------------------------------
+    def test_vision_fail_still_green(self):
+        env = _env_for(status_overrides={"vision": "fail"})
+        proc = self._run(env)
+        self.assertEqual(proc.returncode, 0,
+                         "even vision 'fail' is advisory and must not block")
+
+    # ---- skip does not fail ----------------------------------------------
+    def test_skip_does_not_fail(self):
+        env = _env_for(status_overrides={"fea": "skip", "cfd": "skip"})
+        proc = self._run(env)
+        self.assertEqual(proc.returncode, 0)
+
+    # ---- stage order + shape preserved -----------------------------------
+    def test_stage_order_and_shape(self):
+        proc = self._run(_env_for())
+        self.assertEqual(proc.returncode, 0)
+        gate = self._read_gate()
+        self.assertEqual([s["stage"] for s in gate["stages"]], STAGE_NAMES)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1234

The centerpiece integrator. `stl-release-gate.py` + `release_gate_stages.py`: ordered STAGE_ORDER of all 12 stages (geometry→docs; all blocking except **vision** = advisory). Runs each stage as a subprocess (`--in/--model/--out`; `--stages-dir` overridable for stubbing), aggregates fragments into a schema-valid `.autospec/fab/release-gate.json` (schema_version 1 + name + geometry_hash + stages[] + vision_findings), ajv-validates it. **Verdict:** any blocking-stage fail → non-zero exit; vision never blocks (→ vision_findings); skip never fails; missing/crashed blocking stage fails closed.

## Verification
- `python3 -m unittest test_release_gate.py` — 6/6 (all-pass→green schema-valid exit 0 / one hard-reject→non-zero / vision warn+fail non-blocking→exit 0 / skip doesn't fail / order+shape preserved) with stub stages-dir + real ajv. bats gates it.
- empirically confirmed: geometry stub-fail → non-zero exit; written gate ajv-valid.
- <400 LOC, funcs <50; `bash scripts/validate.sh` — exit 0.

Note: built on the fixed main (docs gate green post-#1256); COMPLEXITY nesting/proxy flags = benign class (#1245).