### PR TITLE
[codex] Preserve resumed workflow memory lessons

### DIFF
--- a/docs/memory/MEMORY.md
+++ b/docs/memory/MEMORY.md
@@ -55,6 +55,7 @@ older than 7 days AND the lesson is no longer load-bearing, archive it.
 
 - [Installer excludes runtime libs](feedback_installer_excludes_runtime_libs.md) — install.sh drops scripts/lib/ runtime libs; autospec-explore hard-crashes on a clean install; ship-completeness doesn't catch it
 - [Explore codebase-signals false positives](feedback_explore_codebase_signals_false_positives.md) — TODO/FIXME grep matches prose, assets, and its own source; noise dominates ranking; constitution gate drops 0/45
+- [Explore --once unverified ~0% precision](feedback_explore_once_unverified_near_zero_precision.md) — local discovery on autospec repo: 183 raw → 0 verified; even source-analysis was 4/4 false on direct check; never auto-file --once bare-subprocess output, verify evidence against files first
 
 - [Heartbeat cross-repo collision](feedback_heartbeat_cross_repo_collision.md) — ~/.autospec/process-heartbeats/ is shared across repos; use path-scoped slug subdirs
 - [Bash RETURN trap leaks](feedback_bash_return_trap_leak.md) — RETURN traps leak into caller frames under set -u; use inline cleanup
@@ -65,6 +66,7 @@ older than 7 days AND the lesson is no longer load-bearing, archive it.
 - [OMC autopilot magic-keyword misfire](feedback_omc_autopilot_misfire.md) — system reminders containing "AUTOPILOT" auto-activate OMC autopilot mid-session; recover via state_write(active=false) + state_clear(skill-active)
 - [Mempalace miner flat-form gap](feedback_mempalace_miner_flat_form.md) — M3 miner matches both `metadata.type:` (spec) and `type:` (real CC files); fixture both variants
 - [Harness session-id env vars](reference_harness_session_id_envs.md) — `CLAUDE_CODE_SESSION_ID` is the stable per-session id (ps -o sess=0, no tty under tool calls); fallback chain for harness-neutral per-session locks; PPID fallback is unreliable
+- [Worktree/main topology](reference_worktree_main_topology.md) — autospec runs ~9 parallel worktrees; sibling autospec-autonomous holds `main`, so the primary checkout can't checkout main (rests detached/feature); reconcile stale N-ahead branches by branching fresh off origin/main, never merge the stale commits
 
 # Active project state (review weekly; archive when shipped)
 

--- a/docs/memory/MEMORY.md
+++ b/docs/memory/MEMORY.md
@@ -66,7 +66,7 @@ older than 7 days AND the lesson is no longer load-bearing, archive it.
 - [OMC autopilot magic-keyword misfire](feedback_omc_autopilot_misfire.md) — system reminders containing "AUTOPILOT" auto-activate OMC autopilot mid-session; recover via state_write(active=false) + state_clear(skill-active)
 - [Mempalace miner flat-form gap](feedback_mempalace_miner_flat_form.md) — M3 miner matches both `metadata.type:` (spec) and `type:` (real CC files); fixture both variants
 - [Harness session-id env vars](reference_harness_session_id_envs.md) — `CLAUDE_CODE_SESSION_ID` is the stable per-session id (ps -o sess=0, no tty under tool calls); fallback chain for harness-neutral per-session locks; PPID fallback is unreliable
-- [Worktree/main topology](reference_worktree_main_topology.md) — autospec runs ~9 parallel worktrees; sibling autospec-autonomous holds `main`, so the primary checkout can't checkout main (rests detached/feature); reconcile stale N-ahead branches by branching fresh off origin/main, never merge the stale commits
+- [Worktree/main topology](reference_worktree_main_topology.md) — check `git worktree list` before assuming primary can hold `main`; sibling worktrees may own it, and stale N-ahead branches usually need fresh origin/main branches
 
 # Active project state (review weekly; archive when shipped)
 

--- a/docs/memory/feedback_explore_once_unverified_near_zero_precision.md
+++ b/docs/memory/feedback_explore_once_unverified_near_zero_precision.md
@@ -1,0 +1,37 @@
+---
+name: feedback_explore_once_unverified_near_zero_precision
+description: autospec-explore local discovery on the autospec repo is ~2% raw / ~0% post-verify precision; never auto-file --once output unverified
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 37d298e0-f75e-4f7a-8457-db86f85c4404
+---
+
+A local-tier `/autospec-explore` discovery pass on the autospec repo itself (10
+sources, no internet, `--stage dedup`) produced **183 raw deduped proposals** that
+collapsed to **0 confidently file-worthy** after adversarial verification:
+
+- `quality-resilience` (100) and `self-leverage` (50) both saturated at their per-round
+  caps — a saturation signal, not signal. `self-leverage` grepped *prose in spec docs*
+  ("operator must invoke --resume explicitly so the audit trail is reviewed") and
+  proposed auto-resolving deliberate human-in-loop safety gates (dangerous false positives).
+- `codebase-signals` (24): the known TODO/FIXME-grep noise class ([[feedback_explore_codebase_signals_false_positives]]).
+- `spec-vs-code` (1): matched the template placeholder `{{ac_bullets_from_taxonomy}}` as an "unimplemented AC."
+- `source-analysis` (5) was the *best* source — yet on direct evidence-checking, 4/4 of its
+  filable proposals were **factually false or already-resolved**: README already documents
+  autospec-autonomous (claimed missing); conductor bats tests already exist (claimed absent);
+  install.sh already bundles scripts/lib + `tests/ship-completeness.bats` already guards it
+  (claimed missing — the [[feedback_installer_excludes_runtime_libs]] bug is already fixed).
+
+**Why:** The `--once` path's adversarial-verify stage degrades to `no-op-unverified` when
+run as a bare bash subprocess (no LLM skeptic wired in). At ~2% raw precision, filing
+unverified `--once` output as `auto-implement` would flood `main` with noise — and even the
+"grounded" sources carry false evidence that only direct file inspection catches.
+
+**How to apply:** When a conductor escalates to Tier-2 discovery, do NOT run
+`/autospec-explore --once` as a bare subprocess and auto-file. Instead run `--stage dedup`
+to get candidates, then have the harness LLM (you) serve as the adversarial skeptic —
+**verify each survivor's evidence against the actual files, refute-by-default** — before
+filing anything. A 0-verified pass is a legitimate, honest outcome: report it and keep the
+backlog empty rather than manufacturing work. Relates to [[feedback_per_pr_lgtm_misses_integration]]
+(verification catches what generators miss) and [[feedback_roi_check_new_components]].

--- a/docs/memory/feedback_explore_once_unverified_near_zero_precision.md
+++ b/docs/memory/feedback_explore_once_unverified_near_zero_precision.md
@@ -1,7 +1,7 @@
 ---
 name: feedback_explore_once_unverified_near_zero_precision
 description: autospec-explore local discovery on the autospec repo is ~2% raw / ~0% post-verify precision; never auto-file --once output unverified
-metadata: 
+metadata:
   node_type: memory
   type: feedback
   originSessionId: 37d298e0-f75e-4f7a-8457-db86f85c4404

--- a/docs/memory/feedback_per_session_worktree_isolation.md
+++ b/docs/memory/feedback_per_session_worktree_isolation.md
@@ -36,5 +36,22 @@ path-scoped heartbeats; atomic cross-machine issue-claim).
 4. Keep my work in its own branch/PR; stage only my files; leave others'
    uncommitted changes untouched.
 
+**Refinement (2026-06-26, /autospec-autonomous run):** `claim-issue.sh`'s atomic
+label swap does NOT protect you against a **claim-blind** parallel run. A separate
+flow (distinctive `wt-rl-*` worktrees / `feat/reuse-*` branches, merging via admin,
+not using the claim/heartbeat/registry system) merged the identical work for #1439
+(PR #1446) while I held `in-progress-by-bot` — wasting a full ~110k-token implementer
+dispatch on a duplicate conflicting PR (#1447, closed as superseded). Lessons:
+(a) AFTER claiming an issue and BEFORE dispatching the expensive implementer, run a
+**topic-keyed overlap scan** — search local `git worktree list`, `git ls-remote
+--heads origin`, and open PRs for branches/worktrees matching the issue's SUBJECT
+(not just its number); a rival's local un-pushed worktree (e.g. `/private/tmp/wt-rl-*`)
+is the early-warning sign. (b) One collision = pre-existing work, recover and continue;
+seeing rival worktrees pre-staged for DOWNSTREAM issues (#1440/#1442 here) is
+predictive — stop and surface to the operator rather than racing. (c) When the operator
+confirms "park & monitor," hold the session lock, persist a watermark
+(`~/.autospec/autonomous-park-watermark.json`), and re-engage only on stall.
+
 Related: [[feedback_subagent_cwd_pinned_to_main_checkout]],
-[[feedback_heartbeat_cross_repo_collision]], [[reference_harness_session_id_envs]].
+[[feedback_heartbeat_cross_repo_collision]], [[reference_harness_session_id_envs]],
+[[reference_worktree_main_topology]].

--- a/docs/memory/reference_worktree_main_topology.md
+++ b/docs/memory/reference_worktree_main_topology.md
@@ -1,23 +1,26 @@
 ---
 name: reference_worktree_main_topology
-description: "The autospec repo runs many parallel git worktrees; a sibling worktree holds `main`, so the primary checkout cannot be on main and rests detached/feature-branch"
-metadata: 
+description: "Check `git worktree list` before assuming the primary autospec checkout can hold `main`; sibling worktrees may own it"
+metadata:
   node_type: memory
   type: reference
   originSessionId: 126475a4-f965-4503-a160-92b59f439782
 ---
 
-The `/Users/wohlgemuth/IdeaProjects/autospec` checkout is one of ~9+ concurrent
-git worktrees (others under `/private/tmp/wt-*` and `/Users/wohlgemuth/IdeaProjects/autospec-*`).
-The sibling worktree `/Users/wohlgemuth/IdeaProjects/autospec-autonomous` holds the
-`main` branch. Git forbids the same branch in two worktrees, so the **primary
-checkout can never `git checkout main`** — it sits on a feature branch or detached
-at `origin/main`.
+Snapshot from 2026-06-26/27: the `/Users/wohlgemuth/IdeaProjects/autospec`
+checkout was one of many concurrent git worktrees (others under `/private/tmp/wt-*`
+and `/Users/wohlgemuth/IdeaProjects/autospec-*`). At that point the sibling
+worktree `/Users/wohlgemuth/IdeaProjects/autospec-autonomous` held the `main`
+branch, so the primary checkout could not also `git checkout main` and rested on
+a detached/feature state instead.
 
-How to apply: when cleaning up / anchoring the primary checkout, don't expect to
-land it on `main`. Use `git switch -c <branch> origin/main`, or accept detached
-HEAD at `origin/main` (clean + safe). When diagnosing a "stale branch N-ahead /
-upstream [gone]", remember most of the N "ahead" commits are squash-merge
-divergence, not unmerged work — reconcile by branching FRESH off `origin/main`
-(never try to merge the stale commits). See [[feedback_per_session_worktree_isolation]]
-and [[feedback_pre_pipeline_sync]].
+How to apply: when cleaning up / anchoring the primary checkout, first run
+`git worktree list --porcelain` and verify whether another worktree currently
+owns `main`. If `main` is occupied, use `git switch -c <branch> origin/main` or
+accept detached HEAD at `origin/main` for read-only inspection. When diagnosing a
+"stale branch N-ahead / upstream [gone]", treat the ahead commits as suspect
+squash-merge divergence until checked against `origin/main`; reconcile by
+branching fresh off `origin/main` instead of merging stale commits by default.
+This complements, rather than replaces, sessions where the primary checkout is
+intentionally pinned to `main` (see [[project_gap_remediation_keyword_routing]]).
+See also [[feedback_per_session_worktree_isolation]] and [[feedback_pre_pipeline_sync]].

--- a/docs/memory/reference_worktree_main_topology.md
+++ b/docs/memory/reference_worktree_main_topology.md
@@ -1,0 +1,23 @@
+---
+name: reference_worktree_main_topology
+description: "The autospec repo runs many parallel git worktrees; a sibling worktree holds `main`, so the primary checkout cannot be on main and rests detached/feature-branch"
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 126475a4-f965-4503-a160-92b59f439782
+---
+
+The `/Users/wohlgemuth/IdeaProjects/autospec` checkout is one of ~9+ concurrent
+git worktrees (others under `/private/tmp/wt-*` and `/Users/wohlgemuth/IdeaProjects/autospec-*`).
+The sibling worktree `/Users/wohlgemuth/IdeaProjects/autospec-autonomous` holds the
+`main` branch. Git forbids the same branch in two worktrees, so the **primary
+checkout can never `git checkout main`** — it sits on a feature branch or detached
+at `origin/main`.
+
+How to apply: when cleaning up / anchoring the primary checkout, don't expect to
+land it on `main`. Use `git switch -c <branch> origin/main`, or accept detached
+HEAD at `origin/main` (clean + safe). When diagnosing a "stale branch N-ahead /
+upstream [gone]", remember most of the N "ahead" commits are squash-merge
+divergence, not unmerged work — reconcile by branching FRESH off `origin/main`
+(never try to merge the stale commits). See [[feedback_per_session_worktree_isolation]]
+and [[feedback_pre_pipeline_sync]].


### PR DESCRIPTION
## Summary

Adds resumed-session memory notes for three workflow lessons:

- `autospec-explore --once` output must be evidence-checked before filing work.
- Claim-blind parallel runs can duplicate expensive implementer work unless topic-keyed overlap scans check worktrees, remote branches, and open PRs.
- The primary autospec checkout may be detached because a sibling worktree owns `main`.

## Impact

Future autospec sessions get concrete recovery guidance before expensive dispatches or checkout cleanup, reducing duplicate PRs and stale-branch confusion.

## Validation

- `scripts/validate.sh` passed locally with `validate: OK — all validation checks passed.`
- Note: validation emitted a warn-only stale token-baseline message: `docs/reports/skill-token-baseline.md is stale; run: bash scripts/skill-token-report.sh --update-baseline`.

## Commit

- `397650a docs(memory): preserve resumed workflow lessons`
