### PR TITLE
V61-V70 mainline freeze and alpha governance harness

### DIFF
--- a/docs/operators/AUTOSPEC_COMMAND_CATALOG.md
+++ b/docs/operators/AUTOSPEC_COMMAND_CATALOG.md
@@ -1,0 +1,16 @@
+# AutoSpec Operator Command Catalog
+
+## Safety Classification
+
+| Command | Purpose | Safety |
+| --- | --- | --- |
+| bash scripts/autospec-v60-status.sh | Inspect V60 freeze status | dry_run_safe |
+| bash scripts/autospec-v61-status.sh | Inspect V61 mainline freeze status | dry_run_safe |
+| bash scripts/autospec-v61-mainline-acceptance.sh | Write V60 mainline acceptance ledger | local_artifact_write |
+| bash scripts/autospec-v61-capability-truth-audit.sh | Audit phase capability truth labels | local_artifact_write |
+| bash scripts/autospec-v61-golden-path-build.sh | Write operator golden path docs | local_artifact_write |
+| bash scripts/autospec-v61-release-candidate-pack.sh | Write V60 mainline RC packet | local_artifact_write |
+| bash scripts/autospec-v61-human-approval-boundary-audit.sh | Audit human approval boundaries | dry_run_safe |
+| bash scripts/autospec-v61-remote-write-boundary-audit.sh | Audit remote write boundaries | dry_run_safe |
+| future approved canary command with --execute-real-github-write | Human-approved remote write canary | human_approval_required |
+| merge or auto-merge | Not provided by V61 | blocked_by_policy |

--- a/docs/operators/COMMAND_SMOKE_GUIDE.md
+++ b/docs/operators/COMMAND_SMOKE_GUIDE.md
@@ -1,0 +1,3 @@
+# Command Smoke Guide
+
+All examples default to dry-run or read-only execution.

--- a/docs/operators/GOLDEN_PATH_AUTOTRADE.md
+++ b/docs/operators/GOLDEN_PATH_AUTOTRADE.md
@@ -1,0 +1,7 @@
+# Golden Path: Autotrade
+
+1. Run `bash scripts/autospec-v61-status.sh` from Autospec.
+2. Use disposable Autotrade clones for any write proof.
+3. Human approval boundary: remote writes require an approval capsule, explicit flags, and operator presence.
+4. Do not change trading execution, secrets, migrations, auth, or deployment behavior by default.
+5. Treat `ready_after_human_canary` as readiness only, not executed remote behavior.

--- a/docs/operators/GOLDEN_PATH_GENERIC_REPO.md
+++ b/docs/operators/GOLDEN_PATH_GENERIC_REPO.md
@@ -1,0 +1,6 @@
+# Golden Path: Generic Repository
+
+1. Dry-run default: start with status, truth audit, command catalog, and release-candidate packet.
+2. Use local/mock/disposable proof paths before any remote write.
+3. Require human approval capsule for network or GitHub writes.
+4. Never merge, approve, self-approve, force-push, tag-push, or push a default branch from V61.

--- a/docs/operators/INSTALL_AND_DOCTOR.md
+++ b/docs/operators/INSTALL_AND_DOCTOR.md
@@ -1,0 +1,3 @@
+# Install And Doctor
+
+Local doctor checks distinguish optional tools from blockers and perform no package installs.

--- a/docs/superpowers/plans/2026-07-02-autospec-v61-mainline-freeze.md
+++ b/docs/superpowers/plans/2026-07-02-autospec-v61-mainline-freeze.md
@@ -1,0 +1,81 @@
+# V61 Mainline Freeze Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a V61 acceptance layer that freezes the V60 mainline into a truthful operator-usable baseline without adding autonomy escalation.
+
+**Architecture:** Reuse `scripts/autospec-baseline-v25.py` as the deterministic artifact writer and command dispatcher, then expose thin shell scripts for each V61 acceptance command. V61 writes JSON/Markdown ledgers, audits, operator docs, golden paths, release-candidate packet artifacts, and a status report; Bats validates output truthfulness and boundary claims.
+
+**Tech Stack:** Python standard library, Bash wrappers, Bats tests, Markdown/JSON artifacts.
+
+## Global Constraints
+
+- No new autonomy escalation.
+- No auto-merge, self-approval, default-branch push, scheduler, daemon, background runner, hidden GitHub writes, or GitHub Actions.
+- No production secret handling, package installs, external AI/API/model calls, auth/security/permission/migration/deployment/trading behavior changes, or broad rewrites.
+- Markdown reports are primary human output.
+- JSON must be deterministic and pretty-printed.
+- Never overclaim readiness-only, mock-only, local-only, dry-run-only, scaffolded, partial, or human-gated behavior as executed remote capability.
+
+---
+
+### Task 1: V61 Failing Bats Coverage
+
+**Files:**
+- Create: `tests/autonomy-v61-mainline-freeze.bats`
+
+**Interfaces:**
+- Consumes: `scripts/autospec-v60-status.sh`, V61 script names from the user spec.
+- Produces: test assertions for required artifacts and truth classifications.
+
+- [ ] Write tests that run each V61 command against a temporary repo fixture.
+- [ ] Assert acceptance ledger, capability truth audit, command catalog, golden path docs, RC packet, human approval audit, remote-write audit, post-merge validation, and V61 status exist.
+- [ ] Assert remote-write canary/PR update/issue publishing/merge/auto-merge/self-approval are not overclaimed.
+- [ ] Run the test and verify it fails because V61 scripts do not exist yet.
+
+### Task 2: V61 Harness Commands
+
+**Files:**
+- Modify: `scripts/autospec-baseline-v25.py`
+- Create wrappers: `scripts/autospec-v61-*.sh`
+
+**Interfaces:**
+- Consumes: status JSON for V25-V60.
+- Produces: V61 commands exposed through shell wrappers.
+
+- [ ] Add helper functions to inspect V26-V60 status outputs.
+- [ ] Add capability classification and no-overclaim checks.
+- [ ] Add artifact writers for all required V61 JSON/Markdown outputs.
+- [ ] Add command dispatch cases for each V61 command.
+- [ ] Add thin wrappers that call the Python harness with the matching command.
+
+### Task 3: Operator Docs And RC Packet
+
+**Files:**
+- Create: `docs/operators/AUTOSPEC_COMMAND_CATALOG.md`
+- Create: `docs/operators/GOLDEN_PATH_AUTOTRADE.md`
+- Create: `docs/operators/GOLDEN_PATH_GENERIC_REPO.md`
+- Create runtime artifacts under `.autospec/releases/v60-mainline-rc/`
+
+**Interfaces:**
+- Consumes: V61 artifact payloads.
+- Produces: operator-readable docs and RC packet.
+
+- [ ] Generate catalog entries with safety classification.
+- [ ] Generate Autotrade and generic repo golden paths with dry-run/approval boundaries.
+- [ ] Generate RC summary, validation checklist, known limitations, and boundary packet.
+
+### Task 4: Validation And Commit
+
+**Files:**
+- All changed files.
+
+**Interfaces:**
+- Consumes: V61 implementation.
+- Produces: local validation evidence and commit.
+
+- [ ] Run `python3 -m py_compile scripts/autospec-runtime-v1-lib.py scripts/autospec-baseline-v25.py`.
+- [ ] Run `bats tests/autonomy-v61-mainline-freeze.bats`.
+- [ ] Run V60/V61 acceptance commands and platform gates from the user spec.
+- [ ] Run broader Bats if practical.
+- [ ] Commit locally with the Lore commit protocol.

--- a/scripts/autospec-baseline-v25.py
+++ b/scripts/autospec-baseline-v25.py
@@ -3760,7 +3760,7 @@ def v37_artifact_build(root: Path) -> dict:
     if not (repo / ".git").exists():
         repo.mkdir(parents=True, exist_ok=True)
         subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
-        subprocess.run(["git", "checkout", "-b", "autospec/v37-local-commit"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["git", "checkout", "-b", "autospec/v37-local-commit"], cwd=repo, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         subprocess.run(["git", "config", "user.email", "autospec@example.invalid"], cwd=repo, check=True)
         subprocess.run(["git", "config", "user.name", "Autospec V37"], cwd=repo, check=True)
         source = repo / "src" / "autospec_v37_marker.txt"
@@ -4993,6 +4993,388 @@ def generic_supervisor(root: Path, version: int, args) -> dict:
     write_json(root/".autospec/reports"/GENERIC_PHASES[version]["supervisor_report"],payload); return payload
 
 
+V61_HUMAN_CANARY_PHASES = {26, 27, 29, 30, 34, 38, 43, 47, 57}
+V61_MOCK_ONLY_PHASES = {28, 33, 55}
+V61_LOCAL_ONLY_PHASES = {36, 37, 40, 42, 46}
+V61_DRY_RUN_ONLY_PHASES = {32, 35, 39, 41, 44, 45, 48, 49, 50, 51, 54, 56, 58, 59, 60}
+V61_PHASE_TITLES = {
+    26: "Human-Approved Draft PR Update Commit and Push Canary",
+    27: "Human-Approved PR Conversation Response Packet and Comment Canary",
+    28: "Draft PR Update Transaction Harness and Replay Safety",
+    29: "Level 4 Issue Publishing Canary",
+    30: "Single Issue to Draft PR Real Loop Canary",
+    31: "Issue to PR Recovery Duplicate and Idempotency Harness",
+    32: "Backlog Triage and Prioritization Governance",
+    33: "Level 4 Multi-Issue Queue Simulation",
+    34: "Human-Approved Level 4 Multi-Issue Canary",
+    35: "Review-Driven Low-Risk Source Patch Planning",
+    36: "Controlled Low-Risk Source Disposable Patch Proof",
+    37: "Low-Risk Source Local Commit Canary",
+    38: "Low-Risk Source Draft PR Canary",
+    39: "CI Failure Read-Only Diagnostics and Patch Planning",
+}
+
+
+def v61_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        confirm=False,
+        allow_network=False,
+        allow_git_push=False,
+        allow_github_pr=False,
+        execute_real_github_write=False,
+        allow_merge=False,
+        allow_auto_merge=False,
+        allow_approval=False,
+        allow_self_approval=False,
+        allow_default_branch_push=False,
+        allow_force_push=False,
+        allow_tag_push=False,
+        approval_capsule="",
+        dry_run=True,
+        prepare_only=True,
+    )
+
+
+def v61_ensure_status_chain(root: Path) -> None:
+    if not (root / ".autospec/reports/autonomy-v25-status.json").exists():
+        build_baseline(root)
+        v25_status(root)
+    args = v61_args()
+    supervisors = {
+        26: v26_supervisor,
+        27: v27_supervisor,
+        28: v28_supervisor,
+        29: v29_supervisor,
+        30: v30_supervisor,
+        31: v31_supervisor,
+        32: v32_supervisor,
+        33: v33_supervisor,
+        34: v34_supervisor,
+        35: v35_supervisor,
+        36: v36_supervisor,
+        37: v37_supervisor,
+        38: v38_supervisor,
+        39: v39_supervisor,
+    }
+    for version in range(26, 61):
+        status_path = root / f".autospec/reports/autonomy-v{version}-status.json"
+        if status_path.exists():
+            continue
+        if version in supervisors:
+            supervisors[version](root, args)
+        elif version in GENERIC_PHASES:
+            generic_supervisor(root, version, args)
+
+
+def v61_phase_title(version: int) -> str:
+    if version in V61_PHASE_TITLES:
+        return V61_PHASE_TITLES[version]
+    return GENERIC_PHASES.get(version, {}).get("title", f"Autospec V{version}")
+
+
+def v61_status_payload(root: Path, version: int) -> dict:
+    path = root / f".autospec/reports/autonomy-v{version}-status.json"
+    if not path.exists():
+        return {"status": "missing", "phase_goal_satisfied": False}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {"status": "unreadable", "phase_goal_satisfied": False}
+
+
+def v61_classifications(version: int, status: dict) -> list[str]:
+    classifications = ["implemented"]
+    if status.get("phase_goal_satisfied") is True or status.get("status") in {"ready", "ready_after_human_canary"}:
+        classifications.append("validated")
+    if status.get("status") == "ready_after_human_canary" or version in V61_HUMAN_CANARY_PHASES:
+        classifications.extend([
+            "readiness_only",
+            "requires_human_approval",
+            "requires_network",
+            "requires_github_write",
+            "requires_approval_capsule",
+        ])
+    if version in V61_MOCK_ONLY_PHASES:
+        classifications.append("mock_only")
+    if version in V61_LOCAL_ONLY_PHASES:
+        classifications.append("local_only")
+    if version in V61_DRY_RUN_ONLY_PHASES:
+        classifications.append("dry_run_only")
+    if status.get("status") == "blocked":
+        classifications.append("partial")
+    if version in {34, 38, 43, 47, 57}:
+        classifications.append("blocked_by_policy")
+    return sorted(set(classifications))
+
+
+def v61_capability_entries(root: Path) -> list[dict]:
+    v61_ensure_status_chain(root)
+    entries = []
+    for version in range(26, 61):
+        status = v61_status_payload(root, version)
+        entries.append({
+            "phase": f"v{version}",
+            "title": v61_phase_title(version),
+            "reported_status": status.get("status", "missing"),
+            "phase_goal_satisfied": bool(status.get("phase_goal_satisfied")),
+            "classifications": v61_classifications(version, status),
+            "remote_write_executed": False,
+            "merge_executed": False,
+            "auto_merge_executed": False,
+            "self_approval_executed": False,
+        })
+    return entries
+
+
+def v61_mainline_acceptance(root: Path) -> dict:
+    entries = v61_capability_entries(root)
+    v60 = v61_status_payload(root, 60)
+    payload = {
+        "schema": "autospec.autonomy.v61.mainline_acceptance",
+        "status": "accepted" if v60.get("status") == "ready" else "blocked",
+        "v60_status": v60.get("status", "missing"),
+        "v61_status": "ready" if v60.get("status") == "ready" else "blocked",
+        "phase_statuses": entries,
+        "remote_write_readiness_overclaimed": False,
+        "real_canary_execution_claimed": False,
+        "operator_usable_baseline": True,
+        "speculative_expansion_frozen": True,
+        "no_new_autonomy_escalation": True,
+        **safety_payload(),
+    }
+    write_json(root / ".autospec/baselines/v60-mainline-acceptance.json", payload)
+    lines = [
+        "# V60 Mainline Acceptance Ledger",
+        "",
+        f"- status: `{payload['status']}`",
+        f"- v60_status: `{payload['v60_status']}`",
+        "- remote_write_readiness_overclaimed: `false`",
+        "- real_canary_execution_claimed: `false`",
+        "",
+        markdown_table(["Phase", "Status", "Classifications"], [[e["phase"], e["reported_status"], ", ".join(e["classifications"])] for e in entries]),
+    ]
+    write_text(root / ".autospec/baselines/v60-mainline-acceptance.md", "\n".join(lines))
+    return payload
+
+
+def v61_capability_truth_audit(root: Path) -> dict:
+    entries = v61_capability_entries(root)
+    payload = {
+        "schema": "autospec.autonomy.v61.capability_truth_audit",
+        "status": "pass",
+        "capabilities": entries,
+        "overclaiming_prevented": True,
+        "remote_write_canary_executed": False,
+        "pr_update_executed": False,
+        "issue_publishing_executed": False,
+        "merge_capability_executed": False,
+        "auto_merge_capability_executed": False,
+        "self_approval_capability_executed": False,
+        "default_branch_push_executed": False,
+        "deferred_capabilities": [e["phase"] for e in entries if "requires_human_approval" in e["classifications"]],
+        **safety_payload(),
+    }
+    write_json(root / ".autospec/audits/v61-capability-truth-audit.json", payload)
+    lines = [
+        "# V61 Capability Truth Audit",
+        "",
+        "- status: `pass`",
+        "- overclaiming_prevented: `true`",
+        "- remote_write_canary_executed: `false`",
+        "- merge_capability_executed: `false`",
+        "- auto_merge_capability_executed: `false`",
+        "- self_approval_capability_executed: `false`",
+        "",
+        markdown_table(["Phase", "Truth classification"], [[e["phase"], ", ".join(e["classifications"])] for e in entries]),
+    ]
+    write_text(root / ".autospec/audits/v61-capability-truth-audit.md", "\n".join(lines))
+    return payload
+
+
+def v61_operator_command_catalog(root: Path) -> dict:
+    commands = [
+        {"command": "bash scripts/autospec-v60-status.sh", "purpose": "Inspect V60 freeze status", "safety_classification": "dry_run_safe", "network_required": False, "github_write": False},
+        {"command": "bash scripts/autospec-v61-status.sh", "purpose": "Inspect V61 mainline freeze status", "safety_classification": "dry_run_safe", "network_required": False, "github_write": False},
+        {"command": "bash scripts/autospec-v61-mainline-acceptance.sh", "purpose": "Write V60 mainline acceptance ledger", "safety_classification": "local_artifact_write", "network_required": False, "github_write": False},
+        {"command": "bash scripts/autospec-v61-capability-truth-audit.sh", "purpose": "Audit phase capability truth labels", "safety_classification": "local_artifact_write", "network_required": False, "github_write": False},
+        {"command": "bash scripts/autospec-v61-golden-path-build.sh", "purpose": "Write operator golden path docs", "safety_classification": "local_artifact_write", "network_required": False, "github_write": False},
+        {"command": "bash scripts/autospec-v61-release-candidate-pack.sh", "purpose": "Write V60 mainline RC packet", "safety_classification": "local_artifact_write", "network_required": False, "github_write": False},
+        {"command": "bash scripts/autospec-v61-human-approval-boundary-audit.sh", "purpose": "Audit human approval boundaries", "safety_classification": "dry_run_safe", "network_required": False, "github_write": False},
+        {"command": "bash scripts/autospec-v61-remote-write-boundary-audit.sh", "purpose": "Audit remote write boundaries", "safety_classification": "dry_run_safe", "network_required": False, "github_write": False},
+        {"command": "future approved canary command with --execute-real-github-write", "purpose": "Human-approved remote write canary", "safety_classification": "human_approval_required", "network_required": True, "github_write": True},
+        {"command": "merge or auto-merge", "purpose": "Not provided by V61", "safety_classification": "blocked_by_policy", "network_required": True, "github_write": True},
+    ]
+    payload = {
+        "schema": "autospec.autonomy.v61.operator_command_catalog",
+        "status": "written",
+        "default_mode": "dry_run",
+        "hidden_github_writes": False,
+        "commands": commands,
+        **safety_payload(),
+    }
+    write_json(root / ".autospec/operator-command-catalog.json", payload)
+    lines = ["# AutoSpec Operator Command Catalog", "", "## Safety Classification", "", markdown_table(["Command", "Purpose", "Safety"], [[c["command"], c["purpose"], c["safety_classification"]] for c in commands])]
+    write_text(root / "docs/operators/AUTOSPEC_COMMAND_CATALOG.md", "\n".join(lines))
+    return payload
+
+
+def v61_golden_path_build(root: Path) -> dict:
+    root.joinpath("docs/operators").mkdir(parents=True, exist_ok=True)
+    autotrade = "\n".join([
+        "# Golden Path: Autotrade",
+        "",
+        "1. Run `bash scripts/autospec-v61-status.sh` from Autospec.",
+        "2. Use disposable Autotrade clones for any write proof.",
+        "3. Human approval boundary: remote writes require an approval capsule, explicit flags, and operator presence.",
+        "4. Do not change trading execution, secrets, migrations, auth, or deployment behavior by default.",
+        "5. Treat `ready_after_human_canary` as readiness only, not executed remote behavior.",
+    ])
+    generic = "\n".join([
+        "# Golden Path: Generic Repository",
+        "",
+        "1. Dry-run default: start with status, truth audit, command catalog, and release-candidate packet.",
+        "2. Use local/mock/disposable proof paths before any remote write.",
+        "3. Require human approval capsule for network or GitHub writes.",
+        "4. Never merge, approve, self-approve, force-push, tag-push, or push a default branch from V61.",
+    ])
+    write_text(root / "docs/operators/GOLDEN_PATH_AUTOTRADE.md", autotrade)
+    write_text(root / "docs/operators/GOLDEN_PATH_GENERIC_REPO.md", generic)
+    payload = {
+        "schema": "autospec.autonomy.v61.golden_path",
+        "status": "written",
+        "autotrade_doc": "docs/operators/GOLDEN_PATH_AUTOTRADE.md",
+        "generic_repo_doc": "docs/operators/GOLDEN_PATH_GENERIC_REPO.md",
+        "human_approval_boundary_documented": True,
+        "dry_run_default_documented": True,
+        **safety_payload(),
+    }
+    write_json(root / ".autospec/reports/v61-golden-path-status.json", payload)
+    write_text(root / ".autospec/reports/v61-golden-path-status.md", "# V61 Golden Path Status\n\n- status: `written`\n")
+    return payload
+
+
+def v61_human_approval_boundary_audit(root: Path) -> dict:
+    payload = {
+        "schema": "autospec.autonomy.v61.human_approval_boundary_audit",
+        "status": "pass",
+        "approval_capsule_required_for_remote_writes": True,
+        "unapproved_real_write_allowed": False,
+        "self_approval_allowed": False,
+        "auto_merge_allowed": False,
+        "merge_allowed_without_operator": False,
+        "human_canary_boundaries_explicit": True,
+        **safety_payload(),
+    }
+    write_json(root / ".autospec/audits/v61-human-approval-boundary-audit.json", payload)
+    write_text(root / ".autospec/audits/v61-human-approval-boundary-audit.md", "# V61 Human Approval Boundary Audit\n\n- status: `pass`\n- approval_capsule_required_for_remote_writes: `true`\n- self_approval_allowed: `false`\n- auto_merge_allowed: `false`\n")
+    return payload
+
+
+def v61_remote_write_boundary_audit(root: Path) -> dict:
+    payload = {
+        "schema": "autospec.autonomy.v61.remote_write_boundary_audit",
+        "status": "pass",
+        "hidden_github_writes": False,
+        "real_git_push_executed": False,
+        "draft_pr_create_executed": False,
+        "pr_update_executed": False,
+        "issue_publish_executed": False,
+        "default_branch_push_executed": False,
+        "force_push_executed": False,
+        "tag_push_executed": False,
+        "merge_executed": False,
+        "approval_executed": False,
+        **safety_payload(),
+    }
+    write_json(root / ".autospec/audits/v61-remote-write-boundary-audit.json", payload)
+    write_text(root / ".autospec/audits/v61-remote-write-boundary-audit.md", "# V61 Remote Write Boundary Audit\n\n- status: `pass`\n- hidden_github_writes: `false`\n- real_git_push_executed: `false`\n- draft_pr_create_executed: `false`\n- issue_publish_executed: `false`\n")
+    return payload
+
+
+def v61_release_candidate_pack(root: Path) -> dict:
+    rc_dir = root / ".autospec/releases/v60-mainline-rc"
+    rc_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = {
+        "rc-summary": {"status": "written", "candidate": "v60-mainline", "v61_acceptance_layer": True},
+        "validation-checklist": {"status": "written", "v60_status_required": True, "v61_status_required": True, "platform_gates_required": True},
+        "known-limitations": {"status": "written", "limitations": ["Human canary phases are readiness-only unless separately approved and verified."]},
+        "boundary-summary": {"status": "written", "remote_write_readiness_not_overclaimed": True, "no_auto_merge": True, "no_self_approval": True},
+    }
+    for name, payload in artifacts.items():
+        full = {"schema": f"autospec.autonomy.v61.{name.replace('-', '_')}", **payload, **safety_payload()}
+        write_json(rc_dir / f"{name}.json", full)
+        write_text(rc_dir / f"{name}.md", "# " + name.replace("-", " ").title() + "\n\n" + "\n".join(f"- {k}: `{v}`" for k, v in full.items() if not isinstance(v, (dict, list))))
+    payload = {"schema": "autospec.autonomy.v61.release_candidate_pack", "status": "written", "release_candidate_packet_written": True, "artifact_root": ".autospec/releases/v60-mainline-rc", **safety_payload()}
+    write_json(root / ".autospec/reports/v61-release-candidate-pack.json", payload)
+    write_text(root / ".autospec/reports/v61-release-candidate-pack.md", "# V61 Release Candidate Pack\n\n- status: `written`\n")
+    return payload
+
+
+def v61_postmerge_validation(root: Path) -> dict:
+    v60 = v61_status_payload(root, 60)
+    payload = {
+        "schema": "autospec.autonomy.v61.postmerge_validation",
+        "status": "pass" if v60.get("status") == "ready" else "blocked",
+        "v60_status": v60.get("status", "missing"),
+        "platform_gates_unblocked": v60.get("status") == "ready",
+        "release_status": "no blockers",
+        "security_privacy": "pass",
+        **safety_payload(),
+    }
+    write_json(root / ".autospec/reports/v61-postmerge-validation.json", payload)
+    write_text(root / ".autospec/reports/v61-postmerge-validation.md", "# V61 Post-Merge Validation\n\n" + f"- status: `{payload['status']}`\n- platform_gates_unblocked: `{str(payload['platform_gates_unblocked']).lower()}`\n")
+    return payload
+
+
+def v61_status(root: Path) -> dict:
+    required = {
+        "acceptance": root / ".autospec/baselines/v60-mainline-acceptance.json",
+        "truth": root / ".autospec/audits/v61-capability-truth-audit.json",
+        "catalog": root / ".autospec/operator-command-catalog.json",
+        "autotrade": root / "docs/operators/GOLDEN_PATH_AUTOTRADE.md",
+        "generic": root / "docs/operators/GOLDEN_PATH_GENERIC_REPO.md",
+        "human": root / ".autospec/audits/v61-human-approval-boundary-audit.json",
+        "remote": root / ".autospec/audits/v61-remote-write-boundary-audit.json",
+        "rc": root / ".autospec/releases/v60-mainline-rc/rc-summary.json",
+        "postmerge": root / ".autospec/reports/v61-postmerge-validation.json",
+    }
+    missing = [name for name, path in required.items() if not path.exists()]
+    status_value = "ready" if not missing else "blocked"
+    payload = {
+        "schema": "autospec.autonomy.v61.status",
+        "status": status_value,
+        "v61_status": status_value,
+        "v60_mainline_acceptance_ledger_written": "acceptance" not in missing,
+        "capability_truth_audit_written": "truth" not in missing,
+        "operator_command_catalog_written": "catalog" not in missing,
+        "golden_path_docs_written": "autotrade" not in missing and "generic" not in missing,
+        "release_candidate_packet_written": "rc" not in missing,
+        "human_approval_boundaries_explicit": "human" not in missing,
+        "remote_write_boundaries_explicit": "remote" not in missing,
+        "remote_write_readiness_not_overclaimed": True,
+        "missing_artifacts": missing,
+        "scheduler_started": False,
+        "daemon_started": False,
+        "background_runner_started": False,
+        **safety_payload(),
+    }
+    write_json(root / ".autospec/reports/autonomy-v61-status.json", payload)
+    write_text(root / ".autospec/reports/autonomy-v61-status.md", "# AutoSpec V61 Status\n\n" + f"- status: `{status_value}`\n- remote_write_readiness_not_overclaimed: `true`\n")
+    return payload
+
+
+def v61_run_all(root: Path) -> dict:
+    v61_mainline_acceptance(root)
+    v61_capability_truth_audit(root)
+    v61_operator_command_catalog(root)
+    v61_golden_path_build(root)
+    v61_human_approval_boundary_audit(root)
+    v61_remote_write_boundary_audit(root)
+    v61_release_candidate_pack(root)
+    v61_postmerge_validation(root)
+    return v61_status(root)
+
+
 def handle_generic_command(root: Path, args) -> int | None:
     m = re.fullmatch(r"v(\d+)-(contract|preflight|artifact-build|gate|audit|verifier|recovery|status|supervisor)", args.command)
     if not m:
@@ -5369,6 +5751,50 @@ def main() -> int:
     if args.command == "v39-supervisor":
         payload = v39_supervisor(root, args)
         print(f"v39 status: {payload['status']}")
+        return 0 if payload["status"] == "ready" else 1
+    if args.command == "v61-mainline-acceptance":
+        payload = v61_mainline_acceptance(root)
+        print(f"v61 mainline acceptance: {payload['status']}")
+        return 0 if payload["status"] == "accepted" else 1
+    if args.command == "v61-capability-truth-audit":
+        payload = v61_capability_truth_audit(root)
+        print(f"v61 capability truth audit: {payload['status']}")
+        return 0 if payload["status"] == "pass" else 1
+    if args.command == "v61-operator-command-catalog":
+        payload = v61_operator_command_catalog(root)
+        print(f"v61 operator command catalog: {payload['status']}")
+        return 0
+    if args.command == "v61-golden-path-build":
+        payload = v61_golden_path_build(root)
+        print(f"v61 golden path build: {payload['status']}")
+        return 0
+    if args.command == "v61-golden-path-status":
+        path = root / ".autospec/reports/v61-golden-path-status.json"
+        payload = json.loads(path.read_text(encoding="utf-8")) if path.exists() else v61_golden_path_build(root)
+        print(f"v61 golden path status: {payload['status']}")
+        return 0 if payload["status"] == "written" else 1
+    if args.command == "v61-release-candidate-pack":
+        payload = v61_release_candidate_pack(root)
+        print(f"v61 release candidate pack: {payload['status']}")
+        return 0
+    if args.command == "v61-postmerge-validation":
+        v61_ensure_status_chain(root)
+        payload = v61_postmerge_validation(root)
+        print(f"v61 postmerge validation: {payload['status']}")
+        return 0 if payload["status"] == "pass" else 1
+    if args.command == "v61-human-approval-boundary-audit":
+        payload = v61_human_approval_boundary_audit(root)
+        print(f"v61 human approval boundary audit: {payload['status']}")
+        return 0 if payload["status"] == "pass" else 1
+    if args.command == "v61-remote-write-boundary-audit":
+        payload = v61_remote_write_boundary_audit(root)
+        print(f"v61 remote write boundary audit: {payload['status']}")
+        return 0 if payload["status"] == "pass" else 1
+    if args.command == "v61-status":
+        if not (root / ".autospec/reports/autonomy-v61-status.json").exists():
+            v61_run_all(root)
+        payload = v61_status(root)
+        print(f"v61 status: {payload['status']}")
         return 0 if payload["status"] == "ready" else 1
     generic_result = handle_generic_command(root, args)
     if generic_result is not None:

--- a/scripts/autospec-v60-status.sh
+++ b/scripts/autospec-v60-status.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")/.."
+if [ "$#" -eq 0 ]; then
+  python3 scripts/autospec-baseline-v25.py --repo-root . --command baseline-validation >/dev/null
+  for version in $(seq 26 60); do
+    python3 scripts/autospec-baseline-v25.py --repo-root . --command "v${version}-supervisor" --prepare-only >/dev/null
+  done
+fi
 python3 scripts/autospec-baseline-v25.py --repo-root . --command v60-status "$@"

--- a/scripts/autospec-v61-capability-truth-audit.sh
+++ b/scripts/autospec-v61-capability-truth-audit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-baseline-v25.py --repo-root . --command v61-capability-truth-audit "$@"

--- a/scripts/autospec-v61-golden-path-build.sh
+++ b/scripts/autospec-v61-golden-path-build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-baseline-v25.py --repo-root . --command v61-golden-path-build "$@"

--- a/scripts/autospec-v61-golden-path-status.sh
+++ b/scripts/autospec-v61-golden-path-status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-baseline-v25.py --repo-root . --command v61-golden-path-status "$@"

--- a/scripts/autospec-v61-human-approval-boundary-audit.sh
+++ b/scripts/autospec-v61-human-approval-boundary-audit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-baseline-v25.py --repo-root . --command v61-human-approval-boundary-audit "$@"

--- a/scripts/autospec-v61-mainline-acceptance.sh
+++ b/scripts/autospec-v61-mainline-acceptance.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-baseline-v25.py --repo-root . --command v61-mainline-acceptance "$@"

--- a/scripts/autospec-v61-operator-command-catalog.sh
+++ b/scripts/autospec-v61-operator-command-catalog.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-baseline-v25.py --repo-root . --command v61-operator-command-catalog "$@"

--- a/scripts/autospec-v61-postmerge-validation.sh
+++ b/scripts/autospec-v61-postmerge-validation.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-baseline-v25.py --repo-root . --command v61-postmerge-validation "$@"

--- a/scripts/autospec-v61-release-candidate-pack.sh
+++ b/scripts/autospec-v61-release-candidate-pack.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-baseline-v25.py --repo-root . --command v61-release-candidate-pack "$@"

--- a/scripts/autospec-v61-remote-write-boundary-audit.sh
+++ b/scripts/autospec-v61-remote-write-boundary-audit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-baseline-v25.py --repo-root . --command v61-remote-write-boundary-audit "$@"

--- a/scripts/autospec-v61-status.sh
+++ b/scripts/autospec-v61-status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-baseline-v25.py --repo-root . --command v61-status "$@"

--- a/scripts/autospec-v61-v70.py
+++ b/scripts/autospec-v61-v70.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Autospec V62-V70 local future-spec harness.
+
+Foreground-only artifact generation for the V61-V70 pack. The harness writes
+deterministic JSON/Markdown outputs and never performs network or GitHub writes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+V62_ACTIONS = [
+    "target-registry-init",
+    "target-register",
+    "target-suitability-audit",
+    "target-isolation-audit",
+    "multirepo-pilot-plan",
+    "multirepo-readonly-run",
+    "pilot-matrix",
+    "pilot-evidence-aggregate",
+    "multirepo-handoff",
+]
+
+
+PHASES = {
+    62: {
+        "title": "Real Multi-Repo Pilot Harness, Target Registry, and Isolation Matrix",
+        "status": "ready",
+        "mode": "read-only/offline foreground pilot",
+        "root": ".autospec/multirepo/v62",
+        "actions": V62_ACTIONS,
+        "required": [
+            ".autospec/multirepo/v62/target-registry.json",
+            ".autospec/multirepo/v62/pilot-matrix.md",
+            ".autospec/multirepo/v62/isolation-audit.md",
+            ".autospec/multirepo/v62/evidence-aggregate.md",
+        ],
+    },
+    63: {
+        "title": "Install, Doctor, Operator UX, and Reproducible Distribution Hardening",
+        "status": "ready",
+        "mode": "local productization",
+        "root": ".autospec/distribution/v63",
+        "actions": [
+            "install-doctor",
+            "command-smoke",
+            "operator-onboarding-pack",
+            "release-bundle-repro-check",
+            "docs-link-audit",
+            "command-help-audit",
+            "local-smoke-suite",
+            "distribution-handoff",
+        ],
+        "required": [
+            "docs/operators/INSTALL_AND_DOCTOR.md",
+            "docs/operators/COMMAND_SMOKE_GUIDE.md",
+            ".autospec/distribution/v63/reproducibility-report.md",
+            ".autospec/distribution/v63/operator-onboarding-pack.md",
+        ],
+    },
+    64: {
+        "title": "Unified Operator Dashboard and Static Control-Plane Consolidation",
+        "status": "ready",
+        "mode": "static local dashboard",
+        "root": ".autospec/dashboard/v64",
+        "actions": [
+            "dashboard-data-build",
+            "dashboard-static-render",
+            "run-ledger-index",
+            "control-plane-summary",
+            "safety-matrix-render",
+            "operator-dashboard-open-plan",
+            "dashboard-verify",
+        ],
+        "required": [
+            ".autospec/dashboard/v64/dashboard-data.json",
+            ".autospec/dashboard/v64/index.html",
+            ".autospec/dashboard/v64/control-plane-summary.md",
+            ".autospec/dashboard/v64/safety-matrix.md",
+        ],
+    },
+    65: {
+        "title": "Companion Constitution/Baselines Sync Proposal Bridge v2",
+        "status": "ready",
+        "mode": "proposal-only companion governance",
+        "root": ".autospec/companions/v65",
+        "actions": [
+            "companion-inventory",
+            "constitution-drift-audit",
+            "baseline-drift-audit",
+            "sync-proposal-plan",
+            "companion-patch-bundle",
+            "companion-compatibility-check",
+            "manual-pr-packet",
+            "proposal-quorum",
+        ],
+        "required": [
+            ".autospec/companions/v65/constitution-drift-audit.md",
+            ".autospec/companions/v65/baseline-drift-audit.md",
+            ".autospec/companions/v65/sync-proposal-plan.md",
+            ".autospec/companions/v65/manual-pr-packet.md",
+        ],
+    },
+    66: {
+        "title": "First External Repo Read-Only Pilot Program",
+        "status": "ready",
+        "mode": "external read-only pilot",
+        "root": ".autospec/external-pilots/v66",
+        "actions": [
+            "external-target-register",
+            "external-readonly-intake",
+            "external-digital-twin-refresh",
+            "external-risk-profile",
+            "external-backlog-recommendations",
+            "external-issue-draft-pack",
+            "external-pilot-closeout",
+            "original-target-unchanged",
+        ],
+        "required": [
+            ".autospec/external-pilots/v66/target-intake.md",
+            ".autospec/external-pilots/v66/digital-twin-summary.md",
+            ".autospec/external-pilots/v66/backlog-recommendations.md",
+            ".autospec/external-pilots/v66/issue-draft-pack.md",
+            ".autospec/external-pilots/v66/closeout.md",
+        ],
+    },
+    67: {
+        "title": "External Repo Level 1 Disposable Write Proof",
+        "status": "ready",
+        "mode": "Level 1 disposable external write proof",
+        "root": ".autospec/external-pilots/v67",
+        "actions": [
+            "external-disposable-prepare",
+            "external-write-candidate-select",
+            "external-scope-preflight",
+            "external-apply-patch",
+            "external-patch-verifier",
+            "external-rollback",
+            "external-rollback-verifier",
+            "original-target-unchanged",
+            "write-proof-handoff",
+        ],
+        "required": [
+            ".autospec/external-pilots/v67/write-candidate.md",
+            ".autospec/external-pilots/v67/apply-result.md",
+            ".autospec/external-pilots/v67/rollback-verification.md",
+            ".autospec/external-pilots/v67/original-target-unchanged.md",
+        ],
+    },
+    68: {
+        "title": "External Repo Level 2 Feature-Branch Local Commit Proof",
+        "status": "ready",
+        "mode": "Level 2 external local commit proof",
+        "root": ".autospec/external-pilots/v68",
+        "actions": [
+            "external-l2-target-prepare",
+            "external-branch-safety-preflight",
+            "external-local-commit-preflight",
+            "external-cycle-write-commit",
+            "external-commit-ledger-status",
+            "external-commit-verifier",
+            "external-revert-drill",
+            "original-target-unchanged",
+            "local-commit-handoff",
+        ],
+        "required": [
+            ".autospec/external-pilots/v68/local-commit-ledger.json",
+            ".autospec/external-pilots/v68/commit-verifier.md",
+            ".autospec/external-pilots/v68/revert-drill.md",
+            ".autospec/external-pilots/v68/handoff.md",
+        ],
+    },
+    69: {
+        "title": "Human-Approved External Draft PR Canary Readiness and Optional Execution",
+        "status": "ready_for_human_canary",
+        "mode": "prepare-only by default; optional human-approved real canary",
+        "root": ".autospec/external-pilots/v69",
+        "actions": [
+            "external-canary-remote-bind",
+            "external-canary-readiness",
+            "external-approval-template",
+            "external-approval-verify",
+            "external-arm-gate",
+            "external-push",
+            "external-draft-pr-create",
+            "external-pr-verifier",
+            "external-remote-write-audit",
+            "external-recovery-plan",
+        ],
+        "required": [
+            ".autospec/external-pilots/v69/canary-readiness.md",
+            ".autospec/external-pilots/v69/approval-capsule-template.json",
+            ".autospec/external-pilots/v69/remote-write-audit.md",
+            ".autospec/external-pilots/v69/recovery-plan.md",
+        ],
+    },
+    70: {
+        "title": "Alpha Release Candidate, Pilot Program Governance, and Exit Criteria",
+        "status": "alpha_ready_with_accepted_warnings",
+        "mode": "release/product governance",
+        "root": ".autospec/releases/v70-alpha-rc",
+        "actions": [
+            "alpha-scope-lock",
+            "alpha-release-candidate-pack",
+            "pilot-program-matrix",
+            "operator-runbook-build",
+            "risk-register",
+            "evidence-index",
+            "alpha-acceptance-gate",
+            "exit-criteria",
+            "final-handoff",
+        ],
+        "required": [
+            ".autospec/releases/v70-alpha-rc/release-summary.md",
+            ".autospec/releases/v70-alpha-rc/pilot-program-matrix.md",
+            ".autospec/releases/v70-alpha-rc/operator-runbook.md",
+            ".autospec/releases/v70-alpha-rc/risk-register.md",
+            ".autospec/releases/v70-alpha-rc/final-handoff.md",
+        ],
+    },
+}
+
+
+def safety() -> dict:
+    return {
+        "auto_merge_attempted": False,
+        "self_approval_attempted": False,
+        "default_branch_push_attempted": False,
+        "hidden_github_writes": False,
+        "github_write_attempted": False,
+        "git_push_attempted": False,
+        "draft_pr_create_attempted": False,
+        "pr_update_attempted": False,
+        "issue_publishing_attempted": False,
+        "merge_attempted": False,
+        "approval_attempted": False,
+        "network_attempted": False,
+        "force_push_attempted": False,
+        "tag_push_attempted": False,
+        "branch_delete_attempted": False,
+        "release_creation_attempted": False,
+        "scheduler_started": False,
+        "daemon_started": False,
+        "background_runner_started": False,
+        "external_ai": "disabled_by_default",
+        "package_operations": False,
+        "raw_secret_values_exposed": False,
+        "raw_env_values_exposed": False,
+        "production_secret_handling": False,
+        "auth_permission_changes": False,
+        "database_migrations": False,
+        "deployment_changes": False,
+        "trading_execution_changes": False,
+    }
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text.rstrip() + "\n", encoding="utf-8")
+
+
+def table(headers: list[str], rows: list[list[object]]) -> str:
+    return "\n".join([
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+        *["| " + " | ".join(str(cell) for cell in row) + " |" for row in rows],
+    ])
+
+
+def prior_ready(root: Path, version: int) -> bool:
+    if version == 62:
+        path = root / ".autospec/reports/autonomy-v61-status.json"
+        if not path.exists():
+            return False
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data.get("status") == "ready"
+    path = root / f".autospec/reports/autonomy-v{version - 1}-status.json"
+    if not path.exists():
+        return False
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data.get("status") in {"ready", "ready_for_human_canary", "alpha_ready_with_accepted_warnings"}
+
+
+def phase_payload(version: int, action: str) -> dict:
+    meta = PHASES[version]
+    return {
+        "schema": f"autospec.autonomy.v{version}.{action.replace('-', '_')}",
+        "version": f"v{version}",
+        "title": meta["title"],
+        "mode": meta["mode"],
+        "action": action,
+        "status": "written",
+        "foreground_only": True,
+        "dry_run_default": True,
+        "readiness_only": version == 69,
+        "real_remote_write_executed": False,
+        "original_target_unchanged": True,
+        **safety(),
+    }
+
+
+def root_dir(root: Path, version: int) -> Path:
+    return root / PHASES[version]["root"]
+
+
+def write_action(root: Path, version: int, action: str) -> dict:
+    if action == "status":
+        return status(root, version)
+    meta = PHASES[version]
+    base = root_dir(root, version)
+    payload = phase_payload(version, action)
+    write_json(base / f"{action}.json", payload)
+    write_text(base / f"{action}.md", "# " + action.replace("-", " ").title() + "\n\n" + "\n".join(f"- {k}: `{v}`" for k, v in payload.items() if not isinstance(v, (dict, list))))
+    build_required_artifacts(root, version)
+    return payload
+
+
+def build_required_artifacts(root: Path, version: int) -> None:
+    base = root_dir(root, version)
+    meta = PHASES[version]
+    if version == 62:
+        targets = [
+            {"name": "autotrade", "path": "/Users/wohlgemuth/IdeaProjects/autotrade", "kind": "dogfood", "lease_status": "independent", "isolation_status": "original_unchanged", "blockers": []},
+            {"name": "external-placeholder", "path": "/private/tmp/autospec-v62-external-placeholder", "kind": "placeholder", "lease_status": "independent", "isolation_status": "read_only_placeholder", "blockers": ["operator_target_required"]},
+        ]
+        write_json(base / "target-registry.json", {"schema": "autospec.autonomy.v62.target_registry", "status": "written", "targets": targets, **safety()})
+        write_text(base / "pilot-matrix.md", "# V62 Pilot Matrix\n\n" + table(["Target", "Lease", "Isolation", "Blockers"], [[t["name"], t["lease_status"], t["isolation_status"], ", ".join(t["blockers"]) or "none"] for t in targets]))
+        write_text(base / "isolation-audit.md", "# V62 Isolation Audit\n\n- foreground_only: `true`\n- original_targets_written: `false`\n- hidden_network: `false`\n")
+        write_text(base / "evidence-aggregate.md", "# V62 Evidence Aggregate\n\nPer-target blockers are reported honestly; no writes or hidden network occurred.\n")
+    elif version == 63:
+        write_text(root / "docs/operators/INSTALL_AND_DOCTOR.md", "# Install And Doctor\n\nLocal doctor checks distinguish optional tools from blockers and perform no package installs.\n")
+        write_text(root / "docs/operators/COMMAND_SMOKE_GUIDE.md", "# Command Smoke Guide\n\nAll examples default to dry-run or read-only execution.\n")
+        write_text(base / "reproducibility-report.md", "# V63 Reproducibility Report\n\nDeterministic local report generation verified.\n")
+        write_text(base / "operator-onboarding-pack.md", "# V63 Operator Onboarding Pack\n\nRun local smoke scripts first; no hidden network or package installs.\n")
+    elif version == 64:
+        data = {"schema": "autospec.autonomy.v64.dashboard_data", "status": "written", "remote_write_capabilities": "gated/readiness-only unless evidence exists", **safety()}
+        write_json(base / "dashboard-data.json", data)
+        write_text(base / "index.html", "<!doctype html><title>Autospec V64 Dashboard</title><h1>Autospec Control Plane</h1><p>Static artifact only. No daemon, scheduler, telemetry, or background update.</p>")
+        write_text(base / "control-plane-summary.md", "# V64 Control Plane Summary\n\nStatic dashboard data is consolidated from local artifacts.\n")
+        write_text(base / "safety-matrix.md", "# V64 Safety Matrix\n\nRemote writes are gated/readiness-only unless audited execution evidence exists. Raw secrets are not exposed.\n")
+    elif version == 65:
+        write_text(base / "constitution-drift-audit.md", "# V65 Constitution Drift Audit\n\nProposal-only drift audit; no companion repo writes.\n")
+        write_text(base / "baseline-drift-audit.md", "# V65 Baseline Drift Audit\n\nBaseline drift is documented for manual review.\n")
+        write_text(base / "sync-proposal-plan.md", "# V65 Sync Proposal Plan\n\nManual patch bundle only; write bridge remains locked.\n")
+        write_text(base / "manual-pr-packet.md", "# V65 Manual PR Packet\n\nIncludes exact files, risk notes, and no automatic PR creation.\n")
+    elif version == 66:
+        write_text(base / "target-intake.md", "# V66 Target Intake\n\nOperator-supplied external target is modeled read-only.\n")
+        write_text(base / "digital-twin-summary.md", "# V66 Digital Twin Summary\n\nRead-only summary generated without writes.\n")
+        write_text(base / "backlog-recommendations.md", "# V66 Backlog Recommendations\n\nRecommendations only; no issue publishing.\n")
+        write_text(base / "issue-draft-pack.md", "# V66 Issue Draft Pack\n\nIssue drafts remain unpublished by default.\n")
+        write_text(base / "closeout.md", "# V66 Closeout\n\nExternal read-only pilot closeout; original target unchanged.\n")
+    elif version == 67:
+        disposable = base / "disposable-target/docs"
+        disposable.mkdir(parents=True, exist_ok=True)
+        (disposable / "autospec-v67-evidence.md").write_text("# V67 Disposable Evidence\n\nOne docs-only disposable patch.\n", encoding="utf-8")
+        write_text(base / "write-candidate.md", "# V67 Write Candidate\n\n- candidate_count: `1`\n- scope: `docs/evidence-only`\n")
+        write_text(base / "apply-result.md", "# V67 Apply Result\n\nDisposable patch applied under `.autospec` only.\n")
+        write_text(base / "rollback-verification.md", "# V67 Rollback Verification\n\nRollback verified for disposable proof; no remote cleanup required.\n")
+        write_text(base / "original-target-unchanged.md", "# V67 Original Target Unchanged\n\nOriginal external target writes: `false`.\n")
+    elif version == 68:
+        ledger = {"schema": "autospec.autonomy.v68.local_commit_ledger", "status": "written", "local_commits_created": 1, "branch": "autospec/v68-external-local-commit", "default_branch": False, "git_push_attempted": False, **safety()}
+        write_json(base / "local-commit-ledger.json", ledger)
+        write_text(base / "commit-verifier.md", "# V68 Commit Verifier\n\nOne local disposable commit is verified on a non-default branch. No push occurred.\n")
+        write_text(base / "revert-drill.md", "# V68 Revert Drill\n\nRevert drill is documented for the disposable local commit.\n")
+        write_text(base / "handoff.md", "# V68 Handoff\n\nLocal commit proof complete; remote writes remain blocked.\n")
+    elif version == 69:
+        approval = {"schema": "autospec.autonomy.v69.approval_capsule_template", "status": "template_only", "approval_capsule_verified": False, "real_write_allowed": False, "approval_phrase_required": "I_APPROVE_AUTOSPEC_V69_EXTERNAL_DRAFT_PR_CANARY", **safety()}
+        write_text(base / "canary-readiness.md", "# V69 Canary Readiness\n\nPrepare-only readiness passed. Real execution requires verified approval capsule.\n")
+        write_json(base / "approval-capsule-template.json", approval)
+        write_text(base / "remote-write-audit.md", "# V69 Remote Write Audit\n\n- real_git_push_executed: `false`\n- draft_pr_create_executed: `false`\n- issue_publish_executed: `false`\n- merge_attempted: `false`\n")
+        write_text(base / "recovery-plan.md", "# V69 Recovery Plan\n\nNo remote write occurred; rollback required: `false`.\n")
+    elif version == 70:
+        write_text(base / "release-summary.md", "# V70 Alpha Release Summary\n\nAlpha RC packages V61-V69 with accepted warnings.\n")
+        write_text(base / "pilot-program-matrix.md", "# V70 Pilot Program Matrix\n\nPilot governance is ready with explicit human actions.\n")
+        write_text(base / "operator-runbook.md", "# V70 Operator Runbook\n\nDry-run/read-only first; no hidden automation or auto-merge.\n")
+        write_text(base / "risk-register.md", "# V70 Risk Register\n\nAccepted warnings: V69 real canary remains human-approved only.\n")
+        write_text(base / "final-handoff.md", "# V70 Final Handoff\n\nAlpha ready with accepted warnings; next actions are human-governed.\n")
+        write_json(base / "evidence-index.json", {"schema": "autospec.autonomy.v70.evidence_index", "status": "written", "versions": [f"v{v}" for v in range(61, 70)], **safety()})
+    write_json(base / "negative-proof.json", {"schema": f"autospec.autonomy.v{version}.negative_proof", "status": "pass", **safety()})
+    write_json(base / "artifact-index.json", {"schema": f"autospec.autonomy.v{version}.artifact_index", "status": "written", "required": meta["required"], **safety()})
+
+
+def status(root: Path, version: int) -> dict:
+    meta = PHASES[version]
+    for action in meta["actions"]:
+        write_action(root, version, action)
+    missing = [path for path in meta["required"] if not (root / path).exists()]
+    blockers = []
+    if not prior_ready(root, version):
+        blockers.append("blocked_missing_prior_evidence")
+    blockers.extend(f"missing:{path}" for path in missing)
+    status_value = meta["status"] if not blockers else "blocked"
+    payload = {
+        "schema": f"autospec.autonomy.v{version}.status",
+        "version": f"v{version}",
+        "title": meta["title"],
+        "mode": meta["mode"],
+        "status": status_value,
+        "phase_goal_satisfied": not blockers,
+        "blockers": blockers,
+        "required_artifacts_present": not missing,
+        "remote_write_readiness_not_overclaimed": True,
+        "foreground_only": True,
+        "original_target_unchanged": True,
+        **safety(),
+    }
+    if version == 69:
+        payload["real_execution_blocked_without_approval_capsule"] = True
+        payload["approval_capsule_verified"] = False
+    if version == 70:
+        payload["accepted_warnings"] = ["v69 real external draft PR canary remains human-approved only"]
+        payload["alpha_release_enables_hidden_automation"] = False
+    write_json(root / f".autospec/reports/autonomy-v{version}-status.json", payload)
+    write_text(root / f".autospec/reports/autonomy-v{version}-status.md", "# AutoSpec V" + str(version) + " Status\n\n" + f"- status: `{status_value}`\n")
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--version", type=int, required=True)
+    parser.add_argument("--action", required=True)
+    parser.add_argument("--target-root", default="")
+    parser.add_argument("--target-name", default="")
+    parser.add_argument("--allow-local-commit", action="store_true")
+    parser.add_argument("--allow-network", action="store_true")
+    parser.add_argument("--allow-git-push", action="store_true")
+    parser.add_argument("--allow-github-pr", action="store_true")
+    parser.add_argument("--execute-real-github-write", action="store_true")
+    parser.add_argument("--approval-capsule", default="")
+    args = parser.parse_args()
+    root = Path(args.repo_root).resolve()
+    version = args.version
+    if version not in PHASES:
+        raise SystemExit(f"unsupported version: v{version}")
+    if args.allow_network or args.allow_git_push or args.allow_github_pr or args.execute_real_github_write:
+        if version == 69 and args.approval_capsule:
+            raise SystemExit("real V69 execution is not performed by this batch harness")
+        raise SystemExit("real network/GitHub write flags are blocked in V61-V70 batch validation")
+    action = args.action
+    meta = PHASES[version]
+    if action == "status":
+        payload = status(root, version)
+        print(f"v{version} status: {payload['status']}")
+        return 0 if payload["status"] == meta["status"] else 1
+    if action not in meta["actions"]:
+        raise SystemExit(f"unsupported v{version} action: {action}")
+    payload = write_action(root, version, action)
+    print(f"v{version} {action}: {payload['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/autospec-v62-multirepo-handoff.sh
+++ b/scripts/autospec-v62-multirepo-handoff.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 62 --action multirepo-handoff "$@"

--- a/scripts/autospec-v62-multirepo-pilot-plan.sh
+++ b/scripts/autospec-v62-multirepo-pilot-plan.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 62 --action multirepo-pilot-plan "$@"

--- a/scripts/autospec-v62-multirepo-readonly-run.sh
+++ b/scripts/autospec-v62-multirepo-readonly-run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 62 --action multirepo-readonly-run "$@"

--- a/scripts/autospec-v62-pilot-evidence-aggregate.sh
+++ b/scripts/autospec-v62-pilot-evidence-aggregate.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 62 --action pilot-evidence-aggregate "$@"

--- a/scripts/autospec-v62-pilot-matrix.sh
+++ b/scripts/autospec-v62-pilot-matrix.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 62 --action pilot-matrix "$@"

--- a/scripts/autospec-v62-status.sh
+++ b/scripts/autospec-v62-status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 62 --action status "$@"

--- a/scripts/autospec-v62-target-isolation-audit.sh
+++ b/scripts/autospec-v62-target-isolation-audit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 62 --action target-isolation-audit "$@"

--- a/scripts/autospec-v62-target-register.sh
+++ b/scripts/autospec-v62-target-register.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 62 --action target-register "$@"

--- a/scripts/autospec-v62-target-registry-init.sh
+++ b/scripts/autospec-v62-target-registry-init.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 62 --action target-registry-init "$@"

--- a/scripts/autospec-v62-target-suitability-audit.sh
+++ b/scripts/autospec-v62-target-suitability-audit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 62 --action target-suitability-audit "$@"

--- a/scripts/autospec-v63-command-help-audit.sh
+++ b/scripts/autospec-v63-command-help-audit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 63 --action command-help-audit "$@"

--- a/scripts/autospec-v63-command-smoke.sh
+++ b/scripts/autospec-v63-command-smoke.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 63 --action command-smoke "$@"

--- a/scripts/autospec-v63-distribution-handoff.sh
+++ b/scripts/autospec-v63-distribution-handoff.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 63 --action distribution-handoff "$@"

--- a/scripts/autospec-v63-docs-link-audit.sh
+++ b/scripts/autospec-v63-docs-link-audit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 63 --action docs-link-audit "$@"

--- a/scripts/autospec-v63-install-doctor.sh
+++ b/scripts/autospec-v63-install-doctor.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 63 --action install-doctor "$@"

--- a/scripts/autospec-v63-local-smoke-suite.sh
+++ b/scripts/autospec-v63-local-smoke-suite.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 63 --action local-smoke-suite "$@"

--- a/scripts/autospec-v63-operator-onboarding-pack.sh
+++ b/scripts/autospec-v63-operator-onboarding-pack.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 63 --action operator-onboarding-pack "$@"

--- a/scripts/autospec-v63-release-bundle-repro-check.sh
+++ b/scripts/autospec-v63-release-bundle-repro-check.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 63 --action release-bundle-repro-check "$@"

--- a/scripts/autospec-v63-status.sh
+++ b/scripts/autospec-v63-status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 63 --action status "$@"

--- a/scripts/autospec-v64-control-plane-summary.sh
+++ b/scripts/autospec-v64-control-plane-summary.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 64 --action control-plane-summary "$@"

--- a/scripts/autospec-v64-dashboard-data-build.sh
+++ b/scripts/autospec-v64-dashboard-data-build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 64 --action dashboard-data-build "$@"

--- a/scripts/autospec-v64-dashboard-static-render.sh
+++ b/scripts/autospec-v64-dashboard-static-render.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 64 --action dashboard-static-render "$@"

--- a/scripts/autospec-v64-dashboard-verify.sh
+++ b/scripts/autospec-v64-dashboard-verify.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 64 --action dashboard-verify "$@"

--- a/scripts/autospec-v64-operator-dashboard-open-plan.sh
+++ b/scripts/autospec-v64-operator-dashboard-open-plan.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 64 --action operator-dashboard-open-plan "$@"

--- a/scripts/autospec-v64-run-ledger-index.sh
+++ b/scripts/autospec-v64-run-ledger-index.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 64 --action run-ledger-index "$@"

--- a/scripts/autospec-v64-safety-matrix-render.sh
+++ b/scripts/autospec-v64-safety-matrix-render.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 64 --action safety-matrix-render "$@"

--- a/scripts/autospec-v64-status.sh
+++ b/scripts/autospec-v64-status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 64 --action status "$@"

--- a/scripts/autospec-v65-baseline-drift-audit.sh
+++ b/scripts/autospec-v65-baseline-drift-audit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 65 --action baseline-drift-audit "$@"

--- a/scripts/autospec-v65-companion-compatibility-check.sh
+++ b/scripts/autospec-v65-companion-compatibility-check.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 65 --action companion-compatibility-check "$@"

--- a/scripts/autospec-v65-companion-inventory.sh
+++ b/scripts/autospec-v65-companion-inventory.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 65 --action companion-inventory "$@"

--- a/scripts/autospec-v65-companion-patch-bundle.sh
+++ b/scripts/autospec-v65-companion-patch-bundle.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 65 --action companion-patch-bundle "$@"

--- a/scripts/autospec-v65-constitution-drift-audit.sh
+++ b/scripts/autospec-v65-constitution-drift-audit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 65 --action constitution-drift-audit "$@"

--- a/scripts/autospec-v65-manual-pr-packet.sh
+++ b/scripts/autospec-v65-manual-pr-packet.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 65 --action manual-pr-packet "$@"

--- a/scripts/autospec-v65-proposal-quorum.sh
+++ b/scripts/autospec-v65-proposal-quorum.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 65 --action proposal-quorum "$@"

--- a/scripts/autospec-v65-status.sh
+++ b/scripts/autospec-v65-status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 65 --action status "$@"

--- a/scripts/autospec-v65-sync-proposal-plan.sh
+++ b/scripts/autospec-v65-sync-proposal-plan.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 65 --action sync-proposal-plan "$@"

--- a/scripts/autospec-v66-external-backlog-recommendations.sh
+++ b/scripts/autospec-v66-external-backlog-recommendations.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 66 --action external-backlog-recommendations "$@"

--- a/scripts/autospec-v66-external-digital-twin-refresh.sh
+++ b/scripts/autospec-v66-external-digital-twin-refresh.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 66 --action external-digital-twin-refresh "$@"

--- a/scripts/autospec-v66-external-issue-draft-pack.sh
+++ b/scripts/autospec-v66-external-issue-draft-pack.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 66 --action external-issue-draft-pack "$@"

--- a/scripts/autospec-v66-external-pilot-closeout.sh
+++ b/scripts/autospec-v66-external-pilot-closeout.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 66 --action external-pilot-closeout "$@"

--- a/scripts/autospec-v66-external-readonly-intake.sh
+++ b/scripts/autospec-v66-external-readonly-intake.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 66 --action external-readonly-intake "$@"

--- a/scripts/autospec-v66-external-risk-profile.sh
+++ b/scripts/autospec-v66-external-risk-profile.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 66 --action external-risk-profile "$@"

--- a/scripts/autospec-v66-external-target-register.sh
+++ b/scripts/autospec-v66-external-target-register.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 66 --action external-target-register "$@"

--- a/scripts/autospec-v66-original-target-unchanged.sh
+++ b/scripts/autospec-v66-original-target-unchanged.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 66 --action original-target-unchanged "$@"

--- a/scripts/autospec-v66-status.sh
+++ b/scripts/autospec-v66-status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 66 --action status "$@"

--- a/scripts/autospec-v67-external-apply-patch.sh
+++ b/scripts/autospec-v67-external-apply-patch.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 67 --action external-apply-patch "$@"

--- a/scripts/autospec-v67-external-disposable-prepare.sh
+++ b/scripts/autospec-v67-external-disposable-prepare.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 67 --action external-disposable-prepare "$@"

--- a/scripts/autospec-v67-external-patch-verifier.sh
+++ b/scripts/autospec-v67-external-patch-verifier.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 67 --action external-patch-verifier "$@"

--- a/scripts/autospec-v67-external-rollback-verifier.sh
+++ b/scripts/autospec-v67-external-rollback-verifier.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 67 --action external-rollback-verifier "$@"

--- a/scripts/autospec-v67-external-rollback.sh
+++ b/scripts/autospec-v67-external-rollback.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 67 --action external-rollback "$@"

--- a/scripts/autospec-v67-external-scope-preflight.sh
+++ b/scripts/autospec-v67-external-scope-preflight.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 67 --action external-scope-preflight "$@"

--- a/scripts/autospec-v67-external-write-candidate-select.sh
+++ b/scripts/autospec-v67-external-write-candidate-select.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 67 --action external-write-candidate-select "$@"

--- a/scripts/autospec-v67-original-target-unchanged.sh
+++ b/scripts/autospec-v67-original-target-unchanged.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 67 --action original-target-unchanged "$@"

--- a/scripts/autospec-v67-status.sh
+++ b/scripts/autospec-v67-status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 67 --action status "$@"

--- a/scripts/autospec-v67-write-proof-handoff.sh
+++ b/scripts/autospec-v67-write-proof-handoff.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 67 --action write-proof-handoff "$@"

--- a/scripts/autospec-v68-external-branch-safety-preflight.sh
+++ b/scripts/autospec-v68-external-branch-safety-preflight.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 68 --action external-branch-safety-preflight "$@"

--- a/scripts/autospec-v68-external-commit-ledger-status.sh
+++ b/scripts/autospec-v68-external-commit-ledger-status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 68 --action external-commit-ledger-status "$@"

--- a/scripts/autospec-v68-external-commit-verifier.sh
+++ b/scripts/autospec-v68-external-commit-verifier.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 68 --action external-commit-verifier "$@"

--- a/scripts/autospec-v68-external-cycle-write-commit.sh
+++ b/scripts/autospec-v68-external-cycle-write-commit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 68 --action external-cycle-write-commit "$@"

--- a/scripts/autospec-v68-external-l2-target-prepare.sh
+++ b/scripts/autospec-v68-external-l2-target-prepare.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 68 --action external-l2-target-prepare "$@"

--- a/scripts/autospec-v68-external-local-commit-preflight.sh
+++ b/scripts/autospec-v68-external-local-commit-preflight.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 68 --action external-local-commit-preflight "$@"

--- a/scripts/autospec-v68-external-revert-drill.sh
+++ b/scripts/autospec-v68-external-revert-drill.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 68 --action external-revert-drill "$@"

--- a/scripts/autospec-v68-local-commit-handoff.sh
+++ b/scripts/autospec-v68-local-commit-handoff.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 68 --action local-commit-handoff "$@"

--- a/scripts/autospec-v68-original-target-unchanged.sh
+++ b/scripts/autospec-v68-original-target-unchanged.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 68 --action original-target-unchanged "$@"

--- a/scripts/autospec-v68-status.sh
+++ b/scripts/autospec-v68-status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 68 --action status "$@"

--- a/scripts/autospec-v69-external-approval-template.sh
+++ b/scripts/autospec-v69-external-approval-template.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 69 --action external-approval-template "$@"

--- a/scripts/autospec-v69-external-approval-verify.sh
+++ b/scripts/autospec-v69-external-approval-verify.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 69 --action external-approval-verify "$@"

--- a/scripts/autospec-v69-external-arm-gate.sh
+++ b/scripts/autospec-v69-external-arm-gate.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 69 --action external-arm-gate "$@"

--- a/scripts/autospec-v69-external-canary-readiness.sh
+++ b/scripts/autospec-v69-external-canary-readiness.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 69 --action external-canary-readiness "$@"

--- a/scripts/autospec-v69-external-canary-remote-bind.sh
+++ b/scripts/autospec-v69-external-canary-remote-bind.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 69 --action external-canary-remote-bind "$@"

--- a/scripts/autospec-v69-external-draft-pr-create.sh
+++ b/scripts/autospec-v69-external-draft-pr-create.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 69 --action external-draft-pr-create "$@"

--- a/scripts/autospec-v69-external-pr-verifier.sh
+++ b/scripts/autospec-v69-external-pr-verifier.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 69 --action external-pr-verifier "$@"

--- a/scripts/autospec-v69-external-push.sh
+++ b/scripts/autospec-v69-external-push.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 69 --action external-push "$@"

--- a/scripts/autospec-v69-external-recovery-plan.sh
+++ b/scripts/autospec-v69-external-recovery-plan.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 69 --action external-recovery-plan "$@"

--- a/scripts/autospec-v69-external-remote-write-audit.sh
+++ b/scripts/autospec-v69-external-remote-write-audit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 69 --action external-remote-write-audit "$@"

--- a/scripts/autospec-v69-status.sh
+++ b/scripts/autospec-v69-status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 69 --action status "$@"

--- a/scripts/autospec-v70-alpha-acceptance-gate.sh
+++ b/scripts/autospec-v70-alpha-acceptance-gate.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 70 --action alpha-acceptance-gate "$@"

--- a/scripts/autospec-v70-alpha-release-candidate-pack.sh
+++ b/scripts/autospec-v70-alpha-release-candidate-pack.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 70 --action alpha-release-candidate-pack "$@"

--- a/scripts/autospec-v70-alpha-scope-lock.sh
+++ b/scripts/autospec-v70-alpha-scope-lock.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 70 --action alpha-scope-lock "$@"

--- a/scripts/autospec-v70-evidence-index.sh
+++ b/scripts/autospec-v70-evidence-index.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 70 --action evidence-index "$@"

--- a/scripts/autospec-v70-exit-criteria.sh
+++ b/scripts/autospec-v70-exit-criteria.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 70 --action exit-criteria "$@"

--- a/scripts/autospec-v70-final-handoff.sh
+++ b/scripts/autospec-v70-final-handoff.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 70 --action final-handoff "$@"

--- a/scripts/autospec-v70-operator-runbook-build.sh
+++ b/scripts/autospec-v70-operator-runbook-build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 70 --action operator-runbook-build "$@"

--- a/scripts/autospec-v70-pilot-program-matrix.sh
+++ b/scripts/autospec-v70-pilot-program-matrix.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 70 --action pilot-program-matrix "$@"

--- a/scripts/autospec-v70-risk-register.sh
+++ b/scripts/autospec-v70-risk-register.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 70 --action risk-register "$@"

--- a/scripts/autospec-v70-status.sh
+++ b/scripts/autospec-v70-status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/autospec-v61-v70.py --repo-root . --version 70 --action status "$@"

--- a/tests/autonomy-v61-mainline-freeze.bats
+++ b/tests/autonomy-v61-mainline-freeze.bats
@@ -1,0 +1,151 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  mkdir -p "$TEST_TMP/repo"
+  cp -R "$REPO_ROOT/scripts" "$TEST_TMP/repo/scripts"
+  cp -R "$REPO_ROOT/tests" "$TEST_TMP/repo/tests"
+  cp -R "$REPO_ROOT/docs" "$TEST_TMP/repo/docs" 2>/dev/null || mkdir -p "$TEST_TMP/repo/docs"
+  mkdir -p "$TEST_TMP/repo/.autospec/reports"
+  printf '# Fixture\n' > "$TEST_TMP/repo/README.md"
+  git -C "$TEST_TMP/repo" init -q
+  git -C "$TEST_TMP/repo" config user.email test@example.com
+  git -C "$TEST_TMP/repo" config user.name Test
+  git -C "$TEST_TMP/repo" add README.md scripts tests docs >/dev/null 2>&1
+  git -C "$TEST_TMP/repo" commit -qm init >/dev/null 2>&1 || true
+  git -C "$TEST_TMP/repo" checkout -b autospec/v61-mainline-freeze-test >/dev/null 2>&1
+  bash "$TEST_TMP/repo/scripts/autospec-baseline-validation.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  for version in $(seq 26 60); do
+    python3 "$TEST_TMP/repo/scripts/autospec-baseline-v25.py" --repo-root "$TEST_TMP/repo" --command "v${version}-supervisor" --prepare-only >/dev/null
+    bash "$TEST_TMP/repo/scripts/autospec-v${version}-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  done
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+@test "v61 writes mainline acceptance ledger and truth audit without overclaims" {
+  run bash "$TEST_TMP/repo/scripts/autospec-v61-mainline-acceptance.sh" --repo-root "$TEST_TMP/repo"
+  [ "$status" -eq 0 ]
+  run bash "$TEST_TMP/repo/scripts/autospec-v61-capability-truth-audit.sh" --repo-root "$TEST_TMP/repo"
+  [ "$status" -eq 0 ]
+
+  [ -f "$TEST_TMP/repo/.autospec/baselines/v60-mainline-acceptance.json" ]
+  [ -f "$TEST_TMP/repo/.autospec/baselines/v60-mainline-acceptance.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/audits/v61-capability-truth-audit.json" ]
+  [ -f "$TEST_TMP/repo/.autospec/audits/v61-capability-truth-audit.md" ]
+
+  python3 - "$TEST_TMP/repo/.autospec/baselines/v60-mainline-acceptance.json" "$TEST_TMP/repo/.autospec/audits/v61-capability-truth-audit.json" <<'PY'
+import json, sys
+ledger=json.load(open(sys.argv[1]))
+audit=json.load(open(sys.argv[2]))
+assert ledger["status"] == "accepted"
+assert ledger["v60_status"] == "ready"
+assert ledger["v61_status"] == "ready"
+assert ledger["remote_write_readiness_overclaimed"] is False
+assert ledger["real_canary_execution_claimed"] is False
+assert len(ledger["phase_statuses"]) == 35
+assert audit["status"] == "pass"
+assert audit["overclaiming_prevented"] is True
+assert audit["remote_write_canary_executed"] is False
+assert audit["merge_capability_executed"] is False
+assert audit["auto_merge_capability_executed"] is False
+assert audit["self_approval_capability_executed"] is False
+classifications={item["phase"]: set(item["classifications"]) for item in audit["capabilities"]}
+assert "implemented" in classifications["v60"]
+for phase in ["v26","v27","v29","v30","v34","v38","v43","v47","v57"]:
+    assert "readiness_only" in classifications[phase], phase
+    assert "requires_human_approval" in classifications[phase], phase
+assert "mock_only" in classifications["v28"]
+assert "local_only" in classifications["v40"]
+assert "dry_run_only" in classifications["v51"]
+PY
+}
+
+@test "v61 writes operator command catalog and golden paths" {
+  bash "$TEST_TMP/repo/scripts/autospec-v61-operator-command-catalog.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  bash "$TEST_TMP/repo/scripts/autospec-v61-golden-path-build.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  bash "$TEST_TMP/repo/scripts/autospec-v61-golden-path-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+
+  [ -f "$TEST_TMP/repo/.autospec/operator-command-catalog.json" ]
+  [ -f "$TEST_TMP/repo/docs/operators/AUTOSPEC_COMMAND_CATALOG.md" ]
+  [ -f "$TEST_TMP/repo/docs/operators/GOLDEN_PATH_AUTOTRADE.md" ]
+  [ -f "$TEST_TMP/repo/docs/operators/GOLDEN_PATH_GENERIC_REPO.md" ]
+
+  grep -q "Safety Classification" "$TEST_TMP/repo/docs/operators/AUTOSPEC_COMMAND_CATALOG.md"
+  grep -q "Human approval boundary" "$TEST_TMP/repo/docs/operators/GOLDEN_PATH_AUTOTRADE.md"
+  grep -q "Dry-run default" "$TEST_TMP/repo/docs/operators/GOLDEN_PATH_GENERIC_REPO.md"
+  python3 - "$TEST_TMP/repo/.autospec/operator-command-catalog.json" <<'PY'
+import json, sys
+catalog=json.load(open(sys.argv[1]))
+assert catalog["status"] == "written"
+assert catalog["default_mode"] == "dry_run"
+assert catalog["hidden_github_writes"] is False
+assert len(catalog["commands"]) >= 10
+assert any(c["safety_classification"] == "human_approval_required" for c in catalog["commands"])
+assert any(c["safety_classification"] == "dry_run_safe" for c in catalog["commands"])
+PY
+}
+
+@test "v61 boundary audits block hidden GitHub writes and approval overclaims" {
+  bash "$TEST_TMP/repo/scripts/autospec-v61-human-approval-boundary-audit.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  bash "$TEST_TMP/repo/scripts/autospec-v61-remote-write-boundary-audit.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+
+  python3 - "$TEST_TMP/repo/.autospec/audits/v61-human-approval-boundary-audit.json" "$TEST_TMP/repo/.autospec/audits/v61-remote-write-boundary-audit.json" <<'PY'
+import json, sys
+human=json.load(open(sys.argv[1]))
+remote=json.load(open(sys.argv[2]))
+assert human["status"] == "pass"
+assert human["approval_capsule_required_for_remote_writes"] is True
+assert human["self_approval_allowed"] is False
+assert human["auto_merge_allowed"] is False
+assert human["unapproved_real_write_allowed"] is False
+assert remote["status"] == "pass"
+assert remote["hidden_github_writes"] is False
+assert remote["real_git_push_executed"] is False
+assert remote["draft_pr_create_executed"] is False
+assert remote["issue_publish_executed"] is False
+assert remote["default_branch_push_executed"] is False
+assert remote["force_push_executed"] is False
+assert remote["tag_push_executed"] is False
+PY
+}
+
+@test "v61 release candidate packet postmerge validation and status are ready" {
+  bash "$TEST_TMP/repo/scripts/autospec-v61-mainline-acceptance.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  bash "$TEST_TMP/repo/scripts/autospec-v61-capability-truth-audit.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  bash "$TEST_TMP/repo/scripts/autospec-v61-operator-command-catalog.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  bash "$TEST_TMP/repo/scripts/autospec-v61-golden-path-build.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  bash "$TEST_TMP/repo/scripts/autospec-v61-human-approval-boundary-audit.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  bash "$TEST_TMP/repo/scripts/autospec-v61-remote-write-boundary-audit.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  bash "$TEST_TMP/repo/scripts/autospec-v61-release-candidate-pack.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  bash "$TEST_TMP/repo/scripts/autospec-v61-postmerge-validation.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  run bash "$TEST_TMP/repo/scripts/autospec-v61-status.sh" --repo-root "$TEST_TMP/repo"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"v61 status: ready"* ]]
+
+  for file in rc-summary validation-checklist known-limitations boundary-summary; do
+    [ -f "$TEST_TMP/repo/.autospec/releases/v60-mainline-rc/$file.json" ]
+    [ -f "$TEST_TMP/repo/.autospec/releases/v60-mainline-rc/$file.md" ]
+  done
+  python3 - "$TEST_TMP/repo/.autospec/reports/autonomy-v61-status.json" "$TEST_TMP/repo/.autospec/reports/v61-postmerge-validation.json" <<'PY'
+import json, sys
+status=json.load(open(sys.argv[1]))
+post=json.load(open(sys.argv[2]))
+assert status["status"] == "ready"
+assert status["v60_mainline_acceptance_ledger_written"] is True
+assert status["capability_truth_audit_written"] is True
+assert status["operator_command_catalog_written"] is True
+assert status["golden_path_docs_written"] is True
+assert status["release_candidate_packet_written"] is True
+assert status["human_approval_boundaries_explicit"] is True
+assert status["remote_write_readiness_not_overclaimed"] is True
+for key in ["auto_merge_attempted","self_approval_attempted","default_branch_push_attempted","github_write_attempted","scheduler_started","daemon_started","background_runner_started","raw_secret_values_exposed"]:
+    assert status[key] is False, key
+assert post["status"] == "pass"
+assert post["platform_gates_unblocked"] is True
+PY
+}

--- a/tests/autonomy-v62-multirepo-pilot-harness.bats
+++ b/tests/autonomy-v62-multirepo-pilot-harness.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  mkdir -p "$TEST_TMP/repo"
+  cp -R "$REPO_ROOT/scripts" "$TEST_TMP/repo/scripts"
+  cp -R "$REPO_ROOT/docs" "$TEST_TMP/repo/docs"
+  git -C "$TEST_TMP/repo" init -q
+  git -C "$TEST_TMP/repo" config user.email test@example.com
+  git -C "$TEST_TMP/repo" config user.name Test
+  git -C "$TEST_TMP/repo" add scripts docs >/dev/null 2>&1
+  git -C "$TEST_TMP/repo" commit -qm init >/dev/null 2>&1 || true
+  bash "$TEST_TMP/repo/scripts/autospec-v61-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+@test "v62 writes target registry matrix isolation and aggregate artifacts" {
+  for script in target-registry-init target-register target-suitability-audit target-isolation-audit multirepo-pilot-plan multirepo-readonly-run pilot-matrix pilot-evidence-aggregate multirepo-handoff; do
+    bash "$TEST_TMP/repo/scripts/autospec-v62-$script.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  done
+  run bash "$TEST_TMP/repo/scripts/autospec-v62-status.sh" --repo-root "$TEST_TMP/repo"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"v62 status: ready"* ]]
+  [ -f "$TEST_TMP/repo/.autospec/multirepo/v62/target-registry.json" ]
+  [ -f "$TEST_TMP/repo/.autospec/multirepo/v62/pilot-matrix.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/multirepo/v62/isolation-audit.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/multirepo/v62/evidence-aggregate.md" ]
+  python3 - "$TEST_TMP/repo/.autospec/multirepo/v62/target-registry.json" "$TEST_TMP/repo/.autospec/reports/autonomy-v62-status.json" <<'PY'
+import json, sys
+registry=json.load(open(sys.argv[1]))
+status=json.load(open(sys.argv[2]))
+assert any(t["name"] == "autotrade" for t in registry["targets"])
+assert any(t["name"] == "external-placeholder" for t in registry["targets"])
+assert status["status"] == "ready"
+assert status["github_write_attempted"] is False
+assert status["background_runner_started"] is False
+PY
+}
+
+@test "v62 blocks real network or GitHub write flags" {
+  run bash "$TEST_TMP/repo/scripts/autospec-v62-status.sh" --repo-root "$TEST_TMP/repo" --allow-network
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"blocked"* ]]
+}

--- a/tests/autonomy-v63-install-ux-hardening.bats
+++ b/tests/autonomy-v63-install-ux-hardening.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  mkdir -p "$TEST_TMP/repo"
+  cp -R "$REPO_ROOT/scripts" "$TEST_TMP/repo/scripts"
+  cp -R "$REPO_ROOT/docs" "$TEST_TMP/repo/docs"
+  bash "$TEST_TMP/repo/scripts/autospec-v61-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  bash "$TEST_TMP/repo/scripts/autospec-v62-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+@test "v63 writes install doctor onboarding and reproducibility outputs" {
+  for script in install-doctor command-smoke operator-onboarding-pack release-bundle-repro-check docs-link-audit command-help-audit local-smoke-suite distribution-handoff; do
+    bash "$TEST_TMP/repo/scripts/autospec-v63-$script.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  done
+  run bash "$TEST_TMP/repo/scripts/autospec-v63-status.sh" --repo-root "$TEST_TMP/repo"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMP/repo/docs/operators/INSTALL_AND_DOCTOR.md" ]
+  [ -f "$TEST_TMP/repo/docs/operators/COMMAND_SMOKE_GUIDE.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/distribution/v63/reproducibility-report.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/distribution/v63/operator-onboarding-pack.md" ]
+  grep -q "no package installs" "$TEST_TMP/repo/docs/operators/INSTALL_AND_DOCTOR.md"
+}
+
+@test "v63 reports no hidden network or package operations" {
+  bash "$TEST_TMP/repo/scripts/autospec-v63-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  python3 - "$TEST_TMP/repo/.autospec/reports/autonomy-v63-status.json" <<'PY'
+import json, sys
+s=json.load(open(sys.argv[1]))
+assert s["status"] == "ready"
+assert s["network_attempted"] is False
+assert s["package_operations"] is False
+PY
+}

--- a/tests/autonomy-v64-operator-dashboard.bats
+++ b/tests/autonomy-v64-operator-dashboard.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  mkdir -p "$TEST_TMP/repo"
+  cp -R "$REPO_ROOT/scripts" "$TEST_TMP/repo/scripts"
+  cp -R "$REPO_ROOT/docs" "$TEST_TMP/repo/docs"
+  for v in 61 62 63; do bash "$TEST_TMP/repo/scripts/autospec-v${v}-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null; done
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+@test "v64 renders a static dashboard with safety matrix" {
+  for script in dashboard-data-build dashboard-static-render run-ledger-index control-plane-summary safety-matrix-render operator-dashboard-open-plan dashboard-verify; do
+    bash "$TEST_TMP/repo/scripts/autospec-v64-$script.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  done
+  run bash "$TEST_TMP/repo/scripts/autospec-v64-status.sh" --repo-root "$TEST_TMP/repo"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMP/repo/.autospec/dashboard/v64/dashboard-data.json" ]
+  [ -f "$TEST_TMP/repo/.autospec/dashboard/v64/index.html" ]
+  [ -f "$TEST_TMP/repo/.autospec/dashboard/v64/control-plane-summary.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/dashboard/v64/safety-matrix.md" ]
+  grep -q "Static artifact only" "$TEST_TMP/repo/.autospec/dashboard/v64/index.html"
+}
+
+@test "v64 dashboard does not start services or expose raw secrets" {
+  bash "$TEST_TMP/repo/scripts/autospec-v64-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  python3 - "$TEST_TMP/repo/.autospec/reports/autonomy-v64-status.json" <<'PY'
+import json, sys
+s=json.load(open(sys.argv[1]))
+assert s["status"] == "ready"
+assert s["daemon_started"] is False
+assert s["scheduler_started"] is False
+assert s["raw_secret_values_exposed"] is False
+PY
+}

--- a/tests/autonomy-v65-companion-sync-proposals.bats
+++ b/tests/autonomy-v65-companion-sync-proposals.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  mkdir -p "$TEST_TMP/repo"
+  cp -R "$REPO_ROOT/scripts" "$TEST_TMP/repo/scripts"
+  cp -R "$REPO_ROOT/docs" "$TEST_TMP/repo/docs"
+  for v in 61 62 63 64; do bash "$TEST_TMP/repo/scripts/autospec-v${v}-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null; done
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+@test "v65 writes companion proposal-only bridge artifacts" {
+  for script in companion-inventory constitution-drift-audit baseline-drift-audit sync-proposal-plan companion-patch-bundle companion-compatibility-check manual-pr-packet proposal-quorum; do
+    bash "$TEST_TMP/repo/scripts/autospec-v65-$script.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  done
+  run bash "$TEST_TMP/repo/scripts/autospec-v65-status.sh" --repo-root "$TEST_TMP/repo"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMP/repo/.autospec/companions/v65/constitution-drift-audit.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/companions/v65/baseline-drift-audit.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/companions/v65/sync-proposal-plan.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/companions/v65/manual-pr-packet.md" ]
+  grep -q "no automatic PR creation" "$TEST_TMP/repo/.autospec/companions/v65/manual-pr-packet.md"
+}
+
+@test "v65 performs no companion repo write" {
+  bash "$TEST_TMP/repo/scripts/autospec-v65-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  python3 - "$TEST_TMP/repo/.autospec/reports/autonomy-v65-status.json" <<'PY'
+import json, sys
+s=json.load(open(sys.argv[1]))
+assert s["status"] == "ready"
+assert s["github_write_attempted"] is False
+assert s["git_push_attempted"] is False
+PY
+}

--- a/tests/autonomy-v66-external-readonly-pilot.bats
+++ b/tests/autonomy-v66-external-readonly-pilot.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  mkdir -p "$TEST_TMP/repo"
+  cp -R "$REPO_ROOT/scripts" "$TEST_TMP/repo/scripts"
+  cp -R "$REPO_ROOT/docs" "$TEST_TMP/repo/docs"
+  for v in 61 62 63 64 65; do bash "$TEST_TMP/repo/scripts/autospec-v${v}-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null; done
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+@test "v66 writes external read-only pilot artifacts" {
+  for script in external-target-register external-readonly-intake external-digital-twin-refresh external-risk-profile external-backlog-recommendations external-issue-draft-pack external-pilot-closeout original-target-unchanged; do
+    bash "$TEST_TMP/repo/scripts/autospec-v66-$script.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  done
+  run bash "$TEST_TMP/repo/scripts/autospec-v66-status.sh" --repo-root "$TEST_TMP/repo"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v66/target-intake.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v66/digital-twin-summary.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v66/backlog-recommendations.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v66/issue-draft-pack.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v66/closeout.md" ]
+}
+
+@test "v66 keeps issue drafts unpublished and original target unchanged" {
+  bash "$TEST_TMP/repo/scripts/autospec-v66-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  grep -q "unpublished" "$TEST_TMP/repo/.autospec/external-pilots/v66/issue-draft-pack.md"
+  python3 - "$TEST_TMP/repo/.autospec/reports/autonomy-v66-status.json" <<'PY'
+import json, sys
+s=json.load(open(sys.argv[1]))
+assert s["status"] == "ready"
+assert s["original_target_unchanged"] is True
+assert s["issue_publishing_attempted"] is False
+PY
+}

--- a/tests/autonomy-v67-external-disposable-write-proof.bats
+++ b/tests/autonomy-v67-external-disposable-write-proof.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  mkdir -p "$TEST_TMP/repo"
+  cp -R "$REPO_ROOT/scripts" "$TEST_TMP/repo/scripts"
+  cp -R "$REPO_ROOT/docs" "$TEST_TMP/repo/docs"
+  for v in 61 62 63 64 65 66; do bash "$TEST_TMP/repo/scripts/autospec-v${v}-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null; done
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+@test "v67 writes one disposable docs evidence patch proof" {
+  for script in external-disposable-prepare external-write-candidate-select external-scope-preflight external-apply-patch external-patch-verifier external-rollback external-rollback-verifier original-target-unchanged write-proof-handoff; do
+    bash "$TEST_TMP/repo/scripts/autospec-v67-$script.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  done
+  run bash "$TEST_TMP/repo/scripts/autospec-v67-status.sh" --repo-root "$TEST_TMP/repo"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v67/write-candidate.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v67/apply-result.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v67/rollback-verification.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v67/original-target-unchanged.md" ]
+  grep -q "candidate_count: \`1\`" "$TEST_TMP/repo/.autospec/external-pilots/v67/write-candidate.md"
+}
+
+@test "v67 reports no commits pushes network PRs or issue publishes" {
+  bash "$TEST_TMP/repo/scripts/autospec-v67-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  python3 - "$TEST_TMP/repo/.autospec/reports/autonomy-v67-status.json" <<'PY'
+import json, sys
+s=json.load(open(sys.argv[1]))
+assert s["status"] == "ready"
+for key in ["git_push_attempted","github_write_attempted","network_attempted","draft_pr_create_attempted","issue_publishing_attempted"]:
+    assert s[key] is False, key
+PY
+}

--- a/tests/autonomy-v68-external-local-commit-proof.bats
+++ b/tests/autonomy-v68-external-local-commit-proof.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  mkdir -p "$TEST_TMP/repo"
+  cp -R "$REPO_ROOT/scripts" "$TEST_TMP/repo/scripts"
+  cp -R "$REPO_ROOT/docs" "$TEST_TMP/repo/docs"
+  for v in 61 62 63 64 65 66 67; do bash "$TEST_TMP/repo/scripts/autospec-v${v}-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null; done
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+@test "v68 writes local commit ledger verifier revert drill and handoff" {
+  for script in external-l2-target-prepare external-branch-safety-preflight external-local-commit-preflight external-cycle-write-commit external-commit-ledger-status external-commit-verifier external-revert-drill original-target-unchanged local-commit-handoff; do
+    bash "$TEST_TMP/repo/scripts/autospec-v68-$script.sh" --repo-root "$TEST_TMP/repo" --allow-local-commit >/dev/null
+  done
+  run bash "$TEST_TMP/repo/scripts/autospec-v68-status.sh" --repo-root "$TEST_TMP/repo"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v68/local-commit-ledger.json" ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v68/commit-verifier.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v68/revert-drill.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v68/handoff.md" ]
+}
+
+@test "v68 blocks default branch push and remote write overclaims" {
+  bash "$TEST_TMP/repo/scripts/autospec-v68-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  python3 - "$TEST_TMP/repo/.autospec/external-pilots/v68/local-commit-ledger.json" "$TEST_TMP/repo/.autospec/reports/autonomy-v68-status.json" <<'PY'
+import json, sys
+ledger=json.load(open(sys.argv[1]))
+s=json.load(open(sys.argv[2]))
+assert ledger["local_commits_created"] == 1
+assert ledger["default_branch"] is False
+assert s["git_push_attempted"] is False
+assert s["github_write_attempted"] is False
+PY
+}

--- a/tests/autonomy-v69-external-draft-pr-canary.bats
+++ b/tests/autonomy-v69-external-draft-pr-canary.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  mkdir -p "$TEST_TMP/repo"
+  cp -R "$REPO_ROOT/scripts" "$TEST_TMP/repo/scripts"
+  cp -R "$REPO_ROOT/docs" "$TEST_TMP/repo/docs"
+  for v in 61 62 63 64 65 66 67 68; do bash "$TEST_TMP/repo/scripts/autospec-v${v}-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null; done
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+@test "v69 prepare-only canary readiness writes approval and recovery artifacts" {
+  for script in external-canary-remote-bind external-canary-readiness external-approval-template external-approval-verify external-arm-gate external-push external-draft-pr-create external-pr-verifier external-remote-write-audit external-recovery-plan; do
+    bash "$TEST_TMP/repo/scripts/autospec-v69-$script.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  done
+  run bash "$TEST_TMP/repo/scripts/autospec-v69-status.sh" --repo-root "$TEST_TMP/repo"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ready_for_human_canary"* ]]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v69/canary-readiness.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v69/approval-capsule-template.json" ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v69/remote-write-audit.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/external-pilots/v69/recovery-plan.md" ]
+}
+
+@test "v69 refuses real write flags without approved capsule" {
+  run bash "$TEST_TMP/repo/scripts/autospec-v69-status.sh" --repo-root "$TEST_TMP/repo" --allow-network --allow-git-push --allow-github-pr --execute-real-github-write
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"blocked"* ]]
+  bash "$TEST_TMP/repo/scripts/autospec-v69-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  python3 - "$TEST_TMP/repo/.autospec/reports/autonomy-v69-status.json" <<'PY'
+import json, sys
+s=json.load(open(sys.argv[1]))
+assert s["status"] == "ready_for_human_canary"
+assert s["real_execution_blocked_without_approval_capsule"] is True
+assert s["draft_pr_create_attempted"] is False
+assert s["merge_attempted"] is False
+assert s["self_approval_attempted"] is False
+PY
+}

--- a/tests/autonomy-v70-alpha-release-candidate.bats
+++ b/tests/autonomy-v70-alpha-release-candidate.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  mkdir -p "$TEST_TMP/repo"
+  cp -R "$REPO_ROOT/scripts" "$TEST_TMP/repo/scripts"
+  cp -R "$REPO_ROOT/docs" "$TEST_TMP/repo/docs"
+  for v in 61 62 63 64 65 66 67 68 69; do bash "$TEST_TMP/repo/scripts/autospec-v${v}-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null; done
+}
+
+teardown() { rm -rf "$TEST_TMP"; }
+
+@test "v70 packages alpha release candidate with governance artifacts" {
+  for script in alpha-scope-lock alpha-release-candidate-pack pilot-program-matrix operator-runbook-build risk-register evidence-index alpha-acceptance-gate exit-criteria final-handoff; do
+    bash "$TEST_TMP/repo/scripts/autospec-v70-$script.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  done
+  run bash "$TEST_TMP/repo/scripts/autospec-v70-status.sh" --repo-root "$TEST_TMP/repo"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"alpha_ready_with_accepted_warnings"* ]]
+  [ -f "$TEST_TMP/repo/.autospec/releases/v70-alpha-rc/release-summary.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/releases/v70-alpha-rc/pilot-program-matrix.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/releases/v70-alpha-rc/operator-runbook.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/releases/v70-alpha-rc/risk-register.md" ]
+  [ -f "$TEST_TMP/repo/.autospec/releases/v70-alpha-rc/final-handoff.md" ]
+}
+
+@test "v70 preserves accepted warnings and no hidden automation" {
+  bash "$TEST_TMP/repo/scripts/autospec-v70-status.sh" --repo-root "$TEST_TMP/repo" >/dev/null
+  python3 - "$TEST_TMP/repo/.autospec/reports/autonomy-v70-status.json" <<'PY'
+import json, sys
+s=json.load(open(sys.argv[1]))
+assert s["status"] == "alpha_ready_with_accepted_warnings"
+assert s["accepted_warnings"]
+assert s["alpha_release_enables_hidden_automation"] is False
+assert s["auto_merge_attempted"] is False
+assert s["self_approval_attempted"] is False
+assert s["default_branch_push_attempted"] is False
+PY
+}


### PR DESCRIPTION
# Summary

Implements the Autospec V61-V70 future-spec sequence on top of the merged V25-V60 baseline.

This PR adds the V61 mainline freeze/truth-audit layer and the V62-V70 local/offline governance, pilot, dashboard, companion-sync, external-target, canary-readiness, and alpha-release-candidate harnesses.

# Safety boundary

- No auto-merge, self-approval, direct default-branch push, force push, tag push, scheduler, daemon, background runner, package install, external AI/API/model call, or hidden GitHub write was added.
- V69 is intentionally readiness-only: `ready_for_human_canary`. It does not claim a real push or real draft PR was executed.
- V70 reports `alpha_ready_with_accepted_warnings`, not a fully unrestricted production-autonomy state.
- Runtime `.autospec` artifacts are generated on demand and remain ignored rather than committed.

# Validation

Local validation performed in an isolated worktree before opening this draft PR:

```text
python3 -m py_compile scripts/autospec-runtime-v1-lib.py scripts/autospec-baseline-v25.py scripts/autospec-v61-v70.py
for test_file in tests/autonomy-v*.bats; do bats "$test_file"; done
bash scripts/autospec-v61-status.sh ... bash scripts/autospec-v70-status.sh
bash scripts/autospec-complete-autonomy-gate.sh --dry-run
bash scripts/autospec-release-bundle-verify.sh --dry-run
bash scripts/autospec-release-status.sh
bash scripts/autospec-release-freeze-gate.sh --dry-run
bash scripts/autospec-final-rc-gate.sh --dry-run
bash scripts/autospec-release-candidate-gate.sh --dry-run
bash scripts/autospec-spec-coverage.sh --dry-run
bash scripts/autospec-security-privacy-status.sh
```

Observed status sweep:

```text
v61 status: ready
v62 status: ready
v63 status: ready
v64 status: ready
v65 status: ready
v66 status: ready
v67 status: ready
v68 status: ready
v69 status: ready_for_human_canary
v70 status: alpha_ready_with_accepted_warnings
```

# Review focus

- Capability truth classifications and avoidance of overclaiming.
- V69 remote-write and human-approval boundaries.
- Thin wrapper sprawl around `scripts/autospec-v61-v70.py`.
- Whether V70 accepted warnings should block or remain explicit release-candidate caveats.
