### PR TITLE
feat(autospec-fab): fab-vision-cli real api backend + stub seam (#1290)

### DIFF
--- a/skills/autospec-fab/scripts/fab-vision-cli.py
+++ b/skills/autospec-fab/scripts/fab-vision-cli.py
@@ -20,23 +20,53 @@ Contract guarantees (design spec §"The vision-cli contract (authoritative)"):
     the empty judge ({"observations": []}) / negative verify
     ({"confirmed": false}), exit 0.
 
-SCOPE of this iteration (child #1289): stdlib only. The backend is ALWAYS
-"none" here — there is no real model call yet. The backend-resolution seam
-(resolve_backend()) is left clean so child #1290 can add the real "api" backend
-(Anthropic SDK, base64 PNG image blocks) behind $AUTOSPEC_FAB_VISION_BACKEND
-WITHOUT touching the argument parsing, the contact-sheet→PNG resolver, or the
-degradation contract.
+SCOPE (child #1290): the real "api" backend (Anthropic Claude vision) plus a
+test seam.
 
-Stdlib only; no third-party imports.
+  * BACKEND RESOLUTION ($AUTOSPEC_FAB_VISION_BACKEND, first usable wins):
+    explicit override (api | claude-cli | none); else "api" when a usable
+    backend exists — either the $AUTOSPEC_FAB_VISION_STUB seam is set, or the
+    anthropic SDK imports AND a key resolves; else "none" (honest degradation).
+
+  * api BACKEND: each resolved PNG -> a base64 image content block
+    (media_type image/png); the rules text (if any) + a fixed anti-fabrication
+    instruction -> a text block; model from $AUTOSPEC_FAB_VISION_MODEL (default
+    "claude-opus-4-8"); structured JSON output ({"observations":[...]} for
+    judge, {"confirmed": bool} for verify). The anti-fabrication prompt asks
+    for an EMPTY list when nothing is notable.
+
+  * STUB SEAM ($AUTOSPEC_FAB_VISION_STUB=<path>): when set, the model call is
+    delegated to that executable instead of the real Anthropic API, so CI can
+    exercise the full code path (image/rules pass-through, contract JSON) with
+    NO real API call. The stub is invoked as:
+        <stub> judge  <sheet> [<rules>]   < (image-manifest JSON on stdin)
+        <stub> verify <sheet> [<rules>]   < (candidate-observation JSON on stdin)
+    and must print the same JSON contract the api backend would
+    ({"observations":[...]} / {"confirmed": bool}) to stdout.
+
+  * GRACEFUL DEGRADATION: ANY backend error / offline / timeout / malformed
+    JSON is caught and resolves to the empty judge ({"observations": []}) /
+    negative verify ({"confirmed": false}), exit 0 — never crash, never
+    fabricate a finding.
+
+The anthropic import is OPTIONAL (lazy + guarded): the CLI and its stdlib tests
+work without the SDK installed.
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
+import subprocess
 import sys
 from html.parser import HTMLParser
+
+# Default Anthropic model for the api backend, env-overridable via
+# $AUTOSPEC_FAB_VISION_MODEL. claude-opus-4-8 supports base64 image content
+# blocks + structured JSON output.
+_DEFAULT_MODEL = "claude-opus-4-8"
 
 # Default cap on the number of images handed to a backend, to bound token/cost
 # once a real backend exists (child #1290). Env-overridable. In this iteration
@@ -114,47 +144,292 @@ def resolve_images(sheet_path: str) -> list:
     return resolved
 
 
+def _model() -> str:
+    """Resolve the api-backend model id from $AUTOSPEC_FAB_VISION_MODEL."""
+    raw = os.environ.get("AUTOSPEC_FAB_VISION_MODEL")
+    if raw and raw.strip():
+        return raw.strip()
+    return _DEFAULT_MODEL
+
+
+def _stub_path() -> str | None:
+    """Resolve the $AUTOSPEC_FAB_VISION_STUB test seam, if any."""
+    raw = os.environ.get("AUTOSPEC_FAB_VISION_STUB")
+    if raw and raw.strip():
+        return raw.strip()
+    return None
+
+
+def _resolve_api_key() -> str | None:
+    """
+    Resolve an Anthropic API key from the environment.
+
+    The Anthropic SDK itself reads ANTHROPIC_API_KEY (and other sources), but we
+    check here so backend auto-detection can fall through to "none" cleanly when
+    no key is configured, rather than constructing a client that fails at call
+    time.
+    """
+    for name in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"):
+        val = os.environ.get(name)
+        if val and val.strip():
+            return val.strip()
+    return None
+
+
+def _anthropic_available() -> bool:
+    """True if the optional anthropic SDK can be imported (lazy, guarded)."""
+    try:
+        import anthropic  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
 def resolve_backend() -> str:
     """
-    Resolve which vision backend to use. Seam for child #1290.
+    Resolve which vision backend to use.
 
     First usable wins (design spec §"Backend resolution"):
       1. $AUTOSPEC_FAB_VISION_BACKEND explicit override (api | claude-cli | none)
-      2. Anthropic API ("api")   — added in child #1290 (anthropic SDK + key)
+      2. Anthropic API ("api") — usable when the $AUTOSPEC_FAB_VISION_STUB test
+         seam is set, OR the anthropic SDK imports AND a key resolves
       3. claude CLI ("claude-cli") — candidate, pending support confirmation
-      4. "none"                   — nothing usable -> honest degradation
+      4. "none" — nothing usable -> honest degradation
 
-    In THIS iteration only "none" is implemented: there is no real backend, so
-    we always return "none" (an explicit override is honoured only insofar as it
-    cannot conjure a backend that does not exist yet). Child #1290 fills in the
-    real branches here without touching the rest of the CLI.
+    An explicit override cannot conjure a backend that is not actually usable:
+    e.g. AUTOSPEC_FAB_VISION_BACKEND=api with no stub, no SDK, and no key still
+    degrades to "none" (the contract: never crash, never fabricate). The stub
+    seam makes "api" usable in CI without any real Anthropic call.
     """
     override = os.environ.get("AUTOSPEC_FAB_VISION_BACKEND")
     if override == "none":
         return "none"
-    # No real backend exists in this iteration; everything degrades to "none".
-    # (Child #1290 will return "api" / "claude-cli" here when usable.)
-    return "none"
+    if override == "claude-cli":
+        # Candidate backend; not implemented yet -> honest degradation.
+        return "none"
+
+    # "api" (explicit or auto-detected) is usable iff the stub seam is set, or
+    # the SDK imports and a key resolves.
+    api_usable = _stub_path() is not None or (
+        _anthropic_available() and _resolve_api_key() is not None
+    )
+    if override == "api":
+        return "api" if api_usable else "none"
+    if override:
+        # Unknown override -> honest degradation.
+        return "none"
+
+    # Auto-detect: prefer the real backend when usable, else degrade.
+    return "api" if api_usable else "none"
+
+
+# --- api backend -----------------------------------------------------------
+
+_JUDGE_INSTRUCTION = (
+    "You are reviewing rendered views of a 3D model (a contact sheet of PNG "
+    "images) for STL modeling-rule issues. Report ONLY clearly visible, "
+    "notable problems. Do NOT speculate, infer hidden geometry, or invent "
+    "findings: if nothing is notable, return an EMPTY observations list. "
+    "Respond with JSON of the shape "
+    '{"observations": [{"observation": str, "severity": "info"|"warn", '
+    '"view": str (optional), "rule": str (optional)}]}.'
+)
+
+_VERIFY_INSTRUCTION = (
+    "You are adversarially verifying ONE candidate observation about the "
+    "rendered views below. Confirm it ONLY if it is clearly and directly "
+    "supported by what is visible. When in doubt, reject. Do NOT fabricate "
+    "support. Respond with JSON of the shape {\"confirmed\": true|false}."
+)
+
+_JUDGE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "observations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "observation": {"type": "string"},
+                    "severity": {"type": "string", "enum": ["info", "warn"]},
+                    "view": {"type": "string"},
+                    "rule": {"type": "string"},
+                },
+                "required": ["observation"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["observations"],
+    "additionalProperties": False,
+}
+
+_VERIFY_SCHEMA = {
+    "type": "object",
+    "properties": {"confirmed": {"type": "boolean"}},
+    "required": ["confirmed"],
+    "additionalProperties": False,
+}
+
+
+def _read_rules(rules_path: str | None) -> str:
+    """Read the STL Modeling Rules text, or '' on any error / absence."""
+    if not rules_path:
+        return ""
+    try:
+        with open(rules_path, "r", encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
+def _image_blocks(images: list) -> list:
+    """Build base64 image content blocks for the resolved PNG paths."""
+    blocks = []
+    for path in images:
+        try:
+            with open(path, "rb") as f:
+                data = base64.standard_b64encode(f.read()).decode("ascii")
+        except OSError:
+            continue
+        blocks.append({
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": data,
+            },
+        })
+    return blocks
+
+
+def _stub_call(mode: str, sheet_path: str, rules_path: str | None,
+               images: list, stdin_obj) -> dict | None:
+    """
+    Delegate the model call to the $AUTOSPEC_FAB_VISION_STUB executable.
+
+    The stub stands in for the real Anthropic API so CI exercises the full path
+    without a network call. It is invoked as `<stub> <mode> <sheet> [<rules>]`;
+    the resolved image paths + the candidate observation (verify) are passed as
+    a JSON object on stdin so the stub can assert images/rules passed through.
+
+    Returns the parsed stdout dict, or None on any error (caller degrades).
+    """
+    stub = _stub_path()
+    if not stub:
+        return None
+    argv = [stub, mode, sheet_path]
+    if rules_path:
+        argv.append(rules_path)
+    payload = {
+        "mode": mode,
+        "sheet": sheet_path,
+        "rules": rules_path,
+        "model": _model(),
+        "images": list(images),
+    }
+    if stdin_obj is not None:
+        payload["observation"] = stdin_obj
+    try:
+        proc = subprocess.run(
+            argv,
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    out = (proc.stdout or "").strip()
+    if not out:
+        return None
+    try:
+        value = json.loads(out)
+    except (ValueError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _api_message(content_blocks: list, schema: dict) -> dict | None:
+    """
+    Call the real Anthropic API with the given content blocks + JSON schema.
+
+    Returns the parsed structured JSON dict, or None on ANY error (the caller
+    degrades). The anthropic import is lazy + guarded here too.
+    """
+    try:
+        import anthropic
+    except Exception:
+        return None
+    try:
+        client = anthropic.Anthropic()
+        response = client.messages.create(
+            model=_model(),
+            max_tokens=4096,
+            output_config={"format": {"type": "json_schema", "schema": schema}},
+            messages=[{"role": "user", "content": content_blocks}],
+        )
+    except Exception:
+        return None
+    try:
+        text = next(
+            (b.text for b in response.content if getattr(b, "type", None) == "text"),
+            None,
+        )
+    except Exception:
+        return None
+    if not text:
+        return None
+    try:
+        value = json.loads(text)
+    except (ValueError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _normalize_judge(payload) -> dict:
+    """Coerce a backend judge payload into {"observations": [list of dicts]}."""
+    if not isinstance(payload, dict):
+        return {"observations": []}
+    raw = payload.get("observations")
+    if not isinstance(raw, list):
+        return {"observations": []}
+    return {"observations": [ob for ob in raw if isinstance(ob, dict)]}
 
 
 def judge(sheet_path: str, rules_path: str | None) -> dict:
     """
     JUDGE pass: review the contact sheet against the rules.
 
-    Returns {"observations": [...]}. With backend "none" (this iteration) — or
-    whenever there is nothing to inspect — this is the empty list. Never raises.
+    Returns {"observations": [...]}. With backend "none", nothing to inspect, or
+    ANY backend error this is the empty list — honest degradation, never raises,
+    never fabricates.
     """
     backend = resolve_backend()
-    if backend == "none":
+    if backend != "api":
         return {"observations": []}
 
-    # Unreachable in this iteration. Once child #1290 adds a real backend, the
-    # resolved images + rules text would be sent here. The seam:
-    images = resolve_images(sheet_path)  # noqa: F841  (used by #1290)
+    images = resolve_images(sheet_path)
     if not images:
+        # No PNGs to inspect -> nothing to judge.
         return {"observations": []}
-    # Real backend dispatch lands in child #1290; until then, degrade honestly.
-    return {"observations": []}
+
+    rules = _read_rules(rules_path)
+
+    # Stub seam first: lets CI exercise the full path with no real API call.
+    if _stub_path() is not None:
+        result = _stub_call("judge", sheet_path, rules_path, images, None)
+        return _normalize_judge(result)
+
+    # Real Anthropic vision call.
+    instruction = _JUDGE_INSTRUCTION
+    if rules.strip():
+        instruction += "\n\nSTL Modeling Rules:\n" + rules
+    content = _image_blocks(images) + [{"type": "text", "text": instruction}]
+    result = _api_message(content, _JUDGE_SCHEMA)
+    return _normalize_judge(result)
 
 
 def verify(sheet_path: str, rules_path: str | None,
@@ -162,16 +437,38 @@ def verify(sheet_path: str, rules_path: str | None,
     """
     VERIFY pass: confirm or reject one candidate observation.
 
-    Returns {"confirmed": bool}. With backend "none" (this iteration), an
-    unreadable candidate, or any backend error this is {"confirmed": false}
-    (conservative: an unverified observation is dropped). Never raises.
+    Returns {"confirmed": bool}. With backend "none", a missing candidate, or
+    ANY backend error this is {"confirmed": false} (conservative: an unverified
+    observation is dropped). Never raises, never fabricates a confirmation.
     """
     backend = resolve_backend()
-    if backend == "none" or observation is None:
+    if backend != "api" or observation is None:
         return {"confirmed": False}
 
-    # Real backend dispatch lands in child #1290; until then, degrade honestly.
-    return {"confirmed": False}
+    images = resolve_images(sheet_path)
+    if not images:
+        return {"confirmed": False}
+
+    rules = _read_rules(rules_path)
+
+    # Stub seam first.
+    if _stub_path() is not None:
+        result = _stub_call("verify", sheet_path, rules_path, images,
+                            observation)
+        confirmed = (isinstance(result, dict)
+                     and result.get("confirmed") is True)
+        return {"confirmed": bool(confirmed)}
+
+    # Real Anthropic vision call.
+    instruction = _VERIFY_INSTRUCTION
+    if rules.strip():
+        instruction += "\n\nSTL Modeling Rules:\n" + rules
+    instruction += ("\n\nCandidate observation (JSON):\n"
+                    + json.dumps(observation))
+    content = _image_blocks(images) + [{"type": "text", "text": instruction}]
+    result = _api_message(content, _VERIFY_SCHEMA)
+    confirmed = isinstance(result, dict) and result.get("confirmed") is True
+    return {"confirmed": bool(confirmed)}
 
 
 def _read_stdin_observation():

--- a/skills/autospec-fab/tests/test_fab_vision_cli.bats
+++ b/skills/autospec-fab/tests/test_fab_vision_cli.bats
@@ -16,3 +16,148 @@ SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
             -v
     [ "$status" -eq 0 ]
 }
+
+# --- End-to-end: drive the UNMODIFIED stage_vision.py through fab-vision-cli.py
+# installed as `fab-vision` in $TMP/bin, with the stub backend so there is NO
+# real Anthropic call. Proves the stub's confirmed observation lands in
+# vision_findings and the stage never returns "fail".
+
+# Build a real contact sheet (via stage_render.build_contact_sheet) with one
+# present PNG, install the CLI as `fab-vision`, install a stub backend, then run
+# stage_vision.py. Echoes back: <bin_dir> <sheet> <stub>.
+setup_e2e() {
+    local root="$1"
+    python3 - "$root" "$SCRIPTS_DIR" <<'PY'
+import os, sys, shutil
+root, scripts = sys.argv[1], sys.argv[2]
+sys.path.insert(0, scripts)
+import stage_render
+
+bin_dir = os.path.join(root, "bin")
+os.makedirs(bin_dir, exist_ok=True)
+# Install the CLI as the PATH-resolvable `fab-vision`.
+shutil.copy(os.path.join(scripts, "fab-vision-cli.py"),
+            os.path.join(bin_dir, "fab-vision"))
+os.chmod(os.path.join(bin_dir, "fab-vision"), 0o755)
+
+# Build a real contact sheet with one present PNG (front view).
+render_dir = os.path.join(root, "renders")
+view_dir = os.path.join(render_dir, "widget")
+os.makedirs(view_dir, exist_ok=True)
+results = []
+for v in stage_render.REQUIRED_VIEWS:
+    png = os.path.join(view_dir, v["name"] + ".png")
+    present = v["name"] == "front"
+    if present:
+        with open(png, "wb") as f:
+            f.write(b"\x89PNG\r\n\x1a\n")
+    results.append({"name": v["name"], "kind": v["kind"], "png": png,
+                    "rendered": present})
+sheet = stage_render.build_contact_sheet(render_dir, "widget", results)
+
+# Stub backend: stands in for the real Anthropic call. Emits a confirmed,
+# warn-severity observation on judge and confirms on verify.
+stub = os.path.join(root, "vision-stub.py")
+with open(stub, "w") as f:
+    f.write(
+        "#!/usr/bin/env python3\n"
+        "import json,sys\n"
+        "mode=sys.argv[1]\n"
+        "sys.stdin.read()\n"
+        "if mode=='judge':\n"
+        "    print(json.dumps({'observations':[{'observation':"
+        "'stub exposed gasket groove','severity':'warn','view':'front',"
+        "'rule':'exposed_gasket'}]}))\n"
+        "elif mode=='verify':\n"
+        "    print(json.dumps({'confirmed':True}))\n"
+        "else:\n"
+        "    sys.exit(2)\n"
+    )
+os.chmod(stub, 0o755)
+print(f"{bin_dir} {sheet} {stub}")
+PY
+}
+
+@test "e2e: stub backend confirmed observation flows through unmodified stage_vision.py" {
+    command -v python3 || skip "python3 not found"
+    local tmp; tmp="$(mktemp -d)"
+    local info; info="$(setup_e2e "$tmp")"
+    local bin_dir sheet stub
+    bin_dir="$(echo "$info" | awk '{print $1}')"
+    sheet="$(echo "$info" | awk '{print $2}')"
+    stub="$(echo "$info" | awk '{print $3}')"
+    local out="$tmp/fragment.json"
+
+    run env PATH="$bin_dir:$PATH" \
+        AUTOSPEC_FAB_VISION_CMD=fab-vision \
+        AUTOSPEC_FAB_VISION_STUB="$stub" \
+        python3 "$SCRIPTS_DIR/stage_vision.py" --in "$sheet" --out "$out"
+    [ "$status" -eq 0 ]
+
+    # bats 3.2: the fragment is a real temp file (--out), so [ -f ] is reliable.
+    [ -f "$out" ]
+
+    # The stub's confirmed observation is carried in vision_findings, and the
+    # stage is warn (advisory), never fail.
+    run python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d['vision_findings'][0]['rule']); print(d['status'])" "$out"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "exposed_gasket" ]
+    [ "${lines[1]}" = "warn" ]
+
+    # Blocking findings[] stays empty; status is never "fail".
+    run python3 -c "import json,sys; d=json.load(open(sys.argv[1])); assert d['findings']==[]; assert d['status']!='fail'; print('ok')" "$out"
+    [ "$status" -eq 0 ]
+    [ "$output" = "ok" ]
+
+    rm -rf "$tmp"
+}
+
+@test "e2e: BACKEND=none degrades to empty vision_findings, never fail, exit 0" {
+    command -v python3 || skip "python3 not found"
+    local tmp; tmp="$(mktemp -d)"
+    local info; info="$(setup_e2e "$tmp")"
+    local bin_dir sheet
+    bin_dir="$(echo "$info" | awk '{print $1}')"
+    sheet="$(echo "$info" | awk '{print $2}')"
+    local out="$tmp/fragment.json"
+
+    run env PATH="$bin_dir:$PATH" \
+        AUTOSPEC_FAB_VISION_CMD=fab-vision \
+        AUTOSPEC_FAB_VISION_BACKEND=none \
+        python3 "$SCRIPTS_DIR/stage_vision.py" --in "$sheet" --out "$out"
+    [ "$status" -eq 0 ]
+    [ -f "$out" ]
+
+    run python3 -c "import json,sys; d=json.load(open(sys.argv[1])); assert d['vision_findings']==[]; assert d['status']!='fail'; print('ok')" "$out"
+    [ "$status" -eq 0 ]
+    [ "$output" = "ok" ]
+
+    rm -rf "$tmp"
+}
+
+@test "e2e: stub error degrades, stage stays advisory, exit 0" {
+    command -v python3 || skip "python3 not found"
+    local tmp; tmp="$(mktemp -d)"
+    local info; info="$(setup_e2e "$tmp")"
+    local bin_dir sheet
+    bin_dir="$(echo "$info" | awk '{print $1}')"
+    sheet="$(echo "$info" | awk '{print $2}')"
+    # A stub that always fails (write to a real file, then mark executable).
+    local errstub="$tmp/err-stub.py"
+    printf '#!/usr/bin/env python3\nimport sys\nsys.exit(1)\n' > "$errstub"
+    chmod +x "$errstub"
+    local out="$tmp/fragment.json"
+
+    run env PATH="$bin_dir:$PATH" \
+        AUTOSPEC_FAB_VISION_CMD=fab-vision \
+        AUTOSPEC_FAB_VISION_STUB="$errstub" \
+        python3 "$SCRIPTS_DIR/stage_vision.py" --in "$sheet" --out "$out"
+    [ "$status" -eq 0 ]
+    [ -f "$out" ]
+
+    run python3 -c "import json,sys; d=json.load(open(sys.argv[1])); assert d['vision_findings']==[]; assert d['status']!='fail'; print('ok')" "$out"
+    [ "$status" -eq 0 ]
+    [ "$output" = "ok" ]
+
+    rm -rf "$tmp"
+}

--- a/skills/autospec-fab/tests/test_fab_vision_cli.py
+++ b/skills/autospec-fab/tests/test_fab_vision_cli.py
@@ -43,13 +43,36 @@ import stage_render  # noqa: E402
 _CLI = os.path.join(_SCRIPTS_DIR, "fab-vision-cli.py")
 
 
-def _run_cli(args, stdin_text=None):
-    """Invoke fab-vision-cli.py as a subprocess; return (rc, parsed_stdout)."""
+# Env keys that influence backend resolution. Tests scrub these from the child
+# process so a developer's real ANTHROPIC_API_KEY (or an inherited backend/stub)
+# can't leak into the degradation assertions, then set exactly what each case
+# needs via `env_extra`.
+_BACKEND_ENV_KEYS = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "AUTOSPEC_FAB_VISION_BACKEND",
+    "AUTOSPEC_FAB_VISION_STUB",
+    "AUTOSPEC_FAB_VISION_MODEL",
+)
+
+
+def _run_cli(args, stdin_text=None, env_extra=None):
+    """Invoke fab-vision-cli.py as a subprocess; return (rc, parsed_stdout).
+
+    The child env starts from the parent with all backend-influencing keys
+    scrubbed, then `env_extra` is layered on. This keeps the default cases on
+    the honest-degradation ("none") path regardless of the developer's
+    environment, while letting backend cases opt a stub/backend in explicitly.
+    """
+    env = {k: v for k, v in os.environ.items() if k not in _BACKEND_ENV_KEYS}
+    if env_extra:
+        env.update(env_extra)
     proc = subprocess.run(
         [sys.executable, _CLI] + list(args),
         input=stdin_text,
         capture_output=True,
         text=True,
+        env=env,
     )
     parsed = None
     out = (proc.stdout or "").strip()
@@ -220,6 +243,220 @@ class TestResolver(unittest.TestCase):
             sheet, expected = _build_real_sheet(tmp, present_view_names=all_names)
             got = [os.path.basename(p) for p in self.mod.resolve_images(sheet)]
             self.assertEqual(got, expected[:3])
+
+
+# A stub backend executable. It stands in for the real Anthropic call: it reads
+# the image-manifest JSON the CLI passes on stdin (so we can assert images/rules
+# passed through), records that manifest to a side file, and emits the canned
+# judge/verify contract JSON. No real API call.
+_STUB = r'''#!/usr/bin/env python3
+import json, os, sys
+
+mode = sys.argv[1]
+payload = json.loads(sys.stdin.read() or "{}")
+
+# Record what the CLI handed us, so the test can assert image/rules passthrough.
+record = os.environ.get("STUB_RECORD")
+if record:
+    with open(record, "w") as f:
+        json.dump(payload, f)
+
+if mode == "judge":
+    print(json.dumps({"observations": [
+        {"observation": "stub-confirmed exposed gasket groove",
+         "severity": "warn", "view": "left", "rule": "exposed_gasket"},
+    ]}))
+elif mode == "verify":
+    print(json.dumps({"confirmed": True}))
+else:
+    sys.exit(2)
+'''
+
+# A stub that always fails (non-zero exit), to prove the CLI degrades on a
+# stub/backend error rather than crashing.
+_STUB_ERR = '''#!/usr/bin/env python3
+import sys
+sys.stderr.write("boom\\n")
+sys.exit(1)
+'''
+
+
+def _install_stub(tmp_dir, body, name="vision-stub.py"):
+    """Write an executable stub backend and return its path."""
+    path = os.path.join(tmp_dir, name)
+    with open(path, "w") as f:
+        f.write(body)
+    os.chmod(path, 0o755)
+    return path
+
+
+class TestBackendResolution(unittest.TestCase):
+    """resolve_backend honors the override and auto-detect falls back to none."""
+
+    def setUp(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("fab_vision_cli", _CLI)
+        self.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.mod)
+        self._saved = {k: os.environ.get(k) for k in _BACKEND_ENV_KEYS}
+        for k in _BACKEND_ENV_KEYS:
+            os.environ.pop(k, None)
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_override_none_is_none(self):
+        os.environ["AUTOSPEC_FAB_VISION_BACKEND"] = "none"
+        self.assertEqual(self.mod.resolve_backend(), "none")
+
+    def test_autodetect_no_key_no_stub_is_none(self):
+        # No stub, no key -> nothing usable -> honest degradation.
+        self.assertEqual(self.mod.resolve_backend(), "none")
+
+    def test_override_api_without_usable_backend_is_none(self):
+        # An override can't conjure a backend that isn't usable.
+        os.environ["AUTOSPEC_FAB_VISION_BACKEND"] = "api"
+        self.assertEqual(self.mod.resolve_backend(), "none")
+
+    def test_stub_makes_api_usable(self):
+        os.environ["AUTOSPEC_FAB_VISION_STUB"] = "/path/to/stub"
+        self.assertEqual(self.mod.resolve_backend(), "api")
+
+    def test_claude_cli_override_degrades(self):
+        os.environ["AUTOSPEC_FAB_VISION_BACKEND"] = "claude-cli"
+        self.assertEqual(self.mod.resolve_backend(), "none")
+
+
+class TestStubBackendIntegration(unittest.TestCase):
+    """Full path via the stub seam: images/rules pass through, contract JSON."""
+
+    def test_judge_via_stub_emits_canned_observations(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sheet, _ = _build_real_sheet(tmp, present_view_names={"front",
+                                                                  "left"})
+            rules = os.path.join(tmp, "rules.md")
+            with open(rules, "w") as f:
+                f.write("# STL Modeling Rules\nNo exposed gaskets.\n")
+            stub = _install_stub(tmp, _STUB)
+            record = os.path.join(tmp, "record.json")
+            rc, out = _run_cli(
+                [sheet, rules],
+                env_extra={"AUTOSPEC_FAB_VISION_STUB": stub,
+                           "STUB_RECORD": record},
+            )
+            self.assertEqual(rc, 0)
+            # Contract JSON emitted unchanged from the stub.
+            self.assertEqual(out, {"observations": [
+                {"observation": "stub-confirmed exposed gasket groove",
+                 "severity": "warn", "view": "left", "rule": "exposed_gasket"},
+            ]})
+            # Images + rules passed through to the backend.
+            with open(record) as f:
+                manifest = json.load(f)
+            self.assertEqual(manifest["mode"], "judge")
+            self.assertEqual(manifest["rules"], rules)
+            self.assertEqual(
+                [os.path.basename(p) for p in manifest["images"]],
+                ["front.png", "left.png"])
+
+    def test_verify_via_stub_confirms(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sheet, _ = _build_real_sheet(tmp, present_view_names={"front"})
+            stub = _install_stub(tmp, _STUB)
+            record = os.path.join(tmp, "record.json")
+            candidate = json.dumps({
+                "observation": "exposed gasket groove",
+                "severity": "warn", "view": "left", "rule": "exposed_gasket",
+            })
+            rc, out = _run_cli(
+                ["--verify", sheet],
+                stdin_text=candidate,
+                env_extra={"AUTOSPEC_FAB_VISION_STUB": stub,
+                           "STUB_RECORD": record},
+            )
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, {"confirmed": True})
+            # The candidate observation reached the backend on stdin.
+            with open(record) as f:
+                manifest = json.load(f)
+            self.assertEqual(manifest["mode"], "verify")
+            self.assertEqual(manifest["observation"]["rule"], "exposed_gasket")
+            self.assertTrue(manifest["images"])
+
+    def test_stub_with_zero_pngs_degrades_to_empty(self):
+        # Stub is "usable" but there are no images to inspect -> empty judge,
+        # and the stub is never invoked (no fabricated finding).
+        with tempfile.TemporaryDirectory() as tmp:
+            sheet, _ = _build_real_sheet(tmp, present_view_names=set())
+            stub = _install_stub(tmp, _STUB)
+            record = os.path.join(tmp, "record.json")
+            rc, out = _run_cli(
+                [sheet],
+                env_extra={"AUTOSPEC_FAB_VISION_STUB": stub,
+                           "STUB_RECORD": record},
+            )
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, {"observations": []})
+            self.assertFalse(os.path.exists(record))
+
+
+class TestApiBackendUnavailableDegrades(unittest.TestCase):
+    """No usable api backend -> empty judge / negative verify, exit 0."""
+
+    def test_judge_unavailable_empty_exit0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sheet, _ = _build_real_sheet(tmp, present_view_names={"front"})
+            # AUTOSPEC_FAB_VISION_BACKEND=api but no stub and no key -> none.
+            rc, out = _run_cli(
+                [sheet],
+                env_extra={"AUTOSPEC_FAB_VISION_BACKEND": "api"},
+            )
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, {"observations": []})
+
+    def test_verify_unavailable_confirmed_false_exit0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sheet, _ = _build_real_sheet(tmp, present_view_names={"front"})
+            candidate = json.dumps({"observation": "x", "severity": "warn"})
+            rc, out = _run_cli(
+                ["--verify", sheet],
+                stdin_text=candidate,
+                env_extra={"AUTOSPEC_FAB_VISION_BACKEND": "api"},
+            )
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, {"confirmed": False})
+
+
+class TestStubErrorDegrades(unittest.TestCase):
+    """A failing stub backend degrades to empty/negative, exit 0 (never crash)."""
+
+    def test_judge_stub_error_empty_exit0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sheet, _ = _build_real_sheet(tmp, present_view_names={"front"})
+            stub = _install_stub(tmp, _STUB_ERR)
+            rc, out = _run_cli(
+                [sheet],
+                env_extra={"AUTOSPEC_FAB_VISION_STUB": stub},
+            )
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, {"observations": []})
+
+    def test_verify_stub_error_confirmed_false_exit0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sheet, _ = _build_real_sheet(tmp, present_view_names={"front"})
+            stub = _install_stub(tmp, _STUB_ERR)
+            candidate = json.dumps({"observation": "x", "severity": "warn"})
+            rc, out = _run_cli(
+                ["--verify", sheet],
+                stdin_text=candidate,
+                env_extra={"AUTOSPEC_FAB_VISION_STUB": stub},
+            )
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, {"confirmed": False})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1290 (part of #1271). Adds the real Claude-vision `api` backend behind `resolve_backend()` (#1289's seam): base64 image blocks, `claude-opus-4-8`, structured JSON; usable when anthropic+key present else degrades to none; optional lazy import. `AUTOSPEC_FAB_VISION_STUB` seam = full path in CI with no real call. Anti-fabrication; any error→empty/exit0. **stage_vision.py unchanged.** 24 unittest + 4 e2e bats through the unmodified stage; full suite 461 passed; validate exit 0.