### PR TITLE
feat(autonomous): scoped+redacted transcript-mining persona refiner (F3)

### DIFF
--- a/scripts/autonomous-persona-mine.sh
+++ b/scripts/autonomous-persona-mine.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# autonomous-persona-mine.sh — On the persona refresh cadence, mine the
+# repo-slug-scoped session corpus for recurring decision patterns and emit a
+# compact redacted precedence-3 digest consumed by F1
+# (scripts/autonomous-persona-sources.sh).
+#
+# Usage:
+#   bash scripts/autonomous-persona-mine.sh [--repo-root DIR] [--autospec-home DIR]
+#
+# Environment variables:
+#   AUTOSPEC_PERSONA_MINE=0         Disable mining entirely (no-op exit 0)
+#   AUTOSPEC_PERSONA_MINE_GLOBAL=1  Also mine all Claude projects corpora
+#                                    (default: this repo's corpus only)
+#   AUTOSPEC_PERSONA_MINE_TOP_N     Max patterns to emit (default: 20)
+#   AUTOSPEC_PERSONA_EXTRACT_CMD    Subprocess seam: called as
+#                                    <cmd> <corpus_dir>; overrides built-in
+#                                    grep extractor (used for mocking in tests)
+#   CLAUDE_PROJECTS_DIR             Override ~/.claude/projects path
+#
+# Output:
+#   $AUTOSPEC_HOME/persona-mined-digest.json  (F1 precedence-3 source)
+#
+# Schema (persona-mined-digest/v1):
+#   { schema, mined_at, corpus_scope, truncated, patterns:[{pattern,frequency}] }
+#
+# Engineering rules:
+#   set -eu; if/then/fi (no one-sided && short-circuits); no RETURN traps;
+#   jq --arg / --argjson for safe encoding; no test() with interpolated values.
+#
+# Exit codes:
+#   0  Success or no-op (disabled / corpus absent)
+#   1  Required tool (jq) not available
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+AUTOSPEC_HOME="${AUTOSPEC_HOME:-$HOME/.autospec}"
+CLAUDE_PROJECTS_DIR="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
+TOP_N="${AUTOSPEC_PERSONA_MINE_TOP_N:-20}"
+
+# ── opt-out ────────────────────────────────────────────────────────────────
+if [ "${AUTOSPEC_PERSONA_MINE:-1}" = "0" ]; then
+  exit 0
+fi
+
+# ── argument parsing ───────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-root)
+      if [ $# -lt 2 ]; then
+        printf 'autonomous-persona-mine: --repo-root requires an argument\n' >&2
+        exit 1
+      fi
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --autospec-home)
+      if [ $# -lt 2 ]; then
+        printf 'autonomous-persona-mine: --autospec-home requires an argument\n' >&2
+        exit 1
+      fi
+      AUTOSPEC_HOME="$2"
+      shift 2
+      ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      printf 'autonomous-persona-mine: unknown option: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── dependency check ───────────────────────────────────────────────────────
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'autonomous-persona-mine: jq not found — required for JSON output\n' >&2
+  exit 1
+fi
+
+# ── resolve repo-slug corpus path ─────────────────────────────────────────
+# Convention: ~/.claude/projects/-Users-<whoami>-IdeaProjects-<repo>/memory
+_whoami="$(whoami)"
+_repo_name="$(basename "$REPO_ROOT")"
+_repo_corpus="$CLAUDE_PROJECTS_DIR/-Users-${_whoami}-IdeaProjects-${_repo_name}/memory"
+
+# ── collect corpus directories ────────────────────────────────────────────
+_tmp_corpuslst="$(mktemp -t persona-mine-corpora.XXXXXX)"
+trap 'rm -f "$_tmp_corpuslst"' EXIT
+
+if [ -d "$_repo_corpus" ]; then
+  printf '%s\n' "$_repo_corpus" >> "$_tmp_corpuslst"
+fi
+
+if [ "${AUTOSPEC_PERSONA_MINE_GLOBAL:-0}" = "1" ]; then
+  if [ -d "$CLAUDE_PROJECTS_DIR" ]; then
+    find "$CLAUDE_PROJECTS_DIR" -maxdepth 2 -name "memory" -type d 2>/dev/null \
+      | while IFS= read -r _d; do
+          # skip the repo-scoped entry already added
+          if [ "$_d" = "$_repo_corpus" ]; then
+            continue
+          fi
+          printf '%s\n' "$_d"
+        done >> "$_tmp_corpuslst" || true
+  fi
+fi
+
+# Fail-soft no-op when no corpus found
+if [ ! -s "$_tmp_corpuslst" ]; then
+  exit 0
+fi
+
+# ── built-in pattern extractor ────────────────────────────────────────────
+# Extracts lines that look like imperative decision phrases from .md files.
+_builtin_extract() {
+  local _dir="$1"
+  find "$_dir" -maxdepth 1 -name "*.md" -type f 2>/dev/null \
+    | while IFS= read -r _f; do
+        grep -iE \
+          '^\s*[-*]?\s*(always|never|prefer|avoid|use|reject|require|must|should|do not|don'"'"'t|ensure|check|verify)' \
+          "$_f" 2>/dev/null || true
+      done
+}
+
+# ── gather raw patterns ───────────────────────────────────────────────────
+_tmp_raw="$(mktemp -t persona-mine-raw.XXXXXX)"
+trap 'rm -f "$_tmp_corpuslst" "$_tmp_raw"' EXIT
+
+while IFS= read -r _cdir; do
+  if [ ! -d "$_cdir" ]; then
+    continue
+  fi
+  if [ -n "${AUTOSPEC_PERSONA_EXTRACT_CMD:-}" ]; then
+    bash -c "$AUTOSPEC_PERSONA_EXTRACT_CMD \"\$1\"" _ "$_cdir" >> "$_tmp_raw" 2>/dev/null || true
+  else
+    _builtin_extract "$_cdir" >> "$_tmp_raw" 2>/dev/null || true
+  fi
+done < "$_tmp_corpuslst"
+
+# ── redaction pass ────────────────────────────────────────────────────────
+# Remove lines containing obvious secrets or absolute paths.
+_tmp_redacted="$(mktemp -t persona-mine-redacted.XXXXXX)"
+trap 'rm -f "$_tmp_corpuslst" "$_tmp_raw" "$_tmp_redacted"' EXIT
+
+grep -viE \
+  'password|passwd|secret|token|api[_-]?key|auth[_-]?key|bearer|credential|private[_-]?key|access[_-]?key|/Users/|/home/|/root/' \
+  "$_tmp_raw" > "$_tmp_redacted" 2>/dev/null || true
+
+# ── frequency count + top-N bounding ─────────────────────────────────────
+_tmp_sorted="$(mktemp -t persona-mine-sorted.XXXXXX)"
+trap 'rm -f "$_tmp_corpuslst" "$_tmp_raw" "$_tmp_redacted" "$_tmp_sorted"' EXIT
+
+# Trim leading/trailing whitespace, count duplicates, sort descending
+sed 's/^[[:space:]]*//' "$_tmp_redacted" \
+  | sed 's/[[:space:]]*$//' \
+  | grep -v '^$' \
+  | sort \
+  | uniq -c \
+  | sort -rn \
+  > "$_tmp_sorted" 2>/dev/null || true
+
+_total="$(wc -l < "$_tmp_sorted" | tr -d ' ')"
+_truncated="false"
+if [ "$_total" -gt "$TOP_N" ]; then
+  _truncated="true"
+  printf 'autonomous-persona-mine: INFO truncating %s patterns to top %s\n' \
+    "$_total" "$TOP_N" >&2
+fi
+
+# ── build patterns JSON array ─────────────────────────────────────────────
+_tmp_patterns="$(mktemp -t persona-mine-patterns.XXXXXX)"
+trap 'rm -f "$_tmp_corpuslst" "$_tmp_raw" "$_tmp_redacted" "$_tmp_sorted" "$_tmp_patterns"' EXIT
+
+printf '[\n' > "$_tmp_patterns"
+_first=1
+_n=0
+while IFS= read -r _line; do
+  if [ "$_n" -ge "$TOP_N" ]; then
+    break
+  fi
+  # Parse "   <count> <text>"
+  _freq="$(printf '%s' "$_line" | awk '{print $1}')"
+  _text="$(printf '%s' "$_line" | awk '{$1=""; sub(/^ /, ""); print}')"
+  if [ -z "$_text" ]; then
+    continue
+  fi
+  if [ "$_first" = "1" ]; then
+    _first=0
+  else
+    printf ',\n' >> "$_tmp_patterns"
+  fi
+  jq -n --arg text "$_text" --argjson freq "${_freq:-1}" \
+    '{pattern:$text,frequency:$freq}' >> "$_tmp_patterns"
+  _n=$((_n + 1))
+done < "$_tmp_sorted"
+printf '\n]\n' >> "$_tmp_patterns"
+
+_patterns_json="$(cat "$_tmp_patterns")"
+
+# ── determine scope label ─────────────────────────────────────────────────
+_scope="repo"
+if [ "${AUTOSPEC_PERSONA_MINE_GLOBAL:-0}" = "1" ]; then
+  _scope="global"
+fi
+
+# ── write digest ──────────────────────────────────────────────────────────
+_mined_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')"
+
+mkdir -p "$AUTOSPEC_HOME"
+_digest="$AUTOSPEC_HOME/persona-mined-digest.json"
+
+jq -n \
+  --arg   schema     "persona-mined-digest/v1" \
+  --arg   mined_at   "$_mined_at" \
+  --arg   scope      "$_scope" \
+  --argjson truncated "$_truncated" \
+  --argjson patterns  "$_patterns_json" \
+  '{schema:$schema, mined_at:$mined_at, corpus_scope:$scope, truncated:$truncated, patterns:$patterns}' \
+  > "$_digest"

--- a/tests/autonomous/test_persona_mine.bats
+++ b/tests/autonomous/test_persona_mine.bats
@@ -1,0 +1,401 @@
+#!/usr/bin/env bats
+# tests/autonomous/test_persona_mine.bats
+# TDD contract for scripts/autonomous-persona-mine.sh (F3)
+#
+# Coverage:
+#   - AUTOSPEC_PERSONA_MINE=0 → no-op exit 0, no digest written
+#   - Absent corpus → no-op exit 0, no digest written
+#   - Patterns mined from a runtime fixture transcript dir
+#   - Repo-scoped by default (only reads the current-repo corpus dir)
+#   - Global mining only under AUTOSPEC_PERSONA_MINE_GLOBAL=1
+#   - Redaction strips planted secrets from the emitted digest
+#   - Truncation: logged when patterns exceed TOP_N
+#   - Digest has required schema fields
+#
+# Engineering notes:
+#   - All fixture corpus dirs materialised at runtime (no gitignored static fixtures)
+#   - No [ -f <(...) ] — macOS bash 3.2 process substitution is always false
+#   - Extractor subprocess seam injected via AUTOSPEC_PERSONA_EXTRACT_CMD
+#   - jq used for JSON assertions; no test() with interpolated values
+
+SCRIPT_DIR="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+MINE="$SCRIPT_DIR/scripts/autonomous-persona-mine.sh"
+
+setup() {
+    TMP="$(mktemp -d -t test-persona-mine.XXXXXX)"
+
+    # Fake repo root
+    FAKE_REPO="$TMP/repo"
+    mkdir -p "$FAKE_REPO"
+
+    # Fake autospec home (so we don't touch ~/.autospec during tests)
+    FAKE_AUTOSPEC="$TMP/autospec-home"
+    mkdir -p "$FAKE_AUTOSPEC"
+
+    # Fake ~/.claude/projects base dir
+    FAKE_PROJECTS="$TMP/claude-projects"
+    mkdir -p "$FAKE_PROJECTS"
+
+    # Canonical repo-scoped corpus path:
+    #   $FAKE_PROJECTS/-Users-<whoami>-IdeaProjects-<repo>/memory
+    WHOAMI="$(whoami)"
+    REPO_NAME="$(basename "$FAKE_REPO")"
+    REPO_CORPUS="$FAKE_PROJECTS/-Users-${WHOAMI}-IdeaProjects-${REPO_NAME}/memory"
+    mkdir -p "$REPO_CORPUS"
+
+    # Digest output path
+    DIGEST="$FAKE_AUTOSPEC/persona-mined-digest.json"
+
+    export TMP FAKE_REPO FAKE_AUTOSPEC FAKE_PROJECTS REPO_CORPUS DIGEST REPO_NAME WHOAMI
+    export REPO_ROOT="$FAKE_REPO"
+    export AUTOSPEC_HOME="$FAKE_AUTOSPEC"
+    export CLAUDE_PROJECTS_DIR="$FAKE_PROJECTS"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+# ── helper: write a fixture markdown file with decision-pattern lines ──────
+write_fixture_md() {
+    local path="$1"
+    local content="$2"
+    printf '%s\n' "$content" > "$path"
+}
+
+# ── helper: a stub extractor that outputs fixed patterns ──────────────────
+make_stub_extractor() {
+    local stub_path="$1"
+    local output="$2"
+    # Write a shell script that echoes the supplied output
+    printf '#!/usr/bin/env bash\nprintf '"'"'%s\n'"'"' %s\n' \
+      "$output" > "$stub_path"
+    chmod +x "$stub_path"
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# 1. Basic contract
+# ═══════════════════════════════════════════════════════════════════
+
+@test "script exists and is executable" {
+    [ -f "$MINE" ]
+    [ -x "$MINE" ]
+}
+
+@test "script passes bash -n syntax check" {
+    bash -n "$MINE"
+}
+
+@test "--help exits 0" {
+    run bash "$MINE" --help
+    [ "$status" -eq 0 ]
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# 2. Opt-out: AUTOSPEC_PERSONA_MINE=0
+# ═══════════════════════════════════════════════════════════════════
+
+@test "AUTOSPEC_PERSONA_MINE=0 exits 0 immediately" {
+    run env AUTOSPEC_PERSONA_MINE=0 bash "$MINE" \
+        --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+    [ "$status" -eq 0 ]
+}
+
+@test "AUTOSPEC_PERSONA_MINE=0 writes no digest" {
+    env AUTOSPEC_PERSONA_MINE=0 bash "$MINE" \
+        --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+    [ ! -f "$DIGEST" ]
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# 3. Absent corpus → fail-soft no-op
+# ═══════════════════════════════════════════════════════════════════
+
+@test "absent corpus exits 0 silently" {
+    # Remove the repo corpus so nothing is found
+    rm -rf "$REPO_CORPUS"
+    run bash "$MINE" \
+        --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+    [ "$status" -eq 0 ]
+}
+
+@test "absent corpus writes no digest" {
+    rm -rf "$REPO_CORPUS"
+    bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+    [ ! -f "$DIGEST" ]
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# 4. Pattern mining from fixture corpus
+# ═══════════════════════════════════════════════════════════════════
+
+@test "mines patterns from fixture markdown and writes digest" {
+    # Write a fixture markdown file with decision phrases
+    write_fixture_md "$REPO_CORPUS/feedback_test.md" \
+        "always prefer idempotent operations
+never eval raw input
+prefer smaller commits"
+
+    run bash "$MINE" \
+        --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+    [ "$status" -eq 0 ]
+    [ -f "$DIGEST" ]
+}
+
+@test "digest has required top-level schema fields" {
+    write_fixture_md "$REPO_CORPUS/feedback_test.md" \
+        "always use set -eu in shell scripts
+never skip validation"
+
+    bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    local _out
+    _out="$(cat "$DIGEST")"
+    echo "$_out" | jq -e 'has("schema")' > /dev/null
+    echo "$_out" | jq -e 'has("mined_at")' > /dev/null
+    echo "$_out" | jq -e 'has("corpus_scope")' > /dev/null
+    echo "$_out" | jq -e 'has("truncated")' > /dev/null
+    echo "$_out" | jq -e 'has("patterns")' > /dev/null
+}
+
+@test "digest schema value is persona-mined-digest/v1" {
+    write_fixture_md "$REPO_CORPUS/feedback_test.md" \
+        "always run tests before committing"
+
+    bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    local _schema
+    _schema="$(jq -r '.schema' "$DIGEST")"
+    [ "$_schema" = "persona-mined-digest/v1" ]
+}
+
+@test "digest patterns is an array" {
+    write_fixture_md "$REPO_CORPUS/feedback_test.md" \
+        "prefer functional over imperative code
+never ignore error codes"
+
+    bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    jq -e '.patterns | type == "array"' "$DIGEST" > /dev/null
+}
+
+@test "patterns array entries have pattern and frequency fields" {
+    # Use extractor seam to inject deterministic output
+    _stub="$TMP/extractor.sh"
+    cat > "$_stub" <<'STUB'
+#!/usr/bin/env bash
+printf 'always prefer idempotent operations\n'
+printf 'always prefer idempotent operations\n'
+printf 'never eval raw input\n'
+STUB
+    chmod +x "$_stub"
+
+    AUTOSPEC_PERSONA_EXTRACT_CMD="$_stub" bash "$MINE" \
+        --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    # All patterns must have both fields
+    local _bad
+    _bad="$(jq '[.patterns[] | select(has("pattern") and has("frequency") | not)] | length' "$DIGEST")"
+    [ "$_bad" -eq 0 ]
+}
+
+@test "extractor seam: patterns come from mock extractor output" {
+    _stub="$TMP/extractor.sh"
+    cat > "$_stub" <<'STUB'
+#!/usr/bin/env bash
+printf 'always use the extractor seam\n'
+printf 'never bypass the seam\n'
+STUB
+    chmod +x "$_stub"
+
+    AUTOSPEC_PERSONA_EXTRACT_CMD="$_stub" bash "$MINE" \
+        --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    [ -f "$DIGEST" ]
+    local _count
+    _count="$(jq '.patterns | length' "$DIGEST")"
+    [ "$_count" -ge 1 ]
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# 5. Repo-scoped by default
+# ═══════════════════════════════════════════════════════════════════
+
+@test "default run corpus_scope is repo" {
+    write_fixture_md "$REPO_CORPUS/feedback_test.md" \
+        "always validate inputs"
+
+    bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    local _scope
+    _scope="$(jq -r '.corpus_scope' "$DIGEST")"
+    [ "$_scope" = "repo" ]
+}
+
+@test "default run does NOT read from a second project corpus" {
+    # Create a second project corpus (simulating another repo's corpus)
+    local _other_corpus="$FAKE_PROJECTS/-Users-${WHOAMI}-IdeaProjects-other-repo/memory"
+    mkdir -p "$_other_corpus"
+
+    # Plant a unique marker in the other corpus only
+    write_fixture_md "$_other_corpus/feedback_other.md" \
+        "always use UNIQUE_OTHER_CORPUS_MARKER in tests"
+
+    # The repo corpus has no such phrase
+    write_fixture_md "$REPO_CORPUS/feedback_mine.md" \
+        "prefer small commits"
+
+    bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    # Marker from other-repo must not appear in digest
+    local _found
+    _found="$(jq '[.patterns[] | select(.pattern | test("UNIQUE_OTHER_CORPUS_MARKER"))] | length' "$DIGEST")"
+    [ "$_found" -eq 0 ]
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# 6. Global opt-in
+# ═══════════════════════════════════════════════════════════════════
+
+@test "AUTOSPEC_PERSONA_MINE_GLOBAL=1 sets corpus_scope to global" {
+    write_fixture_md "$REPO_CORPUS/feedback_test.md" \
+        "always document decisions"
+
+    AUTOSPEC_PERSONA_MINE_GLOBAL=1 bash "$MINE" \
+        --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    local _scope
+    _scope="$(jq -r '.corpus_scope' "$DIGEST")"
+    [ "$_scope" = "global" ]
+}
+
+@test "AUTOSPEC_PERSONA_MINE_GLOBAL=1 reads other project corpora too" {
+    # Second project corpus
+    local _other_corpus="$FAKE_PROJECTS/-Users-${WHOAMI}-IdeaProjects-other-global/memory"
+    mkdir -p "$_other_corpus"
+    write_fixture_md "$_other_corpus/feedback_global.md" \
+        "always use GLOBAL_CORPUS_MARKER_XYZ for cross-repo checks"
+
+    # Repo corpus has its own entry
+    write_fixture_md "$REPO_CORPUS/feedback_local.md" \
+        "prefer explicit over implicit"
+
+    AUTOSPEC_PERSONA_MINE_GLOBAL=1 bash "$MINE" \
+        --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    # The global marker from the other corpus must appear
+    local _found
+    _found="$(jq '[.patterns[] | select(.pattern | test("GLOBAL_CORPUS_MARKER_XYZ"))] | length' "$DIGEST")"
+    [ "$_found" -ge 1 ]
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# 7. Redaction
+# ═══════════════════════════════════════════════════════════════════
+
+@test "planted secret token is absent from digest patterns" {
+    # Write a file with a decision line that contains a secret
+    write_fixture_md "$REPO_CORPUS/feedback_secrets.md" \
+        "always rotate the secret token ABC123XYZ_SECRET
+prefer automated rotation"
+
+    bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    local _found
+    _found="$(jq '[.patterns[] | select(.pattern | test("secret"))] | length' "$DIGEST")"
+    [ "$_found" -eq 0 ]
+}
+
+@test "redaction strips lines containing api_key" {
+    _stub="$TMP/extractor.sh"
+    cat > "$_stub" <<'STUB'
+#!/usr/bin/env bash
+printf 'always use api_key rotation\n'
+printf 'never skip validation\n'
+STUB
+    chmod +x "$_stub"
+
+    AUTOSPEC_PERSONA_EXTRACT_CMD="$_stub" bash "$MINE" \
+        --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    local _found
+    _found="$(jq '[.patterns[] | select(.pattern | test("api_key"))] | length' "$DIGEST")"
+    [ "$_found" -eq 0 ]
+}
+
+@test "redaction strips lines containing absolute /Users/ paths" {
+    _stub="$TMP/extractor.sh"
+    cat > "$_stub" <<'STUB'
+#!/usr/bin/env bash
+printf 'always check /Users/alice/.config for settings\n'
+printf 'prefer relative paths\n'
+STUB
+    chmod +x "$_stub"
+
+    AUTOSPEC_PERSONA_EXTRACT_CMD="$_stub" bash "$MINE" \
+        --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    local _found
+    _found="$(jq '[.patterns[] | select(.pattern | test("/Users/"))] | length' "$DIGEST")"
+    [ "$_found" -eq 0 ]
+}
+
+# ═══════════════════════════════════════════════════════════════════
+# 8. Truncation
+# ═══════════════════════════════════════════════════════════════════
+
+@test "truncation: digest has at most TOP_N patterns" {
+    # Generate 30 unique decision lines via extractor seam
+    _stub="$TMP/extractor.sh"
+    {
+        printf '#!/usr/bin/env bash\n'
+        for i in $(seq 1 30); do
+            printf 'printf '"'"'always do thing %s\\n'"'"'\n' "$i"
+        done
+    } > "$_stub"
+    chmod +x "$_stub"
+
+    AUTOSPEC_PERSONA_EXTRACT_CMD="$_stub" \
+    AUTOSPEC_PERSONA_MINE_TOP_N=5 \
+    bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    local _count
+    _count="$(jq '.patterns | length' "$DIGEST")"
+    [ "$_count" -le 5 ]
+}
+
+@test "truncation: logs a message to stderr when patterns exceed TOP_N" {
+    _stub="$TMP/extractor.sh"
+    {
+        printf '#!/usr/bin/env bash\n'
+        for i in $(seq 1 15); do
+            printf 'printf '"'"'always do unique thing %s\\n'"'"'\n' "$i"
+        done
+    } > "$_stub"
+    chmod +x "$_stub"
+
+    AUTOSPEC_PERSONA_EXTRACT_CMD="$_stub" \
+    AUTOSPEC_PERSONA_MINE_TOP_N=3 \
+    run bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    [ "$status" -eq 0 ]
+    # Truncation message must appear in stderr (captured in $output by bats run)
+    [[ "$output" == *"truncat"* ]]
+}
+
+@test "truncation: no log when patterns do not exceed TOP_N" {
+    _stub="$TMP/extractor.sh"
+    cat > "$_stub" <<'STUB'
+#!/usr/bin/env bash
+printf 'always prefer idempotent operations\n'
+printf 'never skip tests\n'
+STUB
+    chmod +x "$_stub"
+
+    AUTOSPEC_PERSONA_EXTRACT_CMD="$_stub" \
+    AUTOSPEC_PERSONA_MINE_TOP_N=20 \
+    run bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"truncat"* ]]
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/autonomous-persona-mine.sh`: mines the repo-slug-scoped Claude projects corpus (`~/.claude/projects/-Users-<user>-IdeaProjects-<repo>/memory`) for recurring decision patterns and emits `~/.autospec/persona-mined-digest.json` as the F1 precedence-3 source.
- Adds `tests/autonomous/test_persona_mine.bats`: 23 tests covering opt-out, absent-corpus no-op, pattern extraction via subprocess seam, repo-scoped default, global opt-in, redaction, and truncation.

## Behaviour

| Env var | Default | Effect |
|---|---|---|
| `AUTOSPEC_PERSONA_MINE` | `1` | Set to `0` to disable entirely (no-op exit 0) |
| `AUTOSPEC_PERSONA_MINE_GLOBAL` | `0` | Set to `1` to mine all Claude projects corpora |
| `AUTOSPEC_PERSONA_MINE_TOP_N` | `20` | Max patterns in digest; logs truncation warning |
| `AUTOSPEC_PERSONA_EXTRACT_CMD` | (built-in grep) | Subprocess seam for testing |

Privacy: output is decision PATTERNS only; redaction pass strips secrets/paths before JSON is written.

## Test plan

- [x] `bats tests/autonomous/test_persona_mine.bats` — 23/23 passed
- [x] `bash scripts/validate.sh` — exit 0, all checks passed

Closes #1420

🤖 Generated with [Claude Code](https://claude.com/claude-code)