### PR TITLE
fix: remove gitleaks API key fixture hit

### DIFF
--- a/tests/continue/test_continue_rate_limit.bats
+++ b/tests/continue/test_continue_rate_limit.bats
@@ -111,19 +111,19 @@ teardown() {
 
 @test "state file contains only hashes + timestamps, never prompt content" {
     export AUTOSPEC_CONTINUE_NOW=1000
-    SECRET="distinctive_prompt_marker_xyz789"
+    PROMPT_MARKER_TEXT="prompt content marker redacted fixture"
     cat > "$MSG" <<EOF
 some prose
 
 ## Next steps
-- $SECRET
+- $PROMPT_MARKER_TEXT
 EOF
     run bash "$SCRIPT" --from-message "$MSG" --no-loop --skip-refine
     [ "$status" -eq 0 ]
     [ -f "$AUTOSPEC_CONTINUE_HISTORY" ]
 
     # MUST NOT contain the prompt content.
-    ! grep -q "$SECRET" "$AUTOSPEC_CONTINUE_HISTORY"
+    ! grep -q "$PROMPT_MARKER_TEXT" "$AUTOSPEC_CONTINUE_HISTORY"
     ! grep -q "Next steps" "$AUTOSPEC_CONTINUE_HISTORY"
 
     # MUST contain the hash + timestamp schema fields.


### PR DESCRIPTION
Closes #1493

## Summary
- Replaced the secret-shaped `SECRET="distinctive_prompt_marker_xyz789"` test fixture in `tests/continue/test_continue_rate_limit.bats` with a plain prompt marker sentence.
- Preserved the existing assertion that continue history stores hashes/timestamps and never raw prompt content.

## Closeout report
**Result** — Removed the canonical tracked gitleaks generic-api-key hit from `tests/continue/test_continue_rate_limit.bats` while preserving continue rate-limit behavior.

**Claims**
- [verified] Proof type: runtime — `bats tests/continue/test_continue_rate_limit.bats` passes all 5 focused tests.
- [verified] Proof type: runtime — direct gitleaks scan of `tests/continue/test_continue_rate_limit.bats` exits 0 with `no leaks found`.
- [verified] Proof type: runtime — repo security scan wrapper for secrets emits no findings for this change.
- [verified] Proof type: runtime — full `bash scripts/validate.sh` exits 0.

**Before/after** — Before: gitleaks reported 1 `generic-api-key` at line 114. After: direct file scan reports 0 leaks.

**Artifacts**
- `tests/continue/test_continue_rate_limit.bats`
- Re-run: `bats tests/continue/test_continue_rate_limit.bats`
- Re-run: `tmp_report=$(mktemp); gitleaks dir --no-banner --report-format json --report-path "$tmp_report" tests/continue/test_continue_rate_limit.bats; cat "$tmp_report"; rm -f "$tmp_report"`
- Re-run: `bash skills/autospec-shared/scripts/security-scan.sh --root . --only secrets`
- Re-run: `bash scripts/validate.sh`

**Scoped git status** — Touched `tests/continue/test_continue_rate_limit.bats` only.

**One likely hidden failure** — Other copied `.claude/worktrees/...` directories may still contain stale duplicates until those worktrees are refreshed or removed; this branch intentionally fixes only the canonical tracked source.
