### PR TITLE
feat(autospec-fab): pinned toolchain Dockerfile + result-contract wrappers (#1300)

### DIFF
--- a/scripts/lint-fab-dockerfile.sh
+++ b/scripts/lint-fab-dockerfile.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# lint-fab-dockerfile.sh — host-portable pin lint for the autospec-fab container
+# Dockerfile (issue #1300; folded from the deferred #1301 nightly CI). Asserts the
+# Dockerfile pins EVERY version so the multi-GB image is reproducible:
+#   - FROM uses a @sha256 digest (never a floating tag, never :latest),
+#   - no ":latest" anywhere,
+#   - every `apt-get install` package carries an exact `=<version>` pin,
+#   - pip installs use --require-hashes.
+# Runs WITHOUT building the image (the build itself runs only in the deferred
+# nightly fab-container.yml). Exit 0 = all pins present; non-zero = a floating pin.
+#
+# Usage: scripts/lint-fab-dockerfile.sh [path/to/Dockerfile]
+
+set -euo pipefail
+
+DOCKERFILE="${1:-skills/autospec-fab/docker/Dockerfile}"
+
+err() { printf 'lint-fab-dockerfile: FAIL: %s\n' "$1" >&2; }
+
+if [ ! -f "$DOCKERFILE" ]; then
+    err "Dockerfile not found: $DOCKERFILE"
+    exit 1
+fi
+
+rc=0
+
+# --- 1. No floating :latest anywhere (comments excluded). ---
+if grep -nE '^[^#]*:latest' "$DOCKERFILE" >/dev/null 2>&1; then
+    err "floating ':latest' tag found:"
+    grep -nE '^[^#]*:latest' "$DOCKERFILE" >&2
+    rc=1
+fi
+
+# --- 2. Every FROM must pin by @sha256 digest. ---
+# FROM lines may reference earlier build stages by name (FROM base AS …);
+# those are local stages, not registry images — allow them. A registry image
+# reference (contains a registry/repo path or a known image name) must carry
+# @sha256. We enforce: any FROM whose image token is not a prior stage name and
+# is not already a build-arg-driven digest must contain '@sha256:'.
+stage_names=""
+while IFS= read -r line; do
+    case "$line" in
+        \#*) continue ;;
+    esac
+    # Extract the image token (2nd field) and optional "AS <stage>".
+    set -- $line
+    [ "${1:-}" = "FROM" ] || continue
+    image="${2:-}"
+    # Record stage alias if present (… AS name).
+    alias=""
+    if [ "${3:-}" = "AS" ] || [ "${3:-}" = "as" ]; then
+        alias="${4:-}"
+    fi
+    # If the image references a known prior stage, it's a local stage ref — OK.
+    is_stage=0
+    for s in $stage_names; do
+        [ "$image" = "$s" ] && is_stage=1 && break
+    done
+    if [ "$is_stage" -eq 0 ]; then
+        case "$image" in
+            *@sha256:*) : ;;          # literal digest — OK
+            *@\$\{*DIGEST*\}*) : ;;   # ARG-driven digest (e.g. @${UBUNTU_DIGEST}) — OK
+            *@\$*DIGEST*) : ;;        # ARG-driven digest, unbraced — OK
+            *)
+                err "FROM not pinned by @sha256 digest: $line"
+                rc=1
+                ;;
+        esac
+    fi
+    [ -n "$alias" ] && stage_names="$stage_names $alias"
+done < "$DOCKERFILE"
+
+# --- 2b. Any *_DIGEST ARG default must itself be a real sha256 digest, so an
+#         ARG-driven FROM (@${UBUNTU_DIGEST}) can't smuggle a floating value. ---
+while IFS= read -r dl; do
+    case "$dl" in \#*) continue ;; esac
+    val="${dl#*=}"
+    case "$val" in
+        sha256:[0-9a-f]*) : ;;
+        *)
+            err "ARG *_DIGEST default is not a sha256 digest: $dl"
+            rc=1
+            ;;
+    esac
+done < <(grep -E '^ARG +[A-Z_]*DIGEST=' "$DOCKERFILE" || true)
+
+# --- 3. Every apt-get install package must carry an exact =<version> pin. ---
+# Tokenize install lines (handling line continuations) and check each package
+# token (not a flag, not apt-get/install) contains '='. ARG/ENV interpolation
+# like pkg=${VERSION} counts as a pin.
+apt_block=""
+in_apt=0
+while IFS= read -r raw; do
+    line="$raw"
+    case "$line" in
+        \#*) continue ;;
+    esac
+    if printf '%s' "$line" | grep -qE 'apt-get +install'; then
+        in_apt=1
+        apt_block=""
+    fi
+    if [ "$in_apt" -eq 1 ]; then
+        apt_block="$apt_block $line"
+        # Continuation? keep accumulating; else close the block.
+        case "$line" in
+            *\\) : ;;
+            *)
+                in_apt=0
+                # Strip everything up to and including 'install', and any && tail.
+                pkgs="${apt_block#*install}"
+                pkgs="${pkgs%%&&*}"
+                for tok in $pkgs; do
+                    case "$tok" in
+                        -*|\\|apt-get|install) continue ;;
+                        *=*) continue ;;            # pinned (pkg=ver or pkg=${VER})
+                        *)
+                            err "unpinned apt package (no =version): '$tok' in: $(printf '%s' "$apt_block" | tr -s ' ')"
+                            rc=1
+                            ;;
+                    esac
+                done
+                ;;
+        esac
+    fi
+done < "$DOCKERFILE"
+
+# --- 4. pip install must use --require-hashes. ---
+if grep -nE 'pip +install' "$DOCKERFILE" >/dev/null 2>&1; then
+    while IFS= read -r pl; do
+        case "$pl" in \#*) continue ;; esac
+        printf '%s' "$pl" | grep -q -- '--require-hashes' || {
+            err "pip install without --require-hashes: $pl"
+            rc=1
+        }
+    done < <(grep -nE 'pip +install' "$DOCKERFILE")
+fi
+
+if [ "$rc" -eq 0 ]; then
+    printf 'lint-fab-dockerfile: OK — %s fully pinned (digest base, =version apt, hashed pip, no :latest)\n' "$DOCKERFILE"
+fi
+exit "$rc"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -4134,6 +4134,31 @@ check_autospec_fab_contract() {
         bats "$t" >"/tmp/validate-fab-$name.log" 2>&1 \
             || { cat "/tmp/validate-fab-$name.log" >&2; fail "$t: failed"; }
     done
+    check_fab_container_dockerfile
+}
+
+# Host-portable pin lint for the autospec-fab container Dockerfile (issue #1300,
+# folded from the deferred nightly CI #1301). Asserts the Dockerfile + the
+# result-contract wrappers are present and that the Dockerfile pins every version
+# (digest base, =version apt, hashed pip, no :latest). Runs WITHOUT building the
+# multi-GB image — the build itself runs only in the deferred fab-container.yml.
+check_fab_container_dockerfile() {
+    info "autospec-fab container: Dockerfile pin lint + wrapper presence (issue #1300)"
+    local docker_dir="skills/autospec-fab/docker"
+    local lint="scripts/lint-fab-dockerfile.sh"
+    # Skip cleanly only before child C lands the docker/ tree; once present, gate hard.
+    [ -f "$docker_dir/Dockerfile" ] || { info "  fab Dockerfile absent — pin lint skipped (pre-#1300)"; return 0; }
+    [ -f "$lint" ] || fail "$lint: pin-lint script missing (issue #1300)"
+    bash -n "$lint" || fail "$lint: bash -n failed"
+    for req in "$docker_dir/Dockerfile" \
+               "$docker_dir/requirements.txt" \
+               "$docker_dir/wrappers/ccx_safety_wrapper.py" \
+               "$docker_dir/wrappers/foam_cfd_reduce.py"; do
+        [ -f "$req" ] || fail "$req: required container file missing (issue #1300)"
+    done
+    bash "$lint" "$docker_dir/Dockerfile" >/tmp/validate-fab-pinlint.log 2>&1 \
+        || { cat /tmp/validate-fab-pinlint.log >&2; fail "fab Dockerfile pin lint failed (issue #1300)"; }
+    tail -1 /tmp/validate-fab-pinlint.log
 }
 
 main "$@"

--- a/skills/autospec-fab/docker/Dockerfile
+++ b/skills/autospec-fab/docker/Dockerfile
@@ -1,0 +1,144 @@
+# syntax=docker/dockerfile:1
+# ---------------------------------------------------------------------------
+# autospec-fab real-toolchain container (issue #1300, part of #1270)
+#
+# Multi-stage, fully pinned image that lands the four real engineering solvers on
+# PATH under the EXACT names the stage scripts resolve via shutil.which():
+#   ccx        (CalculiX)        -> stage_fea.py
+#   simpleFoam (OpenFOAM ESI)    -> stage_cfd.py
+#   freecadcmd (FreeCAD headless)-> freecad_harness.py / render
+#   fab-vision (vision CLI)      -> stage_vision.py   (the SHIPPED scripts/fab-vision-cli.py)
+#
+# Result-contract wrappers (docker/wrappers/) bridge real solver output to the
+# stages' .dat / cfd_results parse contracts — the ccx wrapper shadows the real
+# ccx on PATH and appends SAFETY_FACTOR; foam_cfd_reduce.py reduces OpenFOAM
+# fields to cfd_results.
+#
+# Pinning policy (spec §5.3): base by @sha256 digest; every apt package by exact
+# =<version> (ARG-driven so the nightly build bumps them in lock-step); pip with
+# --require-hashes. No floating :latest, no unpinned apt installs. amd64 only (v1).
+# Build:  docker build --platform=linux/amd64 -f skills/autospec-fab/docker/Dockerfile -t autospec-fab .
+# ---------------------------------------------------------------------------
+
+# ubuntu:24.04 multi-arch index digest (resolved 2026-06-22).
+ARG UBUNTU_DIGEST=sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
+
+# Exact apt versions. Pinned so the build is reproducible; the nightly
+# fab-container.yml bumps these as the repos move. The base-stage + CalculiX pins
+# below were resolved against the live 24.04 "noble" repo on 2026-06-22 and build
+# clean on linux/amd64. The FreeCAD + OpenFOAM pins are repo-dependent
+# (freecad-python3 is not in default noble pockets at this snapshot; OpenFOAM ESI
+# is an external apt repo) — they are documented ARG defaults the deferred nightly
+# resolves against whatever the live repos serve at build time.
+ARG CCX_VERSION=2.21-1
+ARG FREECAD_VERSION=0.21.2+dfsg2-1
+ARG OPENFOAM_VERSION=2406.240730
+ARG XVFB_VERSION=2:21.1.12-1ubuntu1.6
+ARG MESA_VERSION=25.2.8-0ubuntu0.24.04.2
+ARG PYTHON_VERSION=3.12.3-0ubuntu2.1
+ARG CURL_VERSION=8.5.0-2ubuntu10.9
+ARG CA_CERTS_VERSION=20260601~24.04.1
+ARG GNUPG_VERSION=2.4.4-2ubuntu17.4
+ARG SPC_VERSION=0.99.49.3
+
+# ===========================================================================
+# base — minimal pinned ubuntu + python/xvfb/curl, shared by solvers + runtime
+# ===========================================================================
+FROM ubuntu@${UBUNTU_DIGEST} AS base
+ARG XVFB_VERSION
+ARG MESA_VERSION
+ARG PYTHON_VERSION
+ARG CURL_VERSION
+ARG CA_CERTS_VERSION
+ARG GNUPG_VERSION
+ARG SPC_VERSION
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3=${PYTHON_VERSION} \
+        xvfb=${XVFB_VERSION} \
+        libgl1-mesa-dri=${MESA_VERSION} \
+        curl=${CURL_VERSION} \
+        ca-certificates=${CA_CERTS_VERSION} \
+        gnupg=${GNUPG_VERSION} \
+        software-properties-common=${SPC_VERSION} \
+    && rm -rf /var/lib/apt/lists/*
+
+# ===========================================================================
+# solvers — heavy apt layers (CalculiX, FreeCAD, OpenFOAM). Kept ABOVE the COPY
+# of fab scripts so iterating the scripts/smoke never rebuilds these layers.
+# ===========================================================================
+FROM base AS solvers
+ARG CCX_VERSION
+ARG FREECAD_VERSION
+ARG OPENFOAM_VERSION
+ENV DEBIAN_FRONTEND=noninteractive
+
+# CalculiX (ccx) — Ubuntu universe.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        calculix-ccx=${CCX_VERSION} \
+    && rm -rf /var/lib/apt/lists/*
+
+# FreeCAD headless (freecadcmd) + mesa/llvmpipe for offscreen GL.
+# NOTE (2026-06-22): freecad-python3 is NOT in the default Ubuntu 24.04 "noble"
+# apt pockets at this snapshot ("Unable to locate package") — it must come from
+# the FreeCAD PPA. The nightly fab-container.yml enables the pinned PPA before
+# this install; the line below carries the exact-version pin the lint enforces.
+# Verified clean through the base + CalculiX stages on linux/amd64; this FreeCAD
+# layer is the documented apt-availability boundary (operator-deferred to nightly).
+RUN add-apt-repository -y ppa:freecad-maintainers/freecad-stable \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        freecad-python3=${FREECAD_VERSION} \
+    && rm -rf /var/lib/apt/lists/*
+
+# OpenFOAM ESI (openfoam2406) — adds the ESI apt repo (pinned key) then installs
+# the exact point release. Provides simpleFoam under the OpenFOAM platforms bin.
+RUN curl -fsSL https://dl.openfoam.com/add-debian-repo.sh | bash \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        openfoam2406-default=${OPENFOAM_VERSION} \
+    && rm -rf /var/lib/apt/lists/*
+
+# ===========================================================================
+# runtime — final image. Inherits the solver layers, prunes docs/tutorials,
+# wires OpenFOAM env so non-login shells resolve simpleFoam, hash-installs pip
+# deps, then COPYs the fab scripts + wrappers + fab-vision LAST (cache-stable).
+# ===========================================================================
+FROM solvers AS runtime
+ARG OPENFOAM_VERSION
+
+# Prune OpenFOAM tutorials/doc to claw back ~1 GB (spec §3.1).
+RUN rm -rf \
+        /usr/lib/openfoam/openfoam2406/tutorials \
+        /usr/lib/openfoam/openfoam2406/doc \
+        /usr/share/doc/* \
+    || true
+
+# OpenFOAM env so `which simpleFoam` resolves in a non-login shell (spec §5.2):
+# the ESI package exports these via /usr/lib/openfoam/openfoam2406/etc/bashrc;
+# replicate the load-bearing vars statically so PATH carries the platforms bin.
+ENV WM_PROJECT_DIR=/usr/lib/openfoam/openfoam2406 \
+    WM_PROJECT_USER_DIR=/root/OpenFOAM/root-2406 \
+    FOAM_LIBBIN=/usr/lib/openfoam/openfoam2406/platforms/linux64GccDPInt32Opt/lib \
+    PATH=/usr/lib/openfoam/openfoam2406/platforms/linux64GccDPInt32Opt/bin:/usr/local/bin:/usr/bin:/bin
+
+# Hash-pinned pip deps for the wrappers / vision CLI.
+COPY skills/autospec-fab/docker/requirements.txt /tmp/requirements.txt
+RUN python3 -m pip install --no-cache-dir --require-hashes -r /tmp/requirements.txt
+
+# --- fab scripts, wrappers, and the SHIPPED vision CLI (COPY last) ---
+COPY skills/autospec-fab/scripts /opt/autospec-fab/scripts
+COPY skills/autospec-fab/docker/wrappers /opt/autospec-fab/wrappers
+
+# ccx result-contract wrapper SHADOWS the real ccx on PATH: stage_fea.py's
+# which("ccx") resolves here; the wrapper runs the real ccx then appends
+# SAFETY_FACTOR derived from .dat MAX_MISES vs material yield.
+RUN install -m 0755 /opt/autospec-fab/wrappers/ccx_safety_wrapper.py /usr/local/bin/ccx \
+    && install -m 0755 /opt/autospec-fab/wrappers/foam_cfd_reduce.py /usr/local/bin/foam-cfd-reduce
+
+# fab-vision: install the EXISTING shipped CLI (scripts/fab-vision-cli.py from
+# #1289/#1290) under the resolver name stage_vision.py expects. NOT a new CLI.
+RUN install -m 0755 /opt/autospec-fab/scripts/fab-vision-cli.py /usr/local/bin/fab-vision
+
+ENV AUTOSPEC_FAB_VISION_CMD=/usr/local/bin/fab-vision \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /work

--- a/skills/autospec-fab/docker/requirements.txt
+++ b/skills/autospec-fab/docker/requirements.txt
@@ -1,0 +1,21 @@
+# autospec-fab container pip requirements (issue #1300, part of #1270)
+#
+# Installed with: python3 -m pip install --no-cache-dir --require-hashes -r requirements.txt
+#
+# Deliberately EMPTY of third-party packages:
+#   - The result-contract wrappers (docker/wrappers/ccx_safety_wrapper.py,
+#     foam_cfd_reduce.py) are pure Python stdlib (math, re, os, subprocess).
+#   - The shipped fab-vision CLI (scripts/fab-vision-cli.py) imports `anthropic`
+#     LAZILY and GUARDED — absent it degrades gracefully, which is exactly what
+#     the non-skip integration smoke needs. The real model is issue #1271's scope.
+#
+# Pinning policy (spec §5.3): any package added here MUST carry == version pins
+# and --hash sha256 entries so `--require-hashes` stays enforceable and the build
+# is reproducible. Example for a future real-vision dependency:
+#
+#   anthropic==0.39.0 \
+#       --hash=sha256:<wheel-sha256> \
+#       --hash=sha256:<sdist-sha256>
+#
+# An empty hashed requirements file is a no-op install and keeps the Dockerfile's
+# --require-hashes invocation valid and deterministic.

--- a/skills/autospec-fab/docker/wrappers/ccx_safety_wrapper.py
+++ b/skills/autospec-fab/docker/wrappers/ccx_safety_wrapper.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""ccx_safety_wrapper.py — bridge real CalculiX output to stage_fea.py's parse contract.
+
+`stage_fea.py` runs ``ccx <job>`` and then parses a single ``SAFETY_FACTOR <value>``
+line out of ``<job>.dat`` (see ``stage_fea.py:_parse_safety_factor``). Real CalculiX
+does **not** emit a safety factor — with the deck's ``*EL PRINT ... S`` request it
+writes raw stress tensors under a ``stresses`` block in ``<job>.dat``. This wrapper
+is the one place the real solver meets the stage's parse contract:
+
+  1. run the real ``ccx`` binary (resolved via $CCX_REAL_BIN or the next ``ccx`` on
+     PATH that is not this wrapper),
+  2. read MAX von-Mises stress out of the ``.dat`` stress block,
+  3. derive ``SAFETY_FACTOR = material_yield / max_mises`` and append a
+     ``SAFETY_FACTOR <value>`` line to ``<job>.dat`` so the unchanged stage parses it.
+
+Installed in the container as ``/usr/local/bin/ccx`` (ahead of the real ccx on PATH),
+so ``shutil.which("ccx")`` resolves here and the stage is untouched.
+
+Material yield strengths (MPa) keyed by the same material names stage_fea.py uses;
+overridable via $CCX_MATERIAL_YIELD_MPA for one-off parts/materials.
+
+The von-Mises derivation is exposed as importable pure functions (``von_mises``,
+``parse_max_mises``, ``derive_safety_factor``, ``resolve_yield_mpa``) so it is unit
+testable against a sample real-ccx ``.dat`` without building the image or running ccx.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+# Yield strength (MPa) per FDM material, keyed to stage_fea.py's material names.
+# Conservative tensile-yield figures for typical FDM filament.
+_MATERIAL_YIELD_MPA: dict[str, float] = {
+    "PETG": 50.0,
+    "PLA": 60.0,
+    "ABS": 40.0,
+    "ASA": 44.0,
+    "PCTG": 47.0,
+}
+_DEFAULT_YIELD_MPA = 40.0
+
+
+def von_mises(sxx: float, syy: float, szz: float,
+              sxy: float, sxz: float, syz: float) -> float:
+    """Von-Mises equivalent stress from the six Cauchy stress components."""
+    return math.sqrt(
+        0.5 * (
+            (sxx - syy) ** 2 + (syy - szz) ** 2 + (szz - sxx) ** 2
+        )
+        + 3.0 * (sxy ** 2 + sxz ** 2 + syz ** 2)
+    )
+
+
+def parse_max_mises(dat_text: str) -> float | None:
+    """Return the maximum von-Mises stress over every stress row in a ccx .dat.
+
+    CalculiX (with ``*EL PRINT ... S``) writes a ``stresses`` block; each data row
+    is ``<elem> <intpnt> sxx syy szz sxy sxz syz`` (6 stress components after two
+    integer indices). Header / blank / non-numeric lines are skipped. Returns None
+    when no parsable stress row is found.
+
+    Some CalculiX builds already emit a von-Mises column; this derives mises from
+    the six tensor components, which is build-independent.
+    """
+    max_m: float | None = None
+    for raw in dat_text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        toks = line.split()
+        # Need two integer indices + six float stress components.
+        if len(toks) < 8:
+            continue
+        try:
+            int(toks[0])
+            int(toks[1])
+        except ValueError:
+            continue
+        try:
+            comps = [float(t) for t in toks[2:8]]
+        except ValueError:
+            continue
+        m = von_mises(*comps)
+        if max_m is None or m > max_m:
+            max_m = m
+    return max_m
+
+
+def resolve_yield_mpa(material: str | None) -> float:
+    """Material yield strength in MPa, with $CCX_MATERIAL_YIELD_MPA override."""
+    override = os.environ.get("CCX_MATERIAL_YIELD_MPA")
+    if override:
+        try:
+            return float(override)
+        except ValueError:
+            pass
+    if material:
+        return _MATERIAL_YIELD_MPA.get(material.upper(), _DEFAULT_YIELD_MPA)
+    return _DEFAULT_YIELD_MPA
+
+
+def derive_safety_factor(max_mises_pa: float, yield_mpa: float) -> float:
+    """Safety factor = yield / peak von-Mises. ccx stress is in Pa; yield is MPa."""
+    max_mpa = max_mises_pa
+    if max_mpa <= 0.0:
+        # No load / zero stress: effectively unbounded safety; clamp to a large
+        # finite value so the stage's float parse and comparison stay well-defined.
+        return 1.0e6
+    yield_pa = yield_mpa * 1.0e6
+    return yield_pa / max_mpa
+
+
+def annotate_dat(dat_path: str, material: str | None) -> bool:
+    """Append a SAFETY_FACTOR line derived from the .dat stress block.
+
+    Returns True if a line was appended, False if no stress data was parsable
+    (the stage then emits its own parse-failure verdict, unchanged).
+    """
+    if not os.path.exists(dat_path):
+        return False
+    with open(dat_path) as fh:
+        dat_text = fh.read()
+    max_mises = parse_max_mises(dat_text)
+    if max_mises is None:
+        return False
+    yield_mpa = resolve_yield_mpa(material)
+    sf = derive_safety_factor(max_mises, yield_mpa)
+    with open(dat_path, "a") as fh:
+        fh.write(f"SAFETY_FACTOR {sf:.6f}\n")
+    return True
+
+
+def _job_base_from_argv(argv: list[str]) -> str | None:
+    """ccx is invoked as ``ccx <job>`` (last positional, no extension)."""
+    positionals = [a for a in argv if not a.startswith("-")]
+    if not positionals:
+        return None
+    return positionals[-1]
+
+
+def _resolve_real_ccx() -> str | None:
+    """Locate the real ccx binary, skipping this wrapper itself."""
+    explicit = os.environ.get("CCX_REAL_BIN")
+    if explicit and os.path.exists(explicit):
+        return explicit
+    self_path = os.path.realpath(sys.argv[0])
+    for candidate in ("ccx", "ccx_2.21", "ccx_2.20", "ccx_2.19"):
+        found = shutil.which(candidate)
+        if found and os.path.realpath(found) != self_path:
+            return found
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:]) if argv is None else argv
+    real_ccx = _resolve_real_ccx()
+    if real_ccx is None:
+        sys.stderr.write("ccx_safety_wrapper: no real ccx binary found\n")
+        return 127
+    proc = subprocess.run([real_ccx, *argv])
+    if proc.returncode != 0:
+        return proc.returncode
+
+    job_base = _job_base_from_argv(argv)
+    if job_base is None:
+        return 0
+    dat_path = job_base + ".dat"
+    material = os.environ.get("CCX_MATERIAL")
+    annotate_dat(dat_path, material)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/autospec-fab/docker/wrappers/foam_cfd_reduce.py
+++ b/skills/autospec-fab/docker/wrappers/foam_cfd_reduce.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""foam_cfd_reduce.py — reduce real OpenFOAM field output to stage_cfd.py's contract.
+
+`stage_cfd.py` runs ``simpleFoam`` in a case dir, then parses a ``cfd_results`` file
+(see ``stage_cfd.py:_parse_cfd_results``) of the form::
+
+    PRESSURE_DROP <value_pa>
+    MIN_VELOCITY  <value_m_s>
+    STAGNATION    <0|1>
+
+Real OpenFOAM emits no such file — it writes ``p`` and ``U`` volume fields under
+numeric time directories (``0/``, ``100/``, …). This is the **real integration
+work** called out in the design §5.2: read the converged (latest) time-dir fields
+and reduce them to the three scalars the unchanged stage parses.
+
+Reductions (kinematic units; ``simpleFoam`` ``p`` is p/rho in m^2/s^2 — multiply
+by density to get Pa):
+  - PRESSURE_DROP = (max(p) - min(p)) * rho      [Pa]
+  - MIN_VELOCITY  = min over cells of |U|        [m/s]
+  - STAGNATION    = 1 if MIN_VELOCITY < stagnation_eps else 0
+
+Installed in the container so the case/post pipeline calls it after ``simpleFoam``;
+the field parsers + reductions are importable pure functions so they are unit
+testable against sample OpenFOAM field files without OpenFOAM installed.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+import sys
+
+# simpleFoam (incompressible) uses kinematic pressure p/rho. Default density of air
+# at sea level; override via $FOAM_RHO_KG_M3 for water/other fluids.
+_DEFAULT_RHO = 1.225
+# |U| below this (m/s) counts as a stagnation zone.
+_DEFAULT_STAGNATION_EPS = 0.05
+
+
+def _strip_comments(text: str) -> str:
+    """Drop C-style block and // line comments (OpenFOAM dict comment styles)."""
+    text = re.sub(r"/\*.*?\*/", " ", text, flags=re.DOTALL)
+    text = re.sub(r"//[^\n]*", " ", text)
+    return text
+
+
+def _extract_internal_block(text: str) -> str:
+    """Return the substring after ``internalField`` (where the field data lives)."""
+    idx = text.find("internalField")
+    return text[idx:] if idx != -1 else text
+
+
+def parse_scalar_field(text: str) -> list[float]:
+    """Parse the cell values of an OpenFOAM scalarField (e.g. the ``p`` field).
+
+    Handles ``internalField uniform <v>;`` and the
+    ``internalField nonuniform List<scalar> N ( v0 v1 ... );`` long form.
+    """
+    text = _strip_comments(text)
+    block = _extract_internal_block(text)
+    m = re.search(r"internalField\s+uniform\s+([-\d.eE+]+)", block)
+    if m:
+        return [float(m.group(1))]
+    # nonuniform list: N ( v0 v1 ... )
+    m = re.search(r"List<scalar>\s*\d*\s*\((.*?)\)", block, flags=re.DOTALL)
+    if not m:
+        return []
+    return [float(t) for t in m.group(1).split()]
+
+
+def parse_vector_field(text: str) -> list[tuple[float, float, float]]:
+    """Parse the cell vectors of an OpenFOAM vectorField (e.g. the ``U`` field).
+
+    Handles ``internalField uniform (x y z);`` and
+    ``internalField nonuniform List<vector> N ( (x y z) ... );``.
+    """
+    text = _strip_comments(text)
+    block = _extract_internal_block(text)
+    m = re.search(
+        r"internalField\s+uniform\s+\(\s*([-\d.eE+]+)\s+([-\d.eE+]+)\s+([-\d.eE+]+)\s*\)",
+        block,
+    )
+    if m:
+        return [(float(m.group(1)), float(m.group(2)), float(m.group(3)))]
+    m = re.search(r"List<vector>\s*\d*\s*\((.*)\)\s*;", block, flags=re.DOTALL)
+    if not m:
+        return []
+    vectors: list[tuple[float, float, float]] = []
+    for vm in re.finditer(r"\(\s*([-\d.eE+]+)\s+([-\d.eE+]+)\s+([-\d.eE+]+)\s*\)", m.group(1)):
+        vectors.append((float(vm.group(1)), float(vm.group(2)), float(vm.group(3))))
+    return vectors
+
+
+def reduce_pressure_drop(p_values: list[float], rho: float) -> float | None:
+    """(max p - min p) * rho → Pa. None if no values."""
+    if not p_values:
+        return None
+    return (max(p_values) - min(p_values)) * rho
+
+
+def reduce_min_velocity(u_vectors: list[tuple[float, float, float]]) -> float | None:
+    """min over cells of |U|. None if no vectors."""
+    if not u_vectors:
+        return None
+    return min(math.sqrt(x * x + y * y + z * z) for (x, y, z) in u_vectors)
+
+
+def _latest_time_dir(case_dir: str) -> str | None:
+    """Highest-numbered numeric time directory in a case (the converged solution)."""
+    best: tuple[float, str] | None = None
+    for entry in os.listdir(case_dir):
+        full = os.path.join(case_dir, entry)
+        if not os.path.isdir(full):
+            continue
+        try:
+            t = float(entry)
+        except ValueError:
+            continue
+        if best is None or t > best[0]:
+            best = (t, full)
+    return best[1] if best else None
+
+
+def reduce_case(case_dir: str,
+                rho: float | None = None,
+                stagnation_eps: float | None = None) -> dict:
+    """Read the latest time-dir p/U fields and reduce to the cfd_results scalars.
+
+    Returns a dict with keys pressure_drop_pa, min_velocity_m_s, stagnation (bool).
+    Missing fields yield None for that metric (the stage then sees a partial/empty
+    parse and emits its own verdict, unchanged).
+    """
+    rho = _DEFAULT_RHO if rho is None else rho
+    stagnation_eps = _DEFAULT_STAGNATION_EPS if stagnation_eps is None else stagnation_eps
+    out: dict = {"pressure_drop_pa": None, "min_velocity_m_s": None, "stagnation": False}
+
+    time_dir = _latest_time_dir(case_dir)
+    if time_dir is None:
+        return out
+
+    p_path = os.path.join(time_dir, "p")
+    if os.path.exists(p_path):
+        with open(p_path) as fh:
+            out["pressure_drop_pa"] = reduce_pressure_drop(parse_scalar_field(fh.read()), rho)
+
+    u_path = os.path.join(time_dir, "U")
+    if os.path.exists(u_path):
+        with open(u_path) as fh:
+            min_vel = reduce_min_velocity(parse_vector_field(fh.read()))
+        out["min_velocity_m_s"] = min_vel
+        if min_vel is not None:
+            out["stagnation"] = min_vel < stagnation_eps
+    return out
+
+
+def format_cfd_results(reduced: dict) -> str:
+    """Render the reduced scalars as the exact cfd_results line format the stage parses."""
+    lines: list[str] = []
+    dp = reduced.get("pressure_drop_pa")
+    if dp is not None:
+        lines.append(f"PRESSURE_DROP {dp:.6f}")
+    vel = reduced.get("min_velocity_m_s")
+    if vel is not None:
+        lines.append(f"MIN_VELOCITY {vel:.6f}")
+    lines.append(f"STAGNATION {1 if reduced.get('stagnation') else 0}")
+    return "\n".join(lines) + "\n"
+
+
+def write_cfd_results(case_dir: str,
+                      rho: float | None = None,
+                      stagnation_eps: float | None = None) -> str:
+    """Reduce the case and write ``<case_dir>/cfd_results``; return its path."""
+    reduced = reduce_case(case_dir, rho=rho, stagnation_eps=stagnation_eps)
+    out_path = os.path.join(case_dir, "cfd_results")
+    with open(out_path, "w") as fh:
+        fh.write(format_cfd_results(reduced))
+    return out_path
+
+
+def _env_float(name: str, default: float | None) -> float | None:
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    try:
+        return float(val)
+    except ValueError:
+        return default
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:]) if argv is None else argv
+    case_dir = argv[0] if argv else os.getcwd()
+    if not os.path.isdir(case_dir):
+        sys.stderr.write(f"foam_cfd_reduce: not a case dir: {case_dir}\n")
+        return 1
+    rho = _env_float("FOAM_RHO_KG_M3", _DEFAULT_RHO)
+    eps = _env_float("FOAM_STAGNATION_EPS", _DEFAULT_STAGNATION_EPS)
+    out_path = write_cfd_results(case_dir, rho=rho, stagnation_eps=eps)
+    sys.stderr.write(f"foam_cfd_reduce: wrote {out_path}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/autospec-fab/tests/test_ccx_safety_wrapper.bats
+++ b/skills/autospec-fab/tests/test_ccx_safety_wrapper.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# test_ccx_safety_wrapper.bats — thin bats wrapper around the Python unittest suite
+# for the ccx→SAFETY_FACTOR result-contract wrapper (issue #1300). Invoked by
+# validate.sh check_autospec_fab_contract which runs every fab tests/*.bats file.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+WRAPPERS_DIR="$REPO_ROOT/skills/autospec-fab/docker/wrappers"
+
+@test "ccx safety wrapper python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR:$WRAPPERS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_ccx_safety_wrapper.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_ccx_safety_wrapper.py
+++ b/skills/autospec-fab/tests/test_ccx_safety_wrapper.py
@@ -1,0 +1,122 @@
+"""test_ccx_safety_wrapper.py — unit tests for the ccx→SAFETY_FACTOR wrapper.
+
+The wrapper bridges real CalculiX .dat stress output to stage_fea.py's
+``SAFETY_FACTOR <value>`` parse contract. The load-bearing assertion: the line the
+wrapper appends is parsed by stage_fea.py's *real* ``_parse_safety_factor`` (imported
+here, not re-implemented) to the value we derived. A sample real-ccx .dat fixture is
+materialized at runtime so the test runs on a clean checkout.
+"""
+
+import importlib.util
+import math
+import os
+import sys
+import tempfile
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
+_WRAPPERS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "docker", "wrappers"))
+
+sys.path.insert(0, _SCRIPTS_DIR)
+sys.path.insert(0, _WRAPPERS_DIR)
+
+import ccx_safety_wrapper as wrap  # noqa: E402
+import stage_fea  # noqa: E402  (the real, unchanged stage parser is the oracle)
+
+
+# A sample real-ccx .dat: header + a ``stresses`` block with two integration-point
+# rows (elem, intpnt, sxx syy szz sxy sxz syz). Real ccx emits no SAFETY_FACTOR.
+_SAMPLE_DAT = """\
+
+ S T E P   1
+
+ stresses (elem, integ.pnt.,sxx,syy,szz,sxy,sxz,syz) for set EALL and time  0.1000000E+01
+
+         1   1  1.000000E+07  0.000000E+00  0.000000E+00  0.000000E+00  0.000000E+00  0.000000E+00
+         1   2  2.000000E+07  0.000000E+00  0.000000E+00  0.000000E+00  0.000000E+00  0.000000E+00
+
+ displacements (vx,vy,vz) for set NALL and time  0.1000000E+01
+
+         5 -1.0E-04  0.0E+00  0.0E+00
+"""
+
+
+class TestVonMises(unittest.TestCase):
+    def test_uniaxial_equals_axial_stress(self):
+        # Pure uniaxial sxx → von-Mises == sxx.
+        self.assertAlmostEqual(wrap.von_mises(10.0, 0, 0, 0, 0, 0), 10.0, places=6)
+
+    def test_pure_shear(self):
+        # Pure shear sxy=s → von-Mises == sqrt(3)*s.
+        self.assertAlmostEqual(wrap.von_mises(0, 0, 0, 5.0, 0, 0),
+                               math.sqrt(3.0) * 5.0, places=6)
+
+    def test_hydrostatic_is_zero(self):
+        self.assertAlmostEqual(wrap.von_mises(7, 7, 7, 0, 0, 0), 0.0, places=6)
+
+
+class TestParseMaxMises(unittest.TestCase):
+    def test_picks_max_over_rows(self):
+        # Two rows: sxx=1e7 and sxx=2e7 (uniaxial) → max mises = 2e7.
+        self.assertAlmostEqual(wrap.parse_max_mises(_SAMPLE_DAT), 2.0e7, places=1)
+
+    def test_no_stress_rows_returns_none(self):
+        self.assertIsNone(wrap.parse_max_mises("just\nheader\ntext\n"))
+
+
+class TestSafetyDerivation(unittest.TestCase):
+    def test_safety_factor_value(self):
+        # yield 40 MPa = 4e7 Pa; max mises 2e7 Pa → SF = 2.0.
+        sf = wrap.derive_safety_factor(2.0e7, 40.0)
+        self.assertAlmostEqual(sf, 2.0, places=6)
+
+    def test_zero_stress_is_large_finite(self):
+        sf = wrap.derive_safety_factor(0.0, 40.0)
+        self.assertGreater(sf, 1000.0)
+        self.assertTrue(math.isfinite(sf))
+
+    def test_material_yield_lookup_and_override(self):
+        self.assertEqual(wrap.resolve_yield_mpa("PLA"), 60.0)
+        self.assertEqual(wrap.resolve_yield_mpa("unknown"),
+                         wrap.resolve_yield_mpa(None))
+        os.environ["CCX_MATERIAL_YIELD_MPA"] = "123.0"
+        try:
+            self.assertEqual(wrap.resolve_yield_mpa("PLA"), 123.0)
+        finally:
+            del os.environ["CCX_MATERIAL_YIELD_MPA"]
+
+
+class TestContractRoundTrip(unittest.TestCase):
+    """The crux: wrapper output must be parsed by stage_fea.py's real parser."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="ccxwrap_")
+        self.job_base = os.path.join(self.tmp, "fea_job")
+        self.dat_path = self.job_base + ".dat"
+        with open(self.dat_path, "w") as fh:
+            fh.write(_SAMPLE_DAT)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_annotate_then_stage_parses_exact_value(self):
+        appended = wrap.annotate_dat(self.dat_path, material="ABS")  # yield 40 MPa
+        self.assertTrue(appended)
+        # stage_fea.py's own parser is the oracle — proves the line format matches.
+        parsed = stage_fea._parse_safety_factor(self.job_base)
+        self.assertIsNotNone(parsed, "stage_fea could not parse the wrapper's line")
+        # max mises 2e7 Pa, yield 40 MPa → SF = 2.0.
+        self.assertAlmostEqual(parsed, 2.0, places=4)
+
+    def test_no_stress_block_appends_nothing(self):
+        with open(self.dat_path, "w") as fh:
+            fh.write("header only, no stresses\n")
+        appended = wrap.annotate_dat(self.dat_path, material="ABS")
+        self.assertFalse(appended)
+        self.assertIsNone(stage_fea._parse_safety_factor(self.job_base))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/autospec-fab/tests/test_fab_dockerfile_pin_lint.bats
+++ b/skills/autospec-fab/tests/test_fab_dockerfile_pin_lint.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+# test_fab_dockerfile_pin_lint.bats — host-portable pin-lint contract for the
+# autospec-fab container Dockerfile (issue #1300, folded from deferred #1301).
+# Runs WITHOUT building the image. Invoked by validate.sh check_autospec_fab_contract.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+LINT="$REPO_ROOT/scripts/lint-fab-dockerfile.sh"
+DOCKERFILE="$REPO_ROOT/skills/autospec-fab/docker/Dockerfile"
+
+setup() {
+    TMP="$(mktemp -d)"
+}
+teardown() {
+    rm -rf "$TMP"
+}
+
+@test "lint script exists and is bash -n clean" {
+    [ -f "$LINT" ]
+    run bash -n "$LINT"
+    [ "$status" -eq 0 ]
+}
+
+@test "the shipped fab Dockerfile passes the pin lint" {
+    [ -f "$DOCKERFILE" ]
+    run bash "$LINT" "$DOCKERFILE"
+    [ "$status" -eq 0 ]
+}
+
+@test "lint rejects a floating :latest tag" {
+    printf 'FROM ubuntu:latest\nRUN apt-get install -y curl=1.0\n' > "$TMP/D"
+    run bash "$LINT" "$TMP/D"
+    [ "$status" -ne 0 ]
+}
+
+@test "lint rejects an unpinned apt package" {
+    printf 'FROM ubuntu@sha256:abc123\nRUN apt-get install -y curl\n' > "$TMP/D"
+    run bash "$LINT" "$TMP/D"
+    [ "$status" -ne 0 ]
+}
+
+@test "lint rejects a non-digest FROM" {
+    printf 'FROM ubuntu:24.04\nRUN apt-get install -y curl=1.0\n' > "$TMP/D"
+    run bash "$LINT" "$TMP/D"
+    [ "$status" -ne 0 ]
+}
+
+@test "lint rejects pip install without --require-hashes" {
+    printf 'FROM ubuntu@sha256:abc123\nRUN python3 -m pip install requests==2.0\n' > "$TMP/D"
+    run bash "$LINT" "$TMP/D"
+    [ "$status" -ne 0 ]
+}
+
+@test "lint rejects an ARG digest default that is not a sha256" {
+    printf 'ARG UBUNTU_DIGEST=24.04\nFROM ubuntu@${UBUNTU_DIGEST}\n' > "$TMP/D"
+    run bash "$LINT" "$TMP/D"
+    [ "$status" -ne 0 ]
+}
+
+@test "lint accepts a clean ARG-digest multi-stage Dockerfile" {
+    printf 'ARG UBUNTU_DIGEST=sha256:abc\nFROM ubuntu@${UBUNTU_DIGEST} AS base\nFROM base AS final\nRUN apt-get install -y curl=1.0\n' > "$TMP/D"
+    run bash "$LINT" "$TMP/D"
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_foam_cfd_reduce.bats
+++ b/skills/autospec-fab/tests/test_foam_cfd_reduce.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# test_foam_cfd_reduce.bats — thin bats wrapper around the Python unittest suite
+# for the OpenFOAM→cfd_results result-contract reducer (issue #1300). Invoked by
+# validate.sh check_autospec_fab_contract which runs every fab tests/*.bats file.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+WRAPPERS_DIR="$REPO_ROOT/skills/autospec-fab/docker/wrappers"
+
+@test "foam cfd reduce python unittest suite passes" {
+    command -v python3 || skip "python3 not found"
+    run env PYTHONPATH="$SCRIPTS_DIR:$WRAPPERS_DIR" \
+        python3 -m unittest discover \
+            -s "$REPO_ROOT/skills/autospec-fab/tests" \
+            -p "test_foam_cfd_reduce.py" \
+            -v
+    [ "$status" -eq 0 ]
+}

--- a/skills/autospec-fab/tests/test_foam_cfd_reduce.py
+++ b/skills/autospec-fab/tests/test_foam_cfd_reduce.py
@@ -1,0 +1,142 @@
+"""test_foam_cfd_reduce.py — unit tests for the OpenFOAM→cfd_results reducer.
+
+The reducer bridges real OpenFOAM time-dir field output (p/U) to stage_cfd.py's
+``cfd_results`` parse contract. The load-bearing assertion: the cfd_results file the
+reducer writes is parsed by stage_cfd.py's *real* ``_parse_cfd_results`` (imported
+here, not re-implemented) back to the values we reduced. Sample OpenFOAM field files
+are materialized at runtime so the test runs on a clean checkout.
+"""
+
+import math
+import os
+import sys
+import tempfile
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "scripts"))
+_WRAPPERS_DIR = os.path.normpath(os.path.join(_THIS_DIR, "..", "docker", "wrappers"))
+
+sys.path.insert(0, _SCRIPTS_DIR)
+sys.path.insert(0, _WRAPPERS_DIR)
+
+import foam_cfd_reduce as reduce_mod  # noqa: E402
+import stage_cfd  # noqa: E402  (the real, unchanged stage parser is the oracle)
+
+
+_P_NONUNIFORM = """\
+FoamFile { version 2.0; format ascii; class volScalarField; object p; }
+dimensions      [0 2 -2 0 0 0 0];
+internalField   nonuniform List<scalar>
+4
+(
+100.0
+50.0
+0.0
+20.0
+)
+;
+boundaryField { outlet { type zeroGradient; } }
+"""
+
+# Velocities: |U| = 5, 5, 0.01 (near-stagnation), 3 → min = 0.01.
+_U_NONUNIFORM = """\
+FoamFile { version 2.0; format ascii; class volVectorField; object U; }
+dimensions      [0 1 -1 0 0 0 0];
+internalField   nonuniform List<vector>
+4
+(
+(5 0 0)
+(0 5 0)
+(0.01 0 0)
+(3 0 0)
+)
+;
+boundaryField { inlet { type fixedValue; } }
+"""
+
+_P_UNIFORM = "internalField   uniform 42.0;\n"
+_U_UNIFORM = "internalField   uniform (2 0 0);\n"
+
+
+class TestFieldParsers(unittest.TestCase):
+    def test_scalar_nonuniform(self):
+        vals = reduce_mod.parse_scalar_field(_P_NONUNIFORM)
+        self.assertEqual(sorted(vals), [0.0, 20.0, 50.0, 100.0])
+
+    def test_scalar_uniform(self):
+        self.assertEqual(reduce_mod.parse_scalar_field(_P_UNIFORM), [42.0])
+
+    def test_vector_nonuniform(self):
+        vecs = reduce_mod.parse_vector_field(_U_NONUNIFORM)
+        self.assertEqual(len(vecs), 4)
+        self.assertIn((0.01, 0.0, 0.0), vecs)
+
+    def test_vector_uniform(self):
+        self.assertEqual(reduce_mod.parse_vector_field(_U_UNIFORM), [(2.0, 0.0, 0.0)])
+
+
+class TestReductions(unittest.TestCase):
+    def test_pressure_drop(self):
+        # (100 - 0) * rho. rho=1.0 → 100 Pa.
+        dp = reduce_mod.reduce_pressure_drop([100.0, 50.0, 0.0, 20.0], 1.0)
+        self.assertAlmostEqual(dp, 100.0, places=6)
+
+    def test_min_velocity(self):
+        vel = reduce_mod.reduce_min_velocity([(5, 0, 0), (0.01, 0, 0), (3, 0, 0)])
+        self.assertAlmostEqual(vel, 0.01, places=6)
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(reduce_mod.reduce_pressure_drop([], 1.0))
+        self.assertIsNone(reduce_mod.reduce_min_velocity([]))
+
+
+class TestContractRoundTrip(unittest.TestCase):
+    """The crux: reducer output must be parsed by stage_cfd.py's real parser."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="foamred_")
+        # Latest time dir "100" beats "0"; reducer must pick 100.
+        self.t100 = os.path.join(self.tmp, "100")
+        self.t0 = os.path.join(self.tmp, "0")
+        os.makedirs(self.t100)
+        os.makedirs(self.t0)
+        # Decoy values in the 0 dir to prove latest-time selection.
+        with open(os.path.join(self.t0, "p"), "w") as fh:
+            fh.write("internalField   uniform 999.0;\n")
+        with open(os.path.join(self.t100, "p"), "w") as fh:
+            fh.write(_P_NONUNIFORM)
+        with open(os.path.join(self.t100, "U"), "w") as fh:
+            fh.write(_U_NONUNIFORM)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_reduce_picks_latest_time(self):
+        reduced = reduce_mod.reduce_case(self.tmp, rho=1.0, stagnation_eps=0.05)
+        # From the 100/ dir, not the 999.0 decoy in 0/.
+        self.assertAlmostEqual(reduced["pressure_drop_pa"], 100.0, places=6)
+        self.assertAlmostEqual(reduced["min_velocity_m_s"], 0.01, places=6)
+        self.assertTrue(reduced["stagnation"])  # 0.01 < 0.05
+
+    def test_write_then_stage_parses_exact_values(self):
+        reduce_mod.write_cfd_results(self.tmp, rho=1.0, stagnation_eps=0.05)
+        # stage_cfd.py's own parser is the oracle — proves the line format matches.
+        parsed = stage_cfd._parse_cfd_results(self.tmp)
+        self.assertIsNotNone(parsed, "stage_cfd could not parse the reducer's file")
+        self.assertAlmostEqual(parsed["pressure_drop_pa"], 100.0, places=4)
+        self.assertAlmostEqual(parsed["min_velocity_m_s"], 0.01, places=4)
+        self.assertTrue(parsed["stagnation"])
+
+    def test_no_stagnation_when_fast(self):
+        with open(os.path.join(self.t100, "U"), "w") as fh:
+            fh.write("internalField   uniform (3 0 0);\n")
+        reduce_mod.write_cfd_results(self.tmp, rho=1.0, stagnation_eps=0.05)
+        parsed = stage_cfd._parse_cfd_results(self.tmp)
+        self.assertAlmostEqual(parsed["min_velocity_m_s"], 3.0, places=4)
+        self.assertFalse(parsed["stagnation"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1300 (part of #1270). Pinned multi-stage Dockerfile (base+CalculiX build-verified; FreeCAD/OpenFOAM full build **deferred** — they need external repos, and #1301 nightly CI is deferred per operator). Lands ccx/simpleFoam/freecadcmd on PATH + reuses the shipped `fab-vision-cli.py`. **Result-contract wrappers** (the integration crux): ccx→SAFETY_FACTOR + OpenFOAM→cfd_results, **20 unit tests round-tripping through the REAL stage parsers** as oracle. Host-portable pin-lint wired into validate (folded from deferred #1301). validate exit 0; no stage Python changed.