### PR TITLE
feat(lint): add REINVENT_REPO_UTIL, NEW_DEP_UNJUSTIFIED, NEW_ABSTRACTION_SINGLE_CALLER detectors

### DIFF
--- a/scripts/lint-implementation.sh
+++ b/scripts/lint-implementation.sh
@@ -1167,6 +1167,161 @@ check_duplicate_names() {
     fi
 }
 
+# ── §3.2 REINVENT_REPO_UTIL detector ─────────────────────────────────────────
+# Net-new function whose name already exists elsewhere via rg.
+# LINT_SEARCH_ROOT env var overrides the search root (default: .).
+# Fail-open: rg error → no finding, exit 0.
+
+detect_reinvent_repo_util() {
+    command -v rg >/dev/null 2>&1 || return 0
+    local _root="${LINT_SEARCH_ROOT:-.}"
+
+    while IFS= read -r diff_file; do
+        [ -z "$diff_file" ] && continue
+        case "$diff_file" in
+            *.sh|*.bash|*.py|*.js|*.ts|*.go) ;;
+            *) continue ;;
+        esac
+
+        # File-level allow check
+        local _allow_pat="linter:allow-REINVENT_REPO_UTIL[[:space:]]+[^[:space:]]"
+        local _file_allowed=0
+        if get_added_lines_for_file "$diff_file" | grep -qE "$_allow_pat"; then
+            _file_allowed=1
+        fi
+
+        while IFS=: read -r lineno content; do
+            # Match bash/shell function definitions: name() or function name()
+            local fname=""
+            if printf '%s' "$content" | grep -qE '^[[:space:]]*(function[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*\(\)'; then
+                fname="$(printf '%s' "$content" | grep -oE '[A-Za-z_][A-Za-z0-9_]*\(\)' | head -1 | sed 's/()//')"
+            fi
+            [ -z "$fname" ] && continue
+
+            if [ "$_file_allowed" -eq 1 ]; then
+                emit_info "REINVENT_REPO_UTIL" "$diff_file" "$lineno" "suppressed by linter:allow-REINVENT_REPO_UTIL"
+                continue
+            fi
+
+            # rg -wl: list files with a function-definition match; fail-open via pipe.
+            # Exclude test files to avoid false positives from fixture heredocs.
+            local _cnt=0
+            _cnt="$(rg -l "^[[:space:]]*(function[[:space:]]+)?${fname}\(\)" \
+                "$_root" --glob '!*.bats' --glob '!tests/**' \
+                2>/dev/null | wc -l | tr -d ' ')" || _cnt=0
+            if [ "${_cnt:-0}" -gt 0 ]; then
+                emit_capped "REINVENT_REPO_UTIL" "$diff_file" "$lineno" \
+                    "function '${fname}' already defined elsewhere (${_cnt} file(s)) — reuse instead of reinventing"
+            fi
+        done <<EOF
+$(get_added_lines_with_lineno "$diff_file")
+EOF
+    done <<EOF
+$(get_diff_files)
+EOF
+}
+
+# ── §3.2 NEW_DEP_UNJUSTIFIED detector ────────────────────────────────────────
+# Manifest dep-add hunk without a 'why:' justification marker in the same section.
+
+detect_new_dep_unjustified() {
+    local _manifest_pat='(package\.json|requirements[^/]*\.txt|go\.mod|Cargo\.toml|pyproject\.toml|Gemfile)$'
+
+    while IFS= read -r diff_file; do
+        [ -z "$diff_file" ] && continue
+        printf '%s' "$diff_file" | grep -qE "$_manifest_pat" || continue
+
+        local _added
+        _added="$(get_added_lines_for_file "$diff_file")"
+        [ -z "$_added" ] && continue
+
+        # Detect dep-add line based on manifest type
+        local _has_dep=0 _dep_line="-"
+        while IFS=: read -r lineno content; do
+            local _is_dep=0
+            case "$diff_file" in
+                *package.json)
+                    printf '%s' "$content" | grep -qE '"[@A-Za-z][^"]*"[[:space:]]*:[[:space:]]*"[0-9^~>=*]' && _is_dep=1 ;;
+                *requirements*.txt)
+                    printf '%s' "$content" | grep -qE '^[A-Za-z][A-Za-z0-9._-]*[>=<!~^]' && _is_dep=1 ;;
+                *go.mod)
+                    printf '%s' "$content" | grep -qE '^[[:space:]]*[a-zA-Z].*v[0-9]+\.[0-9]' && _is_dep=1 ;;
+                *Cargo.toml)
+                    printf '%s' "$content" | grep -qE '^[a-z][a-z0-9_-]*[[:space:]]*=[[:space:]]*"[0-9^~>=]' && _is_dep=1 ;;
+                *Gemfile)
+                    printf '%s' "$content" | grep -qE "^[[:space:]]*gem[[:space:]]+['\"]" && _is_dep=1 ;;
+                *pyproject.toml)
+                    printf '%s' "$content" | grep -qE '^[A-Za-z][A-Za-z0-9._-]*[>=<!~^]' && _is_dep=1 ;;
+            esac
+            if [ "$_is_dep" -eq 1 ]; then
+                _has_dep=1; _dep_line="$lineno"
+            fi
+        done <<EOF
+$(get_added_lines_with_lineno "$diff_file")
+EOF
+        [ "$_has_dep" -eq 0 ] && continue
+
+        # Check for why: marker anywhere in the added lines for this file
+        if printf '%s\n' "$_added" | grep -qiE '(^|[[:space:]])why:[[:space:]]'; then
+            continue
+        fi
+        emit_capped "NEW_DEP_UNJUSTIFIED" "$diff_file" "$_dep_line" \
+            "dependency added without 'why:' justification marker in the same hunk"
+    done <<EOF
+$(get_diff_files)
+EOF
+}
+
+# ── §3.2 NEW_ABSTRACTION_SINGLE_CALLER detector ───────────────────────────────
+# New file matching *manager*|*factory*|*adapter*|*wrapper*|*base*|*abstract*
+# with <=1 call sites across the diff.
+
+detect_new_abstraction_single_caller() {
+    local _abs_pat='(manager|factory|adapter|wrapper|base|abstract)'
+
+    while IFS= read -r diff_file; do
+        [ -z "$diff_file" ] && continue
+        # Must match abstraction pattern (case-insensitive on basename)
+        printf '%s' "$(basename "$diff_file")" | grep -qiE "$_abs_pat" || continue
+        # Must be a new file in the diff
+        grep -A4 "^diff --git.*b/${diff_file}$" "$TMP_DIFF" 2>/dev/null | grep -q "^new file mode" || continue
+
+        # File-level allow check
+        if get_added_lines_for_file "$diff_file" | \
+            grep -qE "linter:allow-NEW_ABSTRACTION_SINGLE_CALLER[[:space:]]+[^[:space:]]"; then
+            emit_info "NEW_ABSTRACTION_SINGLE_CALLER" "$diff_file" "-" \
+                "suppressed by linter:allow-NEW_ABSTRACTION_SINGLE_CALLER"
+            continue
+        fi
+
+        # Collect function names defined in the new abstraction file
+        local _funcs
+        _funcs="$(get_added_lines_for_file "$diff_file" | \
+            grep -oE '[A-Za-z_][A-Za-z0-9_]*\(\)' | sed 's/()//' | sort -u)"
+
+        # Count call sites of those functions in other diff files
+        local _calls=0
+        while IFS= read -r other; do
+            [ -z "$other" ] && continue
+            [ "$other" = "$diff_file" ] && continue
+            for _fn in $_funcs; do
+                local _n=0
+                _n="$(get_added_lines_for_file "$other" | grep -cE "\b${_fn}\b" 2>/dev/null || true)"
+                _calls=$((_calls + _n))
+            done
+        done <<EOF
+$(get_diff_files)
+EOF
+
+        if [ "$_calls" -le 1 ]; then
+            emit_capped "NEW_ABSTRACTION_SINGLE_CALLER" "$diff_file" "-" \
+                "new abstraction '$(basename "$diff_file")' has only ${_calls} call site(s) in diff — verify a second caller exists or inline this logic"
+        fi
+    done <<EOF
+$(get_diff_files)
+EOF
+}
+
 # ── directives output mode ────────────────────────────────────────────────────
 # Maps each RULE_ID to a short imperative directive line.
 
@@ -1190,6 +1345,9 @@ rule_directive() {
         VACUOUS_EMPTY_TEST) printf 'Add at least one assertion to the empty test body.' ;;
         VACUOUS_NO_ASSERT) printf 'Add an assert/expect/run+grep call to the test so it can actually fail.' ;;
         ASSERTION_DENSITY) printf 'Add at least one assert/expect/run/grep call to each test block — zero-assertion tests cannot catch regressions.' ;;
+        REINVENT_REPO_UTIL) printf 'Reuse the existing helper found by rg instead of reimplementing — or add a linter:allow-REINVENT_REPO_UTIL <reason> comment.' ;;
+        NEW_DEP_UNJUSTIFIED) printf 'Add a "# why: <reason>" comment in the same hunk as the dependency addition.' ;;
+        NEW_ABSTRACTION_SINGLE_CALLER) printf 'Either wire a second call site now, inline the logic into its sole caller, or add linter:allow-NEW_ABSTRACTION_SINGLE_CALLER <reason>.' ;;
         *)               printf 'Fix the flagged %s violation before re-pushing.' "$rule_id" ;;
     esac
 }
@@ -1220,6 +1378,9 @@ if [ "$DIRECTIVES" -eq 1 ]; then
         if [ "$ASSERTION_DENSITY" -eq 1 ]; then
             detect_assertion_density
         fi
+        detect_reinvent_repo_util
+        detect_new_dep_unjustified
+        detect_new_abstraction_single_caller
     } > "$TMP_FINDINGS" 2>&1
 
     # Reformat each finding as a directive line
@@ -1251,6 +1412,9 @@ else
     if [ "$ASSERTION_DENSITY" -eq 1 ]; then
         detect_assertion_density
     fi
+    detect_reinvent_repo_util
+    detect_new_dep_unjustified
+    detect_new_abstraction_single_caller
 fi
 
 # Exit with min(FINDINGS_COUNT, FINDINGS_EXIT_CAP)

--- a/tests/lint/test_reuse_triage.bats
+++ b/tests/lint/test_reuse_triage.bats
@@ -1,0 +1,331 @@
+#!/usr/bin/env bats
+# tests/lint/test_reuse_triage.bats — reuse-triage RULE_IDs:
+#   REINVENT_REPO_UTIL, NEW_DEP_UNJUSTIFIED, NEW_ABSTRACTION_SINGLE_CALLER
+#
+# TDD: written before detectors exist.  Run with:
+#   bats tests/lint/test_reuse_triage.bats
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    LINT="${REPO_ROOT}/scripts/lint-implementation.sh"
+    TMPDIR_BATS="$(mktemp -d)"
+    FIXTURES="${BATS_TEST_DIRNAME}/fixtures"
+}
+
+teardown() {
+    rm -rf "$TMPDIR_BATS"
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# make_diff <rel-path> <src-file> <out-diff>
+# Build a synthetic "new file" git diff from a source payload.
+make_diff() {
+    local rel="$1" src="$2" out="$3"
+    local nlines
+    nlines="$(wc -l < "$src" | tr -d ' ')"
+    {
+        printf 'diff --git a/%s b/%s\n' "$rel" "$rel"
+        printf 'new file mode 100644\n'
+        printf '%s\n' '--- /dev/null'
+        printf '+++ b/%s\n' "$rel"
+        printf '@@ -0,0 +1,%s @@\n' "$nlines"
+        sed 's/^/+/' "$src"
+    } > "$out"
+}
+
+# make_hunk_diff <rel-path> <content> <out-diff>
+# Build a diff with a single +hunk (no new-file mode line) from raw content string.
+make_hunk_diff() {
+    local rel="$1" content="$2" out="$3"
+    local nlines
+    nlines="$(printf '%s\n' "$content" | wc -l | tr -d ' ')"
+    {
+        printf 'diff --git a/%s b/%s\n' "$rel" "$rel"
+        printf '%s\n' '--- a/'"$rel"
+        printf '+++ b/%s\n' "$rel"
+        printf '@@ -1,0 +1,%s @@\n' "$nlines"
+        printf '%s\n' "$content" | sed 's/^/+/'
+    } > "$out"
+}
+
+# ---------------------------------------------------------------------------
+# REINVENT_REPO_UTIL
+# ---------------------------------------------------------------------------
+
+@test "REINVENT_REPO_UTIL: new function whose name already exists in scripts/ is flagged" {
+    # The fixture adds a function called 'log_info' — which already appears in
+    # scripts/lib/ (or we plant a seed file so rg finds it).
+    seed_dir="$TMPDIR_BATS/scripts/lib"
+    mkdir -p "$seed_dir"
+    # Plant an existing definition so rg can find it.
+    printf 'log_info() { printf "[INFO] %s\\n" "$@"; }\n' > "$seed_dir/logging.sh"
+
+    src="$TMPDIR_BATS/new_script.sh"
+    cat > "$src" <<'PAYLOAD'
+#!/usr/bin/env bash
+# linter:allow-SECURITY fixture only
+log_info() {
+    printf '[INFO] %s\n' "$@"
+}
+PAYLOAD
+
+    diff="$TMPDIR_BATS/reinvent.diff"
+    make_diff "scripts/new_script.sh" "$src" "$diff"
+
+    # Run the linter with RG_ROOT pointing at our temp tree so rg finds the seed.
+    run env LINT_SEARCH_ROOT="$TMPDIR_BATS" bash "$LINT" --diff-file "$diff"
+    echo "# output: $output" >&3
+    printf '%s\n' "$output" | grep -q '^REINVENT_REPO_UTIL:'
+}
+
+@test "REINVENT_REPO_UTIL: new function not present anywhere else emits no finding" {
+    src="$TMPDIR_BATS/unique_func.sh"
+    cat > "$src" <<'PAYLOAD'
+#!/usr/bin/env bash
+xyzzy_completely_unique_helper_1439() {
+    printf 'hello\n'
+}
+PAYLOAD
+
+    diff="$TMPDIR_BATS/unique.diff"
+    make_diff "scripts/unique_func.sh" "$src" "$diff"
+
+    run bash "$LINT" --diff-file "$diff"
+    echo "# output: $output" >&3
+    count="$(printf '%s\n' "$output" | grep -c '^REINVENT_REPO_UTIL:' || true)"
+    [ "$count" -eq 0 ]
+}
+
+@test "REINVENT_REPO_UTIL: linter:allow suppresses finding" {
+    seed_dir="$TMPDIR_BATS/scripts/lib"
+    mkdir -p "$seed_dir"
+    printf 'log_info() { printf "[INFO] %s\\n" "$@"; }\n' > "$seed_dir/logging.sh"
+
+    src="$TMPDIR_BATS/allowed_script.sh"
+    cat > "$src" <<'PAYLOAD'
+#!/usr/bin/env bash
+# linter:allow-REINVENT_REPO_UTIL intentional reimplementation with different format
+log_info() {
+    printf '[INFO][%s] %s\n' "$(date +%s)" "$@"
+}
+PAYLOAD
+
+    diff="$TMPDIR_BATS/allowed.diff"
+    make_diff "scripts/allowed_script.sh" "$src" "$diff"
+
+    run env LINT_SEARCH_ROOT="$TMPDIR_BATS" bash "$LINT" --diff-file "$diff"
+    echo "# output: $output" >&3
+    count="$(printf '%s\n' "$output" | grep -c '^REINVENT_REPO_UTIL:' || true)"
+    [ "$count" -eq 0 ]
+}
+
+@test "REINVENT_REPO_UTIL: rg failure causes fail-open (no finding, exit 0)" {
+    src="$TMPDIR_BATS/any_func.sh"
+    cat > "$src" <<'PAYLOAD'
+#!/usr/bin/env bash
+some_func() { :; }
+PAYLOAD
+
+    diff="$TMPDIR_BATS/fail_open.diff"
+    make_diff "scripts/any_func.sh" "$src" "$diff"
+
+    # Point search root at a nonexistent path so rg errors out.
+    run env LINT_SEARCH_ROOT="/nonexistent_path_1439" bash "$LINT" --diff-file "$diff"
+    echo "# output: $output" >&3
+    count="$(printf '%s\n' "$output" | grep -c '^REINVENT_REPO_UTIL:' || true)"
+    [ "$count" -eq 0 ]
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# NEW_DEP_UNJUSTIFIED
+# ---------------------------------------------------------------------------
+
+@test "NEW_DEP_UNJUSTIFIED: dep added to package.json without why: marker is flagged" {
+    diff="$TMPDIR_BATS/dep_add.diff"
+    cat > "$diff" <<'DIFF'
+diff --git a/package.json b/package.json
+--- a/package.json
++++ b/package.json
+@@ -1,4 +1,5 @@
+ {
+   "dependencies": {
++    "some-lib": "^1.2.3"
+   }
+ }
+DIFF
+
+    run bash "$LINT" --diff-file "$diff"
+    echo "# output: $output" >&3
+    printf '%s\n' "$output" | grep -q '^NEW_DEP_UNJUSTIFIED:'
+}
+
+@test "NEW_DEP_UNJUSTIFIED: dep added with why: comment is silent" {
+    diff="$TMPDIR_BATS/dep_why.diff"
+    cat > "$diff" <<'DIFF'
+diff --git a/package.json b/package.json
+--- a/package.json
++++ b/package.json
+@@ -1,4 +1,6 @@
+ {
+   "dependencies": {
++    "some-lib": "^1.2.3"
++  }
++  // why: needed for HTTP client pooling in scripts/fetch.js
+ }
+DIFF
+
+    run bash "$LINT" --diff-file "$diff"
+    echo "# output: $output" >&3
+    count="$(printf '%s\n' "$output" | grep -c '^NEW_DEP_UNJUSTIFIED:' || true)"
+    [ "$count" -eq 0 ]
+}
+
+@test "NEW_DEP_UNJUSTIFIED: dep added to requirements.txt without why: is flagged" {
+    diff="$TMPDIR_BATS/req_add.diff"
+    cat > "$diff" <<'DIFF'
+diff --git a/requirements.txt b/requirements.txt
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,3 +1,4 @@
+ requests==2.28.0
++boto3==1.26.0
+ pytest==7.2.0
+DIFF
+
+    run bash "$LINT" --diff-file "$diff"
+    echo "# output: $output" >&3
+    printf '%s\n' "$output" | grep -q '^NEW_DEP_UNJUSTIFIED:'
+}
+
+@test "NEW_DEP_UNJUSTIFIED: dep in requirements.txt with why: comment in same hunk is silent" {
+    diff="$TMPDIR_BATS/req_why.diff"
+    cat > "$diff" <<'DIFF'
+diff --git a/requirements.txt b/requirements.txt
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,3 +1,5 @@
+ requests==2.28.0
++# why: boto3 needed for S3 uploads in scripts/upload.py
++boto3==1.26.0
+ pytest==7.2.0
+DIFF
+
+    run bash "$LINT" --diff-file "$diff"
+    echo "# output: $output" >&3
+    count="$(printf '%s\n' "$output" | grep -c '^NEW_DEP_UNJUSTIFIED:' || true)"
+    [ "$count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# NEW_ABSTRACTION_SINGLE_CALLER
+# ---------------------------------------------------------------------------
+
+@test "NEW_ABSTRACTION_SINGLE_CALLER: new *-manager file with one call site is flagged" {
+    diff="$TMPDIR_BATS/manager_add.diff"
+    cat > "$diff" <<'DIFF'
+diff --git a/scripts/worker-manager.sh b/scripts/worker-manager.sh
+new file mode 100644
+--- /dev/null
++++ b/scripts/worker-manager.sh
+@@ -0,0 +1,5 @@
++#!/usr/bin/env bash
++manage_workers() {
++    printf 'managing\n'
++}
+diff --git a/scripts/run.sh b/scripts/run.sh
+--- a/scripts/run.sh
++++ b/scripts/run.sh
+@@ -10,0 +11 @@
++manage_workers
+DIFF
+
+    run bash "$LINT" --diff-file "$diff"
+    echo "# output: $output" >&3
+    printf '%s\n' "$output" | grep -q '^NEW_ABSTRACTION_SINGLE_CALLER:'
+}
+
+@test "NEW_ABSTRACTION_SINGLE_CALLER: new *-manager file with zero call sites in diff is flagged" {
+    diff="$TMPDIR_BATS/manager_nocall.diff"
+    cat > "$diff" <<'DIFF'
+diff --git a/scripts/session-manager.sh b/scripts/session-manager.sh
+new file mode 100644
+--- /dev/null
++++ b/scripts/session-manager.sh
+@@ -0,0 +1,4 @@
++#!/usr/bin/env bash
++manage_session() {
++    printf 'session\n'
++}
+DIFF
+
+    run bash "$LINT" --diff-file "$diff"
+    echo "# output: $output" >&3
+    printf '%s\n' "$output" | grep -q '^NEW_ABSTRACTION_SINGLE_CALLER:'
+}
+
+@test "NEW_ABSTRACTION_SINGLE_CALLER: new file without pattern name emits nothing" {
+    diff="$TMPDIR_BATS/plain_add.diff"
+    cat > "$diff" <<'DIFF'
+diff --git a/scripts/helpers.sh b/scripts/helpers.sh
+new file mode 100644
+--- /dev/null
++++ b/scripts/helpers.sh
+@@ -0,0 +1,3 @@
++#!/usr/bin/env bash
++do_thing() { printf 'ok\n'; }
+DIFF
+
+    run bash "$LINT" --diff-file "$diff"
+    echo "# output: $output" >&3
+    count="$(printf '%s\n' "$output" | grep -c '^NEW_ABSTRACTION_SINGLE_CALLER:' || true)"
+    [ "$count" -eq 0 ]
+}
+
+@test "NEW_ABSTRACTION_SINGLE_CALLER: linter:allow suppresses finding" {
+    diff="$TMPDIR_BATS/manager_allowed.diff"
+    cat > "$diff" <<'DIFF'
+diff --git a/scripts/lock-manager.sh b/scripts/lock-manager.sh
+new file mode 100644
+--- /dev/null
++++ b/scripts/lock-manager.sh
+@@ -0,0 +1,5 @@
++#!/usr/bin/env bash
++# linter:allow-NEW_ABSTRACTION_SINGLE_CALLER planned second caller in issue #999
++manage_lock() {
++    printf 'lock\n'
++}
+DIFF
+
+    run bash "$LINT" --diff-file "$diff"
+    echo "# output: $output" >&3
+    count="$(printf '%s\n' "$output" | grep -c '^NEW_ABSTRACTION_SINGLE_CALLER:' || true)"
+    [ "$count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Clean diff — all three silent
+# ---------------------------------------------------------------------------
+
+@test "clean reuse-correct diff emits no reuse-triage findings" {
+    diff="$TMPDIR_BATS/clean.diff"
+    cat > "$diff" <<'DIFF'
+diff --git a/scripts/greet.sh b/scripts/greet.sh
+new file mode 100644
+--- /dev/null
++++ b/scripts/greet.sh
+@@ -0,0 +1,3 @@
++#!/usr/bin/env bash
++say_hello() { printf 'hello\n'; }
+DIFF
+
+    run bash "$LINT" --diff-file "$diff"
+    echo "# output: $output" >&3
+    for rule in REINVENT_REPO_UTIL NEW_DEP_UNJUSTIFIED NEW_ABSTRACTION_SINGLE_CALLER; do
+        count="$(printf '%s\n' "$output" | grep -c "^${rule}:" || true)"
+        [ "$count" -eq 0 ]
+    done
+}


### PR DESCRIPTION
Closes #1439

## Summary

Adds three flag-only RULE_IDs to `scripts/lint-implementation.sh` following the existing detector grammar (`:39` list, `:161` `emit_finding`, `:259` staged-diff, `:225` `# linter:allow-RULE_ID`). Deterministic bash only, no LLM call.

- **REINVENT_REPO_UTIL** — flags net-new `name()` function definitions whose name already matches an existing definition elsewhere in the repo (rg definition-pattern search, test files excluded). Fail-open on rg error (`LINT_SEARCH_ROOT` env var for test isolation).
- **NEW_DEP_UNJUSTIFIED** — flags dependency additions to manifests (`package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pyproject.toml`, `Gemfile`) that lack a `# why: <reason>` marker anywhere in the same diff section.
- **NEW_ABSTRACTION_SINGLE_CALLER** — flags new files matching `*manager*|*factory*|*adapter*|*wrapper*|*base*|*abstract*` with ≤1 call sites across the diff.

All three honour `# linter:allow-RULE_ID <reason>` inline suppression and are wired into both normal and `--directives` dispatch.

## Tests

`tests/lint/test_reuse_triage.bats` — 13 bats tests (TDD: written before detectors, all red then all green):
- Positive detection for each of the 3 rules
- Negative (no false positive) for each rule
- `linter:allow` suppression for REINVENT_REPO_UTIL and NEW_ABSTRACTION_SINGLE_CALLER
- Fail-open assertion for REINVENT_REPO_UTIL (rg error → exit 0, no finding)
- Clean diff → all three silent

`bash scripts/validate.sh` — all checks passed.

## Closeout report

**Result:** Shipped three deterministic reuse-triage detectors to `scripts/lint-implementation.sh` with 13 passing bats tests. Full `validate.sh` suite green.

**Claims:**
- `[verified][runtime]` All 13 bats tests pass: `bats tests/lint/test_reuse_triage.bats` → `1..13 ok 1…ok 13`
- `[verified][runtime]` Full suite: `bash scripts/validate.sh` → `validate: OK — all validation checks passed.`
- `[verified][static]` `bash -n scripts/lint-implementation.sh` passes
- `[assumed]` REINVENT_REPO_UTIL false-positive rate in production is acceptable — no production data yet

**Before/after:** 0 → 3 new RULE_IDs enforced by the deterministic linter; 0 → 13 bats tests in `tests/lint/test_reuse_triage.bats`.

**Artifacts:**
- `scripts/lint-implementation.sh` — three new detector functions + directive entries
- `tests/lint/test_reuse_triage.bats` — 13 tests
- Repro: `bats tests/lint/test_reuse_triage.bats`

**Scoped git status:** `M scripts/lint-implementation.sh`, `A tests/lint/test_reuse_triage.bats`

**One likely hidden failure:** REINVENT_REPO_UTIL may produce false positives in repos where common function names (e.g. `main`, `run`, `log`) exist in many files — the per-file emit_capped cap of 10 limits blast radius but the signal/noise ratio for short names is unknown until production data accumulates.