### PR TITLE
feat(autospec-fab): fab-vision-cli skeleton + contract + degradation (#1289)

### DIFF
--- a/skills/autospec-fab/scripts/fab-vision-cli.py
+++ b/skills/autospec-fab/scripts/fab-vision-cli.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+fab-vision-cli.py — the default, runnable $AUTOSPEC_FAB_VISION_CMD consumer.
+
+This is the drop-in vision command that stage_vision.py invokes (judge +
+adversarial verify). It satisfies the stage's contract byte-for-byte:
+
+    JUDGE pass:   fab-vision-cli.py <sheet> [<rules>]
+                  -> stdout {"observations": [...]}, exit 0
+    VERIFY pass:  fab-vision-cli.py --verify <sheet> [<rules>]
+                  with one observation JSON on stdin
+                  -> stdout {"confirmed": true|false}, exit 0
+
+Contract guarantees (design spec §"The vision-cli contract (authoritative)"):
+  * Exit 0 for every reachable/unreachable-backend outcome — the verdict lives
+    in the JSON, never the exit code. The ONLY non-zero exit is 2, for a usage
+    error (bad flags / no positional <sheet>).
+  * Honest degradation, never a crash and never a fabricated finding: missing /
+    unreadable sheet, zero PNGs on disk, or no usable backend all resolve to
+    the empty judge ({"observations": []}) / negative verify
+    ({"confirmed": false}), exit 0.
+
+SCOPE of this iteration (child #1289): stdlib only. The backend is ALWAYS
+"none" here — there is no real model call yet. The backend-resolution seam
+(resolve_backend()) is left clean so child #1290 can add the real "api" backend
+(Anthropic SDK, base64 PNG image blocks) behind $AUTOSPEC_FAB_VISION_BACKEND
+WITHOUT touching the argument parsing, the contact-sheet→PNG resolver, or the
+degradation contract.
+
+Stdlib only; no third-party imports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from html.parser import HTMLParser
+
+# Default cap on the number of images handed to a backend, to bound token/cost
+# once a real backend exists (child #1290). Env-overridable. In this iteration
+# the cap only trims the resolved list the (none) backend ignores.
+_DEFAULT_MAX_IMAGES = 16
+
+
+class _ImgSrcParser(HTMLParser):
+    """Collect every <img src="..."> value in document order."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.srcs: list = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() != "img":
+            return
+        for name, value in attrs:
+            if name.lower() == "src" and value:
+                self.srcs.append(value)
+
+
+def _max_images() -> int:
+    """Resolve the image cap from $AUTOSPEC_FAB_VISION_MAX_IMAGES (env)."""
+    raw = os.environ.get("AUTOSPEC_FAB_VISION_MAX_IMAGES")
+    if raw is None:
+        return _DEFAULT_MAX_IMAGES
+    try:
+        n = int(raw)
+    except (ValueError, TypeError):
+        return _DEFAULT_MAX_IMAGES
+    return n if n > 0 else _DEFAULT_MAX_IMAGES
+
+
+def resolve_images(sheet_path: str) -> list:
+    """
+    Resolve the contact sheet HTML into a list of on-disk PNG paths.
+
+    Reads the sheet, extracts <img src="..."> basenames in document order (the
+    render stage writes them in REQUIRED_VIEWS table order, so the order is
+    deterministic), resolves each src relative to the sheet's own directory, and
+    keeps only the ones that exist on disk. A missing / unreadable sheet, or a
+    sheet referencing no existing PNG, yields an empty list (the caller then
+    emits the empty-judge degradation). The list is capped at _max_images().
+
+    This NEVER raises: any I/O or parse error degrades to an empty list.
+    """
+    try:
+        with open(sheet_path, "r", encoding="utf-8", errors="replace") as f:
+            html_text = f.read()
+    except OSError:
+        return []
+
+    parser = _ImgSrcParser()
+    try:
+        parser.feed(html_text)
+    except Exception:
+        # An unparseable sheet has nothing we can trust — degrade to empty.
+        return []
+
+    sheet_dir = os.path.dirname(os.path.abspath(sheet_path))
+    resolved = []
+    for src in parser.srcs:
+        # Keep the referenced basename, resolved relative to the sheet dir.
+        candidate = os.path.normpath(os.path.join(sheet_dir, src))
+        if os.path.isfile(candidate):
+            resolved.append(candidate)
+
+    cap = _max_images()
+    if len(resolved) > cap:
+        sys.stderr.write(
+            f"fab-vision-cli: capping {len(resolved)} images to {cap}\n"
+        )
+        resolved = resolved[:cap]
+    return resolved
+
+
+def resolve_backend() -> str:
+    """
+    Resolve which vision backend to use. Seam for child #1290.
+
+    First usable wins (design spec §"Backend resolution"):
+      1. $AUTOSPEC_FAB_VISION_BACKEND explicit override (api | claude-cli | none)
+      2. Anthropic API ("api")   — added in child #1290 (anthropic SDK + key)
+      3. claude CLI ("claude-cli") — candidate, pending support confirmation
+      4. "none"                   — nothing usable -> honest degradation
+
+    In THIS iteration only "none" is implemented: there is no real backend, so
+    we always return "none" (an explicit override is honoured only insofar as it
+    cannot conjure a backend that does not exist yet). Child #1290 fills in the
+    real branches here without touching the rest of the CLI.
+    """
+    override = os.environ.get("AUTOSPEC_FAB_VISION_BACKEND")
+    if override == "none":
+        return "none"
+    # No real backend exists in this iteration; everything degrades to "none".
+    # (Child #1290 will return "api" / "claude-cli" here when usable.)
+    return "none"
+
+
+def judge(sheet_path: str, rules_path: str | None) -> dict:
+    """
+    JUDGE pass: review the contact sheet against the rules.
+
+    Returns {"observations": [...]}. With backend "none" (this iteration) — or
+    whenever there is nothing to inspect — this is the empty list. Never raises.
+    """
+    backend = resolve_backend()
+    if backend == "none":
+        return {"observations": []}
+
+    # Unreachable in this iteration. Once child #1290 adds a real backend, the
+    # resolved images + rules text would be sent here. The seam:
+    images = resolve_images(sheet_path)  # noqa: F841  (used by #1290)
+    if not images:
+        return {"observations": []}
+    # Real backend dispatch lands in child #1290; until then, degrade honestly.
+    return {"observations": []}
+
+
+def verify(sheet_path: str, rules_path: str | None,
+           observation: dict | None) -> dict:
+    """
+    VERIFY pass: confirm or reject one candidate observation.
+
+    Returns {"confirmed": bool}. With backend "none" (this iteration), an
+    unreadable candidate, or any backend error this is {"confirmed": false}
+    (conservative: an unverified observation is dropped). Never raises.
+    """
+    backend = resolve_backend()
+    if backend == "none" or observation is None:
+        return {"confirmed": False}
+
+    # Real backend dispatch lands in child #1290; until then, degrade honestly.
+    return {"confirmed": False}
+
+
+def _read_stdin_observation():
+    """Read one observation JSON object from stdin; None if absent/malformed."""
+    try:
+        raw = sys.stdin.read()
+    except OSError:
+        return None
+    if not raw or not raw.strip():
+        return None
+    try:
+        value = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="fab-vision-cli.py",
+        description="autospec-fab vision CLI consumer "
+                    "($AUTOSPEC_FAB_VISION_CMD target)",
+    )
+    parser.add_argument(
+        "--verify", action="store_true",
+        help="verify pass: confirm one candidate observation read from stdin",
+    )
+    parser.add_argument("sheet", help="contact-sheet HTML path")
+    parser.add_argument("rules", nargs="?", default=None,
+                        help="STL Modeling Rules file (optional)")
+
+    # argparse exits 2 on a usage error (bad flags / missing <sheet>), which is
+    # exactly the contract's usage-error exit code — no special handling needed.
+    args = parser.parse_args(argv)
+
+    if args.verify:
+        observation = _read_stdin_observation()
+        result = verify(args.sheet, args.rules, observation)
+    else:
+        result = judge(args.sheet, args.rules)
+
+    json.dump(result, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/autospec-fab/tests/test_fab_vision_cli.bats
+++ b/skills/autospec-fab/tests/test_fab_vision_cli.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# test_fab_vision_cli.bats — thin bats wrapper around the Python unittest suite.
+# Invoked by validate.sh fab gate (check_autospec_fab_contract) which runs
+# every skills/autospec-fab/tests/*.bats file.
+
+# Resolve the repo root from this file's location (tests/ → skill/ → repo root)
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+
+@test "fab_vision_cli python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_fab_vision_cli.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_fab_vision_cli.py
+++ b/skills/autospec-fab/tests/test_fab_vision_cli.py
@@ -1,0 +1,226 @@
+"""
+test_fab_vision_cli.py — unittest for fab-vision-cli.py.
+
+This is the default $AUTOSPEC_FAB_VISION_CMD consumer. In this iteration the
+backend is ALWAYS "none" (no real model), so every outcome is the honest
+degradation: empty judge / negative verify, exit 0; usage error exit 2.
+
+The CLI is a hyphenated script (fab-vision-cli.py), so it is exercised exactly
+like the real stage exercises it: as a SUBPROCESS with argv + stdin, asserting
+on stdout JSON + exit code. (No module import of the hyphenated file.)
+
+Resolver fixtures are MATERIALIZED AT RUNTIME by calling the REAL producer,
+stage_render.build_contact_sheet (self-consistent-fixture guard: pin the
+resolver against the actual HTML the render stage emits, never a hand-written
+copy). PNG bytes are written for the views we want "present" on disk, so the
+resolver test exercises real existence-filtering on a real sheet.
+
+Assertions:
+  (a) judge `<sheet>`            -> {"observations": []}, exit 0  (backend none)
+  (b) verify `--verify <sheet>`  -> {"confirmed": false}, exit 0  (obs on stdin)
+  (c) resolver: real build_contact_sheet -> <img src> basenames in document /
+      REQUIRED_VIEWS table order; absent PNGs dropped; zero PNGs -> empty.
+  (d) missing / unreadable sheet -> {"observations": []}, exit 0.
+  (e) usage error (bad flag / no <sheet>) -> exit 2.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+# The REAL contact-sheet producer + the deterministic view order. Importing
+# stage_render also makes REQUIRED_VIEWS available (re-exported there).
+import stage_render  # noqa: E402
+
+_CLI = os.path.join(_SCRIPTS_DIR, "fab-vision-cli.py")
+
+
+def _run_cli(args, stdin_text=None):
+    """Invoke fab-vision-cli.py as a subprocess; return (rc, parsed_stdout)."""
+    proc = subprocess.run(
+        [sys.executable, _CLI] + list(args),
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+    )
+    parsed = None
+    out = (proc.stdout or "").strip()
+    if out:
+        try:
+            parsed = json.loads(out)
+        except ValueError:
+            parsed = None
+    return proc.returncode, parsed
+
+
+def _build_real_sheet(tmpdir, present_view_names):
+    """
+    Build a real contact sheet via stage_render.build_contact_sheet.
+
+    `present_view_names` is the set of REQUIRED_VIEWS names whose PNG bytes are
+    actually written to disk; the rest are referenced by the sheet but absent
+    (so the resolver must drop them). Returns (sheet_path, expected_present_pngs)
+    where expected_present_pngs is the list of present PNG basenames in the
+    deterministic REQUIRED_VIEWS table order.
+    """
+    render_dir = os.path.join(tmpdir, "renders")
+    slug = "widget"
+    view_dir = os.path.join(render_dir, slug)
+    os.makedirs(view_dir, exist_ok=True)
+
+    results = []
+    expected_present = []
+    for view in stage_render.REQUIRED_VIEWS:
+        name = view["name"]
+        png = os.path.join(view_dir, name + ".png")
+        present = name in present_view_names
+        if present:
+            with open(png, "wb") as f:
+                f.write(b"\x89PNG\r\n\x1a\n")  # sentinel PNG bytes
+            expected_present.append(name + ".png")
+        results.append({
+            "name": name,
+            "kind": view["kind"],
+            "png": png,
+            "rendered": present,
+        })
+
+    sheet = stage_render.build_contact_sheet(render_dir, slug, results)
+    return sheet, expected_present
+
+
+class TestDegradationJudge(unittest.TestCase):
+
+    def test_judge_empty_observations_exit0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sheet, _ = _build_real_sheet(tmp, present_view_names=set())
+            rc, out = _run_cli([sheet])
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, {"observations": []})
+
+    def test_judge_with_rules_arg_empty_exit0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sheet, _ = _build_real_sheet(tmp, present_view_names={"front"})
+            rules = os.path.join(tmp, "rules.md")
+            with open(rules, "w") as f:
+                f.write("# STL Modeling Rules\n")
+            rc, out = _run_cli([sheet, rules])
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, {"observations": []})
+
+
+class TestDegradationVerify(unittest.TestCase):
+
+    def test_verify_confirmed_false_exit0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sheet, _ = _build_real_sheet(tmp, present_view_names={"front"})
+            candidate = json.dumps({
+                "observation": "left gasket groove appears exposed",
+                "severity": "warn",
+                "view": "left",
+                "rule": "exposed_gasket",
+            })
+            rc, out = _run_cli(["--verify", sheet], stdin_text=candidate)
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, {"confirmed": False})
+
+    def test_verify_empty_stdin_confirmed_false_exit0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sheet, _ = _build_real_sheet(tmp, present_view_names=set())
+            rc, out = _run_cli(["--verify", sheet], stdin_text="")
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, {"confirmed": False})
+
+
+class TestMissingSheet(unittest.TestCase):
+
+    def test_missing_sheet_empty_judge_exit0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = os.path.join(tmp, "nope", "contact-sheet.html")
+            rc, out = _run_cli([missing])
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, {"observations": []})
+
+
+class TestUsageError(unittest.TestCase):
+
+    def test_no_sheet_positional_exit2(self):
+        rc, _ = _run_cli([])
+        self.assertEqual(rc, 2)
+
+    def test_bad_flag_exit2(self):
+        rc, _ = _run_cli(["--definitely-not-a-flag", "sheet.html"])
+        self.assertEqual(rc, 2)
+
+
+class TestResolver(unittest.TestCase):
+    """Resolver pinned against the REAL build_contact_sheet output."""
+
+    def setUp(self):
+        # Import the resolver here so a hyphenated-module import failure surfaces
+        # as a clear skip rather than a collection error. The CLI file name has a
+        # hyphen, so we load it via importlib from its path.
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("fab_vision_cli", _CLI)
+        self.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.mod)
+
+    def test_all_present_pngs_in_table_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Present every required view. REQUIRED_VIEWS has 17 entries, above
+            # the default image cap (16), so lift the cap for this assertion so
+            # we exercise full table-order resolution rather than the cap.
+            os.environ["AUTOSPEC_FAB_VISION_MAX_IMAGES"] = "100"
+            self.addCleanup(os.environ.pop, "AUTOSPEC_FAB_VISION_MAX_IMAGES",
+                            None)
+            all_names = {v["name"] for v in stage_render.REQUIRED_VIEWS}
+            sheet, expected = _build_real_sheet(tmp, present_view_names=all_names)
+            resolved = self.mod.resolve_images(sheet)
+            got = [os.path.basename(p) for p in resolved]
+            self.assertEqual(got, expected)
+            # Document/table order == REQUIRED_VIEWS order.
+            self.assertEqual(
+                got, [v["name"] + ".png" for v in stage_render.REQUIRED_VIEWS])
+
+    def test_absent_pngs_dropped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            present = {"front", "left", "top", "iso-front-right-top"}
+            sheet, expected = _build_real_sheet(tmp, present_view_names=present)
+            resolved = self.mod.resolve_images(sheet)
+            got = [os.path.basename(p) for p in resolved]
+            # Only present PNGs survive, in deterministic table order.
+            self.assertEqual(got, expected)
+            self.assertEqual(len(got), len(present))
+
+    def test_zero_pngs_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sheet, expected = _build_real_sheet(tmp, present_view_names=set())
+            self.assertEqual(expected, [])
+            self.assertEqual(self.mod.resolve_images(sheet), [])
+
+    def test_missing_sheet_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = os.path.join(tmp, "nope.html")
+            self.assertEqual(self.mod.resolve_images(missing), [])
+
+    def test_cap_trims_to_max_images_in_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ["AUTOSPEC_FAB_VISION_MAX_IMAGES"] = "3"
+            self.addCleanup(os.environ.pop, "AUTOSPEC_FAB_VISION_MAX_IMAGES",
+                            None)
+            all_names = {v["name"] for v in stage_render.REQUIRED_VIEWS}
+            sheet, expected = _build_real_sheet(tmp, present_view_names=all_names)
+            got = [os.path.basename(p) for p in self.mod.resolve_images(sheet)]
+            self.assertEqual(got, expected[:3])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1289 (part of #1271 — vision CLI). Ships `scripts/fab-vision-cli.py` satisfying the existing `$AUTOSPEC_FAB_VISION_CMD` judge/`--verify` contract byte-for-byte with an honest `backend=none` degradation path + a contact-sheet→PNG resolver (REQUIRED_VIEWS order, drops absent, 16-cap). `resolve_backend()` leaves the seam for #1290's real api backend. **`stage_vision.py` unchanged.**

## Verification
- 12 unittest cases + a bats wrapper (validate's pytest covers `packages tests`, not `skills` — the wrapper gates the fab suite). Fixtures built from the real `build_contact_sheet` (self-consistent + gitignored-fixture guards). `bash scripts/validate.sh` exit 0. 3 new files only; no docs/specs.