### PR TITLE
feat(autospec-qa): qa-deploy teardown + --skip-teardown + PASS->PARTIAL (#1295)

### DIFF
--- a/scripts/qa-deploy-runner.sh
+++ b/scripts/qa-deploy-runner.sh
@@ -8,7 +8,7 @@
 # those land in #1294/#1295.
 #
 # Usage:
-#   qa-deploy-runner.sh --repo-dir <dir> [--verdict <path>]
+#   qa-deploy-runner.sh --repo-dir <dir> [--verdict <path>] [--skip-teardown]
 #
 # Reads <repo-dir>/.autospec/qa-deploy.yml. The file's PRESENCE makes deploy
 # mandatory; its ABSENCE is a no-op (today's behavior, byte-for-byte).
@@ -40,6 +40,7 @@ SCHEMA_FILE="$REPO_ROOT/schemas/autospec-qa-deploy.schema.json"
 
 REPO_DIR=""
 VERDICT_PATH=""
+SKIP_TEARDOWN=0
 
 # ── Emit a category + message, return the matching exit code ──────────────────
 # emit_and_exit <exit_code> <category> <message>
@@ -62,6 +63,10 @@ while [ $# -gt 0 ]; do
         --verdict)
             VERDICT_PATH="${2:-}"
             shift 2
+            ;;
+        --skip-teardown)
+            SKIP_TEARDOWN=1
+            shift
             ;;
         -h|--help)
             sed -n '2,30p' "$0"
@@ -567,5 +572,161 @@ with open(tmp, "w") as out:
     out.write("\n")
 os.replace(tmp, path)
 PY
+
+# ── Teardown phase (#1295) ────────────────────────────────────────────────────
+# Runs AFTER the deploy: block (the verdict is final). Each teardown command is
+# subject to the SAME safety floor as deploy stages — the static prod-pattern
+# rule already covered teardown commands above; here we add the run-time
+# forbidden-target check (literal, case-insensitive grep -iF — no regex
+# interpolation, per the jq/regex-injection memory) against each teardown
+# command before running it. Failures of an `on_failure: warn` step log only;
+# an `on_failure: fail` step downgrades a PASS verdict to PARTIAL (NEVER a FAIL
+# or already-PARTIAL verdict). All verdict updates are atomic (.tmp+os.replace)
+# and additive (only deploy.teardown_run / deploy.teardown_failures and the
+# verdict downgrade are touched).
+
+# Record teardown_run up front (false when skipped, true otherwise). This is an
+# atomic, additive update — it preserves every other verdict + deploy key.
+write_teardown_run() {
+    local _run="$1"   # "true" or "false"
+    VERDICT_PATH="$VERDICT_PATH" TEARDOWN_RUN="$_run" python3 - <<'PY'
+import json, os
+path = os.environ["VERDICT_PATH"]
+run  = os.environ["TEARDOWN_RUN"] == "true"
+verdict = {}
+if os.path.isfile(path):
+    try:
+        with open(path) as f:
+            verdict = json.load(f) or {}
+    except Exception:
+        verdict = {}
+deploy = dict(verdict.get("deploy", {}) or {})
+deploy["teardown_run"] = run
+verdict["deploy"] = deploy
+os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+tmp = path + ".tmp"
+with open(tmp, "w") as out:
+    json.dump(verdict, out, indent=2)
+    out.write("\n")
+os.replace(tmp, path)
+PY
+}
+
+# Append one failing teardown name and (if downgrade=1) rewrite PASS->PARTIAL.
+# Atomic + additive: only deploy.teardown_failures and (conditionally) the
+# top-level verdict are changed; a FAIL / already-PARTIAL verdict is untouched.
+record_teardown_failure() {
+    local _name="$1" _downgrade="$2"   # _downgrade: "1" to attempt PASS->PARTIAL
+    VERDICT_PATH="$VERDICT_PATH" TEARDOWN_NAME="$_name" TEARDOWN_DOWNGRADE="$_downgrade" \
+    python3 - <<'PY'
+import json, os
+path      = os.environ["VERDICT_PATH"]
+name      = os.environ["TEARDOWN_NAME"]
+downgrade = os.environ["TEARDOWN_DOWNGRADE"] == "1"
+verdict = {}
+if os.path.isfile(path):
+    try:
+        with open(path) as f:
+            verdict = json.load(f) or {}
+    except Exception:
+        verdict = {}
+deploy = dict(verdict.get("deploy", {}) or {})
+failures = list(deploy.get("teardown_failures", []) or [])
+failures.append(name)
+deploy["teardown_failures"] = failures
+verdict["deploy"] = deploy
+# Downgrade ONLY a PASS verdict to PARTIAL. Never touch FAIL or PARTIAL.
+if downgrade and verdict.get("verdict") == "PASS":
+    verdict["verdict"] = "PARTIAL"
+os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+tmp = path + ".tmp"
+with open(tmp, "w") as out:
+    json.dump(verdict, out, indent=2)
+    out.write("\n")
+os.replace(tmp, path)
+PY
+}
+
+# Seed an empty teardown_failures list so the key is always present when
+# teardown runs. Atomic + additive (touches only deploy.teardown_failures).
+seed_teardown_failures() {
+    VERDICT_PATH="$VERDICT_PATH" python3 - <<'PY'
+import json, os
+path = os.environ["VERDICT_PATH"]
+verdict = {}
+if os.path.isfile(path):
+    try:
+        with open(path) as f:
+            verdict = json.load(f) or {}
+    except Exception:
+        verdict = {}
+deploy = dict(verdict.get("deploy", {}) or {})
+if "teardown_failures" not in deploy:
+    deploy["teardown_failures"] = []
+verdict["deploy"] = deploy
+os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+tmp = path + ".tmp"
+with open(tmp, "w") as out:
+    json.dump(verdict, out, indent=2)
+    out.write("\n")
+os.replace(tmp, path)
+PY
+}
+
+TEARDOWN_COUNT="$(printf '%s' "$CONTRACT_JSON" | jq -r '.teardown | length // 0')"
+
+if [ "$SKIP_TEARDOWN" -eq 1 ]; then
+    printf 'qa-deploy-runner: --skip-teardown set; skipping all teardown\n' >&2
+    write_teardown_run "false"
+else
+    write_teardown_run "true"
+    seed_teardown_failures
+
+    t=0
+    while [ "$t" -lt "$TEARDOWN_COUNT" ]; do
+        td_name="$(printf '%s' "$CONTRACT_JSON" | jq -r ".teardown[$t].name // \"\"")"
+        td_cmd="$(printf '%s' "$CONTRACT_JSON" | jq -r ".teardown[$t].command // \"\"")"
+        td_on_failure="$(printf '%s' "$CONTRACT_JSON" | jq -r ".teardown[$t].on_failure // \"warn\"")"
+
+        # ── Run-time forbidden-target check on the teardown COMMAND (rule 1) ──
+        # Literal, case-insensitive; the command text is the searched input — no
+        # contract value is interpolated into a regex.
+        if [ -n "$FORBIDDEN_LIST" ]; then
+            while IFS= read -r token; do
+                if [ -z "$token" ]; then
+                    continue
+                fi
+                if printf '%s' "$td_cmd" | grep -iF -e "$token" >/dev/null 2>&1; then
+                    emit_and_exit 3 "qa_deploy_forbidden_target" \
+                        "forbidden target token '$token' appears in teardown command '$td_name'"
+                fi
+            done <<EOF
+$FORBIDDEN_LIST
+EOF
+        fi
+
+        printf 'qa-deploy-runner: running teardown %s (on_failure=%s)\n' \
+            "$td_name" "$td_on_failure" >&2
+
+        # Run the teardown command with the same portable timeout wrapper as
+        # deploy stages (default 300s — teardown has no per-step timeout field).
+        run_stage_with_timeout 300 "$td_cmd" "$STAGE_OUT"
+        td_rc=$?
+
+        if [ "$td_rc" -ne 0 ]; then
+            if [ "$td_on_failure" = "fail" ]; then
+                printf 'qa-deploy-runner: teardown %s failed (on_failure=fail); downgrading PASS->PARTIAL\n' \
+                    "$td_name" >&2
+                record_teardown_failure "$td_name" "1"
+            else
+                printf 'qa-deploy-runner: teardown %s failed (on_failure=warn); logging only\n' \
+                    "$td_name" >&2
+                record_teardown_failure "$td_name" "0"
+            fi
+        fi
+
+        t=$((t + 1))
+    done
+fi
 
 exit 0

--- a/tests/qa/fixtures/teardown-fail-downgrade.yml
+++ b/tests/qa/fixtures/teardown-fail-downgrade.yml
@@ -1,0 +1,21 @@
+# #1295 fixture (8): a deploy that PASSES, then a teardown step whose command
+# FAILS with on_failure: fail. A failing `fail` teardown must downgrade a PASS
+# verdict to PARTIAL (never a FAIL / already-PARTIAL verdict) and append the
+# teardown name to deploy.teardown_failures. Commands are PATH-stubbed shims.
+required: true
+stages:
+  - name: deploy-to-test-family
+    command: deploy-stub
+    timeout: 30
+    health_check:
+      url: http://stub.test/health
+      expect_status: 200
+      retry: 3
+      retry_interval: 1
+teardown:
+  - name: cleanup-test-family
+    command: teardown-fail-stub
+    on_failure: fail
+target_envs:
+  allowed: [test.tidyboard.org]
+  forbidden: [www.tidyboard.org, app.tidyboard.org]

--- a/tests/qa/fixtures/teardown-ok.yml
+++ b/tests/qa/fixtures/teardown-ok.yml
@@ -1,0 +1,21 @@
+# #1295 fixture (9): a deploy that PASSES with a teardown step that would
+# SUCCEED — used with --skip-teardown to prove teardown is skipped entirely
+# (deploy.teardown_run: false, teardown command never invoked). Commands are
+# PATH-stubbed shims (no network).
+required: true
+stages:
+  - name: deploy-to-test-family
+    command: deploy-stub
+    timeout: 30
+    health_check:
+      url: http://stub.test/health
+      expect_status: 200
+      retry: 3
+      retry_interval: 1
+teardown:
+  - name: snapshot-test-state
+    command: teardown-ok-stub
+    on_failure: warn
+target_envs:
+  allowed: [test.tidyboard.org]
+  forbidden: [www.tidyboard.org, app.tidyboard.org]

--- a/tests/qa/fixtures/teardown-warn-fail.yml
+++ b/tests/qa/fixtures/teardown-warn-fail.yml
@@ -1,0 +1,21 @@
+# #1295 fixture (7): a deploy that PASSES, then a teardown step whose command
+# FAILS with the default on_failure: warn. The failure must be LOGGED ONLY —
+# the verdict is left unchanged — and the teardown name appended to
+# deploy.teardown_failures. Commands are PATH-stubbed shims (no network).
+required: true
+stages:
+  - name: deploy-to-test-family
+    command: deploy-stub
+    timeout: 30
+    health_check:
+      url: http://stub.test/health
+      expect_status: 200
+      retry: 3
+      retry_interval: 1
+teardown:
+  - name: snapshot-test-state
+    command: teardown-fail-stub
+    on_failure: warn
+target_envs:
+  allowed: [test.tidyboard.org]
+  forbidden: [www.tidyboard.org, app.tidyboard.org]

--- a/tests/qa/test_qa_deploy.bats
+++ b/tests/qa/test_qa_deploy.bats
@@ -202,6 +202,24 @@ esac
 exit 0
 EOF
   chmod +x "$STUB_BIN/curl"
+
+  # #1295 teardown shims. teardown-fail-stub exits non-zero (a failing teardown
+  # command); teardown-ok-stub exits 0 and drops a real marker so a test can
+  # prove it ran (or, under --skip-teardown, that it did NOT).
+  cat > "$STUB_BIN/teardown-fail-stub" <<'EOF'
+#!/usr/bin/env bash
+echo "teardown-fail-stub: cleanup failed"
+exit 1
+EOF
+  chmod +x "$STUB_BIN/teardown-fail-stub"
+
+  cat > "$STUB_BIN/teardown-ok-stub" <<EOF
+#!/usr/bin/env bash
+echo "teardown ran" > "$TMP_REPO/.autospec/teardown.marker"
+echo "teardown-ok-stub: cleaned up"
+exit 0
+EOF
+  chmod +x "$STUB_BIN/teardown-ok-stub"
 }
 
 _run_with_stubs() {
@@ -339,4 +357,98 @@ EOF
   _run_with_stubs
   [ "$status" -eq 3 ]
   [[ "$output" == *"qa_deploy_forbidden_target"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #1295 — post-verdict teardown + --skip-teardown + PASS->PARTIAL downgrade.
+#
+# Teardown runs AFTER the deploy: block is written (verdict final). Each
+# teardown command is subject to the same safety floor as deploy stages and is
+# PATH-stubbed (no network). on_failure: warn logs only; on_failure: fail
+# downgrades a PASS verdict to PARTIAL (never a FAIL / already-PARTIAL verdict).
+# All verdict updates are atomic (.tmp+os.replace) and additive.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── fixture 7: teardown warn-failure -> verdict UNCHANGED, name recorded ──────
+@test "fixture 7: teardown on_failure:warn failure -> verdict unchanged, name in teardown_failures" {
+  _require_tools
+  _install_contract "teardown-warn-fail.yml"
+  _install_stub_bin
+  VERDICT="$TMP_REPO/.autospec/qa-verdict.json"
+  # Seed a PASS verdict the audit would own; a warn teardown must NOT touch it.
+  printf '{"verdict":"PASS","findings":[]}\n' > "$VERDICT"
+  [ -f "$VERDICT" ]
+  _run_with_stubs
+  # A warn-only teardown failure does not change the runner's success exit.
+  [ "$status" -eq 0 ]
+  # Verdict left unchanged (still PASS).
+  run jq -r '.verdict' "$VERDICT"
+  [ "$output" = "PASS" ]
+  # Teardown ran.
+  run jq -r '.deploy.teardown_run' "$VERDICT"
+  [ "$output" = "true" ]
+  # The failing teardown name is recorded.
+  run jq -c '.deploy.teardown_failures' "$VERDICT"
+  [ "$output" = '["snapshot-test-state"]' ]
+}
+
+# ── fixture 8: teardown fail-failure on a PASS -> PASS becomes PARTIAL ────────
+@test "fixture 8: teardown on_failure:fail failure -> PASS downgraded to PARTIAL, name recorded" {
+  _require_tools
+  _install_contract "teardown-fail-downgrade.yml"
+  _install_stub_bin
+  VERDICT="$TMP_REPO/.autospec/qa-verdict.json"
+  printf '{"verdict":"PASS","findings":[{"category":"x","summary":"keep me"}]}\n' > "$VERDICT"
+  [ -f "$VERDICT" ]
+  _run_with_stubs
+  [ "$status" -eq 0 ]
+  # PASS -> PARTIAL downgrade.
+  run jq -r '.verdict' "$VERDICT"
+  [ "$output" = "PARTIAL" ]
+  # Additive: pre-existing findings preserved.
+  run jq -r '.findings[0].summary' "$VERDICT"
+  [ "$output" = "keep me" ]
+  run jq -c '.deploy.teardown_failures' "$VERDICT"
+  [ "$output" = '["cleanup-test-family"]' ]
+  run jq -r '.deploy.teardown_run' "$VERDICT"
+  [ "$output" = "true" ]
+}
+
+# ── teardown fail-failure must NOT alter a FAIL verdict (only PASS->PARTIAL) ──
+@test "teardown on_failure:fail failure does NOT alter a FAIL verdict" {
+  _require_tools
+  _install_contract "teardown-fail-downgrade.yml"
+  _install_stub_bin
+  VERDICT="$TMP_REPO/.autospec/qa-verdict.json"
+  # Seed a FAIL verdict; a fail teardown must leave it FAIL (never -> PARTIAL).
+  printf '{"verdict":"FAIL","findings":[]}\n' > "$VERDICT"
+  [ -f "$VERDICT" ]
+  _run_with_stubs
+  [ "$status" -eq 0 ]
+  run jq -r '.verdict' "$VERDICT"
+  [ "$output" = "FAIL" ]
+  # The failure is still recorded.
+  run jq -c '.deploy.teardown_failures' "$VERDICT"
+  [ "$output" = '["cleanup-test-family"]' ]
+}
+
+# ── fixture 9: --skip-teardown -> teardown skipped, teardown_run:false ────────
+@test "fixture 9: --skip-teardown -> teardown skipped entirely, deploy.teardown_run:false" {
+  _require_tools
+  _install_contract "teardown-ok.yml"
+  _install_stub_bin
+  VERDICT="$TMP_REPO/.autospec/qa-verdict.json"
+  printf '{"verdict":"PASS","findings":[]}\n' > "$VERDICT"
+  [ -f "$VERDICT" ]
+  run env PATH="$STUB_BIN:$PATH" bash "$RUNNER" \
+    --repo-dir "$TMP_REPO" --verdict "$VERDICT" --skip-teardown
+  [ "$status" -eq 0 ]
+  # Verdict unchanged.
+  run jq -r '.verdict' "$VERDICT"
+  [ "$output" = "PASS" ]
+  # teardown_run recorded as false.
+  run jq -r '.deploy.teardown_run' "$VERDICT"
+  [ "$output" = "false" ]
+  # The teardown command never ran (no marker written by teardown-ok-stub).
+  [ ! -f "$TMP_REPO/.autospec/teardown.marker" ]
 }


### PR DESCRIPTION
Closes #1295 (part of #694). Teardown phase after the deploy: block is final: teardown[] under the same safety floor (+run-time forbidden-target). `on_failure:warn`→log+record; `on_failure:fail`→record + **PASS→PARTIAL only** (FAIL/PARTIAL untouched). `--skip-teardown`→`teardown_run:false`. Atomic+additive verdict writes. **18/18 bats** (prior cases green); validate exit 0.