### PR TITLE
test(context-monitor): freeze date in test_handoff to kill across-midnight flake (#1333)

### DIFF
--- a/tests/engine/test_handoff.py
+++ b/tests/engine/test_handoff.py
@@ -20,8 +20,31 @@ def _write_md(directory: Path, name: str, content: str = "# handoff\n") -> Path:
 # Helpers
 # ---------------------------------------------------------------------------
 
-TODAY = date.today().isoformat()
-YESTERDAY = (date.today() - timedelta(days=1)).isoformat()
+# Freeze "today" so the date used to NAME the fixture files (below) is the same
+# instant the production glob reads via date.today(). Without this, a test that
+# imports just before midnight and scans just after would build the filename
+# under one date and the glob under the next — a real across-midnight flake
+# (issue #1333). The frozen date keeps the today-only contract intact (the glob
+# still excludes the frozen-yesterday prefix, per test_returns_only_today_dated_files).
+_FROZEN_TODAY = date(2026, 6, 15)
+
+
+class _FrozenDate(date):
+    @classmethod
+    def today(cls) -> date:
+        return _FROZEN_TODAY
+
+
+@pytest.fixture(autouse=True)
+def _freeze_handoff_date(monkeypatch):
+    """Pin handoff.date.today() to _FROZEN_TODAY for every test in this module."""
+    from autospec_context_monitor import handoff
+
+    monkeypatch.setattr(handoff, "date", _FrozenDate)
+
+
+TODAY = _FROZEN_TODAY.isoformat()
+YESTERDAY = (_FROZEN_TODAY - timedelta(days=1)).isoformat()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1333. `test_returns_newest_file_after_since` named fixture files with a module-level `TODAY=date.today()` (captured at import) while `wait_for_handoff` globs with `date.today()` at call time — across midnight they differ → spurious timeout. Today-only globbing is **intended** (guarded by `test_returns_only_today_dated_files`), so the fix is **test-side**: an autouse fixture pins `handoff.date.today()` to a frozen date; the TODAY/YESTERDAY constants use it, so write-time and scan-time always agree. **handoff.py unchanged.** 5/5 deterministic ×3; full suite 178 passed.