### PR TITLE
test: land 6 lint-issue negative-path fixtures + YAML skip->fail-closed

### DIFF
--- a/tests/cli/test_homebrew_formula.bats
+++ b/tests/cli/test_homebrew_formula.bats
@@ -56,7 +56,8 @@ PYEOF
   elif command -v yamllint >/dev/null 2>&1; then
     yamllint "$REPO_ROOT/$WORKFLOW"
   else
-    skip "no yaml validator available (python3+yaml or yamllint)"
+    echo "no YAML validator (install python3-yaml or yamllint) — cannot validate workflow YAML" >&2
+    return 1
   fi
 }
 

--- a/tests/docs/test_quickstart.bats
+++ b/tests/docs/test_quickstart.bats
@@ -120,6 +120,7 @@ PYEOF
   elif command -v yamllint >/dev/null 2>&1; then
     yamllint "$PAGES_WORKFLOW"
   else
-    skip "no yaml validator available"
+    echo "no YAML validator (install python3-yaml or yamllint) — cannot validate workflow YAML" >&2
+    return 1
   fi
 }

--- a/tests/fixtures/issue-quality/bad-ac-empty.md
+++ b/tests/fixtures/issue-quality/bad-ac-empty.md
@@ -1,0 +1,36 @@
+## Goal
+
+Add `scripts/lint-issue.sh` that exits non-zero when an issue body fails the §3 quality contract.
+
+## Files to read first
+
+- scripts/lint-issue.sh
+- scripts/validate.sh
+
+## Implementation outline
+
+1. Parse the `--json` and `--help` flags plus the body-file argument.
+2. Extract each `## ` section and apply the per-rule checks.
+3. Accumulate findings and exit with their count.
+
+## Tests required
+
+- bats tests/unit/test_lint_issue.bats
+
+## Dependencies
+
+Depends on issue #152
+
+## Files touched
+
+- scripts/lint-issue.sh
+
+## Acceptance criteria
+
+## Verification
+
+### Primary smoke test (inner loop)
+
+```bash
+bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md && echo OK
+```

--- a/tests/fixtures/issue-quality/bad-ac-prose.md
+++ b/tests/fixtures/issue-quality/bad-ac-prose.md
@@ -1,0 +1,39 @@
+## Goal
+
+Add `scripts/lint-issue.sh` that exits non-zero when an issue body fails the §3 quality contract.
+
+## Files to read first
+
+- scripts/lint-issue.sh
+- scripts/validate.sh
+
+## Implementation outline
+
+1. Parse the `--json` and `--help` flags plus the body-file argument.
+2. Extract each `## ` section and apply the per-rule checks.
+3. Accumulate findings and exit with their count.
+
+## Tests required
+
+- bats tests/unit/test_lint_issue.bats
+
+## Dependencies
+
+Depends on issue #152
+
+## Files touched
+
+- scripts/lint-issue.sh
+
+## Acceptance criteria
+
+- [ ] `bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md` exits 0.
+The script also prints findings to `stderr` for issue #152.
+
+## Verification
+
+### Primary smoke test (inner loop)
+
+```bash
+bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md && echo OK
+```

--- a/tests/fixtures/issue-quality/bad-ac-subjective.md
+++ b/tests/fixtures/issue-quality/bad-ac-subjective.md
@@ -1,0 +1,38 @@
+## Goal
+
+Add `scripts/lint-issue.sh` that exits non-zero when an issue body fails the §3 quality contract.
+
+## Files to read first
+
+- scripts/lint-issue.sh
+- scripts/validate.sh
+
+## Implementation outline
+
+1. Parse the `--json` and `--help` flags plus the body-file argument.
+2. Extract each `## ` section and apply the per-rule checks.
+3. Accumulate findings and exit with their count.
+
+## Tests required
+
+- bats tests/unit/test_lint_issue.bats
+
+## Dependencies
+
+Depends on issue #152
+
+## Files touched
+
+- scripts/lint-issue.sh
+
+## Acceptance criteria
+
+- [ ] The `scripts/lint-issue.sh` output looks clean for issue #152.
+
+## Verification
+
+### Primary smoke test (inner loop)
+
+```bash
+bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md && echo OK
+```

--- a/tests/fixtures/issue-quality/bad-goal-multi-sentence.md
+++ b/tests/fixtures/issue-quality/bad-goal-multi-sentence.md
@@ -1,0 +1,40 @@
+## Goal
+
+Add `scripts/lint-issue.sh`. It exits non-zero when an issue body fails the §3 quality contract. It also prints findings to stderr. It supports a JSON mode.
+
+## Files to read first
+
+- scripts/lint-issue.sh
+- scripts/validate.sh
+
+## Implementation outline
+
+1. Parse the `--json` and `--help` flags plus the body-file argument.
+2. Extract each `## ` section and apply the per-rule checks.
+3. Accumulate findings and exit with their count.
+
+## Tests required
+
+- bats tests/unit/test_lint_issue.bats
+
+## Dependencies
+
+Depends on issue #152
+
+## Files touched
+
+- scripts/lint-issue.sh
+
+## Acceptance criteria
+
+- [ ] `bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md` exits 0.
+- [ ] `scripts/validate.sh` exits 0 after adding the fixture files.
+- [ ] `grep -c GOAL_VAGUE` returns 0 for this file.
+
+## Verification
+
+### Primary smoke test (inner loop)
+
+```bash
+bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md && echo OK
+```

--- a/tests/fixtures/issue-quality/bad-smoke-no-fence.md
+++ b/tests/fixtures/issue-quality/bad-smoke-no-fence.md
@@ -1,0 +1,37 @@
+## Goal
+
+Add `scripts/lint-issue.sh` that exits non-zero when an issue body fails the §3 quality contract.
+
+## Files to read first
+
+- scripts/lint-issue.sh
+- scripts/validate.sh
+
+## Implementation outline
+
+1. Parse the `--json` and `--help` flags plus the body-file argument.
+2. Extract each `## ` section and apply the per-rule checks.
+3. Accumulate findings and exit with their count.
+
+## Tests required
+
+- bats tests/unit/test_lint_issue.bats
+
+## Dependencies
+
+Depends on issue #152
+
+## Files touched
+
+- scripts/lint-issue.sh
+
+## Acceptance criteria
+
+- [ ] `bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md` exits 0.
+- [ ] `scripts/validate.sh` exits 0 after adding the fixture files.
+
+## Verification
+
+### Primary smoke test (inner loop)
+
+Run `bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md` and confirm it exits 0.

--- a/tests/fixtures/issue-quality/bad-smoke-placeholder.md
+++ b/tests/fixtures/issue-quality/bad-smoke-placeholder.md
@@ -1,0 +1,39 @@
+## Goal
+
+Add `scripts/lint-issue.sh` that exits non-zero when an issue body fails the §3 quality contract.
+
+## Files to read first
+
+- scripts/lint-issue.sh
+- scripts/validate.sh
+
+## Implementation outline
+
+1. Parse the `--json` and `--help` flags plus the body-file argument.
+2. Extract each `## ` section and apply the per-rule checks.
+3. Accumulate findings and exit with their count.
+
+## Tests required
+
+- bats tests/unit/test_lint_issue.bats
+
+## Dependencies
+
+Depends on issue #152
+
+## Files touched
+
+- scripts/lint-issue.sh
+
+## Acceptance criteria
+
+- [ ] `bash scripts/lint-issue.sh tests/fixtures/issue-quality/good.md` exits 0.
+- [ ] `scripts/validate.sh` exits 0 after adding the fixture files.
+
+## Verification
+
+### Primary smoke test (inner loop)
+
+```bash
+bash scripts/lint-issue.sh tests/fixtures/issue-quality/<TODO>
+```

--- a/tests/unit/test_lint_issue.bats
+++ b/tests/unit/test_lint_issue.bats
@@ -30,10 +30,7 @@ setup() {
     echo "$output" | grep -q "GOAL_HEDGE"
 }
 
-@test "lint-issue: bad-goal-multi-sentence triggers GOAL_NOT_ONE_SENTENCE (skip if no fixture)" {
-    if [ ! -f "$FIX/bad-goal-multi-sentence.md" ]; then
-        skip "fixture bad-goal-multi-sentence.md not yet landed"
-    fi
+@test "lint-issue: bad-goal-multi-sentence triggers GOAL_NOT_ONE_SENTENCE" {
     run bash -c "bash '$LINT' '$FIX/bad-goal-multi-sentence.md' 2>&1"
     [ "$status" -ge 1 ]
     echo "$output" | grep -q "GOAL_NOT_ONE_SENTENCE"
@@ -41,19 +38,13 @@ setup() {
 
 # ── AC rule cases ─────────────────────────────────────────────────────────────
 
-@test "lint-issue: bad-ac-prose triggers AC_PROSE (skip if no fixture)" {
-    if [ ! -f "$FIX/bad-ac-prose.md" ]; then
-        skip "fixture bad-ac-prose.md not yet landed"
-    fi
+@test "lint-issue: bad-ac-prose triggers AC_PROSE" {
     run bash -c "bash '$LINT' '$FIX/bad-ac-prose.md' 2>&1"
     [ "$status" -ge 1 ]
     echo "$output" | grep -q "AC_PROSE"
 }
 
-@test "lint-issue: bad-ac-subjective triggers AC_SUBJECTIVE (skip if no fixture)" {
-    if [ ! -f "$FIX/bad-ac-subjective.md" ]; then
-        skip "fixture bad-ac-subjective.md not yet landed"
-    fi
+@test "lint-issue: bad-ac-subjective triggers AC_SUBJECTIVE" {
     run bash -c "bash '$LINT' '$FIX/bad-ac-subjective.md' 2>&1"
     [ "$status" -ge 1 ]
     echo "$output" | grep -q "AC_SUBJECTIVE"
@@ -65,10 +56,7 @@ setup() {
     echo "$output" | grep -q "AC_TOO_LONG"
 }
 
-@test "lint-issue: bad-ac-empty triggers AC_EMPTY (skip if no fixture)" {
-    if [ ! -f "$FIX/bad-ac-empty.md" ]; then
-        skip "fixture bad-ac-empty.md not yet landed"
-    fi
+@test "lint-issue: bad-ac-empty triggers AC_EMPTY" {
     run bash -c "bash '$LINT' '$FIX/bad-ac-empty.md' 2>&1"
     [ "$status" -ge 1 ]
     echo "$output" | grep -q "AC_EMPTY"
@@ -82,19 +70,13 @@ setup() {
     echo "$output" | grep -q "SMOKE_MULTI_LINE"
 }
 
-@test "lint-issue: bad-smoke-placeholder triggers SMOKE_PLACEHOLDER (skip if no fixture)" {
-    if [ ! -f "$FIX/bad-smoke-placeholder.md" ]; then
-        skip "fixture bad-smoke-placeholder.md not yet landed"
-    fi
+@test "lint-issue: bad-smoke-placeholder triggers SMOKE_PLACEHOLDER" {
     run bash -c "bash '$LINT' '$FIX/bad-smoke-placeholder.md' 2>&1"
     [ "$status" -ge 1 ]
     echo "$output" | grep -q "SMOKE_PLACEHOLDER"
 }
 
-@test "lint-issue: bad-smoke-no-fence triggers SMOKE_NOT_FENCED (skip if no fixture)" {
-    if [ ! -f "$FIX/bad-smoke-no-fence.md" ]; then
-        skip "fixture bad-smoke-no-fence.md not yet landed"
-    fi
+@test "lint-issue: bad-smoke-no-fence triggers SMOKE_NOT_FENCED" {
     run bash -c "bash '$LINT' '$FIX/bad-smoke-no-fence.md' 2>&1"
     [ "$status" -ge 1 ]
     echo "$output" | grep -q "SMOKE_NOT_FENCED"


### PR DESCRIPTION
Part of the 2026-06-20 whole-project review (test-coverage holes).

- **6 lint-issue fixtures** — `test_lint_issue.bats` had 6 negative-path tests permanently `skip`-ing on fixtures never landed (the goal/AC/smoke reject paths never ran). Added each, minimally mutated from good.md to trip **exactly one** rule (GOAL_NOT_ONE_SENTENCE/AC_PROSE/AC_SUBJECTIVE/AC_EMPTY/SMOKE_PLACEHOLDER/SMOKE_NOT_FENCED — verified 1 finding each), removed the skip guards → **14 ok / 0 skips**.
- **YAML skip→fail-closed** — the workflow-YAML validity checks (`test_homebrew_formula`, `test_quickstart`) tried python3-yaml→yamllint→`skip`; changed the final `skip` to `return 1` so a missing validator can't silently pass. pyyaml present → happy path green.

## Verification
- `bats tests/unit/test_lint_issue.bats` — 14 ok, 0 skips; each fixture trips its target RULE_ID.
- `bats test_homebrew_formula.bats test_quickstart.bats` — pass; `bash scripts/validate.sh` exit 0; no deletions.