### PR TITLE
fix(context-monitor): map opus-4-8 + 1m family in MODEL_MAX (#898)

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/adapters/claude.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/adapters/claude.py
@@ -26,6 +26,9 @@ MODEL_MAX: dict[str, int] = {
     "claude-sonnet-4-7": 200_000,
     "claude-opus-4-7": 200_000,
     "claude-opus-4-5": 200_000,
+    "claude-opus-4-8": 200_000,
+    "claude-opus-4-8-1m": 1_000_000,
+    "claude-opus-4-8[1m]": 1_000_000,
     "claude-haiku-4-5": 200_000,
     # Legacy identifiers
     "claude-3-5-sonnet-20241022": 200_000,
@@ -34,6 +37,24 @@ MODEL_MAX: dict[str, int] = {
 }
 
 _DEFAULT_MAX = 200_000
+
+
+def _resolve_max(model: str | None) -> int:
+    """Context-window size for a model id.
+
+    Exact ``MODEL_MAX`` entries win; otherwise any id carrying the 1M-context
+    marker (a ``-1m`` suffix or a ``[1m]`` tag, the convention Claude Code uses
+    for million-token sessions) resolves to 1_000_000 so a newly-shipped 1M
+    model is not silently capped at the 200k default (issue #898). Everything
+    else falls back to ``_DEFAULT_MAX``.
+    """
+    if not model:
+        return _DEFAULT_MAX
+    if model in MODEL_MAX:
+        return MODEL_MAX[model]
+    if model.endswith("-1m") or "[1m]" in model:
+        return 1_000_000
+    return _DEFAULT_MAX
 
 _HANDOFF_PROMPT = (
     "Please run /create-handoff and wait for the file to be written "
@@ -103,7 +124,7 @@ class ClaudeAdapter:
             m = msg.get("model")
             if m:
                 model = m
-        max_tokens = MODEL_MAX.get(model, _DEFAULT_MAX)
+        max_tokens = _resolve_max(model)
         return Usage(
             used_tokens=used,
             max_tokens=max_tokens,

--- a/tests/adapters/test_claude.py
+++ b/tests/adapters/test_claude.py
@@ -18,7 +18,11 @@ def adapter():
 
 def test_find_transcript_picks_newest_by_mtime(tmp_path, adapter, monkeypatch):
     """find_transcript returns the most-recently-modified .jsonl in the slug dir."""
-    slug = "Users-test-project"
+    # Slug keeps the leading "-" from the absolute cwd's leading "/" (the live
+    # ~/.claude/projects convention; claude.py derives it via re.sub and the
+    # docstring says do NOT strip it). The fixture dir MUST match or the test
+    # rots (it did — this test was failing on main, un-gated, before the fix).
+    slug = "-Users-test-project"
     session_dir = tmp_path / ".claude" / "projects" / slug
     session_dir.mkdir(parents=True)
 
@@ -72,6 +76,41 @@ def test_read_usage_picks_up_1m_model_max(adapter):
     assert usage.max_tokens == 1_000_000
     assert usage.model == "claude-sonnet-4-5-1m"
     assert usage.used_tokens == 6000  # 5000+1000
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("claude-opus-4-8", 200_000),          # base opus-4-8 (non-1m)
+        ("claude-opus-4-8-1m", 1_000_000),     # explicit 1m variant
+        ("claude-opus-4-8[1m]", 1_000_000),    # [1m]-tagged exact id (issue #898)
+        ("claude-sonnet-4-5-1m", 1_000_000),   # existing 1m model still resolves
+        ("claude-sonnet-4-5", 200_000),        # existing base model
+        ("some-future-model-1m", 1_000_000),   # unknown id, -1m suffix → fallback to 1M
+        ("some-future-model[1m]", 1_000_000),  # unknown id, [1m] tag → fallback to 1M
+        ("totally-unknown-model", 200_000),    # unknown, no marker → default
+        (None, 200_000),                       # no model field → default
+    ],
+)
+def test_resolve_max_covers_opus48_and_1m_family(model, expected):
+    """_resolve_max maps opus-4-8 + any -1m/[1m]-tagged id to 1M, else 200k default."""
+    from autospec_context_monitor.adapters.claude import _resolve_max
+    assert _resolve_max(model) == expected
+
+
+def test_read_usage_opus48_1m_not_over_capped(tmp_path, adapter):
+    """Regression for #898: a 344k-token opus-4-8[1m] session reads as 1M context
+    (pct < 50%), not the 200k default that reported >100% and fired early rollover."""
+    transcript = tmp_path / "opus48-1m.jsonl"
+    transcript.write_text(
+        '{"type":"message","message":{"model":"claude-opus-4-8[1m]",'
+        '"usage":{"input_tokens":300000,"output_tokens":44000}}}\n'
+    )
+    usage = adapter.read_usage(transcript)
+    assert usage.model == "claude-opus-4-8[1m]"
+    assert usage.max_tokens == 1_000_000
+    assert usage.used_tokens == 344_000
+    assert (usage.used_tokens / usage.max_tokens) < 0.5  # ~34%, not 172%
 
 
 def test_command_maps_clear_compact_handoff(adapter):


### PR DESCRIPTION
Part of the 2026-06-20 whole-project review. Fixes the MODEL_MAX half of #898.

**Bug:** `MODEL_MAX` lacked `claude-opus-4-8`, so a 1M opus-4-8 session fell to `_DEFAULT_MAX=200_000` and read >100% (344k→172%), firing compact/handoff/clear early. (Affected live opus-4-8 1M sessions.)

**Fix:** explicit opus-4-8 entries (base 200k + `-1m`/`[1m]`→1M) + a `_resolve_max()` fallback that maps any `-1m`/`[1m]`-marked id to 1M — future-proofs the whole 1M family so a new 1M model is never silently capped.

**Also (same file):** fixed `test_find_transcript_picks_newest_by_mtime`, which was **failing on main** (un-gated) — its slug fixture lacked the leading `-` the live `~/.claude/projects` convention requires.

## Verification
- `pytest tests/adapters/test_claude.py` — **16/16** (was 1 failing pre-fix). New: `_resolve_max` parametrized (opus-4-8 base/[1m]/-1m, fallback, default) + #898 e2e (344k opus-4-8[1m] → <50%).
- `_resolve_max` direct check all-OK.

⚠️ This suite is **not run by validate.sh** (no pytest in the gate) — the gate-breadth follow-up will wire it in. 3 other pre-existing context-monitor failures (protocol-checkable, 2× hook-install) are tracked for that work. The hook-mode-notification half of #898 is architectural and stays open.