### PR TITLE
test(context-monitor): green 16 rotted un-gated python tests (#1280)

### DIFF
--- a/packages/autospec_context_monitor/tests/adapters/test_claude_hook.py
+++ b/packages/autospec_context_monitor/tests/adapters/test_claude_hook.py
@@ -96,8 +96,15 @@ def test_install_hook_mode_claude_merges_keys(tmp_path, monkeypatch):
     assert data.get("existingKey") == "preserved", "existing keys must not be clobbered"
     assert "PreCompact" in data.get("hooks", {}), "hooks.PreCompact must be added"
     assert "SessionStart" in data.get("hooks", {}), "hooks.SessionStart must be added"
-    # Verify the monitor command is present in the hook lists
-    pre_cmds = data["hooks"]["PreCompact"]
+    # Verify the monitor command is present in the hook lists. Claude Code's
+    # canonical schema nests each entry as
+    # {"hooks": [{"type": "command", "command": "..."}]}; descend into the
+    # nested step commands rather than substring-matching a flat string.
+    pre_cmds = [
+        step.get("command", "")
+        for entry in data["hooks"]["PreCompact"]
+        for step in entry.get("hooks", [])
+    ]
     assert any("autospec_context_monitor" in cmd and "PreCompact" in cmd for cmd in pre_cmds)
 
 
@@ -111,7 +118,18 @@ def test_install_hook_mode_claude_idempotent(tmp_path):
     settings.parent.mkdir(parents=True)
     settings.write_text("{}", encoding="utf-8")
 
-    env = {**os.environ, "HOME": str(tmp_path)}
+    # Isolate the subprocess so the surrounding harness's own hooks can't mutate
+    # the test's tmp HOME/.claude/settings.json *between* the two install runs
+    # (install.sh's writes are themselves idempotent — the flakiness is purely
+    # external mutation). Point Claude Code's config dir away from tmp HOME and
+    # disable harness hooks inside the subprocess.
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "CLAUDE_CONFIG_DIR": str(tmp_path / "claude-config-isolated"),
+        "OMC_SKIP_HOOKS": "1",
+        "DISABLE_OMC": "1",
+    }
     cmd = ["bash", str(_INSTALL_SH), "--hook-mode", "claude"]
 
     r1 = subprocess.run(cmd, env=env, capture_output=True, text=True)

--- a/packages/autospec_context_monitor/tests/test_integration_gaps.py
+++ b/packages/autospec_context_monitor/tests/test_integration_gaps.py
@@ -105,6 +105,13 @@ class _FakeAdapter:
             "handoff": "/FAKE_HANDOFF",
         }[logical]
 
+    def prompt_marker(self) -> str:
+        # Empty marker → _dispatch's _prompt_ok guard short-circuits to True
+        # without shelling out to tmux (these unit tests run without a tmux
+        # server). Matches the Protocol signature; a real adapter returns a
+        # non-empty prompt marker.
+        return ""
+
 
 def _make_valid_handoff(handoff_dir: Path) -> Path:
     """Write a structurally-valid handoff file under *handoff_dir*."""

--- a/packages/autospec_context_monitor/tests/test_session_start_handler.py
+++ b/packages/autospec_context_monitor/tests/test_session_start_handler.py
@@ -81,8 +81,16 @@ def test_install_sh_registers_session_start():
         assert "SessionStart" in hooks, (
             "hooks.SessionStart must be registered by --hook-mode claude"
         )
-        sess_cmds = hooks["SessionStart"]
+        # Claude Code's canonical schema nests each entry as
+        # {"hooks": [{"type": "command", "command": "..."}]}; descend into the
+        # nested step commands rather than substring-matching a flat string.
+        sess_entries = hooks["SessionStart"]
+        sess_cmds = [
+            step.get("command", "")
+            for entry in sess_entries
+            for step in entry.get("hooks", [])
+        ]
         assert any(
             "autospec_context_monitor" in cmd and "SessionStart" in cmd
             for cmd in sess_cmds
-        ), f"SessionStart hook must invoke autospec_context_monitor; got: {sess_cmds}"
+        ), f"SessionStart hook must invoke autospec_context_monitor; got: {sess_entries}"

--- a/packages/autospec_context_monitor/tests/test_stats.py
+++ b/packages/autospec_context_monitor/tests/test_stats.py
@@ -114,7 +114,29 @@ def test_integration_compact_and_rollover(tmp_stats, tmp_path, monkeypatch):
     engine = Engine()
     harness = "claude"
     tmux_session = "integ-test"
-    cwd = "/integ/project"
+    # Use a real tmp cwd so the rollover's handoff-discovery/validation gate
+    # (clear action reads <cwd>/.turbo/handoff) can find a valid file.
+    cwd = str(tmp_path / "integ-project")
+
+    # The 'handoff' action (added in g-004) blocks on wait_for_handoff for up
+    # to 180s; mock it to return a structurally-valid handoff path immediately
+    # so the rollover path (handoff → clear → resume) completes and records
+    # rollover_fired. Without this mock the wait times out and the clear gate
+    # never fires.
+    handoff_dir = Path(cwd) / ".turbo" / "handoff"
+    handoff_dir.mkdir(parents=True, exist_ok=True)
+    handoff_file = handoff_dir / "2026-06-20-integ.md"
+    handoff_file.write_text(
+        "# Handoff\n\n"
+        "## Status\nIn progress.\n\n"
+        "## Next step\nKeep going.\n\n"
+        + ("x" * 300)
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        main_mod, "wait_for_handoff", lambda *a, **k: handoff_file
+    )
 
     # Tick 1: 52% → compact_fired
     usage1 = Usage(used_tokens=52, max_tokens=100, model="test", estimated=False)

--- a/tests/adapters/test_base.py
+++ b/tests/adapters/test_base.py
@@ -49,6 +49,9 @@ def test_protocol_runtime_checkable():
         def command(self, logical: Literal["clear", "compact", "handoff"]) -> str:
             return f"/{logical}"
 
+        def prompt_marker(self) -> str:
+            return "> "
+
     adapter = ConcreteAdapter()
     assert isinstance(adapter, HarnessAdapter)
 

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -45,8 +45,15 @@ def test_compacted_to_rolled_at_eighty():
 
 
 def test_normal_direct_to_rolled_at_eighty():
-    """Spec: NORMAL → ROLLED direct climb (skips COMPACTED)."""
+    """Spec (compact-first): a direct climb to >=0.80 from NORMAL still
+    enters COMPACTED and emits [compact] first; compaction must always be
+    attempted before a rollover. ROLLED requires a second >=0.80 tick from
+    COMPACTED (see engine.py docstring + transitions)."""
     e = Engine()
+    actions = e.classify(u(0.80))
+    assert [a.kind for a in actions] == ["compact"]
+    assert e.state is State.COMPACTED
+    # Second >=0.80 tick (compaction hasn't dropped pct yet) → ROLLED.
     actions = e.classify(u(0.80))
     assert [a.kind for a in actions] == ["handoff", "clear", "resume"]
     assert e.state is State.ROLLED
@@ -119,7 +126,8 @@ def test_full_scripted_sequence_10_30_51_25_49_52_75_81():
 
 def test_rolled_to_normal_when_below_thirty():
     e = Engine()
-    e.classify(u(0.80))  # NORMAL → ROLLED
+    e.classify(u(0.80))  # NORMAL → COMPACTED (compact-first)
+    e.classify(u(0.80))  # COMPACTED → ROLLED
     actions = e.classify(u(0.20))  # ROLLED → NORMAL
     assert [a.kind for a in actions] == ["noop"]
     assert actions[0].payload == "reset:rolled->normal"
@@ -129,7 +137,8 @@ def test_rolled_to_normal_when_below_thirty():
 def test_rolled_noop_above_thirty():
     """ROLLED stays ROLLED if pct is still >= 30%."""
     e = Engine()
-    e.classify(u(0.80))  # → ROLLED
+    e.classify(u(0.80))  # NORMAL → COMPACTED (compact-first)
+    e.classify(u(0.80))  # COMPACTED → ROLLED
     actions = e.classify(u(0.50))
     assert actions == []
     assert e.state is State.ROLLED
@@ -138,9 +147,11 @@ def test_rolled_noop_above_thirty():
 def test_second_rollover_after_reset():
     """After ROLLED→NORMAL reset, the engine can roll again."""
     e = Engine()
-    e.classify(u(0.80))  # → ROLLED
-    e.classify(u(0.20))  # → NORMAL
-    actions = e.classify(u(0.90))  # → ROLLED again
+    e.classify(u(0.80))  # NORMAL → COMPACTED (compact-first)
+    e.classify(u(0.80))  # COMPACTED → ROLLED
+    e.classify(u(0.20))  # ROLLED → NORMAL
+    e.classify(u(0.90))  # NORMAL → COMPACTED (compact-first)
+    actions = e.classify(u(0.90))  # COMPACTED → ROLLED again
     assert [a.kind for a in actions] == ["handoff", "clear", "resume"]
     assert e.state is State.ROLLED
 


### PR DESCRIPTION
Part of epic #1280 (green + gate the un-gated suites). These context-monitor pytest suites aren't run by validate.sh and rotted to **16 failures**.

A triage found **zero production bugs** — all test-rot. Critically, the 4 engine 'rollover' tests are stale: the engine deliberately moved to **compact-first** (NORMAL→COMPACTED→ROLLED) in #783 (confirmed by engine.py's docstring + the passing g-005 tests), so 'fixing' the engine would revert that guarantee. Fixes are **test-side only** (6 test files, zero production/install.sh edits):
- engine (4): compact-first sequences/states.
- adapter Protocol stubs (8): add `prompt_marker()` (Protocol grew it at base.py:76).
- install hook schema (2): walk the nested `{hooks:[{command}]}` schema.
- stats (1): mock `wait_for_handoff`.
- idempotent (1): isolate subprocess `CLAUDE_CONFIG_DIR`+OMC flags (install.sh is idempotent).

## Verification
- Full suite: **169 passed, 0 failed** (was 16 failing). No production module / install.sh changed; no deletions.
- `bash scripts/validate.sh` exit 0.

Next in #1280: wire pytest into validate so these can't re-rot, then CI-ubuntu-clean.