### PR TITLE
feat(autonomous): Phase-1 waterfall tier-selection helper

### DIFF
--- a/scripts/autonomous-waterfall.sh
+++ b/scripts/autonomous-waterfall.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# scripts/autonomous-waterfall.sh — Phase-1 tier-selection decision helper.
+#
+# Evaluates tiers top-down per conductor cycle and emits a machine-readable
+# JSON decision on stdout:
+#   { "tier": N, "action": "<string>", "reason": "<string>" }
+#
+# Phase-1 scope (only tiers 0 and 1 are enabled):
+#   Tier 0 — Control channel (preempts everything): a control label is present.
+#   Tier 1 — Backlog (open auto-implement issues via gh).
+#   Tiers 2–4 — Discovery/polish: NOT YET ENABLED; always print not-enabled.
+#
+# Dry-cycle escalation: if the backlog is empty for < AUTOSPEC_AUTO_DRY_CYCLES
+# consecutive cycles, stay at Tier 1 (don't jump to Tier 2+). The caller
+# tracks dry cycles and passes --dry-cycles N.
+#
+# Usage:
+#   autonomous-waterfall.sh [options]
+#
+# Options:
+#   --control-decision LABEL   Active control label (e.g. autospec:pause).
+#                              Empty string / omit = no control signal.
+#   --dry-cycles N             Consecutive dry cycles so far (default 0).
+#   --repo OWNER/REPO          GitHub repo for backlog count (default: detect
+#                              from git remote).
+#   --backlog-count N          Inject backlog count directly (skips gh call;
+#                              useful for testing).
+#   -h, --help                 Print this help.
+#
+# Exit codes:
+#   0  — decision emitted to stdout
+#   2  — usage error
+
+set -u
+
+# ─── defaults ──────────────────────────────────────────────────────────────────
+CONTROL_DECISION=""
+DRY_CYCLES=0
+REPO=""
+BACKLOG_COUNT_INJECT=""          # non-empty → skip gh call
+DRY_CYCLES_THRESHOLD="${AUTOSPEC_AUTO_DRY_CYCLES:-2}"
+
+# ─── helpers ───────────────────────────────────────────────────────────────────
+usage() {
+    cat <<'EOF'
+Usage: autonomous-waterfall.sh [options]
+
+Options:
+  --control-decision LABEL   Active control label (autospec:pause, etc.).
+  --dry-cycles N             Consecutive dry cycles (default 0).
+  --repo OWNER/REPO          GitHub repo slug.
+  --backlog-count N          Inject backlog count (bypasses gh; for testing).
+  -h, --help                 Print this help.
+
+Env:
+  AUTOSPEC_AUTO_DRY_CYCLES   Dry-cycle escalation threshold (default 2).
+
+Output (stdout):
+  {"tier":<0|1|2|3|4>,"action":"<string>","reason":"<string>"}
+EOF
+}
+
+emit() {
+    local tier="$1" action="$2" reason="$3"
+    # Minimal JSON — no external deps required.
+    printf '{"tier":%s,"action":"%s","reason":"%s"}\n' "$tier" "$action" "$reason"
+}
+
+# ─── arg parsing ───────────────────────────────────────────────────────────────
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --control-decision) CONTROL_DECISION="$2"; shift 2 ;;
+        --dry-cycles)       DRY_CYCLES="$2";       shift 2 ;;
+        --repo)             REPO="$2";             shift 2 ;;
+        --backlog-count)    BACKLOG_COUNT_INJECT="$2"; shift 2 ;;
+        -h|--help)          usage; exit 0 ;;
+        *) printf 'autonomous-waterfall: unknown arg: %s\n' "$1" >&2; usage; exit 2 ;;
+    esac
+done
+
+# ─── Tier 0 — Control channel (always preempts) ────────────────────────────────
+if [ -n "$CONTROL_DECISION" ]; then
+    emit 0 "control" "$CONTROL_DECISION"
+    exit 0
+fi
+
+# ─── Tier 1 — Backlog: open auto-implement issues ──────────────────────────────
+backlog_count=0
+
+if [ -n "$BACKLOG_COUNT_INJECT" ]; then
+    backlog_count="$BACKLOG_COUNT_INJECT"
+else
+    # Detect repo slug from git remote when not provided.
+    if [ -z "$REPO" ]; then
+        REPO="$(git remote get-url origin 2>/dev/null \
+            | sed -E 's|.*github\.com[:/]||; s|\.git$||')" || true
+    fi
+
+    if [ -n "$REPO" ]; then
+        # Count open issues with the auto-implement label.
+        # gh may not be available in tests; treat failure as empty backlog.
+        raw="$(gh issue list \
+            --repo "$REPO" \
+            --label auto-implement \
+            --state open \
+            --limit 1000 \
+            --json number \
+            --jq 'length' 2>/dev/null)" || raw=""
+        backlog_count="${raw:-0}"
+    fi
+fi
+
+if [ "$backlog_count" -gt 0 ] 2>/dev/null; then
+    emit 1 "run-backlog" "backlog has $backlog_count open auto-implement issue(s)"
+    exit 0
+fi
+
+# Backlog is empty — check dry-cycle threshold before escalating.
+if [ "$DRY_CYCLES" -lt "$DRY_CYCLES_THRESHOLD" ] 2>/dev/null; then
+    emit 1 "run-backlog" "backlog empty but dry-cycles=$DRY_CYCLES < threshold=$DRY_CYCLES_THRESHOLD; staying at Tier 1"
+    exit 0
+fi
+
+# ─── Tiers 2–4 — NOT YET ENABLED (Phase 2/3) ──────────────────────────────────
+emit 2 "not-yet-enabled" "Tier 2 (local discovery) is not enabled in Phase 1; dry-cycles=$DRY_CYCLES >= threshold=$DRY_CYCLES_THRESHOLD"
+exit 0

--- a/tests/autonomous/test_waterfall.bats
+++ b/tests/autonomous/test_waterfall.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+# tests/autonomous/test_waterfall.bats — unit tests for autonomous-waterfall.sh
+#
+# Tier 0: control label always preempts.
+# Tier 1: backlog present → run-backlog; empty + dry-cycles < threshold → stay Tier 1.
+# Tiers 2-4: not-yet-enabled.
+# gh is stubbed via PATH injection; no real network calls.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/autonomous-waterfall.sh"
+
+    # Isolated temp dir — no git, no gh needed for inject path.
+    TMP="$(mktemp -d -t waterfall.XXXXXX)"
+    export PATH="$TMP/bin:$PATH"
+    mkdir -p "$TMP/bin"
+
+    # Default stub: gh returns 0 issues.
+    cat > "$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+# Stub gh: return 0 for list --json number --jq 'length'
+printf '0\n'
+exit 0
+EOF
+    chmod +x "$TMP/bin/gh"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+# ─── Tier 0 tests ──────────────────────────────────────────────────────────────
+
+@test "Tier 0: control label preempts when backlog count would be non-zero" {
+    run bash "$SCRIPT" \
+        --control-decision "autospec:pause" \
+        --backlog-count 5
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":0'* ]]
+    [[ "$output" == *'"action":"control"'* ]]
+    [[ "$output" == *'autospec:pause'* ]]
+}
+
+@test "Tier 0: control label preempts even with empty backlog" {
+    run bash "$SCRIPT" \
+        --control-decision "autospec:stop" \
+        --backlog-count 0
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":0'* ]]
+    [[ "$output" == *'"action":"control"'* ]]
+}
+
+@test "Tier 0: any non-empty control-decision value triggers Tier 0" {
+    run bash "$SCRIPT" \
+        --control-decision "autospec:steer" \
+        --backlog-count 0 \
+        --dry-cycles 99
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":0'* ]]
+}
+
+# ─── Tier 1 tests ──────────────────────────────────────────────────────────────
+
+@test "Tier 1: backlog present selects run-backlog" {
+    run bash "$SCRIPT" \
+        --backlog-count 3
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":1'* ]]
+    [[ "$output" == *'"action":"run-backlog"'* ]]
+}
+
+@test "Tier 1: backlog present selects Tier 1 even with high dry-cycles" {
+    run bash "$SCRIPT" \
+        --backlog-count 10 \
+        --dry-cycles 99
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":1'* ]]
+}
+
+@test "Tier 1: backlog empty + 1 dry cycle stays Tier 1 (default threshold=2)" {
+    run bash "$SCRIPT" \
+        --backlog-count 0 \
+        --dry-cycles 1
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":1'* ]]
+    [[ "$output" == *'"action":"run-backlog"'* ]]
+}
+
+@test "Tier 1: backlog empty + 0 dry cycles stays Tier 1" {
+    run bash "$SCRIPT" \
+        --backlog-count 0 \
+        --dry-cycles 0
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":1'* ]]
+}
+
+# ─── Tiers 2-4 not-yet-enabled ─────────────────────────────────────────────────
+
+@test "Tiers 2-4: backlog empty + dry-cycles >= threshold emits not-yet-enabled" {
+    run bash "$SCRIPT" \
+        --backlog-count 0 \
+        --dry-cycles 2
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":2'* ]]
+    [[ "$output" == *'"action":"not-yet-enabled"'* ]]
+}
+
+@test "Tiers 2-4: not-yet-enabled with higher dry-cycles above threshold" {
+    run bash "$SCRIPT" \
+        --backlog-count 0 \
+        --dry-cycles 5
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":2'* ]]
+    [[ "$output" == *'not-yet-enabled'* ]]
+}
+
+@test "Tiers 2-4: custom threshold via AUTOSPEC_AUTO_DRY_CYCLES env" {
+    # With threshold=3, dry-cycles=2 should still stay Tier 1.
+    AUTOSPEC_AUTO_DRY_CYCLES=3 run bash "$SCRIPT" \
+        --backlog-count 0 \
+        --dry-cycles 2
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":1'* ]]
+}
+
+@test "Tiers 2-4: custom threshold=3 triggers not-yet-enabled at dry-cycles=3" {
+    AUTOSPEC_AUTO_DRY_CYCLES=3 run bash "$SCRIPT" \
+        --backlog-count 0 \
+        --dry-cycles 3
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":2'* ]]
+    [[ "$output" == *'not-yet-enabled'* ]]
+}
+
+# ─── Output format ─────────────────────────────────────────────────────────────
+
+@test "output is valid JSON with tier, action, reason keys" {
+    run bash "$SCRIPT" --backlog-count 1
+    [ "$status" -eq 0 ]
+    # All three keys must be present.
+    [[ "$output" == *'"tier":'* ]]
+    [[ "$output" == *'"action":'* ]]
+    [[ "$output" == *'"reason":'* ]]
+}
+
+@test "unknown flag exits 2" {
+    run bash "$SCRIPT" --unknown-flag
+    [ "$status" -eq 2 ]
+}
+
+# ─── gh subprocess boundary ────────────────────────────────────────────────────
+
+@test "gh stub returning 5 is treated as backlog present (Tier 1)" {
+    # Override stub to return 5 issues.
+    cat > "$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '5\n'
+exit 0
+EOF
+    chmod +x "$TMP/bin/gh"
+
+    # Use a fake git dir so repo detection gets a slug.
+    git_dir="$(mktemp -d -t wf-git.XXXXXX)"
+    git -C "$git_dir" init -q
+    git -C "$git_dir" remote add origin "https://github.com/owner/repo.git"
+
+    run bash "$SCRIPT" --repo "owner/repo"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":1'* ]]
+    rm -rf "$git_dir"
+}
+
+@test "gh failure degrades gracefully to empty backlog (stays Tier 1 at dry-cycles=0)" {
+    # Override stub to fail.
+    cat > "$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$TMP/bin/gh"
+
+    run bash "$SCRIPT" --repo "owner/repo" --dry-cycles 0
+    [ "$status" -eq 0 ]
+    # gh failure → backlog_count=0 → dry-cycles=0 < 2 → still Tier 1
+    [[ "$output" == *'"tier":1'* ]]
+}


### PR DESCRIPTION
Closes #1374

`scripts/autonomous-waterfall.sh` — Phase-1 tier selection: Tier 0 (control) preempts → Tier 1 (backlog→main). Tiers 2-4 emit a not-yet-enabled marker (Phase 2). Emits JSON {tier,action,reason}; fail-open on gh error. 15/15 bats pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)