### PR TITLE
feat(watchdog): GitHub-authority + liveness reclaim gate (F1+F2+F3)

### DIFF
--- a/scripts/autospec-watchdog.sh
+++ b/scripts/autospec-watchdog.sh
@@ -35,6 +35,12 @@ WATCHDOG_GC_HEARTBEAT_FRESH_SECS="${AUTOSPEC_WATCHDOG_GC_HEARTBEAT_FRESH_SECS:-$
 
 WATCHDOG_LOG_PREFIX="[autospec-watchdog]"
 
+# Sibling helpers (F2 liveness + F4 canonical slug). Resolved relative to this
+# script so a checkout/worktree picks up its own copies; overridable for tests.
+WATCHDOG_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKER_LIVENESS_SH="${AUTOSPEC_WORKER_LIVENESS_SH:-$WATCHDOG_SCRIPT_DIR/worker-liveness.sh}"
+REPO_SLUG_SH="${AUTOSPEC_REPO_SLUG_SH:-$WATCHDOG_SCRIPT_DIR/repo-slug.sh}"
+
 if ! command -v gh >/dev/null 2>&1; then
     echo "$WATCHDOG_LOG_PREFIX ERROR: gh CLI not found" >&2
     exit 1
@@ -42,21 +48,26 @@ fi
 
 # ── Derive repo slug and scoped heartbeat dir ─────────────────────────────────
 
-_resolve_repo_slug() {
+_resolve_repo_full() {
     local repo="${WATCHDOG_REPO:-}"
     if [ -z "$repo" ]; then
         repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
     fi
-    if [ -z "$repo" ]; then
-        printf '' # fallback: empty slug → use base dir directly
-        return
-    fi
-    printf '%s' "$repo" | tr '/' '_'
+    printf '%s' "$repo"
 }
 
-REPO_SLUG="$(_resolve_repo_slug)"
-if [ -n "$REPO_SLUG" ]; then
-    WATCHDOG_DIR="${WATCHDOG_BASE}/${REPO_SLUG}"
+REPO_FULL="$(_resolve_repo_full)"
+if [ -n "$REPO_FULL" ]; then
+    # Reuse repo-slug.sh canonical-slug resolver (F4): prefers the canonical
+    # owner__name dir but transparently falls back to legacy owner_name /
+    # owner-name dirs so in-flight heartbeats written by the legacy `tr '/' '_'`
+    # form are still found.
+    if [ -x "$REPO_SLUG_SH" ]; then
+        WATCHDOG_DIR="$(bash "$REPO_SLUG_SH" --resolve-dir "$WATCHDOG_BASE" "$REPO_FULL" 2>/dev/null || true)"
+    fi
+    if [ -z "${WATCHDOG_DIR:-}" ]; then
+        WATCHDOG_DIR="${WATCHDOG_BASE}/$(printf '%s' "$REPO_FULL" | tr '/' '_')"
+    fi
 else
     WATCHDOG_DIR="$WATCHDOG_BASE"
 fi
@@ -184,7 +195,7 @@ reclaim_issue() {
         --add-label auto-implement >/dev/null 2>&1 || true
     # shellcheck disable=SC2086
     gh issue comment "$issue" $REPO_ARGS \
-        --body "autospec watchdog reclaimed this issue after ${age}s of no check-in." >/dev/null 2>&1 || true
+        --body "autospec watchdog released and reclaimed this issue after ${age}s with no live owner." >/dev/null 2>&1 || true
 }
 
 nudge_issue() {
@@ -355,6 +366,105 @@ if [ "${AUTOSPEC_WATCHDOG_GC_ONLY:-}" = "1" ]; then
     exit 0
 fi
 
+# ── GitHub-authority + liveness reclaim gate (F1+F2+F3) ───────────────────────
+#
+# The local heartbeat age is only a *trigger to check* — never the decision.
+# Once a `claimed` heartbeat is older than the claimed-timeout, the GitHub
+# `autospec-run-state` comment plus same-host PID-liveness are authoritative.
+
+# Fetch the run-state comment body for an issue (the marked comment written by
+# claim-issue.sh / release-issue.sh). Defined before the main loop so the
+# heartbeat path can consult it. Empty when absent.
+run_state_body_for_issue() {
+    issue="$1"
+    # shellcheck disable=SC2086
+    gh issue view "$issue" $REPO_ARGS \
+        --json comments \
+        --jq '[.comments[]? | select((.body // "") | contains("<!-- autospec-run-state:begin -->") and contains("<!-- autospec-run-state:end -->")) | .body][0] // ""' \
+        2>/dev/null || true
+}
+
+# Strip the run-state JSON out of a marked comment body.
+extract_run_state_json() {
+    awk '
+      /^<!-- autospec-run-state:begin -->$/ { inside=1; next }
+      /^<!-- autospec-run-state:end -->$/ { inside=0; exit }
+      inside { print }
+    '
+}
+
+# worker_liveness <worker_id> → alive|dead|unknown (delegates to the F2 helper).
+# Cross-host, malformed, or missing ids resolve to `unknown` so the caller falls
+# back to GitHub-timestamp freshness.
+worker_liveness() {
+    wid="${1:-}"
+    [ -n "$wid" ] || { printf 'unknown'; return 0; }
+    if [ -x "$WORKER_LIVENESS_SH" ]; then
+        bash "$WORKER_LIVENESS_SH" "$wid" 2>/dev/null || printf 'unknown'
+    else
+        printf 'unknown'
+    fi
+}
+
+# reclaim_decision <issue> <window_secs> → "reclaim" | "hold"
+#
+# Decision table for a `claimed` heartbeat already past the claimed-timeout:
+#   run-state absent / released / failed        → reclaim   (no live owner)
+#   same-host worker, kill -0 alive             → hold      (#1055 regression)
+#   same-host worker, kill -0 dead              → reclaim   (provably dead)
+#   cross-host/unknown, GitHub ts fresh (<win)  → hold      (live sibling)
+#   cross-host/unknown, GitHub ts stale (>=win) → reclaim
+reclaim_decision() {
+    rd_issue="$1"
+    rd_window="$2"
+
+    rd_body="$(run_state_body_for_issue "$rd_issue")"
+    if [ -z "$rd_body" ]; then
+        printf 'reclaim'   # run-state absent → no authoritative owner
+        return 0
+    fi
+
+    rd_json="$(printf '%s\n' "$rd_body" | extract_run_state_json)"
+    rd_state="$(printf '%s\n' "$rd_json" | jq -r '.state // .step // empty' 2>/dev/null || true)"
+    rd_worker="$(printf '%s\n' "$rd_json" | jq -r '.worker_id // empty' 2>/dev/null || true)"
+    rd_updated="$(printf '%s\n' "$rd_json" | jq -r '.updated_at // empty' 2>/dev/null || true)"
+
+    case "$rd_state" in
+        ''|released|failed)
+            printf 'reclaim'   # absent/parse-fail or explicitly relinquished
+            return 0
+            ;;
+    esac
+
+    # F2 — same-host PID-liveness short-circuit.
+    case "$(worker_liveness "$rd_worker")" in
+        alive)
+            printf 'hold'      # provably-live same-host owner — never reclaim
+            return 0
+            ;;
+        dead)
+            printf 'reclaim'   # provably-dead same-host owner — safe to reclaim
+            return 0
+            ;;
+    esac
+
+    # F1 — cross-host / unknown: fall back to GitHub `updated_at` freshness.
+    rd_epoch="$(iso_to_epoch "$rd_updated")"
+    case "$rd_epoch" in *[!0-9]*|'') rd_epoch=0 ;; esac
+    if [ "$rd_epoch" -le 0 ]; then
+        printf 'reclaim'       # unparseable GitHub ts → treat as stale
+        return 0
+    fi
+    rd_age=$(( now_ts - rd_epoch ))
+    [ "$rd_age" -ge 0 ] || rd_age=0
+    if [ "$rd_age" -ge "$rd_window" ]; then
+        printf 'reclaim'       # GitHub claim is stale past the window
+    else
+        printf 'hold'          # GitHub claim is fresh — live sibling
+    fi
+    return 0
+}
+
 load_state
 
 for hb in "$WATCHDOG_DIR"/*.json; do
@@ -406,10 +516,15 @@ for hb in "$WATCHDOG_DIR"/*.json; do
     fi
 
     if [ "$step" = "claimed" ] && [ "$age" -ge "$WATCHDOG_CLAIMED_TIMEOUT_SECS" ]; then
-        reclaim_issue "$issue" "$age"
-        claimed_released=$((claimed_released + 1))
-        state_unset "$issue"
-        rm -f "$hb"
+        # The stale heartbeat is only the trigger. GitHub authority + same-host
+        # PID-liveness decide whether to actually reclaim (F1+F2+F3). A live
+        # owner is never reclaimed — this closes the go-modules #1055 regression.
+        if [ "$(reclaim_decision "$issue" "$WATCHDOG_CLAIMED_TIMEOUT_SECS")" = "reclaim" ]; then
+            reclaim_issue "$issue" "$age"
+            claimed_released=$((claimed_released + 1))
+            state_unset "$issue"
+            rm -f "$hb"
+        fi
         continue
     fi
 
@@ -439,23 +554,6 @@ for hb in "$WATCHDOG_DIR"/*.json; do
         skipped=$((skipped + 1))
     fi
 done
-
-run_state_body_for_issue() {
-    issue="$1"
-    # shellcheck disable=SC2086
-    gh issue view "$issue" $REPO_ARGS \
-        --json comments \
-        --jq '[.comments[]? | select((.body // "") | contains("<!-- autospec-run-state:begin -->") and contains("<!-- autospec-run-state:end -->")) | .body][0] // ""' \
-        2>/dev/null || true
-}
-
-extract_run_state_json() {
-    awk '
-      /^<!-- autospec-run-state:begin -->$/ { inside=1; next }
-      /^<!-- autospec-run-state:end -->$/ { inside=0; exit }
-      inside { print }
-    '
-}
 
 pr_is_open() {
     pr="$1"
@@ -504,6 +602,13 @@ reconcile_run_state_comments() {
         esac
 
         if [ "$step" = "claimed" ] && [ "$age" -ge "$WATCHDOG_CLAIMED_TIMEOUT_SECS" ]; then
+            # F2 — never reclaim a provably-live same-host owner (#1055). A dead
+            # same-host pid is reclaimed; cross-host falls through to the stale
+            # GitHub `ts` already proven by `age >= claimed-timeout`.
+            worker_id="$(printf '%s\n' "$run_state_json" | jq -r '.worker_id // empty' 2>/dev/null || true)"
+            if [ "$(worker_liveness "$worker_id")" = "alive" ]; then
+                continue
+            fi
             reclaim_issue "$issue" "$age"
             claimed_released=$((claimed_released + 1))
             continue

--- a/scripts/autospec-watchdog.sh
+++ b/scripts/autospec-watchdog.sh
@@ -132,8 +132,11 @@ now_ts="$(date -u +%s)"
 
 _migrate_flat_heartbeats "$WATCHDOG_BASE" "$now_ts"
 
-# Create scoped dir if needed
-mkdir -p "$WATCHDOG_DIR"
+# NOTE: do NOT create WATCHDOG_DIR here. The read loop and GC tolerate a missing
+# dir (every access is `[ -f ]`-guarded). repo-slug.sh --resolve-dir only returns
+# the canonical owner__name path when no dir exists yet; eagerly creating it
+# would shadow the legacy owner_name dir that heartbeat-write.sh creates later,
+# orphaning real heartbeats. The dir is created by the writer, not the watchdog.
 
 nudged=0
 reclaimed=0
@@ -377,10 +380,15 @@ fi
 # heartbeat path can consult it. Empty when absent.
 run_state_body_for_issue() {
     issue="$1"
+    # Pick the CAS-authoritative marked comment: run-state.sh keeps the
+    # lowest-id (oldest) comment as the single owner and deletes losers, so in a
+    # transient duplicate window we mirror that by sorting marked comments oldest
+    # -first (createdAt, then id) and taking the first — never an arbitrary
+    # array-order comment that could carry a loser's worker_id.
     # shellcheck disable=SC2086
     gh issue view "$issue" $REPO_ARGS \
         --json comments \
-        --jq '[.comments[]? | select((.body // "") | contains("<!-- autospec-run-state:begin -->") and contains("<!-- autospec-run-state:end -->")) | .body][0] // ""' \
+        --jq '[.comments[]? | select((.body // "") | contains("<!-- autospec-run-state:begin -->") and contains("<!-- autospec-run-state:end -->"))] | sort_by(.createdAt, .id) | (.[0].body // "")' \
         2>/dev/null || true
 }
 

--- a/tests/unit/test_autospec_watchdog_run_state.bats
+++ b/tests/unit/test_autospec_watchdog_run_state.bats
@@ -30,7 +30,14 @@ if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
 fi
 
 if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
-  jq -r '.[].number' "${COMMENTS:?}"
+  # Heartbeat-path tests set ISSUE_LIST to an explicit (possibly empty) file so
+  # the reconcile pass can be isolated from the local-heartbeat pass. Default:
+  # derive the in-progress list from the run-state comments fixture.
+  if [ -n "${ISSUE_LIST:-}" ] && [ -f "${ISSUE_LIST}" ]; then
+    cat "${ISSUE_LIST}"
+  else
+    jq -r '.[].number' "${COMMENTS:?}"
+  fi
   exit 0
 fi
 
@@ -119,4 +126,118 @@ write_state_comment() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"reclaimed=0"* ]]
     grep -q 'in-progress-by-bot' "$LABELS"
+}
+
+# ── F1+F2+F3: GitHub-authority + same-host PID-liveness reclaim gate ───────────
+#
+# These exercise the LOCAL HEARTBEAT path (the bare line-408 reclaim that caused
+# go-modules #1055): a `claimed` heartbeat older than the timeout is only a
+# TRIGGER; the GitHub `autospec-run-state` worker_id + PID-liveness decide.
+# ISSUE_LIST is forced empty so only the heartbeat pass runs (isolating it from
+# the reconcile pass, which would otherwise double-process the same issue).
+
+# Heartbeat dir matches the canonical slug repo-slug.sh resolves for testorg/testrepo.
+HB_DIR_FOR() { printf '%s/testorg__testrepo' "$AUTOSPEC_WATCHDOG_DIR"; }
+
+write_hb() {
+    local issue="$1" step="$2" age="$3"
+    local dir; dir="$(HB_DIR_FOR)"
+    mkdir -p "$dir"
+    local now ts; now="$(date -u +%s)"; ts=$((now - age))
+    printf '{"issue":"%s","branch":"feat/x","step":"%s","ts":%s,"pr":"","repo":"testorg/testrepo"}\n' \
+        "$issue" "$step" "$ts" > "${dir}/${issue}.json"
+}
+
+# Run-state comment with an explicit worker_id and updated_at (host:user:harness:pid).
+write_state_worker() {
+    local issue="$1" state="$2" updated_at="$3" worker_id="$4"
+    jq -n \
+      --argjson issue "$issue" \
+      --arg state "$state" \
+      --arg updated_at "$updated_at" \
+      --arg worker_id "$worker_id" \
+      '[{
+        number: $issue,
+        body: ("<!-- autospec-run-state:begin -->\n" +
+          ({schema:1,repo:"testorg/testrepo",issue:$issue,worker_id:$worker_id,state:$state,branch:"feat/x",pr:"",step:$state,paths:[],claimed_at:$updated_at,updated_at:$updated_at,ttl_seconds:300} | tojson) +
+          "\n<!-- autospec-run-state:end -->")
+      }]'
+}
+
+isolate_heartbeat_pass() {
+    : > "$TEST_TMP/issue-list.txt"          # empty → reconcile pass is a no-op
+    export ISSUE_LIST="$TEST_TMP/issue-list.txt"
+    export WORKER_LIVENESS_HOSTNAME="thishost"
+}
+
+@test "regression #1055: live same-host pid past timeout with fresh claim is NOT reclaimed" {
+    isolate_heartbeat_pass
+    fresh="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+    write_hb 1055 claimed 360
+    write_state_worker 1055 claimed "$fresh" "thishost:me:shell:$$" > "$COMMENTS"
+
+    run bash "$WATCHDOG"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"claimed_released=0"* ]]
+    [ -f "$(HB_DIR_FOR)/1055.json" ]                       # heartbeat preserved
+    grep -q 'in-progress-by-bot' "$LABELS"                 # label untouched
+    ! grep -q -- '--add-label auto-implement' "$CALLS"
+}
+
+@test "dead same-host pid past timeout is reclaimed and a released comment is written" {
+    isolate_heartbeat_pass
+    fresh="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+    write_hb 42 claimed 360
+    # PID 999999 is not a live process on this host → worker-liveness = dead.
+    write_state_worker 42 claimed "$fresh" "thishost:me:shell:999999" > "$COMMENTS"
+
+    run bash "$WATCHDOG"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"claimed_released=1"* ]]
+    [ ! -f "$(HB_DIR_FOR)/42.json" ]
+    grep -q -- '--remove-label in-progress-by-bot --add-label auto-implement' "$CALLS"
+    grep -q 'released' "$CALLS"
+}
+
+@test "cross-host worker with stale GitHub ts past the window is reclaimed" {
+    isolate_heartbeat_pass
+    stale="$(date -u -v-10M +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '10 minutes ago' +'%Y-%m-%dT%H:%M:%SZ')"
+    write_hb 42 claimed 360
+    write_state_worker 42 claimed "$stale" "otherhost:me:shell:$$" > "$COMMENTS"
+
+    run bash "$WATCHDOG"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"claimed_released=1"* ]]
+    [ ! -f "$(HB_DIR_FOR)/42.json" ]
+    grep -q -- '--add-label auto-implement' "$CALLS"
+}
+
+@test "cross-host worker with fresh GitHub ts is NOT reclaimed" {
+    isolate_heartbeat_pass
+    fresh="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+    write_hb 42 claimed 360
+    write_state_worker 42 claimed "$fresh" "otherhost:me:shell:$$" > "$COMMENTS"
+
+    run bash "$WATCHDOG"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"claimed_released=0"* ]]
+    [ -f "$(HB_DIR_FOR)/42.json" ]
+    grep -q 'in-progress-by-bot' "$LABELS"
+}
+
+@test "absent run-state past timeout is reclaimed" {
+    isolate_heartbeat_pass
+    write_hb 42 claimed 360
+    printf '[]\n' > "$COMMENTS"                            # no run-state comment
+
+    run bash "$WATCHDOG"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"claimed_released=1"* ]]
+    [ ! -f "$(HB_DIR_FOR)/42.json" ]
+    grep -q -- '--add-label auto-implement' "$CALLS"
 }

--- a/tests/unit/test_autospec_watchdog_run_state.bats
+++ b/tests/unit/test_autospec_watchdog_run_state.bats
@@ -44,8 +44,19 @@ fi
 if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
   if printf '%s\n' "$*" | grep -q -- '--json comments'; then
     issue="$3"
-    jq --argjson issue "$issue" \
-      -r '[.[] | select(.number == $issue) | .body][0] // ""' "${COMMENTS:?}"
+    # Run the REAL --jq filter the production code passes (gh applies --jq
+    # client-side after fetching --json comments). We reconstruct the
+    # {comments:[...]} shape gh would return for this issue and pipe it through
+    # the production filter verbatim, so the SUT's own selection logic — not a
+    # re-implementation in this mock — is what the test exercises.
+    filter=""; prev=""
+    for a in "$@"; do
+      [ "$prev" = "--jq" ] && filter="$a"
+      prev="$a"
+    done
+    comments_for_issue="$(jq --argjson issue "$issue" \
+      '[.[] | select(.number == $issue)]' "${COMMENTS:?}")"
+    printf '{"comments":%s}\n' "$comments_for_issue" | jq -r "${filter:-.}"
   else
     cat "${LABELS:?}"
   fi
@@ -239,5 +250,38 @@ isolate_heartbeat_pass() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"claimed_released=1"* ]]
     [ ! -f "$(HB_DIR_FOR)/42.json" ]
+    grep -q -- '--add-label auto-implement' "$CALLS"
+}
+
+# A marked run-state comment with a marker body, parametrized worker_id/ts/order.
+state_comment_obj() {
+    local issue="$1" state="$2" updated_at="$3" worker_id="$4" created_at="$5" id="$6"
+    jq -n \
+      --argjson issue "$issue" --arg state "$state" --arg updated_at "$updated_at" \
+      --arg worker_id "$worker_id" --arg created_at "$created_at" --argjson id "$id" \
+      '{
+        number: $issue, createdAt: $created_at, id: $id,
+        body: ("<!-- autospec-run-state:begin -->\n" +
+          ({schema:1,repo:"testorg/testrepo",issue:$issue,worker_id:$worker_id,state:$state,branch:"feat/x",pr:"",step:$state,paths:[],claimed_at:$updated_at,updated_at:$updated_at,ttl_seconds:300} | tojson) +
+          "\n<!-- autospec-run-state:end -->")
+      }'
+}
+
+@test "duplicate run-state comments: oldest (CAS-authoritative) owner decides, not array order" {
+    isolate_heartbeat_pass
+    fresh="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+    write_hb 42 claimed 360
+    # Array order puts the LOSER first (a live pid → would hold under naive [0]).
+    # The CAS winner is the OLDEST/lowest-id comment, whose pid is dead → reclaim.
+    # Reclaim proves the watchdog honored CAS order, not array order.
+    jq -n \
+      --argjson loser "$(state_comment_obj 42 claimed "$fresh" "thishost:me:shell:$$" "2024-06-01T00:00:00Z" 200)" \
+      --argjson winner "$(state_comment_obj 42 claimed "$fresh" "thishost:me:shell:999999" "2020-01-01T00:00:00Z" 100)" \
+      '[$loser, $winner]' > "$COMMENTS"
+
+    run bash "$WATCHDOG"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"claimed_released=1"* ]]
     grep -q -- '--add-label auto-implement' "$CALLS"
 }


### PR DESCRIPTION
Closes #1353.

## What & why
Closes the go-modules #1055 double-processing regression. `scripts/autospec-watchdog.sh:408` reclaimed a `claimed` heartbeat purely on local heartbeat age, so a sibling monitor reset a still-live worker's issue from `in-progress-by-bot` → `auto-implement`. The heartbeat age is now only a **trigger to check**; the GitHub `autospec-run-state` comment + same-host PID-liveness are authoritative (spec §F1+F2+F3).

## Decision table (heartbeat past `claimed`-timeout)
| GitHub run-state | Action |
|---|---|
| absent / `released` / `failed` | reclaim + comment |
| same-host worker, `kill -0` **alive** | **hold** (never reclaim — #1055) |
| same-host worker, `kill -0` **dead** | reclaim + `released` comment |
| cross-host / unknown, GitHub `ts` fresh (< window) | hold |
| cross-host / unknown, GitHub `ts` stale (≥ window) | reclaim + comment |

The same alive short-circuit is added to the `reconcile_run_state_comments` pass.

## Reuse
- **Reusing `scripts/worker-liveness.sh` (#1352)** for host-match + `kill -0` PID-liveness (`alive`/`dead`/`unknown`); cross-host/malformed → `unknown` → GitHub-freshness fallback.
- **Reusing `scripts/repo-slug.sh` (#1351)** `--resolve-dir` for canonical heartbeat-dir keying (prefers `owner__name`, falls back to legacy `owner_name`/`owner-name`). The watchdog no longer eagerly creates the canonical dir, so it can't shadow the legacy dir `heartbeat-write.sh` still writes.

## Tests (TDD, PATH-stubbed `gh`, `$$`/`999999` PID boundaries)
- **#1055 regression**: live same-host pid + heartbeat age > timeout + fresh GitHub claim → NOT reclaimed.
- dead same-host pid → reclaimed + `released` comment.
- cross-host stale `ts` → reclaimed; cross-host fresh `ts` → NOT reclaimed; absent run-state → reclaimed.
- duplicate run-state comments → CAS-authoritative (oldest `createdAt`/`id`) owner decides, not array order. The `gh` mock runs the production `--jq` filter verbatim (no re-implemented selection); all behaviors verified by mutation.

`bats tests/unit/test_autospec_watchdog_run_state.bats` (8) + `tests/unit/test_autospec_watchdog.bats` (5) green. `bash scripts/validate.sh` → "all validation checks passed" (exit 0), no flake exclusions needed.

## Peer-review notes (addressed)
Codex raised both must-fix items (CAS comment ordering, canonical-dir shadow); both fixed in commit 2 with regression coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)