### PR TITLE
feat(autospec-qa): qa-deploy-runner core — parse + safety floor (#1293)

### DIFF
--- a/scripts/qa-deploy-runner.sh
+++ b/scripts/qa-deploy-runner.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# qa-deploy-runner.sh — autospec-qa deploy contract runner (CORE: parse +
+# safety floor + no-op). Part of #694; this is child #1293.
+#
+# SCOPE (this child): contract load + ajv validation, exit-0 no-op when the
+# contract is absent, and the three non-negotiable safety-floor rules. It does
+# NOT execute stages, run health probes, or write the verdict deploy block —
+# those land in #1294/#1295.
+#
+# Usage:
+#   qa-deploy-runner.sh --repo-dir <dir> [--verdict <path>]
+#
+# Reads <repo-dir>/.autospec/qa-deploy.yml. The file's PRESENCE makes deploy
+# mandatory; its ABSENCE is a no-op (today's behavior, byte-for-byte).
+#
+# Exit codes (shared with the spec's Error handling table):
+#   0 = ok / no-op (contract absent, or — in later children — deploy passed)
+#   2 = usage / contract invalid (ajv fail, malformed YAML, missing required,
+#       or a missing yq/jq/ajv tool) -> category code_health:qa_deploy_invalid_contract
+#   3 = safety-floor violation -> category one of:
+#         qa_deploy_forbidden_target | qa_deploy_prod_pattern | qa_deploy_missing_records_cap
+#
+# Per the project memory:
+#   * set -u, NOT set -e — failures are handled explicitly so the right exit
+#     code/category is emitted (no `[ test ] && action` one-sided conditionals
+#     under set -e; we use if/then/fi throughout).
+#   * bash 3.2-safe: no `[ -f <(...) ]` process substitution against a test;
+#     all intermediate data is written to real temp files first.
+#   * injection-safe matching: contract-supplied values (forbidden tokens) are
+#     matched as LITERAL substrings via `grep -iF -e "$token"` — never
+#     interpolated into a regex test(). The production-pattern and data-clone
+#     regexes are FIXED (compiled into this script), with the command/name as
+#     the searched input, so no user value reaches a regex.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCHEMA_FILE="$REPO_ROOT/schemas/autospec-qa-deploy.schema.json"
+
+REPO_DIR=""
+VERDICT_PATH=""
+
+# ── Emit a category + message, return the matching exit code ──────────────────
+# emit_and_exit <exit_code> <category> <message>
+emit_and_exit() {
+    local code="$1" category="$2" message="$3"
+    printf 'qa-deploy-runner: %s: %s\n' "$category" "$message" >&2
+    # Also print the bare category to stdout so callers/tests can scrape it
+    # without parsing stderr formatting.
+    printf '%s\n' "$category"
+    exit "$code"
+}
+
+# ── Arg parsing ──────────────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo-dir)
+            REPO_DIR="${2:-}"
+            shift 2
+            ;;
+        --verdict)
+            VERDICT_PATH="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,30p' "$0"
+            exit 0
+            ;;
+        *)
+            emit_and_exit 2 "code_health:qa_deploy_invalid_contract" "unknown argument: $1"
+            ;;
+    esac
+done
+
+if [ -z "$REPO_DIR" ]; then
+    emit_and_exit 2 "code_health:qa_deploy_invalid_contract" "--repo-dir <dir> is required"
+fi
+if [ ! -d "$REPO_DIR" ]; then
+    emit_and_exit 2 "code_health:qa_deploy_invalid_contract" "repo dir not found: $REPO_DIR"
+fi
+
+CONTRACT_FILE="$REPO_DIR/.autospec/qa-deploy.yml"
+
+# ── No-op: contract absent ───────────────────────────────────────────────────
+# Absence is byte-for-byte today's behavior. Write nothing, touch no verdict.
+if [ ! -f "$CONTRACT_FILE" ]; then
+    exit 0
+fi
+
+# ── Dependency checks (missing tool -> exit 2 + actionable brew message) ──────
+if ! command -v yq >/dev/null 2>&1; then
+    emit_and_exit 2 "code_health:qa_deploy_invalid_contract" \
+        "yq not found. Install with: brew install yq"
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    emit_and_exit 2 "code_health:qa_deploy_invalid_contract" \
+        "jq not found. Install with: brew install jq"
+fi
+if ! command -v ajv >/dev/null 2>&1; then
+    emit_and_exit 2 "code_health:qa_deploy_invalid_contract" \
+        "ajv CLI not found. Install with: npm install -g ajv-cli"
+fi
+
+# ── Step 1: YAML -> JSON via yq (malformed YAML fails here) ───────────────────
+YQ_ERR="$(mktemp -t qa-deploy-yq-err.XXXXXX)"
+CONTRACT_JSON_FILE="$(mktemp -t qa-deploy-contract.XXXXXX)"
+cleanup() { rm -f "$YQ_ERR" "$CONTRACT_JSON_FILE"; }
+trap cleanup EXIT
+
+if ! yq -o=json '.' "$CONTRACT_FILE" > "$CONTRACT_JSON_FILE" 2>"$YQ_ERR"; then
+    emit_and_exit 2 "code_health:qa_deploy_invalid_contract" \
+        "failed to parse $CONTRACT_FILE: $(cat "$YQ_ERR")"
+fi
+
+CONTRACT_JSON="$(cat "$CONTRACT_JSON_FILE")"
+if [ "$CONTRACT_JSON" = "null" ] || [ -z "$CONTRACT_JSON" ]; then
+    emit_and_exit 2 "code_health:qa_deploy_invalid_contract" \
+        "$CONTRACT_FILE parsed to empty/null"
+fi
+
+# ── Step 2: ajv schema validation (missing required / wrong shape -> exit 2) ──
+if [ ! -f "$SCHEMA_FILE" ]; then
+    emit_and_exit 2 "code_health:qa_deploy_invalid_contract" \
+        "schema not found: $SCHEMA_FILE"
+fi
+
+# Use Node/Ajv2020 directly (same approach as validate-contract.sh: ajv-cli's
+# --spec flag has a known parsing bug for draft2020).
+AJV_OUT="$(node -e "
+try {
+  var fs = require('fs');
+  var Ajv2020;
+  try { Ajv2020 = require('ajv/dist/2020'); }
+  catch(e) {
+    var paths = [
+      '/opt/homebrew/lib/node_modules/ajv-cli/node_modules/ajv/dist/2020',
+      '/usr/local/lib/node_modules/ajv-cli/node_modules/ajv/dist/2020'
+    ];
+    for (var i = 0; i < paths.length; i++) {
+      try { Ajv2020 = require(paths[i]); break; } catch(e2) {}
+    }
+  }
+  if (!Ajv2020) { console.error('ajv/dist/2020 not found'); process.exit(1); }
+  var schema = JSON.parse(fs.readFileSync('$SCHEMA_FILE', 'utf8'));
+  var data   = JSON.parse(fs.readFileSync('$CONTRACT_JSON_FILE', 'utf8'));
+  var ajv    = new Ajv2020({strict: false, allErrors: true});
+  var valid  = ajv.validate(schema, data);
+  if (valid) { console.log('valid'); process.exit(0); }
+  else { console.error(ajv.errorsText()); process.exit(2); }
+} catch(e) { console.error(e.message); process.exit(1); }
+" 2>&1)"
+AJV_RC=$?
+if [ "$AJV_RC" -ne 0 ]; then
+    emit_and_exit 2 "code_health:qa_deploy_invalid_contract" \
+        "schema validation failed: $AJV_OUT"
+fi
+
+# ── Safety floor ─────────────────────────────────────────────────────────────
+# Enforced BEFORE any stage execution; each violation aborts immediately with
+# exit 3 and the named category. No stage runs once any rule trips.
+
+# Collect the values we need as newline-delimited lists via jq (jq reads the
+# JSON; no contract value is interpolated into any pattern).
+FORBIDDEN_LIST="$(printf '%s' "$CONTRACT_JSON" | jq -r '.target_envs.forbidden[]? // empty')"
+
+# All stage commands (deploy stages).
+STAGE_COMMANDS="$(printf '%s' "$CONTRACT_JSON" | jq -r '.stages[]?.command // empty')"
+# All teardown commands.
+TEARDOWN_COMMANDS="$(printf '%s' "$CONTRACT_JSON" | jq -r '.teardown[]?.command // empty')"
+# All health_check URLs.
+HEALTHCHECK_URLS="$(printf '%s' "$CONTRACT_JSON" | jq -r '.stages[]?.health_check?.url // empty')"
+
+# ── Rule 1: Forbidden-target match ───────────────────────────────────────────
+# Each target_envs.forbidden token matched LITERAL, case-insensitive substring
+# against each stage command, each health_check.url. (stdout matching happens at
+# stage run time in #1294.) `grep -iF -e "$token"` keeps the token literal — no
+# regex interpolation, so a token like "a.b.c" or "x|y" can never act as a
+# pattern. The searched haystack is the command/url text on stdin.
+HAYSTACK_FOR_FORBIDDEN="$(printf '%s\n%s\n' "$STAGE_COMMANDS" "$HEALTHCHECK_URLS")"
+if [ -n "$FORBIDDEN_LIST" ]; then
+    while IFS= read -r token; do
+        if [ -z "$token" ]; then
+            continue
+        fi
+        if printf '%s' "$HAYSTACK_FOR_FORBIDDEN" | grep -iF -e "$token" >/dev/null 2>&1; then
+            emit_and_exit 3 "qa_deploy_forbidden_target" \
+                "forbidden target token '$token' appears in a stage command or health_check.url"
+        fi
+    done <<EOF
+$FORBIDDEN_LIST
+EOF
+fi
+
+# ── Rule 2: Production-pattern rejection ──────────────────────────────────────
+# Each command (deploy + teardown) word-boundary case-insensitive matched
+# against a FIXED set of production patterns. The regex is hardcoded here; the
+# command text is the searched input (stdin), so no contract value reaches the
+# pattern. Patterns: --prod, --production, " prod ", " production ",
+# production-only, live-prod. `--prod(uction)?` is anchored so it does not match
+# inside an unrelated longer flag (e.g. --prod-dry-run-disabled would still
+# match --prod as a token, which is the intended over-block).
+PROD_REGEX='(--prod([^a-z0-9]|$)|--production([^a-z0-9]|$)| prod | production |production-only|live-prod)'
+ALL_COMMANDS="$(printf '%s\n%s\n' "$STAGE_COMMANDS" "$TEARDOWN_COMMANDS")"
+if [ -n "$ALL_COMMANDS" ]; then
+    while IFS= read -r cmd; do
+        if [ -z "$cmd" ]; then
+            continue
+        fi
+        if printf '%s' "$cmd" | grep -iE "$PROD_REGEX" >/dev/null 2>&1; then
+            emit_and_exit 3 "qa_deploy_prod_pattern" \
+                "production pattern detected in command: $cmd"
+        fi
+    done <<EOF
+$ALL_COMMANDS
+EOF
+fi
+
+# ── Rule 3: max_records required for data-clone stages ────────────────────────
+# Any stage whose name OR command matches (case-insensitive) clone|copy|
+# replicate|sync MUST declare safety.max_records. The clone regex is FIXED; the
+# name/command is the searched input. We resolve per-stage with jq so a missing
+# max_records is detected precisely (null/absent -> violation).
+CLONE_REGEX='(clone|copy|replicate|sync)'
+STAGE_COUNT="$(printf '%s' "$CONTRACT_JSON" | jq -r '.stages | length // 0')"
+i=0
+while [ "$i" -lt "$STAGE_COUNT" ]; do
+    s_name="$(printf '%s' "$CONTRACT_JSON" | jq -r ".stages[$i].name // \"\"")"
+    s_cmd="$(printf '%s' "$CONTRACT_JSON" | jq -r ".stages[$i].command // \"\"")"
+    s_max="$(printf '%s' "$CONTRACT_JSON" | jq -r ".stages[$i].safety.max_records // \"\"")"
+    is_clone=0
+    if printf '%s' "$s_name" | grep -iE "$CLONE_REGEX" >/dev/null 2>&1; then
+        is_clone=1
+    elif printf '%s' "$s_cmd" | grep -iE "$CLONE_REGEX" >/dev/null 2>&1; then
+        is_clone=1
+    fi
+    if [ "$is_clone" -eq 1 ] && [ -z "$s_max" ]; then
+        emit_and_exit 3 "qa_deploy_missing_records_cap" \
+            "data-clone stage '$s_name' is missing required safety.max_records"
+    fi
+    i=$((i + 1))
+done
+
+# ── Parse + safety floor passed ──────────────────────────────────────────────
+# Stage execution, health probes, and verdict-write are deferred to #1294/#1295.
+# A valid, safe contract that this core cannot yet execute exits 0 (no-op for
+# the execution half) so the gate does not block on the unimplemented portion.
+exit 0

--- a/tests/qa/fixtures/invalid-forbidden-in-command.yml
+++ b/tests/qa/fixtures/invalid-forbidden-in-command.yml
@@ -1,0 +1,12 @@
+# Schema-VALID, but trips the runner safety floor (#1293 rule 1):
+# a stage command embeds a forbidden target token (literal, case-insensitive
+# substring of a target_envs.forbidden entry) -> runner must abort exit 3
+# qa_deploy_forbidden_target BEFORE running any stage.
+required: true
+stages:
+  - name: deploy-to-test-family
+    command: bash scripts/deploy.sh --url https://Tidyboard.org/release
+    timeout: 600
+target_envs:
+  allowed: [test.tidyboard.org]
+  forbidden: [tidyboard.org, www.tidyboard.org]

--- a/tests/qa/fixtures/invalid-prod-pattern.yml
+++ b/tests/qa/fixtures/invalid-prod-pattern.yml
@@ -1,0 +1,12 @@
+# Schema-VALID, but trips the runner safety floor (#1293 rule 2):
+# a stage command contains a production pattern (word-boundary,
+# case-insensitive: --prod here) -> runner must abort exit 3
+# qa_deploy_prod_pattern BEFORE running any stage.
+required: true
+stages:
+  - name: deploy-to-test-family
+    command: bash scripts/deploy.sh --target test-family --prod
+    timeout: 600
+target_envs:
+  allowed: [test.tidyboard.org]
+  forbidden: [example.invalid]

--- a/tests/qa/fixtures/valid.yml
+++ b/tests/qa/fixtures/valid.yml
@@ -25,6 +25,10 @@ teardown:
     on_failure: warn
 target_envs:
   allowed: [test.tidyboard.org, staging.tidyboard.org]
-  forbidden: [tidyboard.org, www.tidyboard.org]
+  # Forbidden tokens are matched as literal, case-insensitive SUBSTRINGS by the
+  # runner safety floor (rule 1), so they must not be substrings of an allowed
+  # host. The bare apex "tidyboard.org" would substring-match the allowed
+  # "test.tidyboard.org"; list specific prod hostnames instead.
+  forbidden: [www.tidyboard.org, app.tidyboard.org]
 safety:
   notes: "clone script anonymizes PII in step 2; test family is read-isolated from prod."

--- a/tests/qa/test_qa_deploy.bats
+++ b/tests/qa/test_qa_deploy.bats
@@ -1,0 +1,151 @@
+#!/usr/bin/env bats
+#
+# test_qa_deploy.bats — runner CORE coverage for scripts/qa-deploy-runner.sh
+# (autospec issue #1293, part of #694).
+#
+# Scope of THIS test (parse + safety floor + no-op only; stage execution,
+# health probes, and verdict-write are #1294/#1295):
+#   fixture 1 — absent contract        -> exit 0, no-op, writes nothing
+#   fixture 3 — forbidden URL/command  -> exit 3 qa_deploy_forbidden_target
+#   fixture 4 — production pattern      -> exit 3 qa_deploy_prod_pattern
+#   fixture 5 — clone w/o max_records   -> exit 3 qa_deploy_missing_records_cap
+#   plus: invalid contract (malformed YAML / missing required) -> exit 2
+#
+# bats 3.2-safe: every contract is copied to a REAL temp file/dir before the
+# runner reads it (no `[ -f <(...) ]` process substitution). Tests skip with a
+# message — never silently false-pass — when yq/jq/ajv/node are unavailable.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  RUNNER="$REPO_ROOT/scripts/qa-deploy-runner.sh"
+  FIXTURES="$REPO_ROOT/tests/qa/fixtures"
+  TMP_REPO="$(mktemp -d /tmp/autospec-qa-deploy-runner-XXXXXX)"
+  mkdir -p "$TMP_REPO/.autospec"
+}
+
+teardown() {
+  rm -rf "$TMP_REPO"
+}
+
+# Require the full toolchain or skip with a message (no false pass).
+_require_tools() {
+  command -v yq   >/dev/null 2>&1 || skip "yq not available (brew install yq)"
+  command -v jq   >/dev/null 2>&1 || skip "jq not available (brew install jq)"
+  command -v ajv  >/dev/null 2>&1 || skip "ajv CLI not available (npm install -g ajv-cli)"
+  command -v node >/dev/null 2>&1 || skip "node not available"
+}
+
+# Copy a fixture into the temp repo's real .autospec/qa-deploy.yml on disk.
+_install_contract() {
+  cp "$FIXTURES/$1" "$TMP_REPO/.autospec/qa-deploy.yml"
+  [ -f "$TMP_REPO/.autospec/qa-deploy.yml" ]   # bats 3.2-safe: real file
+}
+
+@test "runner exists and is executable" {
+  [ -f "$RUNNER" ]
+  [ -x "$RUNNER" ]
+}
+
+# ── fixture 1: absent contract -> exit 0, no-op, writes nothing ───────────────
+@test "fixture 1: absent contract -> exit 0 no-op, writes nothing" {
+  # No .autospec/qa-deploy.yml present.
+  rm -f "$TMP_REPO/.autospec/qa-deploy.yml"
+  run bash "$RUNNER" --repo-dir "$TMP_REPO"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  # Nothing written into .autospec.
+  run ls -A "$TMP_REPO/.autospec"
+  [ -z "$output" ]
+}
+
+# ── valid cross-directory: --repo-dir outside the checkout passes safety floor ─
+# Proves the runner reads its contract from --repo-dir (a mktemp dir under /tmp,
+# a different directory tree from $REPO_ROOT) rather than SCRIPT_DIR/.., and
+# that a valid contract clears the safety floor. Scope is parse + safety-floor +
+# no-op only: no stage execution, health probes, or verdict-write is asserted.
+@test "valid contract via --repo-dir outside checkout -> passes safety floor, writes nothing" {
+  _require_tools
+  _install_contract "valid.yml"
+  # $TMP_REPO is a mktemp -d /tmp/... dir (see setup), outside $REPO_ROOT.
+  run bash "$RUNNER" --repo-dir "$TMP_REPO"
+  [ "$status" -eq 0 ]
+  # Safety floor passed: none of the violation categories appear.
+  [[ "$output" != *"qa_deploy_forbidden_target"* ]]
+  [[ "$output" != *"qa_deploy_prod_pattern"* ]]
+  [[ "$output" != *"qa_deploy_missing_records_cap"* ]]
+  [[ "$output" != *"qa_deploy_invalid_contract"* ]]
+  # No artifact written into .autospec beyond the installed contract.
+  run ls -A "$TMP_REPO/.autospec"
+  [ "$output" = "qa-deploy.yml" ]
+}
+
+# ── fixture 3: forbidden token in command/url -> exit 3 forbidden_target ──────
+@test "fixture 3: forbidden target token in command -> exit 3 qa_deploy_forbidden_target, zero stages run" {
+  _require_tools
+  _install_contract "invalid-forbidden-in-command.yml"
+  run bash "$RUNNER" --repo-dir "$TMP_REPO"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"qa_deploy_forbidden_target"* ]]
+  # Zero stages run: this core never executes stages, and no verdict/output
+  # artifact is written into .autospec beyond the contract we installed.
+  run ls -A "$TMP_REPO/.autospec"
+  [ "$output" = "qa-deploy.yml" ]
+}
+
+# ── fixture 4: production pattern -> exit 3 prod_pattern ──────────────────────
+@test "fixture 4: production pattern in command -> exit 3 qa_deploy_prod_pattern" {
+  _require_tools
+  _install_contract "invalid-prod-pattern.yml"
+  run bash "$RUNNER" --repo-dir "$TMP_REPO"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"qa_deploy_prod_pattern"* ]]
+}
+
+# ── fixture 5: clone stage missing max_records -> exit 3 missing_records_cap ──
+@test "fixture 5: data-clone stage missing max_records -> exit 3 qa_deploy_missing_records_cap" {
+  _require_tools
+  _install_contract "invalid-clone-missing-max-records.yml"
+  run bash "$RUNNER" --repo-dir "$TMP_REPO"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"qa_deploy_missing_records_cap"* ]]
+}
+
+# ── invalid contract: malformed YAML -> exit 2 ───────────────────────────────
+@test "malformed YAML contract -> exit 2 qa_deploy_invalid_contract" {
+  _require_tools
+  _install_contract "invalid-malformed-yaml.yml"
+  run bash "$RUNNER" --repo-dir "$TMP_REPO"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"qa_deploy_invalid_contract"* ]]
+}
+
+# ── invalid contract: missing required (schema) -> exit 2 ────────────────────
+@test "contract missing required target_envs.forbidden -> exit 2 qa_deploy_invalid_contract" {
+  _require_tools
+  _install_contract "invalid-missing-forbidden.yml"
+  run bash "$RUNNER" --repo-dir "$TMP_REPO"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"qa_deploy_invalid_contract"* ]]
+}
+
+# ── missing tool path is reachable + actionable (only meaningful w/o ajv) ─────
+@test "missing tool -> exit 2 with actionable brew/npm install message" {
+  command -v yq >/dev/null 2>&1 || skip "yq not available (brew install yq)"
+  _install_contract "valid.yml"
+  # Build a sanitized PATH dir that contains every tool the script needs to even
+  # start (bash, mktemp, cat, grep, jq, node) EXCEPT yq, so the first dependency
+  # check (yq) fires exit 2 with an install hint. This exercises the
+  # missing-tool branch without nuking PATH entirely (which would break bash).
+  local stub="$TMP_REPO/stubbin"
+  mkdir -p "$stub"
+  for t in bash sh env mktemp cat grep sed dirname jq node ls printf; do
+    p="$(command -v "$t" 2>/dev/null || true)"
+    if [ -n "$p" ]; then ln -sf "$p" "$stub/$t"; fi
+  done
+  # Deliberately do NOT link yq into $stub.
+  run env PATH="$stub" bash "$RUNNER" --repo-dir "$TMP_REPO"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"qa_deploy_invalid_contract"* ]]
+  [[ "$output" == *"install"* ]]
+  [[ "$output" == *"yq"* ]]
+}


### PR DESCRIPTION
Closes #1293 (part of #694). `scripts/qa-deploy-runner.sh`: absent contract → exit 0 no-op; else yq→ajv-validate (#1292 schema; invalid → exit 2). **Three safety-floor rules** enforced before any stage, exit 3 + category: forbidden-target (literal `grep -iF`), production-pattern (fixed regex), data-clone missing `max_records`. **Injection-safe** (contract values are literal needles only — jq-regex memory); `set -u` not `set -e`; bats real temp files. 9 bats + teeth proof. **No stage-exec/verdict-write** (deferred #1294/#1295). validate exit 0.