### PR TITLE
feat(repo-lock): optional repo-scoped advisory lock + opt-in wiring (F5)

### DIFF
--- a/scripts/autospec-repo-lock.sh
+++ b/scripts/autospec-repo-lock.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# scripts/autospec-repo-lock.sh — optional repo-scoped advisory lock
+#
+# Provides acquire/release keyed by canonical repo slug (owner__name form
+# produced by scripts/repo-slug.sh).  Default: completely OFF.  Opt-in:
+#   export AUTOSPEC_REPO_LOCK=1
+#
+# Lock store: ${AUTOSPEC_REPO_LOCK_DIR:-~/.autospec/repo-locks}/<slug>.lock/
+#   The lock "directory" is created atomically via `mkdir`; a "pid" file
+#   inside records the owner PID so stale locks from dead processes can be
+#   detected and broken.
+#
+# Cross-host workers do NOT share this lock dir → they are never blocked.
+# Same-machine monitors sharing one checkout DO share it → contention is
+# serialised via the bounded spin loop.
+#
+# Reusing scripts/repo-slug.sh: canonical_slug() is the same function that
+# all other helpers (heartbeat-write, watchdog) use; no fork of slug logic.
+#
+# Usage (source or standalone):
+#   bash scripts/autospec-repo-lock.sh acquire <slug>   # exits 0 on success
+#   bash scripts/autospec-repo-lock.sh release <slug>   # exits 0 always
+#
+# Environment:
+#   AUTOSPEC_REPO_LOCK          set to "1" to enable; unset/empty → no-op
+#   AUTOSPEC_REPO_LOCK_DIR      override default lock-store path
+#   AUTOSPEC_REPO_LOCK_TIMEOUT  max seconds to wait (default 30)
+#   AUTOSPEC_REPO_LOCK_POLL     poll interval in seconds (default 2)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+AUTOSPEC_REPO_LOCK_DIR="${AUTOSPEC_REPO_LOCK_DIR:-${HOME}/.autospec/repo-locks}"
+AUTOSPEC_REPO_LOCK_TIMEOUT="${AUTOSPEC_REPO_LOCK_TIMEOUT:-30}"
+AUTOSPEC_REPO_LOCK_POLL="${AUTOSPEC_REPO_LOCK_POLL:-2}"
+
+# ---------------------------------------------------------------------------
+# _lock_dir <slug> → path of the lock directory for this slug
+# ---------------------------------------------------------------------------
+_lock_dir() {
+    local slug="${1:?_lock_dir: slug required}"
+    printf '%s/%s.lock' "$AUTOSPEC_REPO_LOCK_DIR" "$slug"
+}
+
+# ---------------------------------------------------------------------------
+# _is_pid_alive <pid> → 0 if the process is running, 1 otherwise
+# ---------------------------------------------------------------------------
+_is_pid_alive() {
+    local pid="${1:-}"
+    [ -n "$pid" ] || return 1
+    # kill -0 checks existence without sending a signal
+    kill -0 "$pid" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# _break_stale_lock <lock_dir>
+# Removes the lock directory if the recorded PID is no longer running.
+# ---------------------------------------------------------------------------
+_break_stale_lock() {
+    local ldir="$1"
+    local pid_file="${ldir}/pid"
+    if [ ! -d "$ldir" ]; then
+        return 0   # already gone
+    fi
+    if [ ! -f "$pid_file" ]; then
+        # Malformed lock dir — remove it
+        rm -rf "$ldir" 2>/dev/null || true
+        return 0
+    fi
+    local owner_pid
+    owner_pid="$(cat "$pid_file" 2>/dev/null || true)"
+    if ! _is_pid_alive "$owner_pid"; then
+        # Stale lock: owner process is dead
+        rm -rf "$ldir" 2>/dev/null || true
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# repo_lock_acquire <slug>
+# Acquires the advisory lock.  Returns 0 on success, 1 on timeout.
+# ---------------------------------------------------------------------------
+repo_lock_acquire() {
+    local slug="${1:?repo_lock_acquire: slug required}"
+
+    # Fast path: opt-in not set → no-op
+    if [ "${AUTOSPEC_REPO_LOCK:-}" != "1" ]; then
+        return 0
+    fi
+
+    local ldir
+    ldir="$(_lock_dir "$slug")"
+    mkdir -p "$AUTOSPEC_REPO_LOCK_DIR"
+
+    local deadline=$(( $(date +%s) + AUTOSPEC_REPO_LOCK_TIMEOUT ))
+    local my_pid="$$"
+
+    while true; do
+        # Try to break a stale lock before attempting mkdir
+        if [ -d "$ldir" ]; then
+            _break_stale_lock "$ldir"
+        fi
+
+        # Atomic mkdir — succeeds only for one caller
+        if mkdir "$ldir" 2>/dev/null; then
+            printf '%s\n' "$my_pid" > "${ldir}/pid"
+            return 0
+        fi
+
+        # Check for timeout
+        local now
+        now="$(date +%s)"
+        if [ "$now" -ge "$deadline" ]; then
+            printf 'autospec-repo-lock: acquire timed out after %s seconds (slug=%s, lock=%s)\n' \
+                "$AUTOSPEC_REPO_LOCK_TIMEOUT" "$slug" "$ldir" >&2
+            return 1
+        fi
+
+        sleep "$AUTOSPEC_REPO_LOCK_POLL"
+    done
+}
+
+# ---------------------------------------------------------------------------
+# repo_lock_release <slug>
+# Releases the advisory lock.  Safe to call when not held; always returns 0.
+# ---------------------------------------------------------------------------
+repo_lock_release() {
+    local slug="${1:?repo_lock_release: slug required}"
+
+    # Fast path: opt-in not set → no-op
+    if [ "${AUTOSPEC_REPO_LOCK:-}" != "1" ]; then
+        return 0
+    fi
+
+    local ldir
+    ldir="$(_lock_dir "$slug")"
+
+    if [ ! -d "$ldir" ]; then
+        # Already released or never held — silent success
+        return 0
+    fi
+
+    local pid_file="${ldir}/pid"
+    if [ -f "$pid_file" ]; then
+        local owner_pid
+        owner_pid="$(cat "$pid_file" 2>/dev/null || true)"
+        # Only refuse if a *different, live* process owns the lock.
+        # If the owner PID is dead (e.g. standalone acquire exited, or crashed),
+        # treat it as a stale lock and allow the release.
+        if [ "$owner_pid" != "$$" ] && _is_pid_alive "$owner_pid"; then
+            printf 'autospec-repo-lock: release skipped; lock owned by live pid %s, we are %s (slug=%s)\n' \
+                "$owner_pid" "$$" "$slug" >&2
+            return 0
+        fi
+    fi
+
+    rm -rf "$ldir" 2>/dev/null || true
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Standalone entrypoint
+# ---------------------------------------------------------------------------
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    cmd="${1:-}"
+    slug="${2:-}"
+    if [ -z "$slug" ]; then
+        printf 'Usage: %s acquire|release <slug>\n' "$0" >&2
+        exit 1
+    fi
+    case "$cmd" in
+        acquire) repo_lock_acquire "$slug" ;;
+        release) repo_lock_release "$slug" ;;
+        *)
+            printf 'autospec-repo-lock: unknown command "%s" (expected acquire|release)\n' "$cmd" >&2
+            exit 1
+            ;;
+    esac
+fi

--- a/scripts/autospec-repo-lock.sh
+++ b/scripts/autospec-repo-lock.sh
@@ -17,9 +17,20 @@
 # Reusing scripts/repo-slug.sh: canonical_slug() is the same function that
 # all other helpers (heartbeat-write, watchdog) use; no fork of slug logic.
 #
-# Usage (source or standalone):
-#   bash scripts/autospec-repo-lock.sh acquire <slug>   # exits 0 on success
-#   bash scripts/autospec-repo-lock.sh release <slug>   # exits 0 always
+# ── IMPORTANT: source, do not exec, for critical-section use ──────────────
+# When used to guard a critical section, SOURCE this file inside the
+# long-running shell and call repo_lock_acquire / repo_lock_release directly:
+#
+#   source scripts/autospec-repo-lock.sh
+#   repo_lock_acquire "$slug" || exit 1
+#   <critical section>
+#   repo_lock_release "$slug"
+#
+# Calling `bash autospec-repo-lock.sh acquire <slug>` spawns a subprocess
+# that exits immediately; the PID written into the lock dir then looks dead
+# to any subsequent acquire attempt.  The standalone entrypoint is provided
+# only for quick smoke-testing and release commands; it is NOT suitable for
+# serialising a critical section across separate process invocations.
 #
 # Environment:
 #   AUTOSPEC_REPO_LOCK          set to "1" to enable; unset/empty → no-op
@@ -35,6 +46,38 @@ set -euo pipefail
 AUTOSPEC_REPO_LOCK_DIR="${AUTOSPEC_REPO_LOCK_DIR:-${HOME}/.autospec/repo-locks}"
 AUTOSPEC_REPO_LOCK_TIMEOUT="${AUTOSPEC_REPO_LOCK_TIMEOUT:-30}"
 AUTOSPEC_REPO_LOCK_POLL="${AUTOSPEC_REPO_LOCK_POLL:-2}"
+
+# ---------------------------------------------------------------------------
+# _validate_slug <slug>
+# Rejects slugs containing path-traversal characters (/, ..) or shell
+# metacharacters.  Canonical form is owner__name where both parts are
+# alphanumeric plus hyphens/underscores/dots — no slashes, no spaces.
+# ---------------------------------------------------------------------------
+_validate_slug() {
+    local slug="${1:-}"
+    if [ -z "$slug" ]; then
+        printf 'autospec-repo-lock: slug must be non-empty\n' >&2
+        return 1
+    fi
+    # Must match: word-chars, hyphens, dots, underscores only; no slash.
+    # Also require at least one __ separator (canonical form).
+    case "$slug" in
+        */* | *..* | *' '* | *$'\t'*)
+            printf 'autospec-repo-lock: slug "%s" contains illegal characters (/, .., or whitespace)\n' \
+                "$slug" >&2
+            return 1
+            ;;
+    esac
+    # Require the canonical double-underscore separator
+    case "$slug" in
+        *__*) : ;;
+        *)
+            printf 'autospec-repo-lock: slug "%s" is not in canonical owner__name form\n' \
+                "$slug" >&2
+            return 1
+            ;;
+    esac
+}
 
 # ---------------------------------------------------------------------------
 # _lock_dir <slug> → path of the lock directory for this slug
@@ -56,23 +99,26 @@ _is_pid_alive() {
 
 # ---------------------------------------------------------------------------
 # _break_stale_lock <lock_dir>
-# Removes the lock directory if the recorded PID is no longer running.
+# Removes the lock directory ONLY when the owner PID is confirmed dead.
+# A lock dir with a missing pid file is treated as "potentially initialising"
+# (another process just ran mkdir and has not yet written pid) and is left
+# alone; this avoids the TOCTOU window between mkdir and pid-write.
 # ---------------------------------------------------------------------------
 _break_stale_lock() {
     local ldir="$1"
-    local pid_file="${ldir}/pid"
     if [ ! -d "$ldir" ]; then
         return 0   # already gone
     fi
+    local pid_file="${ldir}/pid"
     if [ ! -f "$pid_file" ]; then
-        # Malformed lock dir — remove it
-        rm -rf "$ldir" 2>/dev/null || true
+        # Missing pid file: could be another process mid-acquire (mkdir done,
+        # pid not yet written).  Leave it alone; the spinner will retry.
         return 0
     fi
     local owner_pid
     owner_pid="$(cat "$pid_file" 2>/dev/null || true)"
-    if ! _is_pid_alive "$owner_pid"; then
-        # Stale lock: owner process is dead
+    if [ -n "$owner_pid" ] && ! _is_pid_alive "$owner_pid"; then
+        # Stale lock: owner process is confirmed dead
         rm -rf "$ldir" 2>/dev/null || true
     fi
 }
@@ -89,6 +135,8 @@ repo_lock_acquire() {
         return 0
     fi
 
+    _validate_slug "$slug" || return 1
+
     local ldir
     ldir="$(_lock_dir "$slug")"
     mkdir -p "$AUTOSPEC_REPO_LOCK_DIR"
@@ -97,13 +145,16 @@ repo_lock_acquire() {
     local my_pid="$$"
 
     while true; do
-        # Try to break a stale lock before attempting mkdir
+        # Attempt to break a stale lock before trying mkdir.
+        # Only breaks when pid file exists and owner is confirmed dead.
         if [ -d "$ldir" ]; then
             _break_stale_lock "$ldir"
         fi
 
         # Atomic mkdir — succeeds only for one caller
         if mkdir "$ldir" 2>/dev/null; then
+            # Write pid immediately; tiny window before this write is
+            # protected by _break_stale_lock's "no pid file → leave alone" rule.
             printf '%s\n' "$my_pid" > "${ldir}/pid"
             return 0
         fi
@@ -133,6 +184,8 @@ repo_lock_release() {
         return 0
     fi
 
+    _validate_slug "$slug" || return 0   # invalid slug → no lock to release
+
     local ldir
     ldir="$(_lock_dir "$slug")"
 
@@ -161,6 +214,9 @@ repo_lock_release() {
 
 # ---------------------------------------------------------------------------
 # Standalone entrypoint
+# NOTE: standalone acquire exits immediately after writing the pid, so the
+# lock appears stale to subsequent processes.  Use this only for release or
+# quick smoke-testing.  For critical-section guards, source this file.
 # ---------------------------------------------------------------------------
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
     cmd="${1:-}"

--- a/tests/autospec-repo-lock.bats
+++ b/tests/autospec-repo-lock.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# tests/autospec-repo-lock.bats — TDD tests for scripts/autospec-repo-lock.sh
+#
+# Covers:
+#   1. Default-off (AUTOSPEC_REPO_LOCK unset) → acquire/release are no-ops.
+#   2. AUTOSPEC_REPO_LOCK=1 → acquire creates lock dir; second acquire times out.
+#   3. Release frees the lock so a subsequent acquire succeeds.
+#   4. Two distinct slugs never contend with each other.
+#   5. Script passes bash -n syntax check.
+
+bats_require_minimum_version 1.5.0
+
+LOCK_SCRIPT="${BATS_TEST_DIRNAME}/../scripts/autospec-repo-lock.sh"
+SLUG_SCRIPT="${BATS_TEST_DIRNAME}/../scripts/repo-slug.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+    export AUTOSPEC_REPO_LOCK_DIR="$TEST_TMP/repo-locks"
+    # Point repo-slug at a known repo
+    export _TEST_REPO="testorg/testrepo"
+    # Unset the opt-in flag by default; individual tests override as needed
+    unset AUTOSPEC_REPO_LOCK || true
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+# ── Syntax ────────────────────────────────────────────────────────────────────
+
+@test "autospec-repo-lock.sh passes bash -n syntax check" {
+    run bash -n "$LOCK_SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+# ── Default-off: AUTOSPEC_REPO_LOCK unset ────────────────────────────────────
+
+@test "default-off: acquire exits 0 without AUTOSPEC_REPO_LOCK set" {
+    unset AUTOSPEC_REPO_LOCK
+    run bash "$LOCK_SCRIPT" acquire testorg__testrepo
+    [ "$status" -eq 0 ]
+}
+
+@test "default-off: release exits 0 without AUTOSPEC_REPO_LOCK set" {
+    unset AUTOSPEC_REPO_LOCK
+    run bash "$LOCK_SCRIPT" release testorg__testrepo
+    [ "$status" -eq 0 ]
+}
+
+@test "default-off: no lock dir created when AUTOSPEC_REPO_LOCK unset" {
+    unset AUTOSPEC_REPO_LOCK
+    bash "$LOCK_SCRIPT" acquire testorg__testrepo
+    bash "$LOCK_SCRIPT" release testorg__testrepo
+    # Lock dir should NOT have been created
+    [ ! -d "$AUTOSPEC_REPO_LOCK_DIR" ]
+}
+
+# ── Enabled: AUTOSPEC_REPO_LOCK=1 ────────────────────────────────────────────
+
+@test "enabled: acquire creates lock dir" {
+    export AUTOSPEC_REPO_LOCK=1
+    run bash "$LOCK_SCRIPT" acquire testorg__testrepo
+    [ "$status" -eq 0 ]
+    [ -d "$AUTOSPEC_REPO_LOCK_DIR/testorg__testrepo.lock" ]
+}
+
+@test "enabled: acquire records pid file inside lock dir" {
+    export AUTOSPEC_REPO_LOCK=1
+    bash "$LOCK_SCRIPT" acquire testorg__testrepo
+    [ -f "$AUTOSPEC_REPO_LOCK_DIR/testorg__testrepo.lock/pid" ]
+}
+
+@test "enabled: release removes lock dir" {
+    export AUTOSPEC_REPO_LOCK=1
+    bash "$LOCK_SCRIPT" acquire testorg__testrepo
+    bash "$LOCK_SCRIPT" release testorg__testrepo
+    [ ! -d "$AUTOSPEC_REPO_LOCK_DIR/testorg__testrepo.lock" ]
+}
+
+@test "enabled: acquire then release then re-acquire succeeds" {
+    export AUTOSPEC_REPO_LOCK=1
+    bash "$LOCK_SCRIPT" acquire testorg__testrepo
+    bash "$LOCK_SCRIPT" release testorg__testrepo
+    run bash "$LOCK_SCRIPT" acquire testorg__testrepo
+    [ "$status" -eq 0 ]
+    [ -d "$AUTOSPEC_REPO_LOCK_DIR/testorg__testrepo.lock" ]
+}
+
+@test "enabled: second acquire on same slug exits non-zero after timeout" {
+    export AUTOSPEC_REPO_LOCK=1
+    export AUTOSPEC_REPO_LOCK_TIMEOUT=2   # short timeout for test speed
+    export AUTOSPEC_REPO_LOCK_POLL=1      # 1-second poll interval
+    # Plant a lock manually with a LIVE pid (the bats test process itself).
+    # This simulates another same-machine process currently holding the lock.
+    mkdir -p "$AUTOSPEC_REPO_LOCK_DIR/testorg__testrepo.lock"
+    printf '%s\n' "$$" > "$AUTOSPEC_REPO_LOCK_DIR/testorg__testrepo.lock/pid"
+    # Second acquire must time out and exit non-zero
+    run bash "$LOCK_SCRIPT" acquire testorg__testrepo
+    [ "$status" -ne 0 ]
+}
+
+@test "enabled: release by wrong slug is a no-op (does not remove another slug's lock)" {
+    export AUTOSPEC_REPO_LOCK=1
+    bash "$LOCK_SCRIPT" acquire testorg__testrepo
+    # Release a different slug — should not touch the first slug's lock
+    run bash "$LOCK_SCRIPT" release otherorg__otherrepo
+    [ "$status" -eq 0 ]
+    [ -d "$AUTOSPEC_REPO_LOCK_DIR/testorg__testrepo.lock" ]
+}
+
+# ── Two distinct slugs never contend ─────────────────────────────────────────
+
+@test "enabled: two distinct slugs can both be acquired without contention" {
+    export AUTOSPEC_REPO_LOCK=1
+    run bash "$LOCK_SCRIPT" acquire slugA__repo
+    [ "$status" -eq 0 ]
+    run bash "$LOCK_SCRIPT" acquire slugB__repo
+    [ "$status" -eq 0 ]
+    [ -d "$AUTOSPEC_REPO_LOCK_DIR/slugA__repo.lock" ]
+    [ -d "$AUTOSPEC_REPO_LOCK_DIR/slugB__repo.lock" ]
+}
+
+# ── Stale lock cleanup ────────────────────────────────────────────────────────
+
+@test "enabled: stale lock (pid not running) is forcibly broken on acquire" {
+    export AUTOSPEC_REPO_LOCK=1
+    export AUTOSPEC_REPO_LOCK_TIMEOUT=2
+    export AUTOSPEC_REPO_LOCK_POLL=1
+    # Manually plant a stale lock with a dead PID
+    mkdir -p "$AUTOSPEC_REPO_LOCK_DIR/testorg__testrepo.lock"
+    # Use PID 99999 — very unlikely to be running; if it is, skip gracefully
+    echo "99999" > "$AUTOSPEC_REPO_LOCK_DIR/testorg__testrepo.lock/pid"
+    run bash "$LOCK_SCRIPT" acquire testorg__testrepo
+    [ "$status" -eq 0 ]
+}
+
+# ── Canonical-slug integration (source repo-slug.sh) ─────────────────────────
+
+@test "enabled: acquire works when slug is derived via repo-slug.sh canonical_slug" {
+    export AUTOSPEC_REPO_LOCK=1
+    slug="$(bash -c "source '$SLUG_SCRIPT'; canonical_slug 'testorg/testrepo'")"
+    run bash "$LOCK_SCRIPT" acquire "$slug"
+    [ "$status" -eq 0 ]
+    [ -d "$AUTOSPEC_REPO_LOCK_DIR/${slug}.lock" ]
+}

--- a/tests/autospec-repo-lock.bats
+++ b/tests/autospec-repo-lock.bats
@@ -134,6 +134,26 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+# ── Slug validation (injection guard) ────────────────────────────────────────
+
+@test "enabled: acquire rejects slug containing a slash" {
+    export AUTOSPEC_REPO_LOCK=1
+    run bash "$LOCK_SCRIPT" acquire "owner/repo"
+    [ "$status" -ne 0 ]
+}
+
+@test "enabled: acquire rejects slug containing path traversal" {
+    export AUTOSPEC_REPO_LOCK=1
+    run bash "$LOCK_SCRIPT" acquire "../etc__passwd"
+    [ "$status" -ne 0 ]
+}
+
+@test "enabled: acquire rejects slug without canonical double-underscore" {
+    export AUTOSPEC_REPO_LOCK=1
+    run bash "$LOCK_SCRIPT" acquire "ownerrepo"
+    [ "$status" -ne 0 ]
+}
+
 # ── Canonical-slug integration (source repo-slug.sh) ─────────────────────────
 
 @test "enabled: acquire works when slug is derived via repo-slug.sh canonical_slug" {


### PR DESCRIPTION
## Summary

- Adds `scripts/autospec-repo-lock.sh`: an OPTIONAL advisory lock keyed by canonical repo slug (`owner__name` produced by `scripts/repo-slug.sh`), default OFF, opt-in via `AUTOSPEC_REPO_LOCK=1`.
- Provides `acquire`/`release` around the claim+worktree-create critical section so two monitors sharing one checkout+store cannot both create the same branch/worktree simultaneously.
- `tests/autospec-repo-lock.bats`: 16 bats tests (TDD) covering all acceptance criteria.

## Reuse decision

**Reusing `scripts/repo-slug.sh`** (`canonical_slug`) as the slug source — the same function used by `heartbeat-write` and `watchdog`; no fork of slug logic. No other reuse candidates — existing session-lock helpers are session-keyed, not repo-keyed.

## Design decisions

| Concern | Decision |
|---|---|
| Opt-in | `AUTOSPEC_REPO_LOCK=1` only; default off; cross-host workers never blocked |
| Atomic primitive | `mkdir <slug>.lock/` — atomic on POSIX filesystems |
| PID tracking | `<slug>.lock/pid` records owner PID for stale-lock detection |
| Stale-lock cleanup | `_break_stale_lock`: only breaks when pid file exists AND owner PID is dead (avoids TOCTOU between `mkdir` and pid-write) |
| Slug injection | `_validate_slug()` rejects `/`, `..`, whitespace, and non-canonical (no `__`) slugs before any path construction |
| Critical-section use | Must source the script; standalone exec is documented as unsuitable for critical-section guarding (subprocess exits, PID looks dead) |

## Acceptance criteria

- [x] With `AUTOSPEC_REPO_LOCK` unset, acquire and release exit 0 and create no lock dir.
- [x] With `AUTOSPEC_REPO_LOCK=1`, a second acquire on the same canonical slug exits non-zero after timeout.
- [x] Two distinct slugs acquire concurrently without contention.
- [x] `bats tests/autospec-repo-lock.bats` passes (16/16).
- [x] `bash scripts/validate.sh` passes ("OK — all validation checks passed.").

## Test results

```
bats tests/autospec-repo-lock.bats: 16/16 ok
bash scripts/validate.sh: OK — all validation checks passed.
```

## Peer-review notes (applied as must-fix commits)

Codex peer-review identified three must-fix findings — all addressed:

1. **Standalone-acquire lifetime**: documented that standalone exec is not suitable for critical-section use; production path is sourcing the script.
2. **TOCTOU in `_break_stale_lock`**: fixed to only break locks when pid file exists AND owner PID is confirmed dead.
3. **Slug injection**: added `_validate_slug()` rejecting `/`, `..`, whitespace, and non-canonical slugs; 3 new injection tests added.

Peer-review: codex ran; all must-fix findings addressed above.

Closes #1354