### PR TITLE
fix(autonomous): usage-governor fail-open on malformed JSON + visible arm-failure

### DIFF
--- a/scripts/autonomous-usage-governor.sh
+++ b/scripts/autonomous-usage-governor.sh
@@ -212,25 +212,35 @@ do_soft_park() {
     fi
 
     # Arm autospec-usage-limit.sh if a resume command was supplied.
+    #
+    # The park verdict is the safety-critical output: at/over the soft threshold
+    # we MUST stop spending, so a failed arm never suppresses the park (failing
+    # closed here would mean "keep spending", the unsafe direction). But a silent
+    # arm failure leaves the operator parked with no durable auto-resume, so the
+    # failure is surfaced loudly on stderr rather than swallowed by `|| true`.
     if [ -n "$RESUME_COMMAND" ]; then
         limit_sh="$(find_script "autospec-usage-limit.sh")"
         if [ -n "$limit_sh" ]; then
+            arm_rc=0
             if [ -n "$RUN_ID" ]; then
                 bash "$limit_sh" arm \
                     --harness "$HARNESS" \
                     --repo-dir "$REPO_DIR" \
                     --command "$RESUME_COMMAND" \
                     --resume-at "$RESUME_AT" \
-                    --run-id "$RUN_ID" || true
+                    --run-id "$RUN_ID" || arm_rc=$?
             else
                 bash "$limit_sh" arm \
                     --harness "$HARNESS" \
                     --repo-dir "$REPO_DIR" \
                     --command "$RESUME_COMMAND" \
-                    --resume-at "$RESUME_AT" || true
+                    --resume-at "$RESUME_AT" || arm_rc=$?
+            fi
+            if [ "$arm_rc" -ne 0 ]; then
+                info "WARNING: autospec-usage-limit.sh arm failed (rc=${arm_rc}); parked WITHOUT durable auto-resume — operator must resume manually"
             fi
         else
-            info "autospec-usage-limit.sh not found; skipping arm"
+            info "autospec-usage-limit.sh not found; skipping arm (no durable auto-resume)"
         fi
     fi
 
@@ -248,9 +258,12 @@ if [ -n "$observe_sh" ]; then
     observe_json="$(bash "$observe_sh" "$HARNESS" 2>/dev/null)" || observe_rc=$?
 
     if [ "$observe_rc" -eq 0 ] && [ -n "$observe_json" ]; then
-        observable="$(printf '%s' "$observe_json" | jq -r '.observable // "false"')"
+        # Guard jq against malformed observe JSON (2>/dev/null || echo fallback):
+        # under set -e an unguarded jq failure in this command substitution would
+        # abort the script, breaking the fail-open continue|park contract.
+        observable="$(printf '%s' "$observe_json" | jq -r '.observable // "false"' 2>/dev/null || echo false)"
         if [ "$observable" = "true" ]; then
-            live_pct="$(printf '%s' "$observe_json" | jq -r '.percent // "null"')"
+            live_pct="$(printf '%s' "$observe_json" | jq -r '.percent // "null"' 2>/dev/null || echo null)"
             if is_valid_percent "$live_pct"; then
                 # Compare live_pct to SOFT_PCT using awk (handles decimals; avoids
                 # shell integer overflow; exit 0 = at/above threshold).
@@ -276,7 +289,11 @@ if [ -n "$ledger_sh" ]; then
     ledger_json="$(bash "$ledger_sh" status --repo-dir "$REPO_DIR" 2>/dev/null)" || ledger_rc=$?
 
     if [ "$ledger_rc" -eq 0 ] && [ -n "$ledger_json" ]; then
-        current_tokens="$(printf '%s' "$ledger_json" | jq -r '.tokens // 0')"
+        # Guard jq against malformed ledger JSON: under set -e an unguarded jq
+        # failure in this main-body command substitution aborted the script with
+        # a non-zero exit and NO verdict (reproducible rc 5), violating the
+        # fail-open continue|park contract. 2>/dev/null || echo 0 keeps it open.
+        current_tokens="$(printf '%s' "$ledger_json" | jq -r '.tokens // 0' 2>/dev/null || echo 0)"
         if ! is_valid_integer "$current_tokens"; then
             current_tokens=0
         fi

--- a/tests/autonomous/test_usage_governor.bats
+++ b/tests/autonomous/test_usage_governor.bats
@@ -393,3 +393,55 @@ SH
     [ "$status" -eq 0 ]
     [ "$output" = "continue" ]
 }
+
+# ── Regression: malformed-JSON fail-open (#1409 hardening) ────────────────────
+# A safety governor must never abort with no verdict. Before the jq guards, a
+# malformed ledger/observe payload under set -e aborted the script (rc 5) with
+# empty stdout, breaking the advertised continue|park contract.
+
+@test "malformed observe JSON falls through to ledger tally (fail-open, rc 0)" {
+    cat > "$TEST_DIR/usage-observe.sh" <<'SH'
+#!/usr/bin/env bash
+echo "this is not json {{{"
+SH
+    chmod +x "$TEST_DIR/usage-observe.sh"
+
+    _write_ledger_mock 9000000
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=10000000 run_governor claude
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q '^park '
+}
+
+@test "malformed ledger JSON emits continue, never aborts (fail-open, rc 0)" {
+    # observe is unobservable so we reach the ledger path.
+    _write_observe_mock_unobservable
+    cat > "$TEST_DIR/autonomous-spend-ledger.sh" <<'SH'
+#!/usr/bin/env bash
+echo "not json at all {{{"
+SH
+    chmod +x "$TEST_DIR/autonomous-spend-ledger.sh"
+
+    AUTOSPEC_AUTONOMOUS_LIFETIME_TOKENS=10000000 run_governor claude
+    [ "$status" -eq 0 ]
+    [ "$output" = "continue" ]
+}
+
+# ── Regression: failed arm still parks and warns (safety-first) ───────────────
+
+@test "arm failure still parks and warns on stderr" {
+    _write_observe_mock_observable 90
+    # usage-limit mock that fails.
+    cat > "$TEST_DIR/autospec-usage-limit.sh" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+    chmod +x "$TEST_DIR/autospec-usage-limit.sh"
+
+    run bash "$SCRIPT" claude \
+        --repo-dir "$REPO_DIR" \
+        --resume-command "autospec-autonomous resume" \
+        --wait-seconds 3600
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q '^park '
+    printf '%s\n' "$output" | grep -q 'WARNING: autospec-usage-limit.sh arm failed'
+}


### PR DESCRIPTION
## Summary

Hardens the F6b usage-governor (`scripts/autonomous-usage-governor.sh`) that was merged in #1409 (issue #1401). A peer-review of the just-merged code surfaced two defects in the safety governor; this is a focused follow-up bugfix (the original issue is already closed/merged, so this is **not** a duplicate of #1401).

## Findings fixed

**HIGH — fail-open contract violation.** The governor advertises "exit code always 0; stdout is `continue` | `park <resume-at>`". Under `set -e`, an unguarded `jq` failure on **malformed** observe/ledger JSON aborted the whole script with `rc 5` and **no verdict** on stdout. For a safety governor whose entire purpose is to halt runaway autonomous spend, an undefined abort is dangerous (the caller has no decision to act on). Reproducible before the fix:

```
# malformed ledger status -> rc 5, empty stdout
```

Fix: `2>/dev/null || echo <fallback>` on every `jq` read (observe `.observable`, observe `.percent`, ledger `.tokens`), so a broken upstream payload fails open — falls through to the next signal source and ultimately emits `continue`.

**MEDIUM — silent arm failure.** A failed `autospec-usage-limit.sh arm` was swallowed by `|| true` while the governor still printed `park`, leaving the operator parked with no durable auto-resume **and no signal**. The park verdict is deliberately preserved (failing closed here would mean "keep spending" — the unsafe direction), but the arm failure is now surfaced loudly on stderr so the operator knows to resume manually.

## Tests

3 new regression tests in `tests/autonomous/test_usage_governor.bats`:
- malformed observe JSON falls through to ledger tally (fail-open, rc 0)
- malformed ledger JSON emits `continue`, never aborts (fail-open, rc 0)
- arm failure still parks **and** warns on stderr

31/31 governor tests pass. `bash scripts/validate.sh` exits 0.

## Reuse

Reusing the existing `find_script` / `find_notify` helpers and the established subprocess-mock-on-PATH test pattern; no new patterns introduced.

## Known lint notes (benign)
- `DOC_OUT_OF_SYNC` fires on the arm block because edited lines carry pre-existing `--flag` strings (no **new** public surface); the governor's flags are unchanged. `is_doc_file`'s top-level `README*` glob also doesn't recognize the nested skill README, so it is a known false positive.
- Test file is 447 LOC (was 395 on main; soft cap 400) — the 3 regression tests are worth the small overage.

## Out of scope (follow-up needed)
Peer-review also noted the governor is **not yet wired** into the conductor (`scripts/lib/autospec-loop.sh`) or the per-skill installer (`AUTONOMOUS_SCRIPT_FILES` in `skills/autospec-autonomous/install.sh`, which also omits F6a's `usage-observe.sh`). That is an integration concern beyond this bugfix and beyond #1401's 2-file scope — it should be tracked as a separate F6 integration issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)