### PR TITLE
feat(autonomous): Tier 2/3 enablement + escalation state machine (F2)

### DIFF
--- a/scripts/autonomous-waterfall.sh
+++ b/scripts/autonomous-waterfall.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
-# scripts/autonomous-waterfall.sh — Phase-1 tier-selection decision helper.
+# scripts/autonomous-waterfall.sh — Tier-selection decision helper.
 #
 # Evaluates tiers top-down per conductor cycle and emits a machine-readable
 # JSON decision on stdout:
 #   { "tier": N, "action": "<string>", "reason": "<string>" }
 #
-# Phase-1 scope (only tiers 0 and 1 are enabled):
+# Tiers:
 #   Tier 0 — Control channel (preempts everything): a control label is present.
 #   Tier 1 — Backlog (open auto-implement issues via gh).
-#   Tiers 2–4 — Discovery/polish: NOT YET ENABLED; always print not-enabled.
+#   Tier 2 — Local discovery: explore --once over local sources (spec-vs-code,
+#             codebase-signals, source-analysis, dependency-health, prior-reports).
+#             Selected after Tier 1 is dry for AUTOSPEC_AUTO_DRY_CYCLES cycles.
+#   Tier 3 — Internet discovery: explore --once --research-sources internet.
+#             Selected after Tier 2 is dry for AUTOSPEC_AUTO_DRY_CYCLES cycles.
 #
-# Dry-cycle escalation: if the backlog is empty for < AUTOSPEC_AUTO_DRY_CYCLES
-# consecutive cycles, stay at Tier 1 (don't jump to Tier 2+). The caller
-# tracks dry cycles and passes --dry-cycles N.
+# Dry-cycle escalation:
+#   The caller tracks dry cycles per tier and passes --dry-cycles (Tier 1) and
+#   --tier2-dry-cycles (Tier 2). A non-empty backlog floats selection back to
+#   Tier 1 next cycle (dry counters are managed by the conductor).
 #
 # Usage:
 #   autonomous-waterfall.sh [options]
@@ -20,7 +25,8 @@
 # Options:
 #   --control-decision LABEL   Active control label (e.g. autospec:pause).
 #                              Empty string / omit = no control signal.
-#   --dry-cycles N             Consecutive dry cycles so far (default 0).
+#   --dry-cycles N             Consecutive Tier-1 dry cycles so far (default 0).
+#   --tier2-dry-cycles N       Consecutive Tier-2 dry cycles so far (default 0).
 #   --repo OWNER/REPO          GitHub repo for backlog count (default: detect
 #                              from git remote).
 #   --backlog-count N          Inject backlog count directly (skips gh call;
@@ -36,6 +42,7 @@ set -u
 # ─── defaults ──────────────────────────────────────────────────────────────────
 CONTROL_DECISION=""
 DRY_CYCLES=0
+TIER2_DRY_CYCLES=0
 REPO=""
 BACKLOG_COUNT_INJECT=""          # non-empty → skip gh call
 DRY_CYCLES_THRESHOLD="${AUTOSPEC_AUTO_DRY_CYCLES:-2}"
@@ -47,7 +54,8 @@ Usage: autonomous-waterfall.sh [options]
 
 Options:
   --control-decision LABEL   Active control label (autospec:pause, etc.).
-  --dry-cycles N             Consecutive dry cycles (default 0).
+  --dry-cycles N             Consecutive Tier-1 dry cycles (default 0).
+  --tier2-dry-cycles N       Consecutive Tier-2 dry cycles (default 0).
   --repo OWNER/REPO          GitHub repo slug.
   --backlog-count N          Inject backlog count (bypasses gh; for testing).
   -h, --help                 Print this help.
@@ -56,7 +64,7 @@ Env:
   AUTOSPEC_AUTO_DRY_CYCLES   Dry-cycle escalation threshold (default 2).
 
 Output (stdout):
-  {"tier":<0|1|2|3|4>,"action":"<string>","reason":"<string>"}
+  {"tier":<0|1|2|3>,"action":"<string>","reason":"<string>"}
 EOF
 }
 
@@ -69,11 +77,12 @@ emit() {
 # ─── arg parsing ───────────────────────────────────────────────────────────────
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        --control-decision) CONTROL_DECISION="$2"; shift 2 ;;
-        --dry-cycles)       DRY_CYCLES="$2";       shift 2 ;;
-        --repo)             REPO="$2";             shift 2 ;;
-        --backlog-count)    BACKLOG_COUNT_INJECT="$2"; shift 2 ;;
-        -h|--help)          usage; exit 0 ;;
+        --control-decision)  CONTROL_DECISION="$2";    shift 2 ;;
+        --dry-cycles)        DRY_CYCLES="$2";          shift 2 ;;
+        --tier2-dry-cycles)  TIER2_DRY_CYCLES="$2";   shift 2 ;;
+        --repo)              REPO="$2";                shift 2 ;;
+        --backlog-count)     BACKLOG_COUNT_INJECT="$2"; shift 2 ;;
+        -h|--help)           usage; exit 0 ;;
         *) printf 'autonomous-waterfall: unknown arg: %s\n' "$1" >&2; usage; exit 2 ;;
     esac
 done
@@ -115,12 +124,20 @@ if [ "$backlog_count" -gt 0 ] 2>/dev/null; then
     exit 0
 fi
 
-# Backlog is empty — check dry-cycle threshold before escalating.
+# Backlog is empty — check Tier-1 dry-cycle threshold before escalating.
 if [ "$DRY_CYCLES" -lt "$DRY_CYCLES_THRESHOLD" ] 2>/dev/null; then
     emit 1 "run-backlog" "backlog empty but dry-cycles=$DRY_CYCLES < threshold=$DRY_CYCLES_THRESHOLD; staying at Tier 1"
     exit 0
 fi
 
-# ─── Tiers 2–4 — NOT YET ENABLED (Phase 2/3) ──────────────────────────────────
-emit 2 "not-yet-enabled" "Tier 2 (local discovery) is not enabled in Phase 1; dry-cycles=$DRY_CYCLES >= threshold=$DRY_CYCLES_THRESHOLD"
+# ─── Tier 2 — Local discovery via explore --once ───────────────────────────────
+# Tier 1 has been dry for >= threshold cycles. Check whether Tier 2 is also
+# saturated before escalating to Tier 3.
+if [ "$TIER2_DRY_CYCLES" -lt "$DRY_CYCLES_THRESHOLD" ] 2>/dev/null; then
+    emit 2 "run-explore-once" "Tier 1 dry for $DRY_CYCLES cycle(s) >= threshold=$DRY_CYCLES_THRESHOLD; running local discovery (tier2-dry-cycles=$TIER2_DRY_CYCLES)"
+    exit 0
+fi
+
+# ─── Tier 3 — Internet discovery via explore --once --research-sources internet ─
+emit 3 "run-explore-once-internet" "Tier 2 dry for $TIER2_DRY_CYCLES cycle(s) >= threshold=$DRY_CYCLES_THRESHOLD; running internet discovery"
 exit 0

--- a/scripts/lib/autospec-loop.sh
+++ b/scripts/lib/autospec-loop.sh
@@ -493,6 +493,7 @@ autospec_conductor_run() {
 
     local _cycle=0
     local _dry_cycles=0
+    local _tier2_dry_cycles=0
     local _last_digest_day=""
     local _stop_reason=""
     local _conductor_session="${AUTOSPEC_SESSION_ID:-conductor-$$}"
@@ -568,6 +569,7 @@ autospec_conductor_run() {
         local _tier_json
         _tier_json="$(bash "$_waterfall" \
             --dry-cycles "$_dry_cycles" \
+            --tier2-dry-cycles "$_tier2_dry_cycles" \
             ${_repo:+--repo "$_repo"} \
             2>/dev/null \
             || printf '{"tier":1,"action":"run-backlog","reason":"waterfall-unavailable"}')"
@@ -707,12 +709,11 @@ autospec_conductor_run() {
                     ;;
             esac
 
-        else
-            # Tier 2+ are not enabled in Phase 1.
-            # Consult source weights before discovery ranking (best-effort).
-            # The ranking already reads them via explore-research-cycle.sh;
-            # the conductor passes AUTOSPEC_EXPLORE_LEDGER so the cycle picks
-            # up the right ledger when F2 enables Tier 2.
+        elif [ "$_action" = "run-explore-once" ] || [ "$_action" = "run-explore-once-internet" ]; then
+            # ── Tier 2/3: discovery via autospec-explore --once ───────────────
+            # Consult source weights before discovery ranking (best-effort, F5).
+            # The ranking reads them via explore-research-cycle.sh; the conductor
+            # passes AUTOSPEC_EXPLORE_LEDGER so the cycle picks up the right ledger.
             if [ -n "$_weights_bin" ] && [ -x "$_weights_bin" ]; then
                 printf '[conductor] consulting source weights for discovery cycle (Tier %s)\n' \
                     "$_tier" >&2
@@ -720,16 +721,87 @@ autospec_conductor_run() {
                     >/dev/null 2>&1 || true
             fi
             export AUTOSPEC_EXPLORE_LEDGER="$_ledger_path"
-            # Park and notify.
-            printf '[conductor] Tier %s not enabled in Phase 1; dry-cycles=%s — parking\n' \
-                "$_tier" "$_dry_cycles" >&2
-            if [ -n "$_notify_sh" ]; then
-                bash "$_notify_sh" "autospec-autonomous" \
-                    "conductor parked: backlog dry (tier $((${_tier} - 1)) exhausted); Tier 2+ not enabled" \
-                    || true
+
+            # Resolve the explore command: AUTOSPEC_EXPLORE_CMD override for
+            # tests, else the explore script sibling of this scripts/ dir.
+            local _explore_cmd="${AUTOSPEC_EXPLORE_CMD:-}"
+            if [ -z "$_explore_cmd" ]; then
+                local _explore_script="${_sdir}/autospec-explore.sh"
+                if [ -f "$_explore_script" ]; then
+                    _explore_cmd="bash $_explore_script"
+                elif command -v autospec-explore >/dev/null 2>&1; then
+                    _explore_cmd="autospec-explore"
+                fi
             fi
-            _stop_reason="phase1:tier${_tier}-not-enabled"
-            break
+
+            if [ -z "$_explore_cmd" ]; then
+                printf '[conductor] WARN: no explore command available for Tier %s — skipping\n' \
+                    "$_tier" >&2
+                if [ "$_tier" = "2" ]; then
+                    _tier2_dry_cycles=$((_tier2_dry_cycles + 1))
+                fi
+            else
+                # Build the --once invocation for the selected tier.
+                local _explore_out
+                if [ "$_dry" = "1" ]; then
+                    printf '[conductor] [dry-run] would invoke explore --once for Tier %s\n' \
+                        "$_tier" >&2
+                    # Simulate a dry yield in dry-run mode.
+                    _explore_out='{"tier":"local","proposals_seen":0,"new_candidates":0,"filed":0,"dry":true,"reason":"dry-run"}'
+                elif [ "$_action" = "run-explore-once-internet" ]; then
+                    printf '[conductor] Tier 3: invoking explore --once --research-sources internet\n' >&2
+                    _explore_out="$(bash -c "$_explore_cmd --once --research-sources internet" \
+                        2>/dev/null || printf '{"dry":true,"reason":"explore-error"}')"
+                else
+                    printf '[conductor] Tier 2: invoking explore --once (local sources)\n' >&2
+                    _explore_out="$(bash -c "$_explore_cmd --once" \
+                        2>/dev/null || printf '{"dry":true,"reason":"explore-error"}')"
+                fi
+
+                # Parse yield JSON for dryness.
+                local _explore_dry
+                _explore_dry="$(printf '%s' "$_explore_out" \
+                    | jq -r '.dry // true' 2>/dev/null || echo 'true')"
+                local _explore_filed
+                _explore_filed="$(printf '%s' "$_explore_out" \
+                    | jq -r '.filed // 0' 2>/dev/null || echo 0)"
+
+                printf '[conductor] Tier %s explore result: dry=%s filed=%s\n' \
+                    "$_tier" "$_explore_dry" "$_explore_filed" >&2
+
+                if [ "$_explore_dry" = "false" ]; then
+                    # New candidates were filed — they become Tier-1 backlog.
+                    # Float selection back up: reset both dry counters so the
+                    # waterfall selects Tier 1 next cycle.
+                    printf '[conductor] Tier %s filed %s candidate(s) — floating back to Tier 1\n' \
+                        "$_tier" "$_explore_filed" >&2
+                    _dry_cycles=0
+                    _tier2_dry_cycles=0
+                    _work_done=1
+                else
+                    # Explore was dry for this tier.
+                    if [ "$_tier" = "2" ]; then
+                        _tier2_dry_cycles=$((_tier2_dry_cycles + 1))
+                        printf '[conductor] Tier 2 dry (tier2-dry-cycles=%s)\n' \
+                            "$_tier2_dry_cycles" >&2
+                    else
+                        # Tier 3 dry — all discovery tiers exhausted; park and notify.
+                        printf '[conductor] Tier 3 dry — all discovery tiers exhausted; parking\n' >&2
+                        if [ -n "$_notify_sh" ]; then
+                            bash "$_notify_sh" "autospec-autonomous" \
+                                "conductor parked: Tier 3 (internet) discovery also dry; all tiers exhausted" \
+                                || true
+                        fi
+                        _stop_reason="discovery:all-tiers-dry"
+                        break
+                    fi
+                fi
+            fi
+        else
+            # Unknown action — log and treat as dry cycle.
+            printf '[conductor] unknown waterfall action=%s for tier=%s — skipping\n' \
+                "$_action" "$_tier" >&2
+            _dry_cycles=$((_dry_cycles + 1))
         fi
 
         # ── Step 6: Spend-ledger tally (autonomous-spend-ledger.sh) ──────────

--- a/tests/autonomous/test_waterfall.bats
+++ b/tests/autonomous/test_waterfall.bats
@@ -3,7 +3,9 @@
 #
 # Tier 0: control label always preempts.
 # Tier 1: backlog present → run-backlog; empty + dry-cycles < threshold → stay Tier 1.
-# Tiers 2-4: not-yet-enabled.
+# Tier 2: Tier 1 dry >= threshold → run-explore-once (local sources).
+# Tier 3: Tier 2 dry >= threshold → run-explore-once-internet.
+# Refill: non-empty backlog always floats back to Tier 1 regardless of dry-cycles.
 # gh is stubbed via PATH injection; no real network calls.
 
 setup() {
@@ -94,28 +96,38 @@ teardown() {
     [[ "$output" == *'"tier":1'* ]]
 }
 
-# ─── Tiers 2-4 not-yet-enabled ─────────────────────────────────────────────────
+# ─── Tier 2 escalation ─────────────────────────────────────────────────────────
 
-@test "Tiers 2-4: backlog empty + dry-cycles >= threshold emits not-yet-enabled" {
+@test "Tier 2: Tier-1 dry x2 (default threshold) selects run-explore-once" {
     run bash "$SCRIPT" \
         --backlog-count 0 \
         --dry-cycles 2
     [ "$status" -eq 0 ]
     [[ "$output" == *'"tier":2'* ]]
-    [[ "$output" == *'"action":"not-yet-enabled"'* ]]
+    [[ "$output" == *'"action":"run-explore-once"'* ]]
 }
 
-@test "Tiers 2-4: not-yet-enabled with higher dry-cycles above threshold" {
+@test "Tier 2: Tier-1 dry above threshold also selects Tier 2 when Tier-2 counter is 0" {
     run bash "$SCRIPT" \
         --backlog-count 0 \
-        --dry-cycles 5
+        --dry-cycles 5 \
+        --tier2-dry-cycles 0
     [ "$status" -eq 0 ]
     [[ "$output" == *'"tier":2'* ]]
-    [[ "$output" == *'not-yet-enabled'* ]]
+    [[ "$output" == *'"action":"run-explore-once"'* ]]
 }
 
-@test "Tiers 2-4: custom threshold via AUTOSPEC_AUTO_DRY_CYCLES env" {
-    # With threshold=3, dry-cycles=2 should still stay Tier 1.
+@test "Tier 2: Tier-1 dry >= threshold, Tier-2 dry < threshold stays at Tier 2" {
+    run bash "$SCRIPT" \
+        --backlog-count 0 \
+        --dry-cycles 2 \
+        --tier2-dry-cycles 1
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":2'* ]]
+    [[ "$output" == *'"action":"run-explore-once"'* ]]
+}
+
+@test "Tier 2: custom threshold via AUTOSPEC_AUTO_DRY_CYCLES, dry-cycles below stays Tier 1" {
     AUTOSPEC_AUTO_DRY_CYCLES=3 run bash "$SCRIPT" \
         --backlog-count 0 \
         --dry-cycles 2
@@ -123,13 +135,69 @@ teardown() {
     [[ "$output" == *'"tier":1'* ]]
 }
 
-@test "Tiers 2-4: custom threshold=3 triggers not-yet-enabled at dry-cycles=3" {
+@test "Tier 2: custom threshold=3 escalates at dry-cycles=3" {
     AUTOSPEC_AUTO_DRY_CYCLES=3 run bash "$SCRIPT" \
         --backlog-count 0 \
-        --dry-cycles 3
+        --dry-cycles 3 \
+        --tier2-dry-cycles 0
     [ "$status" -eq 0 ]
     [[ "$output" == *'"tier":2'* ]]
-    [[ "$output" == *'not-yet-enabled'* ]]
+    [[ "$output" == *'"action":"run-explore-once"'* ]]
+}
+
+# ─── Tier 3 escalation ─────────────────────────────────────────────────────────
+
+@test "Tier 3: Tier-2 dry x2 selects run-explore-once-internet" {
+    run bash "$SCRIPT" \
+        --backlog-count 0 \
+        --dry-cycles 2 \
+        --tier2-dry-cycles 2
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":3'* ]]
+    [[ "$output" == *'"action":"run-explore-once-internet"'* ]]
+}
+
+@test "Tier 3: Tier-2 dry above threshold also selects Tier 3" {
+    run bash "$SCRIPT" \
+        --backlog-count 0 \
+        --dry-cycles 10 \
+        --tier2-dry-cycles 5
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":3'* ]]
+    [[ "$output" == *'"action":"run-explore-once-internet"'* ]]
+}
+
+@test "Tier 3: custom threshold=3 escalates at tier2-dry-cycles=3" {
+    AUTOSPEC_AUTO_DRY_CYCLES=3 run bash "$SCRIPT" \
+        --backlog-count 0 \
+        --dry-cycles 3 \
+        --tier2-dry-cycles 3
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":3'* ]]
+    [[ "$output" == *'"action":"run-explore-once-internet"'* ]]
+}
+
+# ─── Refill floats back to Tier 1 ─────────────────────────────────────────────
+# When a higher tier files candidates they become backlog; next cycle the
+# waterfall sees backlog_count > 0 and selects Tier 1 regardless of dry-cycles.
+
+@test "Refill: non-empty backlog overrides high dry-cycles and tier2-dry-cycles" {
+    run bash "$SCRIPT" \
+        --backlog-count 1 \
+        --dry-cycles 99 \
+        --tier2-dry-cycles 99
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":1'* ]]
+    [[ "$output" == *'"action":"run-backlog"'* ]]
+}
+
+@test "Refill: backlog-count 3 after Tier 3 escalation returns to Tier 1" {
+    run bash "$SCRIPT" \
+        --backlog-count 3 \
+        --dry-cycles 5 \
+        --tier2-dry-cycles 5
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":1'* ]]
 }
 
 # ─── Output format ─────────────────────────────────────────────────────────────
@@ -138,6 +206,22 @@ teardown() {
     run bash "$SCRIPT" --backlog-count 1
     [ "$status" -eq 0 ]
     # All three keys must be present.
+    [[ "$output" == *'"tier":'* ]]
+    [[ "$output" == *'"action":'* ]]
+    [[ "$output" == *'"reason":'* ]]
+}
+
+@test "Tier 2 output contains tier, action, reason keys" {
+    run bash "$SCRIPT" --backlog-count 0 --dry-cycles 2 --tier2-dry-cycles 0
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"tier":'* ]]
+    [[ "$output" == *'"action":'* ]]
+    [[ "$output" == *'"reason":'* ]]
+}
+
+@test "Tier 3 output contains tier, action, reason keys" {
+    run bash "$SCRIPT" --backlog-count 0 --dry-cycles 2 --tier2-dry-cycles 2
+    [ "$status" -eq 0 ]
     [[ "$output" == *'"tier":'* ]]
     [[ "$output" == *'"action":'* ]]
     [[ "$output" == *'"reason":'* ]]


### PR DESCRIPTION
## Summary

Implements **F2** of the /autospec-autonomous Phase 2 design: replaces the not-yet-enabled Tier 2/3 stubs in `scripts/autonomous-waterfall.sh` with a real dry-cycle escalation state machine and wires per-cycle `autospec-explore --once` calls into `autospec_conductor_run()`.

## Behavior

- **Tier 1 dry** for `AUTOSPEC_AUTO_DRY_CYCLES` (default 2) consecutive cycles → **Tier 2** (`explore --once`, local sources): `run-explore-once`.
- **Tier 2 dry** for the same threshold → **Tier 3** (`explore --once --research-sources internet`): `run-explore-once-internet`.
- A **non-empty backlog floats selection back to Tier 1** (waterfall sees `backlog_count>0` regardless of dry-cycles).
- Conductor parses the F1 yield JSON (`.dry`, `.filed`); a tier that files candidates resets both dry counters so selection floats up next cycle; Tier 3 dry parks ("all tiers exhausted").

## Changes

- `scripts/autonomous-waterfall.sh` — `--tier2-dry-cycles` flag; Tier 2/3 selection replacing the `not-yet-enabled` emit.
- `scripts/lib/autospec-loop.sh` — `_tier2_dry_cycles` counter; pass `--tier2-dry-cycles` to waterfall; Tier 2/3 discovery branch invoking `explore --once`, integrating F5's source-weights consultation + `AUTOSPEC_EXPLORE_LEDGER` export ahead of the discovery cycle.
- `tests/autonomous/test_waterfall.bats` — escalation state machine: Tier 1 dry×2 → Tier 2; Tier 2 dry×2 → Tier 3; refill floats back; counter/threshold cases. `gh` + `autospec-explore.sh` mocked as subprocesses.

## Reuse

No reuse — existing waterfall logic was Tier 0/1 only; the escalation state machine is new. Reuses the F1 `explore --once` 6-key yield JSON contract and F5's ledger/weights globals.

## Validation

- `bats tests/autonomous/test_waterfall.bats` — 23/23 pass.
- `bats tests/autospec/test_conductor_wiring.bats` — 12/12 pass.
- `bash scripts/validate.sh` — exit 0 (full run, no flakes), post-rebase on origin/main.

Closes #1394

🤖 Generated with [Claude Code](https://claude.com/claude-code)