### PR TITLE
feat(worker-liveness): host-match + PID-liveness helper scripts/worker-liveness.sh + bats

### DIFF
--- a/scripts/worker-liveness.sh
+++ b/scripts/worker-liveness.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# scripts/worker-liveness.sh — host-match + PID-liveness decision helper
+#
+# Given a worker_id of the form "host:user:harness:pid" (the format written by
+# autospec into heartbeats and the autospec-run-state GitHub comment), decide
+# whether that worker is provably alive, provably dead, or unknown.
+#
+# Outputs (stdout) — always exits 0; never error-exits the caller:
+#   alive   — same host AND kill -0 <pid> succeeded (provably live)
+#   dead    — same host AND kill -0 <pid> failed   (provably dead; safe to reclaim)
+#   unknown — cross-host, malformed, or non-numeric pid
+#             (caller falls back to GitHub-timestamp freshness per F1 rule)
+#
+# Usage:
+#   worker-liveness.sh <worker_id>
+#
+# Mockable boundary:
+#   WORKER_LIVENESS_HOSTNAME — override hostname for tests (default: $(hostname))
+#
+# Reuse decision: No reuse — no existing helper performs host-match + kill-0 on
+# a colon-delimited worker_id; heartbeat-read.sh parses heartbeat JSON files,
+# not run-state worker_id strings.
+
+set -eu
+
+worker_id="${1:-}"
+
+# Resolve hostname; allow env override for testing.
+this_host="${WORKER_LIVENESS_HOSTNAME:-$(hostname)}"
+
+# Guard: empty input → unknown.
+if [ -z "$worker_id" ]; then
+    echo "unknown"
+    exit 0
+fi
+
+# Require at least 3 colons (4 fields: host:user:harness:pid).
+colon_count=$(printf '%s' "$worker_id" | tr -cd ':' | wc -c | tr -d ' ')
+if [ "$colon_count" -lt 3 ]; then
+    echo "unknown"
+    exit 0
+fi
+
+# Parse the four fields. cut -f4 handles the pid even when extra colons exist
+# in later fields (forward-compat).
+whost=$(printf '%s' "$worker_id" | cut -d: -f1)
+wpid=$(printf '%s' "$worker_id" | cut -d: -f4)
+
+# Guard: host or pid field empty → unknown.
+if [ -z "$whost" ] || [ -z "$wpid" ]; then
+    echo "unknown"
+    exit 0
+fi
+
+# Guard: pid must be numeric (kill -0 requires an integer).
+case "$wpid" in
+    ''|*[!0-9]*)
+        echo "unknown"
+        exit 0
+        ;;
+esac
+
+# Cross-host: caller falls back to GitHub freshness (F1 rule).
+if [ "$whost" != "$this_host" ]; then
+    echo "unknown"
+    exit 0
+fi
+
+# Same host: PID-liveness via kill -0.
+if kill -0 "$wpid" 2>/dev/null; then
+    echo "alive"
+else
+    echo "dead"
+fi
+
+exit 0

--- a/tests/worker-liveness.bats
+++ b/tests/worker-liveness.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# tests/worker-liveness.bats — host-match + PID-liveness decision helper
+#
+# External boundaries mocked:
+#   WORKER_LIVENESS_HOSTNAME — injects a fake hostname so cross-host tests
+#   don't require a second machine.  The real kill -0 is used for PID
+#   liveness; tests use $$ (guaranteed alive) and 999999 (guaranteed dead).
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/worker-liveness.sh"
+
+setup() {
+    THIS_HOST="$(hostname)"
+    THIS_PID="$$"
+}
+
+# ── basic sanity ──────────────────────────────────────────────────────────────
+
+@test "worker-liveness.sh exists and is executable" {
+    [ -x "$SCRIPT" ]
+}
+
+@test "bash -n passes (no syntax errors)" {
+    bash -n "$SCRIPT"
+}
+
+# ── same host, live pid ───────────────────────────────────────────────────────
+
+@test "same-host with live pid ($$) prints alive, exit 0" {
+    run bash "$SCRIPT" "${THIS_HOST}:testuser:autospec-run:${THIS_PID}"
+    [ "$status" -eq 0 ]
+    [ "$output" = "alive" ]
+}
+
+# ── same host, dead pid ───────────────────────────────────────────────────────
+
+@test "same-host with dead pid (999999) prints dead, exit 0" {
+    # 999999 is above the typical PID max on macOS/Linux and will not exist.
+    run bash "$SCRIPT" "${THIS_HOST}:testuser:autospec-run:999999"
+    [ "$status" -eq 0 ]
+    [ "$output" = "dead" ]
+}
+
+# ── cross host ────────────────────────────────────────────────────────────────
+
+@test "different host prints unknown, exit 0" {
+    # Inject a hostname that differs from $(hostname) so the same-host branch
+    # is not taken, even when this test runs on a machine named "other-host".
+    run env WORKER_LIVENESS_HOSTNAME="__test_override_host__" \
+        bash "$SCRIPT" "other-host.example.com:testuser:autospec-run:12345"
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+@test "fabricated cross-host worker_id returns unknown regardless of pid" {
+    run env WORKER_LIVENESS_HOSTNAME="myhost" \
+        bash "$SCRIPT" "notmyhost:bob:autospec-run:${THIS_PID}"
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+# ── malformed / empty ─────────────────────────────────────────────────────────
+
+@test "empty worker_id prints unknown, exit 0" {
+    run bash "$SCRIPT" ""
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+@test "no args prints unknown, exit 0" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+@test "too few fields (host:user) prints unknown, exit 0" {
+    run bash "$SCRIPT" "somehost:someuser"
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+@test "three fields (host:user:harness) prints unknown, exit 0" {
+    run bash "$SCRIPT" "somehost:someuser:autospec-run"
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+@test "non-numeric pid in same-host worker_id prints unknown, exit 0" {
+    run bash "$SCRIPT" "${THIS_HOST}:testuser:autospec-run:notapid"
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}


### PR DESCRIPTION
Closes #1352

## Summary

Adds `scripts/worker-liveness.sh` — a pure, testable helper that decides worker liveness from a `host:user:harness:pid` worker_id (the format written by autospec into heartbeats and the `autospec-run-state` GitHub comment).

**Decision table:**

| Condition | Output |
|---|---|
| Same host + `kill -0 <pid>` succeeds | `alive` (exit 0) |
| Same host + `kill -0 <pid>` fails | `dead` (exit 0) |
| Different host | `unknown` (exit 0 — caller falls back to GitHub-timestamp freshness per F1) |
| Malformed / empty worker_id | `unknown` (exit 0 — never error-exits the caller) |

## Reuse decision

No reuse — no existing helper performs host-match + `kill -0` on a colon-delimited worker_id. `heartbeat-read.sh` parses heartbeat JSON files; `autospec-watchdog.sh` embeds reclaim logic inline. This helper is the pure, mockable extraction called for by F2.

## Test results

`bats tests/worker-liveness.bats` — 11/11 pass (TDD: tests written first, red → green).

`bash scripts/validate.sh` — **all validation checks passed** (exit 0).

## Mockable boundaries

- `WORKER_LIVENESS_HOSTNAME` env var overrides `$(hostname)` in tests — no internal mocks, no PATH stubs needed.
- PID boundary: `$$` (guaranteed alive) and `999999` (guaranteed dead on macOS/Linux).

## Peer-review

Codex ran but its `git diff main...HEAD` resolved to a multi-merge-base tree (1.9 MB diff across the full repo), making output non-actionable for this 2-file change. No must-fix findings were surfaced for `worker-liveness.sh` or `worker-liveness.bats`. Noting this as a known limitation of the `main...HEAD` range when the branch has multiple merge bases.