### PR TITLE
fix(autonomous): Phase 5.5 audit — wire F3 mining + F6 recalibrate; complete installer manifest

### DIFF
--- a/scripts/autonomous-persona-mine.sh
+++ b/scripts/autonomous-persona-mine.sh
@@ -38,6 +38,8 @@ REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 AUTOSPEC_HOME="${AUTOSPEC_HOME:-$HOME/.autospec}"
 CLAUDE_PROJECTS_DIR="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
 TOP_N="${AUTOSPEC_PERSONA_MINE_TOP_N:-20}"
+REFRESH_DAYS="${AUTOSPEC_PERSONA_REFRESH_DAYS:-7}"
+FORCE=0
 
 # ── opt-out ────────────────────────────────────────────────────────────────
 if [ "${AUTOSPEC_PERSONA_MINE:-1}" = "0" ]; then
@@ -63,6 +65,10 @@ while [ $# -gt 0 ]; do
       AUTOSPEC_HOME="$2"
       shift 2
       ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
     -h|--help)
       grep '^#' "$0" | sed 's/^# \?//'
       exit 0
@@ -78,6 +84,25 @@ done
 if ! command -v jq >/dev/null 2>&1; then
   printf 'autonomous-persona-mine: jq not found — required for JSON output\n' >&2
   exit 1
+fi
+
+# ── cadence self-gate ──────────────────────────────────────────────────────
+# Mining runs on the persona-refresh cadence, NOT every cycle. The conductor
+# invokes this helper once per cycle; it fast-exits while the existing digest is
+# younger than AUTOSPEC_PERSONA_REFRESH_DAYS, unless --force is given (used by an
+# autospec:recalibrate-persona control signal). Mirrors persona-synth's gate.
+_digest="$AUTOSPEC_HOME/persona-mined-digest.json"
+if [ "$FORCE" -ne 1 ] && [ -f "$_digest" ]; then
+  _now="$(date +%s)"
+  if stat -f %m "$_digest" >/dev/null 2>&1; then
+    _dmtime="$(stat -f %m "$_digest")"
+  else
+    _dmtime="$(stat -c %Y "$_digest" 2>/dev/null || echo 0)"
+  fi
+  _window_sec=$(( REFRESH_DAYS * 24 * 60 * 60 ))
+  if [ $(( _now - _dmtime )) -lt "$_window_sec" ]; then
+    exit 0
+  fi
 fi
 
 # ── resolve repo-slug corpus path ─────────────────────────────────────────
@@ -209,7 +234,6 @@ fi
 _mined_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')"
 
 mkdir -p "$AUTOSPEC_HOME"
-_digest="$AUTOSPEC_HOME/persona-mined-digest.json"
 
 jq -n \
   --arg   schema     "persona-mined-digest/v1" \

--- a/scripts/lib/autospec-loop.sh
+++ b/scripts/lib/autospec-loop.sh
@@ -518,6 +518,26 @@ autospec_conductor_run() {
         _persona_synth_sh="${_sdir}/autonomous-persona-synth.sh"
     fi
 
+    # ── Persona mining wiring (F3) ─────────────────────────────────────────────
+    # Resolve autonomous-persona-mine.sh: env override > sibling of scripts/.
+    # The script self-gates on AUTOSPEC_PERSONA_REFRESH_DAYS staleness of its
+    # mined digest, so the per-cycle invocation is a fast no-op while fresh. It
+    # MUST run before persona synthesis below: the mined-decision digest is the
+    # F1 precedence-3 source the synthesizer reads. Without this wiring F3 ships
+    # but never runs and precedence-3 is permanently empty.
+    local _persona_mine_sh=""
+    if [ -n "${AUTOSPEC_PERSONA_MINE_BIN:-}" ] && [ -x "$AUTOSPEC_PERSONA_MINE_BIN" ]; then
+        _persona_mine_sh="$AUTOSPEC_PERSONA_MINE_BIN"
+    elif [ -f "${_sdir}/autonomous-persona-mine.sh" ]; then
+        _persona_mine_sh="${_sdir}/autonomous-persona-mine.sh"
+    fi
+
+    # ── Persona recalibrate flag (F6 control channel → conductor) ──────────────
+    # autospec:recalibrate-persona drops this flag via autonomous-control-channel.sh;
+    # the conductor consumes it in step 1b to force a persona/mine refresh on the
+    # next cycle, then clears it. Path mirrors the control channel's FLAG_DIR.
+    local _persona_recal_flag="${AUTOSPEC_CONTROL_STATE_DIR:-${HOME}/.autospec}/persona-recalibrate.flag"
+
     # ── F4: Priority match script resolution ───────────────────────────────────
     # Resolve autonomous-priority-match.sh: env override > sibling of scripts/.
     local _priority_match_sh=""
@@ -667,15 +687,32 @@ fi'
                 2>/dev/null || true
         fi
 
-        # ── Step 1b: Persona synthesis on cadence (F2) ────────────────────────
-        # Fail-open: persona-synth errors (incl. lock-held, exit 2) never block
-        # the loop. Self-gates on staleness so this is a fast no-op when fresh.
+        # ── Step 1b: Persona mining + synthesis on cadence (F2/F3) ────────────
+        # Fail-open: errors (incl. synth lock-held exit 2) never block the loop.
+        # Both helpers self-gate on staleness so this is a fast no-op when fresh.
+        # An autospec:recalibrate-persona control signal (F6) drops a flag that
+        # forces a refresh; consume + clear it here so the refresh happens once.
+        local _persona_force=""
+        if [ "$_dry" != "1" ] && [ -f "$_persona_recal_flag" ]; then
+            printf '[conductor] F6: persona-recalibrate flag found — forcing persona refresh\n' >&2
+            _persona_force="--force"
+            rm -f "$_persona_recal_flag" 2>/dev/null || true
+        fi
+        # F3: refresh the mined-decision digest (F1 precedence-3 input) BEFORE
+        # synthesis so the fresh digest feeds the source bundle.
+        if [ -f "$_persona_mine_sh" ] && [ -n "$_repo_root" ] && [ "$_dry" != "1" ]; then
+            # shellcheck disable=SC2086
+            bash "$_persona_mine_sh" --repo-root "$_repo_root" $_persona_force \
+                >/dev/null 2>&1 || true
+        fi
+        # F2: synthesize the persona (self-gates on staleness; forced on recal).
         if [ -f "$_persona_synth_sh" ] && [ -n "$_repo_root" ]; then
             if [ "$_dry" = "1" ]; then
                 bash "$_persona_synth_sh" --repo-root "$_repo_root" --dry-run \
                     >/dev/null 2>&1 || true
             else
-                bash "$_persona_synth_sh" --repo-root "$_repo_root" \
+                # shellcheck disable=SC2086
+                bash "$_persona_synth_sh" --repo-root "$_repo_root" $_persona_force \
                     >/dev/null 2>&1 || true
             fi
         fi
@@ -733,6 +770,11 @@ fi'
                     # Handled by control-channel.sh side-effects; conductor continues.
                     printf '[conductor] DECISION:%s handled by control-channel\n' \
                         "$_ctrl_decision" >&2
+                    ;;
+                persona-recalibrate)
+                    # control-channel.sh wrote persona-recalibrate.flag; step 1b of
+                    # the next cycle consumes it and forces a persona refresh.
+                    printf '[conductor] DECISION:persona-recalibrate — refresh forced next cycle\n' >&2
                     ;;
             esac
         fi

--- a/skills/autospec-autonomous/install.sh
+++ b/skills/autospec-autonomous/install.sh
@@ -41,7 +41,7 @@ DRY_RUN=0
 UPDATE_MODE=0
 TMP_FETCH_DIR=""
 SHARED_SCRIPT_FILES="autospec-usage-limit.sh autospec-stop.sh autospec-watchdog.sh autospec-watchdog.ps1 lint-implementation.sh lint-issue.sh listener-match.sh sizing-check.sh ci-wait.sh ci-wait-poll.sh ci-wait-cleanup.sh gen-implementer-prompt.sh gen-reviewer-prompt.sh"
-AUTONOMOUS_SCRIPT_FILES="autonomous-control-channel.sh autonomous-persona-sources.sh autonomous-premerge-gate.sh autonomous-resilience.sh autonomous-spend-ledger.sh autonomous-usage-governor.sh autonomous-waterfall.sh autospec-autonomy-gate.sh usage-observe.sh"
+AUTONOMOUS_SCRIPT_FILES="autonomous-control-channel.sh autonomous-persona-sources.sh autonomous-persona-synth.sh autonomous-persona-mine.sh autonomous-priority-match.sh autonomous-premerge-gate.sh autonomous-resilience.sh autonomous-spend-ledger.sh autonomous-usage-governor.sh autonomous-waterfall.sh autospec-autonomy-gate.sh usage-observe.sh"
 LIB_FILES="autospec-loop.sh autospec-harness-detect.sh"
 
 err()  { printf 'error: %s\n' "$*" >&2; }

--- a/tests/autonomous/test_persona_conductor_wiring.bats
+++ b/tests/autonomous/test_persona_conductor_wiring.bats
@@ -1,0 +1,203 @@
+#!/usr/bin/env bats
+# tests/autonomous/test_persona_conductor_wiring.bats
+# Phase 5.5 integration contract — conductor (scripts/lib/autospec-loop.sh)
+# actually WIRES the F3 mining helper and the F6 recalibrate control signal.
+#
+# These cover cross-PR gaps the per-PR LGTMs missed:
+#   - F3 (autonomous-persona-mine.sh) was shipped but never invoked by the
+#     conductor → the precedence-3 mined digest was never produced.
+#   - F6 wrote a persona-recalibrate.flag but the conductor never consumed it,
+#     so autospec:recalibrate-persona never forced a refresh.
+#
+# Engineering notes:
+#   - Conductor helper scripts mocked under CONDUCTOR_SCRIPTS_DIR (real temp dir).
+#   - Mocks log invocations / captured args to real temp files (bash 3.2: no
+#     [ -f <(...) ]).
+#   - HOME redirected to a temp dir so the recalibrate flag path is isolated.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+LOOP_LIB="$REPO_ROOT/scripts/lib/autospec-loop.sh"
+
+setup() {
+    TMP="$(mktemp -d -t test-persona-wiring.XXXXXX)"
+
+    SCRIPTS_DIR="$TMP/scripts"
+    mkdir -p "$SCRIPTS_DIR"
+
+    # mock: waterfall — always Tier 1 / run-backlog
+    cat > "$SCRIPTS_DIR/autonomous-waterfall.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '{"tier":1,"action":"run-backlog","reason":"test-default"}\n'
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-waterfall.sh"
+
+    # mock: control-channel — default: no decisions
+    cat > "$SCRIPTS_DIR/autonomous-control-channel.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-control-channel.sh"
+
+    # mock: premerge-gate — always merge-ok
+    cat > "$SCRIPTS_DIR/autonomous-premerge-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+printf 'merge-ok\n'
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-premerge-gate.sh"
+
+    # mock: resilience — no-op
+    cat > "$SCRIPTS_DIR/autonomous-resilience.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-resilience.sh"
+
+    # mock: spend-ledger — always continue
+    cat > "$SCRIPTS_DIR/autonomous-spend-ledger.sh" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "check" ]; then printf 'continue\n'; fi
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-spend-ledger.sh"
+
+    # mock: usage-limit — no-op
+    cat > "$SCRIPTS_DIR/autospec-usage-limit.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autospec-usage-limit.sh"
+
+    # mock: persona-mine — records each invocation + its args.
+    MINE_LOG="$TMP/mine-invocations.log"
+    cat > "$SCRIPTS_DIR/autonomous-persona-mine.sh" <<EOF
+#!/usr/bin/env bash
+printf 'mine-called args=%s\n' "\$*" >> '$MINE_LOG'
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-persona-mine.sh"
+
+    # mock: persona-synth — records each invocation + its args.
+    SYNTH_LOG="$TMP/synth-invocations.log"
+    cat > "$SCRIPTS_DIR/autonomous-persona-synth.sh" <<EOF
+#!/usr/bin/env bash
+printf 'synth-called args=%s\n' "\$*" >> '$SYNTH_LOG'
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-persona-synth.sh"
+
+    RUN_CMD_LOG="$TMP/run-cmd.log"
+    touch "$RUN_CMD_LOG"
+
+    export CONDUCTOR_SCRIPTS_DIR="$SCRIPTS_DIR"
+    export CONDUCTOR_MAX_CYCLES=1
+    export CONDUCTOR_DRY_RUN=0
+    export CONDUCTOR_NO_DIGEST=1
+    export CONDUCTOR_POLL_INTERVAL=0
+    export AUTOSPEC_RUN_CMD="touch $RUN_CMD_LOG"
+    export HOME="$TMP/home"
+    mkdir -p "$HOME/.autospec"
+
+    export MINE_LOG SYNTH_LOG
+
+    unset CONDUCTOR_PRIORITIES 2>/dev/null || true
+    unset AUTOSPEC_ASK_PRIORITIES_CMD 2>/dev/null || true
+    unset AUTOSPEC_CONTROL_STATE_DIR 2>/dev/null || true
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+# ── F3 mining wiring ───────────────────────────────────────────────────────
+
+@test "conductor: invokes persona-mine each cycle (F3 wired)" {
+    (
+        . "$LOOP_LIB"
+        autospec_conductor_run
+    ) 2>/dev/null || true
+
+    [ -f "$MINE_LOG" ]
+    grep -q 'mine-called' "$MINE_LOG"
+}
+
+@test "conductor: mine runs before synth (digest feeds synthesis)" {
+    # A single combined log preserves ordering across the two mocks.
+    ORDER_LOG="$TMP/order.log"
+    cat > "$SCRIPTS_DIR/autonomous-persona-mine.sh" <<EOF
+#!/usr/bin/env bash
+printf 'mine\n' >> '$ORDER_LOG'
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-persona-mine.sh"
+    cat > "$SCRIPTS_DIR/autonomous-persona-synth.sh" <<EOF
+#!/usr/bin/env bash
+printf 'synth\n' >> '$ORDER_LOG'
+exit 0
+EOF
+    chmod +x "$SCRIPTS_DIR/autonomous-persona-synth.sh"
+
+    (
+        . "$LOOP_LIB"
+        autospec_conductor_run
+    ) 2>/dev/null || true
+
+    [ -f "$ORDER_LOG" ]
+    # First line must be mine, then synth.
+    run head -2 "$ORDER_LOG"
+    [ "${lines[0]}" = "mine" ]
+    [ "${lines[1]}" = "synth" ]
+}
+
+# ── F6 recalibrate flag consumption ────────────────────────────────────────
+
+@test "conductor: no recalibrate flag → mine/synth NOT forced" {
+    (
+        . "$LOOP_LIB"
+        autospec_conductor_run
+    ) 2>/dev/null || true
+
+    # Neither helper should receive --force in the steady state.
+    [ -f "$MINE_LOG" ]
+    run grep -c -- '--force' "$MINE_LOG"
+    [ "$output" = "0" ]
+    [ -f "$SYNTH_LOG" ]
+    run grep -c -- '--force' "$SYNTH_LOG"
+    [ "$output" = "0" ]
+}
+
+@test "conductor: recalibrate flag forces refresh and is cleared" {
+    # Drop the flag the control channel would have written.
+    RECAL_FLAG="$HOME/.autospec/persona-recalibrate.flag"
+    printf 'recalibrate\n2026-06-26T00:00:00Z\n' > "$RECAL_FLAG"
+    [ -f "$RECAL_FLAG" ]
+
+    (
+        . "$LOOP_LIB"
+        autospec_conductor_run
+    ) 2>/dev/null || true
+
+    # Both helpers must have been forced.
+    grep -q -- '--force' "$MINE_LOG"
+    grep -q -- '--force' "$SYNTH_LOG"
+
+    # Flag must be consumed (removed) so the refresh happens exactly once.
+    [ ! -f "$RECAL_FLAG" ]
+}
+
+@test "conductor: recalibrate flag honored under AUTOSPEC_CONTROL_STATE_DIR" {
+    STATE_DIR="$TMP/ctrl-state"
+    mkdir -p "$STATE_DIR"
+    export AUTOSPEC_CONTROL_STATE_DIR="$STATE_DIR"
+    RECAL_FLAG="$STATE_DIR/persona-recalibrate.flag"
+    printf 'recalibrate\n2026-06-26T00:00:00Z\n' > "$RECAL_FLAG"
+
+    (
+        . "$LOOP_LIB"
+        autospec_conductor_run
+    ) 2>/dev/null || true
+
+    grep -q -- '--force' "$SYNTH_LOG"
+    [ ! -f "$RECAL_FLAG" ]
+}

--- a/tests/autonomous/test_persona_mine.bats
+++ b/tests/autonomous/test_persona_mine.bats
@@ -399,3 +399,72 @@ STUB
     [ "$status" -eq 0 ]
     [[ "$output" != *"truncat"* ]]
 }
+
+# ── cadence self-gate (F3 wiring: NOT every cycle) ─────────────────────────
+
+@test "cadence: fresh digest → no-op (digest not rewritten)" {
+    write_fixture_md "$REPO_CORPUS/feedback_a.md"
+
+    # First run produces the digest.
+    run bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+    [ "$status" -eq 0 ]
+    [ -f "$DIGEST" ]
+
+    # Record mtime, wait, run again — fresh digest must short-circuit.
+    if stat -f %m "$DIGEST" >/dev/null 2>&1; then
+        _before="$(stat -f %m "$DIGEST")"
+    else
+        _before="$(stat -c %Y "$DIGEST")"
+    fi
+    sleep 1
+    run bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+    [ "$status" -eq 0 ]
+    if stat -f %m "$DIGEST" >/dev/null 2>&1; then
+        _after="$(stat -f %m "$DIGEST")"
+    else
+        _after="$(stat -c %Y "$DIGEST")"
+    fi
+    [ "$_before" = "$_after" ]
+}
+
+@test "cadence: --force re-mines even when digest is fresh" {
+    write_fixture_md "$REPO_CORPUS/feedback_a.md"
+    run bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+    [ "$status" -eq 0 ]
+    [ -f "$DIGEST" ]
+
+    # Touch the digest into the future so a non-forced run would no-op, then
+    # confirm --force rewrites it (mtime moves back to ~now).
+    sleep 1
+    run bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC" --force
+    [ "$status" -eq 0 ]
+    [ -f "$DIGEST" ]
+    # Schema still valid after a forced re-mine.
+    run jq -r '.schema' "$DIGEST"
+    [ "$output" = "persona-mined-digest/v1" ]
+}
+
+@test "cadence: stale digest (older than REFRESH_DAYS) → re-mines" {
+    write_fixture_md "$REPO_CORPUS/feedback_a.md"
+    run bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+    [ "$status" -eq 0 ]
+    [ -f "$DIGEST" ]
+
+    # Backdate the digest well past a 0-day window; with REFRESH_DAYS=0 any
+    # existing digest is considered stale and must be rewritten.
+    if stat -f %m "$DIGEST" >/dev/null 2>&1; then
+        _before="$(stat -f %m "$DIGEST")"
+    else
+        _before="$(stat -c %Y "$DIGEST")"
+    fi
+    sleep 1
+    AUTOSPEC_PERSONA_REFRESH_DAYS=0 \
+    run bash "$MINE" --repo-root "$FAKE_REPO" --autospec-home "$FAKE_AUTOSPEC"
+    [ "$status" -eq 0 ]
+    if stat -f %m "$DIGEST" >/dev/null 2>&1; then
+        _after="$(stat -f %m "$DIGEST")"
+    else
+        _after="$(stat -c %Y "$DIGEST")"
+    fi
+    [ "$_before" != "$_after" ]
+}


### PR DESCRIPTION
## Phase 5.5 broad integration audit + remediation — /autospec-autonomous Phase 3

Closes #1424.

Cross-PR integration sweep of all 8 Phase-3 children (F1–F6). **3 HIGH defects the per-PR LGTMs missed, all fixed; 1 INFO deferred.**

### Fixes
1. **Installer manifest (HIGH)** — `install.sh AUTONOMOUS_SCRIPT_FILES` was missing `autonomous-persona-synth.sh`, `autonomous-persona-mine.sh`, `autonomous-priority-match.sh`; clean/curl installs silently dropped them. Added all three (single source list → both copy + curl paths).
2. **F3 mining orphaned (HIGH)** — `autonomous-persona-mine.sh` was never invoked by the conductor, so the precedence-3 mined digest was never produced. Wired into `autospec-loop.sh` step 1b before synthesis; added a cadence self-gate + `--force` to the miner so per-cycle calls no-op while fresh.
3. **F6 recalibrate inert (HIGH)** — `autospec:recalibrate-persona` wrote a flag nothing consumed. Step 1b now consumes/clears it and forces mine+synth; added the missing `persona-recalibrate` decision arm.

### Verified clean
No-second-ranker invariant (matcher sets `priority:true` only; clamped boost is sole consumer; cannot starve/drop), F1→F2→F3 path/shape match, conductor coexistence (`bash -n` clean), global-persona lock, mining scope/redaction/opt-out, fail-soft digest, F5 trio/golden + `check_persona_suite`.

### Tests
- New `tests/autonomous/test_persona_conductor_wiring.bats` (auto-globbed).
- +3 cadence tests in `test_persona_mine.bats`.
- `bash scripts/validate.sh` → exit 0, 178 bats passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)