### PR TITLE
feat: detect route registry drift in quality audits

### DIFF
--- a/skills/autospec-shared/scripts/repo-quality-audit.sh
+++ b/skills/autospec-shared/scripts/repo-quality-audit.sh
@@ -125,6 +125,79 @@ add_guard_finding() {
     '{probe:$probe,classification:$classification,severity:$severity,file:$file,line:$line,title:$title,body:$body,dedupe_key:$key,guard_script:$guard_script,rule:(if $rule == "" then null else $rule end),class:(if $class_name == "" then null else $class_name end),excerpt:(if $excerpt == "" then null else $excerpt end)}'
 }
 
+add_route_registry_drift_finding() {
+  script="$1"; family="$2"; routes_json="$3"
+  count="$(printf '%s' "$routes_json" | jq 'length')"
+  sample="$(printf '%s' "$routes_json" | jq -r 'join(", ")')"
+  key="route-registry-drift:$script:$family"
+  target="$FINDINGS_ND"
+  classification="app-follow-up"
+  if is_accepted "$key"; then
+    classification="inherited-accepted-debt"
+    target="$SUPPRESSED_ND"
+  fi
+  json_append "$target" \
+    --arg probe "route-registry-drift" \
+    --arg classification "$classification" \
+    --arg severity "high" \
+    --arg file "package.json" \
+    --argjson line "0" \
+    --arg title "route registry drift in $family routes" \
+    --arg body "Route coverage meta test $script reported $count live route(s) missing from the curated route registry or smoke-test catalog for family $family: $sample." \
+    --arg key "$key" \
+    --arg script "$script" \
+    --arg family "$family" \
+    --argjson routes "$routes_json" \
+    '{probe:$probe,classification:$classification,severity:$severity,file:$file,line:$line,title:$title,body:$body,dedupe_key:$key,route_coverage_script:$script,route_family:$family,missing_routes:$routes}'
+}
+
+add_route_compiler_warning_finding() {
+  script="$1"; code="$2"; line_text="$3"; idx="$4"
+  excerpt="$(printf '%s' "$line_text" | cut -c1-240)"
+  key="route-coverage-warning:$script:$code:$idx"
+  target="$FINDINGS_ND"
+  classification="app-follow-up"
+  if is_accepted "$key"; then
+    classification="inherited-accepted-debt"
+    target="$SUPPRESSED_ND"
+  fi
+  json_append "$target" \
+    --arg probe "route-coverage-compiler-warning" \
+    --arg classification "$classification" \
+    --arg severity "medium" \
+    --arg file "package.json" \
+    --argjson line "0" \
+    --arg title "route coverage compiler warning $code" \
+    --arg body "Route coverage meta test $script emitted Angular compiler warning $code. Output: $excerpt" \
+    --arg key "$key" \
+    --arg script "$script" \
+    --arg code "$code" \
+    --arg excerpt "$excerpt" \
+    '{probe:$probe,classification:$classification,severity:$severity,file:$file,line:$line,title:$title,body:$body,dedupe_key:$key,route_coverage_script:$script,warning_code:$code,excerpt:$excerpt}'
+}
+
+add_route_setup_failure_finding() {
+  script="$1"; summary="$2"
+  key="route-coverage-setup:$script"
+  target="$FINDINGS_ND"
+  classification="verification-contract-drift"
+  if is_accepted "$key"; then
+    classification="inherited-accepted-debt"
+    target="$SUPPRESSED_ND"
+  fi
+  json_append "$target" \
+    --arg probe "route-coverage-setup" \
+    --arg classification "$classification" \
+    --arg severity "high" \
+    --arg file "package.json" \
+    --argjson line "0" \
+    --arg title "route coverage meta test setup failed" \
+    --arg body "Route coverage meta test could not reach its required local server or setup dependency. First output: ${summary:-<empty>}" \
+    --arg key "$key" \
+    --arg script "$script" \
+    '{probe:$probe,classification:$classification,severity:$severity,file:$file,line:$line,title:$title,body:$body,dedupe_key:$key,route_coverage_script:$script}'
+}
+
 rel_path() {
   case "$1" in
     "$REPO"/*) printf '%s' "${1#"$REPO"/}" ;;
@@ -224,6 +297,165 @@ probe_design_template_guard_script() {
     fi
     record_verification_lane "$script" "configured but failing" "$command_text" "${summary:-<empty>}"
   else
+    record_verification_lane "$script" "passed" "$command_text" "command probe exited 0"
+  fi
+}
+
+route_coverage_scripts() {
+  [ -f "$REPO/package.json" ] || return 0
+  jq -r '
+    (.scripts // {}) | to_entries[]
+    | select(((.key + " " + .value) | ascii_downcase | test("route"))
+        and ((.key + " " + .value) | ascii_downcase | test("coverage|registry|smoke|catalog|meta")))
+    | .key
+  ' "$REPO/package.json" 2>/dev/null | sort -u
+}
+
+route_coverage_targets() {
+  route_coverage_scripts | while IFS= read -r script; do
+    [ -n "$script" ] || continue
+    printf 'npm-script\t%s\tnpm run %s\n' "$script" "$script"
+  done
+  for spec in \
+    "e2e-playwright/route-coverage.meta.spec.ts" \
+    "e2e-playwright/route-coverage.spec.ts" \
+    "tests/route-coverage.meta.spec.ts" \
+    "tests/route-coverage.spec.ts"
+  do
+    [ -f "$REPO/$spec" ] || continue
+    printf 'playwright-spec\troute-coverage:%s\tCI=1 npx playwright test %s --project=chrome\n' "$spec" "$spec"
+  done
+}
+
+route_family_for() {
+  route="$1"
+  first="${route%%/*}"
+  case "$first" in
+    ""|"."|".."|":"*) printf 'root' ;;
+    *) printf '%s' "$first" | tr -c 'A-Za-z0-9_.-' '-' | sed 's/^-*//; s/-*$//; s/^$/root/' ;;
+  esac
+}
+
+route_coverage_setup_failed() {
+  out="$1"
+  grep -Eiq 'ECONNREFUSED|ERR_CONNECTION_REFUSED|server[^[:alnum:]]+(not )?running|dev server|baseURL|base url|connection refused|unable to connect|could not connect|failed to connect|address already in use|EADDRINUSE' "$out"
+}
+
+extract_route_registry_missing_routes() {
+  out="$1"
+  awk '
+    function clean(s) {
+      gsub(/\r/, "", s)
+      gsub(/^[[:space:]]*([-*]|•)[[:space:]]*/, "", s)
+      gsub(/^[[:space:]]*(Missing|missing)[^:]*:[[:space:]]*/, "", s)
+      gsub(/[`"'\'';,]/, "", s)
+      sub(/[[:space:]]+$/, "", s)
+      sub(/^[[:space:]]+/, "", s)
+      sub(/[[:space:]].*$/, "", s)
+      sub(/^\/+/, "", s)
+      sub(/\/+$/, "", s)
+      return s
+    }
+    function valid(s) {
+      return s != "" && s !~ /^(ROUTE_REGISTRY|Route|route|routes|registry|catalog)$/ && s ~ /^[A-Za-z0-9_.:-]+(\/[A-Za-z0-9_.:-]+)*$/
+    }
+    {
+      low = tolower($0)
+      if (low ~ /(live routes missing|missing.*(route_registry|route registry|smoke-test catalog|smoke test catalog|route catalog|registry)|not registered|unregistered)/) {
+        in_missing = 1
+        if ($0 ~ /:/) {
+          cand = $0
+          sub(/^.*:/, "", cand)
+          cand = clean(cand)
+          if (valid(cand)) print cand
+        }
+        next
+      }
+      if (in_missing && $0 ~ /^[[:space:]]*([-*]|•)[[:space:]]*"?[A-Za-z0-9_.:-]+(\/[A-Za-z0-9_.:-]+)*/) {
+        cand = clean($0)
+        if (valid(cand)) print cand
+        next
+      }
+      if (in_missing && $0 !~ /^[[:space:]]*$/ && $0 !~ /^[[:space:]]*([-*]|•)/) {
+        in_missing = 0
+      }
+    }
+  ' "$out" | sort -u
+}
+
+parse_route_coverage_output() {
+  script="$1"; out="$2"
+  routes_file="$TMP_DIR/route-coverage-routes.tsv"
+  : > "$routes_file"
+  while IFS= read -r route; do
+    [ -n "$route" ] || continue
+    family="$(route_family_for "$route")"
+    printf '%s\t%s\n' "$family" "$route" >> "$routes_file"
+  done <<EOF
+$(extract_route_registry_missing_routes "$out")
+EOF
+
+  if [ -s "$routes_file" ]; then
+    cut -f1 "$routes_file" | sort -u | while IFS= read -r family; do
+      [ -n "$family" ] || continue
+      routes_json="$(awk -F '\t' -v family="$family" '$1 == family {print $2}' "$routes_file" | sort -u | jq -R . | jq -s '.')"
+      add_route_registry_drift_finding "$script" "$family" "$routes_json"
+    done
+  fi
+
+  warning_idx=0
+  while IFS= read -r warning_line; do
+    [ -n "$warning_line" ] || continue
+    code="$(printf '%s\n' "$warning_line" | grep -Eo 'NG[0-9]{4}' | head -1 || true)"
+    [ -n "$code" ] || continue
+    warning_idx=$((warning_idx + 1))
+    add_route_compiler_warning_finding "$script" "$code" "$warning_line" "$warning_idx"
+  done <<EOF
+$(grep -E 'NG[0-9]{4}' "$out" 2>/dev/null || true)
+EOF
+
+  [ -s "$routes_file" ] || [ "$warning_idx" -gt 0 ]
+}
+
+probe_route_coverage_script() {
+  kind="$1"; script="$2"; command_text="$3"
+  if ! run_probe_commands_enabled; then
+    record_verification_lane "$script" "not run" "$command_text" "command probe disabled"
+    return 0
+  fi
+  safe_script="$(printf '%s' "$script" | tr ':/' '--')"
+  out="$TMP_DIR/route-coverage-$safe_script.log"
+  if [ "$kind" = "playwright-spec" ]; then
+    spec="${script#route-coverage:}"
+    if (cd "$REPO" && CI=1 npx playwright test "$spec" --project=chrome) >"$out" 2>&1; then
+      status=0
+    else
+      status=$?
+    fi
+  else
+    if (cd "$REPO" && npm run -s "$script") >"$out" 2>&1; then
+      status=0
+    else
+      status=$?
+    fi
+  fi
+  if [ "$status" -ne 0 ]; then
+    summary="$(summarize_command_output "$out")"
+    if parse_route_coverage_output "$script" "$out"; then
+      :
+    elif route_coverage_setup_failed "$out"; then
+      add_route_setup_failure_finding "$script" "$summary"
+      record_verification_lane "$script" "setup failure" "$command_text" "${summary:-<empty>}"
+      return 0
+    else
+      add_finding "route-coverage-command" "verification-contract-drift" "high" "package.json" 0 \
+        "route coverage meta test fails" \
+        "Configured route coverage meta test $script exited non-zero, but autospec could not parse route registry drift from its output. First output: ${summary:-<empty>}" \
+        "route-coverage-command:$script"
+    fi
+    record_verification_lane "$script" "configured but failing" "$command_text" "${summary:-<empty>}"
+  else
+    parse_route_coverage_output "$script" "$out" || true
     record_verification_lane "$script" "passed" "$command_text" "command probe exited 0"
   fi
 }
@@ -471,6 +703,12 @@ if [ -f "$REPO/package.json" ]; then
   for script in lint:styles lint:templates; do
     probe_design_template_guard_script "$script"
   done
+  while IFS="$(printf '\t')" read -r kind script command_text; do
+    [ -n "$script" ] || continue
+    probe_route_coverage_script "$kind" "$script" "$command_text"
+  done <<EOF
+$(route_coverage_targets)
+EOF
   probe_npm_audit_script
   if ! jq -e '.engines.node // empty' "$REPO/package.json" >/dev/null 2>&1; then
     add_finding "runtime-engine-compatibility" "autospec-process-gap" "low" "package.json" 0 \

--- a/skills/autospec-shared/tests/unit/repo-quality-audit.bats
+++ b/skills/autospec-shared/tests/unit/repo-quality-audit.bats
@@ -242,6 +242,206 @@ EOF
     grep -q 'design-template-guard / design-template-contract' "$OUT_MD"
 }
 
+@test "audit discovers route coverage meta scripts without running them by default" {
+    OUT_JSON="$TEST_TMP/audit.json"
+    OUT_MD="$TEST_TMP/audit.md"
+    cat > "$REPO/package.json" <<'EOF'
+{
+  "engines": { "node": ">=20" },
+  "scripts": {
+    "test": "node --test",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "test:route-coverage": "node scripts/check-route-registry.js"
+  }
+}
+EOF
+
+    run bash "$AUDIT" --repo "$REPO" --json "$OUT_JSON" --markdown "$OUT_MD"
+    [ "$status" -eq 0 ]
+    jq -e '.verification.lanes["test:route-coverage"].status == "not run"' "$OUT_JSON"
+    jq -e '.verification.lanes["test:route-coverage"].command == "npm run test:route-coverage"' "$OUT_JSON"
+    ! jq -e '.findings[] | select(.probe=="route-registry-drift")' "$OUT_JSON"
+}
+
+@test "audit discovers direct Playwright route coverage meta specs without route-specific npm scripts" {
+    OUT_JSON="$TEST_TMP/audit.json"
+    OUT_MD="$TEST_TMP/audit.md"
+    mkdir -p "$REPO/e2e-playwright"
+    touch "$REPO/e2e-playwright/route-coverage.meta.spec.ts"
+    cat > "$REPO/package.json" <<'EOF'
+{
+  "engines": { "node": ">=20" },
+  "scripts": {
+    "test": "node --test",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "e2e": "npx playwright test"
+  }
+}
+EOF
+
+    run bash "$AUDIT" --repo "$REPO" --json "$OUT_JSON" --markdown "$OUT_MD"
+    [ "$status" -eq 0 ]
+    jq -e '.verification.lanes["route-coverage:e2e-playwright/route-coverage.meta.spec.ts"].status == "not run"' "$OUT_JSON"
+    jq -e '.verification.lanes["route-coverage:e2e-playwright/route-coverage.meta.spec.ts"].command == "CI=1 npx playwright test e2e-playwright/route-coverage.meta.spec.ts --project=chrome"' "$OUT_JSON"
+}
+
+@test "audit runs discovered direct Playwright route coverage meta specs when command probes are enabled" {
+    OUT_JSON="$TEST_TMP/audit.json"
+    OUT_MD="$TEST_TMP/audit.md"
+    mkdir -p "$REPO/e2e-playwright" "$TEST_TMP/bin"
+    touch "$REPO/e2e-playwright/route-coverage.meta.spec.ts"
+    cat > "$REPO/package.json" <<'EOF'
+{
+  "engines": { "node": ">=20" },
+  "scripts": {
+    "test": "node --test",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "e2e": "npx playwright test"
+  }
+}
+EOF
+    cat > "$TEST_TMP/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "--version") echo "11.16.0"; exit 0 ;;
+  "run -s test"|"run -s typecheck"|"run -s lint") exit 0 ;;
+esac
+exit 0
+EOF
+    cat > "$TEST_TMP/bin/npx" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "playwright test e2e-playwright/route-coverage.meta.spec.ts --project=chrome")
+    cat <<'LOG'
+Route coverage meta test failed
+Live routes missing from ROUTE_REGISTRY:
+• "database/samples"
+LOG
+    exit 1
+    ;;
+esac
+exit 0
+EOF
+    chmod +x "$TEST_TMP/bin/npm" "$TEST_TMP/bin/npx"
+    export PATH="$TEST_TMP/bin:$PATH"
+    export AUTOSPEC_QUALITY_AUDIT_RUN_COMMANDS=1
+
+    run bash "$AUDIT" --repo "$REPO" --json "$OUT_JSON" --markdown "$OUT_MD"
+    [ "$status" -eq 0 ]
+    jq -e '.verification.lanes["route-coverage:e2e-playwright/route-coverage.meta.spec.ts"].status == "configured but failing"' "$OUT_JSON"
+    jq -e '.findings[] | select(.probe=="route-registry-drift" and .route_family=="database" and (.missing_routes | index("database/samples")))' "$OUT_JSON"
+}
+
+@test "audit parses route registry drift and compiler warnings into bounded family issues" {
+    OUT_JSON="$TEST_TMP/audit.json"
+    OUT_MD="$TEST_TMP/audit.md"
+    mkdir -p "$TEST_TMP/bin"
+    cat > "$REPO/package.json" <<'EOF'
+{
+  "engines": { "node": ">=20" },
+  "scripts": {
+    "test": "node --test",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "test:route-coverage": "node scripts/check-route-registry.js"
+  }
+}
+EOF
+    cat > "$TEST_TMP/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "--version") echo "11.16.0"; exit 0 ;;
+  "run -s test"|"run -s typecheck"|"run -s lint") exit 0 ;;
+  "run -s test:route-coverage")
+    cat <<'LOG'
+Route coverage meta test failed
+baseURL: http://127.0.0.1:4200
+Live routes missing from ROUTE_REGISTRY:
+• "admin/assistant-site-defaults"
+• "stats/admin/state-over-time"
+• "stats/database-content"
+Missing smoke-test catalog entry: system
+Warning: src/app/app.component.ts:15:10 - warning NG8113: RouterLink is not used within the template
+LOG
+    exit 1
+    ;;
+esac
+exit 0
+EOF
+    export GH_LOG="$TEST_TMP/gh.log"
+    export GH_OPEN="$TEST_TMP/open.json"
+    printf '[]\n' > "$GH_OPEN"
+    cat > "$TEST_TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s|%s\n' "$PWD" "$*" >> "$GH_LOG"
+case "$*" in
+  *"issue list"*) cat "$GH_OPEN"; exit 0 ;;
+  *"label create"*) exit 0 ;;
+  *"issue create"*) echo "https://github.com/example/repo/issues/30"; exit 0 ;;
+esac
+exit 0
+EOF
+    chmod +x "$TEST_TMP/bin/npm" "$TEST_TMP/bin/gh"
+    export PATH="$TEST_TMP/bin:$PATH"
+    export AUTOSPEC_QUALITY_AUDIT_RUN_COMMANDS=1
+    export AUTOSPEC_QUALITY_AUDIT_FILE_ISSUES=1
+
+    run bash "$AUDIT" --repo "$REPO" --json "$OUT_JSON" --markdown "$OUT_MD" --file-issues
+    [ "$status" -eq 0 ]
+    jq -e '.verification.lanes["test:route-coverage"].status == "configured but failing"' "$OUT_JSON"
+    jq -e '.findings[] | select(.probe=="route-registry-drift" and .route_family=="admin" and (.missing_routes | index("admin/assistant-site-defaults")))' "$OUT_JSON"
+    jq -e '.findings[] | select(.probe=="route-registry-drift" and .route_family=="stats" and (.missing_routes | index("stats/admin/state-over-time")) and (.missing_routes | index("stats/database-content")))' "$OUT_JSON"
+    jq -e '.findings[] | select(.probe=="route-registry-drift" and .route_family=="system" and (.missing_routes | index("system")))' "$OUT_JSON"
+    jq -e '.findings[] | select(.probe=="route-coverage-compiler-warning" and .warning_code=="NG8113" and (.body | contains("RouterLink")))' "$OUT_JSON"
+    jq -e '.issue_links | map(select(.dedupe_key=="route-registry-drift:test:route-coverage:admin")) | length == 1' "$OUT_JSON"
+    jq -e '.issue_links | map(select(.dedupe_key=="route-registry-drift:test:route-coverage:stats")) | length == 1' "$OUT_JSON"
+    jq -e '.issue_links | map(select(.dedupe_key=="route-registry-drift:test:route-coverage:system")) | length == 1' "$OUT_JSON"
+    grep -q 'route-registry-drift / app-follow-up' "$OUT_MD"
+    grep -q 'NG8113' "$OUT_MD"
+}
+
+@test "audit classifies route coverage setup failures without route drift findings" {
+    OUT_JSON="$TEST_TMP/audit.json"
+    OUT_MD="$TEST_TMP/audit.md"
+    mkdir -p "$TEST_TMP/bin"
+    cat > "$REPO/package.json" <<'EOF'
+{
+  "engines": { "node": ">=20" },
+  "scripts": {
+    "test": "node --test",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "test:route-coverage": "playwright test route-coverage.spec.ts"
+  }
+}
+EOF
+    cat > "$TEST_TMP/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "--version") echo "11.16.0"; exit 0 ;;
+  "run -s test"|"run -s typecheck"|"run -s lint") exit 0 ;;
+  "run -s test:route-coverage")
+    echo "Error: connect ECONNREFUSED 127.0.0.1:4200"
+    echo "Is the dev server running?"
+    exit 1
+    ;;
+esac
+exit 0
+EOF
+    chmod +x "$TEST_TMP/bin/npm"
+    export PATH="$TEST_TMP/bin:$PATH"
+    export AUTOSPEC_QUALITY_AUDIT_RUN_COMMANDS=1
+
+    run bash "$AUDIT" --repo "$REPO" --json "$OUT_JSON" --markdown "$OUT_MD"
+    [ "$status" -eq 0 ]
+    jq -e '.verification.lanes["test:route-coverage"].status == "setup failure"' "$OUT_JSON"
+    jq -e '.findings[] | select(.probe=="route-coverage-setup" and .classification=="verification-contract-drift")' "$OUT_JSON"
+    ! jq -e '.findings[] | select(.probe=="route-registry-drift")' "$OUT_JSON"
+}
+
 @test "audit reports missing scripts as not configured verification-contract drift" {
     OUT_JSON="$TEST_TMP/audit.json"
     OUT_MD="$TEST_TMP/audit.md"


### PR DESCRIPTION
## Summary
- discover route coverage meta checks from route-specific npm scripts and known Playwright route coverage spec files
- parse missing route registry/catalog entries into route-family `route-registry-drift` findings with bounded issue dedupe keys
- classify route coverage setup failures separately and keep route parsing ahead of setup heuristics so baseURL/server noise cannot hide drift
- capture Angular compiler warnings emitted by route coverage checks as first-class audit findings

## Validation
- `bash -n skills/autospec-shared/scripts/repo-quality-audit.sh`
- `bats skills/autospec-shared/tests/unit/repo-quality-audit.bats tests/autospec/test_quality_audit_summary.bats tests/autospec/test_run_summary.bats`
- `git diff --check`
- `bash scripts/validate.sh`
- code-reviewer LGTM after fixing initial review findings

Closes #1479
