### PR TITLE
docs(memory): land 2 session memory notes from stale branch

### DIFF
--- a/docs/memory/MEMORY.md
+++ b/docs/memory/MEMORY.md
@@ -47,6 +47,7 @@ older than 7 days AND the lesson is no longer load-bearing, archive it.
 - [validate.sh lockstep duo gap](feedback_validate_sh_lockstep_duo_gap.md) — check_lockstep() must guard SKILL.md+codex/prompt.md duos, not just full trios
 - [Skill golden + derivation workflow](feedback_skill_golden_derivation_workflow.md) — editing any trio skill (esp. with autospec-block markers) needs re-derive codex/opencode AND regenerate tests/fixtures/skill-goldens sha256, or validate.sh fails closed
 - [Decompose: trio prose + goldens must be one issue](feedback_decompose_trio_prose_goldens_atomic.md) — never split "edit trio prose" and "regen goldens" into separate auto-implement issues; the prose-only intermediate fails validate closed (bit 3x in one run); combine into one implementer that Closes both
+- [Trio derivation tooling (use it)](reference_trio_derivation_tooling.md) — edit SKILL.md then `derive-trio.sh --in-place` + `gen-skill-goldens.sh`; stop hand-maintaining codex/opencode + goldens; validate's check_derive_trio_consistency enforces it; decomposer now treats trio+goldens as one unit
 - [jq test() regex metachar injection](feedback_jq_test_regex_metachar_injection.md) — interpolating host/user-derived values into jq test() is regex injection; dotted hostnames made claim self-clean delete the wrong worker's lock comment; use capture()+==
 - [Self-consistent test fixtures mask bugs](feedback_self_consistent_test_fixtures_mask_bugs.md) — tests that build fixtures with the SUT's own derivation expression can't catch a bug in it; the Claude transcript-slug `lstrip` bug shipped green for months. Pin against the real convention / live values; reproduce end-to-end
 
@@ -69,6 +70,7 @@ older than 7 days AND the lesson is no longer load-bearing, archive it.
 
 - [Autospec tooling optimization — tracker #421](project_autospec_tooling_optimization.md) — convert LLM-driven steps to deterministic tools
 - [Autospec mutation testing — tracker #420](project_autospec_mutation_testing.md) — test-of-tests layer: mutation gate + assertion-density floor + negative-path-pair lint
+- [Babysit-tax → Autonomy Charter](project_babysit_tax_autonomy_charter.md) — session mining: operator confirmations are ~always rubber-stamps of the agent's own recommendation; build a standing recommendation=action charter, auto-chain define→run→explore, push notifications on async waits
 
 <!-- Archived (shipped or session-historical; files kept on disk, removed from index):
 - project_2026_05_22_23_session_close.md — historical session close 2026-05-22→23

--- a/docs/memory/project_babysit_tax_autonomy_charter.md
+++ b/docs/memory/project_babysit_tax_autonomy_charter.md
@@ -1,0 +1,20 @@
+---
+name: project_babysit_tax_autonomy_charter
+description: "Session-mining shows the operator's confirmation turns are ~always rubber-stamps of the agent's own stated recommendation; autospec needs a standing Autonomy Charter"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 5bdc71c2-d23b-4462-9d28-61ca3ab6e3dd
+---
+
+Mined all ~2963 Claude + ~1538 Codex transcripts (2026-06-25). Pure low-information steering turns: Claude 5.2% of human turns, Codex 13.4%; autospec project = 76 turns (22 bare "yes/looks good"). Dominant bucket is `approve_long` ("yes, do X" / "ok fix that one once and for all" / "review the whole project for gaps").
+
+**Why:** Every gate is the same shape — the agent *states its own recommendation*, then asks permission, and the operator always grants it. Four recurring stop-points:
+1. **Design ratification** before spec-writing ("State machine make sense? Test plan look sound? UX feel right?") — operator never overrides.
+2. **Spec→plan→implement handoff gates** built into autospec-define ("review the spec before I invoke writing-plans").
+3. **"Want me to commit / file these gap issues / run fixture-gen?"** — permission for the obviously-next reversible action.
+4. **End-of-queue stall** ("queue empty, next work: none, standing by") — operator always replies "review the whole project for gaps," which IS [[feedback_autospec_design_prefs]]'s explore/review loop.
+
+Plus a `poll` bucket during async CI/monitor waits ("how do they look?") = the agent goes silent instead of pushing transition notifications.
+
+**How to apply:** Build a single shared **Autonomy Charter** referenced by all autospec entrypoints (no central one exists today; gates are scattered across autospec-define/run/the orchestrator). Rule: *recommendation = action*. Auto-proceed on reversible/local steps and on the agent's own stated next step; pause ONLY for destructive remote ops, irreversible deletes, genuine no-clear-winner forks, or cost thresholds — consistent with [[feedback_autospec_autonomy_scope]]. Collapse design-ratification into "Decisions I made (flag if wrong)" + self-review. Auto-advance define→run; on queue drain auto-chain into /autospec-explore or /autospec-review. Use PushNotification on async-wait transitions instead of waiting to be pinged. Related: [[feedback_proactively_query_memory]].

--- a/docs/memory/reference_trio_derivation_tooling.md
+++ b/docs/memory/reference_trio_derivation_tooling.md
@@ -1,0 +1,32 @@
+---
+name: reference_trio_derivation_tooling
+description: Edit a trio skill via SKILL.md + derive-trio.sh --in-place + gen-skill-goldens.sh — do NOT hand-maintain codex/opencode or hand-regen goldens anymore
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 59916493-7c02-4311-889a-2cbeccc1c071
+---
+
+As of the 2026-06-16 efficiency wave, the trio skill maintenance workflow is
+automated — stop hand-copying the mirrors and hand-hashing goldens:
+
+1. Edit `skills/<name>/SKILL.md` only (the authoritative source).
+2. `bash scripts/derive-trio.sh --in-place skills/<name>` — regenerates
+   `codex/prompt.md` (frontmatter-stripped SKILL body) and `opencode/agent.md`
+   (its own frontmatter + SKILL body). `--check` is the deterministic
+   `check_lockstep` equivalent (exit 0 / non-zero + diff); `--stdout <member>`
+   prints one mirror.
+3. `bash scripts/gen-skill-goldens.sh <name>` — regenerates the
+   `tests/fixtures/skill-goldens/<name>.*.sha256` (the `expand-skill-blocks.sh |
+   shasum` one-liner, automated).
+4. `scripts/validate.sh` now runs `check_derive_trio_consistency()` — on drift
+   it fails NAMING the skill + the exact fix command. The transform is exact:
+   `--check` passed for all 24 trios with zero divergence at ship time.
+
+Also: the decomposer (`autospec-define` Phase 3 + `sizing-check.sh`/`lint-issue.sh`)
+now counts a trio + its derived goldens as ONE logical unit, so the ≤3-files cap
+no longer forces the prose/golden split-then-recombine tax.
+
+Supersedes the manual steps in [[feedback_skill_golden_derivation_workflow]] and
+resolves [[feedback_decompose_trio_prose_goldens_atomic]] (the atomic-unit
+exemption shipped). Use the tooling; do not regress to hand edits.


### PR DESCRIPTION
Rescues two genuinely-new memory notes (`project_babysit_tax_autonomy_charter`, `reference_trio_derivation_tooling`) that existed only on the abandoned `feat/closeout-report-contract` branch, plus their MEMORY.md index lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)