### PR TITLE
feat(autonomous): deterministic persona source-gathering helper (F1) (#1417)

### DIFF
--- a/scripts/autonomous-persona-sources.sh
+++ b/scripts/autonomous-persona-sources.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# autonomous-persona-sources.sh — Gathers and orders operator-persona inputs
+# into a structured JSON bundle with global and overlay sub-bundles.
+#
+# Usage:
+#   bash scripts/autonomous-persona-sources.sh [--repo-root DIR] [--autospec-home DIR]
+#
+# Options:
+#   --repo-root     Override repository root (default: parent of scripts/)
+#   --autospec-home Override ~/.autospec home directory
+#
+# Output: JSON to stdout
+#   {
+#     "global":  [ {source, precedence, path, present:true}, ... ],
+#     "overlay": [ {source, precedence, path, present:true}, ... ]
+#   }
+#
+# Source classes and precedences:
+#   Global base (operator-level):
+#     0  ~/.autospec/operator-persona.answers.json  (interview answers)
+#     3  ~/.autospec/persona-mined-digest.json      (F3 cross-repo mined patterns)
+#   Overlay (repo-local):
+#     1  docs/memory/feedback_*.md, docs/memory/project_*.md, AGENTS.md
+#     2  docs/AUTONOMY-CHARTER.md
+#     2  .autospec/persona-overlay.md (per-repo override; gitignored, may be absent)
+#
+# Missing sources are silently skipped — never fatal.
+# Arrays in each sub-bundle are sorted by precedence (ascending).
+#
+# Engineering rules:
+#   set -euo pipefail; if/then/fi (no one-sided && short-circuits);
+#   jq capture()/== not test() with interpolated values; no RETURN traps.
+#
+# Exit codes:
+#   0  Bundle emitted (even if all sources absent)
+#   1  jq not available
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+AUTOSPEC_HOME="${AUTOSPEC_HOME:-$HOME/.autospec}"
+
+# ---- argument parsing ----
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --autospec-home)
+      AUTOSPEC_HOME="$2"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n 's/^# \?//p' "$0" | head -30
+      exit 0
+      ;;
+    *)
+      echo "autonomous-persona-sources: unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---- dependency check ----
+if ! command -v jq >/dev/null 2>&1; then
+  echo "autonomous-persona-sources: jq not found — required for JSON output" >&2
+  exit 1
+fi
+
+# ---- temp workspace ----
+_tmp_dir="$(mktemp -d -t persona-sources.XXXXXX)"
+_global_jsonl="$_tmp_dir/global.jsonl"
+_overlay_jsonl="$_tmp_dir/overlay.jsonl"
+touch "$_global_jsonl" "$_overlay_jsonl"
+
+# Cleanup on process exit (EXIT trap is safe; not a RETURN trap)
+trap 'rm -rf "$_tmp_dir"' EXIT
+
+# emit_to OUT SOURCE PRECEDENCE PATH
+#   Appends one JSON entry to OUT if PATH is a regular file.
+#   Silently skips absent or non-regular paths.
+emit_to() {
+  local _out="$1"
+  local _source="$2"
+  local _prec="$3"
+  local _path="$4"
+
+  if [ -f "$_path" ]; then
+    jq -n \
+      --arg   source     "$_source" \
+      --argjson precedence "$_prec" \
+      --arg   path       "$_path" \
+      '{source:$source, precedence:$precedence, path:$path, present:true}' \
+      >> "$_out"
+  fi
+}
+
+# ---- global-base inputs (operator-level) ----
+
+# Precedence 0: supervised interview answers
+emit_to "$_global_jsonl" "interview-answers" 0 \
+  "$AUTOSPEC_HOME/operator-persona.answers.json"
+
+# Precedence 3: F3 cross-repo mined decision digest (may be absent — F3 not yet shipped)
+emit_to "$_global_jsonl" "mined-digest" 3 \
+  "$AUTOSPEC_HOME/persona-mined-digest.json"
+
+# ---- overlay inputs (repo-local) ----
+
+# Precedence 1: docs/memory feedback_* and project_* files
+_memory_dir="$REPO_ROOT/docs/memory"
+if [ -d "$_memory_dir" ]; then
+  for _f in "$_memory_dir"/feedback_*.md "$_memory_dir"/project_*.md; do
+    if [ -f "$_f" ]; then
+      emit_to "$_overlay_jsonl" "repo-memory" 1 "$_f"
+    fi
+  done
+fi
+
+# Precedence 1: AGENTS.md (repo-level conventions and contracts)
+emit_to "$_overlay_jsonl" "agents-md" 1 "$REPO_ROOT/AGENTS.md"
+
+# Precedence 2: docs/AUTONOMY-CHARTER.md (operator autonomy decisions)
+emit_to "$_overlay_jsonl" "autonomy-charter" 2 "$REPO_ROOT/docs/AUTONOMY-CHARTER.md"
+
+# Precedence 2: .autospec/persona-overlay.md (per-repo operator override; gitignored)
+_per_repo_overlay="$REPO_ROOT/.autospec/persona-overlay.md"
+if [ -f "$_per_repo_overlay" ]; then
+  emit_to "$_overlay_jsonl" "per-repo-overlay" 2 "$_per_repo_overlay"
+fi
+
+# ---- emit final bundle, each sub-bundle sorted by precedence ----
+_global_json="$(jq -s 'sort_by(.precedence)' "$_global_jsonl")"
+_overlay_json="$(jq -s 'sort_by(.precedence)' "$_overlay_jsonl")"
+
+jq -n \
+  --argjson global  "$_global_json" \
+  --argjson overlay "$_overlay_json" \
+  '{global: $global, overlay: $overlay}'

--- a/tests/autonomous/test_persona_sources.bats
+++ b/tests/autonomous/test_persona_sources.bats
@@ -1,0 +1,297 @@
+#!/usr/bin/env bats
+# tests/autonomous/test_persona_sources.bats
+# TDD contract for scripts/autonomous-persona-sources.sh
+#
+# Coverage:
+#   - Output structure (top-level keys, per-entry fields)
+#   - Class routing: repo-local sources → overlay; operator-level sources → global
+#   - Precedence ordering within each sub-bundle
+#   - Per-repo .autospec/persona-overlay.md lands in overlay, not global
+#   - Missing sources are silently skipped (not fatal); empty run exits 0
+#
+# Engineering notes:
+#   - All fixtures written to real temp files; no process substitutions with [ -f ]
+#     (macOS bash 3.2: [ -f <(...) ] is always false)
+#   - .autospec/persona-overlay.md is gitignored; materialized at runtime
+#   - Negation via jq count == 0, never via ! piped grep
+#   - jq capture()/== patterns used; no test() with interpolated values
+
+SCRIPT_DIR="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+PERSONA_SOURCES="$SCRIPT_DIR/scripts/autonomous-persona-sources.sh"
+
+setup() {
+    TMP="$(mktemp -d -t test-persona-sources.XXXXXX)"
+
+    FAKE_REPO="$TMP/repo"
+    mkdir -p "$FAKE_REPO/docs/memory"
+    mkdir -p "$FAKE_REPO/docs"
+    mkdir -p "$FAKE_REPO/.autospec"
+
+    FAKE_AUTOSPEC="$TMP/autospec-home"
+    mkdir -p "$FAKE_AUTOSPEC"
+
+    export REPO_ROOT="$FAKE_REPO"
+    export AUTOSPEC_HOME="$FAKE_AUTOSPEC"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run_sources uses env vars set in setup / individual tests
+# ---------------------------------------------------------------------------
+run_sources() {
+    run bash "$PERSONA_SOURCES"
+}
+
+# Helper: count occurrences of source value in bundle key
+count_source_in() {
+    local bundle="$1"   # "global" or "overlay"
+    local src="$2"
+    echo "$output" | jq --arg bundle "$bundle" --arg src "$src" \
+      '.[$bundle] | map(select(.source == $src)) | length'
+}
+
+# ---------------------------------------------------------------------------
+# Output structure
+# ---------------------------------------------------------------------------
+
+@test "script is executable and exists" {
+    [ -f "$PERSONA_SOURCES" ]
+    [ -x "$PERSONA_SOURCES" ]
+}
+
+@test "empty run: exits 0 with global and overlay arrays" {
+    run_sources
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'has("global") and has("overlay")' > /dev/null
+}
+
+@test "empty run: both arrays are empty when no sources present" {
+    run_sources
+    [ "$status" -eq 0 ]
+    local _gc _oc
+    _gc="$(echo "$output" | jq '.global | length')"
+    _oc="$(echo "$output" | jq '.overlay | length')"
+    [ "$_gc" -eq 0 ]
+    [ "$_oc" -eq 0 ]
+}
+
+@test "each present entry has source, precedence, path, present fields" {
+    # Materialize a real file so at least one entry is present
+    echo '{"version":1,"batches":[]}' > "$FAKE_AUTOSPEC/operator-persona.answers.json"
+    run_sources
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e \
+      '.global[0] | has("source") and has("precedence") and has("path") and has("present")' \
+      > /dev/null
+}
+
+@test "present field is boolean true for found files" {
+    echo '{"version":1}' > "$FAKE_AUTOSPEC/operator-persona.answers.json"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _present
+    _present="$(echo "$output" | jq '.global[0].present')"
+    [ "$_present" = "true" ]
+}
+
+# ---------------------------------------------------------------------------
+# Class routing: operator-level sources → global
+# ---------------------------------------------------------------------------
+
+@test "interview answers land in global, not overlay" {
+    echo '{"version":1,"batches":[]}' > "$FAKE_AUTOSPEC/operator-persona.answers.json"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _in_global _in_overlay
+    _in_global="$(count_source_in global interview-answers)"
+    _in_overlay="$(count_source_in overlay interview-answers)"
+    [ "$_in_global" -ge 1 ]
+    [ "$_in_overlay" -eq 0 ]
+}
+
+@test "mined digest lands in global, not overlay" {
+    echo '{}' > "$FAKE_AUTOSPEC/persona-mined-digest.json"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _in_global _in_overlay
+    _in_global="$(count_source_in global mined-digest)"
+    _in_overlay="$(count_source_in overlay mined-digest)"
+    [ "$_in_global" -ge 1 ]
+    [ "$_in_overlay" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Class routing: repo-local sources → overlay
+# ---------------------------------------------------------------------------
+
+@test "docs/memory feedback_* files land in overlay, not global" {
+    # Write a real temp file (not process sub)
+    echo "# feedback note" > "$FAKE_REPO/docs/memory/feedback_test.md"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _in_overlay _in_global
+    _in_overlay="$(count_source_in overlay repo-memory)"
+    _in_global="$(count_source_in global repo-memory)"
+    [ "$_in_overlay" -ge 1 ]
+    [ "$_in_global" -eq 0 ]
+}
+
+@test "docs/memory project_* files land in overlay, not global" {
+    echo "# project note" > "$FAKE_REPO/docs/memory/project_foo.md"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _in_overlay _in_global
+    _in_overlay="$(count_source_in overlay repo-memory)"
+    _in_global="$(count_source_in global repo-memory)"
+    [ "$_in_overlay" -ge 1 ]
+    [ "$_in_global" -eq 0 ]
+}
+
+@test "AGENTS.md lands in overlay, not global" {
+    echo "# agents" > "$FAKE_REPO/AGENTS.md"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _in_overlay _in_global
+    _in_overlay="$(count_source_in overlay agents-md)"
+    _in_global="$(count_source_in global agents-md)"
+    [ "$_in_overlay" -ge 1 ]
+    [ "$_in_global" -eq 0 ]
+}
+
+@test "docs/AUTONOMY-CHARTER.md lands in overlay, not global" {
+    echo "# charter" > "$FAKE_REPO/docs/AUTONOMY-CHARTER.md"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _in_overlay _in_global
+    _in_overlay="$(count_source_in overlay autonomy-charter)"
+    _in_global="$(count_source_in global autonomy-charter)"
+    [ "$_in_overlay" -ge 1 ]
+    [ "$_in_global" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Per-repo overlay (.autospec/persona-overlay.md — gitignored, runtime-only)
+# ---------------------------------------------------------------------------
+
+@test "per-repo overlay file lands in overlay bundle, not global" {
+    # Materialize at runtime (gitignored; never committed)
+    echo "# per-repo persona override" > "$FAKE_REPO/.autospec/persona-overlay.md"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _in_overlay _in_global
+    _in_overlay="$(count_source_in overlay per-repo-overlay)"
+    _in_global="$(count_source_in global per-repo-overlay)"
+    [ "$_in_overlay" -ge 1 ]
+    [ "$_in_global" -eq 0 ]
+}
+
+@test "absent per-repo overlay is silently skipped, not fatal" {
+    # No .autospec/persona-overlay.md in FAKE_REPO
+    run_sources
+    [ "$status" -eq 0 ]
+    local _cnt
+    _cnt="$(count_source_in overlay per-repo-overlay)"
+    [ "$_cnt" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Missing sources — skipped not fatal
+# ---------------------------------------------------------------------------
+
+@test "all optional sources absent: exits 0" {
+    run_sources
+    [ "$status" -eq 0 ]
+}
+
+@test "only AGENTS.md present: overlay has one entry, global is empty" {
+    echo "# agents" > "$FAKE_REPO/AGENTS.md"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _oc _gc
+    _oc="$(echo "$output" | jq '.overlay | length')"
+    _gc="$(echo "$output" | jq '.global | length')"
+    [ "$_oc" -eq 1 ]
+    [ "$_gc" -eq 0 ]
+}
+
+@test "only interview answers present: global has one entry, overlay is empty" {
+    echo '{"version":1}' > "$FAKE_AUTOSPEC/operator-persona.answers.json"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _gc _oc
+    _gc="$(echo "$output" | jq '.global | length')"
+    _oc="$(echo "$output" | jq '.overlay | length')"
+    [ "$_gc" -eq 1 ]
+    [ "$_oc" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Precedence ordering
+# ---------------------------------------------------------------------------
+
+@test "global entries sorted ascending by precedence: interview(0) before mined(3)" {
+    echo '{"version":1}' > "$FAKE_AUTOSPEC/operator-persona.answers.json"
+    echo '{}'            > "$FAKE_AUTOSPEC/persona-mined-digest.json"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _first _last
+    _first="$(echo "$output" | jq '.global[0].precedence')"
+    _last="$(echo  "$output" | jq '.global[-1].precedence')"
+    [ "$_first" -eq 0 ]
+    [ "$_last"  -eq 3 ]
+}
+
+@test "overlay entries: repo-memory(1) entries all precede autonomy-charter(2)" {
+    echo "# feedback" > "$FAKE_REPO/docs/memory/feedback_a.md"
+    echo "# charter"  > "$FAKE_REPO/docs/AUTONOMY-CHARTER.md"
+    run_sources
+    [ "$status" -eq 0 ]
+    # All prec-1 entries must appear before prec-2 entries in the sorted array
+    local _max1 _min2
+    _max1="$(echo "$output" | jq \
+      '[.overlay[] | select(.precedence == 1)] | map(.precedence) | max // -1')"
+    _min2="$(echo "$output" | jq \
+      '[.overlay[] | select(.precedence == 2)] | map(.precedence) | min // 999')"
+    [ "$_max1" -le "$_min2" ]
+}
+
+@test "overlay sorted: multiple feedback files all at precedence 1" {
+    echo "# fb1" > "$FAKE_REPO/docs/memory/feedback_one.md"
+    echo "# fb2" > "$FAKE_REPO/docs/memory/feedback_two.md"
+    echo "# pr1" > "$FAKE_REPO/docs/memory/project_one.md"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _cnt
+    _cnt="$(echo "$output" | jq \
+      '[.overlay[] | select(.source == "repo-memory" and .precedence == 1)] | length')"
+    [ "$_cnt" -eq 3 ]
+}
+
+# ---------------------------------------------------------------------------
+# Path values in output
+# ---------------------------------------------------------------------------
+
+@test "interview answers entry records absolute path" {
+    local _fixture="$FAKE_AUTOSPEC/operator-persona.answers.json"
+    echo '{"version":1}' > "$_fixture"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _path
+    _path="$(echo "$output" | jq -r \
+      '.global[] | select(.source == "interview-answers") | .path')"
+    [ "$_path" = "$_fixture" ]
+}
+
+@test "repo-memory entry path points to the actual file" {
+    local _fixture="$FAKE_REPO/docs/memory/feedback_check.md"
+    echo "# check" > "$_fixture"
+    run_sources
+    [ "$status" -eq 0 ]
+    local _found
+    _found="$(echo "$output" | jq --arg p "$_fixture" \
+      '[.overlay[] | select(.path == $p)] | length')"
+    [ "$_found" -eq 1 ]
+}


### PR DESCRIPTION
## Summary

- Add `scripts/autonomous-persona-sources.sh` — a pure-shell, no-LLM helper that gathers operator-persona inputs and emits a structured `{"global":[...],"overlay":[...]}` JSON bundle
- Class routing: interview answers + F3 mined digest → global base (precedences 0, 3); `docs/memory/feedback_*`/`project_*`, `AGENTS.md`, `docs/AUTONOMY-CHARTER.md`, `.autospec/persona-overlay.md` → overlay (precedences 1, 2)
- Missing sources are silently skipped — never fatal; empty-sources run exits 0
- Add `tests/autonomous/test_persona_sources.bats` — 21 bats assertions auto-globbed by `check_autonomous_phase2_suite`

## Engineering discipline

- `set -euo pipefail`; if/then/fi throughout (no one-sided `&&` short-circuits)
- EXIT trap for temp-dir cleanup (not RETURN — no caller-frame leak)
- jq `capture()`/`==` patterns; no `test()` with interpolated values
- Real temp fixture files in tests (no process substitutions with `[ -f ]`)
- `.autospec/persona-overlay.md` materialized at runtime in tests (gitignored, never committed)

## Test plan

- [x] `bats tests/autonomous/test_persona_sources.bats` — 21/21 pass
- [x] `bash scripts/validate.sh` — exit 0, `validate: OK — all validation checks passed`
- [x] `test_persona_sources.bats` confirmed present in `check_autonomous_phase2_suite` run

## Closes

Closes #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)