### PR TITLE
feat(autospec-fab): aggregate fea/cfd structured results into release-gate.json

### DIFF
--- a/skills/autospec-fab/scripts/stage_cfd.py
+++ b/skills/autospec-fab/scripts/stage_cfd.py
@@ -257,18 +257,32 @@ def _result_fragment(results: dict | None, flow: dict) -> dict:
     misses = _evaluate_targets(results, flow)
     if misses:
         detail = "CFD target miss: " + "; ".join(misses)
-        return _make_fragment(
+        fragment = _make_fragment(
             "cfd", "fail", detail,
             [_make_finding("cfd_target_miss", detail)],
         )
+    else:
+        dp = results.get("pressure_drop_pa", 0.0)
+        vel = results.get("min_velocity_m_s", 0.0)
+        detail = (
+            f"CFD targets met: pressure_drop={dp:.1f} Pa, "
+            f"min_velocity={vel:.2f} m/s"
+        )
+        fragment = _make_fragment("cfd", "pass", detail, [])
 
-    dp = results.get("pressure_drop_pa", 0.0)
-    vel = results.get("min_velocity_m_s", 0.0)
-    detail = (
-        f"CFD targets met: pressure_drop={dp:.1f} Pa, "
-        f"min_velocity={vel:.2f} m/s"
-    )
-    return _make_fragment("cfd", "pass", detail, [])
+    fragment["cfd_results"] = _cfd_results_object(results, fragment["status"])
+    return fragment
+
+
+def _cfd_results_object(results: dict, status: str) -> dict:
+    """Structured CFD metrics for the fragment + top-level gate aggregation."""
+    obj = {
+        "pressure_drop_pa": results.get("pressure_drop_pa"),
+        "min_velocity_m_s": results.get("min_velocity_m_s"),
+        "stagnation": results.get("stagnation", False),
+        "status": status,
+    }
+    return obj
 
 
 def run_cfd_stage(

--- a/skills/autospec-fab/scripts/stage_fea.py
+++ b/skills/autospec-fab/scripts/stage_fea.py
@@ -7,21 +7,14 @@ Uniform stage CLI:
                  [--load <load.json>]
 
 Behaviour:
-  - load_critical: false  → status skip, detail "not load-critical".
-  - ccx absent from PATH  → status skip, detail "ccx not found …".
-  - Geometry-hash cache   → hit returns cached fragment without re-running ccx.
-  - Cache miss            → build anisotropic ccx deck, run ccx, parse result,
-                            compare safety factor to minimum, write cache entry.
-  - Safety factor < min   → status fail + finding fea_below_safety.
-  - Safety factor ≥ min   → status pass.
+  - load_critical: false / ccx absent → status skip (no fea_results).
+  - Geometry-hash cache hit → cached fragment (no re-run).
+  - Cache miss → build anisotropic ccx deck, run ccx, parse safety factor,
+    compare to minimum, write cache entry. Pass/fail fragments carry a
+    structured fea_results {safety_factor, required_min, status}.
 
-Cache location:
-  ${AUTOSPEC_FAB_CACHE_DIR}/<hash>.json
-  (default: .autospec/fab/fea-cache/ relative to cwd)
-
-Exit codes:
-  0 — harness success (verdict lives in fragment "status", not exit code).
-  1 — harness/usage error (bad args, missing --out, etc.).
+Cache: ${AUTOSPEC_FAB_CACHE_DIR}/<hash>.json (default .autospec/fab/fea-cache/).
+Exit 0 on harness success (verdict lives in fragment "status"); 1 on usage error.
 """
 
 from __future__ import annotations
@@ -41,11 +34,9 @@ from typing import Any
 # Material anisotropy tables
 # ---------------------------------------------------------------------------
 
-# Per-axis Young's modulus scale factors relative to the isotropic base value.
-# FDM extrusion is strongest along the X/Y print plane (along-layer) and
-# weakest in Z (between-layer bonding).  These ratios are representative of
-# typical FDM PETG/PLA/ABS; the exact numbers are less important than encoding
-# the orientation dependency.
+# Per-axis Young's modulus scale factors vs the isotropic base value. FDM is
+# strongest in the X/Y print plane and weakest in Z (between-layer bonding);
+# the ratios encode that orientation dependency for typical FDM PETG/PLA/ABS.
 _ORIENTATION_SCALE: dict[str, dict[str, float]] = {
     # orientation → {E_x, E_y, E_z} scale factors
     "flat":    {"E_x": 1.00, "E_y": 1.00, "E_z": 0.55},
@@ -89,12 +80,7 @@ def _load_json(path: str) -> dict:
 # ---------------------------------------------------------------------------
 
 def _geometry_hash(stl_path: str, model: dict, load: dict | None) -> str:
-    """
-    Hash the STL content plus material, print_orientation, and load spec.
-
-    The hash is used as the cache key.  Any change to the geometry, material,
-    orientation, or load invalidates the cache entry.
-    """
+    """Hash STL content + material + print_orientation + load spec (cache key)."""
     h = hashlib.sha256()
     with open(stl_path, "rb") as fh:
         for chunk in iter(lambda: fh.read(65536), b""):
@@ -152,99 +138,69 @@ def _build_ccx_deck(
     work_dir: str,
     job_name: str = "fea_job",
 ) -> str:
-    """
-    Write a minimal CalculiX input deck (.inp) and return the job base path.
+    """Write a minimal CalculiX input deck (.inp); return the job base path.
 
     The deck encodes per-axis anisotropic elastic constants derived from the
-    material + print_orientation.  A simple nodal model is used (single
-    8-node brick element) since the goal is to exercise the solver integration
-    and orientation encoding, not to produce production-accurate FEA results.
-    The real solver workflow uses a properly meshed geometry.
-
-    Deck sections:
-      *MATERIAL — orthotropic constants (per-axis E, nu)
-      *ELASTIC, TYPE=ENGINEERING CONSTANTS
-      *BOUNDARY — fixed base nodes
-      *CLOAD — applied force on top nodes
-      *STEP/*STATIC/*EL PRINT/*NODE PRINT/*END STEP
+    material + print_orientation on a single 8-node brick element (the goal is
+    to exercise solver integration + orientation encoding, not production FEA).
     """
     mat_name = model.get("material", "GENERIC")
     orientation = model.get("print_orientation", "flat")
     base = _MATERIAL_BASE.get(mat_name, _DEFAULT_MATERIAL_BASE)
     scale = _ORIENTATION_SCALE.get(orientation, _DEFAULT_ORIENTATION_SCALE)
 
-    E_x = base["E_mpa"] * scale["E_x"]
-    E_y = base["E_mpa"] * scale["E_y"]
-    E_z = base["E_mpa"] * scale["E_z"]
+    E = (base["E_mpa"] * scale["E_x"],
+         base["E_mpa"] * scale["E_y"],
+         base["E_mpa"] * scale["E_z"])
     nu = base["nu"]
-    G = base["E_mpa"] / (2.0 * (1.0 + nu))  # shear modulus (isotropic approximation)
+    G = base["E_mpa"] / (2.0 * (1.0 + nu))  # shear modulus (isotropic approx)
 
     force_n = load.get("force_n", 10.0)
     direction = load.get("direction", [0, 0, -1])
 
     inp_path = os.path.join(work_dir, f"{job_name}.inp")
     with open(inp_path, "w") as fh:
-        fh.write("** autospec-fab FEA deck\n")
-        fh.write(f"** Material: {mat_name}  Orientation: {orientation}\n")
-        fh.write(f"** E_x={E_x:.1f} E_y={E_y:.1f} E_z={E_z:.1f} MPa\n")
-        fh.write("**\n")
-
-        # Minimal 8-node hexahedral element (C3D8) — unit cube
-        fh.write("*NODE\n")
-        nodes = [
-            (1, 0.0, 0.0, 0.0),
-            (2, 1.0, 0.0, 0.0),
-            (3, 1.0, 1.0, 0.0),
-            (4, 0.0, 1.0, 0.0),
-            (5, 0.0, 0.0, 1.0),
-            (6, 1.0, 0.0, 1.0),
-            (7, 1.0, 1.0, 1.0),
-            (8, 0.0, 1.0, 1.0),
-        ]
-        for n, x, y, z in nodes:
-            fh.write(f"{n}, {x}, {y}, {z}\n")
-
-        fh.write("*ELEMENT, TYPE=C3D8, ELSET=EALL\n")
-        fh.write("1, 1, 2, 3, 4, 5, 6, 7, 8\n")
-
-        # Orthotropic material encoding orientation via per-axis E values
-        fh.write(f"*MATERIAL, NAME={mat_name}\n")
-        fh.write("*ELASTIC, TYPE=ENGINEERING CONSTANTS\n")
-        # E1, E2, E3, nu12, nu13, nu23, G12, G13
-        fh.write(f"{E_x:.2f}, {E_y:.2f}, {E_z:.2f}, "
-                 f"{nu:.4f}, {nu:.4f}, {nu:.4f}, {G:.2f}, {G:.2f}\n")
-        # G23 on continuation line
-        fh.write(f"{G:.2f}\n")
-
-        fh.write("*SOLID SECTION, ELSET=EALL, MATERIAL={}\n".format(mat_name))
-
-        # Boundary: fix bottom face (nodes 1-4) in all DOF
-        fh.write("*BOUNDARY\n")
-        for nid in range(1, 5):
-            fh.write(f"{nid}, 1, 3, 0.0\n")
-
-        # Load: apply force distributed over top face (nodes 5-8)
-        fx = force_n * direction[0] / 4.0
-        fy = force_n * direction[1] / 4.0
-        fz = force_n * direction[2] / 4.0
-        fh.write("*CLOAD\n")
-        for nid in range(5, 9):
-            if fx != 0.0:
-                fh.write(f"{nid}, 1, {fx:.4f}\n")
-            if fy != 0.0:
-                fh.write(f"{nid}, 2, {fy:.4f}\n")
-            if fz != 0.0:
-                fh.write(f"{nid}, 3, {fz:.4f}\n")
-
-        fh.write("*STEP\n")
-        fh.write("*STATIC\n")
-        fh.write("*EL PRINT, ELSET=EALL\n")
-        fh.write("S\n")
-        fh.write("*NODE PRINT, NSET=NALL\n")
-        fh.write("U\n")
-        fh.write("*END STEP\n")
-
+        _write_ccx_inp(fh, mat_name, orientation, E, nu, G, force_n, direction)
     return os.path.join(work_dir, job_name)
+
+
+# Unit-cube C3D8 nodes: (id, x, y, z). Bottom face 1-4 fixed; load on top 5-8.
+_CUBE_NODES = (
+    (1, 0.0, 0.0, 0.0), (2, 1.0, 0.0, 0.0), (3, 1.0, 1.0, 0.0),
+    (4, 0.0, 1.0, 0.0), (5, 0.0, 0.0, 1.0), (6, 1.0, 0.0, 1.0),
+    (7, 1.0, 1.0, 1.0), (8, 0.0, 1.0, 1.0),
+)
+
+
+def _write_ccx_inp(fh, mat_name, orientation, E, nu, G, force_n, direction):
+    """Write the .inp deck body (one 8-node brick, orthotropic material)."""
+    E_x, E_y, E_z = E
+    fh.write("** autospec-fab FEA deck\n")
+    fh.write(f"** Material: {mat_name}  Orientation: {orientation}\n")
+    fh.write(f"** E_x={E_x:.1f} E_y={E_y:.1f} E_z={E_z:.1f} MPa\n**\n")
+    fh.write("*NODE\n")
+    for n, x, y, z in _CUBE_NODES:
+        fh.write(f"{n}, {x}, {y}, {z}\n")
+    fh.write("*ELEMENT, TYPE=C3D8, ELSET=EALL\n1, 1, 2, 3, 4, 5, 6, 7, 8\n")
+    # Orthotropic: E1,E2,E3, nu12,nu13,nu23, G12,G13 then G23 on next line.
+    fh.write(f"*MATERIAL, NAME={mat_name}\n")
+    fh.write("*ELASTIC, TYPE=ENGINEERING CONSTANTS\n")
+    fh.write(f"{E_x:.2f}, {E_y:.2f}, {E_z:.2f}, "
+             f"{nu:.4f}, {nu:.4f}, {nu:.4f}, {G:.2f}, {G:.2f}\n")
+    fh.write(f"{G:.2f}\n")
+    fh.write(f"*SOLID SECTION, ELSET=EALL, MATERIAL={mat_name}\n")
+    fh.write("*BOUNDARY\n")
+    for nid in range(1, 5):
+        fh.write(f"{nid}, 1, 3, 0.0\n")
+    comps = (force_n * direction[0] / 4.0, force_n * direction[1] / 4.0,
+             force_n * direction[2] / 4.0)
+    fh.write("*CLOAD\n")
+    for nid in range(5, 9):
+        for axis, val in enumerate(comps, start=1):
+            if val != 0.0:
+                fh.write(f"{nid}, {axis}, {val:.4f}\n")
+    fh.write("*STEP\n*STATIC\n*EL PRINT, ELSET=EALL\nS\n")
+    fh.write("*NODE PRINT, NSET=NALL\nU\n*END STEP\n")
 
 
 # ---------------------------------------------------------------------------
@@ -252,10 +208,9 @@ def _build_ccx_deck(
 # ---------------------------------------------------------------------------
 
 def _run_ccx(job_base: str) -> tuple[bool, str]:
-    """
-    Run ccx on job_base.inp.  Returns (success, stderr_text).
+    """Run ccx on job_base.inp; return (success, stderr_text).
 
-    ccx is invoked as: ccx <job_base>   (no extension — ccx appends .inp/.dat).
+    Invoked as: ccx <job_base> (no extension — ccx appends .inp/.dat).
     """
     ccx_bin = shutil.which("ccx")
     if ccx_bin is None:
@@ -277,12 +232,9 @@ def _run_ccx(job_base: str) -> tuple[bool, str]:
 
 
 def _parse_safety_factor(job_base: str) -> float | None:
-    """
-    Parse the safety factor from the ccx .dat output file.
+    """Parse the safety factor from the ccx .dat output file.
 
-    The shim (and a real ccx wrapper) is expected to write:
-        SAFETY_FACTOR <value>
-    in the .dat file.  If that line is absent, return None (parse failure).
+    The shim/real wrapper writes `SAFETY_FACTOR <value>`; absent → None.
     """
     dat_path = job_base + ".dat"
     if not os.path.exists(dat_path):
@@ -325,8 +277,7 @@ def run_fea_stage(
         load = _load_json(load_path)
     safety_min = float(load.get("safety_factor_min", _DEFAULT_SAFETY_MIN))
 
-    # --- Check ccx availability BEFORE cache lookup ---
-    # If ccx is absent we skip (real solver deferred); cache is irrelevant.
+    # ccx absent -> skip (real solver deferred); cache is irrelevant.
     ccx_bin = shutil.which("ccx")
     if ccx_bin is None:
         return _make_fragment("fea", "skip", "ccx not found on PATH; real solver deferred to container", [])
@@ -339,48 +290,61 @@ def run_fea_stage(
         return cached
 
     # --- Cache miss: build deck, run ccx, parse result ---
+    success, err_msg, safety_factor = _run_and_parse(stl_path, model, load)
+    if not success:
+        fragment = _make_fragment(
+            "fea", "fail",
+            f"ccx execution failed: {err_msg[:200]}",
+            [_make_finding("fea_below_safety", f"ccx failed: {err_msg[:200]}")],
+        )
+    else:
+        fragment = _safety_fragment(safety_factor, safety_min, model)
+    _cache_write(cache_root, digest, fragment)
+    return fragment
+
+
+def _run_and_parse(stl_path, model, load):
+    """Build the ccx deck, run ccx, parse the safety factor.
+
+    Returns (success, err_msg, safety_factor). safety_factor is None on a parse
+    failure (success stays True so the caller emits the parse-failure verdict).
+    """
     with tempfile.TemporaryDirectory(prefix="fea_run_") as work_dir:
         job_base = _build_ccx_deck(stl_path, model, load, work_dir)
         success, err_msg = _run_ccx(job_base)
-
         if not success:
-            fragment = _make_fragment(
-                "fea", "fail",
-                f"ccx execution failed: {err_msg[:200]}",
-                [_make_finding("fea_below_safety", f"ccx failed: {err_msg[:200]}")],
-            )
-            _cache_write(cache_root, digest, fragment)
-            return fragment
+            return False, err_msg, None
+        return True, "", _parse_safety_factor(job_base)
 
-        safety_factor = _parse_safety_factor(job_base)
 
-    # --- Evaluate safety factor ---
+def _safety_fragment(safety_factor, safety_min, model):
+    """Map a parsed safety factor to a pass/fail fragment + fea_results.
+
+    safety_factor is None -> parse-failure fail (no fea_results numbers).
+    """
     if safety_factor is None:
-        fragment = _make_fragment(
+        return _make_fragment(
             "fea", "fail",
             "ccx ran but safety factor could not be parsed from .dat output",
             [_make_finding("fea_below_safety", "Safety factor parse failure")],
         )
-        _cache_write(cache_root, digest, fragment)
-        return fragment
-
+    cmp = "<" if safety_factor < safety_min else "≥"
+    detail = (
+        f"Safety factor {safety_factor:.3f} {cmp} required {safety_min:.1f} "
+        f"(material={model.get('material')}, "
+        f"orientation={model.get('print_orientation')})"
+    )
     if safety_factor < safety_min:
-        detail = (
-            f"Safety factor {safety_factor:.3f} < required {safety_min:.1f} "
-            f"(material={model.get('material')}, orientation={model.get('print_orientation')})"
-        )
         fragment = _make_fragment(
             "fea", "fail", detail,
-            [_make_finding("fea_below_safety", detail)],
-        )
+            [_make_finding("fea_below_safety", detail)])
     else:
-        detail = (
-            f"Safety factor {safety_factor:.3f} ≥ required {safety_min:.1f} "
-            f"(material={model.get('material')}, orientation={model.get('print_orientation')})"
-        )
         fragment = _make_fragment("fea", "pass", detail, [])
-
-    _cache_write(cache_root, digest, fragment)
+    fragment["fea_results"] = {
+        "safety_factor": safety_factor,
+        "required_min": safety_min,
+        "status": fragment["status"],
+    }
     return fragment
 
 

--- a/skills/autospec-fab/scripts/stl-release-gate.py
+++ b/skills/autospec-fab/scripts/stl-release-gate.py
@@ -175,6 +175,7 @@ def run_gate(stl_path, model_path, stages_dir, out_path):
     """
     stages = []
     vision_findings = []
+    extras = {}  # top-level structured results keyed by gate field name
     blocking_failed = False
     render_dir = render_dir_for(out_path)
     ctx = {"render_dir": render_dir, "in_override": {}}
@@ -187,11 +188,7 @@ def run_gate(stl_path, model_path, stages_dir, out_path):
             stage, stl_path, model_path, stages_dir, ctx)
         record = _clean_stage_record(fragment, stage["name"])
         stages.append(record)
-
-        if stage["name"] == "vision":
-            vf = fragment.get("vision_findings")
-            if isinstance(vf, list):
-                vision_findings.extend(vf)
+        _collect_stage_extras(stage["name"], fragment, vision_findings, extras)
 
         if stage["blocking"]:
             if record["status"] == "fail" or not harness_ok:
@@ -204,7 +201,32 @@ def run_gate(stl_path, model_path, stages_dir, out_path):
         "stages": stages,
         "vision_findings": vision_findings,
     }
+    gate.update(extras)
     return gate, blocking_failed
+
+
+# Stage name -> the top-level gate field its structured results object feeds.
+_STRUCTURED_RESULT_FIELDS = {"fea": "fea_results", "cfd": "cfd_results"}
+
+
+def _collect_stage_extras(name, fragment, vision_findings, extras):
+    """Mirror per-stage extras into the gate top level.
+
+    vision -> advisory vision_findings (appended); fea/cfd -> structured
+    fea_results/cfd_results dicts (placed at gate top-level, parallel to
+    vision_findings). Absent/ill-typed extras are skipped (no fabrication).
+    """
+    if name == "vision":
+        vf = fragment.get("vision_findings")
+        if isinstance(vf, list):
+            vision_findings.extend(vf)
+        return
+    field = _STRUCTURED_RESULT_FIELDS.get(name)
+    if field is None:
+        return
+    value = fragment.get(field)
+    if isinstance(value, dict):
+        extras[field] = value
 
 
 def _ajv_validate(schema_path, out_path):

--- a/skills/autospec-fab/tests/test_release_gate.py
+++ b/skills/autospec-fab/tests/test_release_gate.py
@@ -76,6 +76,12 @@ def main():
     vision = os.environ.get("AUTOSPEC_STUB_VISION_" + key)
     if vision is not None:
         fragment["vision_findings"] = json.loads(vision)
+    fea = os.environ.get("AUTOSPEC_STUB_FEA_RESULTS_" + key)
+    if fea is not None:
+        fragment["fea_results"] = json.loads(fea)
+    cfd = os.environ.get("AUTOSPEC_STUB_CFD_RESULTS_" + key)
+    if cfd is not None:
+        fragment["cfd_results"] = json.loads(cfd)
     # exercise the "engine strips non-schema keys" path
     fragment["_stub_extra"] = "should-be-dropped-by-engine"
     with open(args.out, "w", encoding="utf-8") as f:

--- a/skills/autospec-fab/tests/test_release_gate_results.py
+++ b/skills/autospec-fab/tests/test_release_gate_results.py
@@ -1,0 +1,112 @@
+"""test_release_gate_results.py — engine aggregation of fea_results/cfd_results.
+
+The release-gate engine extracts the structured `fea_results` from the fea
+stage fragment and `cfd_results` from the cfd stage fragment (mirroring the
+existing vision_findings extraction) and places them at the TOP LEVEL of the
+written gate. The per-stage stages[] records stay projected to
+{stage,status,detail,findings}; the structured results live at gate top-level.
+
+Stage fragments are stubbed via test_release_gate's stub harness, which emits
+fea_results/cfd_results from AUTOSPEC_STUB_FEA_RESULTS_FEA /
+AUTOSPEC_STUB_CFD_RESULTS_CFD. Schema validation uses the real `ajv` CLI when
+present (guarded by shutil.which).
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+from test_release_gate import (  # noqa: E402
+    ENGINE, SCHEMA, _build_stub_dir, _env_for)
+
+
+class ReleaseGateResultsTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="relgate-results-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.stl = os.path.join(self.tmp, "model.stl")
+        with open(self.stl, "w", encoding="utf-8") as f:
+            f.write("solid m\nendsolid m\n")
+        self.model = os.path.join(self.tmp, "model.json")
+        with open(self.model, "w", encoding="utf-8") as f:
+            json.dump({"name": "DogfoodManifold"}, f)
+        self.out = os.path.join(self.tmp, "release-gate.json")
+        self.stages_dir = _build_stub_dir(self.tmp)
+
+    def _run(self, env):
+        argv = [
+            sys.executable, ENGINE,
+            "--in", self.stl,
+            "--model", self.model,
+            "--out", self.out,
+            "--stages-dir", self.stages_dir,
+        ]
+        return subprocess.run(argv, env=env, capture_output=True, text=True)
+
+    def _read_gate(self):
+        with open(self.out, encoding="utf-8") as f:
+            return json.load(f)
+
+    def _ajv_validate(self):
+        return subprocess.run(
+            ["ajv", "validate", "-s", SCHEMA, "--spec=draft2020", "-d", self.out],
+            capture_output=True, text=True,
+        )
+
+    def _env_with_results(self):
+        env = _env_for()
+        env["AUTOSPEC_STUB_FEA_RESULTS_FEA"] = json.dumps(
+            {"safety_factor": 3.5, "required_min": 2.0, "status": "pass"})
+        env["AUTOSPEC_STUB_CFD_RESULTS_CFD"] = json.dumps(
+            {"pressure_drop_pa": 200.0, "min_velocity_m_s": 3.0,
+             "stagnation": False, "status": "pass"})
+        return env
+
+    def test_results_aggregated_to_top_level(self):
+        proc = self._run(self._env_with_results())
+        self.assertEqual(proc.returncode, 0,
+                         "green gate expected; stderr=%s" % proc.stderr)
+        gate = self._read_gate()
+        self.assertEqual(
+            gate["fea_results"],
+            {"safety_factor": 3.5, "required_min": 2.0, "status": "pass"})
+        self.assertEqual(
+            gate["cfd_results"],
+            {"pressure_drop_pa": 200.0, "min_velocity_m_s": 3.0,
+             "stagnation": False, "status": "pass"})
+
+    def test_results_not_in_stage_records(self):
+        self._run(self._env_with_results())
+        gate = self._read_gate()
+        for s in gate["stages"]:
+            self.assertEqual(set(s.keys()),
+                             {"stage", "status", "detail", "findings"})
+
+    def test_aggregated_gate_is_schema_valid(self):
+        self._run(self._env_with_results())
+        if not shutil.which("ajv"):
+            self.skipTest("ajv not on PATH")
+        v = self._ajv_validate()
+        self.assertEqual(v.returncode, 0,
+                         "gate must be schema-valid; ajv: %s %s"
+                         % (v.stdout, v.stderr))
+
+    def test_absent_results_omitted_from_gate(self):
+        """fea/cfd skip (no results emitted) -> no top-level keys, still valid."""
+        proc = self._run(_env_for())
+        self.assertEqual(proc.returncode, 0)
+        gate = self._read_gate()
+        self.assertNotIn("fea_results", gate)
+        self.assertNotIn("cfd_results", gate)
+        if shutil.which("ajv"):
+            self.assertEqual(self._ajv_validate().returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/autospec-fab/tests/test_stage_cfd.py
+++ b/skills/autospec-fab/tests/test_stage_cfd.py
@@ -240,6 +240,17 @@ class TestPassingPart(_WithSolverShim):
         count = _read_count(self.count_file)
         self.assertGreater(count, 0, "Expected solver shim to be invoked at least once")
 
+    def test_cfd_results_carries_metrics(self):
+        results = self.fragment.get("cfd_results")
+        self.assertIsInstance(
+            results, dict,
+            f"Expected structured cfd_results dict; fragment={self.fragment}",
+        )
+        self.assertAlmostEqual(results["pressure_drop_pa"], float(_PASSING_PRESSURE))
+        self.assertAlmostEqual(results["min_velocity_m_s"], float(_PASSING_VELOCITY))
+        self.assertFalse(results["stagnation"])
+        self.assertEqual(results["status"], "pass")
+
 
 class TestTargetMiss(_WithSolverShim):
     """A flow-critical part exceeding pressure-drop target must fail + emit cfd_target_miss."""
@@ -263,6 +274,13 @@ class TestTargetMiss(_WithSolverShim):
             "cfd_target_miss", codes,
             f"Expected cfd_target_miss finding; findings={self.fragment['findings']}",
         )
+
+    def test_cfd_results_carries_fail_status(self):
+        results = self.fragment.get("cfd_results")
+        self.assertIsInstance(results, dict,
+                              f"Expected cfd_results dict; fragment={self.fragment}")
+        self.assertAlmostEqual(results["pressure_drop_pa"], float(_FAILING_PRESSURE))
+        self.assertEqual(results["status"], "fail")
 
 
 class TestVelocityMiss(_WithSolverShim):
@@ -322,6 +340,12 @@ class TestNonCriticalPart(_WithSolverShim):
         count = _read_count(self.count_file)
         self.assertEqual(count, 0, "Solver must not run for non-flow-critical parts")
 
+    def test_no_fabricated_cfd_results_on_skip(self):
+        self.assertNotIn(
+            "cfd_results", self.fragment,
+            "skip path must not fabricate cfd_results numbers",
+        )
+
 
 class TestSolverAbsent(unittest.TestCase):
     """When simpleFoam is not on PATH, stage must skip (solver deferred to container)."""
@@ -353,6 +377,10 @@ class TestSolverAbsent(unittest.TestCase):
         )
         self.assertEqual(fragment["findings"], [],
                          "No findings when solver absent (deferred to container)")
+        self.assertNotIn(
+            "cfd_results", fragment,
+            "solver-absent skip must not fabricate cfd_results",
+        )
 
 
 if __name__ == "__main__":

--- a/skills/autospec-fab/tests/test_stage_fea.py
+++ b/skills/autospec-fab/tests/test_stage_fea.py
@@ -1,16 +1,9 @@
-"""
-test_stage_fea.py — unittest for stage_fea.py (CalculiX FEA stage).
+"""test_stage_fea.py — unittest for stage_fea.py (CalculiX FEA stage).
 
-Tests:
-  1. strong_part: shim emits high safety factor  → status pass.
-  2. weak_part:   shim emits low safety factor   → status fail + fea_below_safety.
-  3. non_critical model (load_critical: false)   → status skip.
-  4. cache hit: re-run same inputs               → ccx invoked 0 times on second run.
-  5. ccx absent from PATH                        → status skip (solver deferred).
-  6. fragment validates release-gate stage-record shape.
-
-The ccx shim writes an invocation counter to $CCX_SHIM_COUNT_FILE and emits
-a synthetic .dat file whose safety factor is controlled by $CCX_SHIM_SAFETY.
+Covers pass/fail/skip verdicts, the geometry-hash cache, ccx-absent skip, the
+stage-record fragment shape, and the structured fea_results object (emitted on
+pass/fail; absent on skip). The ccx shim writes an invocation counter to
+$CCX_SHIM_COUNT_FILE and a synthetic .dat whose safety factor is $CCX_SHIM_SAFETY.
 """
 
 import json
@@ -39,28 +32,16 @@ _LOW_SAFETY = "0.8"
 
 
 def _make_ccx_shim(bin_dir: str, safety_factor: str, count_file: str) -> str:
-    """
-    Write a ccx shim to bin_dir/ccx.
+    """Write a ccx shim to bin_dir/ccx.
 
-    The shim:
-      - Increments the integer in count_file by 1 (creates it at 0 first).
-      - Writes a minimal .dat file that stage_fea.py can parse for the safety factor.
-        The stage looks for a line:  MAX_MISES <value>
-        and a line:                  SAFETY_FACTOR <value>
-        in the <job>.dat output (we write it alongside the input deck).
-      - Exits 0.
-
-    Parameters controlling output are taken from env vars at shim-invocation time
-    so the fixture can set them once before running the stage:
-      CCX_SHIM_SAFETY       — float safety factor to emit  (default 3.5)
-      CCX_SHIM_COUNT_FILE   — path to the counter file
+    The shim increments the counter in count_file, writes a <job>.dat with a
+    SAFETY_FACTOR line, and exits 0. Env-driven: CCX_SHIM_SAFETY (default 3.5),
+    CCX_SHIM_COUNT_FILE (counter path).
     """
     shim_path = os.path.join(bin_dir, "ccx")
     shim_content = f"""\
 #!/bin/sh
 # ccx shim for autospec-fab FEA tests
-
-# --- increment invocation counter ---
 count_file="${{CCX_SHIM_COUNT_FILE:-{count_file}}}"
 if [ -f "$count_file" ]; then
     count=$(cat "$count_file")
@@ -69,9 +50,7 @@ else
 fi
 echo $((count + 1)) > "$count_file"
 
-# --- emit synthetic .dat with safety factor ---
 safety="${{CCX_SHIM_SAFETY:-{safety_factor}}}"
-
 # The last positional arg to ccx is the job name (no extension).
 job_name="${{@: -1}}"
 dat_file="${{job_name}}.dat"
@@ -96,12 +75,9 @@ def _run_stage(
     extra_env: dict | None = None,
     cache_dir: str | None = None,
 ) -> tuple[int, dict | None, str]:
-    """
-    Run stage_fea.py, return (returncode, fragment_dict, stderr).
+    """Run stage_fea.py; return (returncode, fragment_dict, stderr).
 
-    extra_env — env vars merged on top of the current environment.
-    cache_dir — if given, set AUTOSPEC_FAB_CACHE_DIR so the stage uses an
-                isolated cache per test.
+    extra_env merges over os.environ; cache_dir sets AUTOSPEC_FAB_CACHE_DIR.
     """
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
         out_path = tf.name
@@ -174,8 +150,6 @@ class _WithCcxShim(unittest.TestCase):
 
 
 class TestFragmentShape(_WithCcxShim):
-    """Every fragment must match release-gate stage-record shape."""
-
     def _assert_valid_fragment(self, fragment, label):
         self.assertIsInstance(fragment, dict, f"{label}: fragment must be a dict")
         for key in ("stage", "status", "detail", "findings"):
@@ -215,8 +189,6 @@ class TestFragmentShape(_WithCcxShim):
 
 
 class TestStrongPart(_WithCcxShim):
-    """A load-critical part with high safety factor must pass."""
-
     def setUp(self):
         super().setUp()
         self._install_shim(_HIGH_SAFETY)
@@ -241,6 +213,16 @@ class TestStrongPart(_WithCcxShim):
         count = _read_count(self.count_file)
         self.assertGreater(count, 0, "Expected ccx shim to be invoked at least once")
 
+    def test_fea_results_carries_safety_factor(self):
+        results = self.fragment.get("fea_results")
+        self.assertIsInstance(
+            results, dict,
+            f"Expected structured fea_results dict; fragment={self.fragment}",
+        )
+        self.assertAlmostEqual(results["safety_factor"], float(_HIGH_SAFETY))
+        self.assertEqual(results["required_min"], 2.0)
+        self.assertEqual(results["status"], "pass")
+
 
 class TestWeakPart(_WithCcxShim):
     """A load-critical part with low safety factor must fail + emit fea_below_safety."""
@@ -264,6 +246,14 @@ class TestWeakPart(_WithCcxShim):
         codes = _finding_codes(self.fragment)
         self.assertIn("fea_below_safety", codes,
                       f"Expected fea_below_safety finding; findings={self.fragment['findings']}")
+
+    def test_fea_results_carries_fail_status(self):
+        results = self.fragment.get("fea_results")
+        self.assertIsInstance(results, dict,
+                              f"Expected fea_results dict; fragment={self.fragment}")
+        self.assertAlmostEqual(results["safety_factor"], float(_LOW_SAFETY))
+        self.assertEqual(results["required_min"], 2.0)
+        self.assertEqual(results["status"], "fail")
 
 
 class TestNonCriticalPart(_WithCcxShim):
@@ -300,6 +290,12 @@ class TestNonCriticalPart(_WithCcxShim):
         count = _read_count(self.count_file)
         self.assertEqual(count, 0, "ccx must not run for non-load-critical parts")
 
+    def test_no_fabricated_fea_results_on_skip(self):
+        self.assertNotIn(
+            "fea_results", self.fragment,
+            "skip path must not fabricate fea_results numbers",
+        )
+
 
 class TestCacheHit(_WithCcxShim):
     """Re-running the same inputs must hit the cache; ccx must not be re-invoked."""
@@ -314,9 +310,7 @@ class TestCacheHit(_WithCcxShim):
         count_after_first = _read_count(self.count_file)
         self.assertGreater(count_after_first, 0, "ccx must be called on first run")
 
-        # Reset counter (shim will create the file fresh from 0 + 1)
-        # Actually we set the count file content to 0 manually so we can
-        # detect exactly what happens on the second call.
+        # Reset counter so the second call's count is unambiguous.
         with open(self.count_file, "w") as f:
             f.write("0")
 
@@ -334,18 +328,13 @@ class TestCacheHit(_WithCcxShim):
 
     def test_changed_orientation_busts_cache(self):
         """A changed print_orientation must MISS the cache against the SAME cache
-        dir — proving the geometry-hash key includes print_orientation. (A prior
-        version of this test used a fresh cache dir, which only proved cold-cache
-        behaviour and would NOT catch a regression that dropped orientation from
-        the hash.)"""
+        dir — proving the geometry-hash key includes print_orientation."""
         self._install_shim(_HIGH_SAFETY)
 
         # Prime the cache with the upright critical model.
         rc1, _, _ = self._run(_HIGH_SAFETY, model=_CRITICAL_MODEL)
         self.assertEqual(rc1, 0)
         self.assertGreater(_read_count(self.count_file), 0)
-
-        # Reset the invocation counter so the second run's count is unambiguous.
         with open(self.count_file, "w") as f:
             f.write("0")
 
@@ -358,13 +347,13 @@ class TestCacheHit(_WithCcxShim):
         with open(variant_path, "w") as f:
             json.dump(variant, f)
 
-        # Re-run against the SAME cache dir → different hash → cache MISS → ccx runs.
+        # Same cache dir → different hash → cache MISS → ccx re-runs.
         rc2, _, _ = self._run(_HIGH_SAFETY, model=variant_path)
         self.assertEqual(rc2, 0)
         self.assertGreater(
             _read_count(self.count_file), 0,
-            "ccx MUST be re-invoked when print_orientation changes against the "
-            "same cache dir (hash key must include print_orientation)",
+            "ccx MUST re-run when print_orientation changes (hash key must "
+            "include print_orientation)",
         )
 
 
@@ -399,6 +388,10 @@ class TestCcxAbsent(unittest.TestCase):
         )
         self.assertEqual(fragment["findings"], [],
                          "No findings when ccx absent (solver deferred)")
+        self.assertNotIn(
+            "fea_results", fragment,
+            "ccx-absent skip must not fabricate fea_results",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1264 (#1238 audit follow-up)

`stage_fea` emits `fea_results {safety_factor, required_min, status}`; `stage_cfd` emits `cfd_results {pressure_drop_pa, min_velocity_m_s, stagnation, status}` (additive — from values already computed; status/findings/cache unchanged). The engine's `run_gate` aggregates them to the gate top-level (mirror of `vision_findings`); `stages[]` entries unchanged. Schema already declared both fields (no schema change). **Skip paths emit no results — no fabricated numbers** (verified: not-load-critical fea → skip, no fea_results).

Also refactored two pre-existing oversized fea functions (`_build_ccx_deck`, `run_fea_stage`) into helpers to honor <50 LOC — behavior-preserving.

## Verification
- `python3 -m unittest discover` — 258 OK. New: fea/cfd emit structured results when running, none on skip; engine aggregates top-level; written gate ajv-valid (real ajv). All fea/cfd/engine suites green (refactor non-regressing).
- files <400 / funcs <50; `bash scripts/validate.sh` — exit 0.