### PR TITLE
feat(autospec-autonomous): conductor skill packaging (install/uninstall/README)

### DIFF
--- a/skills/autospec-autonomous/README.md
+++ b/skills/autospec-autonomous/README.md
@@ -58,6 +58,46 @@ cd skills/autospec-autonomous
 ./uninstall.sh --harness all
 ```
 
+## Control labels (GitHub)
+
+Apply these labels to any open issue to send a Tier-0 control-channel signal:
+
+| Label                  | Effect                                                                     |
+|------------------------|----------------------------------------------------------------------------|
+| `autospec:stop`        | Write `~/.autospec/stop.flag`; finish the current issue; exit cleanly.    |
+| `autospec:pause`       | Park the loop; notify operator; wait for resume or `autospec:stop`.       |
+| `autospec:priority`    | Re-sort the Tier-1 backlog by the label body before the next drain.       |
+| `autospec:steer`       | Parse the label body as a directive; update the active waterfall intent; remove the label. |
+
+Tier 0 always preempts Tier 1. A `stop` or `pause` signal is honored at the next
+cycle boundary — never mid-issue.
+
+## Phase-1 waterfall
+
+Each cycle executes in order:
+
+1. **Tier-0 poll** — read GitHub control channel (`autonomous-control-channel.sh`).
+2. **Tier selection** — `autonomous-waterfall.sh` picks Tier 0 or Tier 1.
+3. **Tier-1 drain** — pick the highest-priority `auto-implement` issue and invoke `/autospec-run`.
+4. **Pre-merge gate** — `autonomous-premerge-gate.sh` + `autospec-autonomy-gate.sh` validate before merge.
+5. **Spend ledger** — `autonomous-spend-ledger.sh` tallies tokens/issues; parks when `AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS` or the issue ceiling is reached.
+6. **Resilience** — `autonomous-resilience.sh` handles failures; notifies operator on persistent errors.
+
+**Phase 1 scope:** Tier 0 + Tier 1 only. Tiers 2–4 (explore-backed discovery, persona,
+self-brainstorm) are Phase 2/3 roadmap entries and are **not yet enabled**.
+
+## Environment variables
+
+| Variable                              | Default               | Description                                                |
+|---------------------------------------|-----------------------|------------------------------------------------------------|
+| `AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS` | `50000000`            | Cumulative token ceiling; triggers park-and-notify.        |
+| `AUTOSPEC_SCRIPTS_DIR`                | `~/.autospec/scripts` | Runtime scripts directory.                                 |
+| `CLAUDE_CONFIG_DIR`                   | `~/.claude`           | Claude Code config directory.                              |
+| `OPENCODE_CONFIG_DIR`                 | `~/.config/opencode`  | OpenCode config directory.                                 |
+| `CODEX_HOME`                          | `~/.codex`            | Codex CLI home directory.                                  |
+| `AUTOSPEC_AUTONOMOUS_REF`             | `main`                | Git ref to fetch from when piped via curl.                 |
+| `AUTOSPEC_AUTONOMOUS_RAW_BASE`        | —                     | Override the raw GitHub URL base entirely.                 |
+
 ## Design spec
 
 `docs/specs/2026-06-25-autospec-autonomous-design.md`

--- a/skills/autospec-autonomous/install.sh
+++ b/skills/autospec-autonomous/install.sh
@@ -41,6 +41,8 @@ DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
 SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
+AUTONOMOUS_SCRIPT_FILES="autonomous-control-channel.sh autonomous-premerge-gate.sh autonomous-resilience.sh autonomous-spend-ledger.sh autonomous-waterfall.sh autospec-autonomy-gate.sh"
+LIB_FILES="autospec-loop.sh autospec-harness-detect.sh"
 
 err()  { printf 'error: %s\n' "$*" >&2; }
 warn() { printf 'warn:  %s\n' "$*" >&2; }
@@ -88,7 +90,7 @@ fetch_source_files() {
     TMP_FETCH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t autospec)"
     info "Fetching ${SKILL_NAME} source files from ${SKILL_RAW_BASE} ..."
     RAW_REPO_BASE="${SKILL_RAW_BASE%/skills/$SKILL_NAME}"
-    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts"
+    mkdir -p "$TMP_FETCH_DIR/opencode" "$TMP_FETCH_DIR/codex" "$TMP_FETCH_DIR/scripts" "$TMP_FETCH_DIR/scripts/lib"
     for rel in SKILL.md opencode/agent.md codex/prompt.md; do
         if ! curl -fsSL "$SKILL_RAW_BASE/$rel" -o "$TMP_FETCH_DIR/$rel"; then
             err "failed to download $SKILL_RAW_BASE/$rel"
@@ -98,6 +100,18 @@ fetch_source_files() {
     for rel in $SHARED_SCRIPT_FILES; do
         if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
             err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
+    for rel in $AUTONOMOUS_SCRIPT_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/$rel" -o "$TMP_FETCH_DIR/scripts/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/$rel"
+            exit 1
+        fi
+    done
+    for rel in $LIB_FILES; do
+        if ! curl -fsSL "$RAW_REPO_BASE/scripts/lib/$rel" -o "$TMP_FETCH_DIR/scripts/lib/$rel"; then
+            err "failed to download $RAW_REPO_BASE/scripts/lib/$rel"
             exit 1
         fi
     done
@@ -125,6 +139,32 @@ install_shared_scripts() {
         install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
         case "$rel" in
             *.sh) run "chmod +x \"$HOME/.autospec/scripts/$rel\"" ;;
+        esac
+    done
+}
+
+install_autonomous_scripts() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install autonomous helper scripts"
+        return 1
+    fi
+    for rel in $AUTONOMOUS_SCRIPT_FILES; do
+        install_one "$src_dir/$rel" "$HOME/.autospec/scripts/$rel" || return 1
+        run "chmod +x \"$HOME/.autospec/scripts/$rel\""
+    done
+}
+
+install_lib_files() {
+    src_dir="$(resolve_shared_scripts_dir)"
+    if [ -z "$src_dir" ]; then
+        err "missing shared scripts directory; cannot install runtime lib files"
+        return 1
+    fi
+    for rel in $LIB_FILES; do
+        install_one "$src_dir/lib/$rel" "$HOME/.autospec/scripts/lib/$rel" || return 1
+        case "$rel" in
+            *.sh) run "chmod +x \"$HOME/.autospec/scripts/lib/$rel\"" ;;
         esac
     done
 }
@@ -252,6 +292,14 @@ fi
 info ""
 info "Shared autospec helper scripts:"
 install_shared_scripts
+
+info ""
+info "Autonomous helper scripts:"
+install_autonomous_scripts
+
+info ""
+info "Runtime lib files (scripts/lib/):"
+install_lib_files
 
 CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"

--- a/skills/autospec-autonomous/uninstall.sh
+++ b/skills/autospec-autonomous/uninstall.sh
@@ -17,6 +17,8 @@
 set -eu
 
 SKILL_NAME="autospec-autonomous"
+AUTONOMOUS_SCRIPT_FILES="autonomous-control-channel.sh autonomous-premerge-gate.sh autonomous-resilience.sh autonomous-spend-ledger.sh autonomous-waterfall.sh autospec-autonomy-gate.sh"
+LIB_FILES="autospec-loop.sh autospec-harness-detect.sh"
 
 HARNESS=""
 DRY_RUN=0
@@ -137,6 +139,18 @@ if [ "$HARNESS" = "codex" ] || [ "$HARNESS" = "all" ]; then
     info "Codex CLI:"
     remove_one "$CODEX_DEST"
 fi
+
+info ""
+info "Autonomous helper scripts:"
+for rel in $AUTONOMOUS_SCRIPT_FILES; do
+    remove_one "$HOME/.autospec/scripts/$rel"
+done
+
+info ""
+info "Runtime lib files (scripts/lib/):"
+for rel in $LIB_FILES; do
+    remove_one "$HOME/.autospec/scripts/lib/$rel"
+done
 
 info ""
 if [ "$DRY_RUN" -eq 1 ]; then


### PR DESCRIPTION
## Summary

- `install.sh`: adds `AUTONOMOUS_SCRIPT_FILES` (6 conductor scripts) and `LIB_FILES` (autospec-loop.sh, autospec-harness-detect.sh) so the installer ships `scripts/lib/` runtime libs — fixes the installer-excludes-runtime-libs regression
- `uninstall.sh`: reverses all newly installed autonomous + lib paths (idempotent)
- `README.md`: adds **Control labels**, **Phase-1 waterfall**, and **Environment variables** sections per the issue acceptance criteria

## Reuse decision

No reuse — the changes are additive packaging extensions to an existing install/uninstall pair; no upstream helper pattern covers multi-list installer extension.

## Verification

- `bash scripts/validate.sh` → **OK — all validation checks passed.**
- `bash skills/autospec-autonomous/install.sh --harness all --dry-run` lists all 6 autonomous scripts and 2 lib files (autospec-loop.sh, autospec-harness-detect.sh) in the install plan

## Closes

Closes #1379