### PR TITLE
docs: Autonomy Charter + automations design spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,20 @@ Operators can halt a running autospec monitor in two ways, both leaving clean st
 
 **Inline sub-modes**: both `/autospec` and `/autospec-run` accept `stop [--flag]` as a feature-request argument (regex `^\s*stop(\s+--\w+)*\s*$`, case-insensitive), routing through the same `scripts/autospec-stop.sh`.
 
+## Autonomy charter (default-on)
+
+The operator's standing preference is **autonomous by default**: when
+`~/.autospec/autonomous.flag` is present, `/autospec-define` and `/autospec-run`
+skip design-ratification, spec→plan→run handoff gates, and per-issue
+confirmations. The governing rule is **recommendation = action** — if the agent
+is confident enough to recommend a next step, it takes it and reports rather than
+asking permission. Safety is unchanged: `scripts/autospec-autonomy-gate.sh
+--check all` still surfaces a confirmation for destructive remote actions,
+force-push to a protected branch, out-of-scope files, cost over the aggressive
+caps (`AUTOSPEC_AUTONOMOUS_ISSUE_CAP`, `AUTOSPEC_AUTONOMOUS_TOKEN_CAP`), and
+genuine no-clear-winner forks. Full policy and rationale (mined from session
+transcripts): [`docs/AUTONOMY-CHARTER.md`](docs/AUTONOMY-CHARTER.md).
+
 ## Startup self-update
 
 Every multi-harness skill runs a preflight at startup that updates the installed copy

--- a/docs/AUTONOMY-CHARTER.md
+++ b/docs/AUTONOMY-CHARTER.md
@@ -1,0 +1,88 @@
+# Autospec Autonomy Charter
+
+**Status:** active default for this operator (`~/.autospec/autonomous.flag` present).
+**Boundary:** aggressive (see §3).
+**Origin:** derived 2026-06-25 from mining ~2,963 Claude + ~1,538 Codex session
+transcripts. See `docs/memory/project_babysit_tax_autonomy_charter.md`.
+
+## 1. Why this exists
+
+Session mining found that the operator's short steering turns (5.2% of all
+Claude human turns, 13.4% of Codex turns) are almost never course corrections —
+they are **rubber-stamps of a recommendation the agent had already made**. Every
+recurring gate has the same shape: the agent states its own next step, then asks
+permission, and the operator grants it ("looks good", "ok fix that one once and
+for all", "review the whole project for gaps").
+
+The governing rule of this charter:
+
+> **Recommendation = action.** If the agent is confident enough to *recommend* a
+> next step, it is confident enough to *take* it and report the result. Asking
+> permission for your own recommendation is friction, not safety.
+
+## 2. The four collapsed stop-points
+
+| # | Old behavior (asked) | New behavior (proceed + report) |
+|---|---|---|
+| 1 | **Design ratification** before writing the spec — "State machine make sense? Test plan look sound? UX feel right?" | Write the spec immediately. Record judgment calls inline as `> AUTONOMOUS ASSUMPTION:` blockquotes (already implemented in `autospec-define` autonomous mode). A self-review pass replaces the human ratify. |
+| 2 | **Spec → plan → implement handoff gates** — "review the spec before I invoke writing-plans" / `[run / defer / refine]` | Auto-advance the chain. `autospec-define` defaults to `run` and hands off to `autospec-run` without a gate. |
+| 3 | **"Want me to commit / file these gap issues / run fixture-gen?"** for reversible local actions | Just do it and report. No permission turn for reversible, in-scope, local work. |
+| 4 | **Queue-drain stall** — "queue empty, next work: none, standing by" | Auto-chain into the next improvement loop: `autospec-review` (already auto-fires post-batch) and, when enabled, `autospec-explore`. The operator's reflexive "review the whole project for gaps" *is* that loop. |
+
+Plus the async-wait pattern: during CI / monitor waits the agent must **push a
+notification on each state transition** rather than going silent and waiting to
+be pinged "how do they look?".
+
+## 3. The boundary — when autospec STILL pauses (aggressive)
+
+Default-proceed on everything reversible **and** on remote merges/PRs (the
+operator already admin-auto-merges). Surface a confirmation ONLY for:
+
+- **Irreversible destructive remote actions** — repo delete/archive, release
+  delete, mass label changes, prod DB writes, `rm -rf /`, `DROP`/`TRUNCATE`.
+- **Force-push to a protected branch** (e.g. `main`).
+- **Out-of-scope file changes** — planned files extending beyond the spec's
+  Goal + Implementation outline.
+- **Cost over threshold** — issue count or token estimate above the aggressive
+  caps (§4).
+- **A genuine no-clear-winner fork** — two+ options with no defensible default.
+  (Note: a fork where one option is clearly better is *not* this — pick it.)
+
+Enforcement is unchanged and already implemented:
+`scripts/autospec-autonomy-gate.sh --check all` is invoked before each
+would-have-asked decision; exit 1 surfaces the confirmation even in autonomous
+mode. This charter does not weaken the gate — it makes "proceed" the default for
+everything the gate does **not** flag.
+
+## 4. Configuration
+
+| Lever | Default | Aggressive (recommended) |
+|---|---|---|
+| `~/.autospec/autonomous.flag` | absent (interactive) | **present** |
+| `AUTOSPEC_AUTONOMOUS_ISSUE_CAP` | 10 | **40** |
+| `AUTOSPEC_AUTONOMOUS_TOKEN_CAP` | 500000 | **2000000** |
+| `~/.autospec/no-review.flag` | absent (review auto-fires) | absent |
+
+To raise the cost caps persistently, export in your shell profile:
+
+```sh
+export AUTOSPEC_AUTONOMOUS_ISSUE_CAP=40
+export AUTOSPEC_AUTONOMOUS_TOKEN_CAP=2000000
+```
+
+Turn the whole charter off at any time: `rm ~/.autospec/autonomous.flag`.
+
+## 5. Already built vs. still to build
+
+**Already in place** — `autospec-run` is fully autonomous (no operator gates in
+normal operation); `autospec-define` autonomous mode collapses the brainstorm
+and the pre-impl gate; the autonomy gate enforces the boundary; `autospec-review`
+and `autospec-secaudit` auto-fire after each run batch.
+
+**Still to build** (tracked as autospec meta-improvements):
+
+1. **Queue-drain → `autospec-explore` auto-chain** — on `ALL_DONE`, optionally
+   launch the perpetual improvement loop instead of stopping (opt-in via a
+   `~/.autospec/explore-on-drain.flag`).
+2. **Async-transition push notifications** — emit a notification on each CI /
+   monitor state transition so the operator never has to ask "how do they look?".

--- a/docs/specs/2026-06-25-autonomy-charter-automations-design.md
+++ b/docs/specs/2026-06-25-autonomy-charter-automations-design.md
@@ -1,0 +1,153 @@
+# Autonomy Charter automations — design spec
+
+**Date:** 2026-06-25
+**Source charter:** `docs/AUTONOMY-CHARTER.md` §5 ("Still to build")
+**Origin:** session-transcript mining (see `docs/memory/project_babysit_tax_autonomy_charter.md`).
+
+## Goal
+
+Eliminate the two operator-babysitting patterns that the Autonomy Charter named
+but did not yet automate: (1) the queue-drain stall ("standing by") and (2)
+async-wait silence ("how do they look?"). Both are `autospec-run` /
+`autospec-shared` changes.
+
+## Team personality
+
+**Reliability/backend automation team** — orchestration engineer (monitor loop),
+platform/shell engineer (sentinels, notifiers), test engineer (bats with mocked
+external boundaries). Fits because both features are control-flow + side-effect
+plumbing in the autonomous monitor, where the risks are runaway loops and
+cross-platform notifier portability.
+
+**Review counter-team** — operations + safety lens: challenge "does the
+drain→explore chain ever loop unbounded?", "does a notifier failure ever block
+the merge path?", "does this fire during CI/headless runs where notifications
+are noise?".
+
+---
+
+## Feature 1 — Queue-drain → autospec-explore auto-chain
+
+### Problem
+When the Phase 4 monitor drains the queue it writes `status=ALL_DONE` to
+`~/.autospec/batch-done.json` and the orchestrator exits with a "standing by"
+report. The operator's reflexive next instruction is always "review the whole
+project for gaps" — which is exactly what `/autospec-explore` does.
+
+### Design
+Hook the existing `ALL_DONE` branch in `skills/autospec-run/SKILL.md` (the
+orchestrator relaunch loop, ~the `if [ "$status" = "ALL_DONE" ]` block). Add an
+**opt-in** sentinel so default behavior is byte-unchanged:
+
+- `~/.autospec/explore-on-drain.flag` **absent** → current behavior (write final
+  report, exit). This is the default; no regression.
+- **present** → instead of exiting, auto-chain into `/autospec-explore` on the
+  sandbox branch (never `main`, per the existing explore sandbox contract).
+
+Guardrails (all must hold to chain; otherwise fall back to normal exit + log):
+- **Autonomy gate** — call `autospec-autonomy-gate.sh --check all` before
+  chaining; exit 1 → do not chain, surface instead.
+- **Max-cycle cap** — `AUTOSPEC_EXPLORE_ON_DRAIN_MAX_CYCLES` (default 3). A
+  per-repo counter at `~/.autospec/explore-on-drain.cycles` increments each
+  chain; at the cap, stop and log `explore-on-drain: max cycles reached`.
+  Counter resets when the operator clears it or starts a fresh `/autospec-run`.
+- **Idle/empty guard** — if `/autospec-explore` itself produces zero shippable
+  PRs for a full cycle, stop chaining (no point looping on a dry well).
+
+A small helper `scripts/explore-on-drain.sh` encapsulates: flag check →
+gate call → cycle-cap check/increment → emit the decision (`chain` | `stop`)
+as stdout for the orchestrator to act on. Pure decision logic, no side effects
+beyond the counter file, so it is unit-testable.
+
+### Files touched (1 logical unit + 1 trio unit)
+- `scripts/explore-on-drain.sh` (new) + `tests/explore-on-drain.bats` (new)
+- `skills/autospec-run/{SKILL.md,codex/prompt.md,opencode/agent.md}` + derived
+  `tests/fixtures/skill-goldens/autospec-run.*.sha256` (one trio unit — edit
+  SKILL.md, `derive-trio.sh --in-place`, `gen-skill-goldens.sh`)
+
+### Tests required
+- flag absent → decision `stop` (default unchanged).
+- flag present, gate OK, under cap → decision `chain`, counter incremented.
+- at `AUTOSPEC_EXPLORE_ON_DRAIN_MAX_CYCLES` → decision `stop`.
+- gate exit 1 → decision `stop` even with flag present.
+
+### Acceptance criteria
+- [ ] `bash scripts/explore-on-drain.sh` with no flag prints `stop` and exits 0.
+- [ ] With `~/.autospec/explore-on-drain.flag` present and cycles < cap, prints `chain`.
+- [ ] At cap, prints `stop` and does not increment past cap.
+- [ ] `tests/explore-on-drain.bats` passes.
+- [ ] `scripts/validate.sh` passes (trio goldens regenerated).
+
+---
+
+## Feature 2 — Async-transition push notifications
+
+### Problem
+During CI/monitor waits the agent goes silent; the operator pings "how do they
+look?". Transcript mining found that exact phrase repeated within a single run.
+
+### Design
+**Reuse the existing notifier**, do not build a new one. `packages/
+autospec_context_monitor/autospec_context_monitor/adapters/claude_hook.py` and
+`injector.py` already route to `osascript` (macOS) / `notify-send` (Linux) with
+proper escaping. Extract that into a single shared shell entry point
+`skills/autospec-shared/scripts/notify.sh "<title>" "<body>"` that:
+- emits a desktop notification via `osascript`/`notify-send` when available;
+- **degrades gracefully** to a stdout log line `notify: <title> — <body>` when
+  no notifier exists (headless/CI);
+- is a no-op when `AUTOSPEC_NOTIFY=0` (default on; set 0 to silence).
+
+Wire `notify.sh` at the run-state transition points:
+- **CI verdict** — in `scripts/ci-wait.sh`'s background poller, on the
+  queued→running→settled transition (one notification per terminal verdict:
+  pass/fail/timeout), not per poll.
+- **Monitor lifecycle** — in the Phase 4 monitor, on `claimed → tests_passed →
+  pr_created → merged` and on terminal `failed`. One line per transition,
+  deduped so a transition fires at most once per issue.
+
+### Files touched (1 logical unit + targeted edits)
+- `skills/autospec-shared/scripts/notify.sh` (new) + `tests/notify.bats` (new)
+- `scripts/ci-wait.sh` (transition hook)
+- `skills/autospec-run/{SKILL.md,...}` trio (monitor transition hook + goldens)
+
+> Split into two child issues so each stays ≤3 logical units: (2a) the shared
+> `notify.sh` helper + tests + ci-wait hook; (2b) the monitor-transition wiring
+> in the autospec-run trio.
+
+### Tests required
+Mock the external notifier subprocess — `osascript`/`notify-send` are EXTERNAL
+boundaries, so subprocess mocks ARE allowed (per
+`feedback_per_pr_lgtm_misses_integration`). No real notifications in tests.
+- notifier present (mock) → mock invoked with title+body.
+- notifier absent → stdout log fallback, exit 0.
+- `AUTOSPEC_NOTIFY=0` → no-op, exit 0.
+- transition dedup → same transition fires at most once.
+
+### Acceptance criteria
+- [ ] `AUTOSPEC_NOTIFY=0 bash skills/autospec-shared/scripts/notify.sh t b` is a silent no-op exit 0.
+- [ ] With a mocked `osascript` on PATH, `notify.sh "t" "b"` invokes it once with the title+body.
+- [ ] With no notifier and `AUTOSPEC_NOTIFY` unset, `notify.sh` prints `notify: t — b` and exits 0.
+- [ ] `tests/notify.bats` passes.
+- [ ] `scripts/validate.sh` passes.
+
+---
+
+## Decomposition preview (≈5 children + 1 epic + Phase 5.5 audit)
+
+1. EPIC umbrella — Autonomy Charter automations.
+2. `explore-on-drain.sh` decision helper + bats (Feature 1 logic).
+3. autospec-run trio: ALL_DONE → explore-on-drain chain wiring + goldens (Feature 1).
+4. shared `notify.sh` helper (reusing context-monitor pattern) + bats + ci-wait hook (Feature 2a).
+5. autospec-run trio: monitor-transition notify wiring + goldens (Feature 2b).
+6. Phase 5.5 audit + remediation.
+Each ≤400 words, ≤3 logical units, `reasoning:medium` / `ctx:64k`.
+
+## Self-review
+- **Placeholders:** none.
+- **Consistency:** both features opt-in / default-off by toggle; neither blocks
+  the merge path (notifier failure only logs; drain-chain failure only exits).
+- **Scope:** single multi-issue pipeline; two related epics under one umbrella.
+- **Critical risk:** runaway drain→explore loop — mitigated by the max-cycle
+  cap + autonomy gate + dry-well guard. Notifier portability — mitigated by
+  reusing the already-shipped, already-tested context-monitor notify path.
+- **On merge:** update `docs/AUTONOMY-CHARTER.md` §5, removing each item as it ships.


### PR DESCRIPTION
## What

Lands the **Autonomy Charter** and the design spec for its two remaining automations.

Derived from mining all ~2,963 Claude + ~1,538 Codex session transcripts: the operator's short steering turns (5.2% of Claude human turns, 13.4% of Codex) are almost never course corrections — they are rubber-stamps of a recommendation the agent had already made.

### Files
- `docs/AUTONOMY-CHARTER.md` — canonical *recommendation = action* policy: the four collapsed stop-points, the aggressive pause-boundary, config levers. Already honored today via `~/.autospec/autonomous.flag` + the existing `autospec-autonomy-gate.sh`.
- `AGENTS.md` — "Autonomy charter (default-on)" pointer (single source of truth).
- `docs/specs/2026-06-25-autonomy-charter-automations-design.md` — design for:
  1. **Queue-drain → autospec-explore auto-chain** (opt-in `~/.autospec/explore-on-drain.flag`, max-cycle cap, autonomy-gated).
  2. **Async state-transition notifications** — reusing the existing `autospec_context_monitor` `osascript`/`notify-send` path (no new notifier).

### Next
On merge, `/autospec-define` decomposes the spec into ~5 auto-implement issues citing real `main` blob URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)