### PR TITLE
fix(install): ship 3 unshipped runtime scripts + broaden ship-completeness gate

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -882,8 +882,12 @@ copy_repo_scripts() {
     fi
 
     mkdir -p "$autospec_scripts_dir"
-    # Copy only top-level script files (no recursion into scripts/lib/).
-    for ext in sh mjs ps1; do
+    # Copy only top-level script files (no recursion into scripts/lib/). The yml
+    # extension ships runtime data assets that installed scripts hard-require at
+    # ${AUTOSPEC_SCRIPTS_DIR}/<name>.yml (e.g. assemble-impl-prompt.sh -> memory-tags.yml,
+    # which exit 1's if absent — a clean-install crash). Only memory-tags.yml lives at
+    # scripts/ top level today; the glob stays extension-scoped so it never sweeps subdirs.
+    for ext in sh mjs ps1 yml; do
         for f in "$repo_scripts_src"/*."$ext"; do
             [ -e "$f" ] || continue
             cp "$f" "$autospec_scripts_dir/"
@@ -921,6 +925,17 @@ skills/autospec-run/scripts/post-token-report.sh::post-token-report.sh \
 skills/autospec-run/scripts/release-issue.sh::release-issue.sh \
 skills/autospec-resume/scripts/resume-scan.sh::resume-scan.sh \
 skills/autospec-doc/scripts/doc-orchestrator-entry.mjs::doc-orchestrator.mjs \
+skills/autospec-harmonize/scripts/harmonize.sh::harmonize.sh \
+skills/autospec-harmonize/scripts/design-discover.sh::design-discover.sh \
+skills/autospec-harmonize/scripts/design-generalize.mjs::design-generalize.mjs \
+skills/autospec-harmonize/scripts/design-variants.mjs::design-variants.mjs \
+skills/autospec-harmonize/scripts/design-preview.mjs::design-preview.mjs \
+skills/autospec-harmonize/scripts/gen-migration-spec.mjs::gen-migration-spec.mjs \
+skills/autospec-harmonize/scripts/extract-source.mjs::extract-source.mjs \
+skills/autospec-harmonize/scripts/extract-runtime.mjs::extract-runtime.mjs \
+skills/autospec-harmonize/scripts/fetch-vendor.sh::fetch-vendor.sh \
+skills/autospec-harmonize/scripts/lib/color.mjs::lib/color.mjs \
+skills/autospec-qa/scripts/qa-visual-findings.sh::qa-visual-findings.sh \
 skills/autospec-sweep/scripts/run.sh::autospec-sweep-run.sh \
 skills/autospec-sweep/scripts/wizard.sh::autospec-sweep-wizard.sh"
 
@@ -967,6 +982,9 @@ skills/autospec-doc/scripts/verify-examples.mjs"
         src="$REPO_ROOT/${entry%%::*}"
         dest="$autospec_scripts_dir/${entry##*::}"
         if [ -f "$src" ]; then
+            # Create the dest's parent so subdir destinations (e.g. lib/color.mjs, the
+            # harmonize ./lib import) land correctly regardless of prior steps.
+            mkdir -p "$(dirname "$dest")"
             cp "$src" "$dest"
             case "$dest" in
                 *.sh|*.mjs) chmod +x "$dest" ;;

--- a/skills/autospec-harmonize/install.sh
+++ b/skills/autospec-harmonize/install.sh
@@ -44,6 +44,12 @@ DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
 SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+# Per-skill runtime stage scripts that harmonize.sh shells out to via
+# ${AUTOSPEC_SCRIPTS_DIR}/<name> (resolved as STAGE_DIR). They MUST ship to
+# ~/.autospec/scripts/ or /autospec-harmonize crashes on a clean install. lib/color.mjs
+# is the relative ./lib/color.mjs import shared by design-generalize/design-variants and
+# ships preserving its lib/ subdir so the import resolves alongside the .mjs files.
+SKILL_SCRIPT_FILES="harmonize.sh design-discover.sh design-generalize.mjs design-variants.mjs design-preview.mjs gen-migration-spec.mjs extract-source.mjs extract-runtime.mjs fetch-vendor.sh lib/color.mjs"
 
 # ---------- helpers --------------------------------------------------------
 
@@ -131,6 +137,28 @@ install_shared_scripts() {
         case "$rel" in
             *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
         esac
+    done
+}
+
+resolve_skill_scripts_dir() {
+    if [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_skill_scripts() {
+    src_dir="$(resolve_skill_scripts_dir)"
+    [ -n "$src_dir" ] || return 0
+    for rel in $SKILL_SCRIPT_FILES; do
+        src="$src_dir/$rel"
+        if [ -f "$src" ]; then
+            install_one "$src" "$HOME/.autospec/scripts/$rel" || return 1
+            case "$rel" in
+                *.sh|*.mjs) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+            esac
+        fi
     done
 }
 
@@ -259,6 +287,10 @@ fi
 info ""
 info "Shared autospec helper scripts:"
 install_shared_scripts
+
+info ""
+info "autospec-harmonize stage scripts:"
+install_skill_scripts
 
 # ---------- per-harness paths ---------------------------------------------
 

--- a/skills/autospec-qa/install.sh
+++ b/skills/autospec-qa/install.sh
@@ -18,6 +18,10 @@ DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
 SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+# Per-skill runtime helper that the QA clusters shell out to via
+# ${AUTOSPEC_SCRIPTS_DIR}/qa-visual-findings.sh. Must ship to ~/.autospec/scripts/ or the
+# accessibility-and-responsive cluster crashes on a clean install.
+SKILL_SCRIPT_FILES="qa-visual-findings.sh"
 
 err()  { printf 'error: %s\n' "$*" >&2; }
 warn() { printf 'warn: %s\n' "$*" >&2; }
@@ -95,6 +99,26 @@ install_shared_scripts() {
     done
 }
 
+resolve_skill_scripts_dir() {
+    if [ -d "$SKILL_DIR/scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/scripts"
+    else
+        printf ''
+    fi
+}
+
+install_skill_scripts() {
+    src_dir="$(resolve_skill_scripts_dir)"
+    [ -n "$src_dir" ] || return 0
+    for rel in $SKILL_SCRIPT_FILES; do
+        src="$src_dir/$rel"
+        if [ -f "$src" ]; then
+            install_one "$src" "$HOME/.autospec/scripts/$rel" || return 1
+            case "$rel" in *.sh|*.mjs) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;; esac
+        fi
+    done
+}
+
 while [ $# -gt 0 ]; do
     case "$1" in
         --harness) shift; HARNESS="${1:-}" ;;
@@ -129,6 +153,10 @@ done
 info ""
 info "Shared autospec helper scripts:"
 install_shared_scripts
+
+info ""
+info "autospec-qa skill scripts:"
+install_skill_scripts
 
 CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"

--- a/tests/ship-completeness.bats
+++ b/tests/ship-completeness.bats
@@ -13,6 +13,10 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 
 # Skill surface files that may reference helper scripts at runtime: per-skill trios,
 # the autospec orchestrator surface, and any prompt files dispatched to subagents.
+# This set drives the bare-repo-relative-invocation guard (test 2), which must stay
+# scoped to authored skill prose — not script bodies (whose comments legitimately
+# mention scripts/<x>.sh in prose) — so it is deliberately narrower than the
+# runtime-reference scan below.
 surface_files() {
   {
     ls "$REPO_ROOT"/skills/*/SKILL.md 2>/dev/null
@@ -23,6 +27,23 @@ surface_files() {
   } | sort -u
 }
 
+# Files scanned for ${AUTOSPEC_SCRIPTS_DIR}-resolved runtime-asset references (test 1):
+# every surface file PLUS the per-skill cluster docs (skills/*/clusters/*.md, which pipe
+# through helper scripts), the per-skill runtime scripts themselves (skills/*/scripts/*
+# that shell out to siblings via a resolved scripts dir, e.g. harmonize.sh ->
+# $STAGE_DIR/design-discover.sh), and the repo-root scripts/*.sh that hard-require runtime
+# assets at install-resolved paths (e.g. assemble-impl-prompt.sh -> memory-tags.yml). A
+# reference to an unshipped asset from ANY of these crashes a clean install.
+reference_scan_files() {
+  {
+    surface_files
+    ls "$REPO_ROOT"/skills/*/clusters/*.md 2>/dev/null
+    find "$REPO_ROOT"/skills/*/scripts -maxdepth 1 -type f \
+      \( -name '*.sh' -o -name '*.mjs' \) 2>/dev/null
+    ls "$REPO_ROOT"/scripts/*.sh 2>/dev/null
+  } | sort -u
+}
+
 # The set of relative paths (under ~/.autospec/scripts) the installers ship: repo-root
 # scripts/ globs (.sh/.mjs/.ps1, excluding install-time-only scripts/lib/) land at the
 # top level, while the entire skills/autospec-shared/scripts/ tree is copied preserving
@@ -30,8 +51,11 @@ surface_files() {
 # reference can be matched whether or not it carries a subdirectory prefix.
 shippable_paths() {
   {
-    # Repo-root scripts/*.{sh,mjs,ps1} ship flat (basename only); exclude scripts/lib/.
-    ls "$REPO_ROOT"/scripts/*.sh "$REPO_ROOT"/scripts/*.mjs "$REPO_ROOT"/scripts/*.ps1 2>/dev/null \
+    # Repo-root scripts/*.{sh,mjs,ps1,yml} ship flat (basename only); exclude scripts/lib/.
+    # .yml is included because copy_repo_scripts() now also globs runtime data assets
+    # (e.g. memory-tags.yml) that installed scripts require at ${AUTOSPEC_SCRIPTS_DIR}/<x>.yml.
+    ls "$REPO_ROOT"/scripts/*.sh "$REPO_ROOT"/scripts/*.mjs "$REPO_ROOT"/scripts/*.ps1 \
+       "$REPO_ROOT"/scripts/*.yml 2>/dev/null \
       | while read -r f; do basename "$f"; done
     # Shared scripts ship preserving their tree under ~/.autospec/scripts/.
     if [ -d "$REPO_ROOT/skills/autospec-shared/scripts" ]; then
@@ -49,15 +73,42 @@ shippable_paths() {
         "$REPO_ROOT/install.sh" \
         | sed -E 's#^.*::##'
     fi
+    # Per-skill installers ship additional helpers into ~/.autospec/scripts/<basename>
+    # via their SHARED_SCRIPT_FILES / SKILL_SCRIPT_FILES / SHARED_LIB_SCRIPT_FILES lists
+    # (install_shared_scripts / install_skill_scripts copy src -> $HOME/.autospec/scripts/$rel).
+    # Harvest every basename declared in those lists so the guard tracks this shipping
+    # mechanism too. The references being checked come from skill surfaces / script bodies,
+    # not from these installers, so this remains a true cross-check.
+    for inst in "$REPO_ROOT"/skills/*/install.sh; do
+      [ -f "$inst" ] || continue
+      sed -nE 's/^[A-Z_]*SCRIPT_FILES="([^"]*)".*/\1/p' "$inst" | tr ' ' '\n'
+    done
   } | sort -u
 }
 
-# Every ${AUTOSPEC_SCRIPTS_DIR...}/<path> reference, reduced to the path after the var.
+# Every runtime-asset reference resolved against the installed scripts dir, reduced to
+# the path after the resolver. Two reference forms are matched:
+#   1. ${AUTOSPEC_SCRIPTS_DIR[...]}/<name>  — the canonical surface form (SKILL.md,
+#      clusters, prompts, repo-root scripts). Now also matches .yml / .json runtime
+#      assets (e.g. memory-tags.yml), not just .sh/.mjs/.ps1.
+#   2. $STAGE_DIR/<name> and ${SCRIPT_DIR}/<name>  — the sibling-resolver form used
+#      inside per-skill runtime scripts (e.g. harmonize.sh resolves STAGE_DIR to
+#      AUTOSPEC_SCRIPTS_DIR then shells out to "$STAGE_DIR/design-discover.sh"). These
+#      siblings must ALSO be shipped flat into the installed scripts dir, so they belong
+#      in the same shipped-vs-referenced cross-check.
+# lib/ sub-imports (./lib/<x>.mjs) are covered by the doc-orchestrator-style closure
+# guards / copy steps and are not extracted here.
 referenced_paths() {
-  surface_files | while read -r f; do
-    grep -hoE '\$\{AUTOSPEC_SCRIPTS_DIR[^}]*\}/[A-Za-z0-9_./-]+\.(sh|mjs|ps1)' "$f" 2>/dev/null
+  # Match only a single basename after the resolver (no embedded '/'), so relative
+  # ES-module imports (./lib/x.mjs, ../../autospec-shared/scripts/y.mjs) and other
+  # checkout-relative paths are not mistaken for installed-scripts-dir siblings — those
+  # have their own dedicated closure/subdir guards.
+  reference_scan_files | while read -r f; do
+    grep -hoE '\$\{AUTOSPEC_SCRIPTS_DIR[^}]*\}/[A-Za-z0-9_.-]+\.(sh|mjs|ps1|yml|json)' "$f" 2>/dev/null
+    grep -hoE '\$\{?STAGE_DIR\}?/[A-Za-z0-9_.-]+\.(sh|mjs|ps1|yml|json)' "$f" 2>/dev/null
   done \
     | sed -E 's#\$\{AUTOSPEC_SCRIPTS_DIR[^}]*\}/##' \
+    | sed -E 's#\$\{?STAGE_DIR\}?/##' \
     | sort -u
 }
 


### PR DESCRIPTION
Part of the 2026-06-20 whole-project review. Fixes **3 clean-install crashes** (referenced-but-unshipped runtime scripts) + the gate that should have caught them.

- `memory-tags.yml` — `assemble-impl-prompt.sh` hard-exits without it (`.yml` excluded from copy glob).
- **autospec-harmonize** entire `scripts/` set (9 + `lib/color.mjs`) — `/autospec-harmonize` crashed on clean install.
- `qa-visual-findings.sh` — autospec-qa a11y cluster.

**Meta-fix:** `ship-completeness.bats` now scans `clusters/`, `scripts/`, root `scripts/` + `.yml`/`.json` refs + the `$STAGE_DIR` sibling form, and harvests per-skill `*_SCRIPT_FILES` (cleared a `mutation-gate.sh` false positive). TDD: it flagged exactly the 3 before the ship.

## Verification
- **Real isolated install** (`HOME=$tmp bash install.sh`): memory-tags.yml + 9/9 harmonize + lib/color.mjs + qa-visual-findings.sh all land.
- `bats ship-completeness.bats` 5/5 (red pre-ship → green); `bash scripts/validate.sh` exit 0; no deletions.