### PR TITLE
fix(validate): dynamic+conditional check_shared_script_install (#1278)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -483,22 +483,61 @@ check_codex_skills_install() {
     done
 }
 
-# Every per-skill installer must install shared helper scripts into
-# ~/.autospec/scripts so runtime commands work in target repositories that do
-# not contain this repo's scripts/ directory.
+# Every per-skill installer that REFERENCES a shared runtime helper must install
+# the shared-helper runtime dir (~/.autospec/scripts) so those commands work in
+# target repositories that do not contain this repo's scripts/ directory.
+#
+# Dynamic + conditional (was a hardcoded ~14-skill list against a fixed 8-helper
+# set — the hardcoded-subset class: new per-skill installers silently escaped the
+# assertion, and the 5 unlisted install.sh skills could not be blindly required
+# because some legitimately ship no shared helpers). Now:
+#   1. iterate every per-skill install.sh present under skills/*/;
+#   2. for each, determine whether the skill NEEDS shared helpers — TRUE iff any
+#      of its trio/cluster/script files reference a `${AUTOSPEC_SCRIPTS_DIR...}/<h>`
+#      runtime helper whose <h> is SHARED: it lives in repo-root scripts/ OR in
+#      skills/autospec-shared/scripts/ (the shared-lib dir) and is NOT one of the
+#      skill's OWN scripts/<h>;
+#   3. needs-shared  -> assert the install.sh installs into ~/.autospec/scripts
+#      (the runtime-dir mechanism that ships the shared helpers; this is
+#      name-agnostic so it tolerates the install_shared_scripts /
+#      install_runtime_scripts naming variance across siblings);
+#   4. otherwise     -> exempt (e2e-clone / playwright / secaudit and any other
+#      skill that references no shared runtime helper).
+#
+# referenced_shared_helpers SKILL_DIR -> prints the (sorted, unique) basenames of
+# the SHARED runtime helpers a skill references.
+referenced_shared_helpers() {
+    rsh_skill_dir="$1"
+    rsh_name="$(basename "$rsh_skill_dir")"
+    grep -rhoE '\$\{AUTOSPEC_SCRIPTS_DIR[^}]*\}/[A-Za-z0-9._-]+' "$rsh_skill_dir" 2>/dev/null \
+        | sed -E 's#^.*\}/##' | sort -u | while IFS= read -r rsh_h; do
+        [ -n "$rsh_h" ] || continue
+        # Skip the skill's own scripts/<helper>.
+        [ -f "$rsh_skill_dir/scripts/$rsh_h" ] && continue
+        # SHARED iff present in repo-root scripts/ or skills/autospec-shared/scripts/.
+        if [ -f "scripts/$rsh_h" ] || [ -f "skills/autospec-shared/scripts/$rsh_h" ]; then
+            printf '%s\n' "$rsh_h"
+        fi
+    done
+}
+
 check_shared_script_install() {
-    info "shared helper install: all skills"
-    helpers="autospec-stop.sh autospec-usage-limit.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh"
-    for s in autospec autospec-release autospec-split autospec-define autospec-run autospec-listen autospec-classify autospec-story autospec-stop autospec-sweep autospec-design autospec-fleet autospec-qa autospec-doc; do
-        f="skills/$s/install.sh"
-        grep -q 'install_shared_scripts' "$f" \
-            || fail "$f missing install_shared_scripts function/call"
-        grep -q '\.autospec/scripts' "$f" \
-            || fail "$f missing ~/.autospec/scripts install target"
-        for helper in $helpers; do
-            grep -q "$helper" "$f" \
-                || fail "$f missing shared helper install entry: $helper"
-        done
+    info "shared helper install: all skills (dynamic + conditional)"
+    for f in skills/*/install.sh; do
+        [ -f "$f" ] || continue
+        skill_dir="$(dirname "$f")"
+        name="$(basename "$skill_dir")"
+        shared="$(referenced_shared_helpers "$skill_dir")"
+        if [ -z "$shared" ]; then
+            info "  exempt (no shared runtime helper referenced): $name"
+            continue
+        fi
+        # needs-shared: must ship the shared-helper runtime dir.
+        if ! grep -q '\.autospec/scripts' "$f"; then
+            printf 'validate: %s references shared runtime helper(s):\n' "$name" >&2
+            printf '%s\n' "$shared" | sed 's/^/    /' >&2
+            fail "$f references shared runtime helper(s) but does not install into ~/.autospec/scripts"
+        fi
     done
 }
 

--- a/skills/autospec-review/install.sh
+++ b/skills/autospec-review/install.sh
@@ -37,6 +37,11 @@ USE_SYMLINK=0
 DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
+# Shared runtime helpers this skill calls via ${AUTOSPEC_SCRIPTS_DIR}/<name> and
+# that live under skills/autospec-shared/scripts/ (not repo-root scripts/). They
+# MUST ship into ~/.autospec/scripts so a standalone install of autospec-review
+# can run /autospec-review in a target repo without this checkout present.
+SHARED_LIB_SCRIPT_FILES="emit-gaps.sh inject-relevant-memory.sh"
 
 # ---------- helpers --------------------------------------------------------
 
@@ -75,6 +80,7 @@ fetch_source_files() {
     fi
     TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
     info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
+    RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
     mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex"
     for rel in SKILL.md opencode/agent.md codex/prompt.md; do
         if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
@@ -82,7 +88,44 @@ fetch_source_files() {
             exit 1
         fi
     done
+    mkdir -p "$TMP_FETCH_DIR/lib-scripts"
+    for rel in $SHARED_LIB_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/skills/autospec-shared/scripts/$rel" \
+            -o "$TMP_FETCH_DIR/lib-scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/skills/autospec-shared/scripts/$rel"
+            exit 1
+        fi
+    done
     SKILL_DIR="$TMP_FETCH_DIR"
+}
+
+# resolve_shared_lib_scripts_dir — locate skills/autospec-shared/scripts/ in a
+# full checkout, or the fetched lib-scripts/ dir when running from stdin.
+resolve_shared_lib_scripts_dir() {
+    checkout_root="$(cd "$SKILL_DIR/../.." 2>/dev/null && pwd || true)"
+    if [ -n "$checkout_root" ] && [ -d "$checkout_root/skills/autospec-shared/scripts" ]; then
+        printf '%s\n' "$checkout_root/skills/autospec-shared/scripts"
+    elif [ -d "$SKILL_DIR/lib-scripts" ]; then
+        printf '%s\n' "$SKILL_DIR/lib-scripts"
+    else
+        printf ''
+    fi
+}
+
+# install_shared_scripts — ship the shared-lib runtime helpers this skill calls
+# at runtime into ~/.autospec/scripts so /autospec-review works standalone.
+install_shared_scripts() {
+    lib_dir="$(resolve_shared_lib_scripts_dir)"
+    if [ -z "$lib_dir" ]; then
+        err "missing shared-lib scripts directory; cannot install autospec-review helpers"
+        return 1
+    fi
+    for rel in $SHARED_LIB_SCRIPT_FILES; do
+        install_one "$lib_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
 }
 
 install_one() {
@@ -226,6 +269,12 @@ if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
     installed_paths="${installed_paths}  Codex CLI:   ${CODEX_DEST}\n"
     installed_paths="${installed_paths}  Codex skill: ${CODEX_DIR}/skills/${SKILL_NAME}/SKILL.md\n"
 fi
+
+# ---------- install shared helper scripts ---------------------------------
+
+info ""
+info "Shared autospec helper scripts:"
+install_shared_scripts
 
 # ---------- final summary --------------------------------------------------
 

--- a/tests/validate-shared-script-install.bats
+++ b/tests/validate-shared-script-install.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+# tests/validate-shared-script-install.bats — bats tests for scripts/validate.sh
+# check_shared_script_install() dynamic + conditional behavior (issue #1278).
+#
+# The old check iterated a hardcoded ~14-skill list against a fixed 8-helper set,
+# so new per-skill installers silently escaped the shared-helper-install
+# assertion. The new check is DYNAMIC over skills/*/install.sh and CONDITIONAL:
+# a skill is only required to install into ~/.autospec/scripts when it actually
+# references a SHARED ${AUTOSPEC_SCRIPTS_DIR}/<helper> runtime helper (one that
+# lives in repo-root scripts/ or skills/autospec-shared/scripts/ and is NOT one
+# of the skill's own scripts/<helper>).
+#
+# These tests source the REAL functions out of validate.sh (so they stay in
+# lockstep with the source) and run them against a synthetic skills/ tree.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/validate.sh"
+
+# Extract the two functions under test from the live validate.sh into a sourceable
+# snippet, with minimal fail/info stubs. We extract by function name with awk so
+# edits to the source flow straight into the test.
+extract_funcs() {
+    awk '
+        $0 ~ /^referenced_shared_helpers\(\) \{/ {grab=1}
+        $0 ~ /^check_shared_script_install\(\) \{/ {grab=1}
+        grab {print}
+        grab && /^\}$/ {grab=0}
+    ' "$SCRIPT"
+}
+
+# Run check_shared_script_install against a synthetic skills/ tree rooted at $1.
+# Prints output, returns the check exit status.
+run_check_in_tree() {
+    local tree="$1"
+    (
+        cd "$tree"
+        bash -c "
+            set -u
+            fail() { printf 'validate: FAIL — %s\n' \"\$*\" >&2; exit 1; }
+            info() { printf 'validate: %s\n' \"\$*\"; }
+            $(extract_funcs)
+            check_shared_script_install
+        "
+    )
+}
+
+# Build a synthetic repo tree: repo-root scripts/<shared-helper>, an
+# autospec-shared/scripts/<lib-helper>, and per-skill dirs created by the caller.
+new_tree() {
+    local t
+    t="$(mktemp -d)"
+    mkdir -p "$t/scripts" "$t/skills/autospec-shared/scripts"
+    # A shared repo-root helper and a shared-lib helper.
+    printf '#!/bin/sh\n' > "$t/scripts/shared-helper.sh"
+    printf '#!/bin/sh\n' > "$t/skills/autospec-shared/scripts/lib-helper.sh"
+    printf '%s' "$t"
+}
+
+# Add a skill that references a SHARED helper but whose install.sh does NOT
+# install into ~/.autospec/scripts (the real-gap shape, e.g. pre-fix review).
+add_skill_needs_no_install() {
+    local tree="$1" name="$2"
+    mkdir -p "$tree/skills/$name"
+    cat > "$tree/skills/$name/SKILL.md" <<EOF
+---
+name: $name
+---
+Runtime call:
+\`bash "\${AUTOSPEC_SCRIPTS_DIR:-\$HOME/.autospec/scripts}/shared-helper.sh" --go\`
+EOF
+    cat > "$tree/skills/$name/install.sh" <<'EOF'
+#!/usr/bin/env sh
+# installs nothing into the shared runtime dir
+echo "installed skill files only"
+EOF
+}
+
+# Add a skill that references a SHARED helper AND installs into ~/.autospec/scripts.
+add_skill_needs_with_install() {
+    local tree="$1" name="$2"
+    mkdir -p "$tree/skills/$name"
+    cat > "$tree/skills/$name/SKILL.md" <<EOF
+---
+name: $name
+---
+Runtime call:
+\`bash "\${AUTOSPEC_SCRIPTS_DIR:-\$HOME/.autospec/scripts}/lib-helper.sh" --go\`
+EOF
+    cat > "$tree/skills/$name/install.sh" <<'EOF'
+#!/usr/bin/env sh
+install_shared_scripts() {
+    cp "$SRC/lib-helper.sh" "$HOME/.autospec/scripts/lib-helper.sh"
+}
+EOF
+}
+
+# Add a skill that references NO shared helper (exempt). It only references its
+# OWN scripts/<helper>, so it must NOT be required to install the shared dir.
+add_skill_exempt() {
+    local tree="$1" name="$2"
+    mkdir -p "$tree/skills/$name/scripts"
+    printf '#!/bin/sh\n' > "$tree/skills/$name/scripts/own-helper.sh"
+    cat > "$tree/skills/$name/SKILL.md" <<EOF
+---
+name: $name
+---
+Runtime call (own script):
+\`bash "\${AUTOSPEC_SCRIPTS_DIR:-\$HOME/.autospec/scripts}/own-helper.sh" --go\`
+EOF
+    cat > "$tree/skills/$name/install.sh" <<'EOF'
+#!/usr/bin/env sh
+echo "no shared runtime dir install needed"
+EOF
+}
+
+teardown() {
+    [ -n "${TREE:-}" ] && rm -rf "$TREE"
+    return 0
+}
+
+@test "needs-shared skill WITHOUT ~/.autospec/scripts install FAILS the check" {
+    TREE="$(new_tree)"
+    add_skill_needs_no_install "$TREE" "skill-gap"
+    run run_check_in_tree "$TREE"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"skill-gap"* ]]
+    [[ "$output" == *".autospec/scripts"* ]]
+}
+
+@test "skill referencing NO shared helper is EXEMPT (passes)" {
+    TREE="$(new_tree)"
+    add_skill_exempt "$TREE" "skill-exempt"
+    run run_check_in_tree "$TREE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"exempt"* ]]
+}
+
+@test "needs-shared skill WITH ~/.autospec/scripts install passes" {
+    TREE="$(new_tree)"
+    add_skill_needs_with_install "$TREE" "skill-ok"
+    run run_check_in_tree "$TREE"
+    [ "$status" -eq 0 ]
+}
+
+@test "exempt + ok pass together while the gap skill still fails (mixed tree)" {
+    TREE="$(new_tree)"
+    add_skill_exempt "$TREE" "skill-exempt"
+    add_skill_needs_with_install "$TREE" "skill-ok"
+    add_skill_needs_no_install "$TREE" "skill-gap"
+    run run_check_in_tree "$TREE"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"skill-gap"* ]]
+}
+
+@test "referenced_shared_helpers skips the skill's OWN scripts/<helper>" {
+    TREE="$(new_tree)"
+    # Skill references BOTH its own helper and a shared helper; only the shared
+    # one should make it needs-shared. Remove the install -> must fail naming the
+    # shared helper, not the own one.
+    mkdir -p "$TREE/skills/skill-mixed/scripts"
+    printf '#!/bin/sh\n' > "$TREE/skills/skill-mixed/scripts/own-helper.sh"
+    cat > "$TREE/skills/skill-mixed/SKILL.md" <<'EOF'
+---
+name: skill-mixed
+---
+Own: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/own-helper.sh"`
+Shared: `bash "${AUTOSPEC_SCRIPTS_DIR:-$HOME/.autospec/scripts}/shared-helper.sh"`
+EOF
+    printf '#!/usr/bin/env sh\necho noop\n' > "$TREE/skills/skill-mixed/install.sh"
+    run run_check_in_tree "$TREE"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"shared-helper.sh"* ]]
+    [[ "$output" != *"own-helper.sh"* ]]
+}


### PR DESCRIPTION
Closes #1278 (2026-06-20 review follow-up; the shared-script sibling of the codex-install fix in #1277).

`check_shared_script_install` was hardcoded to ~14 skills. Now **dynamic + conditional**: a skill needs shared helpers iff it references a `${AUTOSPEC_SCRIPTS_DIR}/<helper>` that's shared (repo-root scripts/ or autospec-shared/scripts/, not its own scripts/). needs-shared → assert it installs into ~/.autospec/scripts (name-agnostic — tolerates install_shared_scripts vs install_runtime_scripts); else exempt. 27 install.sh skills: 7 exempt, 20 needs-shared.

**Real gap fixed:** `autospec-review` referenced emit-gaps.sh + inject-relevant-memory.sh but shipped nothing → standalone install broke. Added the shared-lib install mechanism (isolated install now lands both). resume already ships its helper.

## Verification
- new `tests/validate-shared-script-install.bats` — 5/5 (incl. the fail-case = teeth + own-scripts exclusion).
- review isolated install ships both referenced helpers; conditional teeth proven (strip → validate exit 1 → restore).
- `bash scripts/validate.sh` exit 0; no deletions. (Per-helper-by-name coverage stays with ship-completeness #1273.)