### PR TITLE
feat(autospec-qa): qa-deploy contract schema + fixtures (#1292)

### DIFF
--- a/schemas/autospec-qa-deploy.schema.json
+++ b/schemas/autospec-qa-deploy.schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/berlinguyinca/autospec/schemas/autospec-qa-deploy.schema.json",
+  "title": "autospec qa-deploy contract",
+  "description": "Schema for .autospec/qa-deploy.yml — the declarative deploy contract consumed by scripts/qa-deploy-runner.sh. Mirrors the style of .autospec/test.yml. Parsed with `yq -o=json` and validated with ajv (same toolchain as skills/autospec-test/scripts/load-contract.sh). The file's PRESENCE makes deploy mandatory; `required` only governs whether absence could be an error (it never is). The safety floor (forbidden-target match, production-pattern rejection, max_records for data-clone stages) is enforced by the runner, not by this schema.",
+  "type": "object",
+  "required": ["stages", "target_envs"],
+  "additionalProperties": false,
+  "properties": {
+    "required": {
+      "type": "boolean",
+      "default": false,
+      "description": "Governs only whether the file being absent could be an error (it never is). The file's presence makes deploy mandatory."
+    },
+    "stages": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Ordered deploy stages, sequential; first failure aborts the rest.",
+      "items": { "$ref": "#/$defs/stage" }
+    },
+    "teardown": {
+      "type": "array",
+      "description": "Post-verdict teardown steps.",
+      "items": { "$ref": "#/$defs/teardown_step" }
+    },
+    "target_envs": {
+      "type": "object",
+      "required": ["forbidden"],
+      "additionalProperties": false,
+      "description": "Allowed/forbidden target environments. `forbidden` is the absolute safety floor.",
+      "properties": {
+        "allowed": {
+          "type": "array",
+          "default": [],
+          "description": "Advisory; recorded.",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "forbidden": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Absolute safety floor — any forbidden token in a stage command, a health_check.url, or stage stdout aborts with exit 3. At least one entry required.",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Top-level safety metadata.",
+      "properties": {
+        "notes": {
+          "type": "string",
+          "description": "Free text."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "stage": {
+      "type": "object",
+      "required": ["name", "command"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable id; appears in deploy.stages_run."
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Shell command via bash -c. Subject to the safety floor."
+        },
+        "timeout": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 300,
+          "description": "Hard wall-clock cap in seconds; exceeding it = stage failed."
+        },
+        "env": {
+          "type": "object",
+          "default": {},
+          "description": "Extra env; values passed verbatim, secret values never logged/recorded (only key names).",
+          "additionalProperties": { "type": ["string", "number", "boolean"] }
+        },
+        "health_check": { "$ref": "#/$defs/health_check" },
+        "safety": { "$ref": "#/$defs/stage_safety" }
+      }
+    },
+    "health_check": {
+      "type": "object",
+      "required": ["url"],
+      "additionalProperties": false,
+      "description": "Polled after the command. URL subject to target_envs.forbidden.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "URL polled after the command."
+        },
+        "expect_status": {
+          "type": "integer",
+          "default": 200,
+          "description": "Ready status."
+        },
+        "retry": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 30,
+          "description": "Max poll attempts."
+        },
+        "retry_interval": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 10,
+          "description": "Delay between attempts in seconds."
+        }
+      }
+    },
+    "stage_safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Per-stage safety. max_records is required by the runner for any data-clone stage (name/command matches clone|copy|replicate|sync).",
+      "properties": {
+        "max_records": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Cap on records copied. Required for any data-clone stage (enforced by the runner)."
+        },
+        "forbid_production_writes": {
+          "type": "boolean",
+          "default": false,
+          "description": "Operator intent flag; recorded, advisory."
+        }
+      }
+    },
+    "teardown_step": {
+      "type": "object",
+      "required": ["name", "command"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Identifier."
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Shell command; same safety floor."
+        },
+        "on_failure": {
+          "type": "string",
+          "enum": ["warn", "fail"],
+          "default": "warn",
+          "description": "warn -> logs only; fail -> downgrades a PASS verdict to PARTIAL."
+        }
+      }
+    }
+  }
+}

--- a/tests/qa/fixtures/.autospec/qa-deploy.yml
+++ b/tests/qa/fixtures/.autospec/qa-deploy.yml
@@ -1,0 +1,30 @@
+required: true
+stages:
+  - name: deploy-to-test-family
+    command: bash scripts/deploy-tidyboard-test.sh
+    timeout: 600
+    env:
+      DEPLOY_TARGET: test-family
+    health_check:
+      url: https://test.tidyboard.org/health
+      expect_status: 200
+      retry: 30
+      retry_interval: 10
+  - name: clone-production-data
+    command: bash scripts/clone-prod-data-to-test.sh --target test-family
+    timeout: 1800
+    safety:
+      forbid_production_writes: true
+      max_records: 10000          # required: stage name contains "clone"
+teardown:
+  - name: snapshot-test-state
+    command: bash scripts/snapshot-test-state.sh
+    on_failure: warn
+  - name: cleanup
+    command: bash scripts/cleanup-test-family.sh
+    on_failure: warn
+target_envs:
+  allowed: [test.tidyboard.org, staging.tidyboard.org]
+  forbidden: [tidyboard.org, www.tidyboard.org]
+safety:
+  notes: "clone script anonymizes PII in step 2; test family is read-isolated from prod."

--- a/tests/qa/fixtures/invalid-clone-missing-max-records.yml
+++ b/tests/qa/fixtures/invalid-clone-missing-max-records.yml
@@ -1,0 +1,16 @@
+# Data-clone stage (name contains "clone") without safety.max_records.
+# NOTE: this is structurally SCHEMA-VALID — the "max_records required for
+# data-clone stages" rule is a runner safety-floor check (regex on
+# name/command -> exit 3), not expressible in pure JSON Schema. The runner
+# bats in #1293 asserts the exit-3 rejection; this fixture seeds that case.
+required: true
+stages:
+  - name: clone-production-data
+    command: bash scripts/clone-prod-data-to-test.sh --target test-family
+    timeout: 1800
+    safety:
+      forbid_production_writes: true
+      # max_records intentionally omitted -> runner must reject with exit 3
+target_envs:
+  allowed: [test.tidyboard.org]
+  forbidden: [tidyboard.org, www.tidyboard.org]

--- a/tests/qa/fixtures/invalid-empty-forbidden.yml
+++ b/tests/qa/fixtures/invalid-empty-forbidden.yml
@@ -1,0 +1,8 @@
+# Invalid: target_envs.forbidden present but empty (minItems: 1 -> >=1 required).
+required: true
+stages:
+  - name: deploy-to-test-family
+    command: bash scripts/deploy-tidyboard-test.sh
+target_envs:
+  allowed: [test.tidyboard.org]
+  forbidden: []

--- a/tests/qa/fixtures/invalid-healthcheck-missing-url.yml
+++ b/tests/qa/fixtures/invalid-healthcheck-missing-url.yml
@@ -1,0 +1,10 @@
+# Invalid: a health_check block is present but missing the required `url`.
+required: true
+stages:
+  - name: deploy-to-test-family
+    command: bash scripts/deploy-tidyboard-test.sh
+    health_check:
+      expect_status: 200
+      retry: 30
+target_envs:
+  forbidden: [tidyboard.org]

--- a/tests/qa/fixtures/invalid-malformed-yaml.yml
+++ b/tests/qa/fixtures/invalid-malformed-yaml.yml
@@ -1,0 +1,9 @@
+# Invalid: malformed YAML — unclosed flow sequence + bad indentation.
+# yq -o=json must fail to parse this before any schema validation runs.
+required: true
+stages:
+  - name: deploy-to-test-family
+    command: bash scripts/deploy-tidyboard-test.sh
+   timeout: 600
+target_envs:
+  forbidden: [tidyboard.org, www.tidyboard.org

--- a/tests/qa/fixtures/invalid-missing-forbidden.yml
+++ b/tests/qa/fixtures/invalid-missing-forbidden.yml
@@ -1,0 +1,8 @@
+# Invalid: target_envs.forbidden is required (>=1 entry) but absent.
+required: true
+stages:
+  - name: deploy-to-test-family
+    command: bash scripts/deploy-tidyboard-test.sh
+    timeout: 600
+target_envs:
+  allowed: [test.tidyboard.org, staging.tidyboard.org]

--- a/tests/qa/fixtures/invalid-missing-stages.yml
+++ b/tests/qa/fixtures/invalid-missing-stages.yml
@@ -1,0 +1,7 @@
+# Invalid: top-level `stages` is required but absent.
+required: true
+target_envs:
+  allowed: [test.tidyboard.org]
+  forbidden: [tidyboard.org]
+safety:
+  notes: "no stages declared"

--- a/tests/qa/fixtures/invalid-stage-missing-command.yml
+++ b/tests/qa/fixtures/invalid-stage-missing-command.yml
@@ -1,0 +1,7 @@
+# Invalid: a stage is missing the required `command` field.
+required: true
+stages:
+  - name: deploy-to-test-family
+    timeout: 600
+target_envs:
+  forbidden: [tidyboard.org]

--- a/tests/qa/fixtures/valid.yml
+++ b/tests/qa/fixtures/valid.yml
@@ -1,0 +1,30 @@
+required: true
+stages:
+  - name: deploy-to-test-family
+    command: bash scripts/deploy-tidyboard-test.sh
+    timeout: 600
+    env:
+      DEPLOY_TARGET: test-family
+    health_check:
+      url: https://test.tidyboard.org/health
+      expect_status: 200
+      retry: 30
+      retry_interval: 10
+  - name: clone-production-data
+    command: bash scripts/clone-prod-data-to-test.sh --target test-family
+    timeout: 1800
+    safety:
+      forbid_production_writes: true
+      max_records: 10000          # required: stage name contains "clone"
+teardown:
+  - name: snapshot-test-state
+    command: bash scripts/snapshot-test-state.sh
+    on_failure: warn
+  - name: cleanup
+    command: bash scripts/cleanup-test-family.sh
+    on_failure: warn
+target_envs:
+  allowed: [test.tidyboard.org, staging.tidyboard.org]
+  forbidden: [tidyboard.org, www.tidyboard.org]
+safety:
+  notes: "clone script anonymizes PII in step 2; test family is read-isolated from prod."

--- a/tests/qa/test_qa_deploy_schema.bats
+++ b/tests/qa/test_qa_deploy_schema.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+#
+# test_qa_deploy_schema.bats — schema-shape coverage for the qa-deploy contract
+# (autospec issue #1292, part of #694).
+#
+# Validates schemas/autospec-qa-deploy.schema.json against the fixtures under
+# tests/qa/fixtures/ using the SAME toolchain as
+# skills/autospec-test/scripts/load-contract.sh: yq (YAML->JSON) -> ajv.
+#
+# Scope of THIS test (schema only):
+#   - schema is valid JSON and compiles with `ajv compile`
+#   - the valid fixture validates (exit 0)
+#   - every STRUCTURALLY-invalid fixture is rejected by the schema (exit != 0)
+#   - malformed YAML fails at the yq parse step (before schema validation)
+#
+# Out of scope (covered by the runner bats in #1293): the safety-floor rules
+# (forbidden-target match, production-pattern rejection, max_records required
+# for data-clone stages). Those are runner regex checks, NOT JSON Schema, so
+# tests/qa/fixtures/invalid-clone-missing-max-records.yml is intentionally
+# schema-VALID here.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SCHEMA="$REPO_ROOT/schemas/autospec-qa-deploy.schema.json"
+  FIXTURES="$REPO_ROOT/tests/qa/fixtures"
+  TMPDIR_TEST="$(mktemp -d /tmp/autospec-qa-deploy-schema-XXXXXX)"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_TEST"
+}
+
+# Convert a YAML fixture to JSON on disk, returning the JSON path.
+# Skips the test if yq is unavailable.
+_yaml_to_json() {
+  local yml="$1" out="$2"
+  command -v yq >/dev/null 2>&1 || skip "yq not available (brew install yq)"
+  yq -o=json '.' "$yml" > "$out"
+}
+
+@test "qa-deploy schema file exists and is valid JSON" {
+  [ -f "$SCHEMA" ]
+  command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+  run python3 -m json.tool "$SCHEMA"
+  [ "$status" -eq 0 ]
+}
+
+@test "qa-deploy schema compiles with ajv" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (npm install -g ajv-cli)"
+  run ajv compile -s "$SCHEMA" --spec=draft2020
+  [ "$status" -eq 0 ]
+}
+
+@test "valid fixture passes schema validation" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (npm install -g ajv-cli)"
+  _yaml_to_json "$FIXTURES/valid.yml" "$TMPDIR_TEST/valid.json"
+  run ajv validate -s "$SCHEMA" --spec=draft2020 -d "$TMPDIR_TEST/valid.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "canonical .autospec/qa-deploy.yml fixture passes schema validation" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (npm install -g ajv-cli)"
+  _yaml_to_json "$FIXTURES/.autospec/qa-deploy.yml" "$TMPDIR_TEST/canonical.json"
+  run ajv validate -s "$SCHEMA" --spec=draft2020 -d "$TMPDIR_TEST/canonical.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "fixture missing top-level stages is rejected" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (npm install -g ajv-cli)"
+  _yaml_to_json "$FIXTURES/invalid-missing-stages.yml" "$TMPDIR_TEST/x.json"
+  run ajv validate -s "$SCHEMA" --spec=draft2020 -d "$TMPDIR_TEST/x.json"
+  [ "$status" -ne 0 ]
+}
+
+@test "fixture missing target_envs.forbidden is rejected" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (npm install -g ajv-cli)"
+  _yaml_to_json "$FIXTURES/invalid-missing-forbidden.yml" "$TMPDIR_TEST/x.json"
+  run ajv validate -s "$SCHEMA" --spec=draft2020 -d "$TMPDIR_TEST/x.json"
+  [ "$status" -ne 0 ]
+}
+
+@test "fixture with empty target_envs.forbidden is rejected (>=1 entry required)" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (npm install -g ajv-cli)"
+  _yaml_to_json "$FIXTURES/invalid-empty-forbidden.yml" "$TMPDIR_TEST/x.json"
+  run ajv validate -s "$SCHEMA" --spec=draft2020 -d "$TMPDIR_TEST/x.json"
+  [ "$status" -ne 0 ]
+}
+
+@test "fixture with a stage missing command is rejected" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (npm install -g ajv-cli)"
+  _yaml_to_json "$FIXTURES/invalid-stage-missing-command.yml" "$TMPDIR_TEST/x.json"
+  run ajv validate -s "$SCHEMA" --spec=draft2020 -d "$TMPDIR_TEST/x.json"
+  [ "$status" -ne 0 ]
+}
+
+@test "fixture with a health_check missing url is rejected" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (npm install -g ajv-cli)"
+  _yaml_to_json "$FIXTURES/invalid-healthcheck-missing-url.yml" "$TMPDIR_TEST/x.json"
+  run ajv validate -s "$SCHEMA" --spec=draft2020 -d "$TMPDIR_TEST/x.json"
+  [ "$status" -ne 0 ]
+}
+
+@test "malformed YAML fixture fails to parse at the yq step" {
+  command -v yq >/dev/null 2>&1 || skip "yq not available (brew install yq)"
+  run yq -o=json '.' "$FIXTURES/invalid-malformed-yaml.yml"
+  [ "$status" -ne 0 ]
+}
+
+@test "data-clone-without-max_records fixture is schema-valid (runner enforces the floor, #1293)" {
+  command -v ajv >/dev/null 2>&1 || skip "ajv CLI not available (npm install -g ajv-cli)"
+  _yaml_to_json "$FIXTURES/invalid-clone-missing-max-records.yml" "$TMPDIR_TEST/x.json"
+  run ajv validate -s "$SCHEMA" --spec=draft2020 -d "$TMPDIR_TEST/x.json"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #1292 (part of #694). `schemas/autospec-qa-deploy.schema.json` (draft-2020-12) encoding the spec Fields table — `stages` (minItems 1) + `target_envs.forbidden` REQUIRED (≥1, the safety floor). `tests/qa/fixtures/` valid + 7 invalid; `test_qa_deploy_schema.bats` 11 cases via the yq→ajv toolchain (matches load-contract.sh). clone-missing-max_records is a runner check (#1293), seeded here as schema-valid. No runner yet. validate exit 0.