### PR TITLE
feat(explore-on-drain): decision helper + bats (issue #1337)

### DIFF
--- a/scripts/explore-on-drain.sh
+++ b/scripts/explore-on-drain.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scripts/explore-on-drain.sh — queue-drain → autospec-explore decision helper.
+#
+# Emits exactly one of:
+#   chain   — all guardrails passed; caller should auto-chain into autospec-explore
+#   stop    — default behavior; caller exits normally without chaining
+#
+# Decision logic (all must hold to emit "chain"):
+#   1. Opt-in flag present: ${AUTOSPEC_HOME}/explore-on-drain.flag
+#   2. Autonomy gate passes: autospec-autonomy-gate.sh --check all exits 0
+#   3. Cycle cap not reached: counter at ${AUTOSPEC_HOME}/explore-on-drain.cycles
+#      is strictly less than AUTOSPEC_EXPLORE_ON_DRAIN_MAX_CYCLES (default 3)
+#
+# Side effects:
+#   - Increments the cycle counter file ONLY when emitting "chain".
+#   - No other side effects; safe to call repeatedly in tests with an
+#     isolated HOME / AUTOSPEC_HOME.
+#
+# Usage:
+#   decision=$(bash scripts/explore-on-drain.sh)
+#   # decision is "chain" or "stop"
+#
+# Env:
+#   AUTOSPEC_HOME                        default: ~/.autospec
+#   AUTOSPEC_EXPLORE_ON_DRAIN_MAX_CYCLES default: 3
+#
+# Bash rules (per project conventions):
+#   set -eu; if/then/fi for conditionals (no `[ x ] && y` under set -e);
+#   no RETURN traps.
+#
+# No reuse — autospec-stop-check.sh uses exit-code protocol, not stdout
+# chain/stop; this is a different interface per spec.
+
+set -eu
+
+AUTOSPEC_HOME="${AUTOSPEC_HOME:-${HOME}/.autospec}"
+MAX_CYCLES="${AUTOSPEC_EXPLORE_ON_DRAIN_MAX_CYCLES:-3}"
+FLAG_FILE="${AUTOSPEC_HOME}/explore-on-drain.flag"
+CYCLES_FILE="${AUTOSPEC_HOME}/explore-on-drain.cycles"
+
+# 1. Flag absent → stop (default unchanged behavior).
+if [ ! -f "$FLAG_FILE" ]; then
+    echo "stop"
+    exit 0
+fi
+
+# 2. Autonomy gate check — gate exit non-zero → stop.
+if ! autospec-autonomy-gate.sh --check all >/dev/null 2>&1; then
+    echo "stop"
+    exit 0
+fi
+
+# 3. Cycle cap check — read current counter (default 0).
+cycles=0
+if [ -f "$CYCLES_FILE" ]; then
+    cycles="$(cat "$CYCLES_FILE")"
+fi
+
+if [ "$cycles" -ge "$MAX_CYCLES" ]; then
+    echo "stop"
+    exit 0
+fi
+
+# All guardrails passed — increment counter and emit chain.
+new_cycles=$((cycles + 1))
+printf '%s\n' "$new_cycles" > "$CYCLES_FILE"
+echo "chain"
+exit 0

--- a/scripts/explore-on-drain.sh
+++ b/scripts/explore-on-drain.sh
@@ -51,9 +51,15 @@ if ! autospec-autonomy-gate.sh --check all >/dev/null 2>&1; then
 fi
 
 # 3. Cycle cap check — read current counter (default 0).
+# Sanitize to numeric: treat missing or non-numeric content as 0 so a
+# corrupted counter file does not abort the script under set -eu.
 cycles=0
 if [ -f "$CYCLES_FILE" ]; then
-    cycles="$(cat "$CYCLES_FILE")"
+    raw="$(cat "$CYCLES_FILE")"
+    case "$raw" in
+        ''|*[!0-9]*) cycles=0 ;;   # empty or non-numeric → reset to 0
+        *)            cycles="$raw" ;;
+    esac
 fi
 
 if [ "$cycles" -ge "$MAX_CYCLES" ]; then

--- a/tests/explore-on-drain.bats
+++ b/tests/explore-on-drain.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# tests/explore-on-drain.bats — TDD coverage for scripts/explore-on-drain.sh
+#
+# Tests run in isolation: HOME is redirected to a temp dir so the flag and
+# counter files never touch the real ~/.autospec.
+#
+# External boundary stub: autospec-autonomy-gate.sh is placed on PATH as a
+# fake so we control its exit code without touching the real gate.
+
+bats_require_minimum_version 1.5.0
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SUT="$REPO_ROOT/scripts/explore-on-drain.sh"
+STUB_DIR=""
+
+setup() {
+    STUB_DIR="$(mktemp -d)"
+    export HOME="${BATS_TMPDIR}/home-$$"
+    mkdir -p "${HOME}/.autospec"
+
+    # Default gate stub: exit 0 (gate OK)
+    cat > "${STUB_DIR}/autospec-autonomy-gate.sh" <<'GATE'
+#!/usr/bin/env bash
+exit 0
+GATE
+    chmod +x "${STUB_DIR}/autospec-autonomy-gate.sh"
+}
+
+teardown() {
+    rm -rf "${STUB_DIR}" "${HOME}"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: flag absent → stop (default unchanged behavior)
+# ---------------------------------------------------------------------------
+
+@test "flag absent: prints 'stop' and exits 0" {
+    # No flag file created
+    run env PATH="${STUB_DIR}:${PATH}" bash "$SUT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "stop" ]
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: flag present + gate OK + under cap → chain, counter incremented
+# ---------------------------------------------------------------------------
+
+@test "flag present, gate OK, under cap: prints 'chain' and increments counter" {
+    touch "${HOME}/.autospec/explore-on-drain.flag"
+    # No cycles file → defaults to 0 (under cap of 3)
+
+    run env PATH="${STUB_DIR}:${PATH}" bash "$SUT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "chain" ]
+
+    # Counter must now be 1
+    cycles="$(cat "${HOME}/.autospec/explore-on-drain.cycles")"
+    [ "$cycles" -eq 1 ]
+}
+
+@test "flag present, gate OK, cycles at 2 (under cap 3): prints 'chain' and counter goes to 3" {
+    touch "${HOME}/.autospec/explore-on-drain.flag"
+    echo "2" > "${HOME}/.autospec/explore-on-drain.cycles"
+
+    run env PATH="${STUB_DIR}:${PATH}" bash "$SUT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "chain" ]
+
+    cycles="$(cat "${HOME}/.autospec/explore-on-drain.cycles")"
+    [ "$cycles" -eq 3 ]
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: at cap → stop, counter does not increment past cap
+# ---------------------------------------------------------------------------
+
+@test "flag present, gate OK, cycles at cap (3): prints 'stop' without incrementing" {
+    touch "${HOME}/.autospec/explore-on-drain.flag"
+    echo "3" > "${HOME}/.autospec/explore-on-drain.cycles"
+
+    run env PATH="${STUB_DIR}:${PATH}" bash "$SUT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "stop" ]
+
+    # Counter must NOT have been incremented past cap
+    cycles="$(cat "${HOME}/.autospec/explore-on-drain.cycles")"
+    [ "$cycles" -eq 3 ]
+}
+
+@test "AUTOSPEC_EXPLORE_ON_DRAIN_MAX_CYCLES=2: at cap=2 prints 'stop'" {
+    touch "${HOME}/.autospec/explore-on-drain.flag"
+    echo "2" > "${HOME}/.autospec/explore-on-drain.cycles"
+
+    run env PATH="${STUB_DIR}:${PATH}" AUTOSPEC_EXPLORE_ON_DRAIN_MAX_CYCLES=2 bash "$SUT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "stop" ]
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: gate exit 1 → stop (even with flag present, under cap)
+# ---------------------------------------------------------------------------
+
+@test "gate exit 1: prints 'stop' even when flag present and under cap" {
+    touch "${HOME}/.autospec/explore-on-drain.flag"
+    # cycles file absent → 0
+
+    # Override gate stub to exit 1
+    cat > "${STUB_DIR}/autospec-autonomy-gate.sh" <<'GATE'
+#!/usr/bin/env bash
+exit 1
+GATE
+    chmod +x "${STUB_DIR}/autospec-autonomy-gate.sh"
+
+    run env PATH="${STUB_DIR}:${PATH}" bash "$SUT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "stop" ]
+
+    # Counter must NOT have been incremented
+    [ ! -f "${HOME}/.autospec/explore-on-drain.cycles" ]
+}


### PR DESCRIPTION
Closes #1337

## Summary

- Adds `scripts/explore-on-drain.sh`: pure decision helper that emits `chain` or `stop` based on three guards in sequence — opt-in flag presence, autonomy-gate exit code, and a cycle-cap counter.
- Adds `tests/explore-on-drain.bats`: 6 TDD cases covering all four spec scenarios plus a custom-cap variant.

## Reuse decision

No reuse — `scripts/autospec-stop-check.sh` is the closest analogue (reads a flag file, emits a verdict) but uses exit-code protocol; this helper emits `chain`/`stop` to stdout, which is a different interface per spec. Pattern conventions (set -eu, if/then/fi, temp HOME isolation in tests, PATH stub for external boundaries) are followed.

## Test plan

- [x] `bats tests/explore-on-drain.bats` — 6/6 pass
- [x] `bash -n scripts/explore-on-drain.sh` — syntax OK
- [x] Primary smoke test (`bats tests/explore-on-drain.bats`) — pass
- [x] Doc drift check — clean (exit 0)
- [x] No migration files touched — replay hook skipped

## Implementation details

Decision logic (all must hold to emit `chain`):
1. `~/.autospec/explore-on-drain.flag` present (opt-in sentinel)
2. `autospec-autonomy-gate.sh --check all` exits 0
3. `~/.autospec/explore-on-drain.cycles` < `AUTOSPEC_EXPLORE_ON_DRAIN_MAX_CYCLES` (default 3)

On `chain`: counter is incremented. On `stop`: no side effects (counter not incremented at/past cap).

## Peer-review notes (must-fix applied)

Codex identified that a non-numeric cycles file would abort the script under `set -eu` with `integer expression expected`. Fixed in the second commit: the cycles value is now sanitized — empty or non-numeric content is treated as 0 so a corrupted counter file degrades gracefully to "under cap" rather than crashing.

## Peer-review notes (nice-to-have, not addressed)

- Could add a `--dry-run` flag that prints the decision without incrementing the counter (useful for debugging without side effects).
- Could emit a stderr log line explaining why `stop` was chosen (flag absent / gate blocked / cap reached) to aid operator diagnosis.

**Peer-review:** codex exec timed out before completing full output; the non-numeric cycles finding was captured from partial output and applied as a must-fix commit.