### PR TITLE
docs: design specs for #1271 (vision CLI), #694 (qa-deploy), #1270 (fab container)

### DIFF
--- a/docs/specs/2026-06-22-autospec-fab-toolchain-container-design.md
+++ b/docs/specs/2026-06-22-autospec-fab-toolchain-container-design.md
@@ -1,0 +1,148 @@
+# autospec-fab: Pinned Container for the Real FreeCAD / CalculiX / OpenFOAM / Vision Toolchain — Design
+
+**Status:** Draft design (2026-06-22)
+**Author:** berlinguyinca + brainstorm
+**Tracking issue:** #1270 (`area:fab`) — surfaced by the 2026-06-20 whole-project review (ship-completeness / ROI dimension)
+**Related:** #1271 (real vision CLI consumer — vision stage currently always skips)
+**Classification:** INFRASTRUCTURE with real, ongoing cost (image size + CI minutes + registry storage). NOT a free-to-implement skill change. The heaviest child must be explicitly cost-flagged and gated on operator sign-off (§4).
+
+---
+
+## 1. Problem
+
+`autospec-fab` gates printable STL through twelve stages. Four shell out to **real external engineering solvers**, resolved off `PATH`:
+
+| Stage | Script | Binary (PATH name) | Invocation contract |
+| --- | --- | --- | --- |
+| `fea` | `scripts/stage_fea.py` | `ccx` (CalculiX) | `shutil.which("ccx")`; runs `ccx <job_base>`; reads `<job_base>.dat`, parses `SAFETY_FACTOR <value>` |
+| `cfd` | `scripts/stage_cfd.py` | `simpleFoam` (OpenFOAM) | `shutil.which("simpleFoam")`; runs `simpleFoam` in the case dir; reads `cfd_results` (`PRESSURE_DROP`/`MIN_VELOCITY`/`STAGNATION`) |
+| `render` (+ geometry/section) | `scripts/freecad_harness.py` | `freecadcmd` (FreeCAD headless) | `shutil.which("freecadcmd")`; runs `freecadcmd <script.py>`; render drives `FreeCADGui` for offscreen PNG |
+| `vision` (advisory) | `scripts/stage_vision.py` | `fab-vision` / `$AUTOSPEC_FAB_VISION_CMD` | judge `fab-vision <sheet> <rules>` → `{"observations":[…]}`; `--verify` on stdin → `{"confirmed":bool}` |
+
+Today every one resolves to **nothing** on a normal host; each stage's absent-binary branch is deliberate and graceful (`ccx`/`simpleFoam` → "real solver deferred to container", `status: skip`; vision → `skip`; freecad → sentinel/`FileNotFoundError`). The unit suites prove wiring via `$TMP/bin` shims and are green; that mocked path must stay the default.
+
+What's missing — what #1270 asks for — is a **reproducible, pinned environment supplying the real binaries** plus **one end-to-end smoke** proving the real toolchain integrates with the existing stage CLIs. There is no `Dockerfile` in the repo (CI is `python.yml`, `pages.yml`, `release-cli.yml` only) and the README has zero solver install instructions.
+
+## 2. Goal
+
+Ship a **pinned, reproducible container** carrying the real toolchain whose binaries land on `PATH` under the exact resolver names (`freecadcmd`, `ccx`, `simpleFoam`, `fab-vision`), plus:
+
+1. A **real-solver integration smoke** driving one tiny part through `fea`+`cfd`+`render`+`vision` end-to-end inside the image, asserting a non-`skip`, structurally-valid release-gate fragment from each.
+2. **Documented system packages** in `skills/autospec-fab/README.md` (container path + bare-metal recipe).
+3. A clear operator workflow (`docker run` mapping a model dir, honoring `MODELDIR/{circuit,duct,load,flow,…}.json`).
+
+### Non-goals
+Changing any stage's resolution logic / result-file contract / skip semantics (image satisfies the **existing** `shutil.which` contract; no Python stage changes); running real solvers on every PR (§3); a real vision model beyond a thin contract-conformant CLI (the model decision is #1271; this ships a minimal compatible CLI so the smoke exercises a non-skip vision pass); GPU / MPI OpenFOAM / solver tuning; publishing the image to a public registry as a supported artifact (open decision §4).
+
+## 3. Cost analysis (read before approving)
+
+Conservative `linux/amd64` estimates.
+
+### 3.1 Image size
+
+| Layer | Source | Est. on-disk |
+| --- | --- | --- |
+| `ubuntu:24.04` base | apt | ~80 MB |
+| FreeCAD headless (+ xvfb + mesa/llvmpipe) | apt | ~1.3–1.8 GB |
+| OpenFOAM (`openfoam2406`/`openfoam12`, full solver set) | OpenFOAM apt repo | ~2.0–4.0 GB |
+| CalculiX `ccx` | apt | ~30–80 MB |
+| `fab-vision` CLI (python wrapper + deps) | pip | ~150–400 MB |
+| Python 3.12 + fab scripts + test deps | apt/pip | ~150 MB |
+| **Total (single-stage naive)** | | **~4–6.5 GB** |
+| **Total (multi-stage, stripped)** | | **~3–4.5 GB** |
+
+**This image is multi-GB and there is no way around it** — OpenFOAM dominates. Multi-stage + prune (`*-dev`, OpenFOAM tutorials/doc, apt lists) saves ~1–2 GB but can't get under ~3 GB.
+
+### 3.2 Build time
+Clean build (cold cache, both heavy repos): **~10–20 min** on a GitHub runner; ~5–10 min locally warm. The OpenFOAM apt repo is the long pole — pin a point release to keep it cacheable. Layer ordering: solvers early (cache-stable), `COPY skills/autospec-fab` last (iterating the smoke doesn't rebuild solver layers).
+
+### 3.3 CI minutes / registry storage
+Building on **every PR** would add ~15 min × per-PR fab churn — unacceptable. Registry storage for ~3–4.5 GB is cheap in $ but every consumer pays the **pull** (~3–4.5 GB egress + disk) on first use. The real-solver smoke (real FreeCAD + meshing + simpleFoam iterations) is minutes of CPU even on a tiny part.
+
+### 3.4 Recommendation (proposed; operator confirms in §4)
+1. **Default stays mocked** — the `$TMP/bin`-shim unit suites remain the every-PR gate via `python.yml`/validate.sh. The default path doesn't change or slow.
+2. **Container build + real smoke is OPT-IN, dedicated workflow** — `workflow_dispatch` + nightly `schedule`, `paths: skills/autospec-fab/**`. **Never** on `pull_request`.
+3. **Build fresh in the nightly job, run the smoke, do NOT push by default** — pushing to a registry is a separate explicitly-enabled step behind §4.
+4. **Pin everything** — base by digest, OpenFOAM/FreeCAD/ccx by exact apt version, pip deps with hashes.
+
+## 4. Open decisions — needs operator sign-off
+
+Resolve before the cost-incurring child (C/E) runs.
+
+1. **Run the real-solver smoke in CI at all?** Proposed: yes, **nightly + manual-dispatch only**, never per-PR. (Confirm cadence.)
+2. **Publish the image?** (a) build-and-discard, never pushed [proposed default]; (b) push to GHCR (`ghcr.io/berlinguyinca/autospec-fab`) tagged date+SHA; (c) Docker Hub. (If pushed: public/private? retention/prune for old multi-GB tags?)
+3. **Accept a multi-GB image (~3–4.5 GB)?** No small variant exists.
+4. **OpenFOAM flavor + version pin:** ESI (`openfoam2406`) vs Foundation (`openfoam12`). Both ship `simpleFoam`. Proposed: ESI `openfoam2406`.
+5. **`fab-vision` real consumer scope:** ship a minimal contract-conformant CLI here (enough for non-skip smoke) vs block on #1271. Proposed: ship minimal here; #1271 upgrades the model behind the same contract.
+6. **Architecture matrix:** `linux/amd64` only, or also `linux/arm64`? arm64 ~doubles build time + OpenFOAM arm64 apt is shakier. Proposed: amd64 only for v1.
+
+## 5. Architecture
+
+### 5.1 New files
+```
+skills/autospec-fab/docker/
+  Dockerfile                  # multi-stage, pinned
+  fab-vision                  # minimal contract-conformant vision CLI (judge + --verify)
+  requirements.txt            # pip deps, hash-pinned
+  smoke/
+    run_smoke.sh              # drives one tiny part through fea+cfd+render+vision
+    part.stl                  # tiny fixture part
+    model/{metadata.json,load.json,flow.json}   # MODELDIR sibling layout
+.github/workflows/fab-container.yml             # opt-in: workflow_dispatch + nightly, NOT pull_request
+```
+
+### 5.2 Dockerfile strategy (multi-stage, pinned)
+Minimize final size; land each binary on `PATH` under the resolver's exact name; keep heavy solver layers above the `COPY` of fab scripts. Stages: `base` (ubuntu pinned by digest + python/xvfb/curl), `solvers` (apt `calculix-ccx`, `freecad-python3`+mesa, OpenFOAM ESI repo `openfoam2406-default`), `runtime` (COPY only needed binaries/libs from `solvers`, set OpenFOAM `PATH`/`WM_PROJECT_DIR`/`FOAM_LIBBIN` env so non-login shells resolve `simpleFoam`, prune `doc`/`tutorials`, COPY fab scripts + `fab-vision` last).
+
+**PATH-resolution mapping (the contract the image must satisfy):** `which("ccx")` → `/usr/bin/ccx`; `which("simpleFoam")` → OpenFOAM `platforms/.../bin` on `ENV PATH`; `which("freecadcmd")` → `/usr/bin/freecadcmd`; `which("fab-vision")`/`$AUTOSPEC_FAB_VISION_CMD` → `/usr/local/bin/fab-vision`.
+
+**Result-file conformance (the crux — beyond `apt install`):**
+- `ccx` writes `<job>.dat`; the stage parses a `SAFETY_FACTOR <value>` line. Real ccx emits stress/displacement, not a safety factor — so the container ships a thin **post-process wrapper** deriving `SAFETY_FACTOR` from the `.dat` MAX_MISES vs material yield. This is the one place the real solver meets the stage's parse contract; spec + test it explicitly.
+- `simpleFoam` workflow writes `cfd_results` (`PRESSURE_DROP`/`MIN_VELOCITY`/`STAGNATION`). Real OpenFOAM emits field data under time dirs; the case build + a post step must reduce fields into the `cfd_results` file the stage reads. **This reduction is the real integration work** and lives in the container's case/post pipeline.
+
+> **Load-bearing note:** the gap between real solver output and the `.dat`/`cfd_results` line format the stages already parse is the crux. Keep stages unchanged; ship post-process wrappers in `docker/` (bundled into child C).
+
+### 5.3 Pinned versions (pin all at build)
+`ubuntu:24.04` by `@sha256`; `calculix-ccx` exact apt version; `freecad-python3` exact; `openfoam2406-default` pinned; `requirements.txt` `--require-hashes`.
+
+## 6. Real-solver integration smoke + where it runs
+
+### 6.1 `docker/smoke/run_smoke.sh` (inside the image, one tiny fixture part with `metadata.json`+`load.json`+`flow.json`)
+Run the gate / each stage, then assert: **FEA** non-`skip` with structured `safety_factor` (real `ccx` + `.dat` parse); **CFD** non-`skip` with parsed `PRESSURE_DROP`/`MIN_VELOCITY` (real `simpleFoam` + `cfd_results`); **render** real PNG + `contact-sheet.html` (headless `freecadcmd` + xvfb); **vision** non-`skip` with a structurally-valid (possibly empty) `vision_findings` (real `fab-vision` judge+verify). Exit non-zero on any `skip`-where-real-expected or malformed fragment. This is a **wiring/integration** assertion, not numerical-accuracy.
+
+### 6.2 Where (`.github/workflows/fab-container.yml`)
+`on: workflow_dispatch` + `schedule: cron "0 6 * * *"` (nightly) — **NOT `pull_request`**. Job: checkout, `docker build`, `docker run … run_smoke.sh`. Registry push is a separate step behind §4, disabled by default. Mirror `python.yml` conventions (`ubuntu-latest`, `actions/checkout@v4`, `set -euo pipefail`, `concurrency`, `timeout-minutes`).
+
+## 7. Operator usage
+Bare-metal: install solvers, `/autospec-fab --repo .` (stages resolve binaries off PATH). Container: `docker build -f skills/autospec-fab/docker/Dockerfile -t autospec-fab .` then `docker run --rm -v "$PWD/model:/work/model" -v "$PWD/stls:/work/stls" autospec-fab python3 …/release_gate_stages.py --in /work/stls/part.stl --model /work/model/metadata.json --out /work/release-gate.json`. Sibling-file convention unchanged: present sidecar → real solver runs; absent → stage skips cleanly.
+
+## 8. Testing
+- **Default (unchanged, every-PR):** existing `$TMP/bin`-shim unit suites stay green and authoritative; no regression to the mocked path.
+- **New host-portable lint (cheap, in validate.sh):** assert the Dockerfile pins every version (no floating `:latest`, no unpinned apt), the smoke fixture `MODELDIR` is well-formed, `run_smoke.sh` asserts non-`skip`. Runnable without building the image.
+- **New real-integration smoke:** §6, only in `fab-container.yml` (nightly/dispatch).
+- **`fab-vision` CLI unit test:** the shipped minimal CLI conforms to the §1 contract (reuse `test_stage_vision.py`'s shim contract as oracle).
+- Adding `docker/` + a workflow does not touch the trio → goldens unaffected; verify validate.sh stays green.
+
+## 9. File pointers
+- Stage solver contracts: `stage_fea.py` (`_run_ccx`, `_parse_safety_factor`), `stage_cfd.py` (`_run_solver`, `_parse_cfd_results`), `freecad_harness.py` (`resolve_freecadcmd`, `_script_render`), `stage_vision.py` (`resolve_vision_cmd`, judge/verify).
+- Engine + sibling input: `release_gate_stages.py` (`STAGE_ORDER`, `_SIBLING_INPUTS`, `extra_args_for`).
+- OpenFOAM case builder (snappyHexMesh-on-real-STL belongs here): `openfoam_case.py`.
+- Test shim patterns to mirror: `tests/test_stage_fea.py` (`_make_ccx_shim`), `tests/test_stage_cfd.py` (`_make_solver_shim`), `tests/test_stage_vision.py` (`_install_vision_shim`), `tests/freecad_shim.py`.
+- CI style: `.github/workflows/python.yml`.
+- README to extend: `skills/autospec-fab/README.md`.
+
+## 10. Decomposition hint (auto-implement children)
+
+Ordered; each small and independently mergeable. **Children C and E are cost-incurring — gate behind §4 sign-off.**
+
+1. **A — README system-packages + container-usage docs (cheap, no cost).** "Required system packages" table (`calculix-ccx`, `freecad-python3`, `openfoam2406`, mesa/xvfb) + "Container usage" section + `$AUTOSPEC_FAB_VISION_CMD` doc. Closes the doc half of #1270 and the README ask of #1271. No image build.
+2. **B — minimal `fab-vision` CLI + conformance test (cheap).** `docker/fab-vision` (judge + `--verify`) conforming to `stage_vision.py`'s contract, unit test reusing `test_stage_vision.py`'s shim as oracle. No heavy deps. Unblocks a non-skip vision pass in the smoke. (Overlaps #1271; coordinate — prefer #1271's `fab-vision-cli.py` as the real consumer and have the container install it.)
+3. **C — Dockerfile + result-contract wrappers [COST-INCURRING: multi-GB build, ~10–20 min CI].** Multi-stage pinned Dockerfile landing the 4 binaries on PATH + the `ccx`→`SAFETY_FACTOR` and OpenFOAM-fields→`cfd_results` post-process wrappers. **Requires §4 decisions 3,4,6.** `ctx:` high.
+4. **D — real-solver smoke fixture + `run_smoke.sh` (cheap to author; runs heavy only in workflow).** Tiny fixture part + `MODELDIR` + `run_smoke.sh` asserting non-`skip` fragments. Depends on C for a runnable image; the script/fixture itself is light.
+5. **E — `fab-container.yml` opt-in workflow [COST-INCURRING: nightly build minutes].** `workflow_dispatch` + nightly `schedule`, builds C's image, runs D's smoke, NOT on `pull_request`. Registry-push present but disabled pending §4 decision 2. Plus the host-portable Dockerfile-pin lint wired into validate.sh.
+
+> A, B, D are safe auto-implement (no real cost). **C and E must not run until §4 is signed off** — they incur the multi-GB image + nightly CI minutes. Combine C's Dockerfile with its result-contract wrappers in one child.
+
+---
+
+**Note:** the single hardest piece of real work (beyond `apt install`) is bridging real solver output to the existing `.dat`/`cfd_results` parse contracts the stages already depend on — flagged in §5.2, bundled into child C. Issue #1271 (real vision CLI) overlaps and is satisfied by/coordinated with child B.

--- a/docs/specs/2026-06-22-autospec-fab-vision-cli-design.md
+++ b/docs/specs/2026-06-22-autospec-fab-vision-cli-design.md
@@ -1,0 +1,123 @@
+# autospec-fab vision stage — ship a real vision CLI consumer (design)
+
+Status: proposed
+Owner: berlinguyinca
+Date: 2026-06-22
+Slug: autospec-fab-vision-cli
+Tracking issue: #1271 (area:fab)
+
+## Problem
+
+`skills/autospec-fab/scripts/stage_vision.py` is a well-formed **advisory** vision stage. It resolves a vision command from `$AUTOSPEC_FAB_VISION_CMD` (else PATH `fab-vision`), runs a JUDGE pass over the render contact sheet, runs an adversarial `--verify` pass, and records only confirmed observations into the non-blocking `vision_findings[]`. It degrades honestly: no command resolved → `status: "skip"`.
+
+But **no real vision CLI ships**. `$AUTOSPEC_FAB_VISION_CMD` is unset and no `fab-vision` is on PATH in any real deployment, so `resolve_vision_cmd()` returns `None` and **every fab run SKIPS vision**. The stage has a defined API + a full test suite (`tests/test_stage_vision.py` exercises it through a PATH/env shim) but **zero real consumers** — exactly the ROI gap memory flags ("every new component needs a named consumer that benefits today"). The 2026-06-20 whole-project review surfaced this.
+
+The contract is already proven plumbed end-to-end: `stage_render.py` writes `<render-dir>/<slug>/contact-sheet.html` (an HTML grid of per-view `<img>` tags), and `stl-release-gate.py` threads that sheet as the vision stage's `--in` (the render→vision handoff, #1266). The only missing piece is a real, runnable command that satisfies the existing `$AUTOSPEC_FAB_VISION_CMD` contract.
+
+## Goal
+
+Ship a **real, default, runnable vision CLI consumer** — `scripts/fab-vision-cli.py` (installed/discoverable as `fab-vision`) — that:
+
+1. Satisfies the existing `$AUTOSPEC_FAB_VISION_CMD` contract **exactly** (judge pass + `--verify` pass; same argv and JSON shapes the stage already calls and `test_stage_vision.py` already pins), so `stage_vision.py` needs **no changes**.
+2. Reads the render contact sheet, resolves the per-view PNGs it references, and asks **Claude vision** (`claude-opus-4-8` via the Anthropic API, or the `claude` CLI when available) to inspect the renders against the STL Modeling Rules.
+3. **Degrades gracefully and never hard-fails a fab run**: no API key, offline, missing `anthropic` SDK, no images on disk, or any backend error → it exits in a way that makes the stage record `status: "skip"` (honest deferral, same as today), never a crash and never a fabricated finding.
+4. Is genuinely usable: a named CLI an operator can run by hand, point `$AUTOSPEC_FAB_VISION_CMD` at, and that pays off on the next real fab run — not another shim.
+
+This is the **opposite of an honest deferral**: we ship the consumer. The deferral path remains, but only as the degradation behavior when no backend is reachable.
+
+## Approach / Architecture
+
+### One new script, zero stage changes
+
+Add `skills/autospec-fab/scripts/fab-vision-cli.py` (stdlib + optional `anthropic`). The stage (`stage_vision.py`), the engine (`stl-release-gate.py`, `release_gate_stages.py`), and the render→vision handoff are **untouched**. The new CLI is a drop-in `$AUTOSPEC_FAB_VISION_CMD` target.
+
+How the stage drives it today (load-bearing — the CLI must match these byte-for-byte):
+
+- **Judge pass:** stage runs `<cmd> <sheet> [<rules>]`, expects stdout JSON `{"observations": [ {observation, severity, view?, rule?}, ... ]}`, exit 0. Non-zero or unparseable → stage treats it as zero candidates.
+- **Verify pass:** stage runs `<cmd> --verify <sheet> [<rules>]` with one candidate observation as JSON on **stdin**, expects stdout JSON `{"confirmed": <bool>}`, exit 0. Missing/malformed/non-zero → stage drops that observation (conservative).
+- `<sheet>` is the contact-sheet HTML path; `<rules>` is an optional STL Modeling Rules file (the engine does **not** currently pass `--rules`, so the CLI must work with `<rules>` absent).
+
+Because the stage already wraps the command in `_run_cmd` (catches `OSError`) and treats any non-zero / unparseable result as "nothing to report," the CLI's degradation story is simple: **on any backend unavailability, the CLI prints `{"observations": []}` (judge) / `{"confirmed": false}` (verify) to stdout and exits 0.**
+
+### Contact sheet → images
+
+The contact sheet is **HTML referencing sibling PNGs** (`stage_render.build_contact_sheet`: `<img src="<basename>.png">` in the sheet's own directory), not an inline image. The CLI:
+
+1. Reads the sheet HTML, extracts `<img src="...">` basenames in document order (deterministic — render writes them in `REQUIRED_VIEWS` table order).
+2. Resolves each `src` relative to the sheet's directory; keeps the ones that exist on disk.
+3. Caps the number of images sent (default 16, env-overridable) to bound tokens/cost; logs (to stderr) when capping.
+4. If **no** referenced PNG exists on disk, the CLI has nothing to inspect → emits the empty-judge degradation and exits 0.
+
+Each resolved PNG becomes a base64 `image` content block (`media_type: image/png`); the rules text (when `<rules>` given) plus a fixed instruction prompt become the `text` block.
+
+### Backend resolution (decided default + override)
+
+First usable wins:
+
+1. **`$AUTOSPEC_FAB_VISION_BACKEND`** — explicit override: `api` | `claude-cli` | `none`.
+2. **Anthropic API** (`api`) — if `import anthropic` succeeds **and** a key resolves (`ANTHROPIC_API_KEY` or SDK default). Model `claude-opus-4-8` (vision-capable; **read the `claude-api` skill before editing the call**), base64 PNG image blocks + text prompt, structured-output JSON. The **default real consumer**.
+3. **`claude` CLI** (`claude-cli`) — if `claude` is on PATH and supports non-interactive image input (verify support; see Open decisions).
+4. **none** — nothing usable → honest skip.
+
+The judge prompt asks Claude to return observations only for things it can actually see, each tagged `severity: info|warn` and an optional `view`/`rule`, and to **return an empty list when nothing is notable** (anti-fabrication). The verify prompt re-shows the renders + the single candidate and asks `{"confirmed": true|false}`.
+
+### The vision-cli contract (authoritative)
+
+**Judge pass:** `fab-vision-cli.py <sheet> [<rules>]` → stdout `{"observations": [{"observation": str, "severity": "info"|"warn", "view"?: str, "rule"?: str}, ...]}`, exit 0. Missing/unreadable sheet → `{"observations": []}`, exit 0.
+
+**Verify pass:** `fab-vision-cli.py --verify <sheet> [<rules>]` with one observation JSON on stdin → stdout `{"confirmed": true|false}`, exit 0. Unreadable stdin / backend error → `{"confirmed": false}`, exit 0.
+
+**Exit codes:** `0` always for reachable/unreachable-backend outcomes (verdict lives in JSON); `2` usage error only (bad flags / no positional `<sheet>`).
+
+**Environment**
+
+| Var | Meaning | Default |
+| --- | --- | --- |
+| `AUTOSPEC_FAB_VISION_CMD` | (consumed by the **stage**) path/name of this CLI | unset → stage skips |
+| `AUTOSPEC_FAB_VISION_BACKEND` | force `api` \| `claude-cli` \| `none` | auto-detect |
+| `ANTHROPIC_API_KEY` | API backend credential | unset → API unavailable |
+| `AUTOSPEC_FAB_VISION_MODEL` | override model id | `claude-opus-4-8` |
+| `AUTOSPEC_FAB_VISION_MAX_IMAGES` | cap images sent | `16` |
+
+### Graceful degradation (the non-negotiable rule)
+
+Every failure mode resolves to **honest skip/empty, exit 0, no crash, no fabricated finding**: CMD unset → stage `skip`; CLI present but no key/SDK/`BACKEND=none` → empty judge → stage `pass` with empty findings; offline/API error/timeout → caught, empty, exit 0; sheet present but zero PNGs → empty; malformed backend JSON → salvage-or-empty; a confirmed warn → `vision_findings` populated, `status` advisory `warn` (never `fail`).
+
+We do **not** add a backend-unavailable→skip channel in this iteration (would need a stage change). Empty-`pass` is an honest "vision ran, nothing actionable / nothing to inspect" — flagged in Open decisions.
+
+## Testing (real-services rule)
+
+Mirror `test_stage_vision.py`: **PATH-stub the vision backend, never mock the stage**. New `tests/test_fab_vision_cli.py` (unittest) + `tests/test_fab_vision_cli.bats`:
+
+1. **CLI-unit (backend=none):** judge `{"observations": []}` exit 0; verify `{"confirmed": false}` exit 0.
+2. **Contact-sheet parsing:** generate the fixture via the real `stage_render.build_contact_sheet` (self-consistent-fixture guard — pin against the producer, don't hand-write the HTML the resolver also parses); resolver finds N images in table order; absent PNGs → zero.
+3. **Backend stub (integration):** an `AUTOSPEC_FAB_VISION_STUB` seam returns canned judge/verify; assert images/rules pass through and the contract JSON is emitted unchanged. No real Anthropic call in CI.
+4. **End-to-end through the unmodified stage (bats):** install the CLI as `fab-vision` in `$TMP/bin`, set CMD + stub backend, run `stage_vision.py`, assert `vision_findings` carries the confirmed observation, `status` `warn`/`pass` (never `fail`). (bats 3.2: write candidate JSON to a real temp file, never `[ -f <(...) ]`.)
+5. **Degradation E2E:** `BACKEND=none` → empty findings, `pass`, exit 0; CLI removed from PATH → stage `skip`.
+6. **Never-fail invariant:** alarming confirmed warn → `status != "fail"` end-to-end.
+
+Real Anthropic API exercise is **manual/opt-in only** (README), never in unit/bats — keeps validate.sh deterministic/offline.
+
+## File pointers
+
+- Contract being satisfied: `skills/autospec-fab/scripts/stage_vision.py` (`resolve_vision_cmd`, `judge_contact_sheet`, `_confirm_observation`) — **do not modify**.
+- Input producer: `skills/autospec-fab/scripts/stage_render.py` (`build_contact_sheet`), `scripts/render_views.py` (`REQUIRED_VIEWS` order) — generate fixtures from `build_contact_sheet`.
+- Handoff: `scripts/stl-release-gate.py` (`_vision_in_override`, `run_gate`), `scripts/release_gate_stages.py` (`contact_sheet_for`).
+- Test pattern: `tests/test_stage_vision.py` (`$TMP/bin` shim + env-driven fake backend).
+- Backend call reference: the `claude-api` skill (base64 image content blocks, `messages.create`, `claude-opus-4-8`) — read before writing the API call.
+- README env docs to extend: `skills/autospec-fab/README.md`.
+
+## Decomposition hint (small auto-implement children, sized for a 32B LLM)
+
+1. **`fab-vision-cli` skeleton + contract + degradation (backend=none) + unit tests.** argparse (judge/`--verify`), contact-sheet→PNG resolver (against real `build_contact_sheet`), `none`/unavailable degradation (empty judge/`confirmed:false`, exit 0), `tests/test_fab_vision_cli.py` parsing + degradation. No real backend yet. (Trio note: `scripts/`-only Python + tests — NOT a SKILL.md trio edit — no derive-trio/goldens regen; confirm during implementation.)
+2. **Real Claude-vision backend + stub seam + integration test.** `api` backend (anthropic SDK, `claude-opus-4-8`, base64 images, JSON verdict) behind `AUTOSPEC_FAB_VISION_BACKEND`, plus `AUTOSPEC_FAB_VISION_STUB`. Integration + `tests/test_fab_vision_cli.bats` end-to-end through the unmodified `stage_vision.py`. No real API call in CI.
+3. **README env-var docs + concrete example + manual smoke note.** Document the 4 env vars; runnable example; graceful-skip behavior; opt-in real-API smoke. Docs-only.
+
+> Children 1+2 must keep validate.sh green on a clean checkout — materialize PNG/sheet fixtures at runtime (call `build_contact_sheet`) or `git add -f` + assert presence (gitignored-fixture guard).
+
+## Open decisions (need operator)
+
+1. **Default backend = Anthropic API (`claude-opus-4-8`) vs `claude` CLI.** Spec defaults to **API** (portable, deterministic auth). Prefer the `claude` CLI as primary where installed? Needs confirmation the installed `claude` supports non-interactive single-shot **image** input; if not, `claude-cli` backend is dropped this iteration and API-only ships.
+2. **Honest-skip signal when backend unavailable: empty-`pass` (chosen) vs explicit `deferred` advisory.** Empty-`pass` requires zero stage changes; a distinguishing `deferred` marker needs a small `stage_vision.py` change (out of scope).
+3. **Model + cost ceiling.** `claude-opus-4-8`, ~16 images, two passes → non-trivial per-model token cost. Acceptable, or cap to a cheaper vision model / fewer images / verify-only-warns? Overridable via env.
+4. **STL Modeling Rules source.** Engine doesn't thread `--rules` to vision today. Wire the rules file into `extra_args_for("vision", ...)` as a fast-follow? Recommended, not blocking.

--- a/docs/specs/2026-06-22-autospec-qa-deploy-contract-design.md
+++ b/docs/specs/2026-06-22-autospec-qa-deploy-contract-design.md
@@ -1,0 +1,185 @@
+# autospec-qa — declarative pre-QA deployment contract (`.autospec/qa-deploy.yml`)
+
+**Date:** 2026-06-22
+**Issue:** #694 (`feat: autospec-qa deploy contract`)
+**Labels:** `autospec:v2-flow`, `needs-human-review` (failed auto-implement once — this spec is written to be implementable from the text alone)
+**Status:** Design
+
+## Problem
+
+`/autospec-qa` today assumes the app under audit is *already running* at the URL the operator hands it. The skill has rich after-the-fact recovery for a dead backend — the **Live backend blocker triage prompt** (`skills/autospec-qa/SKILL.md`) — but no notion of "stand the app up first." For repos like tidyboard where each QA cycle needs a fresh deploy plus a production-data clone into a scoped test family, operators do this by hand *before* invoking `/autospec-qa`, and that work is invisible to the artifact trail.
+
+Two concrete failures result:
+
+1. **Deploy failures masquerade as app bugs.** When the manual pre-deploy fails, QA runs against a dead URL, the triage prompt fires on the resulting `502`/`504`, and the operator must reverse-engineer whether the app is broken or simply never deployed.
+2. **The deploy is unrecorded.** When the manual deploy *succeeds*, `.autospec/qa-verdict.json` records nothing about *what* was deployed (SHA), *when*, *where* (target env), or what data was cloned in.
+
+## Goal
+
+A declarative deployment contract at `.autospec/qa-deploy.yml`. **When the file is present**, `/autospec-qa` runs the documented deploy stages **before** the audit (deploy → wait-for-ready → optional data-clone into a scoped test family → record what/when/where into the verdict), fails fast on any stage failure with a clear `code_health:qa_deploy_*` error (never a downstream mystery `502`), and records a `deploy:` block in `.autospec/qa-verdict.json`. **When the file is absent**, behavior is byte-for-byte today's behavior.
+
+Non-goals (out of scope): network-egress allowlist around stage execution (deferred to v2); auto-generating the contract from spec/issue keyword detection; cross-repo deploys / persistent staging across runs; production-data anonymization (operator's responsibility; documented in `safety.notes`).
+
+## Schema
+
+`.autospec/qa-deploy.yml` mirrors the declarative style of `.autospec/test.yml` and `.autospec/autospec.yml`. Parsed with `yq -o=json`, validated against `schemas/autospec-qa-deploy.schema.json` with `ajv` — the exact toolchain `skills/autospec-test/scripts/load-contract.sh` already uses (yq → jq → ajv).
+
+### Fields
+
+| Field | Type | Required | Default | Meaning |
+| --- | --- | --- | --- | --- |
+| `required` | bool | no | `false` | Governs only whether the file being *absent* could be an error (it never is). The file's *presence* makes deploy mandatory. |
+| `stages` | list | **yes** | — | Ordered deploy stages, sequential; first failure aborts the rest. |
+| `stages[].name` | string | **yes** | — | Stable id; appears in `deploy.stages_run`. |
+| `stages[].command` | string | **yes** | — | Shell command via `bash -c`. Subject to the safety floor. |
+| `stages[].timeout` | int (s) | no | `300` | Hard wall-clock cap; exceeding it = stage failed. |
+| `stages[].env` | map | no | `{}` | Extra env; values passed verbatim, secret *values* never logged/recorded (only key names). |
+| `stages[].health_check.url` | string | yes (in block) | — | URL polled after the command. Subject to `target_envs.forbidden`. |
+| `stages[].health_check.expect_status` | int | no | `200` | Ready status. |
+| `stages[].health_check.retry` | int | no | `30` | Max poll attempts. |
+| `stages[].health_check.retry_interval` | int (s) | no | `10` | Delay between attempts. |
+| `stages[].safety.max_records` | int | conditional | — | **Required for any data-clone stage** (name/command matches `clone\|copy\|replicate\|sync`). |
+| `stages[].safety.forbid_production_writes` | bool | no | `false` | Operator intent flag; recorded, advisory. |
+| `teardown[].name` | string | **yes** (per entry) | — | Identifier. |
+| `teardown[].command` | string | **yes** (per entry) | — | Shell command; same safety floor. |
+| `teardown[].on_failure` | enum | no | `warn` | `warn` → logs only; `fail` → downgrades a `PASS` verdict to `PARTIAL`. |
+| `target_envs.allowed` | list | no | `[]` | Advisory; recorded. |
+| `target_envs.forbidden` | list | **yes** | — | **Absolute safety floor** — any forbidden token in a stage command, a `health_check.url`, or stage **stdout** aborts with exit 3. ≥1 entry required. |
+| `safety.notes` | string | no | — | Free text. |
+
+### Safety floor (non-negotiable; enforced regardless of operator config)
+
+`scripts/qa-deploy-runner.sh` enforces before/during stage execution; each violation aborts immediately, runs no further stages, exits **3** with the named category in the verdict:
+
+1. **Forbidden-target match** — each `target_envs.forbidden` entry matched (literal substring, case-insensitive) against each stage `command`, `health_check.url`, and captured **stdout** → `code_health:qa_deploy_forbidden_target`.
+2. **Production-pattern rejection** — each `command` (deploy+teardown) word-boundary case-insensitive matched against `--prod`, `--production`, ` prod `, ` production `, `production-only`, `live-prod` → `code_health:qa_deploy_prod_pattern`.
+3. **`max_records` required for data-clone stages** — name/command containing `clone|copy|replicate|sync` must declare `safety.max_records` → else `code_health:qa_deploy_missing_records_cap`.
+
+The egress allowlist (rule 4 in #694) is **deferred to v2**.
+
+### Example `.autospec/qa-deploy.yml`
+
+```yaml
+required: true
+stages:
+  - name: deploy-to-test-family
+    command: bash scripts/deploy-tidyboard-test.sh
+    timeout: 600
+    env:
+      DEPLOY_TARGET: test-family
+    health_check:
+      url: https://test.tidyboard.org/health
+      expect_status: 200
+      retry: 30
+      retry_interval: 10
+  - name: clone-production-data
+    command: bash scripts/clone-prod-data-to-test.sh --target test-family
+    timeout: 1800
+    safety:
+      forbid_production_writes: true
+      max_records: 10000          # required: stage name contains "clone"
+teardown:
+  - name: snapshot-test-state
+    command: bash scripts/snapshot-test-state.sh
+    on_failure: warn
+  - name: cleanup
+    command: bash scripts/cleanup-test-family.sh
+    on_failure: warn
+target_envs:
+  allowed: [test.tidyboard.org, staging.tidyboard.org]
+  forbidden: [tidyboard.org, www.tidyboard.org]
+safety:
+  notes: "clone script anonymizes PII in step 2; test family is read-isolated from prod."
+```
+
+### `deploy:` block added to `.autospec/qa-verdict.json`
+
+```json
+{
+  "verdict": "PASS",
+  "deploy": {
+    "stages_run": ["deploy-to-test-family", "clone-production-data"],
+    "stage_durations_ms": {"deploy-to-test-family": 145000, "clone-production-data": 902000},
+    "target_env": "https://test.tidyboard.org",
+    "head_sha_deployed": "abc1234",
+    "data_clone": {"source": "prod-readonly", "records_copied": 8500, "max_records": 10000},
+    "teardown_run": true,
+    "teardown_failures": []
+  },
+  "findings": []
+}
+```
+
+`head_sha_deployed` = `git rev-parse --short HEAD` at deploy time. `data_clone.records_copied` parsed from a `records_copied=<int>` stdout line if present; else omitted. The block is **additive** — every existing verdict consumer (heal loop, `/autospec-release`, `/autospec-sweep`) is unaffected.
+
+## Architecture / integration
+
+`scripts/qa-deploy-runner.sh --repo-dir . --verdict .autospec/qa-verdict.json` is invoked at the **very start** of the `/autospec-qa` orchestration — before any cluster fan-out — and its exit code gates the audit:
+
+- no `.autospec/qa-deploy.yml` → exit 0, no-op → today's QA path, unchanged.
+- parse + ajv-validate; enforce safety floor (rules 1-3) → exit 3 on hit.
+- run stages in order, each under `timeout`; run `health_check` probes (retry/interval).
+- any stage/probe failure → exit 1, write `verdict.deploy` + a `qa_deploy_failed` finding.
+- success → write `verdict.deploy` block atomically.
+
+A failed deploy never reaches the cluster fan-out: the operator sees a single `code_health:qa_deploy_*` finding naming the failing stage + stdout tail, not a `502` triage trail. The Live backend blocker triage prompt stays as-is for the deploy-succeeds-but-app-unhealthy-mid-audit case.
+
+**Atomic verdict update** uses the sibling `.tmp` + `mv` pattern from `scripts/qa-finding-filter.sh`. If no verdict exists yet (deploy runs first), the runner creates a minimal `{"deploy": {...}}` the later audit merges into.
+
+**Teardown** runs after the verdict is final (unless `--skip-teardown`). `on_failure: fail` rewrites `PASS`→`PARTIAL` (never touches `FAIL`), appends to `deploy.teardown_failures`. `--skip-teardown` sets `deploy.teardown_run: false`.
+
+## Graceful behavior when the file is absent
+
+No `.autospec/qa-deploy.yml` → runner exits `0` immediately, writes nothing, QA proceeds exactly as today (verdict byte-identical, no `deploy:` key). This is the most important compatibility contract and gets its own bats fixture.
+
+## Error handling / exit codes
+
+| Exit | Meaning | Verdict category |
+| --- | --- | --- |
+| 0 | No contract (no-op), or all stages + probes succeeded | — / `deploy` block |
+| 1 | Stage failed/timed out, or a `health_check` exhausted retries | `code_health:qa_deploy_failed` |
+| 2 | Usage / contract invalid (ajv fail, malformed YAML, missing required) | `code_health:qa_deploy_invalid_contract` |
+| 3 | Safety-floor violation | `qa_deploy_forbidden_target` \| `qa_deploy_prod_pattern` \| `qa_deploy_missing_records_cap` |
+
+`set -u`, NOT `set -e` around stage execution — stage failures are caught explicitly so the verdict records them (per the project's "set -e short-circuit" memory). Secret env **values** never logged. Missing `yq`/`jq`/`ajv` → exit 2 with an actionable `brew install` message (matches `load-contract.sh`).
+
+## Idempotency / re-run safety
+
+Runner is stateless between runs: re-parses, re-runs stages, **replaces** (not appends) the `deploy:` block. Deploy idempotency is the operator's stage-script responsibility (documented in `safety.notes`). A green health check returns on first poll. `--skip-teardown` leaves the env intact for repeated manual re-QA.
+
+## Testing
+
+Real-services rule: no mocking the contract loader/runner logic. The **deploy commands** are PATH-stubbed (a fixture `bin/` whose `deploy`/`clone`/`curl` shims write a real local file / serve a real readiness file), so the contract runs end-to-end against a real local "stage" without network. Safety floor, parse, verdict-write run for real.
+
+`tests/qa/test_qa_deploy.bats` (10 fixtures, per #694 AC): (1) absent contract → no-op exit 0, no `deploy:` key; (2) simple deploy → ordered `stages_run` + durations + target_env; (3) forbidden URL in command → exit 3 `forbidden_target`, zero stages run; (4) prod pattern → exit 3 `prod_pattern`; (5) clone stage missing `max_records` → exit 3 `missing_records_cap`; (6) health check fails after retry → exit 1 `qa_deploy_failed`; (7) teardown `warn` → no verdict change; (8) teardown `fail` → `PASS`→`PARTIAL`; (9) `--skip-teardown` → skipped, `teardown_run:false`; (10) synthetic end-to-end → `deploy:` block matches expected JSON. (bats memory: write any stub-served readiness file to a real temp file before any `[ -f ]`.)
+
+`scripts/validate.sh` gains `check_qa_deploy_contract()` (mirroring `check_closeout_contract`): trio lockstep for the new `## Deployment contract` section (`check_lockstep`/`check_lockstep_duo`); `qa-deploy-runner.sh` exists + executable + `bash -n` clean; `schemas/autospec-qa-deploy.schema.json` valid (ajv compile); runs the bats. Trio prose + goldens are **one atomic change** (memory): edit `SKILL.md`, then `derive-trio.sh --in-place` + `gen-skill-goldens.sh` in the same child.
+
+## File pointers
+
+- `skills/autospec-qa/SKILL.md` — new `## Deployment contract` section, URL intake, Live backend triage prompt to coordinate with, orchestrator entry.
+- `skills/autospec-qa/{codex/prompt.md, opencode/agent.md}` — lockstep trio targets.
+- `skills/autospec-test/scripts/load-contract.sh` — **the** yq→jq→ajv load+validate pattern to copy.
+- `skills/autospec-test/scripts/run-gate.sh` — contract-gates-pipeline + exit-code (0/1/2) convention.
+- `scripts/qa-finding-filter.sh` — atomic `.tmp`+`mv` verdict rewrite.
+- `skills/autospec-test/tests/fixtures/repos/minimal-valid/.autospec/test.yml` — declarative-yml fixture style.
+- `scripts/validate.sh` (`check_closeout_contract`, `check_lockstep`, `check_derive_trio_consistency`) — check-function shape.
+- `schemas/autospec-*.schema.json` — schema-file precedent for the new `autospec-qa-deploy.schema.json`.
+
+## Decomposition hint (3-5 small auto-implement children)
+
+1. **Schema + JSON-Schema file.** `schemas/autospec-qa-deploy.schema.json` (`target_envs.forbidden` + `stages` required) + `tests/qa/fixtures/` valid + each-invalid samples. No runner yet.
+2. **Runner core: parse + safety floor + no-op.** yq/jq/ajv load (copy `load-contract.sh`), exit-0 no-op on absent file, the 3 safety rules (exit 3), invalid-contract (exit 2). Bats fixtures 1, 3, 4, 5.
+3. **Runner stage execution + health probe + atomic verdict write.** Sequential stages under `timeout`, retry loop, `deploy:` block via `.tmp`+`mv`, `qa_deploy_failed`. Bats fixtures 2, 6, 10.
+4. **Teardown + `--skip-teardown` + verdict downgrade.** Post-verdict teardown, `on_failure: warn|fail`, PASS→PARTIAL. Bats fixtures 7, 8, 9.
+5. **Trio prose + validate gate (atomic with goldens).** `## Deployment contract` in `SKILL.md`, `derive-trio.sh --in-place` + `gen-skill-goldens.sh`, `check_qa_deploy_contract()` in `validate.sh`. Must Close in one PR.
+
+Ordering: 1 → {2,3,4} → 5 (children 2-4 each Close against child 1's schema; child 5 depends on the runner existing).
+
+## Open decisions (operator-level)
+
+1. **`required: true` on a *failed* stage.** Spec: presence ⇒ deploy mandatory regardless of `required`. Alternative: `required: false` = best-effort (failed stage warns, QA proceeds). Strict reading chosen for fail-fast clarity.
+2. **Re-deploy every re-run vs skip-if-healthy.** Always re-runs today; an optional `stages[].skip_if_healthy` would save long clones but adds state assumptions. Deferred unless wanted.
+3. **`data_clone.records_copied` source.** Spec parses a `records_copied=<int>` stdout convention; alternative is a `--report <path>` JSON.
+4. **Forbidden-target matching strictness.** Literal case-insensitive substring (simple, no regex-injection risk per the jq/regex memory); deliberately over-blocks rather than under-blocks. Confirm acceptable.
+5. **Teardown on a `FAIL` verdict.** Spec runs teardown regardless (cleanup should happen). Invert to preserve failed envs for forensics?


### PR DESCRIPTION
Three implementable design specs for the open heavy issues, sized for small-LLM decomposition. Each: Problem/Goal, Architecture, Testing (real-services), File pointers, a Decomposition hint, and an **Open decisions** section.

- **#1271** fab vision CLI — `scripts/fab-vision-cli.py` satisfying the existing `$AUTOSPEC_FAB_VISION_CMD` contract (Claude vision over the contact sheet) + graceful offline skip. 3 children.
- **#694** qa-deploy contract — declarative `.autospec/qa-deploy.yml` + `qa-deploy-runner.sh` pre-QA gate with a safety floor + a `deploy:` verdict block. 5 children.
- **#1270** fab toolchain container — pinned multi-GB image + opt-in **nightly** real-solver smoke. Includes a **cost analysis** (~3-4.5GB, ~10-20min build) and open decisions; **children C/E are cost-incurring and HELD pending operator sign-off**.

Docs-only (3 new files under docs/specs/).