### PR TITLE
fix(context-monitor): honest hook-mode + non-blocking poll loop (#898)

### DIFF
--- a/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/__main__.py
@@ -23,7 +23,9 @@ The daemon (tmux mode):
    - Checks ``~/.autospec/no-auto-rollover.flag`` (kill-switch).
    - Checks the tmux session is still alive.
    - Reads Usage via the selected adapter; runs Engine.classify(); dispatches
-     Actions via inject/wait_for_handoff.
+     Actions via inject. A pending ``/create-handoff`` is awaited
+     non-blockingly across ticks (see ``_PendingHandoff``) so the poll cadence
+     is never frozen.
 4. Removes the PID file on normal exit or SIGTERM.
 """
 
@@ -40,16 +42,37 @@ from pathlib import Path
 
 from .adapters.base import TranscriptNotFoundError, Usage
 from .engine import Action, Engine, State
-from .handoff import HandoffTimeoutError, validate_handoff, wait_for_handoff
+from .handoff import (
+    HandoffTimeoutError,
+    check_handoff,
+    validate_handoff,
+    wait_for_handoff,
+)
+
+# ``wait_for_handoff`` / ``HandoffTimeoutError`` are no longer called from the
+# dispatch path (the handoff wait is now non-blocking, owned by the poll loop
+# via ``_PendingHandoff`` / ``_advance_pending_handoff``). They remain imported
+# as part of this module's public surface: external callers and existing tests
+# reference ``autospec_context_monitor.__main__.wait_for_handoff``.
+_ = (HandoffTimeoutError, wait_for_handoff)
 from .injector import SessionGone, inject, session_exists, wait_for_cancel, wait_for_prompt
 from . import stats as _stats
 
 _POLL_INTERVAL = 15  # seconds
+# Wall-clock budget for the harness to write a handoff file after /create-handoff
+# is injected. Previously consumed by a single 180s blocking wait_for_handoff;
+# now spread across poll ticks so the loop stays responsive (kill-switch /
+# session-alive / usage keep being checked while the handoff is pending).
+_HANDOFF_DEADLINE = 180.0  # seconds
 _KILL_SWITCH = Path.home() / ".autospec" / "no-auto-rollover.flag"
 _MONITORS_DIR = Path.home() / ".autospec" / "monitors"
 
 # Hook-mode constants
 _HOOK_EVENTS = ("PreCompact", "SessionStart")
+# Window (seconds) used to judge a handoff "fresh" when no explicit session
+# start timestamp is available — a handoff written within this many seconds of
+# the transcript's last activity is treated as belonging to the current session.
+_FRESH_WINDOW = 6 * 60 * 60  # 6 hours
 
 
 # ---------------------------------------------------------------------------
@@ -104,10 +127,12 @@ def _dispatch(
     ``"clear"`` → ``/new``, OpenCode maps ``"handoff"`` to a prose prompt).
 
     Handoff handling:
-    - ``Action('handoff')`` injects ``adapter.command('handoff')`` then blocks
-      on :func:`wait_for_handoff` for up to 180s. On
-      :class:`HandoffTimeoutError`, the rollover is aborted (returns True so
-      the main loop reverts engine state to COMPACTED).
+    - ``Action('handoff')`` injects ``adapter.command('handoff')`` and returns
+      immediately. It does NOT block waiting for the handoff file — that wait
+      is owned by the main poll loop via :class:`_PendingHandoff` /
+      :func:`_advance_pending_handoff`, which polls non-blockingly each tick so
+      the loop stays responsive. The deferred ``clear`` + ``resume`` actions
+      are dispatched once the handoff file is observed.
     - ``Action('clear')`` validates the most recent handoff file under
       ``<cwd>/.turbo/handoff`` (per spec) before injecting.
 
@@ -125,8 +150,9 @@ def _dispatch(
 
     Returns:
         ``True`` if the action was canceled (user pressed Esc during the
-        clear cancel window, handoff failed validation, or
-        wait_for_handoff timed out); ``False`` otherwise.
+        clear cancel window, or the handoff failed validation); ``False``
+        otherwise. The handoff *timeout* path no longer flows through here —
+        it is handled by :func:`_advance_pending_handoff`.
     """
     if action.kind == "noop":
         _log(logf, {"event": "noop", "payload": action.payload})
@@ -179,33 +205,17 @@ def _dispatch(
         return False
 
     if action.kind == "handoff":
+        # Inject /create-handoff and return immediately. The blocking wait for
+        # the handoff file to appear is NOT done here — it would freeze the
+        # entire poll loop for up to 180s. Instead the main loop carries a
+        # deadline-based "pending handoff" state and polls non-blockingly each
+        # tick (see _check_pending_handoff and the loop). Injection of the
+        # subsequent /clear + resume is deferred until the file is observed.
         cmd = adapter.command("handoff") if adapter is not None else "/create-handoff"
-        since = time.time()
         _log(logf, {"event": "inject", "kind": "handoff", "cmd": cmd})
         if not _prompt_ok("handoff"):
             return False
         inject(tmux_session, cmd)
-        # Block until the harness writes a fresh handoff file under
-        # <cwd>/.turbo/handoff/.  Must complete before /clear (next action
-        # in [handoff, clear, resume]) is injected, otherwise the handoff
-        # payload is lost.
-        try:
-            path = wait_for_handoff(
-                Path(cwd) if cwd else Path.cwd(),
-                since=since,
-                timeout=180.0,
-            )
-            _log(logf, {"event": "handoff_written", "path": str(path)})
-        except HandoffTimeoutError as exc:
-            _log(logf, {"event": "handoff_timeout", "err": str(exc)})
-            _stats.record(
-                "handoff_timeout",
-                harness=harness,
-                tmux_session=tmux_session,
-                pct=round(pct, 4),
-                cwd=cwd,
-            )
-            return True
         return False
 
     if action.kind == "clear":
@@ -404,18 +414,186 @@ def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) ->
             )
 
 
+class _PendingHandoff:
+    """Deadline-based carrier for an in-flight ``/create-handoff`` wait.
+
+    Created when the daemon injects ``/create-handoff`` (the ``handoff``
+    action) and consulted on every subsequent poll tick. It replaces the old
+    single 180s blocking :func:`wait_for_handoff` call so the poll loop keeps
+    checking the kill-switch / session-alive / usage while the handoff is
+    pending.
+
+    Attributes:
+        since:    Timestamp captured just before ``/create-handoff`` was
+                  injected; only handoff files newer than this count.
+        deadline: ``time.monotonic()`` value past which the wait is abandoned.
+        rest:     The remaining actions to run once the handoff appears
+                  (typically ``[clear, resume]``).
+    """
+
+    __slots__ = ("since", "deadline", "rest")
+
+    def __init__(self, since: float, deadline: float, rest: list[Action]) -> None:
+        self.since = since
+        self.deadline = deadline
+        self.rest = rest
+
+
+def _advance_pending_handoff(
+    pending: _PendingHandoff,
+    repo_root: Path,
+    logf: Path,
+    *,
+    harness: str,
+    tmux_session: str,
+    cwd: str,
+    pct: float,
+    adapter,
+    now: float | None = None,
+) -> tuple[str, bool]:
+    """Advance an in-flight handoff wait by exactly one non-blocking poll.
+
+    Performs a single :func:`check_handoff` scan (never blocks). When the
+    handoff file has appeared, dispatches the deferred actions (``clear`` then
+    ``resume``); when the deadline has passed without a file, reports a timeout.
+
+    Args:
+        pending: The :class:`_PendingHandoff` carrier to advance.
+        repo_root: Repo root containing ``.turbo/handoff``.
+        logf: Daemon log path.
+        now: Injectable ``time.monotonic()`` value (for fast, deterministic
+             tests). Defaults to the real clock.
+
+    Returns:
+        A ``(status, canceled)`` tuple. ``status`` is one of:
+        - ``"pending"`` — no file yet and deadline not reached; keep waiting.
+        - ``"done"``    — handoff observed; deferred actions dispatched.
+        - ``"timeout"`` — deadline exceeded with no handoff; rollover aborted.
+        ``canceled`` is ``True`` when the loop should revert engine state to
+        COMPACTED (on timeout, or if a deferred action canceled).
+    """
+    path = check_handoff(repo_root, pending.since)
+    if path is not None:
+        _log(logf, {"event": "handoff_written", "path": str(path)})
+        canceled = False
+        for action in pending.rest:
+            if _dispatch(
+                action,
+                tmux_session,
+                logf,
+                harness=harness,
+                cwd=cwd,
+                pct=pct,
+                adapter=adapter,
+            ):
+                canceled = True
+                break
+        return "done", canceled
+
+    clock = time.monotonic() if now is None else now
+    if clock >= pending.deadline:
+        _log(
+            logf,
+            {
+                "event": "handoff_timeout",
+                "err": (
+                    f"no handoff under {repo_root / '.turbo' / 'handoff'} "
+                    f"with mtime > {pending.since:.3f} before deadline"
+                ),
+            },
+        )
+        _stats.record(
+            "handoff_timeout",
+            harness=harness,
+            tmux_session=tmux_session,
+            pct=round(pct, 4),
+            cwd=cwd,
+        )
+        return "timeout", True
+
+    return "pending", False
+
+
 # ---------------------------------------------------------------------------
 # Hook-mode entry point
 # ---------------------------------------------------------------------------
 
+def _resolve_session_start(args: argparse.Namespace, transcript: "Path | None") -> float:
+    """Resolve a best-effort "session start" cutoff for fresh-handoff checks.
+
+    Preference order:
+    1. ``args.started_at`` (the harness-supplied session start timestamp).
+    2. The transcript's last-modified time minus a recent window
+       (``_FRESH_WINDOW``) — the transcript is rewritten throughout the
+       session, so its mtime tracks recent activity; subtracting a window
+       lets us treat a handoff written shortly before this PreCompact as
+       "fresh" without admitting one from a prior, long-idle session.
+    3. ``time.time() - _FRESH_WINDOW`` when neither is available.
+
+    A handoff is considered *fresh* iff its mtime is strictly greater than the
+    returned cutoff.
+    """
+    if args.started_at is not None:
+        try:
+            return float(args.started_at)
+        except (TypeError, ValueError):
+            pass
+    if transcript is not None:
+        try:
+            return transcript.stat().st_mtime - _FRESH_WINDOW
+        except OSError:
+            pass
+    return time.time() - _FRESH_WINDOW
+
+
+def _hook_daemon_running(args: argparse.Namespace) -> bool:
+    """Best-effort check for a live tmux-daemon monitor for this session.
+
+    True auto-rollover (handoff -> clear -> resume) is performed *only* by the
+    tmux-daemon path, which writes a ``<session>.pid`` file under
+    :data:`_MONITORS_DIR`. Hook mode is notification-only, so we look for any
+    live (PID still running) monitor pidfile and, when none is found, warn that
+    the hook cannot actually roll over on its own.
+    """
+    if not _MONITORS_DIR.exists():
+        return False
+    for pidf in _MONITORS_DIR.glob("*.pid"):
+        try:
+            pid = int(pidf.read_text().strip())
+        except (OSError, ValueError):
+            continue
+        try:
+            os.kill(pid, 0)  # signal 0: existence check, no signal delivered
+        except OSError:
+            continue
+        return True
+    return False
+
+
 def _run_hook_mode(args: argparse.Namespace) -> None:
     """Handle Claude Code PreCompact / SessionStart hook invocations.
 
-    The hook fires synchronously inside Claude Code with no tmux pane to
-    inject into.  At ``PreCompact``, we read the current transcript, classify
-    usage, and surface a desktop notification (via the ``claude_hook``
-    adapter) so the user knows the handoff file is ready.  ``SessionStart``
-    is currently a no-op (reserved for resume hints in a future revision).
+    **Notification-only by design.** A PreCompact hook runs as a short-lived
+    Python subprocess *inside* Claude Code with no tmux pane to drive and no
+    way to summarize the conversation — it cannot run ``/create-handoff``,
+    cannot ``/clear``, and cannot ``/resume``. It can only *observe* usage and
+    surface a desktop notification. Real handoff->clear->resume orchestration
+    requires the tmux-daemon mode (the ``_dispatch`` path), which injects slash
+    commands into a live pane.
+
+    So at ``PreCompact`` this function:
+    - Reads usage from the transcript (logged for diagnostics).
+    - Surfaces a desktop notification that points at a *fresh* handoff (one
+      written after this session started) when one exists, or honestly says
+      "no fresh handoff — run /create-handoff before compaction" when the only
+      handoff on disk predates the session (a stale handoff must never be
+      presented as if it captured the current work).
+    - Warns (log + notification note) when hook mode is the *only* thing wired
+      (no live tmux daemon for this machine): auto-rollover will not happen and
+      the user must create the handoff manually.
+
+    ``SessionStart`` is currently a no-op (reserved for resume hints in a
+    future revision).
 
     All output goes to ``~/.autospec/monitors/hook-<event>.log`` so the daemon
     never pollutes the Claude Code transcript.  Failures are logged and
@@ -431,7 +609,7 @@ def _run_hook_mode(args: argparse.Namespace) -> None:
         _log(logf, {"event": "hook_noop", "hook_event": "SessionStart"})
         return
 
-    # PreCompact: best-effort notification path.
+    # PreCompact: best-effort, notification-only path.
     try:
         from .adapters.claude_hook import ClaudeHookAdapter
 
@@ -454,20 +632,61 @@ def _run_hook_mode(args: argparse.Namespace) -> None:
                 "model": usage.model,
             },
         )
-        # Resolve the latest handoff under <cwd>/.turbo/handoff and surface
-        # it via the desktop notification.
+
+        # Resolve the *fresh* handoff under <cwd>/.turbo/handoff: only a file
+        # newer than the session-start cutoff may be surfaced. Pointing at a
+        # stale handoff from a prior session would mislead the user into
+        # compacting on top of obsolete context.
+        cutoff = _resolve_session_start(args, transcript)
         handoff_dir = Path(cwd) / ".turbo" / "handoff"
         files = (
             sorted(handoff_dir.glob("*.md"), key=lambda p: p.stat().st_mtime)
             if handoff_dir.exists()
             else []
         )
-        latest = files[-1] if files else None
-        ClaudeHookAdapter.notify_clear_needed(handoff_path=latest)
-        _log(
-            logf,
-            {"event": "hook_notify", "handoff": str(latest) if latest else None},
-        )
+        fresh = [p for p in files if p.stat().st_mtime > cutoff]
+        latest_fresh = fresh[-1] if fresh else None
+
+        # Warn when nothing can actually perform the rollover (no live daemon).
+        daemon_running = _hook_daemon_running(args)
+        if not daemon_running:
+            _log(
+                logf,
+                {
+                    "event": "hook_only_no_daemon",
+                    "note": (
+                        "hook mode is notification-only; true auto-rollover "
+                        "(handoff->clear->resume) requires the tmux/daemon mode"
+                    ),
+                },
+            )
+
+        if latest_fresh is not None:
+            ClaudeHookAdapter.notify_clear_needed(handoff_path=latest_fresh)
+            _log(
+                logf,
+                {
+                    "event": "hook_notify",
+                    "handoff": str(latest_fresh),
+                    "fresh": True,
+                    "daemon_running": daemon_running,
+                },
+            )
+        else:
+            # No fresh handoff — be honest rather than pointing at a stale file.
+            note = "No fresh handoff — run /create-handoff before compaction."
+            if not daemon_running:
+                note += " (hook mode is notification-only; no daemon to roll over)"
+            ClaudeHookAdapter.notify_no_fresh_handoff(note)
+            _log(
+                logf,
+                {
+                    "event": "hook_notify_no_fresh",
+                    "stale_present": bool(files),
+                    "stale_latest": str(files[-1]) if files else None,
+                    "daemon_running": daemon_running,
+                },
+            )
     except Exception as exc:  # noqa: BLE001
         _log(
             logf,
@@ -524,6 +743,14 @@ def main(argv: list[str] | None = None) -> None:
     # Track the transcript path seen when ROLLED state was entered so that
     # a new transcript (new path) triggers an immediate reset to NORMAL.
     last_transcript: Path | None = None
+    # In-flight handoff wait, advanced one non-blocking tick at a time so the
+    # poll cadence (kill-switch / session-alive / usage) is never frozen.
+    pending_handoff: _PendingHandoff | None = None
+    repo_root = Path(args.cwd) if args.cwd else Path.cwd()
+
+    def _revert_to_compacted() -> None:
+        engine._state = State.COMPACTED  # noqa: SLF001
+        _log(logf, {"event": "state_reverted", "state": "COMPACTED"})
 
     try:
         # Load adapter inside the try block so PID cleanup runs even if
@@ -537,6 +764,35 @@ def main(argv: list[str] | None = None) -> None:
             if not session_exists(args.tmux_session):
                 _log(logf, {"event": "session_gone", "tmux_session": args.tmux_session})
                 break
+
+            # Advance any in-flight handoff wait FIRST (non-blocking). This is
+            # what keeps the loop responsive: instead of one 180s blocking
+            # wait_for_handoff inside _dispatch, we poll once per tick and fall
+            # through to sleep — so the kill-switch / session checks above keep
+            # running while the handoff is pending.
+            if pending_handoff is not None:
+                status, canceled = _advance_pending_handoff(
+                    pending_handoff,
+                    repo_root,
+                    logf,
+                    harness=args.harness,
+                    tmux_session=args.tmux_session,
+                    cwd=args.cwd,
+                    pct=0.0,
+                    adapter=adapter,
+                )
+                if status != "pending":
+                    pending_handoff = None
+                    if canceled:
+                        # Handoff timed out (or a deferred clear/resume was
+                        # canceled) — revert so the engine re-fires on the next
+                        # 80% climb rather than waiting for a new transcript.
+                        _revert_to_compacted()
+                # While a handoff is pending we skip classify/dispatch for this
+                # tick (the rollover sequence is mid-flight); just sleep and
+                # re-check liveness next tick.
+                time.sleep(_POLL_INTERVAL)
+                continue
 
             try:
                 transcript = adapter.find_transcript(hint)
@@ -559,25 +815,58 @@ def main(argv: list[str] | None = None) -> None:
                     "pct": round(usage.used_tokens / usage.max_tokens, 4),
                     "model": usage.model,
                 })
+                pct = round(usage.used_tokens / usage.max_tokens, 4)
                 actions = engine.classify(usage)
-                for action in actions:
+                for idx, action in enumerate(actions):
+                    if action.kind == "handoff":
+                        # Inject /create-handoff, then DON'T block: hand the
+                        # remaining actions ([clear, resume]) to a deadline-based
+                        # pending state the loop advances on later ticks.
+                        since = time.time()
+                        canceled = _dispatch(
+                            action,
+                            args.tmux_session,
+                            logf,
+                            harness=args.harness,
+                            cwd=args.cwd,
+                            pct=pct,
+                            adapter=adapter,
+                        )
+                        if canceled:
+                            _revert_to_compacted()
+                            break
+                        pending_handoff = _PendingHandoff(
+                            since=since,
+                            deadline=time.monotonic() + _HANDOFF_DEADLINE,
+                            rest=list(actions[idx + 1:]),
+                        )
+                        _log(
+                            logf,
+                            {
+                                "event": "handoff_pending",
+                                "deadline_s": _HANDOFF_DEADLINE,
+                                "rest": [a.kind for a in pending_handoff.rest],
+                            },
+                        )
+                        # Stop dispatching remaining actions now; they run once
+                        # the handoff file is observed.
+                        break
+
                     canceled = _dispatch(
                         action,
                         args.tmux_session,
                         logf,
                         harness=args.harness,
                         cwd=args.cwd,
-                        pct=round(usage.used_tokens / usage.max_tokens, 4),
+                        pct=pct,
                         adapter=adapter,
                     )
                     if canceled:
-                        # User pressed Esc during cancel window, handoff
-                        # validation failed, or wait_for_handoff timed out —
-                        # revert state so the engine re-fires the rollover on
-                        # the next 80% climb rather than waiting for a new
-                        # transcript.
-                        engine._state = State.COMPACTED  # noqa: SLF001
-                        _log(logf, {"event": "state_reverted", "state": "COMPACTED"})
+                        # User pressed Esc during cancel window or handoff
+                        # validation failed — revert state so the engine
+                        # re-fires the rollover on the next 80% climb rather
+                        # than waiting for a new transcript.
+                        _revert_to_compacted()
                         break
 
                 # Update last_transcript after each successful tick so the

--- a/packages/autospec_context_monitor/autospec_context_monitor/adapters/claude_hook.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/adapters/claude_hook.py
@@ -106,26 +106,54 @@ class ClaudeHookAdapter:
         if handoff_path is not None:
             body = f"{body} Handoff: {handoff_path}"
 
+        ClaudeHookAdapter._notify("autospec: rollover needed", body)
+
+    @staticmethod
+    def notify_no_fresh_handoff(
+        message: str = "No fresh handoff — run /create-handoff before compaction.",
+    ) -> None:
+        """Fire an honest notification when no *fresh* handoff exists.
+
+        Hook mode cannot summarize the session, so when the only handoff on
+        disk predates this session (or there is none), it must say so plainly
+        instead of pointing the user at a stale file. Best-effort and bounded
+        like :meth:`notify_clear_needed`.
+
+        Args:
+            message: The notification body to display.
+        """
+        ClaudeHookAdapter._notify("autospec: handoff needed", message)
+
+    @staticmethod
+    def _notify(title: str, body: str) -> None:
+        """Fire a best-effort, timeout-bounded desktop notification.
+
+        On macOS uses ``osascript``; on Linux uses ``notify-send``. Any
+        subprocess error or a missing/blocked notifier is swallowed so the
+        synchronous PreCompact hook can never be aborted or stalled.
+        """
         try:
             if sys.platform == "darwin":
-                # body is embedded inside an AppleScript double-quoted string,
-                # so backslashes and double-quotes must be escaped or osascript
-                # errors out (or hangs) on a handoff path containing them.
-                escaped = body.replace("\\", "\\\\").replace('"', '\\"')
+                # body/title are embedded inside an AppleScript double-quoted
+                # string, so backslashes and double-quotes must be escaped or
+                # osascript errors out (or hangs) on content containing them.
+                def _esc(s: str) -> str:
+                    return s.replace("\\", "\\\\").replace('"', '\\"')
+
                 subprocess.run(
                     [
                         "osascript",
                         "-e",
-                        f'display notification "{escaped}" with title "autospec: rollover needed"',
+                        f'display notification "{_esc(body)}" with title "{_esc(title)}"',
                     ],
                     check=False,
                     timeout=5,
                 )
             else:
                 # notify-send args are passed as separate argv, so no shell/
-                # AppleScript escaping is needed for the body here.
+                # AppleScript escaping is needed here.
                 subprocess.run(
-                    ["notify-send", "autospec: rollover needed", body],
+                    ["notify-send", title, body],
                     check=False,
                     timeout=5,
                 )

--- a/packages/autospec_context_monitor/autospec_context_monitor/handoff.py
+++ b/packages/autospec_context_monitor/autospec_context_monitor/handoff.py
@@ -70,6 +70,34 @@ class HandoffTimeoutError(TimeoutError):
     """Raised when no handoff file appears within the allowed timeout."""
 
 
+def check_handoff(repo_root: Path, since: float) -> Path | None:
+    """Single-shot, non-blocking check for a fresh today-dated handoff.
+
+    Unlike :func:`wait_for_handoff`, this performs exactly one filesystem scan
+    and returns immediately. It lets a caller poll for the handoff across its
+    own loop ticks (so the poll cadence is never frozen by a long blocking
+    wait) while reusing the same match semantics.
+
+    Args:
+        repo_root: Root directory of the repository (contains ``.turbo/``).
+        since:     POSIX timestamp; only files with ``st_mtime > since`` match.
+
+    Returns:
+        The newest matching handoff :class:`~pathlib.Path`, or ``None`` when no
+        qualifying file exists yet.
+    """
+    handoff_dir = repo_root / ".turbo" / "handoff"
+    if not handoff_dir.exists():
+        return None
+    today_glob = f"{date.today().isoformat()}-*.md"
+    candidates = [
+        p for p in handoff_dir.glob(today_glob) if p.stat().st_mtime > since
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
 def wait_for_handoff(
     repo_root: Path,
     since: float,

--- a/packages/autospec_context_monitor/tests/test_handoff_nonblocking_loop.py
+++ b/packages/autospec_context_monitor/tests/test_handoff_nonblocking_loop.py
@@ -1,0 +1,213 @@
+"""Tests for issue #898 Part 2, FIX B: poll loop not frozen by handoff wait.
+
+Previously ``_dispatch(Action('handoff'))`` called ``wait_for_handoff(timeout=180)``
+synchronously, blocking the ENTIRE poll loop for up to 180s. Now the handoff
+wait is a deadline-based pending state advanced one non-blocking tick at a time,
+so the loop keeps checking kill-switch / session-alive / usage while a handoff
+is pending.
+
+These tests fail before the fix:
+- the responsiveness test would hang (or block on real ``wait_for_handoff``)
+  instead of processing a kill-switch tick during the handoff window;
+- the timeout test relied on ``_advance_pending_handoff`` which did not exist.
+"""
+from __future__ import annotations
+
+import time
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import autospec_context_monitor.__main__ as _main
+from autospec_context_monitor.adapters.base import Usage
+from autospec_context_monitor.engine import Action
+
+
+def _usage(used, max_tokens=200_000):
+    return Usage(used_tokens=used, max_tokens=max_tokens, model="m", estimated=False)
+
+
+def _args(tmp_path, session="sess"):
+    return [
+        "--tmux-session", session,
+        "--harness", "claude",
+        "--cwd", str(tmp_path),
+        "--started-at", "0",
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _redirect(tmp_path, monkeypatch):
+    monitors = tmp_path / "monitors"
+    monkeypatch.setattr(_main, "_MONITORS_DIR", monitors)
+    monkeypatch.setattr(_main, "_KILL_SWITCH", tmp_path / "no-auto-rollover.flag")
+    monkeypatch.setattr(_main, "_POLL_INTERVAL", 0)  # no real sleeping
+    return monitors
+
+
+def _write_valid_handoff(tmp_path) -> Path:
+    hd = tmp_path / ".turbo" / "handoff"
+    hd.mkdir(parents=True, exist_ok=True)
+    p = hd / f"{date.today().isoformat()}-h.md"
+    p.write_text(
+        "# Handoff\n\n## Status\nok\n\n## Next step\ngo\n" + ("x" * 250),
+        encoding="utf-8",
+    )
+    return p
+
+
+# ---------------------------------------------------------------------------
+# FIX B core: the loop stays responsive while a handoff is pending.
+# ---------------------------------------------------------------------------
+
+def test_loop_responsive_while_handoff_pending(tmp_path):
+    """While the handoff is pending, the loop keeps polling and honors the
+    kill-switch on a later tick — instead of blocking 180s in one call."""
+    fake_adapter = MagicMock()
+    fake_adapter.find_transcript.return_value = tmp_path / "t"
+    # Climb straight to >=80%: NORMAL->COMPACTED(compact) tick 0, then
+    # COMPACTED->ROLLED([handoff,clear,resume]) tick 1.
+    fake_adapter.read_usage.return_value = _usage(170_000)
+    fake_adapter.command.side_effect = lambda k: f"/{k}"
+    fake_adapter.prompt_marker.return_value = ""
+
+    tick = {"n": 0}
+
+    def session_alive(_sess):
+        # Stay alive for many ticks; the kill-switch (set below) ends the loop,
+        # proving the loop is NOT blocked inside a single 180s handoff wait.
+        tick["n"] += 1
+        if tick["n"] == 4:
+            # Drop the kill switch on the 4th liveness check — well within the
+            # handoff window — to demonstrate responsiveness.
+            (tmp_path / "no-auto-rollover.flag").touch()
+        return True
+
+    inject_calls = []
+
+    with patch.object(_main, "session_exists", side_effect=session_alive), \
+         patch.object(_main, "inject", side_effect=lambda s, c: inject_calls.append(c)), \
+         patch.object(_main, "wait_for_prompt", return_value=True), \
+         patch.object(_main, "_load_adapter", return_value=fake_adapter), \
+         patch.object(_main.time, "sleep", lambda *_: None):
+        _main.main(_args(tmp_path))
+
+    # The handoff command was injected, but /clear was NOT (no handoff file ever
+    # appeared, and the kill-switch ended the loop mid-wait). Crucially the loop
+    # ran several ticks rather than blocking once for 180s.
+    assert any("handoff" in c for c in inject_calls), inject_calls
+    assert not any("clear" in c for c in inject_calls), inject_calls
+    assert tick["n"] >= 4, f"loop did not keep polling while pending (ticks={tick['n']})"
+
+
+# ---------------------------------------------------------------------------
+# Happy path: handoff appears -> clear + resume dispatched.
+# ---------------------------------------------------------------------------
+
+def test_handoff_appears_then_clear_and_resume(tmp_path):
+    """Once a fresh handoff file appears, the deferred clear+resume run."""
+    fake_adapter = MagicMock()
+    fake_adapter.find_transcript.return_value = tmp_path / "t"
+    fake_adapter.read_usage.return_value = _usage(170_000)
+    fake_adapter.command.side_effect = lambda k: f"/{k}"
+    fake_adapter.prompt_marker.return_value = ""
+
+    tick = {"n": 0}
+
+    def session_alive(_sess):
+        tick["n"] += 1
+        # On tick 3 (handoff already injected & pending), the harness "writes"
+        # the handoff file; next pending-advance tick should observe it.
+        if tick["n"] == 3:
+            _write_valid_handoff(tmp_path)
+        if tick["n"] >= 8:
+            (tmp_path / "no-auto-rollover.flag").touch()
+        return True
+
+    inject_calls = []
+
+    with patch.object(_main, "session_exists", side_effect=session_alive), \
+         patch.object(_main, "inject", side_effect=lambda s, c: inject_calls.append(c)), \
+         patch.object(_main, "wait_for_prompt", return_value=True), \
+         patch.object(_main, "wait_for_cancel", return_value=False), \
+         patch.object(_main, "_load_adapter", return_value=fake_adapter), \
+         patch.object(_main.time, "sleep", lambda *_: None):
+        _main.main(_args(tmp_path))
+
+    assert any("handoff" in c for c in inject_calls), inject_calls
+    assert any("clear" in c for c in inject_calls), inject_calls
+    # resume is injected as prose, not via command(); check it ran by message.
+    assert any("continue from where" in c.lower() for c in inject_calls), inject_calls
+
+
+# ---------------------------------------------------------------------------
+# Timeout path: no handoff before deadline -> revert to COMPACTED.
+# ---------------------------------------------------------------------------
+
+def test_handoff_timeout_reverts_to_compacted(tmp_path):
+    """_advance_pending_handoff returns ('timeout', True) past the deadline and
+    records a handoff_timeout; the loop reverts engine state to COMPACTED."""
+    from autospec_context_monitor.engine import State
+
+    logf = tmp_path / "log.jsonl"
+    pending = _main._PendingHandoff(
+        since=time.time(),
+        deadline=100.0,  # monotonic deadline
+        rest=[Action("clear"), Action("resume")],
+    )
+
+    recorded = []
+    with patch.object(_main._stats, "record", side_effect=lambda *a, **k: recorded.append((a, k))):
+        # Before the deadline (now < deadline) and no file: still pending.
+        status, canceled = _main._advance_pending_handoff(
+            pending, tmp_path, logf,
+            harness="claude", tmux_session="s", cwd=str(tmp_path),
+            pct=0.85, adapter=MagicMock(), now=50.0,
+        )
+        assert status == "pending" and canceled is False
+
+        # Past the deadline and still no file: timeout + canceled.
+        status, canceled = _main._advance_pending_handoff(
+            pending, tmp_path, logf,
+            harness="claude", tmux_session="s", cwd=str(tmp_path),
+            pct=0.85, adapter=MagicMock(), now=101.0,
+        )
+        assert status == "timeout" and canceled is True
+
+    assert any(a[0] == "handoff_timeout" for a, _ in recorded), recorded
+
+    # And the full loop reverts to COMPACTED on timeout. Drive a tiny loop that
+    # times out fast via a small deadline through the real main().
+    fake_adapter = MagicMock()
+    fake_adapter.find_transcript.return_value = tmp_path / "t"
+    fake_adapter.read_usage.return_value = _usage(170_000)
+    fake_adapter.command.side_effect = lambda k: f"/{k}"
+    fake_adapter.prompt_marker.return_value = ""
+
+    captured_state = {}
+    tick = {"n": 0}
+
+    def session_alive(_sess):
+        tick["n"] += 1
+        if tick["n"] >= 6:
+            (tmp_path / "no-auto-rollover.flag").touch()
+        return True
+
+    with patch.object(_main, "_HANDOFF_DEADLINE", 0.0), \
+         patch.object(_main, "session_exists", side_effect=session_alive), \
+         patch.object(_main, "inject", lambda s, c: None), \
+         patch.object(_main, "wait_for_prompt", return_value=True), \
+         patch.object(_main, "_load_adapter", return_value=fake_adapter), \
+         patch.object(_main.time, "sleep", lambda *_: None):
+        _main.main(_args(tmp_path, "timeout-sess"))
+
+    # Read the log: a handoff_timeout + a state_reverted->COMPACTED must appear.
+    import json
+    logf2 = tmp_path / "monitors" / "timeout-sess.log"
+    events = [json.loads(l) for l in logf2.read_text().splitlines() if l.strip()]
+    kinds = [e["event"] for e in events]
+    assert "handoff_timeout" in kinds, kinds
+    reverts = [e for e in events if e["event"] == "state_reverted"]
+    assert reverts and reverts[-1]["state"] == "COMPACTED", events

--- a/packages/autospec_context_monitor/tests/test_hook_fresh_handoff.py
+++ b/packages/autospec_context_monitor/tests/test_hook_fresh_handoff.py
@@ -1,0 +1,198 @@
+"""Tests for issue #898 Part 2, FIX A: honest fresh-handoff hook notification.
+
+``_run_hook_mode`` (the PreCompact path) is notification-only — it cannot
+summarize the session, so it must NOT point the user at a stale handoff from a
+prior session. It must:
+
+- surface a FRESH handoff (mtime newer than the session-start cutoff) when one
+  exists, via ``notify_clear_needed``;
+- surface an HONEST "no fresh handoff — run /create-handoff" message (NOT a
+  stale file) when the only handoff predates the session, via
+  ``notify_no_fresh_handoff``;
+- warn (log + note) when hook mode is the only thing wired (no live daemon).
+
+These tests fail before the fix because the old code always surfaced
+``files[-1]`` (newest by mtime) regardless of age and had no
+``notify_no_fresh_handoff`` path.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from autospec_context_monitor.adapters.base import Usage
+
+
+def _args(cwd, started_at):
+    return argparse.Namespace(
+        hook_event="PreCompact",
+        tmux_session=None,
+        harness=None,
+        cwd=str(cwd),
+        started_at=started_at,
+    )
+
+
+def _write_handoff(handoff_dir: Path, name: str, mtime: float) -> Path:
+    handoff_dir.mkdir(parents=True, exist_ok=True)
+    p = handoff_dir / name
+    p.write_text(
+        "# Handoff\n\n## Status\nwork\n\n## Next step\ngo\n" + ("x" * 200),
+        encoding="utf-8",
+    )
+    os.utime(p, (mtime, mtime))
+    return p
+
+
+@pytest.fixture
+def patched_hook(tmp_path, monkeypatch):
+    """Redirect monitor dir + stub the adapter's usage/transcript reads."""
+    import autospec_context_monitor.__main__ as _main
+
+    monitors = tmp_path / "monitors"
+    monkeypatch.setattr(_main, "_MONITORS_DIR", monitors)
+
+    # Stub transcript discovery + usage so we don't need a real Claude session.
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text("{}", encoding="utf-8")
+    os.utime(transcript, (time.time(), time.time()))
+
+    monkeypatch.setattr(
+        "autospec_context_monitor.adapters.claude.ClaudeAdapter.find_transcript",
+        lambda self, hint: transcript,
+    )
+    monkeypatch.setattr(
+        "autospec_context_monitor.adapters.claude.ClaudeAdapter.read_usage",
+        lambda self, t: Usage(
+            used_tokens=170_000, max_tokens=200_000, model="m", estimated=False
+        ),
+    )
+    return _main, monitors
+
+
+def _read_events(logf: Path):
+    return [
+        json.loads(l)
+        for l in logf.read_text().splitlines()
+        if l.strip()
+    ]
+
+
+def test_fresh_handoff_is_surfaced(patched_hook, tmp_path):
+    """A handoff newer than started_at is surfaced via notify_clear_needed."""
+    _main, monitors = patched_hook
+    now = time.time()
+    handoff_dir = tmp_path / ".turbo" / "handoff"
+    today = time.strftime("%Y-%m-%d", time.localtime(now))
+    fresh = _write_handoff(handoff_dir, f"{today}-fresh.md", now)  # newer than start
+
+    started_at = now - 60  # session started a minute ago
+
+    from autospec_context_monitor.adapters.claude_hook import ClaudeHookAdapter
+
+    with patch.object(ClaudeHookAdapter, "notify_clear_needed") as m_fresh, \
+         patch.object(ClaudeHookAdapter, "notify_no_fresh_handoff") as m_none:
+        _main._run_hook_mode(_args(tmp_path, started_at))
+
+    m_fresh.assert_called_once()
+    # The fresh handoff path must be the one surfaced.
+    _, kwargs = m_fresh.call_args
+    surfaced = kwargs.get("handoff_path")
+    if surfaced is None and m_fresh.call_args.args:
+        surfaced = m_fresh.call_args.args[0]
+    assert Path(surfaced) == fresh
+    m_none.assert_not_called()
+
+    events = {e["event"] for e in _read_events(monitors / "hook-PreCompact.log")}
+    assert "hook_notify" in events
+
+
+def test_stale_handoff_yields_honest_message(patched_hook, tmp_path):
+    """When the only handoff predates the session, surface honest 'no fresh' msg."""
+    _main, monitors = patched_hook
+    now = time.time()
+    handoff_dir = tmp_path / ".turbo" / "handoff"
+    today = time.strftime("%Y-%m-%d", time.localtime(now))
+    # Stale: written well before the session started.
+    stale = _write_handoff(handoff_dir, f"{today}-stale.md", now - 10_000)
+
+    started_at = now - 60  # session started after the stale handoff
+
+    from autospec_context_monitor.adapters.claude_hook import ClaudeHookAdapter
+
+    with patch.object(ClaudeHookAdapter, "notify_clear_needed") as m_fresh, \
+         patch.object(ClaudeHookAdapter, "notify_no_fresh_handoff") as m_none:
+        _main._run_hook_mode(_args(tmp_path, started_at))
+
+    # MUST NOT point at the stale file.
+    m_fresh.assert_not_called()
+    m_none.assert_called_once()
+
+    events = _read_events(monitors / "hook-PreCompact.log")
+    kinds = {e["event"] for e in events}
+    assert "hook_notify_no_fresh" in kinds
+    no_fresh = next(e for e in events if e["event"] == "hook_notify_no_fresh")
+    assert no_fresh["stale_present"] is True
+    assert Path(no_fresh["stale_latest"]) == stale
+
+
+def test_no_handoff_at_all_yields_honest_message(patched_hook, tmp_path):
+    """With no handoff dir at all, surface the honest 'no fresh' message."""
+    _main, monitors = patched_hook
+    now = time.time()
+
+    from autospec_context_monitor.adapters.claude_hook import ClaudeHookAdapter
+
+    with patch.object(ClaudeHookAdapter, "notify_clear_needed") as m_fresh, \
+         patch.object(ClaudeHookAdapter, "notify_no_fresh_handoff") as m_none:
+        _main._run_hook_mode(_args(tmp_path, now - 60))
+
+    m_fresh.assert_not_called()
+    m_none.assert_called_once()
+
+
+def test_warns_when_no_daemon_running(patched_hook, tmp_path):
+    """Hook-only (no live daemon pidfile) logs a hook_only_no_daemon warning."""
+    _main, monitors = patched_hook
+    now = time.time()
+    handoff_dir = tmp_path / ".turbo" / "handoff"
+    today = time.strftime("%Y-%m-%d", time.localtime(now))
+    _write_handoff(handoff_dir, f"{today}-fresh.md", now)
+
+    from autospec_context_monitor.adapters.claude_hook import ClaudeHookAdapter
+
+    # No pidfiles in monitors dir => no daemon.
+    with patch.object(ClaudeHookAdapter, "notify_clear_needed"), \
+         patch.object(ClaudeHookAdapter, "notify_no_fresh_handoff"):
+        _main._run_hook_mode(_args(tmp_path, now - 60))
+
+    events = {e["event"] for e in _read_events(monitors / "hook-PreCompact.log")}
+    assert "hook_only_no_daemon" in events
+
+
+def test_no_warning_when_daemon_running(patched_hook, tmp_path):
+    """A live daemon pidfile suppresses the hook_only_no_daemon warning."""
+    _main, monitors = patched_hook
+    now = time.time()
+    handoff_dir = tmp_path / ".turbo" / "handoff"
+    today = time.strftime("%Y-%m-%d", time.localtime(now))
+    _write_handoff(handoff_dir, f"{today}-fresh.md", now)
+
+    # Write a pidfile pointing at THIS process (guaranteed alive).
+    monitors.mkdir(parents=True, exist_ok=True)
+    (monitors / "live.pid").write_text(str(os.getpid()))
+
+    from autospec_context_monitor.adapters.claude_hook import ClaudeHookAdapter
+
+    with patch.object(ClaudeHookAdapter, "notify_clear_needed"), \
+         patch.object(ClaudeHookAdapter, "notify_no_fresh_handoff"):
+        _main._run_hook_mode(_args(tmp_path, now - 60))
+
+    events = {e["event"] for e in _read_events(monitors / "hook-PreCompact.log")}
+    assert "hook_only_no_daemon" not in events

--- a/packages/autospec_context_monitor/tests/test_integration_gaps.py
+++ b/packages/autospec_context_monitor/tests/test_integration_gaps.py
@@ -285,22 +285,29 @@ def test_g003_resume_reads_cwd_handoff(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# g-004 — wait_for_handoff is called between handoff and clear
+# g-004 — handoff wait is non-blocking (issue #898 Part 2, FIX B)
+#
+# The handoff wait NO LONGER blocks inside _dispatch (that froze the whole poll
+# loop for up to 180s). _dispatch('handoff') now only injects /create-handoff
+# and returns immediately; the wait is owned by the poll loop via
+# _PendingHandoff / _advance_pending_handoff, which polls non-blockingly and
+# dispatches the deferred clear+resume once the file appears (or reverts to
+# COMPACTED on deadline). These tests lock in that contract.
 # ---------------------------------------------------------------------------
 
 
-def test_g004_dispatch_handoff_calls_wait_for_handoff(tmp_path):
-    """Action('handoff') must call wait_for_handoff after injecting the prompt."""
+def test_g004_dispatch_handoff_injects_without_blocking(tmp_path):
+    """Action('handoff') injects /create-handoff and returns WITHOUT calling
+    wait_for_handoff (no 180s block inside _dispatch)."""
     from autospec_context_monitor.__main__ import _dispatch
 
     adapter = _FakeAdapter()
-    fake_path = _make_valid_handoff(tmp_path / ".turbo" / "handoff")
 
     wait_calls: list = []
 
-    def _fake_wait(repo_root, since, timeout=180.0, **_kw):
-        wait_calls.append((repo_root, since, timeout))
-        return fake_path
+    def _fake_wait(*a, **_kw):
+        wait_calls.append(a)
+        raise AssertionError("wait_for_handoff must NOT be called from _dispatch")
 
     injects: list[str] = []
 
@@ -309,35 +316,6 @@ def test_g004_dispatch_handoff_calls_wait_for_handoff(tmp_path):
 
     with patch("autospec_context_monitor.__main__.inject", _fake_inject):
         with patch("autospec_context_monitor.__main__.wait_for_handoff", _fake_wait):
-            _dispatch(
-                Action("handoff"),
-                "test-sess",
-                tmp_path / "log",
-                harness="fake",
-                cwd=str(tmp_path),
-                pct=0.85,
-                adapter=adapter,
-            )
-
-    assert wait_calls, "wait_for_handoff must be called during 'handoff' dispatch"
-    repo_root, since, timeout = wait_calls[0]
-    assert Path(repo_root) == tmp_path
-    assert timeout == 180.0
-    assert since <= time.time()
-
-
-def test_g004_dispatch_handoff_aborts_on_timeout(tmp_path):
-    """When wait_for_handoff raises HandoffTimeoutError, _dispatch returns True (canceled)."""
-    from autospec_context_monitor.__main__ import _dispatch
-    from autospec_context_monitor.handoff import HandoffTimeoutError
-
-    adapter = _FakeAdapter()
-
-    def _raise(*_a, **_kw):
-        raise HandoffTimeoutError("no file appeared")
-
-    with patch("autospec_context_monitor.__main__.inject", lambda *_a, **_kw: None):
-        with patch("autospec_context_monitor.__main__.wait_for_handoff", _raise):
             result = _dispatch(
                 Action("handoff"),
                 "test-sess",
@@ -348,9 +326,65 @@ def test_g004_dispatch_handoff_aborts_on_timeout(tmp_path):
                 adapter=adapter,
             )
 
-    assert result is True, (
-        "HandoffTimeoutError must cause _dispatch to return True (canceled) "
-        "so the main loop reverts state to COMPACTED instead of firing /clear."
+    assert "handoff" in adapter.requested
+    assert injects == ["/FAKE_HANDOFF"]
+    assert result is False, "_dispatch('handoff') must not signal cancel by itself"
+    assert not wait_calls, "the 180s blocking wait must not run inside _dispatch"
+
+
+def test_g004_advance_pending_handoff_completes_on_file(tmp_path):
+    """Once the handoff file appears, _advance_pending_handoff dispatches the
+    deferred clear+resume and reports ('done', not-canceled)."""
+    from autospec_context_monitor.__main__ import _advance_pending_handoff, _PendingHandoff
+
+    adapter = _FakeAdapter()
+    _make_valid_handoff(tmp_path / ".turbo" / "handoff")
+
+    injects: list[str] = []
+
+    pending = _PendingHandoff(
+        since=time.time() - 5,  # handoff written after this
+        deadline=time.monotonic() + 180.0,
+        rest=[Action("clear"), Action("resume")],
+    )
+
+    with patch("autospec_context_monitor.__main__.inject", lambda _s, t, **_k: injects.append(t)):
+        with patch("autospec_context_monitor.__main__.wait_for_cancel", return_value=False):
+            status, canceled = _advance_pending_handoff(
+                pending, tmp_path, tmp_path / "log",
+                harness="fake", tmux_session="test-sess", cwd=str(tmp_path),
+                pct=0.85, adapter=adapter,
+            )
+
+    assert status == "done"
+    assert canceled is False
+    assert "/FAKE_CLEAR" in injects  # deferred clear ran
+    assert any("continue from where" in t.lower() for t in injects)  # resume ran
+
+
+def test_g004_advance_pending_handoff_aborts_on_deadline(tmp_path):
+    """Past the deadline with no handoff file, _advance_pending_handoff reports
+    ('timeout', canceled=True) so the loop reverts state to COMPACTED."""
+    from autospec_context_monitor.__main__ import _advance_pending_handoff, _PendingHandoff
+
+    adapter = _FakeAdapter()  # no handoff file written
+
+    pending = _PendingHandoff(
+        since=time.time(),
+        deadline=100.0,
+        rest=[Action("clear"), Action("resume")],
+    )
+
+    status, canceled = _advance_pending_handoff(
+        pending, tmp_path, tmp_path / "log",
+        harness="fake", tmux_session="test-sess", cwd=str(tmp_path),
+        pct=0.85, adapter=adapter, now=101.0,  # past deadline
+    )
+
+    assert status == "timeout"
+    assert canceled is True, (
+        "deadline-exceeded handoff must signal cancel so the main loop reverts "
+        "state to COMPACTED instead of firing /clear."
     )
 
 


### PR DESCRIPTION
Closes #898 (part 2; part 1 MODEL_MAX was #1272).

**FIX A — honest, fresh hook notification:** `_run_hook_mode` surfaces only a handoff newer than the session cutoff (started_at → transcript-mtime−6h fallback) instead of the stale `files[-1]`; else notifies 'No fresh handoff — run /create-handoff'. Adds a no-daemon warning + honest docstring (a subprocess can't summarize; daemon mode required for real rollover).

**FIX B — non-blocking poll loop:** removes the 180s synchronous `wait_for_handoff` from `_dispatch`; the loop carries a deadline-based `_PendingHandoff` advanced each tick via a new non-blocking `check_handoff`. Kill-switch + session-alive checked every tick (responsive); semantics preserved (handoff→clear+resume; timeout→COMPACTED revert).

## Verification
- pytest **178 passed** (+8 new: fresh/stale/no-daemon + happy/timeout/responsive); g-004 tests rewritten to the new non-blocking contract (reviewer-confirmed legit). `bash scripts/validate.sh` exit 0 (python suites gated). Reviewer verified happy+timeout+responsiveness against the real main() loop.