### PR TITLE
chore(install): register autospec-persona in suite installer + bootstrap (F5b)

### DIFF
--- a/skills/autospec-autonomous/install.sh
+++ b/skills/autospec-autonomous/install.sh
@@ -41,7 +41,7 @@ DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
 SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
-AUTONOMOUS_SCRIPT_FILES="autonomous-control-channel.sh autonomous-premerge-gate.sh autonomous-resilience.sh autonomous-spend-ledger.sh autonomous-usage-governor.sh autonomous-waterfall.sh autospec-autonomy-gate.sh usage-observe.sh"
+AUTONOMOUS_SCRIPT_FILES="autonomous-control-channel.sh autonomous-persona-sources.sh autonomous-premerge-gate.sh autonomous-resilience.sh autonomous-spend-ledger.sh autonomous-usage-governor.sh autonomous-waterfall.sh autospec-autonomy-gate.sh usage-observe.sh"
 LIB_FILES="autospec-loop.sh autospec-harness-detect.sh"
 
 err()  { printf 'error: %s\n' "$*" >&2; }


### PR DESCRIPTION
## Summary

Central installer registration for the `autospec-persona` skill (F5b / #1422). F5 (#1426) shipped the `skills/autospec-persona/` trio with its own `install.sh`/`uninstall.sh`; this PR wires the suite-wide discovery + the autonomous runtime-script manifest that F5 did not.

## Changes

- `autospec-persona` is auto-discovered by root `install.sh` via the `skills/*/install.sh` walk — confirmed in `--skill all --dry-run` output (no code change needed; the per-skill `install.sh`/`uninstall.sh` from #1426 are sufficient for discovery).
- Added `autonomous-persona-sources.sh` to `AUTONOMOUS_SCRIPT_FILES` in `skills/autospec-autonomous/install.sh` so the standalone curl-piped installer fetches it alongside the other autonomous runtime helpers.

## Follow-up

`autonomous-persona-synth.sh`, `autonomous-persona-mine.sh`, and `autonomous-priority-match.sh` are not yet on main (F2/F3 work). Only `autonomous-persona-sources.sh` (landed via #1425) exists at this branch point, so it is the only one registered. The siblings should be added to `AUTONOMOUS_SCRIPT_FILES` when their branches land — mirroring the prior usage-governor/usage-observe ship-gap lesson.

## Tests

- `bats tests/ship-completeness.bats` — 5/5 pass
- `bash scripts/validate.sh` — exit 0, 178 passed, all validation checks passed

Closes #1422

🤖 Generated with [Claude Code](https://claude.com/claude-code)