### PR TITLE
feat(autospec-fab): engine render->vision handoff

### DIFF
--- a/skills/autospec-fab/scripts/release_gate_stages.py
+++ b/skills/autospec-fab/scripts/release_gate_stages.py
@@ -50,13 +50,41 @@ _SIBLING_INPUTS = {
 }
 
 
-def extra_args_for(stage_name, stl_path, model_path):
+def render_dir_for(out_path):
+    """Deterministic per-run render dir: <out-dir>/renders/.
+
+    Keyed to the gate `--out` directory so a run's renders land in a stable,
+    predictable location the engine can hand to render (via --render-dir) and
+    then read back for the vision handoff. The render stage writes its
+    contact sheet under <render-dir>/<slug>/contact-sheet.html.
+    """
+    out_dir = os.path.dirname(os.path.abspath(out_path))
+    return os.path.join(out_dir, "renders")
+
+
+def contact_sheet_for(render_dir, stl_path):
+    """Path the render stage writes its sheet to: <render-dir>/<slug>/...html.
+
+    `slug` is the STL stem (matches stage_render._model_slug). The engine
+    threads this path as the vision stage's --in so vision inspects the real
+    renders instead of the STL.
+    """
+    base = os.path.basename(stl_path)
+    slug = os.path.splitext(base)[0] or "model"
+    return os.path.join(render_dir, slug, "contact-sheet.html")
+
+
+def extra_args_for(stage_name, stl_path, model_path, render_dir=None):
     """Return the extra CLI args to thread into <stage_name>, or [].
 
     `docs` is the ONE stage that takes the model DIRECTORY (not the stl) as
-    `--in`, plus an optional `--baseline MODELDIR/baseline.json`. Every other
-    stage keeps `--in <stl>`; this resolver only adds stage-specific flags when
-    the sibling descriptor exists under MODELDIR (= dirname of the sidecar).
+    `--in`, plus an optional `--baseline MODELDIR/baseline.json`. `render`
+    gets `--render-dir <render_dir>` (the deterministic per-run renders dir)
+    when one is supplied, so its contact sheet lands at a known path. `vision`
+    takes that produced contact sheet as its `--in` (NOT the stl) when render
+    actually emitted one — handled by the engine via override, see run_gate.
+    Every other stage keeps `--in <stl>`; this resolver only adds
+    stage-specific flags when the sibling descriptor exists under MODELDIR.
     """
     model_dir = os.path.dirname(os.path.abspath(model_path))
     if stage_name == "docs":
@@ -65,6 +93,8 @@ def extra_args_for(stage_name, stl_path, model_path):
         if os.path.isfile(baseline):
             args += ["--baseline", baseline]
         return args
+    if stage_name == "render" and render_dir:
+        return ["--render-dir", render_dir]
     spec = _SIBLING_INPUTS.get(stage_name)
     if spec is None:
         return []

--- a/skills/autospec-fab/scripts/stl-release-gate.py
+++ b/skills/autospec-fab/scripts/stl-release-gate.py
@@ -41,7 +41,8 @@ import sys
 import tempfile
 
 from release_gate_stages import (
-    STAGE_ORDER, extra_args_for, resolve_stage_script)
+    STAGE_ORDER, contact_sheet_for, extra_args_for, render_dir_for,
+    resolve_stage_script)
 
 # Keys the schema permits on a stage record; the engine strips everything else
 # off each fragment before aggregating (fragments may carry extras like
@@ -72,28 +73,33 @@ def _model_name(model_path):
         return ""
 
 
-def _stage_argv(script, stage_name, stl_path, model_path, out_path):
-    """Build the per-stage argv, threading sibling-file stage inputs.
+def _stage_argv(script, stage, stl_path, model_path, out_path, ctx):
+    """Build the per-stage argv, threading sibling-file + handoff inputs.
 
     Every stage gets `--model` + `--out`. The default input is `--in <stl>`,
-    UNLESS the per-stage resolver already supplies its own `--in` (docs takes
-    the model DIR). Stage-specific flags (--circuit/--duct/--load/--flow,
-    --baseline) come from extra_args_for and are appended only when the sibling
-    descriptor exists.
+    UNLESS the resolver/handoff already supplies its own `--in` (docs takes the
+    model DIR; vision takes the render's contact sheet). render gets a
+    deterministic `--render-dir` (ctx["render_dir"]). `ctx["in_override"]` maps
+    a stage name -> an `--in` value (used to hand vision the render sheet).
     """
-    extra = extra_args_for(stage_name, stl_path, model_path)
+    name = stage["name"]
+    extra = extra_args_for(name, stl_path, model_path, ctx.get("render_dir"))
     argv = [sys.executable, script, "--model", model_path, "--out", out_path]
-    if "--in" not in extra:
+    override = ctx.get("in_override", {}).get(name)
+    if override is not None:
+        argv += ["--in", override]
+    elif "--in" not in extra:
         argv += ["--in", stl_path]
     return argv + extra
 
 
-def _run_stage(stage, stl_path, model_path, stages_dir):
+def _run_stage(stage, stl_path, model_path, stages_dir, ctx):
     """Run one stage; return (fragment_dict, harness_ok).
 
     fragment_dict is the raw JSON the stage wrote (or a synthetic error
     fragment if the stage produced none). harness_ok is False when the stage
-    crashed or emitted no usable fragment.
+    crashed or emitted no usable fragment. `ctx` carries the per-run handoff
+    state (render dir + per-stage --in overrides).
     """
     script = resolve_stage_script(stage["script"], stages_dir)
     if script is None:
@@ -106,7 +112,7 @@ def _run_stage(stage, stl_path, model_path, stages_dir):
     tmp_out.close()
     try:
         argv = _stage_argv(
-            script, stage["name"], stl_path, model_path, tmp_out.name)
+            script, stage, stl_path, model_path, tmp_out.name, ctx)
         proc = subprocess.run(argv, capture_output=True, text=True)
         fragment = _load_fragment(tmp_out.name, stage["name"])
         harness_ok = proc.returncode == 0 and fragment is not None
@@ -150,14 +156,35 @@ def _clean_stage_record(fragment, stage_name):
     return record
 
 
-def run_gate(stl_path, model_path, stages_dir):
-    """Run every stage in order; return (gate_dict, blocking_failed: bool)."""
+def _vision_in_override(render_dir, stl_path):
+    """The vision stage's --in: the render's produced contact sheet.
+
+    Always the deterministic sheet path under the render dir (NOT the STL). If
+    render emitted no sheet (renderer absent → skip), this path won't exist and
+    vision's resolve_contact_sheet returns None → vision skips gracefully.
+    """
+    return contact_sheet_for(render_dir, stl_path)
+
+
+def run_gate(stl_path, model_path, stages_dir, out_path):
+    """Run every stage in order; return (gate_dict, blocking_failed: bool).
+
+    Threads the render→vision handoff: render gets a deterministic
+    --render-dir; vision's --in is pointed at the contact sheet render writes
+    there (resolved AFTER render ran, so an absent sheet makes vision skip).
+    """
     stages = []
     vision_findings = []
     blocking_failed = False
+    render_dir = render_dir_for(out_path)
+    ctx = {"render_dir": render_dir, "in_override": {}}
 
     for stage in STAGE_ORDER:
-        fragment, harness_ok = _run_stage(stage, stl_path, model_path, stages_dir)
+        if stage["name"] == "vision":
+            ctx["in_override"]["vision"] = _vision_in_override(
+                render_dir, stl_path)
+        fragment, harness_ok = _run_stage(
+            stage, stl_path, model_path, stages_dir, ctx)
         record = _clean_stage_record(fragment, stage["name"])
         stages.append(record)
 
@@ -235,7 +262,7 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     gate, blocking_failed = run_gate(
-        args.in_path, args.model_path, args.stages_dir)
+        args.in_path, args.model_path, args.stages_dir, args.out)
 
     out_dir = os.path.dirname(os.path.abspath(args.out))
     if out_dir:

--- a/skills/autospec-fab/tests/test_release_gate.py
+++ b/skills/autospec-fab/tests/test_release_gate.py
@@ -239,6 +239,143 @@ class ReleaseGateEngineTest(unittest.TestCase):
         gate = self._read_gate()
         self.assertEqual([s["stage"] for s in gate["stages"]], STAGE_NAMES)
 
+    # ---- render -> vision handoff: vision gets the contact sheet ---------
+    def _install_render_vision_handoff_stubs(self):
+        """Replace the render+vision stubs with handoff-aware probes.
+
+        render: records the --render-dir it received and emits a real
+        contact-sheet.html under <render-dir>/<slug>/. vision: records the
+        --in it received (so the test can assert it is the contact sheet,
+        NOT the STL) and emits a vision_findings observation.
+        """
+        self.render_dir_probe = os.path.join(self.tmp, "render-dir.txt")
+        self.vision_in_probe = os.path.join(self.tmp, "vision-in.txt")
+        render_src = (
+            "#!/usr/bin/env python3\n"
+            "import argparse, json, os, sys\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('--in', dest='in_path', required=True)\n"
+            "p.add_argument('--model', dest='model_path', default=None)\n"
+            "p.add_argument('--out', required=True)\n"
+            "p.add_argument('--render-dir', dest='render_dir', default=None)\n"
+            "a, _ = p.parse_known_args()\n"
+            "open(%r, 'w').write(a.render_dir or '<none>')\n"
+            "slug = os.path.splitext(os.path.basename(a.in_path))[0] or 'model'\n"
+            "sheet_dir = os.path.join(a.render_dir, slug)\n"
+            "os.makedirs(sheet_dir, exist_ok=True)\n"
+            "open(os.path.join(sheet_dir, 'contact-sheet.html'), 'w').write('<html>')\n"
+            "json.dump({'stage':'render','status':'pass',"
+            "'detail':'stub','findings':[]}, open(a.out,'w'))\n"
+            "sys.exit(0)\n"
+        ) % self.render_dir_probe
+        vision_src = (
+            "#!/usr/bin/env python3\n"
+            "import argparse, json, os, sys\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('--in', dest='in_path', required=True)\n"
+            "p.add_argument('--model', dest='model_path', default=None)\n"
+            "p.add_argument('--out', required=True)\n"
+            "a, _ = p.parse_known_args()\n"
+            "open(%r, 'w').write(a.in_path)\n"
+            "ok = os.path.isfile(a.in_path) and a.in_path.endswith('contact-sheet.html')\n"
+            "vf = [{'observation':'looks ok','severity':'info'}] if ok else []\n"
+            "json.dump({'stage':'vision','status':'pass','detail':'stub',"
+            "'findings':[],'vision_findings':vf}, open(a.out,'w'))\n"
+            "sys.exit(0)\n"
+        ) % self.vision_in_probe
+        for st in STAGE_ORDER:
+            if st["name"] == "render":
+                src = render_src
+            elif st["name"] == "vision":
+                src = vision_src
+            else:
+                continue
+            for fname in self._filenames_for(st["script"]):
+                path = os.path.join(self.stages_dir, fname)
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(src)
+                os.chmod(path, 0o755)
+
+    @staticmethod
+    def _read(path):
+        with open(path, encoding="utf-8") as f:
+            return f.read()
+
+    @staticmethod
+    def _filenames_for(script):
+        if script.startswith("stage-"):
+            alt = "stage_" + script[len("stage-"):].replace("-", "_")
+        else:
+            alt = "stage-" + script[len("stage_"):].replace("_", "-")
+        return [script, alt]
+
+    def test_render_vision_handoff_sheet_not_stl(self):
+        self._install_render_vision_handoff_stubs()
+        proc = self._run(_env_for())
+        self.assertEqual(proc.returncode, 0,
+                         "handoff gate must be green; stderr=%s" % proc.stderr)
+        render_dir = self._read(self.render_dir_probe)
+        self.assertNotEqual(render_dir, "<none>",
+                            "engine must thread --render-dir to the render stage")
+        vision_in = self._read(self.vision_in_probe)
+        self.assertTrue(vision_in.endswith("contact-sheet.html"),
+                        "vision --in must be the contact sheet, got %r" % vision_in)
+        self.assertNotEqual(vision_in, self.stl,
+                            "vision --in must NOT be the STL")
+        # the produced sheet lives under the render-dir the engine handed render
+        slug = os.path.splitext(os.path.basename(self.stl))[0]
+        self.assertEqual(
+            vision_in, os.path.join(render_dir, slug, "contact-sheet.html"))
+        gate = self._read_gate()
+        self.assertEqual(
+            gate["vision_findings"],
+            [{"observation": "looks ok", "severity": "info"}])
+
+    def test_render_absent_vision_skips_green(self):
+        """render produces no sheet (skip) -> vision skips, gate still green."""
+        self.vision_in_probe = os.path.join(self.tmp, "vision-in.txt")
+        # render stub that emits NO contact sheet (renderer-absent path)
+        render_src = (
+            "#!/usr/bin/env python3\n"
+            "import argparse, json, sys\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('--in', dest='in_path', required=True)\n"
+            "p.add_argument('--out', required=True)\n"
+            "a, _ = p.parse_known_args()\n"
+            "json.dump({'stage':'render','status':'skip','detail':'no renderer',"
+            "'findings':[]}, open(a.out,'w'))\n"
+            "sys.exit(0)\n"
+        )
+        vision_src = (
+            "#!/usr/bin/env python3\n"
+            "import argparse, json, os, sys\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('--in', dest='in_path', required=True)\n"
+            "p.add_argument('--out', required=True)\n"
+            "a, _ = p.parse_known_args()\n"
+            "open(%r, 'w').write(a.in_path)\n"
+            "status = 'skip' if not os.path.isfile(a.in_path) else 'pass'\n"
+            "json.dump({'stage':'vision','status':status,'detail':'stub',"
+            "'findings':[],'vision_findings':[]}, open(a.out,'w'))\n"
+            "sys.exit(0)\n"
+        ) % self.vision_in_probe
+        for st in STAGE_ORDER:
+            src = (render_src if st["name"] == "render"
+                   else vision_src if st["name"] == "vision" else None)
+            if src is None:
+                continue
+            for fname in self._filenames_for(st["script"]):
+                path = os.path.join(self.stages_dir, fname)
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(src)
+                os.chmod(path, 0o755)
+        proc = self._run(_env_for())
+        self.assertEqual(proc.returncode, 0,
+                         "render-absent must stay green; stderr=%s" % proc.stderr)
+        gate = self._read_gate()
+        vis = next(s for s in gate["stages"] if s["stage"] == "vision")
+        self.assertEqual(vis["status"], "skip")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/autospec-fab/tests/test_release_gate.py
+++ b/skills/autospec-fab/tests/test_release_gate.py
@@ -241,15 +241,24 @@ class ReleaseGateEngineTest(unittest.TestCase):
 
     # ---- render -> vision handoff: vision gets the contact sheet ---------
     def _install_render_vision_handoff_stubs(self):
-        """Replace the render+vision stubs with handoff-aware probes.
-
-        render: records the --render-dir it received and emits a real
-        contact-sheet.html under <render-dir>/<slug>/. vision: records the
-        --in it received (so the test can assert it is the contact sheet,
-        NOT the STL) and emits a vision_findings observation.
-        """
+        """Replace render+vision stubs with handoff-aware probes (see sub-helpers)."""
         self.render_dir_probe = os.path.join(self.tmp, "render-dir.txt")
         self.vision_in_probe = os.path.join(self.tmp, "vision-in.txt")
+        self._install_render_stub()
+        self._install_vision_stub()
+
+    def _write_stage_stub(self, stage_name, src):
+        for st in STAGE_ORDER:
+            if st["name"] != stage_name:
+                continue
+            for fname in self._filenames_for(st["script"]):
+                path = os.path.join(self.stages_dir, fname)
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(src)
+                os.chmod(path, 0o755)
+
+    def _install_render_stub(self):
+        """render: record the --render-dir + emit a real contact-sheet.html."""
         render_src = (
             "#!/usr/bin/env python3\n"
             "import argparse, json, os, sys\n"
@@ -268,6 +277,10 @@ class ReleaseGateEngineTest(unittest.TestCase):
             "'detail':'stub','findings':[]}, open(a.out,'w'))\n"
             "sys.exit(0)\n"
         ) % self.render_dir_probe
+        self._write_stage_stub("render", render_src)
+
+    def _install_vision_stub(self):
+        """vision: record --in (assert sheet, not STL) + emit an observation."""
         vision_src = (
             "#!/usr/bin/env python3\n"
             "import argparse, json, os, sys\n"
@@ -283,18 +296,7 @@ class ReleaseGateEngineTest(unittest.TestCase):
             "'findings':[],'vision_findings':vf}, open(a.out,'w'))\n"
             "sys.exit(0)\n"
         ) % self.vision_in_probe
-        for st in STAGE_ORDER:
-            if st["name"] == "render":
-                src = render_src
-            elif st["name"] == "vision":
-                src = vision_src
-            else:
-                continue
-            for fname in self._filenames_for(st["script"]):
-                path = os.path.join(self.stages_dir, fname)
-                with open(path, "w", encoding="utf-8") as f:
-                    f.write(src)
-                os.chmod(path, 0o755)
+        self._write_stage_stub("vision", vision_src)
 
     @staticmethod
     def _read(path):


### PR DESCRIPTION
Closes #1262 (#1238 audit follow-up)

Engine threads `--render-dir` to the render stage + passes the produced `contact-sheet.html` as vision's `--in` (not the STL), so vision inspects real renders. render-absent → vision skips (gate green); vision stays non-blocking.

## Verification
- `python3 -m unittest test_release_gate.py` — 229 OK (+2). New tests prove vision --in == contact-sheet (!= STL) + observation in vision_findings; render-absent → vision skip, gate green. Real stub scripts, no mocks.
- funcs <50 / files <400; `bash scripts/validate.sh` — exit 0.