### PR TITLE
feat(repo-slug): canonical slug helper scripts/repo-slug.sh + bats

### DIFF
--- a/scripts/repo-slug.sh
+++ b/scripts/repo-slug.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# scripts/repo-slug.sh — canonical repo-slug helper
+#
+# Maps owner/name → owner__name (double-underscore canonical form).
+# The double underscore disambiguates repos whose names contain a single `_`.
+#
+# Functions (source-able):
+#   canonical_slug  owner/name  → "owner__name" (exits non-zero on bad input)
+#   resolve_slug_dir base owner/name → best matching dir under base:
+#       1. base/owner__name  (canonical)
+#       2. base/owner_name   (legacy — one-release compat)
+#       3. base/owner-name   (legacy — one-release compat)
+#       Falls back to canonical path when none of the dirs exist.
+#
+# Standalone usage:
+#   bash scripts/repo-slug.sh [--canonical] owner/name
+#   bash scripts/repo-slug.sh --resolve-dir <base> owner/name
+#
+# No reuse of the existing `tr '/' '_'` one-liner in autospec-run-registry.sh
+# or autospec-watchdog.sh — those produce legacy forms (single _) and are the
+# callers that MUST migrate to this helper; this file IS the canonical source.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# canonical_slug owner/name → owner__name
+# Exits 1 with a message on stderr if input lacks exactly one '/'.
+# ---------------------------------------------------------------------------
+canonical_slug() {
+    local input="${1:-}"
+    if [ -z "$input" ]; then
+        printf 'repo-slug: input must be non-empty (expected owner/name)\n' >&2
+        return 1
+    fi
+    # Count slashes — must be exactly one
+    local slash_count
+    slash_count="$(printf '%s' "$input" | tr -cd '/' | wc -c | tr -d ' ')"
+    if [ "$slash_count" -ne 1 ]; then
+        printf 'repo-slug: input "%s" must contain exactly one "/" (got %s)\n' \
+            "$input" "$slash_count" >&2
+        return 1
+    fi
+    # Replace the single / with __ (double underscore)
+    printf '%s' "$input" | sed 's#/#__#'
+}
+
+# ---------------------------------------------------------------------------
+# resolve_slug_dir base owner/name → path
+# Returns the best existing dir under base that corresponds to the repo.
+# Priority: canonical (owner__name) > legacy-underscore (owner_name)
+#           > legacy-hyphen (owner-name). Falls back to canonical when
+#           none of the directories exist (new-repo / first write path).
+# ---------------------------------------------------------------------------
+resolve_slug_dir() {
+    local base="${1:-}"
+    local repo="${2:-}"
+    if [ -z "$base" ] || [ -z "$repo" ]; then
+        printf 'repo-slug: resolve_slug_dir requires base and owner/name\n' >&2
+        return 1
+    fi
+
+    local owner name
+    owner="${repo%%/*}"
+    name="${repo##*/}"
+
+    local canonical_dir="${base}/${owner}__${name}"
+    local legacy_under_dir="${base}/${owner}_${name}"
+    local legacy_hyphen_dir="${base}/${owner}-${name}"
+
+    if [ -d "$canonical_dir" ]; then
+        printf '%s' "$canonical_dir"
+    elif [ -d "$legacy_under_dir" ]; then
+        printf '%s' "$legacy_under_dir"
+    elif [ -d "$legacy_hyphen_dir" ]; then
+        printf '%s' "$legacy_hyphen_dir"
+    else
+        # No existing dir — return canonical (caller creates it)
+        printf '%s' "$canonical_dir"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Standalone entry point
+# ---------------------------------------------------------------------------
+_repo_slug_main() {
+    local mode="canonical"
+    local base=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --canonical)
+                mode="canonical"
+                shift
+                ;;
+            --resolve-dir)
+                mode="resolve-dir"
+                shift
+                base="${1:-}"
+                shift
+                ;;
+            --)
+                shift
+                break
+                ;;
+            -*)
+                printf 'repo-slug: unknown flag: %s\n' "$1" >&2
+                return 1
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+
+    local repo="${1:-}"
+
+    case "$mode" in
+        canonical)
+            canonical_slug "$repo"
+            ;;
+        resolve-dir)
+            resolve_slug_dir "$base" "$repo"
+            ;;
+    esac
+}
+
+# Source-guard: only run main when executed directly, not when sourced.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    _repo_slug_main "$@"
+fi

--- a/tests/repo-slug.bats
+++ b/tests/repo-slug.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# tests/repo-slug.bats — tests for scripts/repo-slug.sh
+#
+# Covers: canonical output, names containing '_', legacy read-compat,
+#         resolve_slug_dir, and malformed-input rejection.
+#
+# Pure shell logic — no external tools needed (no gh stub required).
+
+bats_require_minimum_version 1.5.0
+
+SLUG_SCRIPT="${BATS_TEST_DIRNAME}/../scripts/repo-slug.sh"
+
+# ── canonical_slug ────────────────────────────────────────────────────────────
+
+@test "canonical_slug: normal owner/name → owner__name" {
+    run bash -c "source '$SLUG_SCRIPT'; canonical_slug berlinguyinca/autospec"
+    [ "$status" -eq 0 ]
+    [ "$output" = "berlinguyinca__autospec" ]
+}
+
+@test "canonical_slug: acceptance-criteria repo berlinguyinca/autospec" {
+    run bash -c "source '$SLUG_SCRIPT'; canonical_slug berlinguyinca/autospec"
+    [ "$status" -eq 0 ]
+    [ "$output" = "berlinguyinca__autospec" ]
+}
+
+@test "canonical_slug: name containing underscore is unambiguous" {
+    # org/my_tool → org__my_tool (the __ separator cannot be confused with _)
+    run bash -c "source '$SLUG_SCRIPT'; canonical_slug org/my_tool"
+    [ "$status" -eq 0 ]
+    [ "$output" = "org__my_tool" ]
+}
+
+@test "canonical_slug: name containing hyphen passes through" {
+    run bash -c "source '$SLUG_SCRIPT'; canonical_slug my-org/my-repo"
+    [ "$status" -eq 0 ]
+    [ "$output" = "my-org__my-repo" ]
+}
+
+@test "canonical_slug: rejects input with no slash" {
+    run bash -c "source '$SLUG_SCRIPT'; canonical_slug nodomain"
+    [ "$status" -ne 0 ]
+}
+
+@test "canonical_slug: rejects input with two slashes" {
+    run bash -c "source '$SLUG_SCRIPT'; canonical_slug a/b/c"
+    [ "$status" -ne 0 ]
+}
+
+@test "canonical_slug: rejects empty input" {
+    run bash -c "source '$SLUG_SCRIPT'; canonical_slug ''"
+    [ "$status" -ne 0 ]
+}
+
+# ── repo-slug.sh as a standalone command ─────────────────────────────────────
+
+@test "repo-slug.sh --canonical produces canonical slug" {
+    run bash "$SLUG_SCRIPT" --canonical berlinguyinca/autospec
+    [ "$status" -eq 0 ]
+    [ "$output" = "berlinguyinca__autospec" ]
+}
+
+@test "repo-slug.sh without flag defaults to canonical" {
+    run bash "$SLUG_SCRIPT" berlinguyinca/autospec
+    [ "$status" -eq 0 ]
+    [ "$output" = "berlinguyinca__autospec" ]
+}
+
+@test "repo-slug.sh exits non-zero on malformed input" {
+    run bash "$SLUG_SCRIPT" "badslug"
+    [ "$status" -ne 0 ]
+}
+
+# ── resolve_slug_dir (read-compat) ────────────────────────────────────────────
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "resolve_slug_dir: canonical dir exists → returns canonical path" {
+    mkdir -p "$TEST_DIR/berlinguyinca__autospec"
+    run bash -c "source '$SLUG_SCRIPT'; resolve_slug_dir '$TEST_DIR' berlinguyinca/autospec"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$TEST_DIR/berlinguyinca__autospec" ]
+}
+
+@test "resolve_slug_dir: legacy underscore dir found when canonical absent" {
+    mkdir -p "$TEST_DIR/berlinguyinca_autospec"
+    run bash -c "source '$SLUG_SCRIPT'; resolve_slug_dir '$TEST_DIR' berlinguyinca/autospec"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$TEST_DIR/berlinguyinca_autospec" ]
+}
+
+@test "resolve_slug_dir: legacy hyphen dir found when canonical and _ absent" {
+    mkdir -p "$TEST_DIR/berlinguyinca-autospec"
+    run bash -c "source '$SLUG_SCRIPT'; resolve_slug_dir '$TEST_DIR' berlinguyinca/autospec"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$TEST_DIR/berlinguyinca-autospec" ]
+}
+
+@test "resolve_slug_dir: canonical takes precedence over legacy forms" {
+    mkdir -p "$TEST_DIR/berlinguyinca__autospec"
+    mkdir -p "$TEST_DIR/berlinguyinca_autospec"
+    mkdir -p "$TEST_DIR/berlinguyinca-autospec"
+    run bash -c "source '$SLUG_SCRIPT'; resolve_slug_dir '$TEST_DIR' berlinguyinca/autospec"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$TEST_DIR/berlinguyinca__autospec" ]
+}
+
+@test "resolve_slug_dir: returns canonical path even when no dir exists (new-repo path)" {
+    run bash -c "source '$SLUG_SCRIPT'; resolve_slug_dir '$TEST_DIR' berlinguyinca/autospec"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$TEST_DIR/berlinguyinca__autospec" ]
+}
+
+@test "resolve_slug_dir: name with _ resolves to canonical __ form" {
+    mkdir -p "$TEST_DIR/org__my_tool"
+    run bash -c "source '$SLUG_SCRIPT'; resolve_slug_dir '$TEST_DIR' org/my_tool"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$TEST_DIR/org__my_tool" ]
+}


### PR DESCRIPTION
Closes #1351

## Summary

Add `scripts/repo-slug.sh` mapping `owner/name` → `owner__name` (double-underscore canonical form) as the single source of truth for all shared autospec state keying (heartbeat dirs, run-state lookups, lock files, cycle counters).

- `canonical_slug owner/name` — emits `owner__name`; double-underscore unambiguously disambiguates names containing `_`; exits non-zero on input lacking exactly one `/`
- `resolve_slug_dir base owner/name` — read-compat helper; checks `base/owner__name` (canonical), then `base/owner_name` (legacy), then `base/owner-name` (legacy) for one-release in-flight heartbeat compat; falls back to canonical path when no dir exists
- Source-guard so the file is both sourceable and runnable as a standalone command
- 16-test bats suite: canonical output, underscore-name disambiguation, hyphen passthrough, legacy `_`/`-` compat, precedence ordering, new-repo fallback, malformed-input rejection

## Reuse decision

No reuse — the existing `tr '/' '_'` one-liner in `scripts/autospec-run-registry.sh:60` and `_resolve_repo_slug()` in `scripts/autospec-watchdog.sh:44` both produce the legacy single-underscore form, which is the *problem* being fixed. This file is the canonical replacement; those callers migrate to it in child issues #3 and #5 per the design spec.

## Test results

```
bats tests/repo-slug.bats   → 16/16 passed
bash scripts/validate.sh    → OK — all validation checks passed (exit 0)
```

No flakes observed. Known flakes `tests/release/test_release_area_dispatch.bats` and `tests/explore/test_explore_researchers_llm.bats` did not appear in this run.

## Peer-review

Codex invocation errored due to `--yolo` alias flag conflict (`--dangerously-bypass-approvals-and-sandbox` cannot be used multiple times). Peer-review skipped; no must-fix findings to apply.

## Docs drift

`check-doc-drift.sh --working-tree` exit 0 — docs clean.