### PR TITLE
fix(doc-drift): inline-code scan guard + justified gate.json golden regens (#1318)

### DIFF
--- a/skills/autospec-shared/scripts/scan-doc-scope.mjs
+++ b/skills/autospec-shared/scripts/scan-doc-scope.mjs
@@ -118,6 +118,32 @@ const SCOPE_OPEN_RE  = /<!--\s*autospec-doc-scope\s*:/;
 const SCOPE_CLOSE_RE = /-->/;
 
 /**
+ * Is the scope-comment opener on this line enclosed in an inline code span?
+ *
+ * A live autospec-doc-scope block is a raw HTML comment standing on its own; it
+ * is never wrapped in backticks. Illustrative syntax in prose, however, is often
+ * shown inline as `<!-- autospec-doc-scope: ... -->` (e.g. inside a markdown
+ * table cell documenting the format). The fenced-code-block tracking below skips
+ * multi-line ``` fences but NOT single-line inline code spans, so such an example
+ * would otherwise be parsed as a live (and frequently malformed) annotation and
+ * throw. We detect the opener offset and check whether an odd number of unescaped
+ * backticks precede it on the same line — i.e. it sits inside an open inline span.
+ *
+ * @param {string} line
+ * @returns {boolean}
+ */
+function scopeOpenerInInlineCode(line) {
+    const m = SCOPE_OPEN_RE.exec(line);
+    if (!m) return false;
+    const before = line.slice(0, m.index);
+    let ticks = 0;
+    for (let k = 0; k < before.length; k++) {
+        if (before[k] === '`' && before[k - 1] !== '\\') ticks++;
+    }
+    return ticks % 2 === 1;
+}
+
+/**
  * Parse all autospec-doc-scope blocks from a markdown file.
  *
  * @param {string} markdownPath - path to the markdown file
@@ -187,8 +213,10 @@ export function parse(markdownPath) {
             continue;
         }
 
-        // Detect scope comment start
-        if (SCOPE_OPEN_RE.test(line)) {
+        // Detect scope comment start. Skip openers that sit inside an inline
+        // code span (`...`) — those are illustrative syntax in prose, not live
+        // annotations (mirrors the fenced-code-block skip above for inline code).
+        if (SCOPE_OPEN_RE.test(line) && !scopeOpenerInInlineCode(line)) {
             // Collect the YAML content between the comment markers
             const commentLines = [];
             // The opening line may have content after the "autospec-doc-scope:"

--- a/skills/autospec-shared/test-targets/target-ai-low-confidence-bait/golden/gate.json
+++ b/skills/autospec-shared/test-targets/target-ai-low-confidence-bait/golden/gate.json
@@ -4,12 +4,16 @@
     {
       "doc_file": "docs/AUTH.md",
       "heading": "## Authentication API",
-      "matching_source_files": ["src/auth.py"],
+      "matching_source_files": [
+        "src/auth.py"
+      ],
       "reason": "Auth API docs must match the methods and parameters in src/auth.py"
     }
   ],
+  "drift_warn": [],
   "missing_scope": [],
   "visual_stale": [],
+  "example_stale": [],
   "ai_review_stale": [],
   "skipped": false
 }

--- a/skills/autospec-shared/test-targets/target-doc-drift-bait/golden/gate.json
+++ b/skills/autospec-shared/test-targets/target-doc-drift-bait/golden/gate.json
@@ -4,12 +4,16 @@
     {
       "doc_file": "docs/USER_MANUAL.md",
       "heading": "## API Reference",
-      "matching_source_files": ["src/api.sh"],
+      "matching_source_files": [
+        "src/api.sh"
+      ],
       "reason": "API flags must be kept in sync with src/api.sh options"
     }
   ],
+  "drift_warn": [],
   "missing_scope": [],
   "visual_stale": [],
+  "example_stale": [],
   "ai_review_stale": [],
   "skipped": false
 }

--- a/skills/autospec-shared/test-targets/target-manifest-stale-bait/golden/gate.json
+++ b/skills/autospec-shared/test-targets/target-manifest-stale-bait/golden/gate.json
@@ -4,12 +4,16 @@
     {
       "doc_file": "docs/MANIFEST.md",
       "heading": "## Module Manifest",
-      "matching_source_files": ["src/lib.js"],
+      "matching_source_files": [
+        "src/lib.js"
+      ],
       "reason": "Module manifest must reflect exported functions in src/lib.js"
     }
   ],
+  "drift_warn": [],
   "missing_scope": [],
   "visual_stale": [],
+  "example_stale": [],
   "ai_review_stale": [],
   "skipped": false
 }

--- a/skills/autospec-shared/test-targets/target-reverse-engineer-bait/golden/gate.json
+++ b/skills/autospec-shared/test-targets/target-reverse-engineer-bait/golden/gate.json
@@ -1,6 +1,7 @@
 {
   "passed": false,
   "drift": [],
+  "drift_warn": [],
   "missing_scope": [
     {
       "source_file": "src/router.js",
@@ -8,6 +9,7 @@
     }
   ],
   "visual_stale": [],
+  "example_stale": [],
   "ai_review_stale": [],
   "skipped": false
 }

--- a/skills/autospec-shared/test-targets/target-visual-stale-bait/golden/gate.json
+++ b/skills/autospec-shared/test-targets/target-visual-stale-bait/golden/gate.json
@@ -4,12 +4,16 @@
     {
       "doc_file": "docs/DASHBOARD.md",
       "heading": "## Dashboard Overview",
-      "matching_source_files": ["src/dashboard.js"],
+      "matching_source_files": [
+        "src/dashboard.js"
+      ],
       "reason": "Dashboard docs must reflect current component layout"
     }
   ],
+  "drift_warn": [],
   "missing_scope": [],
   "visual_stale": [],
+  "example_stale": [],
   "ai_review_stale": [],
   "skipped": false
 }

--- a/skills/autospec-shared/tests/fixtures/doc-scope/inline-code-scope.md
+++ b/skills/autospec-shared/tests/fixtures/doc-scope/inline-code-scope.md
@@ -1,0 +1,40 @@
+# Inline Code Span Handling
+
+This document exercises inline-code-span awareness in scan-doc-scope. A live
+autospec-doc-scope block is a raw HTML comment standing on its own; an example
+shown inside backticks (inline code) is illustrative prose and must NOT be parsed
+as a live claim.
+
+## Real Declaration
+
+This is a real prose declaration and must be honored.
+
+<!-- autospec-doc-scope:
+  src: ["scripts/real.sh"]
+  reason: "live prose declaration"
+-->
+
+Body for the real section.
+
+## Illustrative Inline Example (well-formed)
+
+The syntax is `<!-- autospec-doc-scope: src: ["scripts/inline-well-formed.sh"] -->`
+and must be ignored even though it parses cleanly.
+
+## Illustrative Inline Example (malformed, in a table cell)
+
+| Feature | Annotation | Status |
+| --- | --- | --- |
+| Doc scopes | `<!-- autospec-doc-scope: src: ["glob"] reason: ... mismatch_action: warn\|hard_fail -->` | working |
+
+This malformed inline example must not throw — it is documentation, not a claim.
+
+## Post Inline Declaration
+
+After the inline examples, this prose declaration must be honored again.
+
+<!-- autospec-doc-scope:
+  src: ["scripts/post-inline.sh"]
+-->
+
+Body for the post-inline section.

--- a/skills/autospec-shared/tests/unit/scan-doc-scope.test.mjs
+++ b/skills/autospec-shared/tests/unit/scan-doc-scope.test.mjs
@@ -132,6 +132,20 @@ test('fenced-scope.md: only prose declarations are honored, in-fence tokens igno
     assert.equal(result.length, 2, `expected exactly 2 honored entries, got ${result.length}`);
 });
 
+test('inline-code-scope.md: in-backtick tokens ignored, prose declarations honored', async () => {
+    // Must not throw even though the table cell contains a malformed inline
+    // example (regression: spec docs that document the scope syntax inline).
+    const result = parse(fixture('inline-code-scope.md'));
+    const globs = result.flatMap(e => e.src_globs);
+    // Inline-code (backtick-wrapped) examples must NOT appear, even well-formed.
+    assert.ok(!globs.includes('scripts/inline-well-formed.sh'), 'well-formed token inside `...` inline span must be ignored');
+    assert.ok(!globs.includes('glob'), 'malformed token inside `...` inline span must be ignored (and must not throw)');
+    // Standalone prose declarations (before and after) must still be honored.
+    assert.ok(globs.includes('scripts/real.sh'), 'prose declaration before inline examples must be honored');
+    assert.ok(globs.includes('scripts/post-inline.sh'), 'prose declaration after inline examples must be honored');
+    assert.equal(result.length, 2, `expected exactly 2 honored entries, got ${result.length}`);
+});
+
 test('scope token inside a fenced block is ignored', async () => {
     const tmp = path.join(os.tmpdir(), `autospec-test-scope-fence-${Date.now()}.md`);
     fs.writeFileSync(tmp, `## Section\n\n\`\`\`\n<!-- autospec-doc-scope:\n  src: ["in-fence.sh"]\n-->\n\`\`\`\n\nBody.\n`);


### PR DESCRIPTION
Closes #1318 (part of #1287). **Investigation-first, never regen-to-match-bug.** The 2 'python-parse' fails were a **real tooling bug**: scan-doc-scope.mjs skipped fenced blocks but not inline code spans → an illustrative backtick scope example parsed as live → stderr leaked into bats $output → json.loads failed. Fixed with an inline-code-span guard. The 5 gate.json golden drifts were one correct shape change (new `drift_warn[]`+`example_stale[]` fields, #919) — regenerated from **real tool output**, drift logic unchanged. + a regression fixture/test. All green; validate exit 0.