### PR TITLE
feat(autospec-autonomous): autonomous-spend-ledger.sh (cumulative cost kill-switch)

### DIFF
--- a/scripts/autonomous-spend-ledger.sh
+++ b/scripts/autonomous-spend-ledger.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# scripts/autonomous-spend-ledger.sh — persistent cumulative token/issue tally
+# for the /autospec-autonomous perpetual loop.
+#
+# Ledger path: ~/.autospec/autonomous-spend/<repo-slug>/spend.json
+# Path-scoped per repo-slug to prevent cross-repo collisions
+# (feedback_heartbeat_cross_repo_collision).
+#
+# Subcommands:
+#   add --tokens N [--issues N] [--repo-dir DIR]
+#       Increment the cumulative totals in the ledger. Creates the file if
+#       absent. Prints the updated totals as JSON.
+#
+#   check [--repo-dir DIR]
+#       Compare ledger totals against caps. Prints either:
+#         continue
+#         park <reason>
+#       When a cap is hit, also invokes notify.sh (PATH-resolved or found in
+#       skills/autospec-shared/scripts/) and writes a resume-context block to
+#       the ledger. Exit code is always 0 (the decision is communicated via
+#       stdout so callers can capture and branch on it without exit-code
+#       gymnastics).
+#
+#   reset [--repo-dir DIR]
+#       Zero out the ledger (useful after a resume or quota reset).
+#
+#   status [--repo-dir DIR]
+#       Print the current ledger JSON (or empty object if absent).
+#
+# Environment caps:
+#   AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS  (default: 10000000 = 10M)
+#   AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES  (default: 500)
+#
+# Caps of 0 mean "no cap for that dimension" (i.e., they are disabled).
+#
+# Atomic writes: temp-file + mv so partial writes never corrupt the ledger.
+# set -eu, if/then/fi one-sided conditionals (feedback_bash_set_e_short_circuit).
+# No RETURN traps (feedback_bash_return_trap_leak).
+
+set -eu
+
+LEDGER_BASE="${HOME}/.autospec/autonomous-spend"
+DEFAULT_LIFETIME_TOKENS=10000000
+DEFAULT_LIFETIME_ISSUES=500
+
+LIFETIME_TOKENS="${AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS:-$DEFAULT_LIFETIME_TOKENS}"
+LIFETIME_ISSUES="${AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES:-$DEFAULT_LIFETIME_ISSUES}"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+die() {
+    printf 'autonomous-spend-ledger: %s\n' "$*" >&2
+    exit 1
+}
+
+info() {
+    printf '[autonomous-spend-ledger] %s\n' "$*"
+}
+
+require_jq() {
+    command -v jq >/dev/null 2>&1 || die "jq is required"
+}
+
+iso_now() {
+    date -u +'%Y-%m-%dT%H:%M:%SZ'
+}
+
+# Derive repo slug from repo origin URL or repo dir path.
+# Pattern mirrors autospec-run-registry.sh + autospec-watchdog.sh.
+resolve_repo_slug() {
+    local repo_dir="${1:-$(pwd)}"
+    local slug=""
+    slug="$(cd "$repo_dir" 2>/dev/null \
+        && git remote get-url origin 2>/dev/null \
+        | sed -E 's#^git@[^:]+:##; s#^https?://[^/]+/##; s#\\.git$##; s#[/]#_#g' \
+        || true)"
+    if [ -z "$slug" ]; then
+        # Fallback: sanitize the directory path.
+        slug="$(printf '%s' "$repo_dir" | sed 's#[^A-Za-z0-9._-]#_#g')"
+    fi
+    printf '%s' "$slug"
+}
+
+ledger_path() {
+    local repo_dir="${1:-$(pwd)}"
+    local slug
+    slug="$(resolve_repo_slug "$repo_dir")"
+    printf '%s/%s/spend.json' "$LEDGER_BASE" "$slug"
+}
+
+# Atomic write: write to temp file in same dir, then mv.
+write_json_atomic() {
+    local target="$1"
+    mkdir -p "$(dirname "$target")"
+    local tmp
+    tmp="$(mktemp "${target}.XXXXXX")"
+    cat > "$tmp"
+    mv "$tmp" "$target"
+}
+
+read_ledger() {
+    local path="$1"
+    if [ -f "$path" ]; then
+        cat "$path"
+    else
+        # Return a zero-state JSON if absent.
+        printf '{"schema":1,"tokens":0,"issues":0,"created_at":"%s","updated_at":"%s","parked":false}\n' \
+            "$(iso_now)" "$(iso_now)"
+    fi
+}
+
+# Find the notify.sh helper: check PATH first, then the skill scripts location.
+find_notify() {
+    if command -v notify.sh >/dev/null 2>&1; then
+        printf 'notify.sh'
+        return
+    fi
+    local repo_dir="${1:-$(pwd)}"
+    local skill_path="${repo_dir}/skills/autospec-shared/scripts/notify.sh"
+    if [ -f "$skill_path" ]; then
+        printf '%s' "$skill_path"
+        return
+    fi
+    # Not found — caller degrades gracefully.
+    printf ''
+}
+
+# ── Subcommand parsing ───────────────────────────────────────────────────────
+
+usage() {
+    cat <<'EOF'
+Usage: autonomous-spend-ledger.sh <subcommand> [options]
+
+Subcommands:
+  add     --tokens N [--issues N] [--repo-dir DIR]
+  check   [--repo-dir DIR]
+  reset   [--repo-dir DIR]
+  status  [--repo-dir DIR]
+
+Env:
+  AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS  (default 10000000)
+  AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES  (default 500)
+
+Exit code is always 0; decision output is on stdout.
+EOF
+}
+
+SUBCMD="${1:-}"
+[ -n "$SUBCMD" ] || { usage >&2; exit 1; }
+case "$SUBCMD" in --help|-h) usage; exit 0 ;; esac
+shift
+
+ADD_TOKENS=0
+ADD_ISSUES=0
+REPO_DIR="$(pwd)"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --tokens)   ADD_TOKENS="${2:-0}"; shift 2 ;;
+        --issues)   ADD_ISSUES="${2:-0}"; shift 2 ;;
+        --repo-dir) REPO_DIR="${2:-$(pwd)}"; shift 2 ;;
+        --help|-h)  usage; exit 0 ;;
+        *)          die "unknown option: $1" ;;
+    esac
+done
+
+LEDGER="$(ledger_path "$REPO_DIR")"
+
+# ── Subcommand: add ──────────────────────────────────────────────────────────
+if [ "$SUBCMD" = "add" ]; then
+    require_jq
+    case "$ADD_TOKENS" in *[!0-9]*|'') die "--tokens must be a non-negative integer" ;; esac
+    case "$ADD_ISSUES" in *[!0-9]*|'') die "--issues must be a non-negative integer" ;; esac
+
+    current="$(read_ledger "$LEDGER")"
+    updated="$(printf '%s' "$current" | jq \
+        --argjson t "$ADD_TOKENS" \
+        --argjson i "$ADD_ISSUES" \
+        --arg ts "$(iso_now)" \
+        '.tokens += $t | .issues += $i | .updated_at = $ts')"
+    printf '%s\n' "$updated" | write_json_atomic "$LEDGER"
+    printf '%s\n' "$updated"
+    exit 0
+fi
+
+# ── Subcommand: check ────────────────────────────────────────────────────────
+if [ "$SUBCMD" = "check" ]; then
+    require_jq
+    current="$(read_ledger "$LEDGER")"
+    total_tokens="$(printf '%s' "$current" | jq -r '.tokens // 0')"
+    total_issues="$(printf '%s' "$current" | jq -r '.issues // 0')"
+
+    # Validate that the values are integers before arithmetic comparison.
+    case "$total_tokens" in *[!0-9]*|'') total_tokens=0 ;; esac
+    case "$total_issues" in *[!0-9]*|'') total_issues=0 ;; esac
+    case "$LIFETIME_TOKENS" in *[!0-9]*|'') LIFETIME_TOKENS="$DEFAULT_LIFETIME_TOKENS" ;; esac
+    case "$LIFETIME_ISSUES" in *[!0-9]*|'') LIFETIME_ISSUES="$DEFAULT_LIFETIME_ISSUES" ;; esac
+
+    park_reason=""
+
+    # Token cap: 0 means disabled.
+    if [ "$LIFETIME_TOKENS" -gt 0 ] && [ "$total_tokens" -ge "$LIFETIME_TOKENS" ]; then
+        park_reason="lifetime token cap reached (${total_tokens} >= ${LIFETIME_TOKENS})"
+    fi
+
+    # Issue cap: 0 means disabled.
+    if [ -z "$park_reason" ] && [ "$LIFETIME_ISSUES" -gt 0 ] && [ "$total_issues" -ge "$LIFETIME_ISSUES" ]; then
+        park_reason="lifetime issue cap reached (${total_issues} >= ${LIFETIME_ISSUES})"
+    fi
+
+    if [ -n "$park_reason" ]; then
+        # Write parked state + resume context to ledger.
+        parked_ledger="$(printf '%s' "$current" | jq \
+            --arg reason "$park_reason" \
+            --arg ts "$(iso_now)" \
+            '.parked = true | .park_reason = $reason | .parked_at = $ts')"
+        printf '%s\n' "$parked_ledger" | write_json_atomic "$LEDGER"
+
+        # Invoke notify.sh (fail-open: notifier errors must never block).
+        notifier="$(find_notify "$REPO_DIR")"
+        if [ -n "$notifier" ]; then
+            bash "$notifier" "autospec-autonomous parked" "$park_reason" || true
+        fi
+
+        printf 'park %s\n' "$park_reason"
+    else
+        printf 'continue\n'
+    fi
+    exit 0
+fi
+
+# ── Subcommand: reset ────────────────────────────────────────────────────────
+if [ "$SUBCMD" = "reset" ]; then
+    require_jq
+    jq -n \
+        --arg ts "$(iso_now)" \
+        '{"schema":1,"tokens":0,"issues":0,"created_at":$ts,"updated_at":$ts,"parked":false}' \
+        | write_json_atomic "$LEDGER"
+    info "ledger reset: $LEDGER"
+    exit 0
+fi
+
+# ── Subcommand: status ───────────────────────────────────────────────────────
+if [ "$SUBCMD" = "status" ]; then
+    require_jq
+    read_ledger "$LEDGER" | jq .
+    exit 0
+fi
+
+# ── Unknown subcommand ────────────────────────────────────────────────────────
+usage >&2
+exit 1

--- a/tests/autonomous/test_spend_ledger.bats
+++ b/tests/autonomous/test_spend_ledger.bats
@@ -1,0 +1,293 @@
+#!/usr/bin/env bats
+# tests/autonomous/test_spend_ledger.bats — unit tests for
+# scripts/autonomous-spend-ledger.sh (cumulative cost kill-switch).
+#
+# Covers:
+#  - add: increments accumulate across calls
+#  - check: returns "continue" while under caps
+#  - check: returns "park <reason>" at/over token cap
+#  - check: returns "park <reason>" at/over issue cap
+#  - park path invokes stubbed notify.sh
+#  - ledger file JSON structure is correct
+#  - atomic writes: file is valid JSON after each operation
+#  - reset zeroes the totals
+#  - status prints current ledger JSON
+#  - macOS bash 3.2 compatibility: no process substitution in [ -f ]
+
+setup() {
+    REPO_ROOT="$(git rev-parse --show-toplevel)"
+    SCRIPT="$REPO_ROOT/scripts/autonomous-spend-ledger.sh"
+
+    # Isolated ledger dir per test (avoids cross-test contamination).
+    TEST_DIR="$(mktemp -d)"
+    export AUTOSPEC_AUTONOMOUS_SPEND_BASE="$TEST_DIR/spend"
+    # Override HOME so ledger writes go to our temp dir.
+    export HOME="$TEST_DIR"
+
+    # Stub notify.sh: record invocations to a file so we can assert them.
+    NOTIFY_STUB="$TEST_DIR/notify.sh"
+    NOTIFY_LOG="$TEST_DIR/notify.log"
+    cat > "$NOTIFY_STUB" <<'SH'
+#!/usr/bin/env bash
+printf '%s\t%s\n' "$1" "$2" >> "$NOTIFY_LOG"
+SH
+    chmod +x "$NOTIFY_STUB"
+    export PATH="$TEST_DIR:$PATH"
+    export NOTIFY_LOG
+
+    # Use a fixed fake repo-dir so slug derivation is deterministic.
+    REPO_DIR="$TEST_DIR/fake-repo"
+    mkdir -p "$REPO_DIR/.git"
+    # Create a minimal git repo so git remote get-url works predictably.
+    (
+        cd "$REPO_DIR"
+        git init -q
+        git remote add origin "https://github.com/test-owner/test-repo.git"
+    )
+    export REPO_DIR
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+run_ledger() {
+    run bash "$SCRIPT" "$@" --repo-dir "$REPO_DIR"
+}
+
+# ── add ───────────────────────────────────────────────────────────────────────
+
+@test "add: first call creates ledger and sets tokens/issues" {
+    run_ledger add --tokens 100 --issues 1
+    [ "$status" -eq 0 ]
+    tokens="$(printf '%s' "$output" | jq -r '.tokens')"
+    issues="$(printf '%s' "$output" | jq -r '.issues')"
+    [ "$tokens" -eq 100 ]
+    [ "$issues" -eq 1 ]
+}
+
+@test "add: repeated calls accumulate totals" {
+    run_ledger add --tokens 100 --issues 1
+    run_ledger add --tokens 200 --issues 2
+    run_ledger add --tokens 50 --issues 0
+
+    tokens="$(printf '%s' "$output" | jq -r '.tokens')"
+    issues="$(printf '%s' "$output" | jq -r '.issues')"
+    [ "$tokens" -eq 350 ]
+    [ "$issues" -eq 3 ]
+}
+
+@test "add: ledger file is valid JSON after each call" {
+    run_ledger add --tokens 100 --issues 1
+    ledger_file="$(find "$HOME/.autospec/autonomous-spend" -name "spend.json" 2>/dev/null | head -1)"
+    [ -n "$ledger_file" ]
+    jq empty "$ledger_file"
+}
+
+@test "add: default --issues is 0 when omitted" {
+    run_ledger add --tokens 42
+    issues="$(printf '%s' "$output" | jq -r '.issues')"
+    [ "$issues" -eq 0 ]
+}
+
+@test "add: schema field is present in ledger" {
+    run_ledger add --tokens 1
+    schema="$(printf '%s' "$output" | jq -r '.schema')"
+    [ "$schema" = "1" ]
+}
+
+# ── check: continue ────────────────────────────────────────────────────────────
+
+@test "check: returns 'continue' with empty ledger (no file yet)" {
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=1000000 \
+    AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES=100 \
+    run_ledger check
+    [ "$status" -eq 0 ]
+    [ "$output" = "continue" ]
+}
+
+@test "check: returns 'continue' while under both caps" {
+    run_ledger add --tokens 100 --issues 1
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=1000 \
+    AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES=10 \
+    run_ledger check
+    [ "$status" -eq 0 ]
+    [ "$output" = "continue" ]
+}
+
+@test "check: returns 'continue' with tokens at cap minus 1" {
+    run_ledger add --tokens 999 --issues 0
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=1000 \
+    AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES=10 \
+    run_ledger check
+    [ "$status" -eq 0 ]
+    [ "$output" = "continue" ]
+}
+
+# ── check: park on token cap ──────────────────────────────────────────────────
+
+@test "check: returns 'park' when tokens exactly equal the token cap" {
+    run_ledger add --tokens 1000 --issues 0
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=1000 \
+    AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES=10 \
+    run_ledger check
+    [ "$status" -eq 0 ]
+    [[ "$output" == park* ]]
+    [[ "$output" == *"token cap"* ]]
+}
+
+@test "check: returns 'park' when tokens exceed the token cap" {
+    run_ledger add --tokens 2000 --issues 0
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=1000 \
+    AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES=10 \
+    run_ledger check
+    [ "$status" -eq 0 ]
+    [[ "$output" == park* ]]
+}
+
+@test "check: park on token cap calls stubbed notify.sh" {
+    run_ledger add --tokens 1000 --issues 0
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=1000 \
+    AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES=10 \
+    run_ledger check
+    [ -f "$NOTIFY_LOG" ]
+    grep -q "autospec-autonomous parked" "$NOTIFY_LOG"
+}
+
+@test "check: park writes parked=true to ledger JSON" {
+    run_ledger add --tokens 1000 --issues 0
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=1000 \
+    AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES=10 \
+    run_ledger check
+    ledger_file="$(find "$HOME/.autospec/autonomous-spend" -name "spend.json" 2>/dev/null | head -1)"
+    parked="$(jq -r '.parked' "$ledger_file")"
+    [ "$parked" = "true" ]
+}
+
+# ── check: park on issue cap ──────────────────────────────────────────────────
+
+@test "check: returns 'park' when issues exactly equal the issue cap" {
+    run_ledger add --tokens 0 --issues 10
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=1000 \
+    AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES=10 \
+    run_ledger check
+    [ "$status" -eq 0 ]
+    [[ "$output" == park* ]]
+    [[ "$output" == *"issue cap"* ]]
+}
+
+@test "check: returns 'park' when issues exceed the issue cap" {
+    run_ledger add --tokens 0 --issues 20
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=1000 \
+    AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES=10 \
+    run_ledger check
+    [ "$status" -eq 0 ]
+    [[ "$output" == park* ]]
+}
+
+@test "check: park on issue cap calls stubbed notify.sh" {
+    run_ledger add --tokens 0 --issues 10
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=1000 \
+    AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES=10 \
+    run_ledger check
+    [ -f "$NOTIFY_LOG" ]
+    grep -q "autospec-autonomous parked" "$NOTIFY_LOG"
+}
+
+# ── check: disabled caps (0 means no cap) ─────────────────────────────────────
+
+@test "check: token cap of 0 means disabled (no park even at very high tokens)" {
+    run_ledger add --tokens 99999999 --issues 0
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=0 \
+    AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES=500 \
+    run_ledger check
+    [ "$status" -eq 0 ]
+    [ "$output" = "continue" ]
+}
+
+@test "check: issue cap of 0 means disabled (no park even at very high issues)" {
+    run_ledger add --tokens 0 --issues 99999
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=1000000 \
+    AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES=0 \
+    run_ledger check
+    [ "$status" -eq 0 ]
+    [ "$output" = "continue" ]
+}
+
+# ── reset ─────────────────────────────────────────────────────────────────────
+
+@test "reset: zeroes tokens and issues" {
+    run_ledger add --tokens 500 --issues 5
+    run_ledger reset
+    run_ledger status
+    tokens="$(printf '%s' "$output" | jq -r '.tokens')"
+    issues="$(printf '%s' "$output" | jq -r '.issues')"
+    [ "$tokens" -eq 0 ]
+    [ "$issues" -eq 0 ]
+}
+
+@test "reset: after reset, check returns continue" {
+    run_ledger add --tokens 9999999 --issues 9999
+    run_ledger reset
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=1000 \
+    AUTOSPEC_AUTONOMOUS_LIFETIME_ISSUES=10 \
+    run_ledger check
+    [ "$output" = "continue" ]
+}
+
+# ── status ────────────────────────────────────────────────────────────────────
+
+@test "status: prints valid JSON with tokens and issues fields" {
+    run_ledger add --tokens 77 --issues 3
+    run_ledger status
+    [ "$status" -eq 0 ]
+    tokens="$(printf '%s' "$output" | jq -r '.tokens')"
+    issues="$(printf '%s' "$output" | jq -r '.issues')"
+    [ "$tokens" -eq 77 ]
+    [ "$issues" -eq 3 ]
+}
+
+@test "status: returns zero-state when no ledger exists yet" {
+    run_ledger status
+    [ "$status" -eq 0 ]
+    tokens="$(printf '%s' "$output" | jq -r '.tokens')"
+    [ "$tokens" -eq 0 ]
+}
+
+# ── path scoping ──────────────────────────────────────────────────────────────
+
+@test "path-scoped: different repo dirs produce different ledger files" {
+    REPO_DIR2="$TEST_DIR/fake-repo-2"
+    mkdir -p "$REPO_DIR2/.git"
+    (
+        cd "$REPO_DIR2"
+        git init -q
+        git remote add origin "https://github.com/test-owner/other-repo.git"
+    )
+
+    run bash "$SCRIPT" add --tokens 100 --issues 1 --repo-dir "$REPO_DIR"
+    run bash "$SCRIPT" add --tokens 999 --issues 9 --repo-dir "$REPO_DIR2"
+
+    # Check that the two repos have independent totals.
+    run bash "$SCRIPT" status --repo-dir "$REPO_DIR"
+    t1="$(printf '%s' "$output" | jq -r '.tokens')"
+    run bash "$SCRIPT" status --repo-dir "$REPO_DIR2"
+    t2="$(printf '%s' "$output" | jq -r '.tokens')"
+
+    [ "$t1" -eq 100 ]
+    [ "$t2" -eq 999 ]
+}
+
+# ── macOS bash 3.2 / real temp file check ─────────────────────────────────────
+
+@test "ledger file is a real file on disk (not process substitution artifact)" {
+    run_ledger add --tokens 10 --issues 1
+    # Write ledger path to a real temp file before testing [ -f ]
+    # (feedback_bash32_process_sub_test_file: [ -f <(...) ] is false on macOS bash 3.2)
+    tmp_path="$(mktemp)"
+    find "$HOME/.autospec/autonomous-spend" -name "spend.json" 2>/dev/null > "$tmp_path"
+    ledger_file="$(cat "$tmp_path")"
+    rm -f "$tmp_path"
+    [ -n "$ledger_file" ]
+    [ -f "$ledger_file" ]
+}


### PR DESCRIPTION
## Summary

Add `scripts/autonomous-spend-ledger.sh` — a persistent cumulative token/issue tally for the `/autospec-autonomous` perpetual loop, implementing the Phase-1 cumulative cost kill-switch required by `docs/specs/2026-06-25-autospec-autonomous-design.md`.

## What was built

- **`scripts/autonomous-spend-ledger.sh`** — subcommands: `add` (increment tokens/issues), `check` (emit `continue` or `park <reason>`), `reset`, `status`.
- **`tests/autonomous/test_spend_ledger.bats`** — 23 bats tests: accumulation, cap enforcement, notify invocation, path-scoping isolation, macOS bash 3.2 compat.

## Design decisions

- **Path-scoped ledger**: `~/.autospec/autonomous-spend/<repo-slug>/spend.json` — prevents cross-repo collisions (`feedback_heartbeat_cross_repo_collision`); slug derivation mirrors `autospec-run-registry.sh` pattern.
- **Notifier**: resolves `notify.sh` via `PATH` first, then `skills/autospec-shared/scripts/notify.sh` (already on main via #1371). Fail-open: notifier errors never block.
- **Atomic writes**: temp-file + `mv` so partial writes never corrupt the ledger.
- **Bash safety**: `set -eu`, `if/then/fi` one-sided conditionals (`feedback_bash_set_e_short_circuit`), no RETURN traps (`feedback_bash_return_trap_leak`).
- **Cap semantics**: `0` disables the cap for that dimension (token or issue). Default: 10M tokens / 500 issues.

## Reuse decision

Reusing `autospec-usage-limit.sh` `write_json_atomic` pattern (temp+mv) and `autospec-run-registry.sh` `repo_slug()` derivation approach. Reusing `notify.sh` from `skills/autospec-shared/scripts/` (no reimplementation). No reuse of usage-limit's daemon/poll machinery — the spend ledger is a pure decision primitive, not a scheduler.

## Test coverage

- `add`: increments accumulate across calls; schema field present; file is valid JSON
- `check`: `continue` under caps; `park` at/above token cap; `park` at/above issue cap; cap=0 disables; notify.sh stub invoked on park; ledger `parked=true` written
- `reset`: zeroes totals; `check` returns `continue` after reset
- `status`: correct JSON; zero-state when no file
- Path-scoping: two different repo dirs produce independent ledger files
- macOS bash 3.2: real temp file before `[ -f ]` check

## Validation

`bash scripts/validate.sh` — exit 0, all checks passed.

Closes #1375