### PR TITLE
fix(autonomous): Phase 5.5 audit — wire usage-governor, break F3 deadlock, gate integration suite

### DIFF
--- a/scripts/explore-research-cycle.sh
+++ b/scripts/explore-research-cycle.sh
@@ -784,6 +784,13 @@ try:
     _pboost = float(os.environ.get("AUTOSPEC_PRIORITY_BOOST", "1.5") or "1.5")
 except Exception:
     _pboost = 1.5
+# Lower-bound the multiplier at 1.0: a "boost" must never DE-rank a priority/
+# steer proposal below organic ones (a misconfigured <1.0 value would invert the
+# intent). The upper bound is already enforced below via _cap (a boosted score is
+# capped at max(non-boosted) * _pboost, so it reorders without swamping the
+# confidence * source_weight * 1/complexity ranking).
+if _pboost < 1.0:
+    _pboost = 1.0
 if _pboost != 1.0 and filtered:
     _is_priority = lambda p: bool(p.get("priority")) or p.get("source") == "steer"
     _non_boosted = [p["score"] for p in filtered if not _is_priority(p)]

--- a/scripts/lib/autospec-loop.sh
+++ b/scripts/lib/autospec-loop.sh
@@ -405,6 +405,9 @@ PY
 #   5b. Outcome-ledger wiring (F5): after drain, record per-source ship/fail
 #       outcome for explore-filed issues (is_discovery=true in last-outcome.json).
 #       Tier-1 backlog issues do not write the file; recording is silently skipped.
+#   6a. Usage-governor soft-park (F6): autonomous-usage-governor.sh parks at
+#       AUTOSPEC_USAGE_SOFT_PCT (default 90%) BEFORE the Step-6 hard cap; layers
+#       on top of the spend-ledger backstop (fail-open continue on any error).
 #   6. Spend-ledger tally (autonomous-spend-ledger.sh); park on cap
 #   7. Once-per-UTC-day digest to .autospec/autonomous-digest.md + pinned issue
 #   8. On park (spend/usage): arm ScheduleWakeup/cron via autospec-usage-limit.sh
@@ -450,6 +453,7 @@ autospec_conductor_run() {
     local _gate="${_sdir}/autonomous-premerge-gate.sh"
     local _resilience="${_sdir}/autonomous-resilience.sh"
     local _usage_limit="${_sdir}/autospec-usage-limit.sh"
+    local _governor="${_sdir}/autonomous-usage-governor.sh"
 
     # ── Ledger wiring (F5) ─────────────────────────────────────────────────────
     # Resolve repo root (parent of scripts/ dir) for ledger data file path.
@@ -660,13 +664,24 @@ autospec_conductor_run() {
                     if [ "$_main_health" = "wait" ]; then
                         printf '[conductor] main-health pending — skipping drain this cycle\n' >&2
                         _dry_cycles=$((_dry_cycles + 1))
-                    elif [ "$_inflight_discovery" -gt 0 ]; then
-                        # F3: discovery issues in-flight → refuse main merge until consumed.
-                        printf 'code_health:autonomous_main_merge_refused\n' >&2
-                        printf '[conductor] F3: refusing Tier-1 drain — %s discovery issue(s) in-flight\n' \
-                            "$_inflight_discovery" >&2
-                        _dry_cycles=$((_dry_cycles + 1))
                     else
+                        # F3: while discovery issues are in flight, main merges are
+                        # refused — but that refusal is enforced PER-PR by the phase4
+                        # implementer via .autospec/explore-mode.json (PRs target the
+                        # sandbox base; gh pr merge against main is refused). The
+                        # conductor MUST still run the drain so discovery issues are
+                        # implemented onto the sandbox and the in-flight counter clears
+                        # as their outcomes are consumed below. Skipping the drain here
+                        # deadlocks: the decrement lives in this same branch, so a
+                        # skipped drain could never lower the counter — once raised,
+                        # the counter would block every future drain forever and the
+                        # discovery tier (the whole point of Phase 2) would never make
+                        # progress (Phase 5.5 integration finding).
+                        if [ "$_inflight_discovery" -gt 0 ]; then
+                            printf 'code_health:autonomous_main_merge_refused\n' >&2
+                            printf '[conductor] F3: %s discovery issue(s) in-flight — main merges refused (phase4 sandbox routing); draining onto sandbox\n' \
+                                "$_inflight_discovery" >&2
+                        fi
                         # Gate + main-health green — invoke drain.
                         if [ "$_dry" = "1" ]; then
                             printf '[conductor] [dry-run] would invoke autospec-run for Tier-1 drain\n' >&2
@@ -848,6 +863,34 @@ autospec_conductor_run() {
             printf '[conductor] unknown waterfall action=%s for tier=%s — skipping\n' \
                 "$_action" "$_tier" >&2
             _dry_cycles=$((_dry_cycles + 1))
+        fi
+
+        # ── Step 6a: Usage governor soft-park (F6) ───────────────────────────
+        # Soft-park at AUTOSPEC_USAGE_SOFT_PCT (default 90%) BEFORE the Phase-1
+        # hard-quota backstop (Step 6) fires. The governor prefers a live usage
+        # fraction (usage-observe.sh) and falls back to the spend-ledger token
+        # tally. It is fail-open ("continue" on any error), so a missing/older
+        # install never blocks the loop; it only ever ADDS an earlier park.
+        if [ -f "$_governor" ]; then
+            local _gov_harness="${AUTOSPEC_GOVERNOR_HARNESS:-${AUTOSPEC_HARNESS:-claude}}"
+            case "$_gov_harness" in
+                claude|codex|opencode) ;;
+                *) _gov_harness="claude" ;;
+            esac
+            local _gov_out
+            _gov_out="$(bash "$_governor" "$_gov_harness" \
+                --repo-dir "$_repo_root" 2>/dev/null || printf 'continue')"
+            case "$_gov_out" in
+                park*)
+                    printf '[conductor] usage-governor: %s — arming resume and exiting\n' \
+                        "$_gov_out" >&2
+                    _conductor_arm_resume \
+                        "$_sdir" "$_repo" "$_conductor_session" \
+                        "$_notify_sh" "usage-governor:${_gov_out}"
+                    _stop_reason="usage-governor:park"
+                    break
+                    ;;
+            esac
         fi
 
         # ── Step 6: Spend-ledger tally (autonomous-spend-ledger.sh) ──────────

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -3031,6 +3031,7 @@ main() {
     check_autospec_autonomous_contract
     check_autospec_autonomous_skill_contract
     check_conductor_wiring_contract
+    check_autonomous_phase2_suite
 
     # Top-level installer / uninstaller (introduced in PR #11) — only check syntax
     # if present; absence is OK before that PR lands.
@@ -4255,6 +4256,33 @@ check_conductor_wiring_contract() {
         bats "$bats_file" >/tmp/validate-conductor-wiring.log 2>&1 \
             || { cat /tmp/validate-conductor-wiring.log >&2; \
                  fail "$bats_file: failed (issue #1378)"; }
+    fi
+}
+
+# Autonomous Phase-2 integration suite (issue #1402, Phase 5.5 audit): the
+# tests/autonomous/*.bats integration tests (waterfall escalation, sandbox
+# routing, premerge gate, outcome ledger, usage governor + conductor wiring)
+# were previously ungated by validate.sh, which let a stale-action test rot and
+# the governor-never-wired defect slip past. Gate the whole suite here so these
+# cross-issue integration seams stay green.
+check_autonomous_phase2_suite() {
+    info "autonomous Phase-2 integration suite: tests/autonomous/*.bats (issue #1402)"
+    if ! command -v bats >/dev/null 2>&1; then
+        info "  bats not available — skipping autonomous integration suite"
+        return 0
+    fi
+    local _any=0
+    local t
+    for t in tests/autonomous/*.bats; do
+        [ -f "$t" ] || continue
+        _any=1
+        info "  running: $t"
+        bats "$t" >/tmp/validate-autonomous-suite.log 2>&1 \
+            || { cat /tmp/validate-autonomous-suite.log >&2; \
+                 fail "$t: failed (issue #1402)"; }
+    done
+    if [ "$_any" -eq 0 ]; then
+        fail "tests/autonomous/*.bats: no autonomous integration tests found (issue #1402)"
     fi
 }
 

--- a/skills/autospec-autonomous/install.sh
+++ b/skills/autospec-autonomous/install.sh
@@ -41,7 +41,7 @@ DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
 SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
-AUTONOMOUS_SCRIPT_FILES="autonomous-control-channel.sh autonomous-premerge-gate.sh autonomous-resilience.sh autonomous-spend-ledger.sh autonomous-waterfall.sh autospec-autonomy-gate.sh"
+AUTONOMOUS_SCRIPT_FILES="autonomous-control-channel.sh autonomous-premerge-gate.sh autonomous-resilience.sh autonomous-spend-ledger.sh autonomous-usage-governor.sh autonomous-waterfall.sh autospec-autonomy-gate.sh usage-observe.sh"
 LIB_FILES="autospec-loop.sh autospec-harness-detect.sh"
 
 err()  { printf 'error: %s\n' "$*" >&2; }

--- a/tests/autonomous/test_conductor_governor.bats
+++ b/tests/autonomous/test_conductor_governor.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+# tests/autonomous/test_conductor_governor.bats — F6: the usage-governor is
+# actually wired into autospec_conductor_run() and parks the loop at the soft
+# ceiling.
+#
+# Regression for the Phase 5.5 integration finding: autonomous-usage-governor.sh
+# existed and was unit-tested in isolation, but the conductor never invoked it,
+# so the 90% soft-park never fired in production.
+#
+# Mocking strategy:
+#   - All helper scripts mocked via CONDUCTOR_SCRIPTS_DIR (subprocess boundary).
+#   - The governor mock records that it was called (real temp file) and emits a
+#     configurable verdict.
+#   - gh is never called (waterfall mock returns a fixed decision).
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+LOOP_LIB="$REPO_ROOT/scripts/lib/autospec-loop.sh"
+
+setup() {
+    TMP="$(mktemp -d -t conductor-governor.XXXXXX)"
+    SCRIPTS_DIR="$TMP/scripts"
+    mkdir -p "$SCRIPTS_DIR"
+
+    GOVERNOR_CALL_LOG="$TMP/governor-calls.log"
+    RUN_CMD_LOG="$TMP/run-cmd.log"
+    touch "$GOVERNOR_CALL_LOG"
+    touch "$RUN_CMD_LOG"
+
+    # ── mock: autonomous-waterfall.sh — Tier 1 / run-backlog ──────────────────
+    cat > "$SCRIPTS_DIR/autonomous-waterfall.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '{"tier":1,"action":"run-backlog","reason":"test-default"}\n'
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-waterfall.sh"
+
+    # ── mock: autonomous-control-channel.sh ──────────────────────────────────
+    cat > "$SCRIPTS_DIR/autonomous-control-channel.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-control-channel.sh"
+
+    # ── mock: autonomous-premerge-gate.sh — merge-ok ─────────────────────────
+    cat > "$SCRIPTS_DIR/autonomous-premerge-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+printf 'merge-ok\n'
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-premerge-gate.sh"
+
+    # ── mock: autonomous-resilience.sh ───────────────────────────────────────
+    cat > "$SCRIPTS_DIR/autonomous-resilience.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-resilience.sh"
+
+    # ── mock: autonomous-spend-ledger.sh — never the hard cap (continue) ──────
+    cat > "$SCRIPTS_DIR/autonomous-spend-ledger.sh" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "check" ]; then
+    printf 'continue\n'
+fi
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-spend-ledger.sh"
+
+    # ── mock: autospec-usage-limit.sh — record arm calls (no daemon) ──────────
+    cat > "$SCRIPTS_DIR/autospec-usage-limit.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autospec-usage-limit.sh"
+
+    export CONDUCTOR_SCRIPTS_DIR="$SCRIPTS_DIR"
+    export CONDUCTOR_MAX_CYCLES=1
+    export CONDUCTOR_DRY_RUN=0
+    export CONDUCTOR_NO_DIGEST=1
+    export CONDUCTOR_POLL_INTERVAL=0
+    export AUTOSPEC_RUN_CMD="printf 'run-cmd-invoked\n' >> $RUN_CMD_LOG"
+    unset CONDUCTOR_REPO 2>/dev/null || true
+    unset AUTOSPEC_REPO  2>/dev/null || true
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+_write_governor_mock() {
+    # $1 = verdict line the mock prints (e.g. "continue" or "park <at>")
+    local verdict="$1"
+    cat > "$SCRIPTS_DIR/autonomous-usage-governor.sh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$GOVERNOR_CALL_LOG"
+printf '${verdict}\n'
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-usage-governor.sh"
+}
+
+_run_conductor() {
+    bash -c "source '$LOOP_LIB'; autospec_conductor_run" 2>&1
+}
+
+@test "conductor invokes the usage-governor each cycle" {
+    _write_governor_mock "continue"
+    _run_conductor
+    [ -s "$GOVERNOR_CALL_LOG" ]
+}
+
+@test "conductor passes a valid harness to the governor" {
+    _write_governor_mock "continue"
+    _run_conductor
+    # First field of the recorded args must be a valid harness keyword.
+    grep -Eq '^(claude|codex|opencode)\b' "$GOVERNOR_CALL_LOG"
+}
+
+@test "governor park stops the conductor with usage-governor:park" {
+    _write_governor_mock "park 2026-06-26T12:00:00Z"
+    run _run_conductor
+    [[ "$output" == *"usage-governor:park"* ]]
+}
+
+@test "governor continue lets the loop proceed (no park)" {
+    _write_governor_mock "continue"
+    run _run_conductor
+    [[ "$output" != *"usage-governor:park"* ]]
+}
+
+@test "AUTOSPEC_GOVERNOR_HARNESS override is honored and validated" {
+    _write_governor_mock "continue"
+    export AUTOSPEC_GOVERNOR_HARNESS="codex"
+    _run_conductor
+    grep -Eq '^codex\b' "$GOVERNOR_CALL_LOG"
+}
+
+@test "invalid harness override falls back to claude" {
+    _write_governor_mock "continue"
+    export AUTOSPEC_GOVERNOR_HARNESS="bogus-harness"
+    _run_conductor
+    grep -Eq '^claude\b' "$GOVERNOR_CALL_LOG"
+}

--- a/tests/autonomous/test_outcome_ledger.bats
+++ b/tests/autonomous/test_outcome_ledger.bats
@@ -122,7 +122,7 @@ _run_conductor_1() {
     # Override waterfall stub to return Tier 2 (not-enabled → weights consult + park).
     cat > "$TMP/bin/autonomous-waterfall.sh" <<'SH'
 #!/usr/bin/env bash
-printf '{"tier":2,"action":"run-discovery","reason":"stub"}\n'
+printf '{"tier":2,"action":"run-explore-once","reason":"stub"}\n'
 exit 0
 SH
 
@@ -137,7 +137,7 @@ SH
 @test "conductor passes ledger path to explore-source-weights.sh" {
     cat > "$TMP/bin/autonomous-waterfall.sh" <<'SH'
 #!/usr/bin/env bash
-printf '{"tier":2,"action":"run-discovery","reason":"stub"}\n'
+printf '{"tier":2,"action":"run-explore-once","reason":"stub"}\n'
 exit 0
 SH
 
@@ -226,7 +226,7 @@ SH
 @test "failing explore-source-weights.sh does not abort the conductor cycle" {
     cat > "$TMP/bin/autonomous-waterfall.sh" <<'SH'
 #!/usr/bin/env bash
-printf '{"tier":2,"action":"run-discovery","reason":"stub"}\n'
+printf '{"tier":2,"action":"run-explore-once","reason":"stub"}\n'
 exit 0
 SH
     # Override weights stub to return non-zero.

--- a/tests/autonomous/test_sandbox_routing.bats
+++ b/tests/autonomous/test_sandbox_routing.bats
@@ -223,7 +223,12 @@ EOF
     [[ "$output" == *"code_health:autonomous_main_merge_refused"* ]]
 }
 
-@test "AUTOSPEC_RUN_CMD not invoked when discovery in-flight" {
+@test "drain still runs onto sandbox while discovery in-flight (phase4 refuses main merges)" {
+    # Regression for the Phase 5.5 deadlock finding: the conductor must NOT skip
+    # the Tier-1 drain while discovery is in-flight. The phase4 implementer
+    # enforces the main-merge refusal per-PR via explore-mode.json (PRs target
+    # the sandbox). Skipping the drain here would deadlock, because the only path
+    # that decrements the in-flight counter lives inside the drain branch.
     CYCLE_COUNT_FILE="$TMP/cycle-count.txt"
     printf '0\n' > "$CYCLE_COUNT_FILE"
 
@@ -250,10 +255,49 @@ EOF
 
     export CONDUCTOR_MAX_CYCLES=2
     _run_conductor
-    # run-cmd must NOT have been invoked (refused by F3 gate).
-    if [ -s "$RUN_CMD_LOG" ]; then
-        false  # fail: run-cmd should have been blocked
-    fi
+    # The drain MUST run on cycle 2 even though discovery is in-flight.
+    [ -s "$RUN_CMD_LOG" ]
+    grep -q "run-cmd-invoked" "$RUN_CMD_LOG"
+}
+
+@test "in-flight counter clears once a discovery outcome is consumed (no permanent deadlock)" {
+    # Three cycles: cycle 1 files a discovery issue (in-flight=1); cycles 2-3 are
+    # Tier-1 drains. The drain mock writes a discovery outcome file, which the
+    # conductor consumes to decrement the counter. By the time the counter hits 0
+    # the main-merge refusal must stop firing — proving the counter can clear.
+    CYCLE_COUNT_FILE="$TMP/cycle-count.txt"
+    printf '0\n' > "$CYCLE_COUNT_FILE"
+
+    OUTCOME_FILE="$TMP/.autospec/last-outcome.json"
+    export AUTOSPEC_LAST_OUTCOME_FILE="$OUTCOME_FILE"
+
+    cat > "$SCRIPTS_DIR/autonomous-waterfall.sh" <<EOF
+#!/usr/bin/env bash
+n=\$(cat "$CYCLE_COUNT_FILE" 2>/dev/null || printf '0')
+n=\$((n + 1))
+printf '%s\n' "\$n" > "$CYCLE_COUNT_FILE"
+if [ "\$n" -le 1 ]; then
+    printf '{"tier":2,"action":"run-explore-once","reason":"cycle1-discovery"}\n'
+else
+    printf '{"tier":1,"action":"run-backlog","reason":"tier1-drain"}\n'
+fi
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-waterfall.sh"
+
+    cat > "$EXPLORE_SCRIPT" <<'EOF'
+#!/usr/bin/env bash
+printf '{"tier":"local","proposals_seen":1,"new_candidates":1,"filed":1,"dry":"false"}\n'
+exit 0
+EOF
+
+    # Drain mock writes a discovery outcome file so the conductor decrements.
+    export AUTOSPEC_RUN_CMD="printf 'run-cmd-invoked\n' >> $RUN_CMD_LOG; mkdir -p '$TMP/.autospec'; printf '{\"is_discovery\":true,\"issue\":4242,\"source\":\"spec-vs-code\",\"outcome\":\"shipped\"}\n' > '$OUTCOME_FILE'"
+
+    export CONDUCTOR_MAX_CYCLES=3
+    run _run_conductor
+    # The decrement path must be reachable: counter returns to 0.
+    [[ "$output" == *"in-flight=0"* ]]
 }
 
 # ── 4. Tier-1 backlog drain unaffected when no discovery in-flight ───────────


### PR DESCRIPTION
Phase 5.5 broad cross-issue integration audit + remediation for /autospec-autonomous Phase 2. Closes #1402.

## Integration defects per-PR reviews could not catch

- **HIGH** — F6 usage-governor existed + unit-tested but was **never invoked** by `autospec_conductor_run()`; the 90% soft-park never fired. Wired into the per-cycle sequence (Step 6a, before the hard cap), fail-open.
- **HIGH** — installer omitted `autonomous-usage-governor.sh` + `usage-observe.sh`; a clean install shipped a governor that could never run. Added to install + piped-fetch lists.
- **HIGH** — F3 in-flight discovery counter **permanent deadlock**: the main-merge refusal skipped the whole Tier-1 drain when `_inflight_discovery>0`, but the decrement lived only inside that drain branch → once raised, the counter blocked every future drain forever and discovery never progressed. Phase4 already enforces the per-PR main-merge refusal via `.autospec/explore-mode.json`, so the drain now runs (routing discovery PRs to the sandbox), emits the refusal signal, and clears the counter via outcome consumption.
- **MEDIUM** — stale F5 weights-consult tests used the pre-F2 action name `run-discovery` (renamed `run-explore-once`) → deterministic failure, masked because validate never ran the suite.
- **MEDIUM** — `tests/autonomous/*.bats` was entirely ungated by `validate.sh`; added a gate running all 11 files.
- **LOW** — F8 priority boost had an upper clamp but no `>=1.0` lower bound; clamped.

## Verified clean
F1 (no nested loop), F2 (escalation state machine), F4 (secaudit fail-closed gate), F5 (ledger consult/feed), F7 (clean-room behavior-only + allowlist). `bash -n` clean, no function/global collisions.

## Verification
`bash scripts/validate.sh` exits 0 (autonomous suite now gated, all green, no flakes).

Full findings: https://github.com/berlinguyinca/autospec/issues/1402#issuecomment-4811054094

🤖 Generated with [Claude Code](https://claude.com/claude-code)