### PR TITLE
fix(validate): autospec-design anchors + dynamic-discovery install tests (#1313)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -442,6 +442,12 @@ check_startup_preflight() {
     #      required of every skill). Matches check_self_update's transition-safe
     #      "accept either form" handling rather than forcing a missing-section
     #      failure on skills that never had the block.
+    # Named-skill regression anchor (issue #1313): the dynamic discovery above
+    # must actually reach autospec-design — assert it is among discover_skills'
+    # output so a future change that drops it from discovery (e.g. a missing trio
+    # file) fails loudly here instead of silently exempting it.
+    discover_skills | grep -qx 'skills/autospec-design' \
+        || fail "check_startup_preflight: autospec-design not discovered (expected a complete multi-harness trio)"
     for skill_dir in $(discover_skills); do
         for f in "$skill_dir/SKILL.md" "$skill_dir/opencode/agent.md" "$skill_dir/codex/prompt.md"; do
             # Case 1: markered — covered by the golden-expansion path.
@@ -474,6 +480,11 @@ check_codex_skills_install() {
     # silently exempted newer skills like fab/harmonize/upgrade from the Codex
     # install invariants — the hardcoded-subset class). Every install.sh present
     # must carry both the skills/ registry path and the legacy prompts-file path.
+    # Named-skill regression anchor (issue #1313): autospec-design must be among
+    # the per-skill install.sh files the loop iterates, so it is held to the same
+    # Codex install invariants as its siblings (not silently exempted).
+    [ -f skills/autospec-design/install.sh ] \
+        || fail "check_codex_skills_install: skills/autospec-design/install.sh missing"
     for f in skills/*/install.sh; do
         [ -f "$f" ] || continue
         grep -q 'skills/\$SKILL_NAME/SKILL\.md' "$f" \
@@ -523,6 +534,15 @@ referenced_shared_helpers() {
 
 check_shared_script_install() {
     info "shared helper install: all skills (dynamic + conditional)"
+    # Named-skill regression anchor (issue #1313): autospec-design references no
+    # shared runtime helper today, so it legitimately takes the exempt branch
+    # below. Assert it stays exempt (no ${AUTOSPEC_SCRIPTS_DIR}/<helper> reference
+    # resolving to a shared helper); if it ever grows one, this loop will hold it
+    # to the needs-shared install requirement like every other skill.
+    if [ -n "$(referenced_shared_helpers skills/autospec-design)" ]; then
+        grep -q '\.autospec/scripts' skills/autospec-design/install.sh \
+            || fail "check_shared_script_install: autospec-design references a shared helper but does not install into ~/.autospec/scripts"
+    fi
     for f in skills/*/install.sh; do
         [ -f "$f" ] || continue
         skill_dir="$(dirname "$f")"

--- a/tests/unit/test_autospec_design.bats
+++ b/tests/unit/test_autospec_design.bats
@@ -192,15 +192,28 @@ teardown() {
 
 # ---- top-level install.sh wiring (issue #574) ----------------------------
 
-@test "top-level install.sh: ALL_SKILLS contains autospec-design" {
-    grep -E '^ALL_SKILLS=' "$REPO_ROOT/install.sh" | grep -q 'autospec-design'
+@test "top-level install.sh: auto-discovery includes autospec-design" {
+    # install.sh builds ALL_SKILLS dynamically from skills/*/ that ship an
+    # install.sh (#705 replaced the old static list + case statement so newly
+    # added skills are never silently missed). The discovery condition for
+    # autospec-design is therefore that it ships an install.sh.
+    [ -f "$REPO_ROOT/skills/autospec-design/install.sh" ]
+    # And it must actually land in the runtime-discovered ALL_SKILLS.
+    discovered="$(for d in "$REPO_ROOT"/skills/*/; do \
+        [ -f "$d/install.sh" ] && basename "$d"; done)"
+    printf '%s\n' "$discovered" | grep -qx 'autospec-design'
 }
 
-@test "top-level install.sh: --skill validation case accepts autospec-design" {
-    # Find the validation case-statement and confirm autospec-design is listed.
-    block="$(awk '/^case "\$SKILL_ARG" in/{f=1} f{print; if (/^esac/) exit}' "$REPO_ROOT/install.sh")"
-    [ -n "$block" ]
-    printf '%s\n' "$block" | grep -q 'autospec-design'
+@test "top-level install.sh: --skill validation accepts autospec-design (rejects bogus)" {
+    # The validator loops the dynamically-discovered ALL_SKILLS (no hardcoded
+    # case), so it accepts autospec-design and rejects an unknown skill.
+    run env AUTOSPEC_NO_STAR_PROMPT=1 AUTOSPEC_NO_SELF_UPDATE=1 \
+        bash "$REPO_ROOT/install.sh" --skill autospec-design --harness all --dry-run
+    [ "$status" -eq 0 ]
+    run env AUTOSPEC_NO_STAR_PROMPT=1 AUTOSPEC_NO_SELF_UPDATE=1 \
+        bash "$REPO_ROOT/install.sh" --skill autospec-bogus-xyz --harness all --dry-run
+    [ "$status" -ne 0 ]
+    printf '%s\n' "$output" | grep -q 'invalid --skill'
 }
 
 @test "install.sh --skill autospec-design --harness all --dry-run exits 0" {


### PR DESCRIPTION
Closes #1313 (part of #1287). **Investigation-first.** Tests 17-20: added named-skill regression anchors asserting validate's now-dynamic checks discover+handle autospec-design like siblings (it references no shared helper → #1278 exempt branch). Tests 23-24 were **stale** — they asserted a static `^ALL_SKILLS=` literal + a `case $SKILL_ARG` block that **#705 deliberately replaced with auto-discovery** + a dynamic validator loop. Rewrote to the real contract (23: ships install.sh → in runtime ALL_SKILLS; 24: dynamic validator accepts it + rejects bogus). Test 206 already proves `--skill autospec-design --dry-run` exits 0. All pass; validate exit 0.