### PR TITLE
feat(autospec-fab): real-solver smoke fixture + run_smoke.sh (#1299)

### DIFF
--- a/skills/autospec-fab/docker/smoke/model/flow.json
+++ b/skills/autospec-fab/docker/smoke/model/flow.json
@@ -1,0 +1,6 @@
+{
+  "inlet_velocity_m_s": 5.0,
+  "max_pressure_drop_pa": 500.0,
+  "min_velocity_m_s": 1.0,
+  "no_stagnation": true
+}

--- a/skills/autospec-fab/docker/smoke/model/load.json
+++ b/skills/autospec-fab/docker/smoke/model/load.json
@@ -1,0 +1,5 @@
+{
+  "force_n": 25.0,
+  "direction": [0, 0, -1],
+  "safety_factor_min": 1.5
+}

--- a/skills/autospec-fab/docker/smoke/model/metadata.json
+++ b/skills/autospec-fab/docker/smoke/model/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "SmokePart10mm",
+  "body_count": 1,
+  "material": "PETG",
+  "print_orientation": "flat",
+  "load_critical": true,
+  "flow_critical": true,
+  "dims": { "x_mm": 10, "y_mm": 10, "z_mm": 10 },
+  "ports": [],
+  "gaskets": []
+}

--- a/skills/autospec-fab/docker/smoke/part.stl
+++ b/skills/autospec-fab/docker/smoke/part.stl
@@ -1,0 +1,86 @@
+solid smoke_part_10mm
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 10 0 0
+      vertex 10 10 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 10 10 0
+      vertex 0 10 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 10
+      vertex 10 10 10
+      vertex 10 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 10
+      vertex 0 10 10
+      vertex 10 10 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 10 0 10
+      vertex 10 0 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 10
+      vertex 10 0 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 10 0
+      vertex 10 10 0
+      vertex 10 10 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 10 0
+      vertex 10 10 10
+      vertex 0 10 10
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 10 0
+      vertex 0 10 10
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 10 10
+      vertex 0 0 10
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10 0 0
+      vertex 10 10 10
+      vertex 10 10 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10 0 0
+      vertex 10 0 10
+      vertex 10 10 10
+    endloop
+  endfacet
+endsolid smoke_part_10mm

--- a/skills/autospec-fab/docker/smoke/run_smoke.sh
+++ b/skills/autospec-fab/docker/smoke/run_smoke.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# run_smoke.sh — real-solver integration smoke for autospec-fab (issue #1299,
+# part of #1270). Drives ONE tiny fixture part through the four real-solver
+# stages — fea + cfd + render + vision — end-to-end and asserts each returns a
+# NON-`skip`, structurally-valid release-gate fragment.
+#
+# WHERE THIS RUNS: INSIDE the pinned #1300 container image, where the real
+# binaries (ccx / simpleFoam / freecadcmd / fab-vision) are on PATH under the
+# exact names the stage scripts resolve via shutil.which(). On a host WITHOUT
+# those binaries every stage correctly `skip`s, so this script would (correctly)
+# fail — that is the point: a skip-where-real-is-expected is a FAILURE here.
+#
+# DEFERRED: the full image build + this heavy run execute ONLY in the opt-in
+# nightly/dispatch workflow (.github/workflows/fab-container.yml, child E /
+# #1301 — deferred per operator). This child (#1299) authors the fixture +
+# script; they are structurally gated host-portably by
+# tests/test_fab_smoke_fixture.bats (no image build) and the validate.sh fab
+# suite. The heavy run is NOT part of validate.sh.
+#
+# This is a WIRING / integration assertion, NOT a numerical-accuracy check: it
+# proves the real toolchain integrates with the existing stage CLIs + result
+# contracts, not that the solver answers are physically correct.
+#
+# Exit 0 only if all four stages ran (non-skip) with structurally-valid
+# fragments; non-zero on any skip-where-real-expected or malformed fragment.
+# ---------------------------------------------------------------------------
+set -u
+
+# --- locations -------------------------------------------------------------
+SMOKE_DIR="$(cd "$(dirname "$0")" && pwd)"      # skills/autospec-fab/docker/smoke
+SKILL_DIR="$(cd "$SMOKE_DIR/../.." && pwd)"     # skills/autospec-fab
+SCRIPTS_DIR="$SKILL_DIR/scripts"
+GATE="$SCRIPTS_DIR/stl-release-gate.py"
+
+STL="$SMOKE_DIR/part.stl"
+MODEL="$SMOKE_DIR/model/metadata.json"          # MODELDIR = $SMOKE_DIR/model
+
+PYTHON="${PYTHON:-python3}"
+
+# Per-run output dir (release-gate.json + renders/ land here). Mktemp keeps
+# concurrent runs isolated and avoids polluting the read-only image layers.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/fab-smoke.XXXXXX")"
+OUT="$WORK/release-gate.json"
+
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+fail() { printf 'SMOKE FAIL: %s\n' "$*" >&2; exit 1; }
+note() { printf 'smoke: %s\n' "$*" >&2; }
+
+# --- pre-flight ------------------------------------------------------------
+command -v "$PYTHON" >/dev/null 2>&1 || fail "python3 not found on PATH"
+[ -f "$GATE" ]  || fail "release-gate engine not found: $GATE"
+[ -f "$STL" ]   || fail "fixture STL not found: $STL"
+[ -f "$MODEL" ] || fail "fixture metadata not found: $MODEL"
+
+# --- drive the full gate over the fixture part -----------------------------
+# The gate threads MODELDIR sibling files (load.json -> fea, flow.json -> cfd)
+# and the render->vision contact-sheet handoff automatically.
+note "running release gate over $STL (model $MODEL)"
+"$PYTHON" "$GATE" --in "$STL" --model "$MODEL" --out "$OUT" \
+    --stages-dir "$SCRIPTS_DIR" >"$WORK/gate.log" 2>&1 \
+    || { cat "$WORK/gate.log" >&2; fail "release gate engine crashed (harness error)"; }
+
+[ -f "$OUT" ] || { cat "$WORK/gate.log" >&2; fail "gate produced no release-gate.json"; }
+
+# --- per-stage NON-skip + structural assertions ----------------------------
+# Each assertion below is run through python3 against the aggregated gate JSON.
+# A helper returns the stage status (or empty if the stage record is missing)
+# and we reject "skip" explicitly plus check the structured fragment shape.
+
+# Assert a named stage exists and its status is NOT "skip" (and not empty/fail
+# for the blocking stages we expect to PASS or at least RUN). We accept any
+# non-skip status that proves the real solver executed; numerical pass/fail is
+# out of scope (wiring assertion).
+assert_stage_ran() {
+    stage_name="$1"
+    status="$("$PYTHON" - "$OUT" "$stage_name" <<'PY'
+import json, sys
+gate = json.load(open(sys.argv[1]))
+name = sys.argv[2]
+rec = next((s for s in gate.get("stages", []) if s.get("stage") == name), None)
+print("" if rec is None else (rec.get("status") or ""))
+PY
+)" || fail "$stage_name: could not parse gate JSON"
+    [ -n "$status" ] || fail "$stage_name: stage record missing from gate"
+    [ "$status" != "skip" ] \
+        || fail "$stage_name: status=skip — real solver did not run (expected non-skip inside the image)"
+    note "$stage_name: status=$status (non-skip)"
+}
+
+# FEA: non-skip AND structured fea_results.safety_factor present + numeric.
+assert_fea() {
+    assert_stage_ran fea
+    "$PYTHON" - "$OUT" <<'PY' || fail "fea: malformed fea_results (no numeric safety_factor)"
+import json, sys
+gate = json.load(open(sys.argv[1]))
+res = gate.get("fea_results")
+assert isinstance(res, dict), "fea_results missing or not an object"
+sf = res.get("safety_factor")
+assert isinstance(sf, (int, float)), "safety_factor missing or non-numeric: %r" % (sf,)
+PY
+    note "fea: fea_results.safety_factor present + numeric"
+}
+
+# CFD: non-skip AND parsed cfd_results.{pressure_drop_pa,min_velocity_m_s}.
+assert_cfd() {
+    assert_stage_ran cfd
+    "$PYTHON" - "$OUT" <<'PY' || fail "cfd: malformed cfd_results (PRESSURE_DROP/MIN_VELOCITY not parsed)"
+import json, sys
+gate = json.load(open(sys.argv[1]))
+res = gate.get("cfd_results")
+assert isinstance(res, dict), "cfd_results missing or not an object"
+dp = res.get("pressure_drop_pa")
+vel = res.get("min_velocity_m_s")
+assert isinstance(dp, (int, float)), "pressure_drop_pa missing/non-numeric: %r" % (dp,)
+assert isinstance(vel, (int, float)), "min_velocity_m_s missing/non-numeric: %r" % (vel,)
+PY
+    note "cfd: cfd_results PRESSURE_DROP + MIN_VELOCITY parsed"
+}
+
+# RENDER: non-skip AND a real contact-sheet.html + at least one PNG on disk.
+# render_dir = <out-dir>/renders ; slug = STL stem (release_gate_stages.py).
+assert_render() {
+    assert_stage_ran render
+    slug="$(basename "$STL")"; slug="${slug%.stl}"
+    [ -n "$slug" ] || slug="model"
+    render_subdir="$WORK/renders/$slug"
+    sheet="$render_subdir/contact-sheet.html"
+    [ -f "$sheet" ] || fail "render: contact-sheet.html not produced at $sheet"
+    # at least one rendered PNG view present
+    png_count=0
+    for png in "$render_subdir"/*.png; do
+        [ -f "$png" ] && png_count=$((png_count + 1))
+    done
+    [ "$png_count" -gt 0 ] || fail "render: no PNG views produced under $render_subdir"
+    note "render: contact-sheet.html + $png_count PNG view(s) produced"
+}
+
+# VISION: non-skip AND a structurally-valid (possibly empty) vision_findings list.
+assert_vision() {
+    assert_stage_ran vision
+    "$PYTHON" - "$OUT" <<'PY' || fail "vision: vision_findings is not a structurally-valid list"
+import json, sys
+gate = json.load(open(sys.argv[1]))
+vf = gate.get("vision_findings")
+assert isinstance(vf, list), "vision_findings missing or not a list: %r" % (type(vf),)
+for f in vf:
+    assert isinstance(f, dict), "vision finding is not an object: %r" % (f,)
+PY
+    note "vision: vision_findings structurally valid (count from list)"
+}
+
+assert_fea
+assert_cfd
+assert_render
+assert_vision
+
+note "ALL STAGES RAN NON-SKIP WITH STRUCTURALLY-VALID FRAGMENTS"
+note "release-gate.json: $OUT (removed on exit)"
+exit 0

--- a/skills/autospec-fab/tests/test_fab_smoke_fixture.bats
+++ b/skills/autospec-fab/tests/test_fab_smoke_fixture.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# test_fab_smoke_fixture.bats — HOST-PORTABLE structural gate for the
+# real-solver smoke (issue #1299, part of #1270). Runs WITHOUT building the
+# multi-GB #1300 image: it asserts the smoke script + MODELDIR fixture are
+# present, well-formed, and wired to the stages that should run. The actual
+# heavy run (real ccx/simpleFoam/freecadcmd/fab-vision) executes only inside
+# the pinned image via the deferred nightly/dispatch fab-container.yml.
+#
+# Auto-discovered by validate.sh's check_autospec_fab_contract, which runs
+# every skills/autospec-fab/tests/*.bats file.
+
+# tests/ -> skill/ -> skills/ -> repo root
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SMOKE_DIR="$REPO_ROOT/skills/autospec-fab/docker/smoke"
+MODEL_DIR="$SMOKE_DIR/model"
+RUN_SMOKE="$SMOKE_DIR/run_smoke.sh"
+
+@test "run_smoke.sh exists" {
+    [ -f "$RUN_SMOKE" ]
+}
+
+@test "run_smoke.sh is bash -n clean" {
+    run bash -n "$RUN_SMOKE"
+    [ "$status" -eq 0 ]
+}
+
+@test "run_smoke.sh uses set -u (bash-3.2-safe discipline)" {
+    grep -Eq '^set -u' "$RUN_SMOKE"
+}
+
+@test "run_smoke.sh does not use [ -f <(...) ] (bash 3.2 process-sub trap)" {
+    # macOS bash 3.2: [ -f <(...) ] is always false. Forbid the pattern.
+    run grep -nE '\[ +-f +<\(' "$RUN_SMOKE"
+    [ "$status" -ne 0 ]
+}
+
+@test "run_smoke.sh rejects skip-where-real-expected for every stage" {
+    # The non-skip assertion is the heart of the smoke: it must explicitly
+    # reject status=skip.
+    grep -q '!= "skip"' "$RUN_SMOKE"
+}
+
+@test "run_smoke.sh asserts all four real-solver stages" {
+    grep -q 'assert_fea' "$RUN_SMOKE"
+    grep -q 'assert_cfd' "$RUN_SMOKE"
+    grep -q 'assert_render' "$RUN_SMOKE"
+    grep -q 'assert_vision' "$RUN_SMOKE"
+}
+
+@test "run_smoke.sh asserts FEA structured safety_factor" {
+    grep -q 'safety_factor' "$RUN_SMOKE"
+}
+
+@test "run_smoke.sh asserts CFD PRESSURE_DROP + MIN_VELOCITY" {
+    grep -q 'pressure_drop_pa' "$RUN_SMOKE"
+    grep -q 'min_velocity_m_s' "$RUN_SMOKE"
+}
+
+@test "run_smoke.sh asserts render PNG + contact-sheet" {
+    grep -q 'contact-sheet.html' "$RUN_SMOKE"
+    grep -q '\.png' "$RUN_SMOKE"
+}
+
+@test "run_smoke.sh asserts structurally-valid vision_findings" {
+    grep -q 'vision_findings' "$RUN_SMOKE"
+}
+
+@test "run_smoke.sh header documents deferred-to-image execution" {
+    grep -qi 'INSIDE the pinned' "$RUN_SMOKE"
+    grep -qi 'fab-container.yml' "$RUN_SMOKE"
+}
+
+@test "fixture part.stl is present and non-empty" {
+    [ -s "$SMOKE_DIR/part.stl" ]
+}
+
+@test "MODELDIR sidecars are present" {
+    [ -f "$MODEL_DIR/metadata.json" ]
+    [ -f "$MODEL_DIR/load.json" ]
+    [ -f "$MODEL_DIR/flow.json" ]
+}
+
+@test "MODELDIR sidecars are valid JSON" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not found"
+    for f in metadata.json load.json flow.json; do
+        run python3 -m json.tool "$MODEL_DIR/$f"
+        [ "$status" -eq 0 ]
+    done
+}
+
+@test "metadata.json marks the part load_critical + flow_critical" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not found"
+    # load_critical=true is the gate flag that lets FEA actually RUN (paired
+    # with the load.json sibling); flow_critical=true does the same for CFD.
+    run python3 -c "import json,sys; m=json.load(open(sys.argv[1])); sys.exit(0 if m.get('load_critical') is True and m.get('flow_critical') is True else 1)" "$MODEL_DIR/metadata.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "load.json carries the FEA load spec (force_n, safety_factor_min)" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not found"
+    run python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if 'force_n' in d and 'safety_factor_min' in d else 1)" "$MODEL_DIR/load.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "flow.json carries the CFD flow spec (max_pressure_drop_pa, min_velocity_m_s)" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not found"
+    run python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if 'max_pressure_drop_pa' in d and 'min_velocity_m_s' in d else 1)" "$MODEL_DIR/flow.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "sibling files map to the stages that should run (_SIBLING_INPUTS convention)" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not found"
+    # Cross-check the fixture against the engine's own sibling-file table: the
+    # fixture's load.json/flow.json must be exactly the filenames the engine
+    # threads into fea/cfd. Guards against a fixture/engine convention drift.
+    SCRIPTS_DIR="$REPO_ROOT/skills/autospec-fab/scripts"
+    run env PYTHONPATH="$SCRIPTS_DIR" MODEL_DIR="$MODEL_DIR" python3 - <<'PY'
+import os
+from release_gate_stages import _SIBLING_INPUTS
+model_dir = os.environ["MODEL_DIR"]
+# fea -> load.json, cfd -> flow.json per the engine table.
+fea_flag, fea_file = _SIBLING_INPUTS["fea"]
+cfd_flag, cfd_file = _SIBLING_INPUTS["cfd"]
+assert fea_file == "load.json", fea_file
+assert cfd_file == "flow.json", cfd_file
+assert os.path.isfile(os.path.join(model_dir, fea_file)), "missing fea sibling"
+assert os.path.isfile(os.path.join(model_dir, cfd_file)), "missing cfd sibling"
+PY
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #1299 (part of #1270). `docker/smoke/run_smoke.sh` + MODELDIR fixture drive a tiny part through fea+cfd+render+vision asserting **non-skip** structurally-valid fragments. Host-portable `test_fab_smoke_fixture.bats` (18 tests) gates it without building the image (proven: on a no-solver host it correctly exits 1 on skip). Full image-run deferred to #1300's image (nightly #1301 deferred per operator). validate exit 0.