### PR TITLE
fix(ci): resolve check-doc-drift.sh from repo checkout in autospec's own CI

### DIFF
--- a/.github/workflows/autospec-doc-drift.yml
+++ b/.github/workflows/autospec-doc-drift.yml
@@ -43,4 +43,14 @@ jobs:
         run: |
           set -euo pipefail
           AUTOSPEC_SCRIPTS_PATH="${HOME}/.autospec/scripts"
-          bash "${AUTOSPEC_SCRIPTS_PATH}/check-doc-drift.sh" --pr "${{ github.event.pull_request.number }}"
+          # Resolve check-doc-drift.sh. In a CONSUMER repo the installer
+          # sed-substitutes AUTOSPEC_SCRIPTS_PATH above to the installed scripts
+          # dir, where the script exists. In autospec's OWN repo CI the scripts
+          # are not installed at ~/.autospec/scripts, so fall back to the repo's
+          # checked-out copy. The fallback path does not exist in a consumer repo
+          # (no autospec skills/ tree), so it is only ever taken here.
+          DRIFT_SCRIPT="${AUTOSPEC_SCRIPTS_PATH}/check-doc-drift.sh"
+          if [ ! -f "$DRIFT_SCRIPT" ]; then
+            DRIFT_SCRIPT="skills/autospec-shared/scripts/check-doc-drift.sh"
+          fi
+          bash "$DRIFT_SCRIPT" --pr "${{ github.event.pull_request.number }}"


### PR DESCRIPTION
**Regression from #1317.** The `autospec-doc-drift` workflow ran `bash ${HOME}/.autospec/scripts/check-doc-drift.sh`, but autospec's own CI never installs scripts there → **exit 127**, red on every autospec PR since #1317 (admin-merges bypassed it; now blocks #1344).

The workflow is dual-purpose (installer ships it to consumer repos with `AUTOSPEC_SCRIPTS_PATH` sed-substituted; it also runs in autospec's own CI). Fix: prefer the installed path (consumer; substituted line preserved), else fall back to the checked-out `skills/autospec-shared/scripts/check-doc-drift.sh` (autospec self-CI). The fallback can't be taken in a consumer repo (no autospec skills/ tree).

## Verification
- YAML valid; installer-substituted line preserved; `install-doc-drift.bats` **17/17**.
- This PR's own `doc-drift` check should now run for real + pass (a workflow-yaml change maps to no doc-scope). Confirms the 127 is fixed.

Note: this repairs the gate mechanism; **#1344's own drift is real** (its autospec-run source change isn't reflected in docs/USER_MANUAL.md) and is that PR's content concern.