### PR TITLE
test(agents-md): honor harness-adapter-core marker in subagent-matrix test (#1312)

### DIFF
--- a/tests/agents-md/test_subagent_matrix.bats
+++ b/tests/agents-md/test_subagent_matrix.bats
@@ -55,6 +55,13 @@ setup() {
     for f in "${d}SKILL.md" "${d}codex/prompt.md" "${d}opencode/agent.md"; do
       [ -f "$f" ] || continue
       grep -q '^## Required capabilities & harness adapter' "$f" || continue
+      # Accept EITHER the literal dispatch row OR the harness-adapter-core block
+      # marker (the marker is single-sourced and expands to that exact row at
+      # install time). Mirrors scripts/validate.sh check_agents_md_subagent_matrix
+      # so the raw-grep test and the validator agree on what satisfies the gate.
+      if grep -q -F '<!-- autospec-block:harness-adapter-core -->' "$f"; then
+        continue
+      fi
       if ! grep -q '^| Subagent dispatch policy' "$f"; then
         echo "missing dispatch-policy row: $f"
         fail_count=$((fail_count + 1))


### PR DESCRIPTION
Closes #1312 (part of #1287). **Investigation (per #1311/#1314): true gaps = 0.** The Subagent dispatch policy row is single-sourced via the `<!-- autospec-block:harness-adapter-core -->` marker, which **validate.sh already honors** (line 834); but `test_subagent_matrix.bats` test 4 grepped raw → 21 marker-skills failed the test while passing validate. Fix is **test-side** (test 4 short-circuits on the marker, mirroring validate.sh) — NOT duplicating the row into 21 skills (which would break single-source). No trio/golden edits. bats 4/5/6 green; validate exit 0.