### PR TITLE
fix(autospec-fab): Phase 5.5 audit remediation — engine input-threading + schema drift

### DIFF
--- a/schemas/autospec-fab-model.schema.json
+++ b/schemas/autospec-fab-model.schema.json
@@ -7,6 +7,15 @@
   "required": ["material", "print_orientation", "load_critical", "flow_critical"],
   "additionalProperties": false,
   "properties": {
+    "name": {
+      "type": "string",
+      "description": "Optional human-readable model name; surfaced by the release-gate engine (stl-release-gate.py _model_name) into release-gate.json[\"name\"]."
+    },
+    "body_count": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Optional expected number of connected solid bodies; read by stage-geometry.py to set expect-bodies."
+    },
     "material": {
       "type": "string",
       "description": "Filament or resin material designation (e.g. PETG, ABS, ASA)."

--- a/skills/autospec-fab/fixtures/dogfood-featureful/circuit.json
+++ b/skills/autospec-fab/fixtures/dogfood-featureful/circuit.json
@@ -1,0 +1,17 @@
+{
+  "nodes": ["inlet_a", "inlet_b", "junction_1", "junction_2", "gasket_x", "cavity_y", "port_z"],
+  "edges": [
+    ["inlet_a", "junction_1"],
+    ["inlet_b", "junction_1"],
+    ["junction_1", "junction_2"],
+    ["junction_2", "gasket_x"],
+    ["junction_2", "cavity_y"],
+    ["junction_2", "port_z"]
+  ],
+  "inlets": ["inlet_a", "inlet_b"],
+  "targets": ["gasket_x", "cavity_y", "port_z"],
+  "isolated_groups": [],
+  "self_clamping": false,
+  "pump_type": "standard",
+  "relief_nodes": []
+}

--- a/skills/autospec-fab/fixtures/dogfood-featureful/dogfood.stl
+++ b/skills/autospec-fab/fixtures/dogfood-featureful/dogfood.stl
@@ -1,0 +1,86 @@
+solid box_20mm
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 20 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 20 20 20
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 20
+      vertex 0 20 20
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 20
+      vertex 20 0 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 20
+      vertex 20 0 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 0
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 20
+      vertex 0 20 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 0
+      vertex 0 20 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 20
+      vertex 0 0 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 20
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 0 20
+      vertex 20 20 20
+    endloop
+  endfacet
+endsolid box_20mm

--- a/skills/autospec-fab/fixtures/dogfood-featureful/duct.json
+++ b/skills/autospec-fab/fixtures/dogfood-featureful/duct.json
@@ -1,0 +1,23 @@
+{
+  "ducts": [
+    {
+      "id": "main_duct",
+      "opening_mm": 100.0,
+      "min_opening_mm": 96.0,
+      "cross_section_mm2": [7854.0, 7800.0, 7850.0, 7900.0],
+      "connected": true,
+      "printed_gate_slot": false,
+      "pvc_as_duct": false
+    },
+    {
+      "id": "branch_duct",
+      "opening_mm": 63.5,
+      "min_opening_mm": 60.0,
+      "cross_section_mm2": [3167.0, 3150.0, 3160.0, 3170.0],
+      "connected": true,
+      "printed_gate_slot": false,
+      "pvc_as_duct": false
+    }
+  ],
+  "nominal_full_size_mm2": 7854.0
+}

--- a/skills/autospec-fab/fixtures/dogfood-featureful/metadata.json
+++ b/skills/autospec-fab/fixtures/dogfood-featureful/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "DogfoodFeaturefulManifold",
+  "body_count": 1,
+  "material": "PETG",
+  "print_orientation": "flat",
+  "load_critical": false,
+  "flow_critical": true,
+  "dims": { "x_mm": 20, "y_mm": 20, "z_mm": 20 },
+  "ports": [],
+  "gaskets": []
+}

--- a/skills/autospec-fab/scripts/release_gate_stages.py
+++ b/skills/autospec-fab/scripts/release_gate_stages.py
@@ -35,6 +35,46 @@ STAGE_ORDER = [
 ]
 
 
+# Per-stage SIBLING-FILE input convention. The engine resolves each stage's
+# stage-specific input relative to MODELDIR (the directory holding the --model
+# sidecar) and threads it ONLY when the file exists. A featureless model (no
+# sibling file) gets no extra flag, so the stage correctly skips. This is what
+# makes a FEATUREFUL model actually RUN vacuum-circuit / dust-airflow / fea /
+# cfd instead of always skipping (Phase 5.5 audit D2).
+#   stage name -> (flag, sibling filename relative to MODELDIR)
+_SIBLING_INPUTS = {
+    "vacuum-circuit": ("--circuit", "circuit.json"),
+    "dust-airflow": ("--duct", "duct.json"),
+    "fea": ("--load", "load.json"),
+    "cfd": ("--flow", "flow.json"),
+}
+
+
+def extra_args_for(stage_name, stl_path, model_path):
+    """Return the extra CLI args to thread into <stage_name>, or [].
+
+    `docs` is the ONE stage that takes the model DIRECTORY (not the stl) as
+    `--in`, plus an optional `--baseline MODELDIR/baseline.json`. Every other
+    stage keeps `--in <stl>`; this resolver only adds stage-specific flags when
+    the sibling descriptor exists under MODELDIR (= dirname of the sidecar).
+    """
+    model_dir = os.path.dirname(os.path.abspath(model_path))
+    if stage_name == "docs":
+        args = ["--in", model_dir]
+        baseline = os.path.join(model_dir, "baseline.json")
+        if os.path.isfile(baseline):
+            args += ["--baseline", baseline]
+        return args
+    spec = _SIBLING_INPUTS.get(stage_name)
+    if spec is None:
+        return []
+    flag, filename = spec
+    sibling = os.path.join(model_dir, filename)
+    if os.path.isfile(sibling):
+        return [flag, sibling]
+    return []
+
+
 def _candidate_dirs(stages_dir):
     """Resolution order: --stages-dir, $AUTOSPEC_FAB_STAGES_DIR, engine dir."""
     dirs = []

--- a/skills/autospec-fab/scripts/stl-release-gate.py
+++ b/skills/autospec-fab/scripts/stl-release-gate.py
@@ -40,7 +40,8 @@ import subprocess
 import sys
 import tempfile
 
-from release_gate_stages import STAGE_ORDER, resolve_stage_script
+from release_gate_stages import (
+    STAGE_ORDER, extra_args_for, resolve_stage_script)
 
 # Keys the schema permits on a stage record; the engine strips everything else
 # off each fragment before aggregating (fragments may carry extras like
@@ -71,6 +72,22 @@ def _model_name(model_path):
         return ""
 
 
+def _stage_argv(script, stage_name, stl_path, model_path, out_path):
+    """Build the per-stage argv, threading sibling-file stage inputs.
+
+    Every stage gets `--model` + `--out`. The default input is `--in <stl>`,
+    UNLESS the per-stage resolver already supplies its own `--in` (docs takes
+    the model DIR). Stage-specific flags (--circuit/--duct/--load/--flow,
+    --baseline) come from extra_args_for and are appended only when the sibling
+    descriptor exists.
+    """
+    extra = extra_args_for(stage_name, stl_path, model_path)
+    argv = [sys.executable, script, "--model", model_path, "--out", out_path]
+    if "--in" not in extra:
+        argv += ["--in", stl_path]
+    return argv + extra
+
+
 def _run_stage(stage, stl_path, model_path, stages_dir):
     """Run one stage; return (fragment_dict, harness_ok).
 
@@ -88,8 +105,8 @@ def _run_stage(stage, stl_path, model_path, stages_dir):
         prefix="fab-frag-", suffix=".json", delete=False)
     tmp_out.close()
     try:
-        argv = [sys.executable, script,
-                "--in", stl_path, "--model", model_path, "--out", tmp_out.name]
+        argv = _stage_argv(
+            script, stage["name"], stl_path, model_path, tmp_out.name)
         proc = subprocess.run(argv, capture_output=True, text=True)
         fragment = _load_fragment(tmp_out.name, stage["name"])
         harness_ok = proc.returncode == 0 and fragment is not None

--- a/skills/autospec-fab/tests/test_engine_featureful.py
+++ b/skills/autospec-fab/tests/test_engine_featureful.py
@@ -1,0 +1,113 @@
+"""test_engine_featureful.py — engine threads per-model stage inputs (D2/D3).
+
+Phase 5.5 integration audit found that stl-release-gate.py invoked every stage
+with only `--in <stl> --model <metadata> --out`, so the vacuum-circuit and
+dust-airflow stages never received their stage-specific descriptor and always
+SKIPPED — a featureful model passed GREEN without those gates ever running
+(false assurance).
+
+The fix: the engine resolves per-model stage-specific inputs by a SIBLING-FILE
+convention relative to the model sidecar's directory (MODELDIR = dirname of
+--model) and threads them when the file exists:
+
+  vacuum-circuit  MODELDIR/circuit.json  -> --circuit
+  dust-airflow    MODELDIR/duct.json     -> --duct
+  fea             MODELDIR/load.json     -> --load
+  cfd             MODELDIR/flow.json     -> --flow
+  docs            --in MODELDIR (the dir, not the stl) [+ baseline.json]
+
+These tests run the REAL engine over the committed featureful dogfood fixture
+(no mocks) and assert the gates actually RAN (status pass, not skip). They also
+prove the threaded gate genuinely BITES: swapping in a broken circuit makes the
+gate go RED. The original featureless dogfood must still go green (circuit/dust
+skip — correct for a model with no sibling descriptors).
+
+Stdlib only; runs on bare python3.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS_DIR = os.path.abspath(os.path.join(HERE, "..", "scripts"))
+FIXTURES = os.path.abspath(os.path.join(HERE, "..", "fixtures"))
+ENGINE = os.path.join(SCRIPTS_DIR, "stl-release-gate.py")
+FEATUREFUL = os.path.join(FIXTURES, "dogfood-featureful")
+FEATURELESS = os.path.join(FIXTURES, "dogfood")
+BROKEN_CIRCUIT = os.path.join(
+    HERE, "fixtures", "circuit", "broken-link.json")
+
+
+def _run_engine(model_dir, out_path):
+    """Run the real engine over <model_dir>/{dogfood.stl,metadata.json}."""
+    argv = [
+        sys.executable, ENGINE,
+        "--in", os.path.join(model_dir, "dogfood.stl"),
+        "--model", os.path.join(model_dir, "metadata.json"),
+        "--out", out_path,
+    ]
+    return subprocess.run(argv, capture_output=True, text=True)
+
+
+def _statuses(out_path):
+    with open(out_path, encoding="utf-8") as f:
+        gate = json.load(f)
+    return {s["stage"]: s["status"] for s in gate["stages"]}, gate
+
+
+class EngineFeaturefulTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="fab-featureful-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.out = os.path.join(self.tmp, "release-gate.json")
+
+    # ---- D3: featureful dogfood -> green, circuit+dust RAN (pass) --------
+    def test_featureful_green_and_gates_ran(self):
+        proc = _run_engine(FEATUREFUL, self.out)
+        self.assertEqual(proc.returncode, 0,
+                         "featureful dogfood must be GREEN; stderr=%s"
+                         % proc.stderr)
+        statuses, gate = _statuses(self.out)
+        # The whole point: these gates must RUN (pass), not skip.
+        self.assertEqual(statuses["vacuum-circuit"], "pass",
+                         "engine must thread circuit.json -> circuit gate ran")
+        self.assertEqual(statuses["dust-airflow"], "pass",
+                         "engine must thread duct.json -> dust gate ran")
+        # D1: metadata sidecar carries name + body_count and must validate.
+        self.assertEqual(statuses["metadata"], "pass",
+                         "metadata gate must pass (schema accepts name+body_count)")
+        self.assertEqual(gate["name"], "DogfoodFeaturefulManifold")
+
+    # ---- D2 bite: a BAD circuit.json drives the gate RED via the engine --
+    def test_featureful_bad_circuit_goes_red(self):
+        # Copy the featureful fixture, swap in a broken circuit graph.
+        staged = os.path.join(self.tmp, "bad-model")
+        shutil.copytree(FEATUREFUL, staged)
+        shutil.copyfile(BROKEN_CIRCUIT, os.path.join(staged, "circuit.json"))
+        proc = _run_engine(staged, self.out)
+        self.assertNotEqual(proc.returncode, 0,
+                            "a broken circuit.json must drive the gate RED "
+                            "(proves the threaded gate genuinely bites)")
+        statuses, _ = _statuses(self.out)
+        self.assertEqual(statuses["vacuum-circuit"], "fail")
+
+    # ---- featureless dogfood still green; circuit/dust skip (no siblings)-
+    def test_featureless_still_green_skips(self):
+        proc = _run_engine(FEATURELESS, self.out)
+        self.assertEqual(proc.returncode, 0,
+                         "featureless dogfood must remain GREEN; stderr=%s"
+                         % proc.stderr)
+        statuses, _ = _statuses(self.out)
+        self.assertEqual(statuses["vacuum-circuit"], "skip",
+                         "no circuit.json sibling -> circuit gate skips")
+        self.assertEqual(statuses["dust-airflow"], "skip",
+                         "no duct.json sibling -> dust gate skips")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fab/test_schemas.bats
+++ b/tests/fab/test_schemas.bats
@@ -34,6 +34,27 @@ JSON
   [ "$status" -eq 0 ]
 }
 
+@test "fab-model schema accepts a sidecar carrying engine-read name + body_count" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (install ajv-cli to run this test)"
+
+  # The engine (stl-release-gate.py _model_name) reads "name" and
+  # stage-geometry.py reads "body_count" off the model sidecar. A real sidecar
+  # carrying either must NOT be rejected by the additionalProperties:false root.
+  cat > "$TEST_TMPDIR/model-named.json" <<'JSON'
+{
+  "name": "DogfoodFeaturefulManifold",
+  "body_count": 1,
+  "material": "PETG",
+  "print_orientation": "flat",
+  "load_critical": false,
+  "flow_critical": true
+}
+JSON
+
+  run ajv validate -s "$MODEL_SCHEMA" --spec=draft2020 -d "$TEST_TMPDIR/model-named.json"
+  [ "$status" -eq 0 ]
+}
+
 @test "fab-model schema rejects a sidecar missing required field material" {
   command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (install ajv-cli to run this test)"
 


### PR DESCRIPTION
Closes #1238

Phase 5.5 broad integration audit + remediation. Three parallel auditors traced schemas↔stages↔engine↔routing↔5.5↔define↔dogfood; the cross-cutting defects per-PR LGTMs missed are remediated:

- **D1 schema drift:** model schema (additionalProperties:false) rejected `name` (engine-read) + `body_count` (geometry-read) → real sidecars failed the metadata gate. Added both as optional schema fields.
- **D2 engine input-threading (the core fix):** engine invoked every stage with only `--in/--model/--out`, so vacuum-circuit/dust/docs/fea/cfd always SKIPPED → featureful models passed green *without those gates running*. Engine now threads per-model sibling files (`circuit.json/duct.json/load.json/flow.json`; docs gets the model dir + `baseline.json`) when present; absent → skip.
- **D3 regression:** new `dogfood-featureful/` fixture proves featureful→green with **vacuum-circuit+dust-airflow=pass (ran, not skip)**, bad circuit→**red** (gate bites), featureless still green.

## Verification (empirical)
- featureful: exit 0, circuit=pass, dust=pass; featureless: exit 0, circuit=skip, dust=skip; bad-circuit: exit 1, circuit=fail; name+body_count sidecar ajv-valid.
- 227 python tests + 16 bats (incl. new schema + engine-featureful tests); `bash scripts/validate.sh` — exit 0.

## Remaining audit gaps (filed as gap-remediation, not un-triaged)
render→vision handoff; slicer `--printer` threading; fea/cfd structured-results aggregation; `gates/<model>` path-layout documentation.