### PR TITLE
docs(autospec-fab): document the model-dir sidecar + output path layout

### DIFF
--- a/skills/autospec-fab/README.md
+++ b/skills/autospec-fab/README.md
@@ -104,6 +104,65 @@ skills/autospec-fab/scripts/load-fab-config.sh .autospec/fab.yml
 skills/autospec-fab/scripts/load-fab-config.sh --validate .autospec/fab.yml
 ```
 
+## Fab model directory & output layout
+
+Two conventions keep the producers (the release-gate engine + its stages) and
+the consumer (the Phase 5.5 `fab-completeness.sh` audit) aligned. They live in
+`scripts/release_gate_stages.py` (`_SIBLING_INPUTS`, `extra_args_for`) and
+`skills/autospec-run/scripts/fab-completeness.sh`.
+
+### Per-model input layout
+
+`MODELDIR` is the directory holding a model's `--model` metadata file. It always
+contains `metadata.json` (validated against `autospec-fab-model.schema.json` by
+the `metadata` stage). Alongside it the engine looks for OPTIONAL stage sidecars
+and threads each one into its stage automatically **only when the file exists**.
+An absent sidecar means the engine adds no extra flag, so that stage skips
+cleanly — correct for a model that lacks the feature.
+
+| Sidecar (`MODELDIR/…`) | Stage | Engine flag |
+| --- | --- | --- |
+| `metadata.json` | `metadata` | `--model` (required) |
+| `circuit.json` | `vacuum-circuit` | `--circuit` |
+| `duct.json` | `dust-airflow` | `--duct` |
+| `printer.json` | `slicer` | `--printer` |
+| `load.json` | `fea` | `--load` |
+| `flow.json` | `cfd` | `--flow` |
+| `baseline.json` | `docs` | `--baseline` (the `docs` stage gets the model DIR as `--in`) |
+
+```text
+manifolds/inlet_manifold/
+├── metadata.json     # required; validated vs the model schema
+├── circuit.json      # optional → runs vacuum-circuit
+├── duct.json         # optional → runs dust-airflow
+├── printer.json      # optional → per-model slicer override
+├── load.json         # optional → runs FEA
+├── flow.json         # optional → runs CFD
+└── baseline.json     # optional → docs NO_HANDEDIT baseline
+```
+
+### Output layout
+
+The engine writes the aggregated `release-gate.json` to its `--out` path. It also
+threads a deterministic render dir (`<out-dir>/renders/`) into the `render` stage
+via `--render-dir`; render writes its contact sheet to
+`<render-dir>/<slug>/contact-sheet.html` (`slug` = STL stem), which the engine
+then hands to the `vision` stage as its `--in` (the render→vision handoff).
+
+The Phase 5.5 `fab-completeness.sh` audit consumes one canonical per-model
+layout under the fab dir (`.autospec/fab`). Keep the STL stem equal to the model
+name so the `<model>` segments stay aligned:
+
+```text
+.autospec/fab/
+├── gates/
+│   └── <model>/
+│       └── release-gate.json     # green + geometry_hash matches current STL
+└── renders/
+    └── <model>/
+        └── contact-sheet.html    # produced by render, read by vision
+```
+
 ## License
 
 MIT - see the repository [LICENSE](../../LICENSE) file.

--- a/skills/autospec-fab/tests/readme-layout.bats
+++ b/skills/autospec-fab/tests/readme-layout.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+#
+# readme-layout.bats — regression guard for the "Fab model directory & output
+# layout" section in skills/autospec-fab/README.md.
+#
+# The per-model sidecar convention (release_gate_stages._SIBLING_INPUTS) and the
+# Phase 5.5 output layout (fab-completeness.sh: gates/<model>/release-gate.json +
+# renders/<model>/contact-sheet.html) live in code. This test fails closed if
+# the documented layout section is removed or loses a key path token, so docs
+# and code can't silently drift apart.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  README="${REPO_ROOT}/skills/autospec-fab/README.md"
+}
+
+readme_has() {
+  # Real file read, no mocks: grep the committed README for a literal token.
+  grep -qF -- "$1" "$README"
+}
+
+@test "README has a Fab model directory & output layout section" {
+  readme_has "## Fab model directory & output layout"
+}
+
+@test "README documents metadata.json + baseline.json model-dir contents" {
+  readme_has "metadata.json"
+  readme_has "baseline.json"
+}
+
+@test "README documents every stage sidecar from _SIBLING_INPUTS" {
+  readme_has "circuit.json"
+  readme_has "duct.json"
+  readme_has "printer.json"
+  readme_has "load.json"
+  readme_has "flow.json"
+}
+
+@test "README documents the Phase 5.5 output path layout" {
+  readme_has "gates/"
+  readme_has "renders/"
+  readme_has "release-gate.json"
+  readme_has "contact-sheet.html"
+}


### PR DESCRIPTION
Closes #1265 (#1238 audit follow-up)

Appends a layout section to `skills/autospec-fab/README.md`: the per-model `MODELDIR` sidecar convention (`metadata.json` + optional auto-threaded `circuit.json`/`duct.json`/`printer.json`/`load.json`/`flow.json`/`baseline.json` — absent → stage skips) and the Phase 5.5 output layout (`.autospec/fab/gates/<model>/release-gate.json` + `renders/<model>/contact-sheet.html`). Sidecar→stage mapping matches `release_gate_stages._SIBLING_INPUTS` exactly.

README-only — **no trio SKILL.md change, no goldens churn**. `readme-layout.bats` (4 tests) guards the documented tokens.

## Verification
- `bats readme-layout.bats` — 4/4; all 10 layout tokens present; `bash scripts/validate.sh` — exit 0.