### PR TITLE
feat: rank maintainability hotspots in quality audits

### DIFF
--- a/skills/autospec-shared/scripts/repo-quality-audit.sh
+++ b/skills/autospec-shared/scripts/repo-quality-audit.sh
@@ -54,8 +54,10 @@ VERIFICATION_ND="$TMP_DIR/verification-lanes.ndjson"
 RUNTIME_JSON="$TMP_DIR/runtime.json"
 ARTIFACTS_JSON="$TMP_DIR/artifacts.json"
 STORAGE_KEYS="$TMP_DIR/storage-keys.txt"
+HOTSPOTS_ND="$TMP_DIR/maintainability-hotspots.ndjson"
+HOTSPOT_KEYS="$TMP_DIR/maintainability-hotspot-keys.txt"
 touch "$FINDINGS_ND" "$SUPPRESSED_ND" "$ISSUES_ND" "$RISKS_ND" "$VERIFICATION_ND"
-touch "$STORAGE_KEYS"
+touch "$STORAGE_KEYS" "$HOTSPOTS_ND" "$HOTSPOT_KEYS"
 
 cleanup() {
   rm -rf "$TMP_DIR"
@@ -264,6 +266,41 @@ add_sensitive_storage_finding() {
     --arg storage_key "$storage_key" \
     --arg excerpt "$excerpt" \
     '{probe:$probe,classification:$classification,severity:$severity,file:$file,line:$line,title:$title,body:$body,dedupe_key:$key,storage_api:$storage_api,sensitive_term:$sensitive_term,storage_key:(if $storage_key == "" then null else $storage_key end),excerpt:$excerpt}'
+}
+
+add_maintainability_hotspot_finding() {
+  file="$1"; rank="$2"; score="$3"; lines="$4"; kind="$5"; any_count="$6"; debug_count="$7"; disabled_count="$8"; eslint_count="$9"; ts_ignore_count="${10}"; recent_touch="${11}"; any_density="${12}"; test_signal="${13}"
+  key="maintainability-hotspot:$file"
+  target="$FINDINGS_ND"
+  classification="maintainability-hotspot"
+  if is_accepted "$key"; then
+    classification="inherited-accepted-debt"
+    target="$SUPPRESSED_ND"
+  fi
+  title="ranked maintainability hotspot #$rank: $file"
+  body="Rank #$rank maintainability hotspot ($kind) scored $score from $lines lines, any=$any_count, any_density=$any_density, debug_logging=$debug_count, disabled_tests=$disabled_count, eslint_disable=$eslint_count, ts_ignore=$ts_ignore_count, recent_touch=$recent_touch, test_signal=$test_signal. File a bounded refactor issue for this file/cluster only, and require behavior locks or regression tests before cleanup edits."
+  json_append "$target" \
+    --arg probe "maintainability-hotspot" \
+    --arg classification "$classification" \
+    --arg severity "medium" \
+    --arg file "$file" \
+    --argjson line "0" \
+    --arg title "$title" \
+    --arg body "$body" \
+    --arg key "$key" \
+    --argjson rank "$rank" \
+    --argjson score "$score" \
+    --argjson lines "$lines" \
+    --arg kind "$kind" \
+    --argjson any_count "$any_count" \
+    --argjson debug_count "$debug_count" \
+    --argjson disabled_count "$disabled_count" \
+    --argjson eslint_count "$eslint_count" \
+    --argjson ts_ignore_count "$ts_ignore_count" \
+    --arg recent_touch "$recent_touch" \
+    --argjson any_density "$any_density" \
+    --arg test_signal "$test_signal" \
+    '{probe:$probe,classification:$classification,severity:$severity,file:$file,line:$line,title:$title,body:$body,dedupe_key:$key,rank:$rank,score:$score,hotspot_kind:$kind,lines:$lines,any_count:$any_count,any_density:$any_density,debug_logging_count:$debug_count,disabled_test_count:$disabled_count,eslint_disable_count:$eslint_count,ts_ignore_count:$ts_ignore_count,recent_touch:$recent_touch,test_signal:$test_signal,remediation:"bounded refactor follow-up; behavior locks/regression tests required before cleanup edits"}'
 }
 
 rel_path() {
@@ -779,7 +816,10 @@ write_runtime_json() {
 
 scan_text_files() {
   find "$REPO" \
-    \( -path "$REPO/.git" -o -path "$REPO/node_modules" -o -path "$REPO/.autospec" \) -prune -o \
+    \( -path "$REPO/.git" -o -path "$REPO/node_modules" -o -path "$REPO/.autospec" \
+      -o -path "$REPO/dist" -o -path "$REPO/build" -o -path "$REPO/coverage" \
+      -o -path "$REPO/.angular" -o -path "$REPO/.next" -o -path "$REPO/out" \
+      -o -path "$REPO/vendor" -o -path "$REPO/public/build" \) -prune -o \
     -type f \( -name '*.js' -o -name '*.jsx' -o -name '*.ts' -o -name '*.tsx' -o -name '*.mjs' -o -name '*.cjs' -o -name '*.html' -o -name '*.vue' -o -name '*.svelte' -o -name '*.py' -o -name '*.sh' \) \
 	    -print
 }
@@ -801,6 +841,157 @@ storage_key_for_line() {
     key="$(printf '%s\n' "$line" | sed -nE "s/.*(localStorage|sessionStorage)\[['\"]([^'\"]+)['\"]\].*/\2/p" | head -1)"
   fi
   printf '%s' "$key"
+}
+
+file_kind_for() {
+  file="$1"
+  case "$file" in
+    *.spec.ts|*.spec.tsx|*.test.ts|*.test.tsx|*.spec.js|*.test.js) printf 'spec' ;;
+    *.html|*.vue|*.svelte) printf 'template' ;;
+    *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs) printf 'source' ;;
+    *) printf 'other' ;;
+  esac
+}
+
+recent_touch_for() {
+  file="$1"
+  if (cd "$REPO" && git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
+    touched="$(cd "$REPO" && git log -1 --format=%cs -- "$file" 2>/dev/null || true)"
+    [ -n "$touched" ] || touched="untracked"
+    printf '%s' "$touched"
+  else
+    printf 'unknown'
+  fi
+}
+
+recent_rank_for() {
+  touch_date="$1"
+  case "$touch_date" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) printf '%s' "$touch_date" | tr -d '-' ;;
+    *) printf '0' ;;
+  esac
+}
+
+json_config_value() {
+  key="$1"
+  config_file="$REPO/.autospec/quality-audit.json"
+  [ -f "$config_file" ] || return 0
+  jq -r --arg key "$key" '.maintainability[$key] // empty' "$config_file"
+}
+
+validate_quality_audit_config() {
+  config_file="$REPO/.autospec/quality-audit.json"
+  [ -f "$config_file" ] || return 0
+  if ! jq -e 'type == "object"' "$config_file" >/dev/null 2>&1; then
+    printf 'repo-quality-audit: .autospec/quality-audit.json must be valid JSON object\n' >&2
+    exit 1
+  fi
+  if ! jq -e '(.maintainability // {}) | type == "object"' "$config_file" >/dev/null 2>&1; then
+    printf 'repo-quality-audit: .autospec/quality-audit.json maintainability must be an object\n' >&2
+    exit 1
+  fi
+}
+
+non_negative_int_or_die() {
+  name="$1"; value="$2"
+  case "$value" in
+    ''|*[!0-9]*)
+      printf 'repo-quality-audit: %s must be a non-negative integer\n' "$name" >&2
+      exit 1
+      ;;
+  esac
+}
+
+maintainability_threshold() {
+  config_key="$1"; env_name="$2"; default_value="$3"
+  env_value="$(eval "printf '%s' \"\${$env_name-}\"")"
+  if [ -n "$env_value" ]; then
+    value="$env_value"
+  else
+    value="$(json_config_value "$config_key")"
+    [ -n "$value" ] || value="$default_value"
+  fi
+  non_negative_int_or_die "$config_key" "$value"
+  printf '%s' "$value"
+}
+
+validate_quality_audit_config
+
+TEST_FILE_EXTENSIONS=".spec.ts .spec.tsx .test.ts .test.tsx .spec.js .test.js"
+
+test_signal_for() {
+  rel="$1"; kind="$2"
+  case "$kind" in
+    spec) printf 'self-spec'; return 0 ;;
+  esac
+  base="${rel%.*}"
+  for ext in $TEST_FILE_EXTENSIONS; do
+    if [ -f "$REPO/$base$ext" ]; then
+      printf 'adjacent-spec'
+      return 0
+    fi
+  done
+  printf 'none'
+}
+
+cap_score_component() {
+  value="$1"; cap="$2"
+  if [ "$value" -gt "$cap" ]; then
+    printf '%s' "$cap"
+  else
+    printf '%s' "$value"
+  fi
+}
+
+record_hotspot_metrics() {
+  rel="$1"; lines="$2"; kind="$3"; any_count="$4"; debug_count="$5"; disabled_count="$6"; eslint_count="$7"; ts_ignore_count="$8"; recent_touch="$9"; test_signal="${10}"
+  threshold_lines="$(maintainability_threshold "large_file_lines" "AUTOSPEC_QUALITY_AUDIT_LARGE_FILE_LINES" "800")"
+  threshold_any="$(maintainability_threshold "any_threshold" "AUTOSPEC_QUALITY_AUDIT_ANY_THRESHOLD" "10")"
+  threshold_debug="$(maintainability_threshold "debug_threshold" "AUTOSPEC_QUALITY_AUDIT_DEBUG_THRESHOLD" "5")"
+  threshold_disabled="$(maintainability_threshold "disabled_test_threshold" "AUTOSPEC_QUALITY_AUDIT_DISABLED_TEST_THRESHOLD" "1")"
+  threshold_disable="$(maintainability_threshold "disable_comment_threshold" "AUTOSPEC_QUALITY_AUDIT_DISABLE_COMMENT_THRESHOLD" "1")"
+  if [ "$lines" -lt "$threshold_lines" ] \
+    && [ "$any_count" -lt "$threshold_any" ] \
+    && [ "$debug_count" -lt "$threshold_debug" ] \
+    && [ "$disabled_count" -lt "$threshold_disabled" ] \
+    && [ "$eslint_count" -lt "$threshold_disable" ] \
+    && [ "$ts_ignore_count" -lt "$threshold_disable" ]; then
+    return 0
+  fi
+  [ "$lines" -gt 0 ] || lines=1
+  any_density_per_1000=$(( any_count * 1000 / lines ))
+  any_density="$(jq -n --argjson density "$any_density_per_1000" '$density / 1000')"
+  any_component="$(cap_score_component "$((any_count * 3))" 60)"
+  debug_component="$(cap_score_component "$((debug_count * 2))" 40)"
+  score=$(( lines / 100 + any_component + any_density_per_1000 / 10 + debug_component + disabled_count * 25 + eslint_count * 10 + ts_ignore_count * 15 ))
+  case "$kind" in
+    source) score=$((score + 10)) ;;
+    template) score=$((score + 8)) ;;
+    spec) score=$((score + 4)) ;;
+  esac
+  case "$test_signal" in
+    adjacent-spec) score=$((score + 25)) ;;
+    self-spec) score=$((score + 10)) ;;
+  esac
+  recent_rank="$(recent_rank_for "$recent_touch")"
+  if [ "$recent_rank" -gt 0 ]; then
+    score=$((score + 20))
+  fi
+  json_append "$HOTSPOTS_ND" \
+    --arg file "$rel" \
+    --arg kind "$kind" \
+    --arg recent_touch "$recent_touch" \
+    --arg test_signal "$test_signal" \
+    --argjson score "$score" \
+    --argjson recent_rank "$recent_rank" \
+    --argjson lines "$lines" \
+    --argjson any_density "$any_density" \
+    --argjson any_count "$any_count" \
+    --argjson debug_count "$debug_count" \
+    --argjson disabled_count "$disabled_count" \
+    --argjson eslint_count "$eslint_count" \
+    --argjson ts_ignore_count "$ts_ignore_count" \
+    '{file:$file,kind:$kind,recent_touch:$recent_touch,test_signal:$test_signal,score:$score,recent_rank:$recent_rank,lines:$lines,any_density:$any_density,any_count:$any_count,debug_count:$debug_count,disabled_count:$disabled_count,eslint_count:$eslint_count,ts_ignore_count:$ts_ignore_count}'
 }
 
 # Probe: dirty git status.
@@ -879,7 +1070,10 @@ fi
 
 # Probe: security-sensitive storage, focused/skipped tests, any usage, debug logging.
 while IFS= read -r f; do
+  [ -n "$f" ] || continue
   rel="$(rel_path "$f")"
+  lines="$(wc -l < "$f" | tr -d ' ')"
+  kind="$(file_kind_for "$rel")"
   while IFS= read -r storage_hit; do
     [ -n "$storage_hit" ] || continue
     line_no="$(printf '%s\n' "$storage_hit" | cut -d: -f1)"
@@ -898,6 +1092,7 @@ while IFS= read -r f; do
 $(grep -nE 'localStorage|sessionStorage|document\.cookie' "$f" 2>/dev/null || true)
 EOF
   focus_hits="$(grep -nE '\b(describe|it|test)\.(only|skip)\b|@skip|\.skip\(' "$f" 2>/dev/null || true)"
+  disabled_count="$(printf '%s\n' "$focus_hits" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')"
   if [ -n "$focus_hits" ]; then
     first_line="$(printf '%s\n' "$focus_hits" | head -1 | cut -d: -f1)"
     add_finding "focused-skipped-tests" "app-follow-up" "medium" "$rel" "${first_line:-0}" \
@@ -906,6 +1101,7 @@ EOF
       "focused-skipped-tests:$rel"
   fi
   any_hits="$(grep -nE '\bas any\b|: *any\b|<any>' "$f" 2>/dev/null || true)"
+  any_count="$(printf '%s\n' "$any_hits" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')"
   if [ -n "$any_hits" ]; then
     first_line="$(printf '%s\n' "$any_hits" | head -1 | cut -d: -f1)"
     add_finding "any-usage" "app-follow-up" "low" "$rel" "${first_line:-0}" \
@@ -914,6 +1110,7 @@ EOF
       "any-usage:$rel"
   fi
   debug_hits="$(grep -nE '\b(console\.(log|debug|warn|error)|debugger)\b' "$f" 2>/dev/null || true)"
+  debug_count="$(printf '%s\n' "$debug_hits" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')"
   if [ -n "$debug_hits" ]; then
     first_line="$(printf '%s\n' "$debug_hits" | head -1 | cut -d: -f1)"
     add_finding "debug-logging-hotspots" "app-follow-up" "low" "$rel" "${first_line:-0}" \
@@ -921,9 +1118,52 @@ EOF
       "Debug logging or debugger statements remain in application code." \
       "debug-logging-hotspots:$rel"
   fi
+  eslint_hits="$(grep -nE 'eslint-disable' "$f" 2>/dev/null || true)"
+  eslint_count="$(printf '%s\n' "$eslint_hits" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')"
+  if [ -n "$eslint_hits" ]; then
+    first_line="$(printf '%s\n' "$eslint_hits" | head -1 | cut -d: -f1)"
+    add_finding "eslint-disable-usage" "app-follow-up" "medium" "$rel" "${first_line:-0}" \
+      "eslint-disable usage" \
+      "eslint-disable comments can hide maintainability and correctness regressions from static checks." \
+      "eslint-disable:$rel"
+  fi
+  ts_ignore_hits="$(grep -nE '@ts-ignore|@ts-expect-error' "$f" 2>/dev/null || true)"
+  ts_ignore_count="$(printf '%s\n' "$ts_ignore_hits" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')"
+  if [ -n "$ts_ignore_hits" ]; then
+    first_line="$(printf '%s\n' "$ts_ignore_hits" | head -1 | cut -d: -f1)"
+    add_finding "ts-ignore-usage" "app-follow-up" "medium" "$rel" "${first_line:-0}" \
+      "TypeScript suppression usage" \
+      "@ts-ignore or @ts-expect-error suppressions should be justified and reduced during bounded cleanup." \
+      "ts-ignore:$rel"
+  fi
+  recent_touch="$(recent_touch_for "$rel")"
+  test_signal="$(test_signal_for "$rel" "$kind")"
+  record_hotspot_metrics "$rel" "$lines" "$kind" "$any_count" "$debug_count" "$disabled_count" "$eslint_count" "$ts_ignore_count" "$recent_touch" "$test_signal"
 done <<EOF
 $(scan_text_files)
 EOF
+
+if [ -s "$HOTSPOTS_ND" ]; then
+  rank=0
+  jq -c -s 'sort_by(-.score, -.recent_rank, -.any_density, -.lines, .file) | .[:10] | .[]' "$HOTSPOTS_ND" | while IFS= read -r hotspot; do
+    [ -n "$hotspot" ] || continue
+    rank=$((rank + 1))
+    file="$(printf '%s' "$hotspot" | jq -r '.file')"
+    printf 'maintainability-hotspot:%s\n' "$file" >> "$HOTSPOT_KEYS"
+    score="$(printf '%s' "$hotspot" | jq -r '.score')"
+    lines="$(printf '%s' "$hotspot" | jq -r '.lines')"
+    kind="$(printf '%s' "$hotspot" | jq -r '.kind')"
+    any_count="$(printf '%s' "$hotspot" | jq -r '.any_count')"
+    any_density="$(printf '%s' "$hotspot" | jq -r '.any_density')"
+    debug_count="$(printf '%s' "$hotspot" | jq -r '.debug_count')"
+    disabled_count="$(printf '%s' "$hotspot" | jq -r '.disabled_count')"
+    eslint_count="$(printf '%s' "$hotspot" | jq -r '.eslint_count')"
+    ts_ignore_count="$(printf '%s' "$hotspot" | jq -r '.ts_ignore_count')"
+    recent_touch="$(printf '%s' "$hotspot" | jq -r '.recent_touch')"
+    test_signal="$(printf '%s' "$hotspot" | jq -r '.test_signal')"
+    add_maintainability_hotspot_finding "$file" "$rank" "$score" "$lines" "$kind" "$any_count" "$debug_count" "$disabled_count" "$eslint_count" "$ts_ignore_count" "$recent_touch" "$any_density" "$test_signal"
+  done
+fi
 
 # Probe: large files.
 while IFS= read -r f; do
@@ -976,6 +1216,16 @@ existing_issue_for_finding() {
     'first(.[] | select((.title == $title) or ((.body // "") | contains($key)))) // empty'
 }
 
+coalesced_by_hotspot() {
+  probe="$1"; file="$2"
+  case "$probe" in
+    any-usage|debug-logging-hotspots|eslint-disable-usage|ts-ignore-usage)
+      grep -Fx "maintainability-hotspot:$file" "$HOTSPOT_KEYS" >/dev/null 2>&1
+      ;;
+    *) return 1 ;;
+  esac
+}
+
 if [ "$issue_policy_permits" -eq 1 ]; then
   (cd "$REPO" && gh label create quality-audit --color d4c5f9 --force >/dev/null 2>&1) || true
   (cd "$REPO" && gh label create auto-implement --color 0e8a16 --force >/dev/null 2>&1) || true
@@ -987,6 +1237,11 @@ if [ "$issue_policy_permits" -eq 1 ]; then
     finding="$(jq -c ".[$i]" "$FINDINGS_JSON")"
     i=$((i + 1))
     key="$(printf '%s' "$finding" | jq -r '.dedupe_key')"
+    probe="$(printf '%s' "$finding" | jq -r '.probe')"
+    file="$(printf '%s' "$finding" | jq -r '.file')"
+    if coalesced_by_hotspot "$probe" "$file"; then
+      continue
+    fi
     if printf '%s\n' "$created_issue_keys" | grep -Fx "$key" >/dev/null 2>&1; then
       continue
     fi
@@ -1020,6 +1275,11 @@ while [ "$i" -lt "$finding_count" ]; do
   finding="$(jq -c ".[$i]" "$FINDINGS_JSON")"
   i=$((i + 1))
   key="$(printf '%s' "$finding" | jq -r '.dedupe_key')"
+  probe="$(printf '%s' "$finding" | jq -r '.probe')"
+  file="$(printf '%s' "$finding" | jq -r '.file')"
+  if coalesced_by_hotspot "$probe" "$file" && [ -n "$issue_keys" ] && printf 'maintainability-hotspot:%s\n' "$file" | grep -E "^($issue_keys)$" >/dev/null 2>&1; then
+    continue
+  fi
   if [ -n "$issue_keys" ] && printf '%s\n' "$key" | grep -E "^($issue_keys)$" >/dev/null 2>&1; then
     continue
   fi

--- a/skills/autospec-shared/tests/unit/repo-quality-audit.bats
+++ b/skills/autospec-shared/tests/unit/repo-quality-audit.bats
@@ -203,6 +203,150 @@ EOF
     jq -e '.findings[] | select(.probe=="security-sensitive-storage" and .storage_api=="document.cookie" and .sensitive_term=="authorization")' "$OUT_JSON"
 }
 
+@test "audit ranks maintainability hotspots and files bounded behavior-lock follow-ups" {
+    OUT_JSON="$TEST_TMP/audit.json"
+    OUT_MD="$TEST_TMP/audit.md"
+    mkdir -p "$REPO/src/app/feature" "$TEST_TMP/bin"
+    {
+        echo "/* eslint-disable @typescript-eslint/no-explicit-any */"
+        echo "// @ts-ignore legacy fixture"
+        for i in $(seq 1 25); do
+            echo "export const value$i: any = console.log('debug-$i') as any;"
+        done
+    } > "$REPO/src/app/feature/giant.service.ts"
+    cat > "$REPO/src/app/feature/giant.service.spec.ts" <<'EOF'
+describe.skip('giant service', () => {
+  it.skip('has a behavior lock', () => {});
+});
+EOF
+    export GH_LOG="$TEST_TMP/gh.log"
+    export GH_OPEN="$TEST_TMP/open.json"
+    printf '[]\n' > "$GH_OPEN"
+    cat > "$TEST_TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s|%s\n' "$PWD" "$*" >> "$GH_LOG"
+case "$*" in
+  *"issue list"*) cat "$GH_OPEN"; exit 0 ;;
+  *"label create"*) exit 0 ;;
+  *"issue create"*) echo "https://github.com/example/repo/issues/40"; exit 0 ;;
+esac
+exit 0
+EOF
+    chmod +x "$TEST_TMP/bin/gh"
+    export PATH="$TEST_TMP/bin:$PATH"
+    export AUTOSPEC_QUALITY_AUDIT_FILE_ISSUES=1
+    export AUTOSPEC_QUALITY_AUDIT_LARGE_FILE_LINES=10
+    export AUTOSPEC_QUALITY_AUDIT_ANY_THRESHOLD=2
+    export AUTOSPEC_QUALITY_AUDIT_DEBUG_THRESHOLD=2
+
+    run bash "$AUDIT" --repo "$REPO" --json "$OUT_JSON" --markdown "$OUT_MD" --file-issues
+    [ "$status" -eq 0 ]
+    jq -e '.findings[] | select(.probe=="maintainability-hotspot" and .file=="src/app/feature/giant.service.ts" and .rank==1 and .hotspot_kind=="source" and .any_count >= 25 and .debug_logging_count >= 25 and .eslint_disable_count==1 and .ts_ignore_count==1 and (.remediation | contains("behavior locks")))' "$OUT_JSON"
+    jq -e '.findings[] | select(.probe=="maintainability-hotspot" and .file=="src/app/feature/giant.service.spec.ts" and .disabled_test_count==2)' "$OUT_JSON"
+    jq -e '.issue_links | map(select(.dedupe_key=="maintainability-hotspot:src/app/feature/giant.service.ts")) | length == 1' "$OUT_JSON"
+    jq -e '.issue_links | map(select(.dedupe_key=="any-usage:src/app/feature/giant.service.ts" or .dedupe_key=="debug-logging-hotspots:src/app/feature/giant.service.ts" or .dedupe_key=="eslint-disable:src/app/feature/giant.service.ts" or .dedupe_key=="ts-ignore:src/app/feature/giant.service.ts")) | length == 0' "$OUT_JSON"
+    run jq -e '.residual_risks[] | select(test("any-usage:src/app/feature/giant.service.ts|debug-logging-hotspots:src/app/feature/giant.service.ts|eslint-disable:src/app/feature/giant.service.ts|ts-ignore:src/app/feature/giant.service.ts"))' "$OUT_JSON"
+    [ "$status" -ne 0 ]
+    grep -q 'bounded refactor issue' "$GH_LOG"
+    grep -q 'behavior locks or regression tests' "$GH_LOG"
+    grep -q 'maintainability-hotspot / maintainability-hotspot' "$OUT_MD"
+}
+
+@test "audit does not emit blank hotspots when only generated files exist" {
+    OUT_JSON="$TEST_TMP/audit.json"
+    OUT_MD="$TEST_TMP/audit.md"
+    rm -rf "$REPO/src" "$REPO/tests"
+    mkdir -p "$REPO/dist"
+    for i in $(seq 1 20); do
+        echo "export const generated$i: any = console.log('generated-$i') as any;"
+    done > "$REPO/dist/bundle.js"
+    export AUTOSPEC_QUALITY_AUDIT_ANY_THRESHOLD=2
+    export AUTOSPEC_QUALITY_AUDIT_DEBUG_THRESHOLD=2
+
+    run bash "$AUDIT" --repo "$REPO" --json "$OUT_JSON" --markdown "$OUT_MD"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"No such file"* ]]
+    run jq -e '.findings[] | select(.probe=="maintainability-hotspot")' "$OUT_JSON"
+    [ "$status" -ne 0 ]
+}
+
+@test "audit ignores generated maintainability hotspots" {
+    OUT_JSON="$TEST_TMP/audit.json"
+    OUT_MD="$TEST_TMP/audit.md"
+    mkdir -p "$REPO/dist" "$REPO/src/app/maintained"
+    for i in $(seq 1 80); do
+        echo "export const generated$i: any = console.log('generated-$i') as any;"
+    done > "$REPO/dist/bundle.js"
+    for i in $(seq 1 5); do
+        echo "export const maintained$i: any = console.log('maintained-$i') as any;"
+    done > "$REPO/src/app/maintained/source.ts"
+    export AUTOSPEC_QUALITY_AUDIT_ANY_THRESHOLD=2
+    export AUTOSPEC_QUALITY_AUDIT_DEBUG_THRESHOLD=2
+
+    run bash "$AUDIT" --repo "$REPO" --json "$OUT_JSON" --markdown "$OUT_MD"
+    [ "$status" -eq 0 ]
+    run jq -e '.findings[] | select(.probe=="maintainability-hotspot" and .file=="dist/bundle.js")' "$OUT_JSON"
+    [ "$status" -ne 0 ]
+    jq -e '.findings[] | select(.probe=="maintainability-hotspot" and .file=="src/app/maintained/source.ts")' "$OUT_JSON"
+}
+
+@test "audit ranks newer denser test-backed maintainability hotspots first" {
+    OUT_JSON="$TEST_TMP/audit.json"
+    OUT_MD="$TEST_TMP/audit.md"
+    mkdir -p "$REPO/src/app/ranking"
+    for i in $(seq 1 100); do
+        echo "export const oldValue$i: any = $i as any;"
+    done > "$REPO/src/app/ranking/aa-old.ts"
+    for i in $(seq 1 20); do
+        echo "export const newValue$i: any = $i as any;"
+    done > "$REPO/src/app/ranking/zz-new.ts"
+    cat > "$REPO/src/app/ranking/zz-new.spec.ts" <<'EOF'
+describe('zz-new', () => {
+  it('locks behavior', () => {});
+});
+EOF
+    git -C "$REPO" init >/dev/null
+    git -C "$REPO" config user.email test@example.com
+    git -C "$REPO" config user.name Test
+    git -C "$REPO" add .
+    GIT_AUTHOR_DATE="2024-01-01T00:00:00Z" GIT_COMMITTER_DATE="2024-01-01T00:00:00Z" git -C "$REPO" commit -m old >/dev/null
+    printf '\nexport const recentTouch = true;\n' >> "$REPO/src/app/ranking/zz-new.ts"
+    git -C "$REPO" add .
+    GIT_AUTHOR_DATE="2026-01-01T00:00:00Z" GIT_COMMITTER_DATE="2026-01-01T00:00:00Z" git -C "$REPO" commit -m new >/dev/null
+    export AUTOSPEC_QUALITY_AUDIT_ANY_THRESHOLD=2
+
+    run bash "$AUDIT" --repo "$REPO" --json "$OUT_JSON" --markdown "$OUT_MD"
+    [ "$status" -eq 0 ]
+    jq -e '.findings[] | select(.probe=="maintainability-hotspot" and .file=="src/app/ranking/zz-new.ts" and .rank==1 and .recent_touch=="2026-01-01" and .test_signal=="adjacent-spec")' "$OUT_JSON"
+    jq -e '.findings[] | select(.probe=="maintainability-hotspot" and .file=="src/app/ranking/aa-old.ts" and .any_density > 0)' "$OUT_JSON"
+}
+
+@test "audit validates maintainability threshold config" {
+    OUT_JSON="$TEST_TMP/audit.json"
+    OUT_MD="$TEST_TMP/audit.md"
+    cat > "$REPO/.autospec/quality-audit.json" <<'EOF'
+{
+  "maintainability": {
+    "debug_threshold": "abc"
+  }
+}
+EOF
+
+    run bash "$AUDIT" --repo "$REPO" --json "$OUT_JSON" --markdown "$OUT_MD"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"debug_threshold must be a non-negative integer"* ]]
+}
+
+@test "audit rejects malformed quality-audit threshold config" {
+    OUT_JSON="$TEST_TMP/audit.json"
+    OUT_MD="$TEST_TMP/audit.md"
+    printf '{not-json\n' > "$REPO/.autospec/quality-audit.json"
+
+    run bash "$AUDIT" --repo "$REPO" --json "$OUT_JSON" --markdown "$OUT_MD"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *".autospec/quality-audit.json must be valid JSON"* ]]
+}
+
 @test "audit discovers design/template guard scripts without running them by default" {
     OUT_JSON="$TEST_TMP/audit.json"
     OUT_MD="$TEST_TMP/audit.md"


### PR DESCRIPTION
## Summary
- rank repo quality audit maintainability hotspots from per-file line count, any density, debug/test-disable/suppression counts, recent touch, and adjacent test signals
- exclude common generated output directories from maintained-source hotspot ranking
- file one bounded hotspot cleanup issue per file/cluster while coalescing subordinate any/debug/eslint/ts suppression findings
- load maintainability thresholds from `.autospec/quality-audit.json` with environment overrides and strict integer/config validation

## Validation
- `bash -n skills/autospec-shared/scripts/repo-quality-audit.sh scripts/autospec-write-run-summary.sh`
- `bats skills/autospec-shared/tests/unit/repo-quality-audit.bats tests/autospec/test_quality_audit_summary.bats tests/autospec/test_run_summary.bats` (30/30)
- `git diff --check`
- `bash scripts/validate.sh` (OK; known warn-only stale token baseline warning)
- code-reviewer findings resolved

Closes #1481
