### PR TITLE
fix(autospec-run): scrub gh admin creds before issue-body smoke eval (W2)

### DIFF
--- a/skills/autospec-run/prompts/phase4-implementer.md
+++ b/skills/autospec-run/prompts/phase4-implementer.md
@@ -329,7 +329,12 @@ if [ -z "$smoke_cmd" ]; then
 fi
 
 # smoke_test_passes: run the smoke command in the worktree.
-if ! eval "$smoke_cmd"; then
+# SECURITY: the smoke command is extracted verbatim from the (untrusted) issue
+# body and runs moments before the admin-merge path under live gh admin creds.
+# Scrub GH_TOKEN/GITHUB_TOKEN from the subshell so a poisoned smoke fence cannot
+# exfiltrate or replay admin credentials via gh. The guardian pass MUST have
+# already inspected the smoke fence as untrusted data before reaching here.
+if ! env -u GH_TOKEN -u GITHUB_TOKEN bash -c "$smoke_cmd"; then
     gh issue comment <ISSUE> --body "Smoke test FAILED (command: \`$smoke_cmd\`). Not merging until smoke passes."
     exit 1
 fi

--- a/tests/test_phase4_executable_smoke_gate.bats
+++ b/tests/test_phase4_executable_smoke_gate.bats
@@ -27,6 +27,19 @@ DEFINE_PROMPT="${BATS_TEST_DIRNAME}/../skills/autospec-define/codex/prompt.md"
     [ "$output" -ge 1 ]
 }
 
+@test "phase4-implementer.md smoke gate scrubs gh admin creds from the subshell" {
+    # The smoke command is extracted verbatim from the untrusted issue body and
+    # runs moments before admin-merge under live gh creds (#W2). It must run in a
+    # credential-scrubbed subshell so a poisoned smoke fence cannot reach
+    # GH_TOKEN/GITHUB_TOKEN. Guard against a regression back to bare `eval`.
+    run grep -c 'env -u GH_TOKEN -u GITHUB_TOKEN bash -c "\$smoke_cmd"' "$PHASE4_PROMPT"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+    # The unscrubbed `eval "$smoke_cmd"` form must no longer be present.
+    run grep -c 'eval "\$smoke_cmd"' "$PHASE4_PROMPT"
+    [ "$output" -eq 0 ]
+}
+
 @test "autospec-split decomposer enforces SMOKE_NOT_FENCED and SMOKE_MULTI_LINE" {
     run grep -c "SMOKE_NOT_FENCED\|SMOKE_MULTI_LINE" "$SPLIT_PROMPT"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Implements W2 of docs/specs/2026-06-27-explore-meta-tuning-round-1-design.md. Sandbox only.

The Phase 4 Primary smoke command is extracted verbatim from the untrusted issue body and was run via `eval "$smoke_cmd"` under live gh admin creds immediately before the admin-merge path — a token-exfil / injection vector. This change runs the smoke command in a credential-scrubbed subshell via `env -u GH_TOKEN -u GITHUB_TOKEN bash -c "$smoke_cmd"` so a poisoned smoke fence cannot reach or replay gh admin credentials, and adds a one-line note that the guardian pass must inspect the smoke fence as untrusted data first.

Adds a regression test (tests/test_phase4_executable_smoke_gate.bats) asserting the scrub form and the absence of the bare `eval` form. validate.sh green.