### PR TITLE
feat(notify): shared notify.sh helper + bats + ci-wait verdict hook

### DIFF
--- a/scripts/ci-wait.sh
+++ b/scripts/ci-wait.sh
@@ -57,6 +57,12 @@ SIGNAL_FILE="${CI_STATE_DIR}/${PR}.signal"
 PID_FILE="${CI_STATE_DIR}/${PR}.pid"
 LOG_FILE="${CI_STATE_DIR}/${PR}.log"
 
+# Resolve shared notify helper relative to this script's repo root.
+# skills/autospec-shared/scripts/notify.sh is the canonical entry point
+# (mirrors the osascript/notify-send pattern from the context-monitor adapter).
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NOTIFY_SH="${_SCRIPT_DIR}/../skills/autospec-shared/scripts/notify.sh"
+
 # Remove stale signal/PID from a previous run
 rm -f "$SIGNAL_FILE" "$PID_FILE"
 
@@ -69,6 +75,7 @@ PR="'"$PR"'"
 TIMEOUT='"$TIMEOUT"'
 REQUIRED_ONLY='"$REQUIRED_ONLY"'
 SIGNAL_FILE="'"$SIGNAL_FILE"'"
+NOTIFY_SH="'"$NOTIFY_SH"'"
 
 write_signal() {
     local state="$1"
@@ -92,16 +99,20 @@ while true; do
 
     if [ "$bad" -gt 0 ]; then
         write_signal "fail" "$rollup"
+        # Notify once on terminal verdict — failure must never block the merge path.
+        bash "$NOTIFY_SH" "autospec: CI failed" "PR #${PR} — one or more checks failed" || true
         exit 0
     fi
 
     if [ "$pending" -eq 0 ] && [ "$total" -gt 0 ]; then
         write_signal "pass" "$rollup"
+        bash "$NOTIFY_SH" "autospec: CI passed" "PR #${PR} — all checks green" || true
         exit 0
     fi
 
     if [ "$(elapsed)" -gt "$TIMEOUT" ]; then
         write_signal "stalled" "$rollup"
+        bash "$NOTIFY_SH" "autospec: CI stalled" "PR #${PR} — timed out after ${TIMEOUT}s" || true
         exit 0
     fi
 

--- a/skills/autospec-shared/scripts/notify.sh
+++ b/skills/autospec-shared/scripts/notify.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# skills/autospec-shared/scripts/notify.sh — shared desktop notifier
+#
+# Usage: notify.sh "<title>" "<body>"
+#
+# Sends a desktop notification via osascript (macOS) or notify-send (Linux)
+# when a notifier is available, degrades to a stdout log line when none is
+# found (headless/CI), and is a silent no-op when AUTOSPEC_NOTIFY=0.
+#
+# Reuses the osascript/notify-send routing + escaping pattern from
+# packages/autospec_context_monitor/autospec_context_monitor/adapters/claude_hook.py
+# (ClaudeHookAdapter.notify_clear_needed), which already ships and is tested.
+# This script is a thin shell entry point over the same pattern.
+#
+# Exit code is always 0 — notifier failures must never block the merge path.
+
+set -u
+
+# ── Guard: silent no-op when notifications are disabled ──────────────────────
+if [ "${AUTOSPEC_NOTIFY:-1}" = "0" ]; then
+    exit 0
+fi
+
+TITLE="${1:-}"
+BODY="${2:-}"
+
+# ── macOS: osascript ──────────────────────────────────────────────────────────
+if command -v osascript > /dev/null 2>&1; then
+    # Mirror claude_hook.py: escape backslashes then double-quotes so the
+    # strings are safe inside an AppleScript double-quoted literal.
+    escaped_title="${TITLE//\\/\\\\}"
+    escaped_title="${escaped_title//\"/\\\"}"
+    escaped_body="${BODY//\\/\\\\}"
+    escaped_body="${escaped_body//\"/\\\"}"
+    osascript -e "display notification \"${escaped_body}\" with title \"${escaped_title}\"" \
+        > /dev/null 2>&1 || true
+    exit 0
+fi
+
+# ── Linux: notify-send ───────────────────────────────────────────────────────
+if command -v notify-send > /dev/null 2>&1; then
+    # Args are separate argv entries — no AppleScript escaping needed.
+    notify-send "$TITLE" "$BODY" > /dev/null 2>&1 || true
+    exit 0
+fi
+
+# ── Fallback: stdout log line (headless / CI) ─────────────────────────────────
+printf 'notify: %s \xe2\x80\x94 %s\n' "$TITLE" "$BODY"

--- a/tests/notify.bats
+++ b/tests/notify.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# tests/notify.bats — TDD for skills/autospec-shared/scripts/notify.sh (issue #1338)
+#
+# External boundaries (osascript / notify-send) are mocked via PATH stubs
+# so no real desktop notifications fire during tests.
+#
+# PATH strategy:
+#   Stub tests (osascript/notify-send present): "${STUB_DIR}:${PATH}" — stub
+#     overrides any real notifier; PATH unchanged so bash/env work normally.
+#   Fallback tests (no notifier): "${STUB_DIR}:/bin" — excludes /usr/bin so
+#     the real macOS osascript (/usr/bin/osascript) is not found; /bin/bash
+#     used directly so bash itself doesn't need to be on PATH.
+#   Stub shebangs use #!/bin/bash (absolute) not #!/usr/bin/env bash so the
+#     stub scripts execute even when PATH is restricted to STUB_DIR only.
+
+bats_require_minimum_version 1.5.0
+
+NOTIFY_SCRIPT="${BATS_TEST_DIRNAME}/../skills/autospec-shared/scripts/notify.sh"
+
+setup() {
+    STUB_DIR="$(mktemp -d)"
+    CALL_LOG="${STUB_DIR}/calls.log"
+    touch "$CALL_LOG"
+}
+
+teardown() {
+    rm -rf "$STUB_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# AUTOSPEC_NOTIFY=0 → silent no-op, exit 0
+# ---------------------------------------------------------------------------
+
+@test "AUTOSPEC_NOTIFY=0 is a silent no-op and exits 0" {
+    run env AUTOSPEC_NOTIFY=0 PATH="${STUB_DIR}:${PATH}" \
+        bash "$NOTIFY_SCRIPT" "Test Title" "Test body"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# notifier present (mock osascript) → invoked once with title and body
+# ---------------------------------------------------------------------------
+
+@test "osascript mock is invoked once when present on PATH" {
+    # Create fake osascript that records its arguments.
+    # Use #!/bin/bash (absolute) so it runs even on restricted PATH.
+    cat > "${STUB_DIR}/osascript" <<'STUB'
+#!/bin/bash
+printf 'osascript called: %s\n' "$*" >> "${CALL_LOG}"
+exit 0
+STUB
+    chmod +x "${STUB_DIR}/osascript"
+
+    run env AUTOSPEC_NOTIFY=1 CALL_LOG="$CALL_LOG" PATH="${STUB_DIR}:${PATH}" \
+        bash "$NOTIFY_SCRIPT" "My Title" "My body"
+    [ "$status" -eq 0 ]
+
+    # Verify osascript was called exactly once
+    call_count="$(grep -c "osascript called:" "$CALL_LOG")"
+    [ "$call_count" -eq 1 ]
+
+    # Verify title appears in the call
+    grep -q "My Title" "$CALL_LOG"
+}
+
+@test "osascript stub receives the body text" {
+    cat > "${STUB_DIR}/osascript" <<'STUB'
+#!/bin/bash
+printf 'osascript called: %s\n' "$*" >> "${CALL_LOG}"
+exit 0
+STUB
+    chmod +x "${STUB_DIR}/osascript"
+
+    run env AUTOSPEC_NOTIFY=1 CALL_LOG="$CALL_LOG" PATH="${STUB_DIR}:${PATH}" \
+        bash "$NOTIFY_SCRIPT" "T" "Hello world body"
+    [ "$status" -eq 0 ]
+    grep -q "Hello world body" "$CALL_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# notifier absent → stdout log fallback, exit 0
+# ---------------------------------------------------------------------------
+
+@test "no notifier on PATH prints fallback log line and exits 0" {
+    # STUB_DIR has no osascript or notify-send.
+    # PATH excludes /usr/bin so real macOS osascript is not found.
+    # Use /bin/bash directly so bash itself doesn't need to be on PATH.
+    run env AUTOSPEC_NOTIFY=1 PATH="${STUB_DIR}:/bin" \
+        /bin/bash "$NOTIFY_SCRIPT" "FallbackTitle" "FallbackBody"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"notify: FallbackTitle"* ]]
+    [[ "$output" == *"FallbackBody"* ]]
+}
+
+@test "fallback log line contains title and body" {
+    run env AUTOSPEC_NOTIFY=1 PATH="${STUB_DIR}:/bin" \
+        /bin/bash "$NOTIFY_SCRIPT" "MyT" "MyB"
+    [ "$status" -eq 0 ]
+    # Output must contain both title and body separated by the em-dash marker
+    [[ "$output" == *"notify: MyT"* ]]
+    [[ "$output" == *"MyB"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# notify-send (Linux mock) → invoked when osascript absent
+# ---------------------------------------------------------------------------
+
+@test "notify-send mock invoked when osascript absent" {
+    # PATH excludes /usr/bin so real osascript is not found.
+    # STUB_DIR has notify-send but not osascript.
+    # Stub shebang is #!/bin/bash (absolute) so it runs on restricted PATH.
+    cat > "${STUB_DIR}/notify-send" <<'STUB'
+#!/bin/bash
+printf 'notify-send called: %s\n' "$*" >> "${CALL_LOG}"
+exit 0
+STUB
+    chmod +x "${STUB_DIR}/notify-send"
+
+    run env AUTOSPEC_NOTIFY=1 CALL_LOG="$CALL_LOG" PATH="${STUB_DIR}:/bin" \
+        /bin/bash "$NOTIFY_SCRIPT" "NSTitle" "NSBody"
+    [ "$status" -eq 0 ]
+    grep -q "notify-send called:" "$CALL_LOG"
+    grep -q "NSTitle" "$CALL_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# notifier failure must not propagate non-zero exit
+# ---------------------------------------------------------------------------
+
+@test "failing osascript stub does not cause notify.sh to exit non-zero" {
+    cat > "${STUB_DIR}/osascript" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+    chmod +x "${STUB_DIR}/osascript"
+
+    run env AUTOSPEC_NOTIFY=1 PATH="${STUB_DIR}:${PATH}" \
+        bash "$NOTIFY_SCRIPT" "T" "B"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #1338

## Summary

- **`skills/autospec-shared/scripts/notify.sh`** (new) — shared desktop notifier entry point
- **`tests/notify.bats`** (new) — 7 bats tests with PATH-stub mocks; all green
- **`scripts/ci-wait.sh`** (modified) — calls `notify.sh` once per terminal verdict (pass/fail/stalled), not per poll

## Reuse decision

**Reusing `packages/autospec_context_monitor/autospec_context_monitor/adapters/claude_hook.py` (`ClaudeHookAdapter.notify_clear_needed`).**

`notify.sh` is a thin shell entry point over the same pattern already shipped in the context-monitor adapter:
- **osascript (macOS):** same backslash-then-double-quote escaping (`body.replace("\\", "\\\\").replace('"', '\\"')`) reproduced in bash parameter expansion for the AppleScript double-quoted literal
- **notify-send (Linux):** same separate-argv pattern (no AppleScript escaping needed)
- **best-effort / no-abort:** same `check=False` / `|| true` contract — notifier failure must never block the merge path
- **Graceful degradation:** stdout fallback `notify: <title> — <body>` for headless/CI, silent no-op when `AUTOSPEC_NOTIFY=0`

No new notifier design was introduced.

## Validation

- `bash -n skills/autospec-shared/scripts/notify.sh` — syntax OK
- `bash -n scripts/ci-wait.sh` — syntax OK
- `bats tests/notify.bats` — 7/7 pass (primary smoke test from issue)
- `bash scripts/validate.sh` — running in background at PR time; bats + bash -n used as permitted fallback per issue scope (≤3 logical units, no trio/golden changes)

## ci-wait.sh hook

`NOTIFY_SH` is resolved once in the outer script (`_SCRIPT_DIR/../skills/autospec-shared/scripts/notify.sh`) and interpolated into the `nohup bash -c` heredoc. Each of the three terminal branches (pass/fail/stalled) calls `bash "$NOTIFY_SH" ... || true` after `write_signal`, so notifications fire exactly once per verdict.

## Peer-review

Peer-review: `codex exec` timed out after 60s — skipping per implementer protocol.

## Out of scope

Monitor-transition wiring (child issue #5 per design spec §"Decomposition preview").