### PR TITLE
ci(doc-drift): skip the gate on autospec's own repo (#1362)

### DIFF
--- a/.github/workflows/autospec-doc-drift.yml
+++ b/.github/workflows/autospec-doc-drift.yml
@@ -10,6 +10,15 @@ name: autospec-doc-drift
 # Runs check-doc-drift.sh --pr <N> against the PR diff. The gate exits non-zero
 # when source changes are not covered by a doc scope (drift), failing the job.
 #
+# The doc-drift job is SKIPPED on autospec's own repository (see the job-level
+# `if:` below). This template is meant for downstream consumer apps; autospec's
+# own repo does not comprehensively annotate its internal tooling
+# (scripts/, skills/*/tests/, *.bats) with `<!-- autospec-doc-scope -->`, so the
+# gate would report `missing_scope` on nearly every source PR — pure noise that
+# masks genuine drift findings (issue #1362). The guard only ever matches
+# `berlinguyinca/autospec`; a consumer's copy keeps running because its
+# repository name differs. (Issue #1362 option 1.)
+#
 # Part of epic #1280 / #1287.
 
 on:
@@ -25,6 +34,9 @@ permissions:
 
 jobs:
   doc-drift:
+    # Skip in autospec's own repo (issue #1362): the doc-scope discipline is for
+    # downstream consumer repos. Consumer copies still run (their repo name differs).
+    if: ${{ github.repository != 'berlinguyinca/autospec' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Closes #1362.

The `autospec-doc-drift` workflow is a **consumer-repo template**. Since #1347 fixed its script path, it runs for real on autospec's own PRs and reports `missing_scope` on nearly every source change — because autospec doesn't comprehensively annotate its internal tooling (scripts/, skills/*/tests/, *.bats) with `<!-- autospec-doc-scope -->`. That's pure noise that masks genuine drift findings.

**Fix (issue #1362 option 1):** gate the job with `if: github.repository != 'berlinguyinca/autospec'`. The guard only ever matches autospec's own repo; **consumer copies keep running** because their repository name differs. Header comment documents the rationale.

- YAML validated; job `if:` parses.
- All 17 `install-doc-drift.bats` tests pass (installer/template unaffected).
- `scripts/validate.sh` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)