### PR TITLE
feat(conductor): wire outcome-ledger consult + record (F5, #1397)

### DIFF
--- a/scripts/lib/autospec-loop.sh
+++ b/scripts/lib/autospec-loop.sh
@@ -402,9 +402,15 @@ PY
 #   4b. Main-health gate (autonomous-resilience.sh main-health): red main →
 #      halt Tier-1 merges; pending → skip drain this cycle (never drain onto red)
 #   5. Drain via AUTOSPEC_RUN_CMD (inherits autospec-run path)
+#   5b. Outcome-ledger wiring (F5): after drain, record per-source ship/fail
+#       outcome for explore-filed issues (is_discovery=true in last-outcome.json).
+#       Tier-1 backlog issues do not write the file; recording is silently skipped.
 #   6. Spend-ledger tally (autonomous-spend-ledger.sh); park on cap
 #   7. Once-per-UTC-day digest to .autospec/autonomous-digest.md + pinned issue
 #   8. On park (spend/usage): arm ScheduleWakeup/cron via autospec-usage-limit.sh
+#   9. Tier 2+ discovery (not yet enabled in Phase 1): consult explore-source-
+#      weights.sh before the discovery cycle ranks proposals, then park.
+#      When F2 enables Tier 2, the cycle runs here with AUTOSPEC_EXPLORE_LEDGER set.
 #
 # Tiers 2-4 are not enabled in Phase 1; a dry Tier-1 parks and notifies.
 #
@@ -415,9 +421,13 @@ PY
 #   CONDUCTOR_POLL_INTERVAL seconds to sleep between cycles (default 60)
 #   CONDUCTOR_DRY_RUN       1 = log only; no autospec-run invocations
 #   CONDUCTOR_NO_DIGEST     1 = skip daily digest writes
-#   AUTOSPEC_RUN_CMD        override autospec-run invocation (for tests/dry-run)
-#   AUTOSPEC_SCRIPTS_DIR    installed scripts path (fallback for helpers)
-#   AUTOSPEC_SESSION_ID     stable session identifier (default: conductor-$$)
+#   AUTOSPEC_RUN_CMD              override autospec-run invocation (for tests/dry-run)
+#   AUTOSPEC_SCRIPTS_DIR          installed scripts path (fallback for helpers)
+#   AUTOSPEC_SESSION_ID           stable session identifier (default: conductor-$$)
+#   AUTOSPEC_EXPLORE_LEDGER       outcome ledger path (default: .autospec/explore-ledger.jsonl)
+#   AUTOSPEC_EXPLORE_LEDGER_BIN   explicit path to explore-ledger.sh (for tests)
+#   AUTOSPEC_EXPLORE_WEIGHTS_BIN  explicit path to explore-source-weights.sh (for tests)
+#   AUTOSPEC_LAST_OUTCOME_FILE    path the run command writes discovery outcomes to
 #
 # Safety rules (AGENTS.md):
 #   set -eu; if/then/fi for one-sided conditionals; no RETURN traps;
@@ -440,6 +450,38 @@ autospec_conductor_run() {
     local _gate="${_sdir}/autonomous-premerge-gate.sh"
     local _resilience="${_sdir}/autonomous-resilience.sh"
     local _usage_limit="${_sdir}/autospec-usage-limit.sh"
+
+    # ── Ledger wiring (F5) ─────────────────────────────────────────────────────
+    # Resolve repo root (parent of scripts/ dir) for ledger data file path.
+    local _repo_root
+    _repo_root="$(cd "${_sdir}/.." 2>/dev/null && pwd || printf '.')"
+
+    # Resolve outcome ledger data path (env override > default under repo root).
+    local _ledger_path="${AUTOSPEC_EXPLORE_LEDGER:-${_repo_root}/.autospec/explore-ledger.jsonl}"
+
+    # Resolve explore-ledger.sh (fail-open: missing script is benign).
+    local _ledger_sh=""
+    if [ -n "${AUTOSPEC_EXPLORE_LEDGER_BIN:-}" ] && [ -x "$AUTOSPEC_EXPLORE_LEDGER_BIN" ]; then
+        _ledger_sh="$AUTOSPEC_EXPLORE_LEDGER_BIN"
+    elif [ -n "${AUTOSPEC_SCRIPTS_DIR:-}" ] && [ -f "${AUTOSPEC_SCRIPTS_DIR}/explore-ledger.sh" ]; then
+        _ledger_sh="${AUTOSPEC_SCRIPTS_DIR}/explore-ledger.sh"
+    elif [ -f "${_sdir}/explore-ledger.sh" ]; then
+        _ledger_sh="${_sdir}/explore-ledger.sh"
+    elif [ -f "${_sdir}/../skills/autospec-shared/scripts/explore-ledger.sh" ]; then
+        _ledger_sh="${_sdir}/../skills/autospec-shared/scripts/explore-ledger.sh"
+    fi
+
+    # Resolve explore-source-weights.sh (same resolution order as explore-research-cycle.sh).
+    local _weights_bin=""
+    if [ -n "${AUTOSPEC_EXPLORE_WEIGHTS_BIN:-}" ] && [ -x "$AUTOSPEC_EXPLORE_WEIGHTS_BIN" ]; then
+        _weights_bin="$AUTOSPEC_EXPLORE_WEIGHTS_BIN"
+    elif [ -n "${AUTOSPEC_SCRIPTS_DIR:-}" ] && [ -f "${AUTOSPEC_SCRIPTS_DIR}/explore-source-weights.sh" ]; then
+        _weights_bin="${AUTOSPEC_SCRIPTS_DIR}/explore-source-weights.sh"
+    elif [ -f "${_sdir}/explore-source-weights.sh" ]; then
+        _weights_bin="${_sdir}/explore-source-weights.sh"
+    elif [ -f "${_sdir}/../skills/autospec-shared/scripts/explore-source-weights.sh" ]; then
+        _weights_bin="${_sdir}/../skills/autospec-shared/scripts/explore-source-weights.sh"
+    fi
 
     # Locate notify.sh: script-relative, then PATH.
     local _notify_sh=""
@@ -613,6 +655,37 @@ autospec_conductor_run() {
                             else
                                 printf '[conductor] WARN: AUTOSPEC_RUN_CMD not set; skipping drain\n' >&2
                             fi
+                            # ── Step 5b: Record per-source outcome for discovery issues ──
+                            # Tier-1 backlog issues do not write this file; recording is
+                            # silently skipped when absent.  All ledger calls are best-effort
+                            # and never abort the cycle.
+                            local _outcome_file
+                            _outcome_file="${AUTOSPEC_LAST_OUTCOME_FILE:-${_repo_root}/.autospec/last-outcome.json}"
+                            if [ -f "$_outcome_file" ]; then
+                                if [ -n "$_ledger_sh" ]; then
+                                    local _is_disc _issue_num _source_val _outcome_val
+                                    _is_disc="$(jq -r '.is_discovery // false' "$_outcome_file" 2>/dev/null || true)"
+                                    if [ "$_is_disc" = "true" ]; then
+                                        _issue_num="$(jq -r '.issue // 0' "$_outcome_file" 2>/dev/null || true)"
+                                        _source_val="$(jq -r '.source // ""' "$_outcome_file" 2>/dev/null || true)"
+                                        _outcome_val="$(jq -r '.outcome // "stalled"' "$_outcome_file" 2>/dev/null || true)"
+                                        if [ -n "$_issue_num" ] && [ "$_issue_num" != "0" ] \
+                                            && [ -n "$_source_val" ]; then
+                                            printf '[conductor] recording discovery outcome: issue=%s source=%s outcome=%s\n' \
+                                                "$_issue_num" "$_source_val" "$_outcome_val" >&2
+                                            bash "$_ledger_sh" \
+                                                --ledger "$_ledger_path" \
+                                                --update-outcome "$_issue_num" "$_outcome_val" \
+                                                2>/dev/null || true
+                                        fi
+                                    fi
+                                else
+                                    printf '[conductor] WARN: explore-ledger.sh unresolved; discarding outcome file\n' >&2
+                                fi
+                                # Always consume the outcome file so a later cycle never
+                                # re-processes a stale outcome (LOW review fix).
+                                rm -f "$_outcome_file" 2>/dev/null || true
+                            fi
                         fi
                         _work_done=1
                         _dry_cycles=0
@@ -635,7 +708,19 @@ autospec_conductor_run() {
             esac
 
         else
-            # Tier 2+ are not enabled in Phase 1 — park and notify.
+            # Tier 2+ are not enabled in Phase 1.
+            # Consult source weights before discovery ranking (best-effort).
+            # The ranking already reads them via explore-research-cycle.sh;
+            # the conductor passes AUTOSPEC_EXPLORE_LEDGER so the cycle picks
+            # up the right ledger when F2 enables Tier 2.
+            if [ -n "$_weights_bin" ] && [ -x "$_weights_bin" ]; then
+                printf '[conductor] consulting source weights for discovery cycle (Tier %s)\n' \
+                    "$_tier" >&2
+                "$_weights_bin" --json --ledger "$_ledger_path" \
+                    >/dev/null 2>&1 || true
+            fi
+            export AUTOSPEC_EXPLORE_LEDGER="$_ledger_path"
+            # Park and notify.
             printf '[conductor] Tier %s not enabled in Phase 1; dry-cycles=%s — parking\n' \
                 "$_tier" "$_dry_cycles" >&2
             if [ -n "$_notify_sh" ]; then

--- a/tests/autonomous/test_outcome_ledger.bats
+++ b/tests/autonomous/test_outcome_ledger.bats
@@ -1,0 +1,278 @@
+#!/usr/bin/env bats
+# tests/autonomous/test_outcome_ledger.bats — outcome-ledger wiring unit tests
+# for autospec_conductor_run() (F5, issue #1397).
+#
+# Covers:
+#  - conductor invokes explore-source-weights.sh before a Tier 2+ discovery cycle
+#  - a shipped discovery issue (is_discovery=true last-outcome.json) triggers
+#    exactly 1 explore-ledger.sh --update-outcome call with the correct issue
+#    and outcome (source is resolved internally by the ledger, not passed)
+#  - a ledger call that returns non-zero does not abort the cycle (fail-open)
+#  - Tier-1 backlog issues (no last-outcome.json) do not trigger ledger recording
+#
+# All external scripts (explore-ledger.sh, explore-source-weights.sh, gh,
+# autonomous-premerge-gate.sh, autonomous-waterfall.sh, autonomous-resilience.sh,
+# autonomous-spend-ledger.sh) are stubbed via PATH injection so no network or
+# disk side-effects occur.
+#
+# Bash 3.2 compat: no [[ ]], no process substitution in [ -f ].
+# set -eu + if/then/fi; jq capture()/== (no interpolated test()).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    LIB="$REPO_ROOT/scripts/lib/autospec-loop.sh"
+
+    # Isolated temp dir per test.
+    TMP="$(mktemp -d -t conductor_ledger.XXXXXX)"
+    export PATH="$TMP/bin:$PATH"
+    mkdir -p "$TMP/bin" "$TMP/scripts" "$TMP/repo/.autospec"
+
+    # ── Stubs ──────────────────────────────────────────────────────────────────
+
+    # autonomous-waterfall.sh: default → Tier 1 run-backlog.
+    cat > "$TMP/bin/autonomous-waterfall.sh" <<'SH'
+#!/usr/bin/env bash
+printf '{"tier":1,"action":"run-backlog","reason":"stub"}\n'
+exit 0
+SH
+
+    # autonomous-premerge-gate.sh: default → merge-ok.
+    cat > "$TMP/bin/autonomous-premerge-gate.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'merge-ok\n'
+exit 0
+SH
+
+    # autonomous-resilience.sh: no-op (fail-open).
+    cat > "$TMP/bin/autonomous-resilience.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
+    # autonomous-spend-ledger.sh: always "continue".
+    cat > "$TMP/bin/autonomous-spend-ledger.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'continue\n'
+exit 0
+SH
+
+    # autonomous-control-channel.sh: no control signal.
+    cat > "$TMP/bin/autonomous-control-channel.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
+    # gh: no-op stub.
+    cat > "$TMP/bin/gh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
+    # explore-source-weights.sh: records call, emits empty JSON.
+    WEIGHTS_LOG="$TMP/weights.log"
+    export WEIGHTS_LOG
+    cat > "$TMP/bin/explore-source-weights.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$WEIGHTS_LOG"
+printf '{}\n'
+exit 0
+SH
+
+    # explore-ledger.sh: records call, exits 0 by default.
+    LEDGER_LOG="$TMP/ledger.log"
+    export LEDGER_LOG
+    cat > "$TMP/bin/explore-ledger.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$LEDGER_LOG"
+exit 0
+SH
+
+    chmod +x "$TMP/bin/"*
+
+    # Export overrides so the conductor resolves our stubs.
+    export AUTOSPEC_EXPLORE_WEIGHTS_BIN="$TMP/bin/explore-source-weights.sh"
+    export AUTOSPEC_EXPLORE_LEDGER_BIN="$TMP/bin/explore-ledger.sh"
+    export AUTOSPEC_EXPLORE_LEDGER="$TMP/repo/.autospec/explore-ledger.jsonl"
+    export AUTOSPEC_LAST_OUTCOME_FILE="$TMP/repo/.autospec/last-outcome.json"
+
+    # Use $TMP/bin as CONDUCTOR_SCRIPTS_DIR so all helpers resolve to our stubs.
+    export CONDUCTOR_SCRIPTS_DIR="$TMP/bin"
+    export CONDUCTOR_REPO=""
+    export CONDUCTOR_NO_DIGEST=1
+    export CONDUCTOR_POLL_INTERVAL=0
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+# Helper: source the lib and run conductor with 1 cycle, then return.
+_run_conductor_1() {
+    # We source the lib so autospec_conductor_run is available, then call it
+    # with CONDUCTOR_MAX_CYCLES=1. AUTOSPEC_RUN_CMD is set by each test.
+    CONDUCTOR_MAX_CYCLES=1 bash -c "
+        . '$LIB'
+        autospec_conductor_run
+    " 2>&1
+}
+
+# ─── Tier 2+ weights consultation ─────────────────────────────────────────────
+
+@test "conductor consults explore-source-weights.sh when Tier 2 waterfall fires" {
+    # Override waterfall stub to return Tier 2 (not-enabled → weights consult + park).
+    cat > "$TMP/bin/autonomous-waterfall.sh" <<'SH'
+#!/usr/bin/env bash
+printf '{"tier":2,"action":"run-discovery","reason":"stub"}\n'
+exit 0
+SH
+
+    export AUTOSPEC_RUN_CMD=""   # no drain needed
+    run _run_conductor_1
+    # Weights script must have been invoked.
+    [ -f "$WEIGHTS_LOG" ]
+    weights_calls="$(wc -l < "$WEIGHTS_LOG" | tr -d ' ')"
+    [ "$weights_calls" -ge 1 ]
+}
+
+@test "conductor passes ledger path to explore-source-weights.sh" {
+    cat > "$TMP/bin/autonomous-waterfall.sh" <<'SH'
+#!/usr/bin/env bash
+printf '{"tier":2,"action":"run-discovery","reason":"stub"}\n'
+exit 0
+SH
+
+    export AUTOSPEC_RUN_CMD=""
+    run _run_conductor_1
+    [ -f "$WEIGHTS_LOG" ]
+    # The call must include --ledger.
+    grep -q -- '--ledger' "$WEIGHTS_LOG"
+}
+
+# ─── Discovery-issue outcome recording ────────────────────────────────────────
+
+@test "shipped discovery issue triggers exactly 1 explore-ledger --update-outcome call" {
+    # AUTOSPEC_RUN_CMD writes a discovery outcome file then exits.
+    cat > "$TMP/run-cmd.sh" <<SH
+#!/usr/bin/env bash
+printf '{"is_discovery":true,"issue":42,"source":"spec-vs-code","outcome":"merged_clean"}' \
+    > "$AUTOSPEC_LAST_OUTCOME_FILE"
+exit 0
+SH
+    chmod +x "$TMP/run-cmd.sh"
+    export AUTOSPEC_RUN_CMD="bash $TMP/run-cmd.sh"
+
+    run _run_conductor_1
+    [ -f "$LEDGER_LOG" ]
+    ledger_calls="$(wc -l < "$LEDGER_LOG" | tr -d ' ')"
+    [ "$ledger_calls" -eq 1 ]
+    grep -q -- '--update-outcome' "$LEDGER_LOG"
+}
+
+@test "outcome record call includes the issue number from last-outcome.json" {
+    cat > "$TMP/run-cmd.sh" <<SH
+#!/usr/bin/env bash
+printf '{"is_discovery":true,"issue":99,"source":"prior-reports","outcome":"merged_clean"}' \
+    > "$AUTOSPEC_LAST_OUTCOME_FILE"
+exit 0
+SH
+    chmod +x "$TMP/run-cmd.sh"
+    export AUTOSPEC_RUN_CMD="bash $TMP/run-cmd.sh"
+
+    run _run_conductor_1
+    [ -f "$LEDGER_LOG" ]
+    grep -q '99' "$LEDGER_LOG"
+}
+
+@test "outcome record call includes the outcome value from last-outcome.json" {
+    cat > "$TMP/run-cmd.sh" <<SH
+#!/usr/bin/env bash
+printf '{"is_discovery":true,"issue":7,"source":"codebase-signals","outcome":"qa_failed"}' \
+    > "$AUTOSPEC_LAST_OUTCOME_FILE"
+exit 0
+SH
+    chmod +x "$TMP/run-cmd.sh"
+    export AUTOSPEC_RUN_CMD="bash $TMP/run-cmd.sh"
+
+    run _run_conductor_1
+    [ -f "$LEDGER_LOG" ]
+    grep -q 'qa_failed' "$LEDGER_LOG"
+}
+
+# ─── Fail-open: ledger errors never abort the cycle ───────────────────────────
+
+@test "failing explore-ledger.sh does not abort the conductor cycle" {
+    # Override ledger stub to return non-zero.
+    cat > "$TMP/bin/explore-ledger.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$LEDGER_LOG"
+exit 2
+SH
+    chmod +x "$TMP/bin/explore-ledger.sh"
+
+    cat > "$TMP/run-cmd.sh" <<SH
+#!/usr/bin/env bash
+printf '{"is_discovery":true,"issue":5,"source":"open-issues","outcome":"merged_clean"}' \
+    > "$AUTOSPEC_LAST_OUTCOME_FILE"
+exit 0
+SH
+    chmod +x "$TMP/run-cmd.sh"
+    export AUTOSPEC_RUN_CMD="bash $TMP/run-cmd.sh"
+
+    # Conductor must exit 0 even though the ledger call fails.
+    run _run_conductor_1
+    [ "$status" -eq 0 ]
+}
+
+@test "failing explore-source-weights.sh does not abort the conductor cycle" {
+    cat > "$TMP/bin/autonomous-waterfall.sh" <<'SH'
+#!/usr/bin/env bash
+printf '{"tier":2,"action":"run-discovery","reason":"stub"}\n'
+exit 0
+SH
+    # Override weights stub to return non-zero.
+    cat > "$TMP/bin/explore-source-weights.sh" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$WEIGHTS_LOG"
+exit 1
+SH
+    chmod +x "$TMP/bin/explore-source-weights.sh"
+
+    export AUTOSPEC_RUN_CMD=""
+    run _run_conductor_1
+    [ "$status" -eq 0 ]
+}
+
+# ─── Tier-1 backlog issues skip ledger recording ──────────────────────────────
+
+@test "Tier-1 backlog issue (no last-outcome.json) does not trigger ledger recording" {
+    # AUTOSPEC_RUN_CMD does NOT write a last-outcome.json.
+    cat > "$TMP/run-cmd.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    chmod +x "$TMP/run-cmd.sh"
+    export AUTOSPEC_RUN_CMD="bash $TMP/run-cmd.sh"
+
+    run _run_conductor_1
+    # ledger.log must not exist (or be empty — no update-outcome call).
+    if [ -f "$LEDGER_LOG" ]; then
+        grep -v '^$' "$LEDGER_LOG" | grep -c '--update-outcome' | grep -q '^0$'
+    fi
+}
+
+@test "last-outcome.json with is_discovery=false is silently skipped" {
+    cat > "$TMP/run-cmd.sh" <<SH
+#!/usr/bin/env bash
+printf '{"is_discovery":false,"issue":3,"source":"spec-vs-code","outcome":"merged_clean"}' \
+    > "$AUTOSPEC_LAST_OUTCOME_FILE"
+exit 0
+SH
+    chmod +x "$TMP/run-cmd.sh"
+    export AUTOSPEC_RUN_CMD="bash $TMP/run-cmd.sh"
+
+    run _run_conductor_1
+    if [ -f "$LEDGER_LOG" ]; then
+        count="$(grep -c -- '--update-outcome' "$LEDGER_LOG" || true)"
+        [ "$count" -eq 0 ]
+    fi
+}


### PR DESCRIPTION
## Summary

Wires the autonomous conductor (`autospec_conductor_run()` in `scripts/lib/autospec-loop.sh`) to close the explore discovery loop (spec §F5):

- **(a) Consult** `explore-source-weights.sh` before a Tier 2+ discovery cycle ranks proposals. The ranking in `explore-research-cycle.sh` already reads the weights; the conductor resolves the weights bin and passes `AUTOSPEC_EXPLORE_LEDGER` through so the cycle picks up the right ledger when F2 enables Tier 2.
- **(b) Record** per-source ship/fail outcomes via `explore-ledger.sh --update-outcome` after each drain. The run command writes a discovery outcome file (`is_discovery=true`); the conductor reads it, records the outcome, and consumes the file. Tier-1 backlog issues write no file and are silently skipped.

So discovery biases toward sources that historically merge clean and stops re-proposing rejected work.

## Reuse

No reuse — the conductor had no ledger seam. This adds the consult/record boundary using the **existing** `explore-ledger.sh` / `explore-source-weights.sh` interfaces (does not reimplement them).

## Safety

All ledger/weights calls are best-effort (`|| true`) and never abort the cycle. jq reads use `-r` + `// default` (no interpolated `test()`). `set -eu` + `if/then/fi`; bash 3.2 clean; no RETURN traps. Outcome file is always consumed even when the ledger script is unresolved (prevents stale re-processing).

## Tests

`tests/autonomous/test_outcome_ledger.bats` (9 tests): weights consult, ledger-path propagation, issue/outcome capture, fail-open for both scripts, and both skip paths. External scripts stubbed via PATH injection — no network/disk leakage.

## Verification

- `bats tests/autonomous/test_outcome_ledger.bats` — 9/9 pass
- `bash scripts/validate.sh` — OK, all checks passed (178 pytest + all bats green) on rebased tree
- Guardian + LGTM review: APPROVE (0 blocking)

Closes #1397

🤖 Generated with [Claude Code](https://claude.com/claude-code)